### PR TITLE
Prepare for marshal error tagging

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,15 @@ User-visible changes in SES:
 
 ## Next Release
 
-- No changes yet
+- Added to `assert.error` an optional options bag with an option named
+  `errorName`. `assert.error` makes error objects with detailed error
+  messages whose unredacted contents appear only in `console` output
+  and are otherwise unobservable. If `errorName` is provided, then
+  it is also used in the console output instead of the normal error name,
+  but is otherwise unobservable. This will rarely be used, but will be
+  used by the `@agoric/marshal` package to name an unserialized error
+  so that it can be traced back to the site that serialized it; and
+  ultimately to its origin.
 
 ## Release 0.12.6 (27-Mar-2021)
 

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -183,7 +183,7 @@ const tagError = (err, optErrorName = err.name) => {
 const makeError = (
   optDetails = redactedDetails`Assert failed`,
   ErrorConstructor = Error,
-  optErrorName = undefined,
+  { errorName = undefined } = {},
 ) => {
   if (typeof optDetails === 'string') {
     // If it is a string, use it as the literal part of the template so
@@ -197,8 +197,8 @@ const makeError = (
   const messageString = getMessageString(hiddenDetails);
   const error = new ErrorConstructor(messageString);
   hiddenMessageLogArgs.set(error, getLogArgs(hiddenDetails));
-  if (optErrorName !== undefined) {
-    tagError(error, optErrorName);
+  if (errorName !== undefined) {
+    tagError(error, errorName);
   }
   // The next line is a particularly fruitful place to put a breakpoint.
   return error;

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -153,12 +153,40 @@ const getLogArgs = ({ template, args }) => {
  */
 const hiddenMessageLogArgs = new WeakMap();
 
+// by "tagged", we mean first sent to the baseConsole as an argument in a
+// console level method call, in which it is shown with an identifying tag
+// number. We number the errors according to the order in
+// which they were first logged to the baseConsole, starting at 1.
+let errorTagNum = 0;
+
+/**
+ * @type {WeakMap<Error, string>}
+ */
+const errorTags = new WeakMap();
+
+/**
+ * @param {Error} err
+ * @param {string=} optErrorName
+ * @returns {string}
+ */
+const tagError = (err, optErrorName = err.name) => {
+  let errorTag = errorTags.get(err);
+  if (errorTag !== undefined) {
+    return errorTag;
+  }
+  errorTagNum += 1;
+  errorTag = `${optErrorName}#${errorTagNum}`;
+  errorTags.set(err, errorTag);
+  return errorTag;
+};
+
 /**
  * @type {AssertMakeError}
  */
 const makeError = (
   optDetails = redactedDetails`Assert failed`,
   ErrorConstructor = Error,
+  optErrorName = undefined,
 ) => {
   if (typeof optDetails === 'string') {
     // If it is a string, use it as the literal part of the template so
@@ -172,6 +200,9 @@ const makeError = (
   const messageString = getMessageString(hiddenDetails);
   const error = new ErrorConstructor(messageString);
   hiddenMessageLogArgs.set(error, getLogArgs(hiddenDetails));
+  if (optErrorName !== undefined) {
+    tagError(error, optErrorName);
+  }
   // The next line is a particularly fruitful place to put a breakpoint.
   return error;
 };
@@ -256,6 +287,11 @@ const defaultGetStackString = error => {
 /** @type {LoggedErrorHandler} */
 const loggedErrorHandler = {
   getStackString: globalThis.getStackString || defaultGetStackString,
+  tagError: error => tagError(error),
+  resetErrorTagNum: () => {
+    errorTagNum = 0;
+  },
+  getMessageLogArgs: error => hiddenMessageLogArgs.get(error),
   takeMessageLogArgs: error => {
     const result = hiddenMessageLogArgs.get(error);
     hiddenMessageLogArgs.delete(error);

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -153,10 +153,7 @@ const getLogArgs = ({ template, args }) => {
  */
 const hiddenMessageLogArgs = new WeakMap();
 
-// by "tagged", we mean first sent to the baseConsole as an argument in a
-// console level method call, in which it is shown with an identifying tag
-// number. We number the errors according to the order in
-// which they were first logged to the baseConsole, starting at 1.
+// So each error tag will be unique.
 let errorTagNum = 0;
 
 /**

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -108,7 +108,9 @@ export const consoleWhitelist = freeze([
 // /////////////////////////////////////////////////////////////////////////////
 
 /** @type {MakeLoggingConsoleKit} */
-const makeLoggingConsoleKit = () => {
+const makeLoggingConsoleKit = loggedErrorHandler => {
+  loggedErrorHandler.resetErrorTagNum();
+
   // Not frozen!
   let logArray = [];
 
@@ -165,33 +167,10 @@ export const BASE_CONSOLE_LEVEL = 'debug';
 const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
   const {
     getStackString,
+    tagError,
     takeMessageLogArgs,
     takeNoteLogArgsArray,
   } = loggedErrorHandler;
-
-  // by "tagged", we mean first sent to the baseConsole as an argument in a
-  // console level method call, in which it is shown with an identifying tag
-  // number. We number the errors according to the order in
-  // which they were first logged to the baseConsole, starting at 1.
-  let numErrorsTagged = 0;
-  /** @type WeakMap<Error, number> */
-  const errorTagOrder = new WeakMap();
-
-  /**
-   * @param {Error} err
-   * @returns {string}
-   */
-  const tagError = err => {
-    let errNum;
-    if (errorTagOrder.has(err)) {
-      errNum = errorTagOrder.get(err);
-    } else {
-      numErrorsTagged += 1;
-      errorTagOrder.set(err, numErrorsTagged);
-      errNum = numErrorsTagged;
-    }
-    return `${err.name}#${errNum}`;
-  };
 
   /**
    * @param {ReadonlyArray<any>} logArgs

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -108,8 +108,13 @@ export const consoleWhitelist = freeze([
 // /////////////////////////////////////////////////////////////////////////////
 
 /** @type {MakeLoggingConsoleKit} */
-const makeLoggingConsoleKit = loggedErrorHandler => {
-  loggedErrorHandler.resetErrorTagNum();
+const makeLoggingConsoleKit = (
+  loggedErrorHandler,
+  { shouldResetForDebugging = false } = {},
+) => {
+  if (shouldResetForDebugging) {
+    loggedErrorHandler.resetErrorTagNum();
+  }
 
   // Not frozen!
   let logArray = [];

--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -31,6 +31,9 @@
  * hidden information to augment the logging of errors.
  *
  * @property {GetStackString} getStackString
+ * @property {(error: Error) => string} tagError
+ * @property {() => void} resetErrorTagNum for debugging purposes only
+ * @property {(error: Error) => (LogArgs | undefined)} getMessageLogArgs
  * @property {(error: Error) => (LogArgs | undefined)} takeMessageLogArgs
  * @property {(error: Error, callback?: NoteCallback) => LogArgs[] } takeNoteLogArgsArray
  */
@@ -55,6 +58,7 @@
  * consumes these, so later calls to `takeLog()` will only provide a log of
  * calls that have happened since then.
  *
+ * @param {LoggedErrorHandler} loggedErrorHandler
  * @returns {LoggingConsoleKit}
  */
 

--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -51,6 +51,11 @@
  */
 
 /**
+ * @typedef {Object} MakeLoggingConsoleKitOptions
+ * @property {boolean=} shouldResetForDebugging
+ */
+
+/**
  * @callback MakeLoggingConsoleKit
  *
  * A logging console just accumulates the contents of all whitelisted calls,
@@ -59,6 +64,7 @@
  * calls that have happened since then.
  *
  * @param {LoggedErrorHandler} loggedErrorHandler
+ * @param {MakeLoggingConsoleKitOptions=} options
  * @returns {LoggingConsoleKit}
  */
 

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -12,6 +12,11 @@
  */
 
 /**
+ * @typedef {Object} AssertMakeErrorOptions
+ * @property {string=} errorName
+ */
+
+/**
  * @callback AssertMakeError
  *
  * The `assert.error` method, recording details for the console.
@@ -20,7 +25,7 @@
  * @param {Details=} optDetails The details of what was asserted
  * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
  * constructor to use.
- * @param {string=} optErrorName
+ * @param {AssertMakeErrorOptions=} options
  * @returns {Error}
  */
 

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -24,6 +24,7 @@
  * @param {Details=} optDetails The details of what was asserted
  * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
  * constructor to use.
+ * @param {string=} optErrorName
  * @returns {Error}
  */
 

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -1,7 +1,3 @@
-// Much of this file is duplicated at
-// https://github.com/Agoric/agoric-sdk/blob/master/packages/assert/src/types.js
-// Coordinate edits until we refactor to avoid this duplication
-
 // @ts-check
 
 /**

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -314,6 +314,35 @@ test('assert error explicit', t => {
   );
 });
 
+test('assert error named', t => {
+  const err = assert.error(d`<${'bar'},${q('baz')}>`, URIError, {
+    errorName: 'Foo-Err',
+  });
+  t.is(err.message, '<(a string),"baz">');
+  t.is(err.name, 'URIError');
+  throwsAndLogs(
+    t,
+    () => {
+      throw err;
+    },
+    /<\(a string\),"baz">/,
+    [['log', 'Caught', URIError]],
+  );
+  throwsAndLogs(
+    t,
+    () => {
+      throw err;
+    },
+    /<\(a string\),"baz">/,
+    [
+      ['log', 'Caught', '(Foo-Err#2)'],
+      ['debug', 'Foo-Err#2:', '<', 'bar', ',', 'baz', '>'],
+      ['debug', 'stack of URIError\n'],
+    ],
+    { wrapWithCausal: true },
+  );
+});
+
 test('assert q', t => {
   throwsAndLogs(
     t,

--- a/packages/ses/test/error/throws-and-logs.js
+++ b/packages/ses/test/error/throws-and-logs.js
@@ -79,7 +79,10 @@ const getBogusStackString = error => {
 // ```
 export const assertLogs = freeze((t, thunk, goldenLog, options = {}) => {
   const { checkLogs = true, wrapWithCausal = false } = options;
-  const { loggingConsole, takeLog } = makeLoggingConsoleKit(loggedErrorHandler);
+  const { loggingConsole, takeLog } = makeLoggingConsoleKit(
+    loggedErrorHandler,
+    { shouldResetForDebugging: true },
+  );
   let useConsole = console;
   if (checkLogs) {
     useConsole = loggingConsole;

--- a/packages/ses/test/error/throws-and-logs.js
+++ b/packages/ses/test/error/throws-and-logs.js
@@ -79,7 +79,7 @@ const getBogusStackString = error => {
 // ```
 export const assertLogs = freeze((t, thunk, goldenLog, options = {}) => {
   const { checkLogs = true, wrapWithCausal = false } = options;
-  const { loggingConsole, takeLog } = makeLoggingConsoleKit();
+  const { loggingConsole, takeLog } = makeLoggingConsoleKit(loggedErrorHandler);
   let useConsole = console;
   if (checkLogs) {
     useConsole = loggingConsole;


### PR DESCRIPTION
The externally visible change is that `assert.error` takes an options bag with an `errorName` option that will be used to form the error tag shown in the privileged console view. It does not affect what's visible to unprivileged code.

This is in preparation for `marshal` using it when unserializing errors, so that the error tag indicates that this is a remote error. See https://github.com/Agoric/agoric-sdk/pull/2769