### PR TITLE
feat: non-security mode for create-react-scripts compat. (KLUDGE)

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,20 @@ User-visible changes in SES:
 
 ## Next release
 
-- No changes yet
+- We temporarily introduced a new `__unsafeKludgeForReact__` option whose
+`'unsafe'` setting that unsafely allows React to work under SES in the browser
+  even before React is fixed. Once React is fixed, this option will disappear.
+
+  As the name indicates, this is a temporary kludge that sacrifies safety
+  to get the current version of React working under SES in the browser by any
+  means necessary. What seems to work is to skip the hardening of the
+  primordials during `lockdown`, but to nevertheless enable `harden` to
+  work. Almost all objects inherit from primordial objects, and `harden`
+  is transitively contaigious across both inheritance and own property
+  traversal, so hardening almost any object will still harden those
+  primordials reachable from there. But this avoids or postpones enough
+  primordial freezing that React seems to be the unsafe monkey patching
+  of the primordials before it is too late.
 
 ## Release 0.12.5 (25-Mar-2021)
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,20 +2,16 @@ User-visible changes in SES:
 
 ## Next release
 
-- We temporarily introduced a new `__unsafeKludgeForReact__` option whose
-`'unsafe'` setting that unsafely allows React to work under SES in the browser
-  even before React is fixed. Once React is fixed, this option will disappear.
+- Added a new temporary `__allowUnsafeMonkeyPatching__` option to `lockdown`.
 
