### PR TITLE
Some fixes for StaticModuleRecord tests

### DIFF
--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -40,6 +40,7 @@ const collectPatternIdentifiers = (path, pattern) => {
 
 function makeModulePlugins(options) {
   const {
+    sourceType,
     exportAlls,
     fixedExportMap,
     imports,
@@ -47,6 +48,10 @@ function makeModulePlugins(options) {
     importSources,
     liveExportMap,
   } = options;
+
+  if (sourceType !== 'module') {
+    throw new Error(`Module sourceType must be 'module'`);
+  }
 
   const updaterSources = Object.create(null);
   /**
@@ -560,29 +565,23 @@ function makeModulePlugins(options) {
       },
     });
 
-    if (options.sourceType === 'module') {
-      // Add the module visitor.
-      switch (pass) {
-        case 0:
-          return {
-            visitor: {
-              ...visitor,
-              ...moduleVisitor(true, false),
-            },
-          };
-        case 1:
-          return { visitor: moduleVisitor(false, true) };
-        default:
-          throw TypeError(`Unrecognized module pass ${pass}`);
-      }
+    // Add the module visitor.
+    switch (pass) {
+      case 0:
+        return {
+          visitor: {
+            ...visitor,
+            ...moduleVisitor(true, false),
+          },
+        };
+      case 1:
+        return { visitor: moduleVisitor(false, true) };
+      default:
+        throw TypeError(`Unrecognized module pass ${pass}`);
     }
-    return { visitor };
   };
 
-  const rewriters = [rewriteModules(0)];
-  if (options.sourceType === 'module') {
-    rewriters.push(rewriteModules(1));
-  }
+  const rewriters = [rewriteModules(0), rewriteModules(1)];
   return rewriters;
 }
 

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -62,19 +62,22 @@ function makeModulePlugins(options) {
     };
 
     const markExported = (name, force = undefined) => {
-      if (force === 'fixed' || (!force && topLevelIsOnce[name])) {
+      const isOnce = topLevelIsOnce[name];
+      if (force === 'fixed' || (!force && isOnce)) {
         topLevelExported[name].forEach(
           importTo => (fixedExportMap[importTo] = [name]),
         );
         return hOnceId;
       }
 
-      if (force === 'live' || (!force && !topLevelIsOnce[name])) {
+      if (force === 'live' || (!force && !isOnce)) {
         topLevelExported[name].forEach(
           importTo => (liveExportMap[importTo] = [name, true]),
         );
         return hLiveId;
       }
+
+      return undefined;
     };
 
     const rewriteVars = (vids, isConst, needsHoisting) =>
@@ -307,7 +310,7 @@ function makeModulePlugins(options) {
             return;
           }
 
-          // const {default: $c_default} = {default: expr.id}; $h_once.default($c_default);
+          // const {default: $c_default} = {default: (XXX)}; $h_once.default($c_default);
           path.replaceWithMultiple([
             t.variableDeclaration('const', [
               t.variableDeclarator(

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -2,7 +2,17 @@
 
 import * as h from './hidden.js';
 
-// export const pattern = ...;
+/*
+ * Collects all of the identifiers on the left-hand-side of an exported
+ * assignment expression, deeply exploring complex destructuring assignment.
+ * In an export assignment, every one of these identifiers is an exported name.
+ *
+ * ```
+ * export const pattern = ...;
+ * export let pattern = ...;
+ * export var pattern = ...;
+ * ```
+ */
 const collectPatternIdentifiers = (path, pattern) => {
   switch (pattern.type) {
     case 'Identifier':
@@ -40,8 +50,26 @@ function makeModulePlugins(options) {
     importSources,
     liveExportMap,
   } = options;
+
   const updaterSources = Object.create(null);
+  /**
+   * Indicates that a name is declared at the top level and is never
+   * reassigned.
+   * All of these declarations are discovered in the analysis pass by visiting
+   * every function, class, and declaration.
+   *
+   * @type {Record<string, boolean>}
+   */
   const topLevelIsOnce = Object.create(null);
+  /**
+   * Indicates that a local name is declared at the top level and exported, and
+   * lists all of the corresponding exported names that should be updated if it
+   * changes.
+   * All of these declarations are discovered in the analysis pass by visiting
+   * every export declaration.
+   *
+   * @type {Record<string, Array<string>}
+   */
   const topLevelExported = Object.create(null);
 
   const rewriteModules = pass => ({ types: t }) => {

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -123,15 +123,16 @@ const makeCreateStaticRecord = transformSource =>
       )
       .join(',')}]));`;
     preamble += sourceOptions.hoistedDecls
-      .map(([vname, cvname]) => {
+      .map(([vname, isOnce, cvname]) => {
         let src = '';
         if (cvname) {
-          // It's a function, so set its name property.
+          // It's a function assigned to, so set its name property.
           src = `Object.defineProperty(${cvname}, 'name', {value: ${js(
             vname,
           )}});`;
         }
-        src += `${h.HIDDEN_LIVE}.${vname}(${cvname || ''});`;
+        const hDeclId = isOnce ? h.HIDDEN_ONCE : h.HIDDEN_LIVE;
+        src += `${hDeclId}.${vname}(${cvname || ''});`;
         return src;
       })
       .join('');

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -622,7 +622,7 @@ test('export all', t => {
 
 // TODO cross product let, class, maybe var:
 
-test.failing('export function should be fixed when not assigned', t => {
+test('export function should be fixed when not assigned', t => {
   const { __fixedExportMap__, __liveExportMap__ } = new StaticModuleRecord(`
     export function work() {}
   `);

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -396,7 +396,7 @@ export function F(arg) { return arg; }
   t.is(F.name, 'F', 'F function name');
 });
 
-test.failing('hoist default async export named function', async t => {
+test('hoist default async export named function', async t => {
   const { namespace } = initialize(
     t,
     `\
@@ -404,22 +404,21 @@ F(123);
 export default async function F(arg) { return arg; }
 `,
   );
-  const { F } = namespace;
+  const { default: F } = namespace;
   t.is(F.name, 'F', 'F function name');
   const ret = F('foo');
   t.truthy(ret instanceof Promise, 'F is async');
   t.is(await ret, 'foo', 'F returns correctly');
 });
 
-test.failing('hoist default async export anonymous function', async t => {
+test('hoist default async export anonymous function', async t => {
   const { namespace } = initialize(
     t,
     `\
-F(123);
 export default async function (arg) { return arg; }
 `,
   );
-  const { F } = namespace;
+  const { default: F } = namespace;
   t.is(F.name, 'default', 'default function name');
   const ret = F('foo');
   t.truthy(ret instanceof Promise, 'F is async');


### PR DESCRIPTION
I was able to fix a few of these tests, and improve the clarity of the Babel transform.

Stacked on 709-export-name-as-default.
