### PR TITLE
doc: Clarify that Endo is aspirational

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ machines.
 The foundation of Endo is [SES][], a tamper-proof JavaScript environment that
 allows safe execution of arbitrary programs in Compartments.
 
-⚠️Endo is not Done.⚠️
+⚠️Endo is not Done. All following statements about Endo are aspirational.⚠️
 
 Most JavaScript libraries built for Node.js, either in CommonJS or ECMAScript
 module format, are suitable for running in Endo without modification, since


### PR DESCRIPTION
The README contains statements of intent in an implied subjunctive mood. This change makes that clearer, but review feedback of the form “Integrate the aspirational sense in the whole document instead” is welcome.