### PR TITLE
fix(compartment-mapper): Generate strict bundle

### DIFF
--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -199,6 +199,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
   }
 
   const bundle = `\
+'use strict';
 (functors => {
   function cell(name, value = undefined) {
     const observers = [];

--- a/packages/ses/error-codes/SES_NO_SLOPPY.md
+++ b/packages/ses/error-codes/SES_NO_SLOPPY.md
@@ -1,0 +1,15 @@
+# SES failed to initialize, sloppy mode (SES_NO_SLOPPY)
+
+SES sources are ECMAScript modules and rely on the execution environment to
+correctly impose strict mode. If you see this error, it is most likely that you
+have used a tool that bundles SES, translating the modules into a single
+JavaScript program/script, but failing to add a `'use strict'` pragma, or
+appeneded the SES distribution bundle to another script that does not lead with
+`'use strict'`.
+
+We advise using `ses/dist/ses.cjs`, `ses.umd.js`, or `ses.umd.min.js` as a
+script or module directly, without passing it through a bundler or transpiler
+since any source-to-source transform may corrupt the security invariants that
+SES attempts to impose. These build products have been generated using
+a module-to-program transform designed for SES that preserves the validity
+of the sources.

--- a/packages/ses/index.js
+++ b/packages/ses/index.js
@@ -23,6 +23,15 @@ import {
 } from './src/compartment-shim.js';
 import { assert } from './src/error/assert.js';
 
+/** getThis returns globalThis in sloppy mode or undefined in strict mode. */
+function getThis() {
+  return this;
+}
+
+if (getThis()) {
+  throw new Error(`SES failed to initialize, sloppy mode (SES_NO_SLOPPY)`);
+}
+
 const nativeBrander = tameFunctionToString();
 
 const Compartment = makeCompartmentConstructor(


### PR DESCRIPTION
Integration with Agoric SDK revealed that the SES bundle, now generated by the compartment-map bundler instead of rollup, by virtue of running under CommonJS rules, was not running in strict mode as is default for ESM. This invalidated SES lockdown which complained vigorously about `arguments` and `caller` properties on some of its own repaired functions. This addresses the issue by generating strict mode bundles.

The bundle as written is sufficient for our purpose but does not compose concatenatively, which is sometimes consider a good practice for UMD style bundles. I’m open to the option of wrapping the entire bundle in yet-another-IFFE if folks feel strongly about that invariant.