### PR TITLE
Fix double disclosure bug, where `assert.quote` can render badly

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -90,7 +90,7 @@ freeze(redactedDetails);
  */
 const unredactedDetails = (template, ...args) => {
   const detailsToken = freeze({ __proto__: null });
-  args = args.map(arg => (hiddenDetailsMap.has(arg) ? arg : quote(arg)));
+  args = args.map(arg => (declassifiers.has(arg) ? arg : quote(arg)));
   hiddenDetailsMap.set(detailsToken, { template, args });
   return detailsToken;
 };

--- a/packages/ses/test/error/test-tame-console-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unfilteredError.js
@@ -6,7 +6,13 @@ const originalConsole = console;
 
 lockdown({ stackFiltering: 'verbose' });
 
-const { details: d } = assert;
+const { details: d, quote: q } = assert;
+
+test('ava message disclosure quiet', t => {
+  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+    message: /a secret \(a number\) and a public 777/,
+  });
+});
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafe-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unfilteredError.js
@@ -6,7 +6,13 @@ const originalConsole = console;
 
 lockdown({ consoleTaming: 'unsafe', stackFiltering: 'verbose' });
 
-const { details: d } = assert;
+const { details: d, quote: q } = assert;
+
+test('ava message disclosure quiet', t => {
+  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+    message: /a secret \(a number\) and a public 777/,
+  });
+});
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafe-unsafeError-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unsafeError-unfilteredError.js
@@ -12,7 +12,13 @@ lockdown({
 });
 
 // Grab `details` only after lockdown
-const { details: d } = assert;
+const { details: d, quote: q } = assert;
+
+test('ava message disclosure blabs', t => {
+  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+    message: /a secret 666 and a public 777/,
+  });
+});
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafe-unsafeError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unsafeError.js
@@ -11,7 +11,13 @@ lockdown({
 });
 
 // Grab `details` only after lockdown
-const { details: d } = assert;
+const { details: d, quote: q } = assert;
+
+test('ava message disclosure blabs', t => {
+  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+    message: /a secret 666 and a public 777/,
+  });
+});
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafe.js
+++ b/packages/ses/test/error/test-tame-console-unsafe.js
@@ -6,7 +6,13 @@ const originalConsole = console;
 
 lockdown({ consoleTaming: 'unsafe' });
 
-const { details: d } = assert;
+const { details: d, quote: q } = assert;
+
+test('ava message disclosure quiet', t => {
+  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+    message: /a secret \(a number\) and a public 777/,
+  });
+});
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console-unsafeError.js
+++ b/packages/ses/test/error/test-tame-console-unsafeError.js
@@ -7,7 +7,13 @@ const originalConsole = console;
 lockdown({ errorTaming: 'unsafe' });
 
 // Grab `details` only after lockdown
-const { details: d } = assert;
+const { details: d, quote: q } = assert;
+
+test('ava message disclosure blabs', t => {
+  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+    message: /a secret 666 and a public 777/,
+  });
+});
 
 test('console', t => {
   t.plan(3);

--- a/packages/ses/test/error/test-tame-console.js
+++ b/packages/ses/test/error/test-tame-console.js
@@ -6,7 +6,13 @@ const originalConsole = console;
 
 lockdown();
 
-const { details: d } = assert;
+const { details: d, quote: q } = assert;
+
+test('ava message disclosure default', t => {
+  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+    message: /a secret \(a number\) and a public 777/,
+  });
+});
 
 test('console', t => {
   t.plan(3);


### PR DESCRIPTION
The setting `{errorTaming: unsafe}` suppresses the redaction of unmarked substitution values in detailed error messages, as it should.
The `assert.quote` function is for marking a particular substitution as immune from redaction, which it does under normal circumstances. 
When both are used together (hence "double disclosure bug") the `q` marked substitution no longer disclose the quoted payload. Due to me using the wrong map, it was instead disclosing the declassifier object itself.