### PR TITLE
Syrup

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "packages/ses-ava",
     "packages/ses-integration-test",
     "packages/static-module-record",
+    "packages/syrup",
     "packages/test262-runner",
     "packages/test262-runner",
     "packages/transform-module",

--- a/packages/syrup/LICENSE
+++ b/packages/syrup/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/syrup/README.md
+++ b/packages/syrup/README.md
@@ -1,0 +1,54 @@
+# Syrup
+
+🚧 Work in progress.
+
+[Syrup](https://gitlab.com/spritely/syrup) is an binary object marshalling
+codec.
+
+This is a partial implementation of Syrup intended to be future-compatible and
+strictly canonical.
+
+- Single point IEEE floating point, with the "F" prefix, is unsupported because
+  JavaScript cannot canonically write any kind of floating point number except
+  a double precision 64 bit float.
+- A future version might introduce `null` or `undefined`, possibly both, either
+  as a record kind supported at a higher layer, or as a single character
+  optimization.
+- A future version might support symbols as JavaScript registered symbols.
+- Future versions cannot support Syrup Dictionaries with non-string keys.
+- A future version might support Syrup Sets as JavaScript Sets with some
+  limitation on what keys are expressible.
+- A future version might support Syrup Maps as JavaScript Maps, provided Syrup
+  adds a notation for Maps.
+  To do this, the Syrup implementation might need to be coupled to
+  a higher layer protocol like CapTP, where some record traps are built
+  into the codec, since passing a dictionary (with only string keys)
+  to a record trap would not be sufficient to express other types of keys.
+- A future version might support Syrup records.
+
+The supported encoding consists of:
+
+- Syrup booleans: `t` or `f`,
+  as JavaScript `true` and `false`
+- Syrup double flonum:
+  `D` _big endian IEEE double precision float (64 bits)_,
+  as JavaScript `number`
+- Syrup signed integers:
+  _whole integer_ `+` or _positive int_ `-`,
+  like `0+` or `1-`,
+  as JavaScript `bigint`
+- Syrup byte strings:
+  _whole integer byte length prefix_ `:` _bytes_,
+  like `3:cat`,
+  as JavaScript `Uint8Array`
+- Syrup strings:
+  _whole integer byte length prefix_ `"` _UTF-8 encoded bytes_,
+  like `3"cat`,
+  as JavaScript `string`
+- Syrup dictionary:
+  `{` _zero or more alternating_ _syrup encoded string key_ _syrup encoded any
+  value_ `}`,
+  as frozen JavaScript record objects
+- Syrup lists:
+  `[` _zero or more syrup encoded values_ `]`
+  as frozen JavaScript arrays

--- a/packages/syrup/decode.js
+++ b/packages/syrup/decode.js
@@ -1,2 +1,1 @@
-export { encodeSyrup } from './src/encode.js';
 export { decodeSyrup } from './src/decode.js';

--- a/packages/syrup/encode.js
+++ b/packages/syrup/encode.js
@@ -1,2 +1,1 @@
 export { encodeSyrup } from './src/encode.js';
-export { decodeSyrup } from './src/decode.js';

--- a/packages/syrup/index.d.ts
+++ b/packages/syrup/index.d.ts
@@ -1,0 +1,1 @@
+export * from './src/main.js';

--- a/packages/syrup/index.js
+++ b/packages/syrup/index.js
@@ -1,0 +1,2 @@
+export { encodeSyrup } from './src/encode.js';
+export { decodeSyrup } from './src/decode.js';

--- a/packages/syrup/jsconfig.json
+++ b/packages/syrup/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.js", "index.d.ts"]
+}

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@endo/syrup",
+  "version": "0.1.0",
+  "description": "Description forthcoming.",
+  "keywords": [],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/syrup#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "parsers": {
+    "js": "mjs"
+  },
+  "main": "./dist/syrup.cjs",
+  "module": "./index.js",
+  "browser": "./dist/syrup.umd.js",
+  "unpkg": "./dist/syrup.umd.js",
+  "types": "./index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./index.js",
+      "require": "./dist/syrup.cjs",
+      "browser": "./dist/syrup.umd.js"
+    }
+  },
+  "scripts": {
+    "build": "rollup --config rollup.config.js",
+    "clean": "rm -rf dist",
+    "cover": "nyc ava",
+    "lint": "yarn lint:types && yarn lint:js",
+    "lint-fix": "eslint --fix '*.js' '**/*.js' 'test*/**.js'",
+    "lint:js": "eslint '*.js' '**/*.js' 'test*/**.js'",
+    "lint:types": "tsc --build jsconfig.json",
+    "prepublish": "yarn clean && yarn build",
+    "test": "ava"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^13.0.0",
+    "@rollup/plugin-node-resolve": "^6.1.0",
+    "ava": "^3.12.1",
+    "babel-eslint": "^10.0.3",
+    "eslint": "^7.23.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-prettier": "^6.9.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-prettier": "^3.1.2",
+    "nyc": "^15.1.0",
+    "prettier": "^1.19.1",
+    "rollup": "1.31.0",
+    "rollup-plugin-terser": "^5.1.3",
+    "typescript": "^4.0.5"
+  },
+  "files": [
+    "LICENSE*",
+    "dist",
+    "src",
+    "types"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@agoric"
+    ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "timeout": "2m"
+  }
+}

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -28,6 +28,16 @@
       "import": "./index.js",
       "require": "./dist/syrup.cjs",
       "browser": "./dist/syrup.umd.js"
