### PR TITLE
feat(endo): Freeze all global objects

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -5,6 +5,7 @@ User-visible changes to the compartment mapper:
 * Applications may now have asynchronous module transforms, per language.
   When applied to archive creation, the transformed sources appear in the
   archive.
+* Every compartment's `globalThis` is frozen.
 
 ## 0.2.3 (2020-11-05)
 

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -4,7 +4,7 @@
 import { resolve } from './node-module-specifier.js';
 import { mapParsers } from './parse.js';
 
-const { entries } = Object;
+const { entries, freeze } = Object;
 
 const defaultCompartment = Compartment;
 
@@ -210,6 +210,8 @@ export const assemble = (
       globalLexicals,
       name: location,
     });
+
+    freeze(compartment.globalThis);
 
     compartments[compartmentName] = compartment;
   }

--- a/packages/compartment-mapper/test/node_modules/app/main.js
+++ b/packages/compartment-mapper/test/node_modules/app/main.js
@@ -15,3 +15,7 @@ export { builtin } from 'builtin';
 
 export const receivedGlobalProperty = globalProperty;
 export const receivedGlobalLexical = globalLexical;
+
+if (!Object.isFrozen(globalThis)) {
+  throw new Error('The global object must be frozen in all compartments');
+}

--- a/packages/compartment-mapper/test/node_modules/brooke/brooke.js
+++ b/packages/compartment-mapper/test/node_modules/brooke/brooke.js
@@ -1,1 +1,5 @@
 export const brooke = 'Brooke';
+
+if (!Object.isFrozen(globalThis)) {
+  throw new Error('The global object must be frozen in all compartments');
+}

--- a/packages/compartment-mapper/test/node_modules/builtin/builtin.js
+++ b/packages/compartment-mapper/test/node_modules/builtin/builtin.js
@@ -1,1 +1,5 @@
 export const builtin = 'builtin';
+
+if (!Object.isFrozen(globalThis)) {
+  throw new Error('The global object must be frozen in all compartments');
+}

--- a/packages/compartment-mapper/test/node_modules/clarke/index.js
+++ b/packages/compartment-mapper/test/node_modules/clarke/index.js
@@ -1,1 +1,5 @@
 export const clarke = 'Clarke';
+
+if (!Object.isFrozen(globalThis)) {
+  throw new Error('The global object must be frozen in all compartments');
+}

--- a/packages/compartment-mapper/test/node_modules/danny/src/danny.js
+++ b/packages/compartment-mapper/test/node_modules/danny/src/danny.js
@@ -1,1 +1,5 @@
 export const danny = 'Danny';
+
+if (!Object.isFrozen(globalThis)) {
+  throw new Error('The global object must be frozen in all compartments');
+}

--- a/packages/compartment-mapper/test/node_modules/danny/src/index.js
+++ b/packages/compartment-mapper/test/node_modules/danny/src/index.js
@@ -1,1 +1,5 @@
 export * from './danny.js';
+
+if (!Object.isFrozen(globalThis)) {
+  throw new Error('The global object must be frozen in all compartments');
+}


### PR DESCRIPTION
By default, freeze the global object in every compartment after endowments. We may in a future version allow some compartments to remain thawn through explicit configuration from the application (possibly recommended on a per library basis). We may in a future version provide a hook for alternate global post processing like `harden`.  We do not take a dependency on `harden` because that would limit the use of compartment mapper as a demonstration of how Node.js could use compartments as a standard module loader API, orthogonal to SES.
