### PR TITLE
feat: create `overrideDebug: [...props]` option

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -31,8 +31,10 @@ User-visible changes in SES:
   under SES to specifically allow the use of `something.import()` or
   `something.eval()` methods.
 - Fix: `new Compartment(null, null, options)` no longer throws.
+- New lockdown option: `overrideDebug: [...props]` to detect where a given
+  override enablement is required.  Most useful as `overrideTaming: 'severe', overrideDebug: ['constructor']`.
 - We reopened Safari bug
-  [Object.defineProperties triggering a setter](https://bugs.webkit.org/show_bug.cgi?id=222538#c17)
+  [Object.defineProperties triggering a setter](https://bugs.webkit.org/show_bug.cgi?id=222538#c17) 
   when we found that it was causing an infinite recursion initializing SES
   on Safari.
 - We revised an error message to include the error tag of a new error

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -31,8 +31,10 @@ User-visible changes in SES:
   under SES to specifically allow the use of `something.import()` or
   `something.eval()` methods.
 - Fix: `new Compartment(null, null, options)` no longer throws.
-- New lockdown option: `overrideDebug: [...props]` to detect where a given
-  override enablement is required.  Most useful as `overrideTaming: 'severe', overrideDebug: ['constructor']`.
+- New lockdown option: `overrideDebug: [...props]` to detect where a property
+  assignment needs to be turned into a `defineProperty` to avoid the override
+  mistake.  Most useful as `overrideTaming: 'severe', overrideDebug:
+  ['constructor']`.
 - We reopened Safari bug
   [Object.defineProperties triggering a setter](https://bugs.webkit.org/show_bug.cgi?id=222538#c17) 
   when we found that it was causing an infinite recursion initializing SES

--- a/packages/ses/lockdown-options.md
+++ b/packages/ses/lockdown-options.md
@@ -28,6 +28,7 @@ Each option is explained in its own section below.
 | `errorTaming`    | `'safe'`    | `'unsafe'`     | `errorInstance.stack`      |
 | `stackFiltering` | `'concise'` | `'verbose'`    | deep stacks signal/noise   |
 | `overrideTaming` | `'moderate'` | `'min'` or `'severe'` | override mistake antidote  |
+| `overrideDebug`  | `[]`        | array of property names | detect override mistake |
 | `__allowUnsafeMonkeyPatching__` | `'safe'` | `'unsafe'` | run unsafe code unsafely |
 
 ## `regExpTaming` Options
@@ -488,6 +489,39 @@ by our override mitigation.
 
 ![overrideTaming: 'severe' vscode inspector display](docs/images/override-taming-star-inspector.png)
 </details>
+
+## `overrideDebug` Options
+
+To help diagnose problems with the override mistake, you can set this option to
+a list of properties that will print diagnostic information when their override
+enablement is triggered.
+
+For example, to find the client code that causes a `constructor` property override
+mistake, set the options as follows:
+
+```js
+{
+  overrideTaming: 'severe',
+  overrideDebug: ['constructor']
+}
+```
+
+The idiom for `@agoric/install-ses` when tracking down the override
+mistake with the `constructor` property is to set the following
+environment variable:
+
+```sh
+LOCKDOWN_OPTIONS='{"errorTaming":"unsafe","stackFiltering":"verbose","overrideTaming":"severe","overrideDebug":["constructor"]}'
+```
+    
+Then, when some script deep in the require stack does:
+    
+```js
+function MyConstructor() { }
+MyConstructor.prototype.constructor = XXX;
+```
+    
+the caller backtrace will be logged to the console.
 
 ## `__allowUnsafeMonkeyPatching__` Options
 

--- a/packages/ses/lockdown-options.md
+++ b/packages/ses/lockdown-options.md
@@ -521,7 +521,17 @@ function MyConstructor() { }
 MyConstructor.prototype.constructor = XXX;
 ```
     
-the caller backtrace will be logged to the console.
+the caller backtrace will be logged to the console, such as:
+
+```
+(Error#1)
+Error#1: Override property constructor
+
+  at Object.setter (packages/ses/src/enable-property-overrides.js:114:27)
+  at packages/ses/test/override-tester.js:26:19
+  at overrideTester (packages/ses/test/override-tester.js:25:9)
+  at packages/ses/test/test-enable-property-overrides-severe-debug.js:14:3
+```
 
 ## `__allowUnsafeMonkeyPatching__` Options
 

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -75,8 +75,14 @@ function isObject(obj) {
  *
  * @param {Record<string, any>} intrinsics
  * @param {'min' | 'moderate' | 'severe'} overrideTaming
+ * @param {Iterable<string | symbol>} [overrideDebug]
  */
-export default function enablePropertyOverrides(intrinsics, overrideTaming) {
+export default function enablePropertyOverrides(
+  intrinsics,
+  overrideTaming,
+  overrideDebug = [],
+) {
+  const debugProperties = new Set(overrideDebug);
   function enable(path, obj, prop, desc) {
     if ('value' in desc && desc.configurable) {
       const { value } = desc;
@@ -91,6 +97,8 @@ export default function enablePropertyOverrides(intrinsics, overrideTaming) {
         configurable: false,
       });
 
+      const isDebug = debugProperties.has(prop);
+
       function setter(newValue) {
         if (obj === this) {
           throw new TypeError(
@@ -102,6 +110,9 @@ export default function enablePropertyOverrides(intrinsics, overrideTaming) {
         if (objectHasOwnProperty(this, prop)) {
           this[prop] = newValue;
         } else {
+          if (isDebug) {
+            console.error(new Error(`Override property ${prop}`));
+          }
           defineProperty(this, prop, {
             value: newValue,
             writable: true,

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -41,6 +41,7 @@ import { assert, makeAssert } from './error/assert.js';
  *   localeTaming?: 'safe' | 'unsafe',
  *   consoleTaming?: 'safe' | 'unsafe',
  *   overrideTaming?: 'min' | 'moderate' | 'severe',
+ *   overrideDebug?: Array<string>,
  *   stackFiltering?: 'concise' | 'verbose',
  *   __allowUnsafeMonkeyPatching__?: 'safe' | 'unsafe',
  * }} LockdownOptions
@@ -140,6 +141,7 @@ export const repairIntrinsics = (
     localeTaming = 'safe',
     consoleTaming = 'safe',
     overrideTaming = 'moderate',
+    overrideDebug = [],
     stackFiltering = 'concise',
     __allowUnsafeMonkeyPatching__ = 'safe',
 
@@ -173,6 +175,7 @@ export const repairIntrinsics = (
     localeTaming,
     consoleTaming,
     overrideTaming,
+    overrideDebug,
     stackFiltering,
     __allowUnsafeMonkeyPatching__,
   };
@@ -295,7 +298,7 @@ export const repairIntrinsics = (
     // TODO consider moving this to the end of the repair phase, and
     // therefore before vetted shims rather than afterwards. It is not
     // clear yet which is better.
-    enablePropertyOverrides(intrinsics, overrideTaming);
+    enablePropertyOverrides(intrinsics, overrideTaming, overrideDebug);
 
     if (__allowUnsafeMonkeyPatching__ !== 'unsafe') {
       // Finally register and optionally freeze all the intrinsics. This

--- a/packages/ses/test/test-enable-property-overrides-severe-debug.js
+++ b/packages/ses/test/test-enable-property-overrides-severe-debug.js
@@ -1,0 +1,28 @@
+import '../index.js';
+import test from 'ava';
+import { overrideTester } from './override-tester.js';
+
+lockdown({
+  overrideTaming: 'severe',
+  overrideDebug: ['constructor', 'push', 'unrecognized'],
+});
+
+const { getPrototypeOf } = Object;
+const { ownKeys } = Reflect;
+
+test('enablePropertyOverrides - on, with debug', t => {
+  overrideTester(t, 'Object', {}, ownKeys(Object.prototype));
+
+  // We allow 'length' *not* because it is in enablements; it is not;
+  // but because each array instance has its own.
+  overrideTester(t, 'Array', [], ['toString', 'length', 'push']);
+
+  const TypedArray = getPrototypeOf(Uint8Array);
+  overrideTester(
+    t,
+    'TypedArray',
+    new Uint8Array(),
+    // because Uint8Array.prototype already overrides `constructor`
+    ownKeys(TypedArray.prototype).filter(name => name !== 'constructor'),
+  );
+});


### PR DESCRIPTION
This allows SES callers to help diagnose which override enablements
are being used, with a backtrace.

The idiom for `@agoric/install-ses` when tracking down the override
mistake with the `constructor` property is to set the following
environment variable:

```sh
export LOCKDOWN_OPTIONS='{"overrideDebug":["constructor"],"overrideTaming":"severe","errorTaming":"unsafe","stackFiltering":"verbose"}'
```

Then, when some script deep in the require stack does:

```js
function MyConstructor() { }
MyConstructor.prototype.constructor = XXX; // Would throw if Object.prototype.constructor is not repaired.
```

the caller backtrace will be logged to the console.  Then, the workaround is to change the second line to:

```js
Object.defineProperty(MyConstructor.prototype, 'constructor', { value: XXX }); // override-mistake aware
```
