### PR TITLE
feat(compartment-mapper): Add module transforms

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,11 @@
 User-visible changes to the compartment mapper:
 
+## Next release
+
+* Applications may now have asynchronous module transforms, per language.
+  When applied to archive creation, the transformed sources appear in the
+  archive.
+
 ## 0.2.3 (2020-11-05)
 
 * Embellishes all calls to methods named `import` to work around SES-shim

--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -89,7 +89,10 @@ const translateCompartmentMap = (compartments, sources, renames) => {
  */
 const renameSources = (sources, renames) => {
   return fromEntries(
-    entries(sources).map(([name, compartment]) => [renames[name], compartment]),
+    entries(sources).map(([name, compartmentSources]) => [
+      renames[name],
+      compartmentSources,
+    ]),
   );
 };
 
@@ -116,9 +119,12 @@ const addSourcesToArchive = async (archive, sources) => {
 /**
  * @param {ReadFn} read
  * @param {string} moduleLocation
+ * @param {Object} [options]
+ * @param {ModuleTransforms} [options.moduleTransforms]
  * @returns {Promise<Uint8Array>}
  */
-export const makeArchive = async (read, moduleLocation) => {
+export const makeArchive = async (read, moduleLocation, options) => {
+  const { moduleTransforms } = options || {};
   const {
     packageLocation,
     packageDescriptorText,
@@ -159,6 +165,7 @@ export const makeArchive = async (read, moduleLocation) => {
   const compartment = assemble(compartmentMap, {
     resolve,
     makeImportHook,
+    moduleTransforms,
   });
   await compartment.load(entryModuleSpecifier);
 
@@ -197,13 +204,15 @@ export const makeArchive = async (read, moduleLocation) => {
  * @param {ReadFn} read
  * @param {string} archiveLocation
  * @param {string} moduleLocation
+ * @param {ArchiveOptions} [options]
  */
 export const writeArchive = async (
   write,
   read,
   archiveLocation,
   moduleLocation,
+  options,
 ) => {
-  const archiveBytes = await makeArchive(read, moduleLocation);
+  const archiveBytes = await makeArchive(read, moduleLocation, options);
   await write(archiveLocation, archiveBytes);
 };

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -164,6 +164,7 @@ export const assemble = (
     globals = {},
     globalLexicals = {},
     transforms = [],
+    moduleTransforms = {},
     __shimTransforms__ = [],
     modules: exitModules = {},
     Compartment = defaultCompartment,
@@ -188,7 +189,7 @@ export const assemble = (
     // The `moduleMapHook` writes back to the compartment map.
     compartmentDescriptor.modules = modules;
 
-    const parse = mapParsers(parsers, types);
+    const parse = mapParsers(parsers, types, moduleTransforms);
     const importHook = makeImportHook(location, parse);
     const moduleMapHook = makeModuleMapHook(
       compartments,

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -4,8 +4,6 @@ import { parseExtension } from './extension.js';
 // q, as in quote, for quoting strings in error messages.
 const q = JSON.stringify;
 
-const decoder = new TextDecoder();
-
 const { freeze } = Object;
 
 /**
@@ -82,15 +80,14 @@ export const makeImportHookMaker = (
           _error => undefined,
         );
         if (moduleBytes !== undefined) {
-          const moduleSource = decoder.decode(moduleBytes);
-
-          const envelope = parse(
-            moduleSource,
+          // eslint-disable-next-line no-await-in-loop
+          const envelope = await parse(
+            moduleBytes,
             candidateSpecifier,
             moduleLocation,
             packageLocation,
           );
-          const { parser } = envelope;
+          const { parser, bytes: transformedBytes } = envelope;
           const { record: concreteRecord } = envelope;
 
           // Facilitate a redirect if the returned record has a different
@@ -116,7 +113,7 @@ export const makeImportHookMaker = (
           packageSources[candidateSpecifier] = {
             location: packageRelativeLocation,
             parser,
-            bytes: moduleBytes,
+            bytes: transformedBytes,
           };
           return record;
         }

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -1,6 +1,7 @@
 // @ts-check
 /* eslint no-shadow: "off" */
 
+import './types.js';
 import { compartmentMapForNodeModules } from './node-modules.js';
 import { search } from './search.js';
 import { assemble } from './assemble.js';
@@ -10,9 +11,12 @@ import * as json from './json.js';
 /**
  * @param {ReadFn} read
  * @param {string} moduleLocation
+ * @param {ArchiveOptions} [options]
  * @returns {Promise<Application>}
  */
-export const loadLocation = async (read, moduleLocation) => {
+export const loadLocation = async (read, moduleLocation, options) => {
+  const { moduleTransforms = {} } = options || {};
+
   const {
     packageLocation,
     packageDescriptorText,
@@ -34,6 +38,7 @@ export const loadLocation = async (read, moduleLocation) => {
     moduleSpecifier,
   );
 
+  /** @type {ExecuteFn} */
   const execute = async (options = {}) => {
     const {
       globals,
@@ -50,6 +55,7 @@ export const loadLocation = async (read, moduleLocation) => {
       globalLexicals,
       modules,
       transforms,
+      moduleTransforms,
       __shimTransforms__,
       Compartment,
     });
@@ -64,12 +70,12 @@ export const loadLocation = async (read, moduleLocation) => {
 /**
  * @param {ReadFn} read
  * @param {string} moduleLocation
- * @param {ExecuteOptions} options
+ * @param {ExecuteOptions & ArchiveOptions} [options]
  * @returns {Promise<Object>} the object of the imported modules exported
  * names.
  */
 export const importLocation = async (read, moduleLocation, options = {}) => {
-  const application = await loadLocation(read, moduleLocation);
+  const application = await loadLocation(read, moduleLocation, options);
   // Call import by property to bypass SES censoring for dynamic import.
   // eslint-disable-next-line dot-notation
   return application['import'](options);

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -100,7 +100,7 @@
 
 /**
  * @callback ExecuteFn
- * @param {ExecuteOptions} options
+ * @param {ExecuteOptions} [options]
  * @returns {Promise<Object>}
  */
 
@@ -122,14 +122,15 @@
 
 /**
  * @callback ParseFn
- * @param {string} source
+ * @param {Uint8Array} bytes
  * @param {string} specifier
  * @param {string} location
  * @param {string} packageLocation
- * @returns {{
+ * @returns {Promise<{
+ *   bytes: Uint8Array,
  *   parser: ParserDescriptor,
  *   record: FinalStaticModuleType,
- * }}
+ * }>}
  */
 
 /**
@@ -145,6 +146,20 @@
 /**
  * @typedef {ExecuteOptions & Object} AssemblyOptions
  * @property {AssembleImportHook} makeImportHook
+ * @property {ModuleTransforms} [moduleTransforms]
+ */
+
+/**
+ * @typedef {Record<string, ModuleTransform>} ModuleTransforms
+ */
+
+/**
+ * @callback ModuleTransform
+ * @param {Uint8Array} bytes
+ * @param {string} specifier
+ * @param {string} location
+ * @param {string} packageLocation
+ * @returns {Promise<{bytes: Uint8Array, parser: ParserDescriptor}>}
  */
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -166,4 +181,15 @@
  * @property {Uint8Array} [bytes]
  * @property {ParserDescriptor} [parser]
  * @property {string} [exit]
+ */
+
+/**
+ * @typedef {Object} Artifact
+ * @property {Uint8Array} bytes
+ * @property {ParserDescriptor} parser
+ */
+
+/**
+ * @typedef {Object} ArchiveOptions
+ * @property {ModuleTransforms} [moduleTransforms]
  */


### PR DESCRIPTION
This change introduces module transforms as an option for running applications and building archives.  The motivating use case is the application of parser-based evasive transforms.  These transforms can change the source slightly such that they do not trip SES censorship of dynamic imports and possibly other patterns, without changing the meaning of the program.

https://github.com/Agoric/agoric-sdk/issues/2684