### PR TITLE
fix(static-module-record): Fix export name as

### DIFF
--- a/packages/compartment-mapper/test/node_modules/app/main.js
+++ b/packages/compartment-mapper/test/node_modules/app/main.js
@@ -2,7 +2,7 @@
 
 import typemodule from 'typemodule';
 import typecommon from 'typecommon';
-import typehybrid from 'typehybrid';
+import { meaning as typehybrid } from 'typehybrid';
 import typeparsers from 'typeparsers';
 
 export { typemodule, typecommon, typehybrid, typeparsers };

--- a/packages/compartment-mapper/test/node_modules/typehybrid/main.js
+++ b/packages/compartment-mapper/test/node_modules/typehybrid/main.js
@@ -1,1 +1,1 @@
-export { meaning as default } from './meaning.js';
+export { meaning } from './meaning.js';

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -446,7 +446,7 @@ function makeModulePlugins(options) {
               const ident = topLevelIsOnce[importFrom]
                 ? h.HIDDEN_ONCE
                 : h.HIDDEN_LIVE;
-              myUpdaterSources.push(`${ident}[${JSON.stringify(importFrom)}]`);
+              myUpdaterSources.push(`${ident}[${JSON.stringify(importTo)}]`);
             }
 
             if (source || myUpdaterSources) {

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -64,13 +64,30 @@ function initialize(t, source, options = {}) {
   const onceUpdaters = {};
   const namespace = {};
   const log = [];
+
+  const compartment = new Compartment(endowments);
+
   Object.keys(record.__liveExportMap__).forEach(name => {
     /** @param {any} value */
-    liveUpdaters[name] = value => {
+    const set = value => {
       namespace[name] = value;
       log.push(`${name}: ${JSON.stringify(value)}`);
     };
+    const get = () => {
+      return namespace[name];
+    };
+
+    // Initialization uses the fast local variable.
+    liveUpdaters[name] = set;
+
+    // Live updates fall through to the scope proxy.
+    // Live updates could be accomodated with an invasive rewrite of all
+    // references to the variable in scope, but we elected to avoid
+    // transforming code except for import and export statements, in order to
+    // minimize surprise in debugging.
+    Object.defineProperty(compartment.globalThis, name, { get, set });
   });
+
   Object.keys(record.__fixedExportMap__).forEach(name => {
     /** @param {any} value */
     onceUpdaters[name] = value => {
@@ -79,7 +96,7 @@ function initialize(t, source, options = {}) {
       log.push(`${name}: ${JSON.stringify(value)}`);
     };
   });
-  const compartment = new Compartment(endowments);
+
   const functor = compartment.evaluate(record.__syncModuleProgram__);
 
   /** @type {Map<string, Map<string, Updater>>} */
@@ -175,14 +192,12 @@ test('export default arguments (not technically valid but must be handled)', t =
 });
 
 test.failing('export default this', t => {
-  const { record, namespace } = initialize(t, `export default this`, {
-    endowments: { leak: 'leaks' },
-  });
+  const { record, namespace } = initialize(t, `export default this`);
   assertDefaultExport(t, record);
   t.is(namespace.default, undefined);
 });
 
-test.failing('export named', t => {
+test('export named', t => {
   const { log } = initialize(
     t,
     `\
@@ -201,8 +216,9 @@ export const ghi = 'abc';
     'def: 456',
     'def2: 456',
     'def: 457', // update
-    'def: 789',
-    'ghi: abc',
+    'def: 458', // update
+    'def: 789', // update
+    'ghi: "abc"',
   ]);
 });
 
@@ -279,7 +295,7 @@ export let abc = 123;
   );
 });
 
-test.failing('var exports with hoisting', t => {
+test('var exports with hoisting', t => {
   const { log } = initialize(
     t,
     `\
@@ -288,10 +304,15 @@ export var abc = 123;
 export const abc3 = abc;
 `,
   );
-  t.deepEqual(log, ['abc2: undefined', 'abc: 123', 'abc3: 123']);
+  t.deepEqual(log, [
+    'abc: undefined',
+    'abc2: undefined',
+    'abc: 123',
+    'abc3: 123',
+  ]);
 });
 
-test.failing('function exports with hoisting', t => {
+test('function exports with hoisting', t => {
   const { namespace } = initialize(
     t,
     `\
@@ -308,7 +329,7 @@ export const fn3 = fn;
   t.is(fn(), 'foo', 'fn evaluates');
 });
 
-test.failing('export class and let', t => {
+test('export class and let', t => {
   const { namespace } = initialize(
     t,
     `\
@@ -358,7 +379,7 @@ export default (class {});
   t.is(C.name, 'default', 'C class name');
 });
 
-test.failing('hoist export function', t => {
+test('hoist export function', t => {
   const { namespace } = initialize(
     t,
     `\

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -60,6 +60,7 @@ test('export default', t => {
 function initialize(t, source, options = {}) {
   const { endowments, imports = new Map() } = options;
   const record = new StaticModuleRecord(source);
+  t.log(record.__syncModuleProgram__);
   const liveUpdaters = {};
   const onceUpdaters = {};
   const namespace = {};
@@ -571,6 +572,32 @@ test('export names', t => {
   t.is(namespace.apples, 'apples');
   t.is(namespace.oranges, 'oranges');
   t.is(namespace.tomatoes, undefined);
+});
+
+test('export name as', t => {
+  const { namespace } = initialize(
+    t,
+    `export { peaches as stonefruit, oranges as citrus } from 'module';`,
+    {
+      imports: new Map([
+        [
+          'module',
+          new Map([
+            ['peaches', 'stonefruit'],
+            ['oranges', 'citrus'],
+            ['tomatoes', 'nightshades'],
+          ]),
+        ],
+      ]),
+    },
+  );
+  t.log(namespace);
+  t.is(namespace.stonefruit, 'stonefruit');
+  t.is(namespace.citrus, 'citrus');
+  t.is(namespace.peaches, undefined);
+  t.is(namespace.oranges, undefined);
+  t.is(namespace.tomatoes, undefined);
+  t.is(namespace.nightshades, undefined);
 });
 
 test('export all', t => {


### PR DESCRIPTION
In adding tests for bundles, I discovered a problem with `export { name as othername } from 'module'`, where the `othername` was ignored.

*needs rebase and merge target change after #710 lands*