-  As the name indicates, this is a temporary kludge that sacrifies safety
-  to get the current version of React working under SES in the browser by any
-  means necessary. What seems to work is to skip the hardening of the
-  primordials during `lockdown`, but to nevertheless enable `harden` to
-  work. Almost all objects inherit from primordial objects, and `harden`
-  is transitively contaigious across both inheritance and own property
-  traversal, so hardening almost any object will still harden those
-  primordials reachable from there. But this avoids or postpones enough
-  primordial freezing that React seems to successully monkey patch
-  the primordials before it is too late.
+  Sometimes SES is used where SES's safety is not required. Some libraries
+  are not compatible with SES because they monkey patch the shared primordials
+  is ways SES cannot allow. We temporarily introduce this option to enable
+  some of these libraries to work in, approximately, a SES environment
+  whose safety was sacrificed in order to allow this monkey patching to
+  succeed. More at the
+  [__allowUnsafeMonkeyPatching__ Options](./lockdown-options.md#__allowUnsafeMonkeyPatching__-options)
+  section of [lockdown-options](./lockdown-options.md).
 
 ## Release 0.12.5 (25-Mar-2021)
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -14,8 +14,8 @@ User-visible changes in SES:
   is transitively contaigious across both inheritance and own property
   traversal, so hardening almost any object will still harden those
   primordials reachable from there. But this avoids or postpones enough
-  primordial freezing that React seems to be the unsafe monkey patching
-  of the primordials before it is too late.
+  primordial freezing that React seems to successully monkey patch
+  the primordials before it is too late.
 
 ## Release 0.12.5 (25-Mar-2021)
 

--- a/packages/ses/lockdown-options.md
+++ b/packages/ses/lockdown-options.md
@@ -499,7 +499,7 @@ whose safety was sacrificed in order to allow this monkey patching to
 succeed.
 
 With this option set to `'unsafe'`, SES initialization
-does not harden the primordials, leaving them is their fully
+does not harden the primordials, leaving them in their fully
 mutable state. But the rest of SES initialization does happen, including
 allowing `harden` to work. Since `harden` is transitively contagious
 by inheritance and own property traversal, any use of `harden` on any

--- a/packages/ses/lockdown-options.md
+++ b/packages/ses/lockdown-options.md
@@ -503,5 +503,5 @@ work. Almost all objects inherit from primordial objects, and `harden`
 is transitively contaigious across both inheritance and own property
 traversal, so hardening almost any object will still harden those
 primordials reachable from there. But this avoids or postpones enough
-primordial freezing that React seems to be the unsafe monkey patching
-of the primordials before it is too late.
+primordial freezing that React seems to successully monkey patch
+the primordials before it is too late.

--- a/packages/ses/lockdown-options.md
+++ b/packages/ses/lockdown-options.md
@@ -520,7 +520,8 @@ that browser page is acceptable.
 
 The "`__`" in the option name indicates that this option is temporary.
 As we encounter libraries that need this option, such as React, we
-plan to encourage them to be fixed so that they work correctly
+[plan to encourage them to be fixed](https://github.com/endojs/endo/issues/576#issuecomment-808562426)
+so that they work correctly
 under SES after SES initialization. Once enough of these are fixed,
 we hope to deprecate and eventually remove this option.
 

--- a/packages/ses/lockdown-options.md
+++ b/packages/ses/lockdown-options.md
@@ -28,6 +28,7 @@ Each option is explained in its own section below.
 | `errorTaming`    | `'safe'`    | `'unsafe'`     | `errorInstance.stack`      |
 | `stackFiltering` | `'concise'` | `'verbose'`    | deep stacks signal/noise   |
 | `overrideTaming` | `'moderate'` | `'min'` or `'severe'` | override mistake antidote  |
+| `__unsafeKludgeForReact__` | `'safe'` | `'unsafe'` | sacrifice safety until react is fixed
 
 ## `regExpTaming` Options
 
@@ -487,3 +488,20 @@ by our override mitigation.
 
 ![overrideTaming: 'severe' vscode inspector display](docs/images/override-taming-star-inspector.png)
 </details>
+
+## `__unsafeKludgeForReact__` Options
+
+We temporarily introduced a new `__unsafeKludgeForReact__` option whose
+`'unsafe'` setting that unsafely allows React to work under SES in the browser
+even before React is fixed. Once React is fixed, this option will disappear.
+
+As the name indicates, this is a temporary kludge that sacrifies safety
+to get the current version of React working under SES in the browser by any
+means necessary. What seems to work is to skip the hardening of the
+primordials during `lockdown`, but to nevertheless enable `harden` to
+work. Almost all objects inherit from primordial objects, and `harden`
+is transitively contaigious across both inheritance and own property
+traversal, so hardening almost any object will still harden those
+primordials reachable from there. But this avoids or postpones enough
+primordial freezing that React seems to be the unsafe monkey patching
+of the primordials before it is too late.

--- a/packages/ses/lockdown-options.md
+++ b/packages/ses/lockdown-options.md
@@ -28,7 +28,7 @@ Each option is explained in its own section below.
 | `errorTaming`    | `'safe'`    | `'unsafe'`     | `errorInstance.stack`      |
 | `stackFiltering` | `'concise'` | `'verbose'`    | deep stacks signal/noise   |
 | `overrideTaming` | `'moderate'` | `'min'` or `'severe'` | override mistake antidote  |
-| `__unsafeKludgeForReact__` | `'safe'` | `'unsafe'` | sacrifice safety until react is fixed
+| `__allowUnsafeMonkeyPatching__` | `'safe'` | `'unsafe'` | run unsafe code unsafely |
 
 ## `regExpTaming` Options
 
@@ -489,19 +489,47 @@ by our override mitigation.
 ![overrideTaming: 'severe' vscode inspector display](docs/images/override-taming-star-inspector.png)
 </details>
 
-## `__unsafeKludgeForReact__` Options
+## `__allowUnsafeMonkeyPatching__` Options
 
-We temporarily introduced a new `__unsafeKludgeForReact__` option whose
-`'unsafe'` setting that unsafely allows React to work under SES in the browser
-even before React is fixed. Once React is fixed, this option will disappear.
+Sometimes SES is used where SES's safety is not required. Some libraries
+are not compatible with SES because they monkey patch the shared primordials
+is ways SES cannot allow. We temporarily introduce this option to enable
+some of these libraries to work in, approximately, a SES environment
+whose safety was sacrificed in order to allow this monkey patching to
+succeed.
 
-As the name indicates, this is a temporary kludge that sacrifies safety
-to get the current version of React working under SES in the browser by any
-means necessary. What seems to work is to skip the hardening of the
-primordials during `lockdown`, but to nevertheless enable `harden` to
-work. Almost all objects inherit from primordial objects, and `harden`
-is transitively contaigious across both inheritance and own property
-traversal, so hardening almost any object will still harden those
-primordials reachable from there. But this avoids or postpones enough
-primordial freezing that React seems to successully monkey patch
-the primordials before it is too late.
+With this option set to `'unsafe'`, SES initialization
+does not harden the primordials, leaving them is their fully
+mutable state. But the rest of SES initialization does happen, including
+allowing `harden` to work. Since `harden` is transitively contagious
+by inheritance and own property traversal, any use of `harden` on any
+object will also happen to harden all primordials reachable from that
+object. For example, `harden({})` will harden `Object.prototype`,
+`Object`, `Function.prototype`, `Function.prototype.constructor`
+(which under SES is not the same as the `Function` constructor), and all
+the methods reachable from any of these.
+
+Because of this transitive `hardening`, the kludge enabled by this
+option may or may not work for any particular monkey patching library.
+React seems to be a library for which this kludge does work, because
+React seems to do its monkey patching is ways that either avoid or
+precede the freezing of primordial caused by other uses of `harden`.
+This option thereby enables React to work under SES and after `lockdown`
+in a browser, and should only be used if the compromise of safety on
+that browser page is acceptable.
+
+The "`__`" in the option name indicates that this option is temporary.
+As we encounter libraries that need this option, such as React, we
+plan to encourage them to be fixed so that they work correctly
+under SES after SES initialization. Once enough of these are fixed,
+we hope to deprecate and eventually remove this option.
+
+For some libraries the monkey patching they are doing can be recast
+as a separate shim that could be vetted to not introduce any violation of SES
+safety. This may include all the React problems we're seeing! We do plan to
+extend the SES initialization mechanism to be able to run vetted shims
+during SES initialization: after repairs and before hardening the primordials.
+This environment would be much like the environment created by the `'unsafe'`
+setting of this option but without a working `harden`. But we have not yet done
+so, and we don't yet know if React's monkey patching could be made into a
+separate vetted shim that runs early.

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -252,6 +252,9 @@ export function repairIntrinsics(
 
   function hardenIntrinsics() {
     // Circumvent the override mistake.
+    // TODO consider moving this to the end of the repair phase, and
+    // therefore before vetted shims rather than afterwards. It is not
+    // clear yet which is better.
     enablePropertyOverrides(intrinsics, overrideTaming);
 
     if (__unsafeKludgeForReact__ !== 'unsafe') {

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -42,7 +42,7 @@ import { assert, makeAssert } from './error/assert.js';
  *   consoleTaming?: 'safe' | 'unsafe',
  *   overrideTaming?: 'min' | 'moderate' | 'severe',
  *   stackFiltering?: 'concise' | 'verbose',
- *   __unsafeKludgeForReact__?: 'safe' | 'unsafe',
+ *   __allowUnsafeMonkeyPatching__?: 'safe' | 'unsafe',
  * }} LockdownOptions
  */
 
@@ -141,7 +141,7 @@ export function repairIntrinsics(
     consoleTaming = 'safe',
     overrideTaming = 'moderate',
     stackFiltering = 'concise',
-    __unsafeKludgeForReact__ = 'safe',
+    __allowUnsafeMonkeyPatching__ = 'safe',
 
     ...extraOptions
   } = options;
@@ -174,7 +174,7 @@ export function repairIntrinsics(
     consoleTaming,
     overrideTaming,
     stackFiltering,
-    __unsafeKludgeForReact__,
+    __allowUnsafeMonkeyPatching__,
   };
 
   /**
@@ -257,7 +257,7 @@ export function repairIntrinsics(
     // clear yet which is better.
     enablePropertyOverrides(intrinsics, overrideTaming);
 
-    if (__unsafeKludgeForReact__ !== 'unsafe') {
+    if (__allowUnsafeMonkeyPatching__ !== 'unsafe') {
       // Finally register and optionally freeze all the intrinsics. This
       // must be the operation that modifies the intrinsics.
       lockdownHarden(intrinsics);

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -247,13 +247,15 @@ export function repairIntrinsics(
    * 3. HARDEN to share the intrinsics.
    */
 
-  function hardenIntrinsics() {
+  function hardenIntrinsics(kludge) {
     // Circumvent the override mistake.
     enablePropertyOverrides(intrinsics, overrideTaming);
 
-    // Finally register and optionally freeze all the intrinsics. This
-    // must be the operation that modifies the intrinsics.
-    lockdownHarden(intrinsics);
+    if (!kludge) {
+      // Finally register and optionally freeze all the intrinsics. This
+      // must be the operation that modifies the intrinsics.
+      lockdownHarden(intrinsics);
+    }
 
     // Having completed lockdown without failing, the user may now
     // call `harden` and expect the object's transitively accessible properties
@@ -282,13 +284,18 @@ export const makeLockdown = (
    * @param {LockdownOptions} [options]
    */
   const lockdown = (options = {}) => {
+    const { skipHardenIntrinsics, ...restOptions } = options;
     const maybeHardenIntrinsics = repairIntrinsics(
       makeCompartmentConstructor,
       compartmentPrototype,
       getAnonymousIntrinsics,
-      options,
+      restOptions,
     );
-    return maybeHardenIntrinsics();
+    if (skipHardenIntrinsics) {
+      maybeHardenIntrinsics(true);
+    } else {
+      maybeHardenIntrinsics();
+    }
   };
   return lockdown;
 };

--- a/packages/ses/test/test-unsafe-kludge-for-react.js
+++ b/packages/ses/test/test-unsafe-kludge-for-react.js
@@ -3,6 +3,7 @@ import '../lockdown.js';
 
 lockdown({
   __unsafeKludgeForReact__: 'unsafe',
+  overrideTaming: 'min',
 });
 
 test('Unsafe kludge for react', t => {
@@ -15,13 +16,22 @@ test('Unsafe kludge for react', t => {
   t.is(x.constructor, 'Foo');
 
   harden(x);
-
+  // Because harden is tranisitively contagious up inheritance chain,
+  // hardening x also hardens Object.prototype.
   t.true(Object.isFrozen(Object.prototype));
 
   const y = {};
+  // Under even the 'min' override taming, we still enable
+  // Object.prototype.toString to be overridden by assignment.
   y.toString = () => 'bar';
   t.throws(
     () => {
+      // At the 'min' override taming, we do not enable
+      // Object.prototype.constructor to be overridden by
+      // assignment. This did not matter before hardening
+      // x because the override mistake only applies to
+      // non-writable properties and Object.prototype had
+      // not yet been frozen.
       y.constructor = 'Bar';
     },
     undefined,

--- a/packages/ses/test/test-unsafe-kludge-for-react.js
+++ b/packages/ses/test/test-unsafe-kludge-for-react.js
@@ -1,0 +1,32 @@
+import test from 'ava';
+import '../lockdown.js';
+
+lockdown({
+  __unsafeKludgeForReact__: 'unsafe',
+});
+
+test('Unsafe kludge for react', t => {
+  t.false(Object.isFrozen(Object.prototype));
+
+  const x = {};
+  x.toString = () => 'foo';
+  x.constructor = 'Foo';
+  t.is(`${x}`, 'foo');
+  t.is(x.constructor, 'Foo');
+
+  harden(x);
+
+  t.true(Object.isFrozen(Object.prototype));
+
+  const y = {};
+  y.toString = () => 'bar';
+  t.throws(
+    () => {
+      y.constructor = 'Bar';
+    },
+    undefined,
+    'Override should not be enabled for "constructor".',
+  );
+  t.is(`${y}`, 'bar');
+  t.is(y.constructor, Object);
+});


### PR DESCRIPTION
We temporarily introduce a new `__unsafeKludgeForReact__` option whose
`'unsafe'` setting that unsafely allows React to work under SES in the browser
  even before React is fixed. Once React is fixed, this option will disappear.

Enables https://github.com/Agoric/dapp-token-economy/issues/159 to be fixed by injecting SES on the page first, as shown at https://github.com/Agoric/dapp-token-economy/pull/155

@dckc @kriskowal This is now ready for review. @dckc Because you created this PR I cannot add you as an official reviewer but please look anyway.