### PR TITLE
assert.notThrows and .atomic terminate on atomicity failure

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -409,9 +409,9 @@ const makeAssert = (optRaise = undefined, unredacted = false) => {
       // Abandons/terminates the unit of computation this `assert` instance
       // is supposed to. `zcf.assert.notThrows(f)` will immediately shut down
       // the contract if `f()` throws.
-      fail(details`Failure was not an option: ${reason}`);
+      throw fail(details`Failure was not an option: ${reason}`);
     }
-  }
+  };
 
   /** @type {Atomic} */
   const atomic = action => {

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -151,11 +151,36 @@
  */
 
 /**
+ * When called, should not terminate by throwing. If it does, the
+ * `assert.notThrows` that called it will escalate that into terminating the
+ * termination unit associated with that `assert`.
+ *
+ * @callback AtomicAction
+ */
+
+/**
+ * The `assert.notThrows` method
+ *
+ * @callback NotThrows
+ * Calls `action()` once. If `action()` returns, that outcome is just
+ * propagated. If `action()` throws, that becomes an
+ * `assert.fail` for this `assert` instance, terminating / abandoning whatever
+ * unit of computation this `assert` instance does on failure. For example,
+ * `zcf.assert.notThrows(f)` will immediately shut down that `zcf`'s contract
+ * if `f()` throws.
+ * @param {AtomicAction} action
+ */
+
+/**
  * @callback Commit
  */
 
 /**
- * @callback AtomicAction
+ * When called, should not call `commit()` and then terminate by throwing.
+ * If it does, the `assert.atomic` that called it will escalate that into
+ * terminating the termination unit associated with that `assert`.
+ *
+ * @callback SplitAtomicAction
  * @param {Commit} commit
  */
 
@@ -173,8 +198,8 @@
  * `assert.fail` for this `assert` instance, terminating / abandoning whatever
  * unit of computation this `assert` instance does on failure. For example,
  * `zcf.assert.atomic(f)` will immediately shut down that `zcf`'s contract
- * if `f` throws after the commit point.
- * @param {AtomicAction} action
+ * if `f(commit)` throws after it calls `commit()`.
+ * @param {SplitAtomicAction} action
  */
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -323,6 +348,7 @@
  *   details: DetailsTag,
  *   quote: AssertQuote,
  *   makeAssert: MakeAssert,
+ *   notThrows: NotThrows,
  *   atomic: Atomic,
  * } } Assert
  */

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -114,7 +114,15 @@
 /**
  * The `assert.typeof` method
  *
- * @typedef {AssertTypeofBigint & AssertTypeofBoolean & AssertTypeofFunction & AssertTypeofNumber & AssertTypeofObject & AssertTypeofString & AssertTypeofSymbol & AssertTypeofUndefined} AssertTypeof
+ * @typedef { AssertTypeofBigint &
+ *   AssertTypeofBoolean &
+ *   AssertTypeofFunction &
+ *   AssertTypeofNumber &
+ *   AssertTypeofObject &
+ *   AssertTypeofString &
+ *   AssertTypeofSymbol &
+ *   AssertTypeofUndefined
+ * } AssertTypeof
  */
 
 /**
@@ -140,6 +148,33 @@
  * @param {Error} error
  * @param {Details} detailsNote
  * @returns {void}
+ */
+
+/**
+ * @callback Commit
+ */
+
+/**
+ * @callback AtomicAction
+ * @param {Commit} commit
+ */
+
+/**
+ * The `assert.atomic` method
+ *
+ * @callback Atomic
+ * Calls back to `action` once, passing it a no-argument `commit` function
+ * which `action` should call to mark its *commit point*. If `action` returns
+ * or throws before the commit point, that outcome is just propagated (with
+ * an added error note on a throw). If `action` returns after the commit
+ * point, that returned value is just propagated.
+ *
+ * However, if `action` throws after that commit point, that becomes an
+ * `assert.fail` for this `assert` instance, terminating / abandoning whatever
+ * unit of computation this `assert` instance does on failure. For example,
+ * `zcf.assert.atomic(f)` will immediately shut down that `zcf`'s contract
+ * if `f` throws after the commit point.
+ * @param {AtomicAction} action
  */
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -288,6 +323,7 @@
  *   details: DetailsTag,
  *   quote: AssertQuote,
  *   makeAssert: MakeAssert,
+ *   atomic: Atomic,
  * } } Assert
  */
 


### PR DESCRIPTION
Our transactional logic, for example in ERTP, has us do all tests which might fail before a commit point, and then perform all state update after the commit point, so that either all these updates happen or none of them do. However, if a throw happens after the commit point, it could leave behind corrupt state where some of these updates happened and others did not.

This PR adds `assert.atomic` so that code within such an atomic block can explicitly say when it crosses the commit point, by calling a `commit()` function. If the atomic block exits with a throw *after* that commit point, then this does an `assert.fail` with this same assert instance. Thus, such an atomicity failure will terminate/abandon whatever unit of computation that `assert.fail` does. For example `zcf.assert.atomic(f)` will immediately terminate that `zcf`'s contract if `f` fails after its commit point.

See https://github.com/Agoric/agoric-sdk/pull/3144