### PR TITLE
refactor: xsnap-native submodule (WIP)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "packages/xsnap/moddable"]
 	path = packages/xsnap/moddable
 	url = https://github.com/Moddable-OpenSource/moddable.git
+[submodule "packages/xsnap/xsnap-native"]
+	path = packages/xsnap/xsnap-native
+	url = https://github.com/agoric-labs/xsnap-pub

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -79,7 +79,9 @@ export function xsnap(options) {
   }
 
   let bin = new URL(
-    `../build/bin/${platform}/${debug ? 'debug' : 'release'}/xsnap`,
+    `../xsnap-native/xsnap/build/bin/${platform}/${
+      debug ? 'debug' : 'release'
+    }/xsnap-ava`,
     importMetaUrl,
   ).pathname;
 


### PR DESCRIPTION
This is a quick-and-dirty integration using a submodule. I didn't update the `yarn build` part. I build it by hand following moddable conventions.

I got `yarn test` pass all but one: a snapshot size test which is iffy.

goal:
fixes #681 

todo:
 - [ ] prune xsnap.c, makefiles from endo (using the one in the submodule instead)
 - [ ] test the submodule build on a mac