### PR TITLE
fix(zip): Tolerate XS null terminated string limitation

### DIFF
--- a/packages/zip/src/compression.js
+++ b/packages/zip/src/compression.js
@@ -1,4 +1,4 @@
 // @ts-check
 
 // STORE is the magic number for "not compressed".
-export const STORE = '\x00\x00';
+export const STORE = 0;

--- a/packages/zip/src/format-reader.js
+++ b/packages/zip/src/format-reader.js
@@ -90,7 +90,7 @@ function readHeaders(reader) {
   return {
     versionNeeded: reader.readUint16LE(),
     bitFlag: reader.readUint16LE(),
-    compressionMethod: textDecoder.decode(reader.read(2)),
+    compressionMethod: reader.readUint16LE(),
     date: readDosDateTime(reader),
     crc32: reader.readUint32LE(),
     compressedLength: reader.readUint32LE(),

--- a/packages/zip/src/format-writer.js
+++ b/packages/zip/src/format-writer.js
@@ -72,7 +72,7 @@ function writeFile(writer, file) {
   // Version needed to extract
   writer.writeUint16LE(10);
   writer.writeUint16LE(file.bitFlag);
-  writer.write(textEncoder.encode(file.compressionMethod));
+  writer.writeUint16LE(file.compressionMethod);
   writeDosDateTime(writer, file.date);
   writer.writeUint32LE(file.crc32);
   writer.writeUint32LE(file.compressedLength);

--- a/packages/zip/src/types.js
+++ b/packages/zip/src/types.js
@@ -26,7 +26,7 @@
  *   mode: number,
  *   date: Date?,
  *   crc32: number,
- *   compressionMethod: string,
+ *   compressionMethod: number,
  *   compressedLength: number,
  *   uncompressedLength: number,
  *   content: Uint8Array,
@@ -36,7 +36,7 @@
  * @typedef {{
  *   versionNeeded: number,
  *   bitFlag: number,
- *   compressionMethod: string,
+ *   compressionMethod: number,
  *   date: Date?,
  *   crc32: number,
  *   compressedLength: number,


### PR DESCRIPTION
We encounter problems when attempting to decode the Uint8Array `[0, 0]` into a `"\x00\x00"` string under XS due to a limitation of our `TextDecoder` shim that is based on the XS `String.fromArrayBuffer` function on that engine https://github.com/Moddable-OpenSource/moddable/issues/644. This work-around maintains the easy values for values comparison of compression method magic numbers/strings by switching the internal representation from string to number.