### PR TITLE
Unsafe errorTaming and consoleTaming needs other adjustments

### DIFF
--- a/packages/ses-ava/test/test-raw-ava-reject.js
+++ b/packages/ses-ava/test/test-raw-ava-reject.js
@@ -29,15 +29,18 @@ test('raw ava reject console output', t => {
 Uncommenting the test code above should produce something like the following.
 This output is all from ava. The stack-like display comes from ava's direct
 use of the `error.stack` property. Ava bypasses the normal `console`.
-For the error message, ava has no access to the non-disclosed
-`'NOTICE ME'`, only the redacted `'(a string)'.
+For the error message, ava has access only to the `message` string carried
+by the error instance, which would normally be redacted to
+`'msg (a string)'`. But `errorTaming: 'unsafe'` suppresses that redaction along
+with suppressing the redaction of the stack, so the console blabs
+`'msg "NOTICE ME"'` instead.
 ```
   raw ava reject console output
 
   Rejected promise returned by test. Reason:
 
   TypeError {
-    message: 'msg (a string)',
+    message: 'msg "NOTICE ME"',
   }
 
   › makeError (file:///Users/markmiller/src/ongithub/agoric/SES-shim/packages/ses/src/error/assert.js:141:17)

--- a/packages/ses-ava/test/test-raw-ava-throw.js
+++ b/packages/ses-ava/test/test-raw-ava-throw.js
@@ -24,15 +24,18 @@ test('raw ava throw console output', t => {
 Uncommenting the test code above should produce something like the following.
 This output is all from ava. The stack-like display comes from ava's direct
 use of the `error.stack` property. Ava bypasses the normal `console`.
-For the error message, ava has no access to the non-disclosed
-`'NOTICE ME'`, only the redacted `'(a string)'.
+For the error message, ava has access only to the `message` string carried
+by the error instance, which would normally be redacted to
+`'msg (a string)'`. But `errorTaming: 'unsafe'` suppresses that redaction along
+with suppressing the redaction of the stack, so the console blabs
+`'msg "NOTICE ME"'` instead.
 ```
   raw ava throw console output
 
   Error thrown in test:
 
   TypeError {
-    message: 'msg (a string)',
+    message: 'msg "NOTICE ME"',
   }
 
   › makeError (file:///Users/alice/agoric/SES-shim/packages/ses/src/error/assert.js:141:17)

--- a/packages/ses/test/error/test-tame-console-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unfilteredError.js
@@ -2,11 +2,11 @@ import test from 'ava';
 import '../../ses.js';
 import { getPrototypeOf } from '../../src/commons.js';
 
-const { details: d } = assert;
-
 const originalConsole = console;
 
 lockdown({ stackFiltering: 'verbose' });
+
+const { details: d } = assert;
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafe-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unfilteredError.js
@@ -2,11 +2,11 @@ import test from 'ava';
 import '../../ses.js';
 import { getPrototypeOf } from '../../src/commons.js';
 
-const { details: d } = assert;
-
 const originalConsole = console;
 
 lockdown({ consoleTaming: 'unsafe', stackFiltering: 'verbose' });
+
+const { details: d } = assert;
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafe-unsafeError-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unsafeError-unfilteredError.js
@@ -2,15 +2,17 @@ import test from 'ava';
 import '../../ses.js';
 import { getPrototypeOf } from '../../src/commons.js';
 
-const { details: d } = assert;
-
 const originalConsole = console;
 
 lockdown({
   consoleTaming: 'unsafe',
   errorTaming: 'unsafe',
   stackFiltering: 'verbose',
+  overrideTaming: 'min',
 });
+
+// Grab `details` only after lockdown
+const { details: d } = assert;
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafe-unsafeError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unsafeError.js
@@ -2,11 +2,16 @@ import test from 'ava';
 import '../../ses.js';
 import { getPrototypeOf } from '../../src/commons.js';
 
-const { details: d } = assert;
-
 const originalConsole = console;
 
-lockdown({ consoleTaming: 'unsafe', errorTaming: 'unsafe' });
+lockdown({
+  consoleTaming: 'unsafe',
+  errorTaming: 'unsafe',
+  overrideTaming: 'min',
+});
+
+// Grab `details` only after lockdown
+const { details: d } = assert;
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafe.js
+++ b/packages/ses/test/error/test-tame-console-unsafe.js
@@ -2,11 +2,11 @@ import test from 'ava';
 import '../../ses.js';
 import { getPrototypeOf } from '../../src/commons.js';
 
-const { details: d } = assert;
-
 const originalConsole = console;
 
 lockdown({ consoleTaming: 'unsafe' });
+
+const { details: d } = assert;
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafeError.js
+++ b/packages/ses/test/error/test-tame-console-unsafeError.js
@@ -2,11 +2,12 @@ import test from 'ava';
 import '../../ses.js';
 import { getPrototypeOf } from '../../src/commons.js';
 
-const { details: d } = assert;
-
 const originalConsole = console;
 
 lockdown({ errorTaming: 'unsafe' });
+
+// Grab `details` only after lockdown
+const { details: d } = assert;
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console.js
+++ b/packages/ses/test/error/test-tame-console.js
@@ -2,11 +2,11 @@ import test from 'ava';
 import '../../ses.js';
 import { getPrototypeOf } from '../../src/commons.js';
 
-const { details: d } = assert;
-
 const originalConsole = console;
 
 lockdown();
+
+const { details: d } = assert;
 
 test('console', t => {
   t.plan(3);


### PR DESCRIPTION
Using `consoleTaming: 'unsafe'` will preserve the original platform console. However, due to #636 the Node console is confused by `constructor` properties that have been turned into accessors. Note that we do *not* recommend this setting. But if you need to use it, it is best used with `overrideTaming: 'min'` which avoids turning any `constructor` properties into accessors.

The `errorTaming: 'unsafe'` option will avoid redacting the information normally hidden from error instances: the call stack and the detailed error message created by the `assert.details` template literal tag. `lockdown` suppresses the redaction of the details by replacing the global `assert` object with one whose `assert.details` does not redact. Thus, if you use `errorTaming: 'unsafe'` be sure to sample the `assert` object and its `details` field only after `lockdown`.

```js
lockdown({ `errorTaming: 'unsafe'` });

// Grab `details` only after lockdown
const { details: X, quote: q } = assert;
```