### PR TITLE
feat(ses): Allow import and eval methods

### DIFF
--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -110,9 +110,7 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
       __shimTransforms__,
       Compartment,
     });
-    // Call import by property to bypass SES censoring for dynamic import.
-    // eslint-disable-next-line dot-notation
-    return compartment['import'](moduleSpecifier);
+    return compartment.import(moduleSpecifier);
   };
 
   return { import: execute };
@@ -136,7 +134,5 @@ export const loadArchive = async (read, archiveLocation) => {
  */
 export const importArchive = async (read, archiveLocation, options) => {
   const archive = await loadArchive(read, archiveLocation);
-  // Call import by property to bypass SES censoring for dynamic import.
-  // eslint-disable-next-line dot-notation
-  return archive['import'](options);
+  return archive.import(options);
 };

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -59,9 +59,7 @@ export const loadLocation = async (read, moduleLocation, options) => {
       __shimTransforms__,
       Compartment,
     });
-    // Call import by property to bypass SES censoring for dynamic import.
-    // eslint-disable-next-line dot-notation
-    return compartment['import'](moduleSpecifier);
+    return compartment.import(moduleSpecifier);
   };
 
   return { import: execute };
@@ -76,7 +74,5 @@ export const loadLocation = async (read, moduleLocation, options) => {
  */
 export const importLocation = async (read, moduleLocation, options = {}) => {
   const application = await loadLocation(read, moduleLocation, options);
-  // Call import by property to bypass SES censoring for dynamic import.
-  // eslint-disable-next-line dot-notation
-  return application['import'](options);
+  return application.import(options);
 };

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,9 @@ User-visible changes in SES:
 
 ## Next Release
 
-No changes yet.
+- Relaxes the censorship of `import` and `eval` in programs evaluated
+  under SES to specifically allow the use of `import.import()` or
+  `evaluator.eval()` methods.
 
 ## Release 0.12.7 (5-April-2021)
 

--- a/packages/ses/error-codes/SES_IMPORT_REJECTED.md
+++ b/packages/ses/error-codes/SES_IMPORT_REJECTED.md
@@ -15,20 +15,10 @@ Moddable's XS machine, does not suffer from this limitation.
 
 ## Manually evading the import expression rejection
 
-Compartments implement a similar `import` method you could use instead. But to
-invoke it without tripping over the regular expression you need to call it as a
-computed property.
+Compartments implement a similar `import` method you could use instead.
 
 ```js
-compartment['import'](specifier);
-```
-
-Using parentheses could also work, but unnecessary parentheses are
-unlikely to survive a round trip through a minifier, so be sure to
-also use a comma expression.
-
-```js
-(0, compartment.import)(specifier);
+compartment.import(specifier);
 ```
 
 However, beware the difference in semantics. The dynamic import expression is

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -89,6 +89,7 @@ export const arrayIncludes = uncurryThis(arrayPrototype.includes);
 export const regexpTest = uncurryThis(regexpPrototype.test);
 //
 export const stringMatch = uncurryThis(stringPrototype.match);
+export const stringStartsWith = uncurryThis(stringPrototype.startsWith);
 export const stringSearch = uncurryThis(stringPrototype.search);
 export const stringSlice = uncurryThis(stringPrototype.slice);
 export const stringSplit = uncurryThis(stringPrototype.split);

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -89,7 +89,6 @@ export const arrayIncludes = uncurryThis(arrayPrototype.includes);
 export const regexpTest = uncurryThis(regexpPrototype.test);
 //
 export const stringMatch = uncurryThis(stringPrototype.match);
-export const stringStartsWith = uncurryThis(stringPrototype.startsWith);
 export const stringSearch = uncurryThis(stringPrototype.search);
 export const stringSlice = uncurryThis(stringPrototype.slice);
 export const stringSplit = uncurryThis(stringPrototype.split);

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -1,10 +1,6 @@
 // @ts-check
 
-import {
-  stringSearch,
-  stringSlice,
-  stringSplit,
-} from './commons.js';
+import { stringSearch, stringSlice, stringSplit } from './commons.js';
 import { getSourceURL } from './get-source-url.js';
 
 /**

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -2,8 +2,6 @@
 
 import {
   stringSearch,
-  stringMatch,
-  stringStartsWith,
   stringSlice,
   stringSplit,
 } from './commons.js';
@@ -26,8 +24,7 @@ function getLineNumber(src, pattern) {
   // The importPattern incidentally captures an initial \n in
   // an attempt to reject a . prefix, so we need to offset
   // the line number in that case.
-  const [p1] = stringMatch(src, pattern);
-  const adjustment = stringStartsWith(p1, '\n') ? 1 : 0;
+  const adjustment = src[index] === '\n' ? 1 : 0;
 
   return stringSplit(stringSlice(src, 0, index), '\n').length + adjustment;
 }

--- a/packages/ses/test/test-reject-direct-eval.js
+++ b/packages/ses/test/test-reject-direct-eval.js
@@ -142,3 +142,13 @@ test('reject direct eval expressions with name', t => {
     'newline with name',
   );
 });
+
+test('allow eval method invocation', t => {
+  t.plan(1);
+
+  const c = new Compartment({
+    evaler: { eval: t.pass },
+  });
+  const code = 'evaler.eval()';
+  c.evaluate(code);
+});

--- a/packages/ses/test/test-reject-import-expression.js
+++ b/packages/ses/test/test-reject-import-expression.js
@@ -139,3 +139,13 @@ test('reject import expressions with error messages', t => {
     'with name',
   );
 });
+
+test('allow import method invocation', t => {
+  t.plan(1);
+
+  const c = new Compartment({
+    importer: { import: t.pass },
+  });
+  const code = 'importer.import()';
+  c.evaluate(code);
+});


### PR DESCRIPTION
Relaxes the censorship of `import` and `eval` in programs evaluated under SES to specifically allow the use of `import.import()` or `evaluator.eval()` methods.

Fixes #664