### PR TITLE
feat(ses): Explicitly remove function caller and arguments

### DIFF
--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -234,6 +234,8 @@ export const FunctionInstance = {
   // Do not specify "prototype" here, since only Function instances that can
   // be used as a constructor have a prototype property. For constructors,
   // since prototype properties are instance-specific, we define it there.
+  caller: false,
+  arguments: false,
 };
 
 // AsyncFunction Instances


### PR DESCRIPTION
For reasons slightly beyond my imagination, running SES under `node -r esm` after @michaelfig’s patch allows us to run dependent packages with either NESM or RESM, but under RESM, we get SES initialization warnings for the removal of `caller` and `arguments`. I take that to mean that SES itself is running under sloppy mode in this emulation.

This change may have nuanced security implications and might be better served by either not running under the RESM emulation, forcing RESM to run with the compiled build (and add 'use strict' to the bundle), or adding an explicit 'use strict' to each of the modules. This change is one possible solution that works.