### PR TITLE
Const exports

### DIFF
--- a/packages/compartment-mapper/src/infer-exports.js
+++ b/packages/compartment-mapper/src/infer-exports.js
@@ -72,7 +72,7 @@ function* interpretExports(name, exports, tags) {
  * with any recognized module's type, if implied by a tag.
  * @yields {[string, string]}
  */
-export function* inferExportsEntries(
+export const inferExportsEntries = function* inferExportsEntries(
   { name, main, module, browser, exports },
   tags,
   types,
@@ -99,7 +99,7 @@ export function* inferExportsEntries(
   }
   // TODO Otherwise, glob 'files' for all '.js', '.cjs', and '.mjs' entry
   // modules, taking care to exclude node_modules.
-}
+};
 
 /**
  * inferExports reads a package.json (package descriptor) and constructs a map

--- a/packages/ses/src/error/tame-v8-error-constructor.js
+++ b/packages/ses/src/error/tame-v8-error-constructor.js
@@ -137,12 +137,12 @@ export const shortenCallSiteString = callSiteString => {
   return callSiteString;
 };
 
-export function tameV8ErrorConstructor(
+export const tameV8ErrorConstructor = (
   OriginalError,
   InitialError,
   errorTaming,
   stackFiltering,
-) {
+) => {
   // const callSiteFilter = _callSite => true;
   const callSiteFilter = callSite => {
     if (stackFiltering === 'verbose') {
@@ -272,4 +272,4 @@ export function tameV8ErrorConstructor(
   });
 
   return tamedMethods.getStackString;
-}
+};

--- a/packages/ses/src/evaluate.js
+++ b/packages/ses/src/evaluate.js
@@ -24,7 +24,7 @@ const { details: d } = assert;
  * @param {bool} [options.sloppyGlobalsMode]
  * @param {WeakSet} [options.knownScopeProxies]
  */
-export function performEval(
+export const performEval = (
   source,
   globalObject,
   localObject = {},
@@ -34,7 +34,7 @@ export function performEval(
     sloppyGlobalsMode = false,
     knownScopeProxies = new WeakSet(),
   } = {},
-) {
+) => {
   // Execute the mandatory transforms last to ensure that any rewritten code
   // meets those mandatory requirements.
   source = applyTransforms(source, [
@@ -79,4 +79,4 @@ export function performEval(
       assert.fail(d`handler did not revoke useUnsafeEvaluator ${err}`);
     }
   }
-}
+};

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -11,6 +11,13 @@ function getConstructorOf(obj) {
   return getPrototypeOf(obj).constructor;
 }
 
+// getAnonymousIntrinsics uses a utility function to construct an arguments
+// object, since it cannot have one of its own and also be a const export.
+function makeArguments() {
+  // eslint-disable-next-line prefer-rest-params
+  return arguments;
+}
+
 /**
  * getAnonymousIntrinsics()
  * Get the intrinsics not otherwise reachable by named own property
@@ -18,7 +25,7 @@ function getConstructorOf(obj) {
  *
  * @returns {Object}
  */
-export function getAnonymousIntrinsics() {
+export const getAnonymousIntrinsics = () => {
   const InertFunction = Function.prototype.constructor;
 
   const SymbolIterator = (typeof Symbol && Symbol.iterator) || '@@iterator';
@@ -26,8 +33,8 @@ export function getAnonymousIntrinsics() {
 
   // 9.2.4.1 %ThrowTypeError%
 
-  // eslint-disable-next-line prefer-rest-params
-  const ThrowTypeError = getOwnPropertyDescriptor(arguments, 'callee').get;
+  const ThrowTypeError = getOwnPropertyDescriptor(makeArguments(), 'callee')
+    .get;
 
   // 21.1.5.2 The %StringIteratorPrototype% Object
 
@@ -116,4 +123,4 @@ export function getAnonymousIntrinsics() {
   };
 
   return intrinsics;
-}
+};

--- a/packages/ses/src/get-source-url.js
+++ b/packages/ses/src/get-source-url.js
@@ -11,7 +11,7 @@ const sourceMetaEntriesRegExp = new RegExp(
   `(?:\\s*//${sourceMetaEntryRegExp}|/\\*${sourceMetaEntryRegExp}\\s*\\*/)\\s*$`,
 );
 
-export function getSourceURL(src) {
+export const getSourceURL = src => {
   let sourceURL = '<unknown>';
 
   // Our regular expression matches the last one or two comments with key value
@@ -42,4 +42,4 @@ export function getSourceURL(src) {
   }
 
   return sourceURL;
-}
+};

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -19,14 +19,14 @@ import { constantProperties, universalPropertyNames } from './whitelist.js';
  * @param {Array<Transform>} [options.globalTransforms]
  * @param {(Object) => void} [options.nativeBrander]
  */
-export function initGlobalObject(
+export const initGlobalObject = (
   globalObject,
   intrinsics,
   newGlobalPropertyNames,
   makeCompartmentConstructor,
   compartmentPrototype,
   { globalTransforms, nativeBrander },
-) {
+) => {
   for (const [name, constant] of entries(constantProperties)) {
     defineProperty(globalObject, name, {
       value: constant,
@@ -87,4 +87,4 @@ export function initGlobalObject(
       nativeBrander(value);
     }
   }
-}
+};

--- a/packages/ses/src/intrinsics.js
+++ b/packages/ses/src/intrinsics.js
@@ -60,7 +60,7 @@ function sampleGlobals(globalObject, newPropertyNames) {
   return newIntrinsics;
 }
 
-export function makeIntrinsicsCollector() {
+export const makeIntrinsicsCollector = () => {
   const intrinsics = { __proto__: null };
   let pseudoNatives;
 
@@ -130,7 +130,7 @@ export function makeIntrinsicsCollector() {
   );
 
   return intrinsicsCollector;
-}
+};
 
 /**
  * getGlobalIntrinsics()
@@ -145,7 +145,7 @@ export function makeIntrinsicsCollector() {
  *
  * @param {Object} globalObject
  */
-export function getGlobalIntrinsics(globalObject) {
+export const getGlobalIntrinsics = globalObject => {
   const intrinsicsCollector = makeIntrinsicsCollector();
 
   intrinsicsCollector.addIntrinsics(
@@ -153,4 +153,4 @@ export function getGlobalIntrinsics(globalObject) {
   );
 
   return intrinsicsCollector.finalIntrinsics();
-}
+};

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -101,12 +101,12 @@ const alreadyHardenedIntrinsics = () => false;
  * @param {LockdownOptions} [options]
  * @returns {() => {}} repairIntrinsics
  */
-export function repairIntrinsics(
+export const repairIntrinsics = (
   makeCompartmentConstructor,
   compartmentPrototype,
   getAnonymousIntrinsics,
   options = {},
-) {
+) => {
   // First time, absent options default to 'safe'.
   // Subsequent times, absent options default to first options.
   // Thus, all present options must agree with first options.
@@ -314,7 +314,7 @@ export function repairIntrinsics(
   }
 
   return hardenIntrinsics;
-}
+};
 
 /**
  * @param {CompartmentConstructorMaker} makeCompartmentConstructor

--- a/packages/ses/src/make-evaluate-factory.js
+++ b/packages/ses/src/make-evaluate-factory.js
@@ -27,7 +27,7 @@ function buildOptimizer(constants) {
  *
  * @param {Array<string>} [constants]
  */
-export function makeEvaluateFactory(constants = []) {
+export const makeEvaluateFactory = (constants = []) => {
   const optimizer = buildOptimizer(constants);
 
   // Create a function in sloppy mode, so that we can use 'with'. It returns
@@ -64,4 +64,4 @@ export function makeEvaluateFactory(constants = []) {
       };
     }
   `);
-}
+};

--- a/packages/ses/src/make-function-constructor.js
+++ b/packages/ses/src/make-function-constructor.js
@@ -17,7 +17,7 @@ const FERAL_FUNCTION = Function;
  * A safe version of the native Function which relies on
  * the safety of performEval for confinement.
  */
-export function makeFunctionConstructor(globaObject, options = {}) {
+export const makeFunctionConstructor = (globaObject, options = {}) => {
   // Define an unused parameter to ensure Function.length === 1
   const newFunction = function Function(_body) {
     // Sanitize all parameters at the entry point.
@@ -82,4 +82,4 @@ export function makeFunctionConstructor(globaObject, options = {}) {
   );
 
   return newFunction;
-}
+};

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -4,14 +4,14 @@ import { create, entries, keys, freeze, defineProperty } from './commons.js';
 // q, for enquoting strings in error messages.
 const q = JSON.stringify;
 
-export function makeThirdPartyModuleInstance(
+export const makeThirdPartyModuleInstance = (
   compartmentPrivateFields,
   staticModuleRecord,
   compartment,
   moduleAliases,
   moduleSpecifier,
   resolvedImports,
-) {
+) => {
   const { exportsProxy, proxiedExports, activate } = getDeferredExports(
     compartment,
     compartmentPrivateFields.get(compartment),
@@ -73,7 +73,7 @@ export function makeThirdPartyModuleInstance(
       }
     },
   });
-}
+};
 
 // `makeModuleInstance` takes a module's compartment record, the live import
 // namespace, and a global object; and produces a module instance.

--- a/packages/ses/src/scope-constants.js
+++ b/packages/ses/src/scope-constants.js
@@ -97,7 +97,7 @@ const identifierPattern = new RegExp('^[a-zA-Z_$][\\w$]*$');
  *
  * @param {string} name
  */
-export function isValidIdentifierName(name) {
+export const isValidIdentifierName = name => {
   // Ensure we have a valid identifier. We use regexpTest rather than
   // /../.test() to guard against the case where RegExp has been poisoned.
   return (
@@ -105,7 +105,7 @@ export function isValidIdentifierName(name) {
     !arrayIncludes(keywords, name) &&
     regexpTest(identifierPattern, name)
   );
-}
+};
 
 /*
  * isImmutableDataProperty
@@ -145,7 +145,7 @@ function isImmutableDataProperty(obj, name) {
  * @param {Object} globalObject
  * @param {Object} localObject
  */
-export function getScopeConstants(globalObject, localObject = {}) {
+export const getScopeConstants = (globalObject, localObject = {}) => {
   // getOwnPropertyNames() does ignore Symbols so we don't need to
   // filter them out.
   const globalNames = getOwnPropertyNames(globalObject);
@@ -169,4 +169,4 @@ export function getScopeConstants(globalObject, localObject = {}) {
   );
 
   return [...globalConstants, ...localConstants];
-}
+};

--- a/packages/ses/src/scope-handler.js
+++ b/packages/ses/src/scope-handler.js
@@ -44,11 +44,11 @@ const alwaysThrowHandler = new Proxy(immutableObject, {
  * - hide the unsafeGlobal which lives on the scope chain above the 'with'.
  * - ensure the Proxy invariants despite some global properties being frozen.
  */
-export function createScopeHandler(
+export const createScopeHandler = (
   globalObject,
   localObject = {},
   { sloppyGlobalsMode = false } = {},
-) {
+) => {
   return {
     // The scope handler throws if any trap other than get/set/has are run
     // (e.g. getOwnPropertyDescriptors, apply, getPrototypeOf).
@@ -168,4 +168,4 @@ export function createScopeHandler(
       return undefined;
     },
   };
-}
+};

--- a/packages/ses/src/tame-function-tostring.js
+++ b/packages/ses/src/tame-function-tostring.js
@@ -12,7 +12,7 @@ let nativeBrander;
  * Replace `Function.prototype.toString` with one that recognizes
  * shimmed functions as honorary native functions.
  */
-export function tameFunctionToString() {
+export const tameFunctionToString = () => {
   if (nativeBrander === undefined) {
     const nativeBrand = new WeakSet();
 
@@ -35,4 +35,4 @@ export function tameFunctionToString() {
     nativeBrander = freeze(func => nativeBrand.add(func));
   }
   return nativeBrander;
-}
+};

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -56,7 +56,7 @@ const htmlCommentPattern = new RegExp(`(?:${'<'}!--|--${'>'})`, 'g');
  * @param {string} src
  * @returns {string}
  */
-export function rejectHtmlComments(src) {
+export const rejectHtmlComments = src => {
   const lineNumber = getLineNumber(src, htmlCommentPattern);
   if (lineNumber < 0) {
     return src;
@@ -65,7 +65,7 @@ export function rejectHtmlComments(src) {
   throw new SyntaxError(
     `Possible HTML comment rejected at ${name}:${lineNumber}. (SES_HTML_COMMENT_REJECTED)`,
   );
-}
+};
 
 /**
  * An optional transform to place ahead of `rejectHtmlComments` to evade *that*
@@ -89,10 +89,10 @@ export function rejectHtmlComments(src) {
  * @param { string } src
  * @returns { string }
  */
-export function evadeHtmlCommentTest(src) {
+export const evadeHtmlCommentTest = src => {
   const replaceFn = match => (match[0] === '<' ? '< ! --' : '-- >');
   return src.replace(htmlCommentPattern, replaceFn);
-}
+};
 
 // /////////////////////////////////////////////////////////////////////////////
 
@@ -128,7 +128,7 @@ const importPattern = new RegExp('(^|[^.])\\bimport(\\s*(?:\\(|/[/*]))', 'g');
  * @param { string } src
  * @returns { string }
  */
-export function rejectImportExpressions(src) {
+export const rejectImportExpressions = src => {
   const lineNumber = getLineNumber(src, importPattern);
   if (lineNumber < 0) {
     return src;
@@ -137,7 +137,7 @@ export function rejectImportExpressions(src) {
   throw new SyntaxError(
     `Possible import expression rejected at ${name}:${lineNumber}. (SES_IMPORT_REJECTED)`,
   );
-}
+};
 
 /**
  * An optional transform to place ahead of `rejectImportExpressions` to evade
@@ -155,10 +155,10 @@ export function rejectImportExpressions(src) {
  * @param { string } src
  * @returns { string }
  */
-export function evadeImportExpressionTest(src) {
+export const evadeImportExpressionTest = src => {
   const replaceFn = (_, p1, p2) => `${p1}__import__${p2}`;
   return src.replace(importPattern, replaceFn);
-}
+};
 
 // /////////////////////////////////////////////////////////////////////////////
 
@@ -196,7 +196,7 @@ const someDirectEvalPattern = new RegExp('(^|[^.])\\beval(\\s*\\()', 'g');
  * @param { string } src
  * @returns { string }
  */
-export function rejectSomeDirectEvalExpressions(src) {
+export const rejectSomeDirectEvalExpressions = src => {
   const lineNumber = getLineNumber(src, someDirectEvalPattern);
   if (lineNumber < 0) {
     return src;
@@ -205,7 +205,7 @@ export function rejectSomeDirectEvalExpressions(src) {
   throw new SyntaxError(
     `Possible direct eval expression rejected at ${name}:${lineNumber}. (SES_EVAL_REJECTED)`,
   );
-}
+};
 
 // /////////////////////////////////////////////////////////////////////////////
 
@@ -216,11 +216,11 @@ export function rejectSomeDirectEvalExpressions(src) {
  * @param {string} source
  * @returns {string}
  */
-export function mandatoryTransforms(source) {
+export const mandatoryTransforms = source => {
   source = rejectHtmlComments(source);
   source = rejectImportExpressions(source);
   return source;
-}
+};
 
 /**
  * Starting with `source`, apply each transform to the result of the
@@ -230,9 +230,9 @@ export function mandatoryTransforms(source) {
  * @param {((str: string) => string)[]} transforms
  * @returns {string}
  */
-export function applyTransforms(source, transforms) {
+export const applyTransforms = (source, transforms) => {
   for (const transform of transforms) {
     source = transform(source);
   }
   return source;
-}
+};

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -263,9 +263,9 @@ const accessor = {
   set: fn,
 };
 
-export function isAccessorPermit(permit) {
+export const isAccessorPermit = permit => {
   return permit === getter || permit === accessor;
-}
+};
 
 // NativeError Object Structure
 function NativeError(prototype) {


### PR DESCRIPTION
Toward #175, an upcoming change introduces a JavaScript module bundler based on our own `StaticModuleRecord`’s internal module-to-program transform and linkage calling conventions. This would allow our module system to host itself.

However, beneath SES, we would not have a scope proxy, and the scope proxy is necessary to facilitate live bindings, such as exported function declarations. We do not need live bindings, so it’s a sensible compromise to use `export const` functions instead. This change prepares SES and the Endo internals for such a bundler.

Ref #175