### PR TITLE
feat(compartment-mapper): Precompiled ESM

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes to the compartment mapper:
 
 * Reenables CommonJS support with a fast lexer and without a dependency on
   Babel.
+* The Compartment Mapper now produces archives containing SES-shim
+  pre-compiled StaticModuleRecords for ESM instead of the source.
 * *BREAKING*: This release parallels a breaking upgrade for SES to version
   0.13. This entails the removal of `StaticModuleRecord` from SES, and the
   removal of the `ses/lockdown` light layering (there is no heavy layer to

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@endo/cjs-module-analyzer": "^0.1.0",
     "@endo/static-module-record": "^0.1.0",
+    "@endo/syrup": "^0.1.0",
     "@endo/zip": "^0.1.0",
     "ses": "^0.12.7"
   },

--- a/packages/compartment-mapper/src/parse.js
+++ b/packages/compartment-mapper/src/parse.js
@@ -3,6 +3,7 @@
 
 import { StaticModuleRecord } from '@endo/static-module-record';
 import { analyzeCommonJS } from '@endo/cjs-module-analyzer';
+import { encodeSyrup, decodeSyrup } from '@endo/syrup';
 import { parseExtension } from './extension.js';
 import * as json from './json.js';
 
@@ -33,10 +34,27 @@ export const parseMjs = async (
   _packageLocation,
 ) => {
   const source = textDecoder.decode(bytes);
+  const record = new StaticModuleRecord(source, location);
+  const pre = encodeSyrup(record);
   return {
-    parser: 'mjs',
+    parser: 'pre',
+    bytes: pre,
+    record,
+  };
+};
+
+/** @type {ParseFn} */
+export const parsePre = async (
+  bytes,
+  _specifier,
+  location,
+  _packageLocation,
+) => {
+  const record = decodeSyrup(bytes, { name: location });
+  return {
+    parser: 'pre',
     bytes,
-    record: new StaticModuleRecord(source, location),
+    record,
   };
 };
 
@@ -131,6 +149,7 @@ export const parseCjs = async (
 export const parserForLanguage = {
   mjs: parseMjs,
   cjs: parseCjs,
+  pre: parsePre,
   json: parseJson,
 };
 

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -62,7 +62,7 @@
  */
 
 /**
- * @typedef {'mjs' | 'cjs' | 'json'} ParserDescriptor
+ * @typedef {'mjs' | 'cjs' | 'json' | 'pre'} ParserDescriptor
  */
 
 // /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This anti-climactic change pre-compiles ESM and executes the compiled
static module records from an archive.

Refs #673

This is a repost of #687 which I mistakenly landed into a branch that has since been overwritten.