### PR TITLE
Enablements needed by Buffer

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -86,7 +86,6 @@ export const moderateEnablements = {
     // may eventually be fixed at the source.
     // hasOwnProperty: true, // set by "vega-util".
 
-    toLocaleString: true, // set by https://github.com/feross/buffer
     toString: true,
     valueOf: true,
   },

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -104,7 +104,6 @@ export const moderateEnablements = {
     constructor: true, // set by "regenerator-runtime"
     bind: true, // set by "underscore", "express"
     toString: true, // set by "rollup"
-    toLocaleString: true, // set by https://github.com/feross/buffer
   },
 
   '%ErrorPrototype%': {

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -5,6 +5,7 @@
  * enviromments subject to the override mistake.
  *
  * @author JF Paradis
+ * @author Mark S. Miller
  */
 
 /**
@@ -85,6 +86,7 @@ export const moderateEnablements = {
     // may eventually be fixed at the source.
     // hasOwnProperty: true, // set by "vega-util".
 
+    toLocaleString: true, // set by https://github.com/feross/buffer
     toString: true,
     valueOf: true,
   },
@@ -102,6 +104,7 @@ export const moderateEnablements = {
     constructor: true, // set by "regenerator-runtime"
     bind: true, // set by "underscore", "express"
     toString: true, // set by "rollup"
+    toLocaleString: true, // set by https://github.com/feross/buffer
   },
 
   '%ErrorPrototype%': {
@@ -141,9 +144,7 @@ export const moderateEnablements = {
     constructor: true, // set by "core-js"
   },
 
-  '%TypedArrayPrototype%': {
-    toString: true,
-  },
+  '%TypedArrayPrototype%': '*', // set by https://github.com/feross/buffer
 
   '%Generator%': {
     constructor: true,

--- a/packages/ses/test/test-enable-default-overrides-default.js
+++ b/packages/ses/test/test-enable-default-overrides-default.js
@@ -1,0 +1,50 @@
+import '../lockdown.js';
+import test from 'ava';
+
+lockdown({
+  // errorTaming: 'unsafe',
+});
+
+// See https://github.com/endojs/endo/issues/616#issuecomment-800733101
+
+test('enable default overrides of Uint8Array', t => {
+  t.notThrows(() => {
+    function Buffer(_arg, _encodingOrOffset, _length) {}
+    Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype);
+    Object.setPrototypeOf(Buffer, Uint8Array);
+    Buffer.prototype.toLocaleString = Buffer.prototype.toString;
+  });
+});
+
+test('enable default overrides of Uint8Array in evaluation', t => {
+  const c = new Compartment();
+  t.notThrows(() =>
+    c.evaluate(
+      `(${function foo() {
+        function Buffer(_arg, _encodingOrOffset, _length) {}
+        Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype);
+        Object.setPrototypeOf(Buffer, Uint8Array);
+        Buffer.prototype.toLocaleString = Buffer.prototype.toString;
+      }})()`,
+    ),
+  );
+});
+
+test('enable default overrides of function', t => {
+  t.notThrows(() => {
+    function Buffer(_arg, _encodingOrOffset, _length) {}
+    Buffer.prototype.toLocaleString = Buffer.prototype.toString;
+  });
+});
+
+test('enable default overrides of function in evaluation', t => {
+  const c = new Compartment();
+  t.notThrows(() =>
+    c.evaluate(
+      `(${function bar() {
+        function Buffer(_arg, _encodingOrOffset, _length) {}
+        Buffer.prototype.toLocaleString = Buffer.prototype.toString;
+      }})()`,
+    ),
+  );
+});

--- a/packages/ses/test/test-enable-default-overrides-default.js
+++ b/packages/ses/test/test-enable-default-overrides-default.js
@@ -1,9 +1,7 @@
 import '../lockdown.js';
 import test from 'ava';
 
-lockdown({
-  // errorTaming: 'unsafe',
-});
+lockdown();
 
 // See https://github.com/endojs/endo/issues/616#issuecomment-800733101
 

--- a/packages/ses/test/test-enable-default-overrides-default.js
+++ b/packages/ses/test/test-enable-default-overrides-default.js
@@ -29,22 +29,3 @@ test('enable default overrides of Uint8Array in evaluation', t => {
     ),
   );
 });
-
-test('enable default overrides of function', t => {
-  t.notThrows(() => {
-    function Buffer(_arg, _encodingOrOffset, _length) {}
-    Buffer.prototype.toLocaleString = Buffer.prototype.toString;
-  });
-});
-
-test('enable default overrides of function in evaluation', t => {
-  const c = new Compartment();
-  t.notThrows(() =>
-    c.evaluate(
-      `(${function bar() {
-        function Buffer(_arg, _encodingOrOffset, _length) {}
-        Buffer.prototype.toLocaleString = Buffer.prototype.toString;
-      }})()`,
-    ),
-  );
-});

--- a/packages/ses/test/test-enable-property-overrides.js
+++ b/packages/ses/test/test-enable-property-overrides.js
@@ -91,7 +91,7 @@ test('enablePropertyOverrides - on', t => {
 
   harden(intrinsics);
 
-  testOverriding(t, 'Object', {}, ['toString', 'toLocaleString', 'valueOf']);
+  testOverriding(t, 'Object', {}, ['toString', 'valueOf']);
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
   testOverriding(t, 'Array', [], ['toString', 'length', 'push']);

--- a/packages/ses/test/test-enable-property-overrides.js
+++ b/packages/ses/test/test-enable-property-overrides.js
@@ -91,7 +91,7 @@ test('enablePropertyOverrides - on', t => {
 
   harden(intrinsics);
 
-  testOverriding(t, 'Object', {}, ['toString', 'valueOf']);
+  testOverriding(t, 'Object', {}, ['toString', 'toLocaleString', 'valueOf']);
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
   testOverriding(t, 'Array', [], ['toString', 'length', 'push']);


### PR DESCRIPTION
Fixes #616 

The culprit here is https://github.com/feross/buffer which we've also encountered in https://github.com/Agoric/agoric-sdk/issues/2663 . From the investigation there, the `feross/buffer` package overrides a lot more of TypedArray than `toLocaleString`, which is why I went all the way back to '*'.

@kumavis your second test is overriding `Object.prototype.toLocaleString` which surprised me. First, could you try this PR out against your failure of `feross/buffer` to see if it really is adequate to fix the problems you're encountering? Second, if so, could you comment out the enabling of `Object.prototype.toLocaleString` and see if it still works? Because it is on `Object.prototype`, I'd like to avoid adding it unless we really need to. Thanks.