### PR TITLE
feat(ses)!: Third-party module exports

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,9 +2,16 @@ User-visible changes in SES:
 
 ## Next Release
 
+- *BREAKING CHANGE* Third-party static module interface implementations *must*
+  now explicitly list their exported names.
+  For CommonJS, this implies using a heuristic static analysis of `exports`
+  changes.
+  Consequently, third-party modules can now participate in linkage with ESM
+  including support for `export * from './spec.cjs'` and also named imports
+  like `import * from './spec.cjs'`.
 - Relaxes the censorship of `import` and `eval` in programs evaluated
-  under SES to specifically allow the use of `import.import()` or
-  `evaluator.eval()` methods.
+  under SES to specifically allow the use of `something.import()` or
+  `something.eval()` methods.
 
 ## Release 0.12.7 (5-April-2021)
 

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -310,40 +310,26 @@ export const makeModuleInstance = (
     for (const [specifier, importUpdaters] of updateRecord.entries()) {
       const instance = importedInstances.get(specifier);
       instance.execute(); // bottom up cycle tolerant
-      const { notifiers: modNotifiers } = instance;
-      if (modNotifiers === undefined) {
-        for (const [importName, updaters] of importUpdaters.entries()) {
-          for (const update of updaters) {
-            update(instance.exportsProxy[importName]);
-          }
+      const { notifiers: importNotifiers } = instance;
+      for (const [importName, updaters] of importUpdaters.entries()) {
+        const importNotify = importNotifiers[importName];
+        if (!importNotify) {
+          throw SyntaxError(
+            `The requested module '${specifier}' does not provide an export named '${importName}'`,
+          );
         }
-        if (exportAlls.includes(specifier)) {
-          for (const [importName, value] of entries(instance.exportsProxy)) {
-            const notify = update => update(value);
-            candidateAll[importName] = notify;
-          }
+        for (const updater of updaters) {
+          importNotify(updater);
         }
-      } else {
-        for (const [importName, updaters] of importUpdaters.entries()) {
-          const notify = modNotifiers[importName];
-          if (!notify) {
-            throw SyntaxError(
-              `The requested module '${specifier}' does not provide an export named '${importName}'`,
-            );
-          }
-          for (const updater of updaters) {
-            notify(updater);
-          }
-        }
-        if (exportAlls.includes(specifier)) {
-          // Make all these imports candidates.
-          for (const [importName, notify] of entries(modNotifiers)) {
-            if (candidateAll[importName] === undefined) {
-              candidateAll[importName] = notify;
-            } else {
-              // Already a candidate: remove ambiguity.
-              candidateAll[importName] = false;
-            }
+      }
+      if (exportAlls.includes(specifier)) {
+        // Make all these imports candidates.
+        for (const [importName, importNotify] of entries(importNotifiers)) {
+          if (candidateAll[importName] === undefined) {
+            candidateAll[importName] = importNotify;
+          } else {
+            // Already a candidate: remove ambiguity.
+            candidateAll[importName] = false;
           }
         }
       }

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -6,9 +6,11 @@
 // module's "imports" with the more specific "resolvedImports" as inferred from
 // the particular compartment's "resolveHook".
 
-import { makeModuleInstance } from './module-instance.js';
-import { getDeferredExports } from './module-proxy.js';
-import { entries, freeze } from './commons.js';
+import {
+  makeModuleInstance,
+  makeThirdPartyModuleInstance,
+} from './module-instance.js';
+import { entries } from './commons.js';
 
 // q, as in quote, for quoting strings in error messages.
 const q = JSON.stringify;
@@ -113,27 +115,14 @@ export const instantiate = (
       globalObject,
     );
   } else {
-    const { exportsProxy, proxiedExports, activate } = getDeferredExports(
+    moduleInstance = makeThirdPartyModuleInstance(
+      compartmentPrivateFields,
+      staticModuleRecord,
       compartment,
-      compartmentPrivateFields.get(compartment),
       moduleAliases,
       moduleSpecifier,
+      resolvedImports,
     );
-    let activated = false;
-    moduleInstance = freeze({
-      exportsProxy,
-      execute() {
-        if (!activated) {
-          activate();
-          activated = true;
-          staticModuleRecord.execute(
-            proxiedExports,
-            compartment,
-            resolvedImports,
-          );
-        }
-      },
-    });
   }
 
   // Memoize.


### PR DESCRIPTION
*BREAKING CHANGE* Third-party static module interface implementations *must* now explicitly list their exported names. For CommonJS, this implies using a heuristic static analysis of `exports` changes. Consequently, third-party modules can now participate in linkage with ESM including support for `export * from './spec.cjs'` and also named imports like `import * from './spec.cjs'`.

Part 1 of #666