### PR TITLE
refactor(ses): Decouple StaticModuleRecord

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -9,6 +9,9 @@ User-visible changes in SES:
   Consequently, third-party modules can now participate in linkage with ESM
   including support for `export * from './spec.cjs'` and also named imports
   like `import * from './spec.cjs'`.
+- A new `__PrecompiledStaticModuleRecord__` allows a third-party package to
+  implement `StaticModuleRecord` by performing a module analysis and transform,
+  then presenting the result to this new constructor.
 - Relaxes the censorship of `import` and `eval` in programs evaluated
   under SES to specifically allow the use of `something.import()` or
   `something.eval()` methods.

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -84,19 +84,17 @@ export function makeThirdPartyModuleInstance(
 // that the execution of the module instance populates.
 export const makeModuleInstance = (
   privateFields,
-  moduleAnalysis,
   moduleAliases,
   moduleRecord,
   importedInstances,
-  globalObject,
 ) => {
+  const { compartment, moduleSpecifier, staticModuleRecord } = moduleRecord;
   const {
-    functorSource,
-    fixedExportMap,
-    liveExportMap,
-    exportAlls,
-  } = moduleAnalysis;
-  const { compartment, moduleSpecifier } = moduleRecord;
+    __functorSource__: functorSource,
+    __fixedExportMap__: fixedExportMap = {},
+    __liveExportMap__: liveExportMap = {},
+    __exportAlls__: exportAlls = [],
+  } = staticModuleRecord;
 
   const compartmentFields = privateFields.get(compartment);
 
@@ -382,7 +380,7 @@ export const makeModuleInstance = (
   }
 
   let optFunctor = compartment.evaluate(functorSource, {
-    globalObject,
+    globalObject: compartment.globalThis,
     transforms: __shimTransforms__,
     __moduleShimLexicals__: localLexicals,
   });


### PR DESCRIPTION
This change refactors SES most of the way back to a simpler form, where the module system is provided by the lightweight `ses/lockdown` and the `ses` layer only adds the `StaticModuleRecord` constructor. The `StaticModuleRecord` constructor is the only part that entrains Babel.

The piece of coupling that made this impossible before was the `moduleAnalyses` `WeakMap` that allowed the `StaticModuleRecord` constructor to produce an opaque object, such that the contract between `StaticModuleRecord` and the `Compartment` `importHook` was private and could be changed without advice on the SES-shim public API or impact on the SES-shim version number. This is a nice property, but it’s not as nice as performance.

So, instead, this change introduces a `__PrecompiledStaticModuleRecord__` which itself has a non-standards-track API that closely follows the object shape produced by `@agoric/transform-module`. It’s conceivable we could make this the shape produced directly by `@agoric/transform-module` and dispense with the constructor.

After this change, it is also conceivable to move `StaticModuleRecord` out of `ses-shim` entirely, moving it into `transform-module` a `static-module-record` shim package, or just getting rid of it entirely since it’s a thin veneer on using `transform-module` to create a `__PrecompiledStaticRecord__`.

Then, the next version of SES would just have a light `ses` and we can eliminate `ses/lockdown`.

Refs #673