### PR TITLE
test: Mute certain test logs

### DIFF
--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -64,7 +64,7 @@ test('export default', t => {
 function initialize(t, source, options = {}) {
   const { endowments, imports = new Map() } = options;
   const record = new StaticModuleRecord(source);
-  t.log(record.__syncModuleProgram__);
+  // t.log(record.__syncModuleProgram__);
   const liveUpdaters = {};
   const onceUpdaters = {};
   const namespace = {};
@@ -665,7 +665,7 @@ test('export name as default from', t => {
   } = new StaticModuleRecord(`
     export { meaning as default } from './meaning.js';
   `);
-  t.log(__syncModuleProgram__);
+  // t.log(__syncModuleProgram__);
   t.deepEqual(__fixedExportMap__, {});
   t.deepEqual(__liveExportMap__, {
     default: ['meaning', false],

--- a/packages/syrup/test/test-fuzz.js
+++ b/packages/syrup/test/test-fuzz.js
@@ -110,8 +110,8 @@ for (let i = 0; i < 1000; i += 1) {
     const syrup2 = encodeSyrup(object1);
     const desc = JSON.stringify(new TextDecoder().decode(syrup2));
     test(`fuzz ${index}`, t => {
-      t.log(random());
-      t.log(object1);
+      // t.log(random());
+      // t.log(object1);
       const object3 = decodeSyrup(syrup2);
       const syrup4 = encodeSyrup(object3);
       t.deepEqual(object1, object3, desc);


### PR DESCRIPTION
These debug logs were intended to be useful in case tests fail, but sometimes generate data that causes a console beep or is simply too verbose to be useful from the top-level `yarn test`.