### PR TITLE
docs: update description of the SES challenge to match reality

### DIFF
--- a/packages/ses/demos/challenge/index.html
+++ b/packages/ses/demos/challenge/index.html
@@ -34,7 +34,7 @@
       the least time, concluding that the full password must start with that
       character. Then they iterate on the second character, and so on until they've
     worked out the full password, roughly 18 seconds later.</p>
-    <p>However an SES-confined program only gets to access non-determinism in the start
+    <p>However a SES-confined program only gets to access non-determinism in the start
     Compartment (the one that ran <code>lockdown()</code>), so this attacker
       doesn't get a clock, and cannot read from the covert channel. Load this page
       <a href="?dateNow=enabled">with ?dateNow=enabled</a> to demonstrate the

--- a/packages/ses/demos/challenge/index.html
+++ b/packages/ses/demos/challenge/index.html
@@ -19,8 +19,8 @@
     <p>In this challenge, the defender has a secret
       "<a href="https://en.wikipedia.org/wiki/Macguffin">MacGuffin</a>", in this
       case a random code which the attacker (below) is trying to guess. Everything
-      is running inside a single SES RootRealm. The attacker's code (pasted into
-      the text box) is evaluated by the defender when the Execute button is
+      is running inside a single locked-down SES Realm. The attacker's code (pasted into
+      the text box) is evaluated by the defender in a separate Compartment when the Execute button is
     pressed.</p>
     <p>The secret consists of a ten-character alphanumeric code (about 52 bits of
       entropy). The attacker's program gets a "check my guess" function, which
@@ -34,21 +34,16 @@
       the least time, concluding that the full password must start with that
       character. Then they iterate on the second character, and so on until they've
     worked out the full password, roughly 18 seconds later.</p>
-    <p>However an SES-confined program does not get access to non-determinism
-      (except as mediated by the code that built the environment), so this attacker
+    <p>However an SES-confined program only gets to access non-determinism in the start
+    Compartment (the one that ran <code>lockdown()</code>), so this attacker
       doesn't get a clock, and cannot read from the covert channel. Load this page
       <a href="?dateNow=enabled">with ?dateNow=enabled</a> to demonstrate the
       attack with <code>Date.now</code> enabled, or <a href="?dateNow=NaN">with
       ?dateNow=NaN</a> to properly confine the attacker.</p>
-      <p>The defender is given access to two functions which the attacker does not
-        get: one which provides random values to create the MacGuffin (normally
-        forbidden since <code>Crypto.getRandomValues</code> is non-deterministic),
-        and a second to delay arbitrary amounts of time (normally forbidden for the
-        same reason). These are created in the Root realm and provided as endowments
-        to the defender. A normal application would need to protect these carefully,
-        as either would allow the defender code to reach the Root realm's
-        full-powered <code>Function</code> constructor, allowing it to break
-      confinement.</p>
+      <p>The defender running in the start Compartment gets access to powerful JS
+      globals.  This includes sources of non-determinism like
+      <code>window.setTimeout</code> and
+      <code>window.crypto.getRandomValues</code> as well as the DOM.</p>
       <center>
       <div class="outer-box">
         <div class="code-box">

--- a/packages/ses/demos/challenge/main.js
+++ b/packages/ses/demos/challenge/main.js
@@ -146,7 +146,7 @@ lockdown();
   }
 
   harden(guess);
-  const compartent = new Compartment({
+  const compartment = new Compartment({
     console,
     assert,
     guess,
@@ -160,7 +160,7 @@ lockdown();
 
     startAttacker();
 
-    const attacker = compartent.evaluate(`(${program})`);
+    const attacker = compartment.evaluate(`(${program})`);
     const attackGen = attacker(); // build the generator
     function nextGuess() {
       if (!enableAttacker) {


### PR DESCRIPTION
The existing challenge UI explanatory text is somewhat misleading.

We don't do confinement of the defender.  While that would be
interesting, the status quo usefully demonstrates that you don't have to jump
through hoops to use SES in normal JS programs.
