### PR TITLE
"Repairs" WeakMap,WeakSet by kludging the #703 kludge to work around acorn staleness.

### DIFF
--- a/packages/make-hardener/src/AltWeakMapSet.js
+++ b/packages/make-hardener/src/AltWeakMapSet.js
@@ -2,6 +2,12 @@
 // I could not find his implementation. Now that it's done, I'd be interested
 // in comparing.
 
+// Put what should have been the source of this module into a big literal
+// string which we evaluate, to workaround our tooling situation where
+// our version of rollup uses a version of acorn that doesn't understand
+// class private field syntax.
+const AltWeakMapSetSrc = `
+
 /* eslint-disable max-classes-per-file */
 class ReturnOverrider {
   constructor(key) {
@@ -28,7 +34,8 @@ class AltWeakMap {
       constructor(key, value) {
         if (key !== Object(key)) {
           throw new TypeError(
-            `Invalid value used as weak map key ${String(key)}`,
+            // eslint-disable-next-line prefer-template
+            'Invalid value used as weak map key ' + String(key),
           );
         }
         super(key);
@@ -139,5 +146,29 @@ Object.defineProperty(AltWeakMap, Symbol.toStringTag, {
   enumerable: false,
   configurable: true,
 });
+
+// eval completion value
+({ OriginalWeakMap, OriginalWeakSet, AltWeakMap, AltWeakSet });
+`;
+
+const {
+  /**
+   * @type {typeof WeakMap}
+   */
+  OriginalWeakMap,
+  /**
+   * @type {typeof WeakSet}
+   */
+  OriginalWeakSet,
+  /**
+   * @type {typeof WeakMap}
+   */
+  AltWeakMap,
+  /**
+   * @type {typeof WeakSet}
+   */
+  AltWeakSet,
+  // eslint-disable-next-line no-eval
+} = (1, eval)(AltWeakMapSetSrc);
 
 export { OriginalWeakMap, OriginalWeakSet, AltWeakMap, AltWeakSet };

