### PR TITLE
feat(ses): Revert "Export SES Transforms (#608)"

### DIFF
--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -36,11 +36,6 @@
       "import": "./lockdown.js",
       "require": "./dist/lockdown.cjs",
       "browser": "./dist/lockdown.umd.js"
-    },
-    "./transforms": {
-      "import": "./transforms.js",
-      "require": "./dist/transforms.cjs",
-      "browser": "./dist/transforms.umd.js"
     }
   },
   "scripts": {

--- a/packages/ses/rollup.config.js
+++ b/packages/ses/rollup.config.js
@@ -25,15 +25,6 @@ export default [
         format: 'cjs',
       },
     ],
-  },
-  {
-    input: 'src/transforms.js',
-    output: [
-      {
-        file: 'dist/transforms.cjs',
-        format: 'cjs',
-      },
-    ],
     plugins: [resolve(), commonjs()],
   },
   {
@@ -55,15 +46,6 @@ export default [
     plugins: [resolve(), commonjs()],
   },
   {
-    input: 'src/transforms.js',
-    output: {
-      file: 'dist/transforms.umd.js',
-      format: 'umd',
-      name: 'SesTransforms',
-    },
-    plugins: [resolve(), commonjs()],
-  },
-  {
     input: 'ses.js',
     output: {
       file: 'dist/ses.umd.min.js',
@@ -78,15 +60,6 @@ export default [
       file: 'dist/lockdown.umd.min.js',
       format: 'umd',
       name: 'SES',
-    },
-    plugins: [resolve(), commonjs(), terser()],
-  },
-  {
-    input: 'src/transforms.js',
-    output: {
-      file: 'dist/transforms.umd.min.js',
-      format: 'umd',
-      name: 'SesTransforms',
     },
     plugins: [resolve(), commonjs(), terser()],
   },


### PR DESCRIPTION
SES is constrained to use a regular expression for evasive transforms.
SES exposes the evasive transforms as options to `evaluate`.
For cases where a bundler is involved, this problem is better solved
with a parser transform that can distinguish comments from names in
scope and can discern whether the transformation it proposes is likely
to cause semantic breakage.

This reverts commit 5ec8858648254e7cd2a1bf9c054a1d5d2749c31b.

Fixes #609