### PR TITLE
docs(ses): fix broken link to SECURITY.md; update links from /Agoric/ org to /endojs/

### DIFF
--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -441,10 +441,9 @@ console uses these side tables to output more informative diagnostics.
 
 ## Bug Disclosure
 
-Please help us practice coordinated security bug disclosure, by using the
-instructions in
-[SECURITY.md](https://github.com/Agoric/ses-shim/blob/master/SECURITY.md)
-to report security-sensitive bugs privately.
+Please help us practice coordinated security bug disclosure, by using
+the instructions in [SECURITY.md](./SECURITY.md) to report
+security-sensitive bugs privately.
 
 For non-security bugs, please use the [regular Issues
 page](https://github.com/Agoric/ses-shim/issues).

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -31,7 +31,7 @@ arbitrary code.
 SES runs atop an ES6-compliant platform, enabling safe interaction of
 mutually-suspicious code, using object-capability -style programming.
 
-See https://github.com/Agoric/Jessie to see how SES fits into the various
+See https://github.com/endojs/Jessie to see how SES fits into the various
 flavors of confined ECMAScript execution. And visit
 https://ses-demo.netlify.app/demos/ for a demo.
 
@@ -446,4 +446,4 @@ the instructions in [SECURITY.md](./SECURITY.md) to report
 security-sensitive bugs privately.
 
 For non-security bugs, please use the [regular Issues
-page](https://github.com/Agoric/ses-shim/issues).
+page](https://github.com/endojs/endo/issues).


### PR DESCRIPTION
fixes #626