--- a/packages/make-hardener/src/AltWeakMapSet.js
+++ b/packages/make-hardener/src/AltWeakMapSet.js
@@ -1,3 +1,7 @@
+// This idea is due to Kevin Smith (@zenparsing). I redid it only because
+// I could not find his implementation. Now that it's done, I'd be interested
+// in comparing.
+
 /* eslint-disable max-classes-per-file */
 class ReturnOverrider {
   constructor(key) {

--- a/packages/make-hardener/src/AltWeakMapSet.js
+++ b/packages/make-hardener/src/AltWeakMapSet.js
@@ -1,0 +1,139 @@
+/* eslint-disable max-classes-per-file */
+class ReturnOverrider {
+  constructor(key) {
+    return key;
+  }
+}
+
+const OriginalWeakMap = WeakMap;
+const OriginalWeakSet = WeakSet;
+
+// Must not escape
+const PUMPKIN = Object.freeze({ __proto__: null });
+
+/**
+ * @type {typeof WeakMap}
+ */
+class AltWeakMap {
+  #hiddenClass;
+
+  constructor(optIterable = undefined) {
+    class HiddenClass extends ReturnOverrider {
+      #value;
+
+      constructor(key, value) {
+        if (key !== Object(key)) {
+          throw new TypeError(
+            `Invalid value used as weak map key ${String(key)}`,
+          );
+        }
+        super(key);
+        this.#value = value;
+      }
+
+      static has(key) {
+        try {
+          return key.#value !== PUMPKIN;
+        } catch (_err) {
+          return false;
+        }
+      }
+
+      static get(key) {
+        try {
+          return key.#value === PUMPKIN ? undefined : key.#value;
+        } catch (_err) {
+          return undefined;
+        }
+      }
+
+      static set(key, value) {
+        try {
+          key.#value = value;
+        } catch (_err) {
+          // eslint-disable-next-line no-new
+          new HiddenClass(key, value);
+        }
+      }
+
+      static delete(key) {
+        try {
+          if (key.#value === PUMPKIN) {
+            return false;
+          }
+          key.#value = PUMPKIN;
+          return true;
+        } catch (_err) {
+          return false;
+        }
+      }
+    }
+    this.#hiddenClass = HiddenClass;
+    if (optIterable) {
+      for (const [k, v] of optIterable) {
+        this.set(k, v);
+      }
+    }
+  }
+
+  has(key) {
+    return this.#hiddenClass.has(key);
+  }
+
+  get(key) {
+    return this.#hiddenClass.get(key);
+  }
+
+  set(key, value) {
+    this.#hiddenClass.set(key, value);
+    return this;
+  }
+
+  delete(key) {
+    return this.#hiddenClass.delete(key);
+  }
+}
+
+Object.defineProperty(AltWeakMap, Symbol.toStringTag, {
+  value: 'WeakMap',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
+
+/**
+ * @type {typeof WeakSet}
+ */
+class AltWeakSet {
+  #wm = new AltWeakMap();
+
+  constructor(optIterable = undefined) {
+    if (optIterable) {
+      for (const k of optIterable) {
+        this.add(k);
+      }
+    }
+  }
+
+  has(key) {
+    return this.#wm.has(key);
+  }
+
+  add(key) {
+    this.#wm.set(key, true);
+    return this;
+  }
+
+  delete(key) {
+    return this.#wm.delete(key);
+  }
+}
+
+Object.defineProperty(AltWeakMap, Symbol.toStringTag, {
+  value: 'WeakMap',
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});
+
+export { OriginalWeakMap, OriginalWeakSet, AltWeakMap, AltWeakSet };

--- a/packages/make-hardener/src/main.js
+++ b/packages/make-hardener/src/main.js
@@ -39,6 +39,8 @@ const { ownKeys } = Reflect;
 
 /**
  * Create a `harden` function.
+ * TODO `true` is the wrong default! Using it for now to avoid config
+ * burden until we see if it even helps.
  *
  * @param {boolean=} useAltWeakness
  * @returns {Hardener}

--- a/packages/make-hardener/src/main.js
+++ b/packages/make-hardener/src/main.js
@@ -21,6 +21,15 @@
 
 // @ts-check
 
+import {
+  OriginalWeakMap,
+  OriginalWeakSet,
+  AltWeakMap,
+  AltWeakSet,
+} from './AltWeakMapSet.js';
+
+export { OriginalWeakMap, OriginalWeakSet, AltWeakMap, AltWeakSet };
+
 const { freeze, getOwnPropertyDescriptors, getPrototypeOf } = Object;
 const { ownKeys } = Reflect;
 
@@ -31,9 +40,17 @@ const { ownKeys } = Reflect;
 /**
  * Create a `harden` function.
  *
+ * @param {boolean=} useAltWeakness
  * @returns {Hardener}
  */
-function makeHardener() {
+function makeHardener(useAltWeakness = true) {
+  if (useAltWeakness) {
+    // @ts-ignore
+    globalThis.WeakMap = AltWeakMap;
+    // @ts-ignore
+    globalThis.WeakSet = AltWeakSet;
+  }
+
   const hardened = new WeakSet();
 
   const { harden } = {

--- a/packages/make-hardener/test/test-AltWeakMapSet.js
+++ b/packages/make-hardener/test/test-AltWeakMapSet.js
@@ -1,0 +1,57 @@
+import test from 'ava';
+import {
+  OriginalWeakMap,
+  OriginalWeakSet,
+  AltWeakMap,
+  AltWeakSet,
+} from '../src/AltWeakMapSet.js';
+
+const x = {};
+const y = {};
+const z = {};
+
+const testWeakMapClass = (title, WeakMapClass) => {
+  test(title, t => {
+    const wmi = new WeakMapClass([
+      [x, 'a'],
+      [y, 'b'],
+    ]);
+    t.true(wmi.has(x));
+    t.false(wmi.has(z));
+    t.is(wmi.get(x), 'a');
+    t.is(wmi.get(z), undefined);
+    t.false(wmi.delete(z));
+    t.true(wmi.delete(x));
+    t.false(wmi.has(x));
+    t.false(wmi.delete(x));
+    t.is(wmi.set(z, 'c'), wmi);
+    t.true(wmi.has(z));
+    t.is(wmi.get(z), 'c');
+    t.is(wmi.set(z, 'd'), wmi);
+    t.is(wmi.get(z), 'd');
+    t.throws(() => wmi.set(88, 'e'));
+  });
+};
+
+testWeakMapClass('test OriginalWeakMap', OriginalWeakMap);
+testWeakMapClass('test AltWeakMap', AltWeakMap);
+
+const testWeakSetClass = (title, WeakSetClass) => {
+  test(title, t => {
+    const wsi = new WeakSetClass([x, y]);
+    t.true(wsi.has(x));
+    t.false(wsi.has(z));
+    t.false(wsi.delete(z));
+    t.true(wsi.delete(x));
+    t.false(wsi.has(x));
+    t.false(wsi.delete(x));
+    t.is(wsi.add(z), wsi);
+    t.true(wsi.has(z));
+    t.is(wsi.add(z), wsi);
+    t.true(wsi.has(z));
+    t.throws(() => wsi.add(88));
+  });
+};
+
+testWeakSetClass('test OriginalWeakSet', OriginalWeakSet);
+testWeakSetClass('test AltWeakSet', AltWeakSet);


### PR DESCRIPTION
#703 implements a slow but constant time emulation of WeakMap and WeakSet, using return-override combined with class private fields. However, our tooling (rollup's use of acorn) does not yet support the class private field syntax. So this variation puts all that code into a big literal string which it then evaluates.