### PR TITLE
feat: Expose package.jsons

### DIFF
--- a/packages/base64/NEWS.md
+++ b/packages/base64/NEWS.md
@@ -2,7 +2,8 @@ User-visible changes in base64:
 
 ## Next release
 
-* No changes yet
+* Expose internal `package.json` through Node.js ESM `exports` for the benefit
+  of `svelte` tooling.
 
 ## v0.1.0
 

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -14,9 +14,12 @@
   "unpkg": "./dist/base64.umd.js",
   "types": "./types/main.d.ts",
   "exports": {
-    "import": "./src/main.js",
-    "require": "./dist/base64.cjs",
-    "browser": "./dist/base64.umd.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/main.js",
+      "require": "./dist/base64.cjs",
+      "browser": "./dist/base64.umd.js"
+    }
   },
   "scripts": {
     "build": "yarn build:types && yarn build:dist",

--- a/packages/ses-ava/NEWS.md
+++ b/packages/ses-ava/NEWS.md
@@ -5,6 +5,8 @@ User-visible changes in SES-Ava
 - *BREAKING*: Removes compatibility layer for UMD and CommonJS consumers.
   Supporting both Node.js ESM and the `node -r esm` shim requires
   the main entry point module to be ESM regardless of environment.
+* Expose internal `package.json` through Node.js ESM `exports` for the benefit
+  of `svelte` tooling.
 
 ## Release 0.1.1 (5-April-2021)
 

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -7,7 +7,10 @@
   "type": "module",
   "main": "./src/main.js",
   "exports": {
-    "import": "./src/main.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/main.js"
+    }
   },
   "scripts": {
     "lint": "yarn lint:types && yarn lint:js",


### PR DESCRIPTION
Svelte tooling needs access to each package’s metadata. Node.js ESM now requires public access to modules in a package to be expressed in an `exports` property (if present). This change lines up `ses-ava` and `base64`, which lagged behind the current package skeleton.