### PR TITLE
feat(compartment-mapper): Introduce rudimentary bundler

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -6,6 +6,9 @@ User-visible changes to the compartment mapper:
   Babel.
 * The Compartment Mapper now produces archives containing SES-shim
   pre-compiled StaticModuleRecords for ESM instead of the source.
+* The Compartment Mapper can now produce bundles of concatenated modules but
+  without Compartments and only supporting ESM but not supporting live
+  bindings.
 * *BREAKING*: Archives created for the previous version will no longer work.
   The `importArchive` feature only supports pre-compiled ESM and CJS.
 * *BREAKING*: This release parallels a breaking upgrade for SES to version

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -258,7 +258,7 @@ const makeModuleMapHook = (
  * @param {CompartmentMapDescriptor} compartmentMap
  * @param {LinkOptions} options
  */
-export const assemble = (
+export const link = (
   { entry, compartments: compartmentDescriptors },
   {
     makeImportHook,
@@ -332,5 +332,15 @@ export const assemble = (
     );
   }
 
-  return compartment;
+  return {
+    compartment,
+    compartments,
+  };
 };
+
+/**
+ * @param {CompartmentMapDescriptor} compartmentMap
+ * @param {LinkOptions} options
+ */
+export const assemble = (compartmentMap, options) =>
+  link(compartmentMap, options).compartment;

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -276,6 +276,8 @@ export const link = (
 
   /** @type {Record<string, Compartment>} */
   const compartments = {};
+  /** @type {Record<string, ResolveHook>} */
+  const resolvers = {};
   for (const [compartmentName, compartmentDescriptor] of entries(
     compartmentDescriptors,
   )) {
@@ -306,6 +308,7 @@ export const link = (
       exitModules,
     );
     const resolveHook = resolve;
+    resolvers[compartmentName] = resolve;
 
     // TODO also thread powers selectively.
     const compartment = new Compartment(globals, exitModules, {
@@ -335,6 +338,7 @@ export const link = (
   return {
     compartment,
     compartments,
+    resolvers,
   };
 };
 

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -1,0 +1,334 @@
+// @ts-check
+/* eslint no-shadow: 0 */
+
+import { resolve } from './node-module-specifier.js';
+import { compartmentMapForNodeModules } from './node-modules.js';
+import { search } from './search.js';
+import { link } from './assemble.js';
+import { makeImportHookMaker } from './import-hook.js';
+import { parseJson } from './parse-json.js';
+import { parseArchiveCjs } from './parse-archive-cjs.js';
+import { parseArchiveMjs } from './parse-archive-mjs.js';
+import { parseLocatedJson } from './json.js';
+
+const textEncoder = new TextEncoder();
+
+/** quotes strings */
+const q = JSON.stringify;
+
+/** @type {Record<string, ParseFn>} */
+export const parserForLanguage = {
+  mjs: parseArchiveMjs,
+  cjs: parseArchiveCjs,
+  json: parseJson,
+};
+
+/**
+ * @param {Record<string, CompartmentDescriptor>} compartmentDescriptors
+ * @param {Record<string, CompartmentSources>} compartmentSources
+ * @param {Record<string, ResolveHook>} compartmentResolvers
+ * @param {string} entryCompartmentName
+ * @param {string} entryModuleSpecifier
+ */
+const sortedModules = (
+  compartmentDescriptors,
+  compartmentSources,
+  compartmentResolvers,
+  entryCompartmentName,
+  entryModuleSpecifier,
+) => {
+  const modules = [];
+  const seen = new Set();
+
+  /**
+   * @param {string} compartmentName
+   * @param {string} moduleSpecifier
+   */
+  const recur = (compartmentName, moduleSpecifier) => {
+    const key = `${compartmentName}#${moduleSpecifier}`;
+    if (seen.has(key)) {
+      return key;
+    }
+    seen.add(key);
+
+    const resolve = compartmentResolvers[compartmentName];
+    const source = compartmentSources[compartmentName][moduleSpecifier];
+    if (source) {
+      const { record, parser } = source;
+      if (record) {
+        const { imports = [], reexports = [] } = record;
+        const resolvedImports = {};
+        for (const importSpecifier of [...imports, ...reexports]) {
+          const resolvedSpecifier = resolve(importSpecifier, moduleSpecifier);
+          resolvedImports[importSpecifier] = recur(
+            compartmentName,
+            resolvedSpecifier,
+          );
+        }
+
+        modules.push({
+          key,
+          compartmentName,
+          moduleSpecifier,
+          parser,
+          record,
+          resolvedImports,
+        });
+
+        return key;
+      }
+    } else {
+      const descriptor =
+        compartmentDescriptors[compartmentName].modules[moduleSpecifier];
+      if (descriptor) {
+        const {
+          compartment: aliasCompartmentName,
+          module: aliasModuleSpecifier,
+        } = descriptor;
+        if (
+          aliasCompartmentName !== undefined &&
+          aliasModuleSpecifier !== undefined
+        ) {
+          return recur(aliasCompartmentName, aliasModuleSpecifier);
+        }
+      }
+    }
+
+    throw new Error(
+      `Cannot bundle: cannot follow module import ${moduleSpecifier} in compartment ${compartmentName}`,
+    );
+  };
+
+  recur(entryCompartmentName, entryModuleSpecifier);
+
+  return modules;
+};
+
+/**
+ * @param {ReadFn} read
+ * @param {string} moduleLocation
+ * @param {Object} [options]
+ * @param {ModuleTransforms} [options.moduleTransforms]
+ * @returns {Promise<string>}
+ */
+export const makeBundle = async (read, moduleLocation, options) => {
+  const { moduleTransforms } = options || {};
+  const {
+    packageLocation,
+    packageDescriptorText,
+    packageDescriptorLocation,
+    moduleSpecifier,
+  } = await search(read, moduleLocation);
+
+  /** @type {Set<string>} */
+  const tags = new Set();
+
+  const packageDescriptor = parseLocatedJson(
+    packageDescriptorText,
+    packageDescriptorLocation,
+  );
+  const compartmentMap = await compartmentMapForNodeModules(
+    read,
+    packageLocation,
+    tags,
+    packageDescriptor,
+    moduleSpecifier,
+  );
+
+  const {
+    compartments,
+    entry: { compartment: entryCompartmentName, module: entryModuleSpecifier },
+  } = compartmentMap;
+  /** @type {Sources} */
+  const sources = {};
+
+  const makeImportHook = makeImportHookMaker(
+    read,
+    packageLocation,
+    sources,
+    compartments,
+  );
+
+  // Induce importHook to record all the necessary modules to import the given module specifier.
+  const { compartment, resolvers } = link(compartmentMap, {
+    resolve,
+    makeImportHook,
+    moduleTransforms,
+    parserForLanguage,
+  });
+  await compartment.load(entryModuleSpecifier);
+
+  const modules = sortedModules(
+    compartmentMap.compartments,
+    sources,
+    resolvers,
+    entryCompartmentName,
+    entryModuleSpecifier,
+  );
+
+  // Create an index of modules so we can resolve import specifiers to the
+  // index of the corresponding functor.
+  const modulesByKey = {};
+  for (let index = 0; index < modules.length; index += 1) {
+    const module = modules[index];
+    module.index = index;
+    modulesByKey[module.key] = module;
+  }
+  for (const module of modules) {
+    module.indexedImports = Object.fromEntries(
+      Object.entries(module.resolvedImports).map(([importSpecifier, key]) => [
+        importSpecifier,
+        modulesByKey[key].index,
+      ]),
+    );
+  }
+
+  // Only support mjs format.
+  const problems = modules
+    .filter(module => module.parser !== 'premjs')
+    .map(
+      ({ moduleSpecifier, compartmentName, parser }) =>
+        `module ${moduleSpecifier} in compartment ${compartmentName} in language ${parser}`,
+    );
+  if (problems.length) {
+    throw new Error(
+      `Can only bundle applications that only have ESM (.mjs-type) modules, got ${problems.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  const bundle = `\
+(functors => {
+  function cell(name, value = undefined) {
+    const observers = [];
+    function set(newValue) {
+      value = newValue;
+      for (const observe of observers) {
+        observe(value);
+      }
+    }
+    function get() {
+      return value;
+    }
+    function observe(observe) {
+      observers.push(observe);
+      observe(value);
+    }
+    return { get, set, observe, enumerable: true };
+  }
+
+  const cells = [${''.concat(
+    ...modules.map(
+      ({ record: { __fixedExportMap__, __liveExportMap__ } }) => `{
+        ${''.concat(
+          ...Object.keys(__fixedExportMap__).map(
+            exportName => `${exportName}: cell(${q(exportName)}),\n`,
+          ),
+        )}
+        ${''.concat(
+          ...Object.keys(__liveExportMap__).map(
+            exportName => `${exportName}: cell(${q(exportName)}),\n`,
+          ),
+        )}
+      },`,
+    ),
+  )}];
+
+  ${''.concat(
+    ...modules.flatMap(({ index, indexedImports, record: { reexports } }) =>
+      reexports.map(
+        (/* @type {string} */ importSpecifier) => `\
+          Object.defineProperties(cells[${index}], Object.getOwnPropertyDescriptors(cells[${indexedImports[importSpecifier]}]));
+        `,
+      ),
+    ),
+  )}
+
+  const namespaces = cells.map(cells => Object.create(null, cells));
+
+  for (let index = 0; index < namespaces.length; index += 1) {
+    cells[index]['*'] = cell('*', namespaces[index]);
+  }
+
+  ${''.concat(
+    ...modules.map(
+      ({
+        index,
+        indexedImports,
+        record: { __liveExportMap__, __fixedExportMap__ },
+      }) => `\
+        functors[${index}]({
+          imports(map) {
+            ${''.concat(
+              ...Object.entries(indexedImports).map(
+                ([importName, importIndex]) => `\
+                  for (const [name, observers] of map.get(${q(
+                    importName,
+                  )}).entries()) {
+                    const cell = cells[${importIndex}][name];
+                    if (cell === undefined) {
+                      throw new ReferenceError(\`Cannot import name \${name}\`);
+                    }
+                    for (const observer of observers) {
+                      cell.observe(observer);
+                    }
+                  }
+                `,
+              ),
+            )}
+          },
+          liveVar: {
+            ${''.concat(
+              ...Object.entries(__liveExportMap__).map(
+                ([exportName, [importName]]) => `\
+                  ${importName}: cells[${index}].${exportName}.set,
+                `,
+              ),
+            )}
+          },
+          onceVar: {
+            ${''.concat(
+              ...Object.entries(__fixedExportMap__).map(
+                ([exportName, [importName]]) => `\
+                  ${importName}: cells[${index}].${exportName}.set,
+                `,
+              ),
+            )}
+          },
+        });
+      `,
+    ),
+  )}
+
+})([
+  ${''.concat(
+    ...modules.map(
+      ({ record: { __syncModuleProgram__ } }) =>
+        `${__syncModuleProgram__}\n,\n`,
+    ),
+  )}
+]);
+`;
+
+  return bundle;
+};
+
+/**
+ * @param {WriteFn} write
+ * @param {ReadFn} read
+ * @param {string} bundleLocation
+ * @param {string} moduleLocation
+ * @param {ArchiveOptions} [options]
+ */
+export const writeBundle = async (
+  write,
+  read,
+  bundleLocation,
+  moduleLocation,
+  options,
+) => {
+  const bundleString = await makeBundle(read, moduleLocation, options);
+  const bundleBytes = textEncoder.encode(bundleString);
+  await write(bundleLocation, bundleBytes);
+};

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -114,6 +114,7 @@ export const makeImportHookMaker = (
             location: packageRelativeLocation,
             parser,
             bytes: transformedBytes,
+            record,
           };
           return record;
         }

--- a/packages/compartment-mapper/src/main.js
+++ b/packages/compartment-mapper/src/main.js
@@ -4,3 +4,4 @@ export { makeArchive, writeArchive } from './archive.js';
 export { parseArchive, loadArchive, importArchive } from './import-archive.js';
 export { search } from './search.js';
 export { compartmentMapForNodeModules } from './node-modules.js';
+export { makeBundle, writeBundle } from './bundle.js';

--- a/packages/compartment-mapper/src/parse-archive-mjs.js
+++ b/packages/compartment-mapper/src/parse-archive-mjs.js
@@ -9,11 +9,11 @@ const textDecoder = new TextDecoder();
 export const parseArchiveMjs = async (
   bytes,
   _specifier,
-  location,
+  _location,
   _packageLocation,
 ) => {
   const source = textDecoder.decode(bytes);
-  const record = new StaticModuleRecord(source, location);
+  const record = new StaticModuleRecord(source);
   const pre = encodeSyrup(record);
   return {
     parser: 'premjs',

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -114,6 +114,13 @@
 // Shared machinery for assembling applications:
 
 /**
+ * @callback ResolveHook
+ * @param {string} importSpecifier
+ * @param {string} referrerSpecifier
+ * @returns {string} moduleSpecifier
+ */
+
+/**
  * @callback ImportHookMaker
  * @param {string} packageLocation
  * @param {ParseFn} parse

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -193,6 +193,7 @@
  * @property {Uint8Array} [bytes]
  * @property {Language} [parser]
  * @property {string} [exit]
+ * @property {FinalStaticModuleType} [record]
  */
 
 /**

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -42,7 +42,7 @@
  * package.json, there is a corresponding module descriptor.
  *
  * @typedef {Object} ModuleDescriptor
- * @property {string} [compartment]
+ * @property {string=} [compartment]
  * @property {string} [module]
  * @property {string} [location]
  * @property {Language} [parser]

--- a/packages/compartment-mapper/test/node_modules/bundle/import-all-from-me.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/import-all-from-me.js
@@ -1,0 +1,6 @@
+export const c = 'sea';
+export const i = 'eye';
+export const k = 'que';
+export const q = 'cue';
+export const u = 'you';
+export const y = 'why';

--- a/packages/compartment-mapper/test/node_modules/bundle/import-and-export-all.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/import-and-export-all.js
@@ -1,0 +1,3 @@
+export const red = '#f00';
+export const green = '#0f0';
+export const blue = '#00f';

--- a/packages/compartment-mapper/test/node_modules/bundle/import-and-reexport-name-from-me.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/import-and-reexport-name-from-me.js
@@ -1,0 +1,1 @@
+export const qux = 'qux';

--- a/packages/compartment-mapper/test/node_modules/bundle/import-default-export-from-me.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/import-default-export-from-me.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/packages/compartment-mapper/test/node_modules/bundle/import-named-export-and-rename.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/import-named-export-and-rename.js
@@ -1,0 +1,1 @@
+export const color = 'blue';

--- a/packages/compartment-mapper/test/node_modules/bundle/import-named-exports-from-me.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/import-named-exports-from-me.js
@@ -1,0 +1,4 @@
+const fizz = 'fizz';
+const bizz = 'bizz';
+const buzz = 'buzz';
+export { fizz, bizz, buzz };

--- a/packages/compartment-mapper/test/node_modules/bundle/main.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/main.js
@@ -1,0 +1,20 @@
+/* global print */
+
+import foo from './import-default-export-from-me.js';
+print(foo);
+
+import * as bar from './import-all-from-me.js';
+print(bar);
+
+import { fizz, buzz } from './import-named-exports-from-me.js';
+print(fizz);
+print(buzz);
+
+import { color as colour } from './import-named-export-and-rename.js';
+print(colour);
+
+import { qux } from './reexport-name.js';
+print(qux);
+
+import * as colors from './reexport-all.js';
+print(colors);

--- a/packages/compartment-mapper/test/node_modules/bundle/package.json
+++ b/packages/compartment-mapper/test/node_modules/bundle/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "bundle",
+  "parsers": {"js": "mjs"},
+  "main": "./main.js"
+}

--- a/packages/compartment-mapper/test/node_modules/bundle/reexport-all.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/reexport-all.js
@@ -1,0 +1,1 @@
+export * from './import-and-export-all.js';

--- a/packages/compartment-mapper/test/node_modules/bundle/reexport-name.js
+++ b/packages/compartment-mapper/test/node_modules/bundle/reexport-name.js
@@ -1,0 +1,1 @@
+export { qux } from './import-and-reexport-name-from-me.js';

--- a/packages/compartment-mapper/test/test-bundle.js
+++ b/packages/compartment-mapper/test/test-bundle.js
@@ -1,0 +1,58 @@
+import 'ses';
+import fs from 'fs';
+import test from 'ava';
+import { makeBundle, makeArchive, parseArchive } from '../src/main.js';
+
+const fixture = new URL(
+  'node_modules/bundle/main.js',
+  import.meta.url,
+).toString();
+
+const read = async location => fs.promises.readFile(new URL(location).pathname);
+
+const expectedLog = [
+  'foo',
+  {
+    c: 'sea',
+    i: 'eye',
+    q: 'cue',
+    k: 'que',
+    u: 'you',
+    y: 'why',
+  },
+  'fizz',
+  'buzz',
+  'blue',
+  'qux',
+  {
+    red: '#f00',
+    green: '#0f0',
+    blue: '#00f',
+  },
+];
+
+test('bundles work', async t => {
+  const bundle = await makeBundle(read, fixture);
+  t.log(bundle);
+  const log = [];
+  const print = entry => {
+    log.push(entry);
+  };
+  const compartment = new Compartment({ print });
+  compartment.evaluate(bundle);
+  t.deepEqual(log, expectedLog);
+});
+
+test('equivalent archive behaves the same as bundle', async t => {
+  const log = [];
+  const print = entry => {
+    log.push(entry);
+  };
+
+  const archive = await makeArchive(read, fixture);
+  const application = await parseArchive(archive, fixture);
+  await application.import({
+    globals: { print },
+  });
+  t.deepEqual(log, expectedLog);
+});

--- a/packages/static-module-record/DESIGN.md
+++ b/packages/static-module-record/DESIGN.md
@@ -17,7 +17,7 @@ const analyze = makeModuleAnalyzer(babel.default);
 const moduleAnalysis = analyze(moduleSource);
 const moduleFunctor = evaluateModuleFunctor(moduleAnalysis.functorSource, /* ... */);
 moduleFunctor({
-  imports(importedVariableUpdaters, exportAlls) { /* ... */ },
+  imports(importedVariableUpdaters) { /* ... */ },
   liveVar: exportedVariableUpdaters,
   onceVar: exportedConstantEmitters,
 });

--- a/packages/static-module-record/src/static-module-record.js
+++ b/packages/static-module-record/src/static-module-record.js
@@ -15,7 +15,7 @@ const analyzeModule = makeModuleAnalyzer(babel);
  * @param {string} source
  * @param {string} [url]
  */
-export function StaticModuleRecord(source, url = '<unknown>') {
+export function StaticModuleRecord(source, url) {
   if (new.target === undefined) {
     throw new TypeError(
       "Class constructor StaticModuleRecord cannot be invoked without 'new'",

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -121,7 +121,7 @@ const makeCreateStaticRecord = transformSource =>
             .map(([exp, upds]) => `[${js(exp)}, [${upds.join(',')}]]`)
             .join(',')}])]`,
       )
-      .join(',')}]), ${js(sourceOptions.exportAlls)});`;
+      .join(',')}]));`;
     preamble += sourceOptions.hoistedDecls
       .map(([vname, cvname]) => {
         let src = '';
@@ -143,7 +143,7 @@ const makeCreateStaticRecord = transformSource =>
     // It must also be strict to enforce strictness of modules.
     // We use destructuring parameters, so 'use strict' is not allowed
     // but the function actually is strict.
-    const functorSource = `\
+    let functorSource = `\
 (({ \
   imports: ${h.HIDDEN_IMPORTS}, \
   liveVar: ${h.HIDDEN_LIVE}, \
@@ -152,7 +152,11 @@ const makeCreateStaticRecord = transformSource =>
   ${preamble} \
   ${scriptSource}
 })
-//# sourceURL=${url}`;
+`;
+
+    if (url) {
+      functorSource += `//# sourceURL=${url}\n`;
+    }
 
     const moduleAnalysis = freeze({
       exportAlls: freeze(sourceOptions.exportAlls),


### PR DESCRIPTION
This change introduces a bundler (module concatenator) that is suitable for applications that consist entirely of ESM/mjs, do not require live bindings, and do not require compartmentalization of packages. This is the first iteration on a bundler and is suitable in its current form to generate a SES bundle on par with the current `dist/ses.umd.js`.

The next iteration will be able to receive built-in modules and be suitable for bootstrapping Endo on Endo’s own modules, providing a clearer migration path from `-r esm` and relaxing the constraint that Endo be able to bootstrap on Node.js.

This change includes a relatively comprehensive test of MJS to MJS linkage and verifies that the behavior is equivalent to importing the same program as an archive.

Refs #175