### PR TITLE
DO NOT MERGE Safari defineProperties bug

### DIFF
--- a/packages/ses/demos/challenge/index.html
+++ b/packages/ses/demos/challenge/index.html
@@ -82,7 +82,8 @@
         <li><button id="sample-counter" type="button">Counter</button></li>
         <li><button id="sample-timing" type="button">Timing Side-Channel</button></li>
       </ul>
-      <p>(<a href="https://github.com/Agoric/ses-shim/tree/master/apps/challenge">challenge source code</a>)</p>
+      <p>(<a href="https://github.com/Agoric/SES-shim/tree/master/packages/ses/demos/challenge">challenge source code</a>)</p>
+      <script src="../../dist/lockdown.umd.js"></script>
       <script src="main.js"></script>
     </body>
   </html>

--- a/packages/ses/demos/challenge/main.js
+++ b/packages/ses/demos/challenge/main.js
@@ -142,7 +142,12 @@ lockdown();
   }
 
   harden(guess);
-  const compartent = new Compartment({ console, guess, ...dateEndowment });
+  const compartent = new Compartment({
+    console,
+    assert,
+    guess,
+    ...dateEndowment,
+  });
 
   function submitProgram(program) {
     // the attacker's code will be submitted here. We expect it to be a

--- a/packages/ses/demos/challenge/main.js
+++ b/packages/ses/demos/challenge/main.js
@@ -17,28 +17,20 @@
 //   limit attacker to some finite number of calls per go()
 //   framework updates UI (with setTimeout(0)), then calls go() again
 
-import('../../dist/ses.esm.js').then(({ lockdown }) => {
+lockdown();
+{
   console.log('starting');
 
   // Helpers
 
-  function $(selector) {
-    return document.querySelector(selector);
-  }
-  // function $$(selector) {
-  //   return document.querySelectorAll(selector);
-  // }
+  const $ = selector => document.querySelector(selector);
 
   // ********************
-  // 1. We build the SES Realm.
+  // 1. Should we endow the real `Date`?
   // ********************
 
-  const dateTaming = window.location.search.includes('dateNow=enabled')
-    ? 'unsafe'
-    : 'safe';
-  $('#dateNowStatus').textContent =
-    dateTaming === 'unsafe' ? 'Date.now() enabled' : 'Date.now() returns NaN';
-  lockdown({ dateTaming });
+  const nowEnabled = window.location.search.includes('dateNow=enabled');
+  const dateEndowment = nowEnabled ? { Date } : {};
 
   // ********************
   // 2. We prepare APIs for the defender code.
@@ -149,15 +141,8 @@ import('../../dist/ses.esm.js').then(({ lockdown }) => {
     return true;
   }
 
-  const tamedConsole = {
-    log() {
-      return console.log();
-    },
-  };
-
-  harden(tamedConsole);
   harden(guess);
-  const compartent = new Compartment({ console: tamedConsole, guess });
+  const compartent = new Compartment({ console, guess, ...dateEndowment });
 
   function submitProgram(program) {
     // the attacker's code will be submitted here. We expect it to be a
@@ -297,6 +282,6 @@ import('../../dist/ses.esm.js').then(({ lockdown }) => {
   });
 
   console.log('loaded');
-});
+}
 
 /* eslint-enable no-plusplus */

--- a/packages/ses/demos/console/index.html
+++ b/packages/ses/demos/console/index.html
@@ -18,9 +18,9 @@
     const x = 0;
     const c1 = new Compartment({ x: 1 });
     const c2 = new Compartment({ x: 2 });
-    
-    const x1 = c1.evaluate('(x)');
-    const x2 = c2.evaluate('(x)');
+
+    const x1 = c1.evaluate('x;');
+    const x2 = c2.evaluate('x;');
     /**
     * This line below will output 3 values to demonstrate that
     * x has a different value in every context:
@@ -29,7 +29,7 @@
     * - 2 in compartment #2
     */
     ({ x, x1, x2 })
-    
+
     </textarea>
     <br />
     <button id="execute">Execute</button>
@@ -43,6 +43,7 @@
       Note: you can look in the console to inspect the original output of the evaluation.
       </small>
     </p>
+    <script src="../../dist/lockdown.umd.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/packages/ses/demos/console/index.html
+++ b/packages/ses/demos/console/index.html
@@ -1,12 +1,12 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-    <title>SES Console</title>
+    <title>SES Demo Console</title>
     <link href="style.css" rel="stylesheet" type="text/css" />
 
   </head>
   <body>
-    <h1>SES Console</h1>
+    <h1>SES Demo Console</h1>
     <label>Input:</label>
     <br/>
     <textarea id="input" rows="25" cols="80">
@@ -19,8 +19,8 @@
     const c1 = new Compartment({ x: 1 });
     const c2 = new Compartment({ x: 2 });
 
-    const x1 = c1.evaluate('x;');
-    const x2 = c2.evaluate('x;');
+    const x1 = c1.evaluate('x');
+    const x2 = c2.evaluate('x');
     /**
     * This line below will output 3 values to demonstrate that
     * x has a different value in every context:

--- a/packages/ses/demos/console/main.js
+++ b/packages/ses/demos/console/main.js
@@ -13,7 +13,7 @@ lockdown();
 
   // Under the default `lockdown` settings, it is safe enough
   // to endow with the safe `console`.
-  const compartment = new Compartment({ console });
+  const compartment = new Compartment({ console, assert });
 
   execute.addEventListener('click', () => {
     const sourceText = input.value;

--- a/packages/ses/demos/console/main.js
+++ b/packages/ses/demos/console/main.js
@@ -24,7 +24,7 @@ lockdown();
       console.log(result);
       outputText = `${q(result, '  ')}`;
     } catch (e) {
-      console.log('threw', result);
+      console.log('threw', e);
       outputText = `threw ${q(e)}`;
     }
     output.value = outputText;

--- a/packages/ses/demos/console/main.js
+++ b/packages/ses/demos/console/main.js
@@ -1,7 +1,7 @@
 /* globals document */
-{
-  lockdown();
 
+lockdown();
+{
   const { quote: q } = assert;
 
   const $ = selector => document.querySelector(selector);
@@ -11,7 +11,9 @@
   const input = $('#input');
   const output = $('#output');
 
-  const compartment = new Compartment();
+  // Under the default `lockdown` settings, it is safe enough
+  // to endow with the safe `console`.
+  const compartment = new Compartment({ console });
 
   execute.addEventListener('click', () => {
     const sourceText = input.value;

--- a/packages/ses/demos/console/main.js
+++ b/packages/ses/demos/console/main.js
@@ -21,12 +21,12 @@ lockdown();
     let outputText;
     try {
       result = compartment.evaluate(sourceText);
+      console.log(result);
       outputText = `${q(result, '  ')}`;
     } catch (e) {
+      console.log('threw', result);
       outputText = `threw ${q(e)}`;
     }
-
-    console.log(result);
     output.value = outputText;
   });
 

--- a/packages/ses/demos/console/main.js
+++ b/packages/ses/demos/console/main.js
@@ -1,6 +1,8 @@
 /* globals document */
-import('../../dist/ses.esm.js').then(({ lockdown }) => {
+{
   lockdown();
+
+  const { quote: q } = assert;
 
   const $ = selector => document.querySelector(selector);
 
@@ -17,18 +19,9 @@ import('../../dist/ses.esm.js').then(({ lockdown }) => {
     let outputText;
     try {
       result = compartment.evaluate(sourceText);
-      switch (typeof result) {
-        case 'function':
-          outputText = result.toString();
-          break;
-        case 'object':
-          outputText = JSON.stringify(result);
-          break;
-        default:
-          outputText = `${result}`;
-      }
+      outputText = `${q(result, '  ')}`;
     } catch (e) {
-      outputText = `${e}`;
+      outputText = `threw ${q(e)}`;
     }
 
     console.log(result);
@@ -39,4 +32,4 @@ import('../../dist/ses.esm.js').then(({ lockdown }) => {
     input.value = '';
     output.value = '';
   });
-});
+}

--- a/packages/ses/demos/index.html
+++ b/packages/ses/demos/index.html
@@ -11,7 +11,7 @@
         <a href="./console">SES Console</a>: a REPL to help you debug code running in SES.
       </li>
       <li>
-      <a href="./challenge">SES Challenge</a>: try to break out of SES and read a secret!
+        <a href="./challenge">SES Challenge</a>: try to break out of SES and read a secret!
       </li>
     </ul>
   </body>

--- a/packages/ses/demos/index.html
+++ b/packages/ses/demos/index.html
@@ -10,11 +10,9 @@
       <li>
         <a href="./console">SES Console</a>: a REPL to help you debug code running in SES.
       </li>
-      <!--
-        <li>
-        <a href="./challenge">SES Challenge</a>: try to break out of SES and read a secret!
-        </li>
-      -->
+      <li>
+      <a href="./challenge">SES Challenge</a>: try to break out of SES and read a secret!
+      </li>
     </ul>
   </body>
 </html>

--- a/packages/ses/demos/index.html
+++ b/packages/ses/demos/index.html
@@ -10,9 +10,11 @@
       <li>
         <a href="./console">SES Console</a>: a REPL to help you debug code running in SES.
       </li>
-      <li>
+      <!--
+        <li>
         <a href="./challenge">SES Challenge</a>: try to break out of SES and read a secret!
-      </li>
+        </li>
+      -->
     </ul>
   </body>
 </html>

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -44,10 +44,18 @@ const objectFromEntries = entryPairs => {
 
 export const fromEntries = Object.fromEntries || objectFromEntries;
 
+// eslint-disable-next-line import/no-mutable-exports
+export let gotcha = false;
+
 export const defineProperty = (object, prop, descriptor) => {
   // Object.defineProperty is allowed to fail silently so we use
   // Object.defineProperties instead.
-  return defineProperties(object, { [prop]: descriptor });
+  gotcha = true;
+  try {
+    return defineProperties(object, { [prop]: descriptor });
+  } finally {
+    gotcha = false;
+  }
 };
 
 export const { apply, construct, get: reflectGet, set: reflectSet } = Reflect;

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -9,6 +9,7 @@ import {
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
   objectHasOwnProperty,
+  gotcha,
 } from './commons.js';
 
 import { moderateEnablements, minEnablements } from './enablements.js';
@@ -98,6 +99,10 @@ export default function enablePropertyOverrides(intrinsics, overrideTaming) {
         if (objectHasOwnProperty(this, prop)) {
           this[prop] = newValue;
         } else {
+          if (gotcha) {
+            // eslint-disable-next-line no-debugger
+            debugger;
+          }
           defineProperty(this, prop, {
             value: newValue,
             writable: true,

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -224,32 +224,38 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
   };
 
   /**
-   * Logs the `subErrors` within a group named `label`.
+   * Logs the `subErrors` within a group name mentioning `optTag`.
    *
    * @param {string | undefined} optTag
    * @param {Error[]} subErrors
    * @returns {void}
    */
   const logSubErrors = (optTag = undefined, subErrors) => {
-    if (subErrors.length >= 1) {
-      let label;
-      if (subErrors.length === 1) {
-        label = `Nested error`;
-      } else {
-        label = `Nested ${subErrors.length} errors`;
+    if (subErrors.length === 0) {
+      return;
+    }
+    if (subErrors.length === 1 && optTag === undefined) {
+      // eslint-disable-next-line no-use-before-define
+      logError(subErrors[0]);
+      return;
+    }
+    let label;
+    if (subErrors.length === 1) {
+      label = `Nested error`;
+    } else {
+      label = `Nested ${subErrors.length} errors`;
+    }
+    if (optTag !== undefined) {
+      label = `${label} under ${optTag}`;
+    }
+    baseConsole.group(label);
+    try {
+      for (const subError of subErrors) {
+        // eslint-disable-next-line no-use-before-define
+        logError(subError);
       }
-      if (optTag !== undefined) {
-        label = `${label} under ${optTag}`;
-      }
-      baseConsole.group(label);
-      try {
-        for (const subError of subErrors) {
-          // eslint-disable-next-line no-use-before-define
-          logError(subError);
-        }
-      } finally {
-        baseConsole.groupEnd();
-      }
+    } finally {
+      baseConsole.groupEnd();
     }
   };
 
@@ -295,7 +301,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     ) {
       stackString += '\n';
     }
-    baseConsole[BASE_CONSOLE_LEVEL]('', stackString);
+    baseConsole[BASE_CONSOLE_LEVEL](stackString);
     // Show the other annotations on error
     for (const noteLogArgs of noteLogArgsArray) {
       logErrorInfo(error, ErrorInfo.NOTE, noteLogArgs, subErrors);

--- a/packages/ses/src/error/tame-error-constructor.js
+++ b/packages/ses/src/error/tame-error-constructor.js
@@ -3,13 +3,25 @@ import {
   construct,
   defineProperties,
   setPrototypeOf,
+  getOwnPropertyDescriptor,
 } from '../commons.js';
 import { NativeErrors } from '../whitelist.js';
 import { tameV8ErrorConstructor } from './tame-v8-error-constructor.js';
 
+// Present on at least FF. Proposed by Error-proposal. Not on SES whitelist
+// so grab it before it is removed.
+const stackDesc = getOwnPropertyDescriptor(Error.prototype, 'stack');
+const stackGetter = stackDesc && stackDesc.get;
+
 // Use concise methods to obtain named functions without constructors.
 const tamedMethods = {
-  getStackString(_error) {
+  getStackString(error) {
+    if (typeof stackGetter === 'function') {
+      return apply(stackGetter, error, []);
+    } else if ('stack' in error) {
+      // The fallback is to just use the de facto `error.stack` if present
+      return `${error.stack}`;
+    }
     return '';
   },
 };
@@ -39,6 +51,7 @@ export default function tameErrorConstructor(
         error = construct(OriginalError, rest, new.target);
       }
       if (platform === 'v8') {
+        // TODO Likely expensive!
         OriginalError.captureStackTrace(error, ResultError);
       }
       return error;
@@ -73,6 +86,63 @@ export default function tameErrorConstructor(
   for (const NativeError of NativeErrors) {
     setPrototypeOf(NativeError, SharedError);
   }
+
+  // https://v8.dev/docs/stack-trace-api#compatibility advises that
+  // programmers can "always" set `Error.stackTraceLimit`
+  // even on non-v8 platforms. On non-v8
+  // it will have no effect, but this advice only makes sense
+  // if the assignment itself does not fail, which it would
+  // if `Error` were naively frozen. Hence, we add setters that
+  // accept but ignore the assignment on non-v8 platforms.
+  defineProperties(InitialError, {
+    stackTraceLimit: {
+      get() {
+        if (typeof OriginalError.stackTraceLimit === 'number') {
+          // OriginalError.stackTraceLimit is only on v8
+          return OriginalError.stackTraceLimit;
+        }
+        return undefined;
+      },
+      set(newLimit) {
+        if (typeof OriginalError.stackTraceLimit === 'number') {
+          // OriginalError.stackTraceLimit is only on v8
+          OriginalError.stackTraceLimit = newLimit;
+          // We place the useless return on the next line to ensure
+          // that anything we place after the if in the future only
+          // happens if the then-case does not.
+          // eslint-disable-next-line no-useless-return
+          return;
+        }
+      },
+      // WTF on v8 stackTraceLimit is enumerable
+      enumerable: false,
+      configurable: true,
+    },
+  });
+
+  // The default SharedError much be completely powerless even on v8,
+  // so the lenient `stackTraceLimit` accessor does nothing on all
+  // platforms.
+  defineProperties(SharedError, {
+    stackTraceLimit: {
+      get() {
+        return undefined;
+      },
+      // https://v8.dev/docs/stack-trace-api#compatibility advises that
+      // programmers can "always" set `Error.stackTraceLimit` and
+      // `Error.prepareStackTrace` even on non-v8 platforms. On non-v8
+      // it will have no effect, but this advice only makes sense
+      // if the assignment itself does not fail, which it would
+      // if `Error` were naively frozen. Hence, we add setters that
+      // accept but ignore the assignment on non-v8 platforms.
+      set(_newLimit) {
+        // do nothing
+      },
+      // WTF on v8 stackTraceLimit is enumerable
+      enumerable: false,
+      configurable: true,
+    },
+  });
 
   let initialGetStackString = tamedMethods.getStackString;
   if (platform === 'v8') {

--- a/packages/ses/src/error/tame-v8-error-constructor.js
+++ b/packages/ses/src/error/tame-v8-error-constructor.js
@@ -245,40 +245,12 @@ export function tameV8ErrorConstructor(
     return systemMethods.prepareStackTrace;
   };
 
+  // Note `stackTraceLimit` accessor already defined by
+  // tame-error-constructor.js
   defineProperties(InitialError, {
     captureStackTrace: {
       value: tamedMethods.captureStackTrace,
       writable: true,
-      enumerable: false,
-      configurable: true,
-    },
-    stackTraceLimit: {
-      get() {
-        if (typeof OriginalError.stackTraceLimit === 'number') {
-          // OriginalError.stackTraceLimit is only on v8
-          return OriginalError.stackTraceLimit;
-        }
-        return undefined;
-      },
-      // https://v8.dev/docs/stack-trace-api#compatibility advises that
-      // programmers can "always" set `Error.stackTraceLimit` and
-      // `Error.prepareStackTrace` even on non-v8 platforms. On non-v8
-      // it will have no effect, but this advise only makes sense
-      // if the assignment itself does not fail, which it would
-      // if `Error` were naively frozen. Hence, we add setters that
-      // accept but ignore the assignment on non-v8 platforms.
-      set(newLimit) {
-        if (typeof OriginalError.stackTraceLimit === 'number') {
-          // OriginalError.stackTraceLimit is only on v8
-          OriginalError.stackTraceLimit = newLimit;
-          // We place the useless return on the next line to ensure
-          // that anything we place after the if in the future only
-          // happens if the then-case does not.
-          // eslint-disable-next-line no-useless-return
-          return;
-        }
-      },
-      // WTF on v8 stackTraceLimit is enumerable
       enumerable: false,
       configurable: true,
     },

--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -238,7 +238,16 @@ export default function whitelistIntrinsics(intrinsics, nativeBrander) {
         // explanation.
         console.log(`Removing ${subPath}`);
       }
-      delete obj[prop];
+      try {
+        delete obj[prop];
+      } catch (err) {
+        if (prop in obj) {
+          console.error(`failed to delete ${subPath}`, err);
+        } else {
+          console.error(`deleting ${subPath} threw`, err);
+        }
+        throw err;
+      }
     }
   }
 

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -1101,6 +1101,7 @@ export const whitelist = {
   DataView: {
     // Properties of the DataView Constructor
     '[[Proto]]': '%FunctionPrototype%',
+    BYTES_PER_ELEMENT: 'number', // Non std but undeletable on Safari.
     prototype: '%DataViewPrototype%',
   },
 

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -29,10 +29,8 @@ test('throwsAndLogs with data', t => {
     [
       ['error', 'what', obj],
       ['log', 'Caught', '(TypeError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'TypeError#1:', 'foo'],
-      ['debug', '', 'stack of TypeError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of TypeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -66,10 +64,8 @@ test('assert', t => {
     /Check failed/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['group', 'Nested error'],
       ['debug', 'Error#1:', 'Check failed'],
-      ['debug', '', 'stack of Error\n'],
-      ['groupEnd'],
+      ['debug', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -114,16 +110,14 @@ test('causal tree', t => {
     /because/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['group', 'Nested error'],
       ['debug', 'Error#1:', 'because', '(Error#2)'],
-      ['debug', '', 'stack of Error\n'],
+      ['debug', 'stack of Error\n'],
       ['group', 'Nested error under Error#1'],
       ['debug', 'Error#2:', 'synful', '(SyntaxError#3)'],
-      ['debug', '', 'stack of Error\n'],
+      ['debug', 'stack of Error\n'],
       ['group', 'Nested error under Error#2'],
       ['debug', 'SyntaxError#3:', 'foo'],
-      ['debug', '', 'stack of SyntaxError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of SyntaxError\n'],
       ['groupEnd'],
       ['groupEnd'],
     ],
@@ -208,10 +202,8 @@ test('assert equals', t => {
     /Expected \(a number\) is same as \(a number\)/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'Expected', 5, 'is same as', 6],
-      ['debug', '', 'stack of RangeError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -224,10 +216,8 @@ test('assert equals', t => {
     /foo/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'foo'],
-      ['debug', '', 'stack of RangeError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -250,10 +240,8 @@ test('assert equals', t => {
     /Expected \(a number\) is same as \(a number\)/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'Expected', -0, 'is same as', 0],
-      ['debug', '', 'stack of RangeError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -292,10 +280,8 @@ test('assert error default', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['group', 'Nested error'],
       ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', '', 'stack of Error\n'],
-      ['groupEnd'],
+      ['debug', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -321,10 +307,8 @@ test('assert error explicit', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(URIError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'URIError#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', '', 'stack of URIError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of URIError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -343,10 +327,8 @@ test('assert q', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['group', 'Nested error'],
       ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', '', 'stack of Error\n'],
-      ['groupEnd'],
+      ['debug', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );


### PR DESCRIPTION
The SES Demo console, after previously having worked on Safari Technology Preview, suddenly started failing with an infinite recursion. This instrumented variation of the PR in which this started failing catches when `Object.defineProperties` causes a setter to be called. The `Object.defineProperties` is attempting to convert `Array.prototype.toString` from a data property to an accessor property, after `Object.prototype.toString` has been similarly converted. Violating the semantics of `defineProperties`, it causes the setter of the `Object.prototype.toString` accessor property to be called. There follows some screenshots examining this state from within the debugger.

This is on Safari Technology Preview
Release 121 (Safari 14.2, WebKit 16612.1.4.3)

Reported as https://bugs.webkit.org/show_bug.cgi?id=222538