### PR TITLE
Setting `{errorTaming: 'unsafe'}` does not redact secrets

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -26,6 +26,22 @@ User-visible changes in SES:
   scopeProxies created during calls to this Compartment instances's
   `Compartment.prototype.evaluate`. See `test-compartment-known-scope-proxy.js`
   for an example of performing a scopeProxy leak workaround.
+- Under the default `{errorTaming: 'safe'}` setting, the SES shim already redacts stack traces from error instances when it can (currently: v8, spiderMonkey, XS). The setting `{errorTaming: 'unsafe'}` suppresses that redaction, instead blabbing these stack traces on error instances via the expected `errorInstance.stack`.
+
+  The purpose of the `details` template literal tag (often spelled `X` or `d`) together with the `quote` function (often spelled `q`) is to redact data from the error messages carried by error instances. With this release, the same `{errorTaming: 'unsafe'}` would suppress that redaction as well, so that all substitution values would act like they've been quoted. IOW, with this setting
+
+   ```js
+   assert(false, X`literal part ${secretData} with ${q(publicData)}.`);
+   ```
+
+  acts like
+
+   ```js
+   assert(false, X`literal part ${q(secretData)} with ${q(publicData)}.`);
+   ```
+
+   Note that the information rendered by the SES shim `console` object always includes all the unredacted data independent of the setting of `errorTaming`.
+
 
 ## Release 0.12.3 (1-Mar-2021)
 

--- a/packages/ses/lockdown-options.md
+++ b/packages/ses/lockdown-options.md
@@ -202,7 +202,7 @@ if present, it should be present only as a deletable accessor property
 inherited from `Error.prototype` so that it can be deleted. The actual
 stack information would be available by other means, the `getStack` and
 `getStackString` functions&mdash;special powers available only in the start
-compartment&mdash;so the SES console can still `operate` as described above.
+compartment&mdash;so the SES console can still operate as described above.
 
 On v8&mdash;the JavaScript engine powering Chrome, Brave, and Node&mdash;the
 default error behavior is much more dangerous. The v8 `Error` constructor
@@ -245,6 +245,27 @@ Since the current JavaScript de facto reality is that the stack is only
 available by saying `err.stack`, a number of development tools assume they
 can find it there. When the information leak is tolerable, the `'unsafe'`
 setting will preserve the filtered stack information on the `err.stack`.
+
+Like hiding the stack, the purpose of the `details` template literal tag (often
+spelled `X` or `d`) together with the `quote` function (often spelled `q`) is
+to redact data from the error messages carried by error instances. The same
+`{errorTaming: 'unsafe'}` suppresses that redaction as well, so that all
+substitution values would act like they've been quoted. With this setting
+
+```js
+assert(false, X`literal part ${secretData} with ${q(publicData)}.`);
+```
+
+acts like
+
+```js
+assert(false, X`literal part ${q(secretData)} with ${q(publicData)}.`);
+```
+
+Like with the stack, the SES shim `console` object always
+shows the unredacted detailed error message independent of the setting of
+`errorTaming`.
+
 
 ## `stackFiltering` Options
 

--- a/packages/ses/src/error/README.md
+++ b/packages/ses/src/error/README.md
@@ -2,7 +2,7 @@
 
 Summary
    * Writing defensive programs under SES requires carefully considering what an error reveals to code positioned to catch those errors up the call chain.
-   * To that end, SES introduces an `assert` global with functions that add to errors annotations that will be hidden from callers. SES also tames the `Error` constructor to hide the `stack` to parent callers.
+   * To that end, SES introduces an `assert` global with functions that add to errors annotations that will be hidden from callers. SES also tames the `Error` constructor to hide the `stack` to parent callers when possible (currently: v8, SpiderMonkey, XS).
    * SES tames the global `console` and grants it the ability to reveal error annotations and stacks to the actual console.
    * Both `assert` and `console` are  powerful globals that SES does not implicitly carry into child compartments. When creating a child compartment, add `assert` to the compartment’s globals. Either add `console` too, or add a wrapper that annotates the console with a topic.
    * SES hides annotations and stack traces by default. To reveal them, use a mechanism like `process.on("uncaughtException")` in Node.js to catch the error and log it back to the `console` tamed by `lockdown`.

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -56,9 +56,9 @@ const hiddenDetailsMap = new WeakMap();
 /**
  * Normally this is the function exported as `assert.details` and often
  * spelled `d`. However, if the `{errorTaming: 'unsafe'}` option is given to
- * `lockdown`, then it `unredactedDetails` is used instead.
+ * `lockdown`, then `unredactedDetails` is used instead.
  *
- * There are some unconditionl uses of `redactedDetails` in this module. All
+ * There are some unconditional uses of `redactedDetails` in this module. All
  * of them should be uses where the template literal has no redacted
  * substitution values. In those cases, the two are equivalent.
  *

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -232,6 +232,7 @@
  * `optRaise(reason)` would still happen.
  *
  * @param {Raise=} optRaise
+ * @param {boolean=} unredacted
  * @returns {Assert}
  */
 

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -31,7 +31,7 @@ import { tameFunctionToString } from './tame-function-tostring.js';
 
 import { tameConsole } from './error/tame-console.js';
 import tameErrorConstructor from './error/tame-error-constructor.js';
-import { assert } from './error/assert.js';
+import { assert, makeAssert } from './error/assert.js';
 
 /**
  * @typedef {{
@@ -205,6 +205,15 @@ export function repairIntrinsics(
   }
   const consoleRecord = tameConsole(consoleTaming, optGetStackString);
   globalThis.console = /** @type {Console} */ (consoleRecord.console);
+
+  if (errorTaming === 'unsafe' && globalThis.assert === assert) {
+    // If errorTaming is 'unsafe' we replace the global assert with
+    // one whose `details` template literal tag does not redact
+    // unmarked substitution values. IOW, it blabs information that
+    // was supposed to be secret from callers, as an aid to debugging
+    // at a further cost in safety.
+    globalThis.assert = makeAssert(undefined, true);
+  }
 
   // Replace *Locale* methods with their non-locale equivalents
   tameLocaleMethods(intrinsics, localeTaming);


### PR DESCRIPTION
Under the default `{errorTaming: 'safe'}` setting, the SES shim already redacts stack traces from error instances when it can (currently: v8, spiderMonkey, XS). The setting `{errorTaming: 'unsafe'}` suppresses that redaction, instead blabbing these stack traces on error instances via the expected `errorInstance.stack`.

The purpose of the `details` template literal tag (often spelled `X` or `d`) together with the `quote` function (often spelled `q`) is to redact data from the error messages carried by error instances. With this PR, the same `{errorTaming: 'unsafe'}` would suppress that redaction as well, so that all substitution values would act like they've been quoted. IOW, with this setting
```js
assert(false, X`literal part ${secretData} with ${q(publicData)}.`);
```
would act like
```js
assert(false, X`literal part ${q(secretData)} with ${q(publicData)}.`);
```

Note that the information rendered by the SES shim `console` object always includes all the unredacted data independent of the setting of `errorTaming`.