### PR TITLE
fix: Realign TS, JS, and package names

### DIFF
--- a/packages/cjs-module-analyzer/index.d.ts
+++ b/packages/cjs-module-analyzer/index.d.ts
@@ -1,1 +1,1 @@
-export * from './src/main.js';
+export { analyzeCommonJS } from './src/main.js';

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@endo/lexer",
+  "name": "@endo/cjs-module-analyzer",
   "version": "0.1.0",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/endojs/endo/tree/master/packages/lexer#readme",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/cjs-module-analyzer#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/endojs/endo.git"

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -25,7 +25,7 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/lexer": "^0.1.0",
+    "@endo/cjs-module-analyzer": "^0.1.0",
     "@endo/static-module-record": "^0.1.0",
     "@endo/zip": "^0.1.0",
     "ses": "^0.12.7"

--- a/packages/compartment-mapper/src/parse.js
+++ b/packages/compartment-mapper/src/parse.js
@@ -2,7 +2,7 @@
 /// <reference types="ses" />
 
 import { StaticModuleRecord } from '@endo/static-module-record';
-import { analyzeCommonJS } from '@endo/lexer';
+import { analyzeCommonJS } from '@endo/cjs-module-analyzer';
 import { parseExtension } from './extension.js';
 import * as json from './json.js';
 


### PR DESCRIPTION
This is a build fix that I will land without review. This raises concern for me because every PR was tested atop HEAD and this issue didn’t show up until after the conflicting branches both landed.