+    },
+    "./encode": {
+      "import": "./encode.js",
+      "require": "./dist/encode.cjs",
+      "browser": "./dist/encode.umd.js"
+    },
+    "./decode": {
+      "import": "./decode.js",
+      "require": "./dist/decode.cjs",
+      "browser": "./dist/decode.umd.js"
     }
   },
   "scripts": {

--- a/packages/syrup/rollup.config.js
+++ b/packages/syrup/rollup.config.js
@@ -1,23 +1,17 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
-import fs from 'fs';
-
-const metaPath = new URL('package.json', import.meta.url).pathname;
-const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-const name = meta.name.split('/').pop();
-const umd = meta.umd || name;
 
 export default [
   {
     input: 'index.js',
     output: [
       {
-        file: `dist/${name}.mjs`,
+        file: `dist/syrup.mjs`,
         format: 'esm',
       },
       {
-        file: `dist/${name}.cjs`,
+        file: `dist/syrup.cjs`,
         format: 'cjs',
       },
     ],
@@ -26,18 +20,84 @@ export default [
   {
     input: 'index.js',
     output: {
-      file: `dist/${name}.umd.js`,
+      file: `dist/syrup.umd.js`,
       format: 'umd',
-      name: umd,
+      name: 'Syrup',
     },
     plugins: [resolve(), commonjs()],
   },
   {
     input: 'index.js',
     output: {
-      file: `dist/${name}.umd.min.js`,
+      file: `dist/syrup.umd.min.js`,
       format: 'umd',
-      name: umd,
+      name: 'Syrup',
+    },
+    plugins: [resolve(), commonjs(), terser()],
+  },
+
+  {
+    input: 'encode.js',
+    output: [
+      {
+        file: `dist/encode.mjs`,
+        format: 'esm',
+      },
+      {
+        file: `dist/encode.cjs`,
+        format: 'cjs',
+      },
+    ],
+    plugins: [resolve(), commonjs()],
+  },
+  {
+    input: 'encode.js',
+    output: {
+      file: `dist/encode.umd.js`,
+      format: 'umd',
+      name: 'SyrupEncoder',
+    },
+    plugins: [resolve(), commonjs()],
+  },
+  {
+    input: 'encode.js',
+    output: {
+      file: `dist/encode.umd.min.js`,
+      format: 'umd',
+      name: 'SyrupEncoder',
+    },
+    plugins: [resolve(), commonjs(), terser()],
+  },
+
+  {
+    input: 'decode.js',
+    output: [
+      {
+        file: `dist/decode.mjs`,
+        format: 'esm',
+      },
+      {
+        file: `dist/decode.cjs`,
+        format: 'cjs',
+      },
+    ],
+    plugins: [resolve(), commonjs()],
+  },
+  {
+    input: 'decode.js',
+    output: {
+      file: `dist/decode.umd.js`,
+      format: 'umd',
+      name: 'SyrupDecoder',
+    },
+    plugins: [resolve(), commonjs()],
+  },
+  {
+    input: 'decode.js',
+    output: {
+      file: `dist/decode.umd.min.js`,
+      format: 'umd',
+      name: 'SyrupDecoder',
     },
     plugins: [resolve(), commonjs(), terser()],
   },

--- a/packages/syrup/rollup.config.js
+++ b/packages/syrup/rollup.config.js
@@ -1,0 +1,44 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import { terser } from 'rollup-plugin-terser';
+import fs from 'fs';
+
+const metaPath = new URL('package.json', import.meta.url).pathname;
+const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+const name = meta.name.split('/').pop();
+const umd = meta.umd || name;
+
+export default [
+  {
+    input: 'index.js',
+    output: [
+      {
+        file: `dist/${name}.mjs`,
+        format: 'esm',
+      },
+      {
+        file: `dist/${name}.cjs`,
+        format: 'cjs',
+      },
+    ],
+    plugins: [resolve(), commonjs()],
+  },
+  {
+    input: 'index.js',
+    output: {
+      file: `dist/${name}.umd.js`,
+      format: 'umd',
+      name: umd,
+    },
+    plugins: [resolve(), commonjs()],
+  },
+  {
+    input: 'index.js',
+    output: {
+      file: `dist/${name}.umd.min.js`,
+      format: 'umd',
+      name: umd,
+    },
+    plugins: [resolve(), commonjs(), terser()],
+  },
+];

--- a/packages/syrup/src/compare.js
+++ b/packages/syrup/src/compare.js
@@ -40,16 +40,22 @@ export function compareByteArrays(
       return leftLength - rightLength;
     }
     if (rightStart >= rightEnd) {
+      // TODO Investigate why this branch never gets visited in tests,
+      // including the extensive fuzz tests.
+      // There is a possiblity this could be replaced with an assertion,
+      // or omitted entirely.
+      //
       // We have reached the end of the right string.
       // We have not reached the end of the left string, otherwise we would
       // have exited out of the prior condition.
-      // So, the right string must be longer than the left string.
-      // The prefixes so far are equal
-      // So, the left string is shorter than the right string.
-      // So, the left string should be ordered before the right string.
-      //   left < right
-      //   compare(left, right) < 0
-      return -1;
+      // So, the left string must be longer than the right string.
+      // The bytes so far are equal.
+      // So, the right string is a prefix of the left string.
+      // So, the right string is shorter than the left string.
+      // So, the right string should be ordered before the left string.
+      //   left > right
+      //   compare(left, right) > 0
+      return 1;
     }
     if (left[leftStart] < right[rightStart]) {
       // Since the prefixes are equal and the left byte is less than the right

--- a/packages/syrup/src/compare.js
+++ b/packages/syrup/src/compare.js
@@ -1,0 +1,71 @@
+// @ts-check
+
+/**
+ * @param {Uint8Array} left
+ * @param {Uint8Array} right
+ * @param {number} leftStart
+ * @param {number} leftEnd
+ * @param {number} rightStart
+ * @param {number} rightEnd
+ */
+export function compareByteArrays(
+  left,
+  right,
+  leftStart,
+  leftEnd,
+  rightStart,
+  rightEnd,
+) {
+  const leftLength = leftEnd - leftStart;
+  const rightLength = rightEnd - rightStart;
+  for (;;) {
+    // The prefixes so far are equal.
+    if (leftStart >= leftEnd) {
+      // We have reached the end of the left string.
+      // The right string must be at least as long as the left: If the right
+      // string were shorter than the left string, we would have returned out
+      // of a prior iteration on one of the subsequent conditions.
+      // So, the left string is either the same as the right string in both
+      // length and content or the right string is longer.
+      //   left === right
+      //   comapre(left, right) === 0
+      //   leftLength - rightLength === 0
+      // If the right string is longer, then the left string is a prefix of the
+      // right string and the left string should come before the right string,
+      // and this algorithm should return -1
+      //   left < right
+      //   compare(left, right) < 0
+      //   leftLength - rightLength < 0
+      //   shorter - longer < 0
+      return leftLength - rightLength;
+    }
+    if (rightStart >= rightEnd) {
+      // We have reached the end of the left string.
+      // We have not reached the end of the right string, otherwise we would
+      // have exited out of the prior condition.
+      // So, the right string must be longer than the left string.
+      // The prefixes so far are equal
+      // So, the left string is shorter than the right string.
+      // So, the left string should be ordered before the right string.
+      //   left < right
+      //   compare(left, right) < 0
+      return -1;
+    }
+    if (left[leftStart] < right[rightStart]) {
+      // Since the prefixes are equal and the left byte is less than the right
+      // byte, the left string should be sorted before the right string.
+      //   left < right
+      //   compare(left, right) < 0
+      return -1;
+    }
+    if (left[leftStart] > right[rightStart]) {
+      // Since the prefixes are equal and the left byte is greater than the
+      // right byte, the left string should be sorted after the right string.
+      //   left > right
+      //   compare(left, right) > 0
+      return 1;
+    }
+    leftStart += 1;
+    rightStart += 1;
+  }
+}

--- a/packages/syrup/src/compare.js
+++ b/packages/syrup/src/compare.js
@@ -40,8 +40,8 @@ export function compareByteArrays(
       return leftLength - rightLength;
     }
     if (rightStart >= rightEnd) {
-      // We have reached the end of the left string.
-      // We have not reached the end of the right string, otherwise we would
+      // We have reached the end of the right string.
+      // We have not reached the end of the left string, otherwise we would
       // have exited out of the prior condition.
       // So, the right string must be longer than the left string.
       // The prefixes so far are equal

--- a/packages/syrup/src/decode.js
+++ b/packages/syrup/src/decode.js
@@ -1,0 +1,342 @@
+// @ts-check
+
+import { compareByteArrays } from './compare.js';
+
+const MINUS = '-'.charCodeAt(0);
+const PLUS = '+'.charCodeAt(0);
+const ZERO = '0'.charCodeAt(0);
+const ONE = '1'.charCodeAt(0);
+const NINE = '9'.charCodeAt(0);
+const LIST_START = '['.charCodeAt(0);
+const LIST_END = ']'.charCodeAt(0);
+const DICT_START = '{'.charCodeAt(0);
+const DICT_END = '}'.charCodeAt(0);
+// const SET_START = '#'.charCodeAt(0);
+// const SET_END = '$'.charCodeAt(0);
+const BYTES_START = ':'.charCodeAt(0);
+const STRING_START = '"'.charCodeAt(0);
+// const SYMBOL_START = "'".charCodeAt(0);
+// const RECORD_START = '<'.charCodeAt(0);
+// const RECORD_END = '>'.charCodeAt(0);
+const TRUE = 't'.charCodeAt(0);
+const FALSE = 'f'.charCodeAt(0);
+// const SINGLE = 'F'.charCodeAt(0);
+const DOUBLE = 'D'.charCodeAt(0);
+
+const textDecoder = new TextDecoder();
+
+const scratch = new ArrayBuffer(8);
+const scratchBytes = new Uint8Array(scratch);
+const scratchData = new DataView(scratch);
+
+scratchData.setFloat64(0, NaN);
+const CANONICAL_NAN_64 = scratchBytes.slice();
+
+const { defineProperty, freeze } = Object;
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {bigint} integer
+ * @param {number} start
+ * @param {number} end
+ * @param {string} name
+ */
+function decodeAfterInteger(bytes, integer, start, end, name) {
+  if (start >= end) {
+    throw new Error(
+      `Unexpected end of Syrup, expected integer suffix in ${name}`,
+    );
+  }
+  const cc = bytes[start];
+  if (cc === PLUS) {
+    return {
+      start: start + 1,
+      value: integer,
+    };
+  }
+  if (cc === MINUS) {
+    if (integer === 0n) {
+      throw new Error(`Unexpected non-canonical -0`);
+    }
+    return {
+      start: start + 1,
+      value: -integer,
+    };
+  }
+  if (cc === BYTES_START) {
+    start += 1;
+    const subStart = start;
+    start += Number(integer);
+    if (start > end) {
+      throw new Error(
+        `Unexpected end of Syrup, expected ${integer} bytes after Syrup bytestring starting at index ${subStart} in ${name}`,
+      );
+    }
+    const value = bytes.subarray(subStart, start);
+    return { start, value };
+  }
+  if (cc === STRING_START) {
+    start += 1;
+    const subStart = start;
+    start += Number(integer);
+    if (start > end) {
+      throw new Error(
+        `Unexpected end of Syrup, expected ${integer} bytes after string starting at index ${subStart} in ${name}`,
+      );
+    }
+    const value = textDecoder.decode(bytes.subarray(subStart, start));
+    return { start, value };
+  }
+  throw new Error(
+    `Unexpected character ${JSON.stringify(
+      String.fromCharCode(cc),
+    )} at Syrup index ${start} of ${name}`,
+  );
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {number} start
+ * @param {number} end
+ */
+function decodeInteger(bytes, start, end) {
+  let at = start + 1;
+  // eslint-disable-next-line no-empty
+  for (; at < end && bytes[at] >= ZERO && bytes[at] <= NINE; at += 1) {}
+  return {
+    start: at,
+    integer: BigInt(textDecoder.decode(bytes.subarray(start, at))),
+  };
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {number} start
+ * @param {number} end
+ * @param {string} name
+ */
+function decodeArray(bytes, start, end, name) {
+  const list = [];
+  for (;;) {
+    if (start >= end) {
+      throw new Error(
+        `Unexpected end of Syrup, expected Syrup value or end of Syrup list marker "]" at index ${start} in ${name}`,
+      );
+    }
+    const cc = bytes[start];
+    if (cc === LIST_END) {
+      return {
+        start: start + 1,
+        value: list,
+      };
+    }
+    let value;
+    // eslint-disable-next-line no-use-before-define
+    ({ start, value } = decodeAny(bytes, start, end, name));
+    list.push(value);
+  }
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {number} start
+ * @param {number} end
+ * @param {string} name
+ */
+function decodeString(bytes, start, end, name) {
+  if (start >= end) {
+    throw new Error(
+      `Unexpected end of Syrup, expected Syrup string at end of ${name}`,
+    );
+  }
+  let length;
+  ({ start, integer: length } = decodeInteger(bytes, start, end));
+
+  const cc = bytes[start];
+  if (cc !== STRING_START) {
+    throw new Error(
+      `Unexpected byte ${JSON.stringify(
+        String.fromCharCode(cc),
+      )}, Syrup dictionary keys must be strings or symbols at index ${start} of ${name}`,
+    );
+  }
+  start += 1;
+
+  const subStart = start;
+  start += Number(length);
+  if (start > end) {
+    throw new Error(
+      `Unexpected end of Syrup, expected ${length} bytes after index ${subStart} of ${name}`,
+    );
+  }
+  const value = textDecoder.decode(bytes.subarray(subStart, start));
+  return { start, value };
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {number} start
+ * @param {number} end
+ * @param {string} name
+ */
+function decodeRecord(bytes, start, end, name) {
+  const record = {};
+  let priorKey = '';
+  let priorKeyStart = -1;
+  let priorKeyEnd = -1;
+  for (;;) {
+    if (start >= end) {
+      throw new Error(
+        `Unexpected end of Syrup, expected Syrup string or end of Syrup dictionary marker "}" at ${start} of ${name}`,
+      );
+    }
+    const cc = bytes[start];
+    if (cc === DICT_END) {
+      return {
+        start: start + 1,
+        value: freeze(record),
+      };
+    }
+    const keyStart = start;
+    let key;
+    ({ start, value: key } = decodeString(bytes, start, end, name));
+    const keyEnd = start;
+
+    // Validate strictly non-descending keys.
+    if (priorKeyStart !== -1) {
+      const order = compareByteArrays(
+        bytes,
+        bytes,
+        priorKeyStart,
+        priorKeyEnd,
+        keyStart,
+        keyEnd,
+      );
+      if (order === 0) {
+        throw new Error(
+          `Syrup dictionary keys must be unique, got repeated ${JSON.stringify(
+            key,
+          )} at index ${start} of ${name}`,
+        );
+      } else if (order > 0) {
+        throw new Error(
+          `Syrup dictionary keys must be in bytewise sorted order, got ${JSON.stringify(
+            key,
+          )} immediately after ${JSON.stringify(
+            priorKey,
+          )} at index ${start} of ${name}`,
+        );
+      }
+    }
+    priorKey = key;
+    priorKeyStart = keyStart;
+    priorKeyEnd = keyEnd;
+
+    let value;
+    // eslint-disable-next-line no-use-before-define
+    ({ start, value } = decodeAny(bytes, start, end, name));
+
+    defineProperty(record, key, {
+      value,
+      enumerable: true,
+      writable: false,
+      configurable: false,
+    });
+  }
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {number} start
+ * @param {number} end
+ * @param {string} name
+ */
+function decodeFloat64(bytes, start, end, name) {
+  const floatStart = start;
+  start += 8;
+  if (start > end) {
+    throw new Error(
+      `Unexpected end of Syrup, expected 8 bytes of a 64 bit floating point number at index ${floatStart} of ${name}`,
+    );
+  }
+  const subarray = bytes.subarray(floatStart, start);
+  scratchBytes.set(subarray);
+  const value = scratchData.getFloat64(0, false); // big end
+
+  if (Number.isNaN(value)) {
+    if (compareByteArrays(CANONICAL_NAN_64, subarray, 0, 8, 0, 8) !== 0) {
+      throw new Error(
+        `Non-canonical NaN at index ${floatStart} of Syrup ${name}`,
+      );
+    }
+  }
+
+  return { start, value };
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {number} start
+ * @param {number} end
+ * @param {string} name
+ * @returns {{start: number, value: any}}
+ */
+function decodeAny(bytes, start, end, name) {
+  if (start >= end) {
+    throw new Error(
+      `Unexpected end of Syrup, expected any value at index ${start} of ${name}`,
+    );
+  }
+  const cc = bytes[start];
+  if (cc === DOUBLE) {
+    return decodeFloat64(bytes, start + 1, end, name);
+  }
+  if (cc >= ONE && cc <= NINE) {
+    let integer;
+    ({ start, integer } = decodeInteger(bytes, start, end));
+    return decodeAfterInteger(bytes, integer, start, end, name);
+  }
+  if (cc === ZERO) {
+    return decodeAfterInteger(bytes, 0n, start + 1, end, name);
+  }
+  if (cc === LIST_START) {
+    return decodeArray(bytes, start + 1, end, name);
+  }
+  if (cc === DICT_START) {
+    return decodeRecord(bytes, start + 1, end, name);
+  }
+  if (cc === TRUE) {
+    return { start: start + 1, value: true };
+  }
+  if (cc === FALSE) {
+    return { start: start + 1, value: false };
+  }
+  throw new Error(
+    `Unexpected character ${JSON.stringify(
+      String.fromCharCode(cc),
+    )} at index ${start} of ${name}`,
+  );
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {Object} options
+ * @param {string} [options.name]
+ * @param {number} [options.start]
+ * @param {number} [options.end]
+ */
+export function decodeSyrup(bytes, options = {}) {
+  const { start = 0, end = bytes.byteLength, name = '<unknown>' } = options;
+  if (end > bytes.byteLength) {
+    throw new Error(
+      `Cannot decode Syrup with with "end" beyond "bytes.byteLength", got ${end}, byteLength ${bytes.byteLength}`,
+    );
+  }
+  const { start: next, value } = decodeAny(bytes, start, end, name);
+  if (next !== end) {
+    throw new Error(
+      `Unexpected trailing bytes after Syrup, length = ${end - next}`,
+    );
+  }
+  return value;
+}

--- a/packages/syrup/src/decode.js
+++ b/packages/syrup/src/decode.js
@@ -50,6 +50,22 @@ function isCanonicalNaN64(bytes) {
 
 /**
  * @param {Uint8Array} bytes
+ */
+function isCanonicalZero64(bytes) {
+  const [a, b, c, d, e, f, g, h] = bytes;
+  return (
+    a === 0 &&
+    b === 0 &&
+    c === 0 &&
+    d === 0 &&
+    e === 0 &&
+    f === 0 &&
+    g === 0 &&
+    h === 0
+  );
+}
+/**
+ * @param {Uint8Array} bytes
  * @param {bigint} integer
  * @param {number} start
  * @param {number} end
@@ -277,6 +293,13 @@ function decodeFloat64(bytes, start, end, name) {
   scratchBytes.set(subarray);
   const value = scratchData.getFloat64(0, false); // big end
 
+  if (value === 0) {
+    if (!isCanonicalZero64(subarray)) {
+      throw new Error(
+        `Non-canonical zero at index ${floatStart} of Syrup ${name}`,
+      );
+    }
+  }
   if (Number.isNaN(value)) {
     if (!isCanonicalNaN64(subarray)) {
       throw new Error(

--- a/packages/syrup/src/decode.js
+++ b/packages/syrup/src/decode.js
@@ -29,10 +29,24 @@ const scratch = new ArrayBuffer(8);
 const scratchBytes = new Uint8Array(scratch);
 const scratchData = new DataView(scratch);
 
-scratchData.setFloat64(0, NaN);
-const CANONICAL_NAN_64 = scratchBytes.slice();
-
 const { defineProperty, freeze } = Object;
+
+/**
+ * @param {Uint8Array} bytes
+ */
+function isCanonicalNaN64(bytes) {
+  const [a, b, c, d, e, f, g, h] = bytes;
+  return (
+    a === 0x7f &&
+    b === 0xf8 &&
+    c === 0 &&
+    d === 0 &&
+    e === 0 &&
+    f === 0 &&
+    g === 0 &&
+    h === 0
+  );
+}
 
 /**
  * @param {Uint8Array} bytes
@@ -264,7 +278,7 @@ function decodeFloat64(bytes, start, end, name) {
   const value = scratchData.getFloat64(0, false); // big end
 
   if (Number.isNaN(value)) {
-    if (compareByteArrays(CANONICAL_NAN_64, subarray, 0, 8, 0, 8) !== 0) {
+    if (!isCanonicalNaN64(subarray)) {
       throw new Error(
         `Non-canonical NaN at index ${floatStart} of Syrup ${name}`,
       );

--- a/packages/syrup/src/encode.js
+++ b/packages/syrup/src/encode.js
@@ -1,0 +1,148 @@
+// @ts-check
+
+import { compareByteArrays } from './compare.js';
+
+const LIST_START = '['.charCodeAt(0);
+const LIST_END = ']'.charCodeAt(0);
+const DICT_START = '{'.charCodeAt(0);
+const DICT_END = '}'.charCodeAt(0);
+const DOUBLE = 'D'.charCodeAt(0);
+const TRUE = new Uint8Array(['t'.charCodeAt(0)]);
+const FALSE = new Uint8Array(['f'.charCodeAt(0)]);
+
+const scratch = new ArrayBuffer(16);
+const scratchBytes = new Uint8Array(scratch);
+const scratchData = new DataView(scratch);
+
+const textEncoder = new TextEncoder();
+
+/**
+ * @param {Record<string, any>} object
+ */
+function encodeDict(object) {
+  let byteLength = 2;
+  let index = 0;
+  const indexes = [];
+  const keys = [];
+  const values = [];
+
+  for (const [key, value] of Object.entries(object)) {
+    // Recursion, it's a thing!
+    // eslint-disable-next-line no-use-before-define
+    const keyBytes = encodeSyrup(key);
+    // eslint-disable-next-line no-use-before-define
+    const valueBytes = encodeSyrup(value);
+    byteLength += keyBytes.byteLength + valueBytes.byteLength;
+    indexes.push(index);
+    keys.push(keyBytes);
+    values.push(valueBytes);
+    index += 1;
+  }
+
+  indexes.sort((i, j) =>
+    compareByteArrays(
+      keys[i],
+      keys[j],
+      0,
+      keys[i].byteLength,
+      0,
+      keys[j].byteLength,
+    ),
+  );
+
+  const bytes = new Uint8Array(byteLength);
+  bytes[0] = DICT_START;
+  bytes[byteLength - 1] = DICT_END;
+  let cursor = 1;
+
+  for (index of indexes) {
+    const key = keys[index];
+    const value = values[index];
+
+    bytes.set(key, cursor);
+    cursor += key.byteLength;
+
+    bytes.set(value, cursor);
+    cursor += value.byteLength;
+  }
+  return bytes;
+}
+
+/**
+ * @param {Array<any>} array
+ */
+function encodeArray(array) {
+  let byteLength = 2;
+  const parts = [];
+  for (const value of array) {
+    // Recursion, it's a thing!
+    // eslint-disable-next-line no-use-before-define
+    const part = encodeSyrup(value);
+    byteLength += part.byteLength;
+    parts.push(part);
+  }
+  const bytes = new Uint8Array(byteLength);
+  bytes[0] = LIST_START;
+  bytes[byteLength - 1] = LIST_END;
+  let cursor = 1;
+  for (const part of parts) {
+    bytes.set(part, cursor);
+    cursor += part.byteLength;
+  }
+  return bytes;
+}
+
+/**
+ * @param {any} value
+ * @returns {Uint8Array}
+ */
+export function encodeSyrup(value) {
+  if (typeof value === 'string') {
+    const suffix = textEncoder.encode(value);
+    const prefix = textEncoder.encode(`${suffix.byteLength}"`);
+    const bytes = new Uint8Array(prefix.byteLength + suffix.byteLength);
+    bytes.set(prefix, 0);
+    bytes.set(suffix, prefix.byteLength);
+    return bytes;
+  }
+
+  if (typeof value === 'number') {
+    scratchData.setFloat64(1, value, false); // big end
+    scratchBytes[0] = DOUBLE;
+    return scratchBytes.slice(0, 9);
+  }
+
+  if (typeof value === 'bigint') {
+    if (value >= 0) {
+      return textEncoder.encode(`${value}+`);
+    } else {
+      return textEncoder.encode(`${-value}-`);
+    }
+  }
+
+  if (value instanceof Uint8Array) {
+    const prefix = textEncoder.encode(`${value.byteLength}:`);
+    const bytes = new Uint8Array(prefix.byteLength + value.byteLength);
+    bytes.set(prefix, 0);
+    bytes.set(value, prefix.byteLength);
+    return bytes;
+  }
+
+  if (Array.isArray(value)) {
+    return encodeArray(value);
+  }
+
+  if (Object(value) === value) {
+    return encodeDict(value);
+  }
+
+  if (value === false) {
+    return FALSE.slice();
+  }
+
+  if (value === true) {
+    return TRUE.slice();
+  }
+
+  throw new TypeError(`Cannot syrialize value ${value}`);
+}

--- a/packages/syrup/src/encode.js
+++ b/packages/syrup/src/encode.js
@@ -2,159 +2,226 @@
 
 import { compareByteArrays } from './compare.js';
 
-const { freeze } = Object;
+const { freeze, keys } = Object;
+
+const defaultCapacity = 256;
 
 const LIST_START = '['.charCodeAt(0);
 const LIST_END = ']'.charCodeAt(0);
 const DICT_START = '{'.charCodeAt(0);
 const DICT_END = '}'.charCodeAt(0);
 const DOUBLE = 'D'.charCodeAt(0);
-const TRUE = new Uint8Array(['t'.charCodeAt(0)]);
-const FALSE = new Uint8Array(['f'.charCodeAt(0)]);
+const TRUE = 't'.charCodeAt(0);
+const FALSE = 'f'.charCodeAt(0);
 
 const NAN64 = freeze([0x7f, 0xf8, 0, 0, 0, 0, 0, 0]);
-
-const scratch = new ArrayBuffer(16);
-const scratchBytes = new Uint8Array(scratch);
-const scratchData = new DataView(scratch);
 
 const textEncoder = new TextEncoder();
 
 /**
- * @param {Record<string, any>} object
+ * @typedef {Object} Buffer
+ * @property {Uint8Array} bytes
+ * @property {DataView} data
+ * @property {number} length
  */
-function encodeDict(object) {
-  let byteLength = 2;
-  let index = 0;
-  const indexes = [];
-  const keys = [];
-  const values = [];
 
-  for (const [key, value] of Object.entries(object)) {
-    // Recursion, it's a thing!
-    // eslint-disable-next-line no-use-before-define
-    const keyBytes = encodeSyrup(key);
-    // eslint-disable-next-line no-use-before-define
-    const valueBytes = encodeSyrup(value);
-    byteLength += keyBytes.byteLength + valueBytes.byteLength;
-    indexes.push(index);
-    keys.push(keyBytes);
-    values.push(valueBytes);
-    index += 1;
+/**
+ * @param {Buffer} buffer
+ * @param {number} length
+ * @returns {number} cursor (old length)
+ */
+function grow(buffer, length) {
+  const cursor = buffer.length;
+  if (length === 0) {
+    return cursor;
+  }
+  buffer.length += length;
+  let newLength = buffer.bytes.length;
+  if (buffer.length + length > newLength) {
+    while (buffer.length + length > newLength) {
+      newLength *= 2;
+    }
+    const bytes = new Uint8Array(newLength);
+    const data = new DataView(bytes.buffer);
+    bytes.set(buffer.bytes.subarray(0, buffer.length), 0);
+    buffer.bytes = bytes;
+    buffer.data = data;
+  }
+  return cursor;
+}
+
+/**
+ * @param {Buffer} buffer
+ * @param {string} value
+ */
+function encodeString(buffer, value) {
+  const start = buffer.length;
+  for (;;) {
+    const { read = 0, written = 0 } = textEncoder.encodeInto(
+      value,
+      buffer.bytes.subarray(start),
+    );
+    if (read === value.length) {
+      const prefix = `${written}"`; // length prefix quote suffix
+      buffer.length = start;
+      grow(buffer, prefix.length + written);
+      buffer.bytes.copyWithin(start + prefix.length, start); // shift right
+      textEncoder.encodeInto(
+        prefix,
+        buffer.bytes.subarray(start, start + prefix.length),
+      );
+      buffer.length = start + prefix.length + written;
+      return;
+    }
+    grow(buffer, buffer.bytes.length);
+  }
+}
+
+/**
+ * @param {Buffer} buffer
+ * @param {Record<string, any>} record
+ */
+function encodeRecord(buffer, record) {
+  const restart = buffer.length;
+  const indexes = [];
+  const keyStrings = [];
+  const keyBytes = [];
+
+  for (const key of keys(record)) {
+    const start = buffer.length;
+    encodeString(buffer, key);
+    const end = buffer.length;
+
+    keyStrings.push(key);
+    keyBytes.push(buffer.bytes.subarray(start, end));
+    indexes.push(indexes.length);
   }
 
   indexes.sort((i, j) =>
     compareByteArrays(
-      keys[i],
-      keys[j],
+      keyBytes[i],
+      keyBytes[j],
       0,
-      keys[i].byteLength,
+      keyBytes[i].length,
       0,
-      keys[j].byteLength,
+      keyBytes[j].length,
     ),
   );
 
-  const bytes = new Uint8Array(byteLength);
-  bytes[0] = DICT_START;
-  bytes[byteLength - 1] = DICT_END;
-  let cursor = 1;
+  buffer.length = restart;
 
-  for (index of indexes) {
-    const key = keys[index];
-    const value = values[index];
+  let cursor = grow(buffer, 1);
+  buffer.bytes[cursor] = DICT_START;
 
-    bytes.set(key, cursor);
-    cursor += key.byteLength;
+  for (const index of indexes) {
+    const key = keyStrings[index];
+    const value = record[key];
 
-    bytes.set(value, cursor);
-    cursor += value.byteLength;
+    encodeString(buffer, key);
+    // Recursion, it's a thing!
+    // eslint-disable-next-line no-use-before-define
+    encodeAny(buffer, value);
   }
-  return bytes;
+
+  cursor = grow(buffer, 1);
+  buffer.bytes[cursor] = DICT_END;
 }
 
 /**
+ * @param {Buffer} buffer
  * @param {Array<any>} array
  */
-function encodeArray(array) {
-  let byteLength = 2;
-  const parts = [];
+function encodeArray(buffer, array) {
+  let cursor = grow(buffer, 1);
+  buffer.bytes[cursor] = LIST_START;
+
   for (const value of array) {
     // Recursion, it's a thing!
     // eslint-disable-next-line no-use-before-define
-    const part = encodeSyrup(value);
-    byteLength += part.byteLength;
-    parts.push(part);
+    encodeAny(buffer, value);
   }
-  const bytes = new Uint8Array(byteLength);
-  bytes[0] = LIST_START;
-  bytes[byteLength - 1] = LIST_END;
-  let cursor = 1;
-  for (const part of parts) {
-    bytes.set(part, cursor);
-    cursor += part.byteLength;
+
+  cursor = grow(buffer, 1);
+  buffer.bytes[cursor] = LIST_END;
+}
+
+/**
+ * @param {Buffer} buffer
+ * @param {any} value
+ */
+function encodeAny(buffer, value) {
+  if (typeof value === 'string') {
+    encodeString(buffer, value);
+    return;
   }
-  return bytes;
+
+  if (typeof value === 'number') {
+    const cursor = grow(buffer, 9);
+    buffer.bytes[cursor] = DOUBLE;
+    if (value === 0) {
+      // no-op
+    } else if (Number.isNaN(value)) {
+      // Canonicalize NaN
+      buffer.bytes.set(NAN64, cursor + 1);
+    } else {
+      buffer.data.setFloat64(cursor + 1, value, false); // big end
+    }
+    return;
+  }
+
+  if (typeof value === 'bigint') {
+    const string = value >= 0 ? `${value}+` : `${-value}-`;
+    const cursor = grow(buffer, string.length);
+    textEncoder.encodeInto(string, buffer.bytes.subarray(cursor));
+    return;
+  }
+
+  if (value instanceof Uint8Array) {
+    const prefix = `${value.length}:`; // decimal and colon suffix
+    const cursor = grow(buffer, prefix.length + value.length);
+    textEncoder.encodeInto(prefix, buffer.bytes.subarray(cursor));
+    buffer.bytes.set(value, cursor + prefix.length);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    encodeArray(buffer, value);
+    return;
+  }
+
+  if (Object(value) === value) {
+    encodeRecord(buffer, value);
+    return;
+  }
+
+  if (value === false) {
+    const cursor = grow(buffer, 1);
+    buffer.bytes[cursor] = FALSE;
+    return;
+  }
+
+  if (value === true) {
+    const cursor = grow(buffer, 1);
+    buffer.bytes[cursor] = TRUE;
+    return;
+  }
+
+  throw new TypeError(`Cannot syrialize value ${value}`);
 }
 
 /**
  * @param {any} value
+ * @param {Object} [options]
+ * @param {number} [options.length] A guess at the length. If provided, must be
+ * greater than zero.
  * @returns {Uint8Array}
  */
-export function encodeSyrup(value) {
-  if (typeof value === 'string') {
-    const suffix = textEncoder.encode(value);
-    const prefix = textEncoder.encode(`${suffix.byteLength}"`);
-    const bytes = new Uint8Array(prefix.byteLength + suffix.byteLength);
-    bytes.set(prefix, 0);
-    bytes.set(suffix, prefix.byteLength);
-    return bytes;
-  }
-
-  if (typeof value === 'number') {
-    if (Number.isNaN(value)) {
-      // Canonicalize NaN
-      return new Uint8Array(NAN64);
-    } else if (value === 0) {
-      // Canonicalize negative zero
-      return new Uint8Array(8);
-    } else {
-      scratchData.setFloat64(1, value, false); // big end
-      scratchBytes[0] = DOUBLE;
-      return scratchBytes.slice(0, 9);
-    }
-  }
-
-  if (typeof value === 'bigint') {
-    if (value >= 0) {
-      return textEncoder.encode(`${value}+`);
-    } else {
-      return textEncoder.encode(`${-value}-`);
-    }
-  }
-
-  if (value instanceof Uint8Array) {
-    const prefix = textEncoder.encode(`${value.byteLength}:`);
-    const bytes = new Uint8Array(prefix.byteLength + value.byteLength);
-    bytes.set(prefix, 0);
-    bytes.set(value, prefix.byteLength);
-    return bytes;
-  }
-
-  if (Array.isArray(value)) {
-    return encodeArray(value);
-  }
-
-  if (Object(value) === value) {
-    return encodeDict(value);
-  }
-
-  if (value === false) {
-    return FALSE.slice();
-  }
-
-  if (value === true) {
-    return TRUE.slice();
-  }
-
-  throw new TypeError(`Cannot syrialize value ${value}`);
+export function encodeSyrup(value, options = {}) {
+  const { length: capacity = defaultCapacity } = options;
+  const bytes = new Uint8Array(capacity);
+  const data = new DataView(bytes.buffer);
+  const length = 0;
+  const buffer = { bytes, data, length };
+  encodeAny(buffer, value);
+  return buffer.bytes.subarray(0, buffer.length);
 }

--- a/packages/syrup/test/table.js
+++ b/packages/syrup/test/table.js
@@ -1,7 +1,5 @@
 const textEncoder = new TextEncoder();
 
-// * indicates a proposed extension or changa to evident defacto syrup
-
 export const table = [
   { syrup: '0+', value: 0n },
   { syrup: '1+', value: 1n },
@@ -13,7 +11,9 @@ export const table = [
   { syrup: '[1+2+3+]', value: [1n, 2n, 3n] },
   { syrup: '[3"abc3"def]', value: ['abc', 'def'] },
   { syrup: '{1"a10+1"b20+}', value: { a: 10n, b: 20n } },
+  { syrup: '{1"a10+1"b20+}', value: { b: 20n, a: 10n } }, // order canonicalization
   { syrup: '{0"10+1"i20+}', value: { '': 10n, i: 20n } },
+  { syrup: '{0"10+1"i20+}', value: { i: 20n, '': 10n } }, // order canonicalization
   { syrup: 'D?\xf0\x00\x00\x00\x00\x00\x00', value: 1 },
   { syrup: 'D@^\xdd/\x1a\x9f\xbew', value: 123.456 },
   { syrup: '[3"foo123+t]', value: ['foo', 123n, true] },

--- a/packages/syrup/test/table.js
+++ b/packages/syrup/test/table.js
@@ -1,0 +1,24 @@
+const textEncoder = new TextEncoder();
+
+// * indicates a proposed extension or changa to evident defacto syrup
+
+export const table = [
+  { syrup: '0+', value: 0n },
+  { syrup: '1+', value: 1n },
+  { syrup: '1-', value: -1n },
+  { syrup: 't', value: true },
+  { syrup: 'f', value: false },
+  { syrup: '5"hello', value: 'hello' },
+  { syrup: '5:hello', value: textEncoder.encode('hello') },
+  { syrup: '[1+2+3+]', value: [1n, 2n, 3n] },
+  { syrup: '[3"abc3"def]', value: ['abc', 'def'] },
+  { syrup: '{1"a10+1"b20+}', value: { a: 10n, b: 20n } },
+  { syrup: '{0"10+1"i20+}', value: { '': 10n, i: 20n } },
+  { syrup: 'D?\xf0\x00\x00\x00\x00\x00\x00', value: 1 },
+  { syrup: 'D@^\xdd/\x1a\x9f\xbew', value: 123.456 },
+  { syrup: '[3"foo123+t]', value: ['foo', 123n, true] },
+  {
+    syrup: '{3"age12+4"name7"Tabatha7"species3"cat}',
+    value: { age: 12n, name: 'Tabatha', species: 'cat' },
+  },
+];

--- a/packages/syrup/test/test-decode.js
+++ b/packages/syrup/test/test-decode.js
@@ -84,3 +84,14 @@ test('must reject non-canonical representations of NaN', t => {
     },
   );
 });
+
+test('must reject non-canonical -0', t => {
+  const bytes = new Uint8Array(9);
+  const data = new DataView(bytes.buffer);
+  bytes[0] = 'D'.charCodeAt(0);
+  data.setFloat64(1, -0);
+
+  t.throws(() => decodeSyrup(bytes), {
+    message: 'Non-canonical zero at index 1 of Syrup <unknown>',
+  });
+});

--- a/packages/syrup/test/test-decode.js
+++ b/packages/syrup/test/test-decode.js
@@ -1,0 +1,86 @@
+import test from 'ava';
+import { decodeSyrup } from '../src/decode.js';
+import { table } from './table.js';
+
+const textEncoder = new TextEncoder();
+
+test('affirmative decode cases', t => {
+  for (const { syrup, value } of table) {
+    const bytes = new Uint8Array(syrup.length);
+    for (let i = 0; i < syrup.length; i += 1) {
+      bytes[i] = syrup.charCodeAt(i);
+    }
+    const actual = decodeSyrup(bytes);
+    t.deepEqual(actual, value, `for ${JSON.stringify(syrup)}`);
+  }
+});
+
+test('must not be empty', t => {
+  t.throws(
+    () => {
+      decodeSyrup(new Uint8Array(0), { name: 'known.sup' });
+    },
+    {
+      message:
+        'Unexpected end of Syrup, expected any value at index 0 of known.sup',
+    },
+  );
+});
+
+test('dictionary keys must be unique', t => {
+  t.throws(
+    () => {
+      decodeSyrup(textEncoder.encode('{1"a10+1"a'));
+    },
+    {
+      message:
+        'Syrup dictionary keys must be unique, got repeated "a" at index 10 of <unknown>',
+    },
+  );
+});
+
+test('dictionary keys must be in bytewise order', t => {
+  t.throws(
+    () => {
+      decodeSyrup(textEncoder.encode('{1"b10+1"a'));
+    },
+    {
+      message:
+        'Syrup dictionary keys must be in bytewise sorted order, got "a" immediately after "b" at index 10 of <unknown>',
+    },
+  );
+});
+
+test('dictionary keys must be strings', t => {
+  t.throws(
+    () => {
+      decodeSyrup(textEncoder.encode('{1+'));
+    },
+    {
+      message:
+        'Unexpected byte "+", Syrup dictionary keys must be strings or symbols at index 2 of <unknown>',
+    },
+  );
+});
+
+test('must reject non-canonical representations of NaN', t => {
+  t.throws(
+    () =>
+      decodeSyrup(
+        new Uint8Array([
+          'D'.charCodeAt(0),
+          0xff,
+          0xf8,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+        ]),
+      ),
+    {
+      message: 'Non-canonical NaN at index 1 of Syrup <unknown>',
+    },
+  );
+});

--- a/packages/syrup/test/test-decode.js
+++ b/packages/syrup/test/test-decode.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import test from 'ava';
 import { decodeSyrup } from '../src/decode.js';
 import { table } from './table.js';
@@ -47,6 +49,18 @@ test('dictionary keys must be in bytewise order', t => {
     {
       message:
         'Syrup dictionary keys must be in bytewise sorted order, got "a" immediately after "b" at index 10 of <unknown>',
+    },
+  );
+});
+
+test('must reject out-of-order prefix key', t => {
+  t.throws(
+    () => {
+      decodeSyrup(textEncoder.encode('{1"i10+0"'));
+    },
+    {
+      message:
+        'Syrup dictionary keys must be in bytewise sorted order, got "" immediately after "i" at index 9 of <unknown>',
     },
   );
 });

--- a/packages/syrup/test/test-encode.js
+++ b/packages/syrup/test/test-encode.js
@@ -14,3 +14,7 @@ test('affirmative encode cases', t => {
     }
   }
 });
+
+test('negative zero', t => {
+  t.deepEqual(encodeSyrup(0), encodeSyrup(-0));
+});

--- a/packages/syrup/test/test-encode.js
+++ b/packages/syrup/test/test-encode.js
@@ -1,17 +1,19 @@
+// @ts-check
+
 import test from 'ava';
 import { encodeSyrup } from '../src/encode.js';
 import { table } from './table.js';
 
 test('affirmative encode cases', t => {
-  for (const { syrup, value, nonCanonical } of table) {
-    if (!nonCanonical) {
-      const actual = encodeSyrup(value);
-      let string = '';
-      for (const cc of actual) {
-        string += String.fromCharCode(cc);
-      }
-      t.deepEqual(string, syrup, `for ${JSON.stringify(syrup)} ${value}`);
+  for (const { syrup, value } of table) {
+    // We test with a length guess of 1 to maximize the probability
+    // of discovering a fault in the buffer resize code.
+    const actual = encodeSyrup(value, { length: 1 });
+    let string = '';
+    for (const cc of Array.from(actual)) {
+      string += String.fromCharCode(cc);
     }
+    t.deepEqual(syrup, string, `for ${JSON.stringify(syrup)} ${value}`);
   }
 });
 

--- a/packages/syrup/test/test-encode.js
+++ b/packages/syrup/test/test-encode.js
@@ -1,0 +1,16 @@
+import test from 'ava';
+import { encodeSyrup } from '../src/encode.js';
+import { table } from './table.js';
+
+test('affirmative encode cases', t => {
+  for (const { syrup, value, nonCanonical } of table) {
+    if (!nonCanonical) {
+      const actual = encodeSyrup(value);
+      let string = '';
+      for (const cc of actual) {
+        string += String.fromCharCode(cc);
+      }
+      t.deepEqual(string, syrup, `for ${JSON.stringify(syrup)} ${value}`);
+    }
+  }
+});

--- a/packages/syrup/test/test-fuzz.js
+++ b/packages/syrup/test/test-fuzz.js
@@ -1,0 +1,121 @@
+// @ts-check
+
+import test from 'ava';
+import { decodeSyrup } from '../src/decode.js';
+import { encodeSyrup } from '../src/encode.js';
+import { XorShift } from './xorshift.js';
+
+/**
+ * @param {number} budget
+ * @param {() => number} random
+ */
+function fuzzyString(budget, random) {
+  const length = Math.floor(budget * random());
+  const partition = random();
+  // Evidently, not every combination of UTF-16 values can survive a
+  // round-trip through encode/decode unaltered.
+  // if (partition < 0.125) {
+  //   // string with lots of unicode
+  //   return Array(length)
+  //     .fill()
+  //     .map(() => String.fromCharCode(random() * random() * 65536))
+  //     .join('');
+  if (partition < 0.25) {
+    // Force common prefix case to be somewhat common.
+    return '';
+  } else if (partition < 0.5) {
+    // string mostly printable
+    return Array(length)
+      .fill()
+      .map(() => String.fromCharCode(random() * 128))
+      .join('');
+  } else {
+    // lower-case strings
+    return Array(length)
+      .fill()
+      .map(() => String.fromCharCode('a'.charCodeAt(0) + random() * 26))
+      .join('');
+  }
+}
+
+/**
+ * @param {number} budget
+ * @param {() => number} random
+ */
+function largeFuzzySyrupable(budget, random) {
+  const partition = random();
+  const length = Math.floor(budget);
+  if (partition < 0.25) {
+    // bigint
+    return BigInt(
+      Array(length)
+        .fill()
+        .map(() => `${Math.floor(random() * 10)}`)
+        .join(''),
+    );
+  } else if (partition < 0.5) {
+    // string
+    return fuzzyString(length, random);
+  } else if (partition < 0.75) {
+    // array
+    return (
+      new Array(length)
+        .fill()
+        // Recursion is a thing, yo.
+        // eslint-disable-next-line no-use-before-define
+        .map(() => fuzzySyrupable(budget / length, random))
+    );
+  } else {
+    // object
+    return Object.fromEntries(
+      new Array(length).fill().map(() => [
+        fuzzyString(20, random),
+        // Recursion is a thing, yo.
+        // eslint-disable-next-line no-use-before-define
+        fuzzySyrupable(budget / length, random),
+      ]),
+    );
+  }
+}
+
+/**
+ * @param {number} budget
+ * @param {() => number} random
+ */
+function fuzzySyrupable(budget, random) {
+  const partition = budget * random();
+  if (partition < 0.25) {
+    return false;
+  } else if (partition < 0.5) {
+    return true;
+  } else if (partition < 0.5) {
+    return random() ** (100 * (random() - 0.5));
+  } else if (partition < 1) {
+    return Math.floor(100000 * random());
+  } else {
+    return largeFuzzySyrupable(budget, random);
+  }
+}
+
+// Chris Hibbert really wanted the default i to be Bob's Coffee Façade,
+// which is conveniently exactly 64 bits long.
+const defaultSeed = [0xb0b5c0ff, 0xeefacade, 0xb0b5c0ff, 0xeefacade];
+
+const prng = new XorShift(defaultSeed);
+const random = () => prng.random();
+
+for (let i = 0; i < 1000; i += 1) {
+  (index => {
+    const object1 = fuzzySyrupable(random() * 100, random);
+    const syrup2 = encodeSyrup(object1);
+    const desc = JSON.stringify(new TextDecoder().decode(syrup2));
+    test(`fuzz ${index}`, t => {
+      t.log(random());
+      t.log(object1);
+      const object3 = decodeSyrup(syrup2);
+      const syrup4 = encodeSyrup(object3);
+      t.deepEqual(object1, object3, desc);
+      t.deepEqual(syrup2, syrup4, desc);
+    });
+  })(i);
+}

--- a/packages/syrup/test/xorshift.js
+++ b/packages/syrup/test/xorshift.js
@@ -1,0 +1,106 @@
+// @ts-check
+
+/* eslint no-bitwise:[0] */
+
+// Forked from CommonJS version at
+// https://github.com/AndreasMadsen/xorshift/blob/d60ca9ca341957a9824908f733f30ce4592c9af4/xorshift.js
+
+/**
+ * Create a pseudorandom number generator, with a seed.
+ *
+ * @param {Array} seed "128-bit" integer, composed of 4x32-bit
+ * integers in big endian order.
+ */
+export function XorShift(seed) {
+  if (!Array.isArray(seed) || seed.length !== 4) {
+    throw new TypeError('seed must be an array with 4 numbers');
+  }
+
+  // uint64_t s = [seed ...]
+  this.state0U = seed[0] | 0;
+  this.state0L = seed[1] | 0;
+  this.state1U = seed[2] | 0;
+  this.state1L = seed[3] | 0;
+}
+
+/**
+ * Returns a 64bit random number as a 2x32bit array
+ *
+ * @returns {Array}
+ */
+XorShift.prototype.randomint = function randomint() {
+  // uint64_t s1 = s[0]
+  let s1U = this.state0U;
+  let s1L = this.state0L;
+  // uint64_t s0 = s[1]
+  const s0U = this.state1U;
+  const s0L = this.state1L;
+
+  // result = s0 + s1
+  const sumL = (s0L >>> 0) + (s1L >>> 0);
+  const resU = (s0U + s1U + ((sumL / 2) >>> 31)) >>> 0;
+  const resL = sumL >>> 0;
+
+  // s[0] = s0
+  this.state0U = s0U;
+  this.state0L = s0L;
+
+  // - t1 = [0, 0]
+  let t1U = 0;
+  let t1L = 0;
+  // - t2 = [0, 0]
+  let t2U = 0;
+  let t2L = 0;
+
+  // s1 ^= s1 << 23;
+  // :: t1 = s1 << 23
+  const a1 = 23;
+  const m1 = 0xffffffff << (32 - a1);
+  t1U = (s1U << a1) | ((s1L & m1) >>> (32 - a1));
+  t1L = s1L << a1;
+  // :: s1 = s1 ^ t1
+  s1U ^= t1U;
+  s1L ^= t1L;
+
+  // t1 = ( s1 ^ s0 ^ ( s1 >> 17 ) ^ ( s0 >> 26 ) )
+  // :: t1 = s1 ^ s0
+  t1U = s1U ^ s0U;
+  t1L = s1L ^ s0L;
+  // :: t2 = s1 >> 18
+  const a2 = 18;
+  const m2 = 0xffffffff >>> (32 - a2);
+  t2U = s1U >>> a2;
+  t2L = (s1L >>> a2) | ((s1U & m2) << (32 - a2));
+  // :: t1 = t1 ^ t2
+  t1U ^= t2U;
+  t1L ^= t2L;
+  // :: t2 = s0 >> 5
+  const a3 = 5;
+  const m3 = 0xffffffff >>> (32 - a3);
+  t2U = s0U >>> a3;
+  t2L = (s0L >>> a3) | ((s0U & m3) << (32 - a3));
+  // :: t1 = t1 ^ t2
+  t1U ^= t2U;
+  t1L ^= t2L;
+
+  // s[1] = t1
+  this.state1U = t1U;
+  this.state1L = t1L;
+
+  // return result
+  return [resU, resL];
+};
+
+/**
+ * Returns a random number normalized [0, 1), just like Math.random()
+ *
+ * @returns {number}
+ */
+XorShift.prototype.random = function random() {
+  const t2 = this.randomint();
+  // Math.pow(2, -32) = 2.3283064365386963e-10
+  // Math.pow(2, -52) = 2.220446049250313e-16
+  return (
+    t2[0] * 2.3283064365386963e-10 + (t2[1] >>> 12) * 2.220446049250313e-16
+  );
+};


### PR DESCRIPTION
This is a partial implementation of Syrup, @dustyweb’s syr/desyrialization codec.

- I have not implemented records. I would hope that the Syrup layer would not have opinions about records and would use a trap.

- The implementation leans strongly on canonicalizability. The wire must be in canonical form, both incoming and outgoing. The reader forbids out of order entries and repeated keys on dictionaries. The writer produces ordered dictionaries.

- I have elected to only support string keys for dictionaries. The JavaScript representation is an Object/Record, not a Map. Agoric *must* have Object/Record support.

- We should discuss how to add Map support later, and exactly what key types would be supported. It might be okay to just allow leaf values and maybe also whatever a record trap returns. The record trap would be the only way to provide an object key and the record trap would be obliged to ensure a stable identity.

- I did not implement Sets. They raise overlapping questions with maps and I don’t think we’re ready.

- I think Maps and Sets will need to be on the same footing and the serializer should be in a position to enforce the ordering and canonicalization of keys and values respectively. I don’t think we should leave maps as a record extension. I think it’s reasonable to leave out maps *and* sets until we iron those details out.

- ~I implemented variations on the idea of integers per @dustyweb’s suggestions. The `i10e` form is canonical. Changing this to `10n` would be aesthetically pleasing at the bottom of the JavaScript gravity well, since `10n` is exactly how to express a bigint in the language proper. Regardless, the forms `10e` and `10i` are both demonstrated and I could go either way. The high order bit is that we could pick exactly one of these to support before I land or publish this.~ I have reduced the integer support down to the forms `10+` and `10-`, and forbidded `0-` explicitly.

- ~I’ve added "n" and "u" single-character values to express null and undefined, similar to the precedent established by "t" and "f". These could be done with records. My intention is to implement records in terms of a user hook and these two types seem too fundamental to punt to the CapTP layer. On the other hand, I could also easily remove them.~

- ~I implemented both symbols and strings, but I think we should only keep one or the other. JavaScript symbols and Racket symbols are not equivalent idioms, so converting a Racket symbol to a JavaScript registered symbol does not make sense. For the moment, I read both as strings, but write only strings. It would be better to leave symbols unimplemented entirely.~ I’ve only implemented strings. Need to figure out Symbols.