### PR TITLE
fix: Regularize format of NEWS.md

### DIFF
--- a/packages/base64/NEWS.md
+++ b/packages/base64/NEWS.md
@@ -2,17 +2,17 @@ User-visible changes in base64:
 
 ## Next release
 
-* *BREAKING*: Removes CommonJS and UMD downgrade compatibility.
+- *BREAKING*: Removes CommonJS and UMD downgrade compatibility.
   Supporting both Node.js ESM and the `node -r esm` shim requires the main
   entry point module to be ESM regardless of environment.
   UMD and CommonJS facets will likely return after all dependees have migrated
   away from depending upon the `esm` JavaScript module emulator.
-* Separates entry points for `@endo/base64/encode.js` and
+- Separates entry points for `@endo/base64/encode.js` and
   `@endo/base64/decode.js`, in addition to the combined entry point at
   `@endo/base64`.
-* Expose internal `package.json` through Node.js ESM `exports` for the benefit
+- Expose internal `package.json` through Node.js ESM `exports` for the benefit
   of `svelte` tooling.
 
-## v0.1.0
+# 0.1.0
 
-* Initial version.
+- Initial version.

--- a/packages/cjs-module-analyzer/NEWS.md
+++ b/packages/cjs-module-analyzer/NEWS.md
@@ -1,3 +1,5 @@
+User-visible changes to the CommonJS module analyzer:
+
 # Next release
 
 - Initial version.

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -2,71 +2,71 @@ User-visible changes to the compartment mapper:
 
 ## Next release
 
-* Reenables CommonJS support with a fast lexer and without a dependency on
+- Reenables CommonJS support with a fast lexer and without a dependency on
   Babel.
-* The Compartment Mapper now produces archives containing SES-shim
+- The Compartment Mapper now produces archives containing SES-shim
   pre-compiled StaticModuleRecords for ESM instead of the source.
-* The Compartment Mapper can now produce bundles of concatenated modules but
+- The Compartment Mapper can now produce bundles of concatenated modules but
   without Compartments and only supporting ESM but not supporting live
   bindings.
-* Adds entrypoint modules `import.js`, `archive.js`, and `import-archive.js`
+- Adds entrypoint modules `import.js`, `archive.js`, and `import-archive.js`
   to capture narrower dependency subgraphs.
-* *BREAKING*: Removes CommonJS and UMD downgrade compatibility.
+- *BREAKING*: Removes CommonJS and UMD downgrade compatibility.
   Supporting both Node.js ESM and the `node -r esm` shim requires the main
   entry point module to be ESM regardless of environment.
   UMD and CommonJS facets will likely return after all dependees have migrated
   away from depending upon the `esm` JavaScript module emulator.
-* *BREAKING*: Archives created for the previous version will no longer work.
+- *BREAKING*: Archives created for the previous version will no longer work.
   The `importArchive` feature only supports pre-compiled ESM and CJS.
-* *BREAKING*: This release parallels a breaking upgrade for SES to version
+- *BREAKING*: This release parallels a breaking upgrade for SES to version
   0.13. This entails the removal of `StaticModuleRecord` from SES, and the
   removal of the `ses/lockdown` light layering (there is no heavy layer to
   distinguish as the weight has shifted to the `@endo/static-module-record`
   package).
-* Archives are now deterministic.
+- Archives are now deterministic.
 
-## 0.2.4 (2021-03-30)
+# 0.2.4 (2021-03-30)
 
-* Applications may now have asynchronous module transforms, per language.
+- Applications may now have asynchronous module transforms, per language.
   When applied to archive creation, the transformed sources appear in the
   archive.
-* Every compartment's `globalThis` is frozen.
+- Every compartment's `globalThis` is frozen.
 
-## 0.2.3 (2020-11-05)
+# 0.2.3 (2020-11-05)
 
-* Embellishes all calls to methods named `import` to work around SES-shim
+- Embellishes all calls to methods named `import` to work around SES-shim
   `Compartment` censoring for dynamic import, using properties instead
   of parentheses, since the syntax transformation tools at hand do not
   currently simplify these.
 
-## 0.2.2 (2020-11-05)
+# 0.2.2 (2020-11-05)
 
-* Embellishes all calls to methods named `import` to work around SES-shim
+- Embellishes all calls to methods named `import` to work around SES-shim
   `Compartment` censoring for dynamic import.
 
-## 0.2.1 (2020-11-04)
+# 0.2.1 (2020-11-04)
 
-* Changes all private fields to internal weak maps to Compartment Mapper
+- Changes all private fields to internal weak maps to Compartment Mapper
   can be read by parsers that do not yet support private fields.
 
-## 0.2.0 (2020-11-03)
+# 0.2.0 (2020-11-03)
 
-* *BREAKING*: All `import` methods now take an options bag that may contain
+- *BREAKING*: All `import` methods now take an options bag that may contain
   `globals` and `modules` options if present, instead of these as positional
   arguments.
-* *BREAKING*: Support for CommonJS is temporarily withdrawn to relieve a
+- *BREAKING*: Support for CommonJS is temporarily withdrawn to relieve a
   dependency on Node.js built-ins entrained by Babel that in turn make
   Compartment Mapper unusable with a combination of `-r esm` and Rollup.
   CommonJS support should be restored with an alternate implementation in
   a future version.
-* The `import` options bag now also accepts `globalLexicals`, `transforms`, and
+- The `import` options bag now also accepts `globalLexicals`, `transforms`, and
   `__shimTransforms__`, passing these without alteration to each `Compartment`.
-* The `import` options bag now also accepts a `Compartment` constructor, to use
+- The `import` options bag now also accepts a `Compartment` constructor, to use
   instead of the one assumed to be present globally.
 
-## Release 0.1.0 (2020-09-21)
+#  0.1.0 (2020-09-21)
 
-* This initial relase supports importing, archiving, and importing archives
+- This initial relase supports importing, archiving, and importing archives
   with the same authorities delegated to every compartment in an application.
   Future releases will support the attenuation of authority per-compartment,
   broaden support for Node.js module conventions, address the issue

--- a/packages/netstring/NEWS.md
+++ b/packages/netstring/NEWS.md
@@ -1,3 +1,5 @@
+User-visible changes to netstring:
+
 ## Next release
 
 - *BREAKING*: Removes CommonJS and UMD downgrade compatibility.
@@ -7,6 +9,6 @@
   away from depending upon the `esm` JavaScript module emulator.
 - Fixes a problem with the external visibility of TypeScript types.
 
-## Release 0.1.0 (2021-04-26)
+# 0.1.0 (2021-04-26)
 
 - Initial release

--- a/packages/ses-ava/NEWS.md
+++ b/packages/ses-ava/NEWS.md
@@ -1,4 +1,4 @@
-User-visible changes in SES-Ava
+User-visible changes in SES-Ava:
 
 ## Next Release
 
@@ -10,10 +10,10 @@ User-visible changes in SES-Ava
 * Expose internal `package.json` through Node.js ESM `exports` for the benefit
   of `svelte` tooling.
 
-## Release 0.1.1 (5-April-2021)
+# 0.1.1 (2021-05-05)
 
 - Extended ses-ava to support the macro feature of the Ava API.
 
-## Release 0.1.0
+# 0.1.0
 
 - Initial release.

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -45,7 +45,7 @@ User-visible changes in SES:
   We hope to add such explanations for more errors over time. Please let us
   know as you encounter errors that strongly needs explaining.
 
-## Release 0.12.7 (5-April-2021)
+# 0.12.7 (2021-05-05)
 
 - Added to `assert.error` an optional options bag with an option named
   `errorName`. The `assert.error` function makes error objects with detailed
@@ -57,7 +57,7 @@ User-visible changes in SES:
   so that it can be traced back to the site that serialized it; and
   ultimately to its origin.
 
-## Release 0.12.6 (27-Mar-2021)
+# 0.12.6 (2021-03-27)
 
 - Added a new temporary `__allowUnsafeMonkeyPatching__` option to `lockdown`.
 
@@ -70,14 +70,14 @@ User-visible changes in SES:
   [\_\_allowUnsafeMonkeyPatching\_\_ Options](./lockdown-options.md#__allowUnsafeMonkeyPatching__-options)
   section of [lockdown-options](./lockdown-options.md).
 
-## Release 0.12.5 (25-Mar-2021)
+# 0.12.5 (2021-03-25)
 
 - The 0.12.4 release was broken by https://github.com/endojs/endo/pull/552
   since fixed by https://github.com/endojs/endo/pull/638
 - These merely remove a repair needed by an old v8 / Node version that
   no one any longer supports.
 
-## Release 0.12.4 (24-Mar-2021)
+# 0.12.4 (2021-03-24)
 
 - Expand TypeScript definitions to include Compartment, StaticModuleRecord,
   StaticModuleType, RedirectStaticModuleInterface, FinalStaticModuleType,
@@ -120,7 +120,7 @@ User-visible changes in SES:
    Note that the information rendered by the SES shim `console` object always includes all the unredacted data independent of the setting of `errorTaming`.
 
 
-## Release 0.12.3 (1-Mar-2021)
+# 0.12.3 (2021-03-01)
 
 - The `assert.js` module in the `ses` package of this repository exports
   a `makeAssert` function, to make other `assert` functions with a different
@@ -167,12 +167,12 @@ User-visible changes in SES:
   a patch) we have stopped enabling this assignment, and so stopped
   confusing the Node debugger.
 
-## Release 0.12.2 (5-Feb-2021)
+# 0.12.2 (2021-02-05)
 
 - fix non-standard regex range syntax that throws on XS (3877d72)
 - refine concise stack traces (cbbabeb)
 
-## Release 0.12.1 (2-Feb-2021)
+# 0.12.1 (2021-02-02)
 
 - Consolidated documentation of [`lockdown` options](./lockdown-options.md) into its
   own page.
@@ -224,7 +224,7 @@ all the code you're running under SES.
 
 </details>
 
-## Release 0.11.1 (21-January-2021)
+# 0.11.1 (2021-01-21)
 
 - Upgrades `harden` such that that it transitively freezes an object's
   prototype chain, eliminating the notion of a "fringe set" and errors
@@ -241,7 +241,7 @@ all the code you're running under SES.
   throw errors that contain the `sourceURL` from any `//#sourceURL=` comment
   toward the end of the source or merely `<unknown>`.
 
-## Release 0.11.0 (3-November-2020)
+# 0.11.0 (2020-11-03)
 
 - `lockdown()` adds new global `assert` and tames the global `console`. The
   error taming hides error stacks, accumulating them in side tables. The
@@ -253,7 +253,7 @@ all the code you're running under SES.
   for both programs passed to `evaluate` and modules that the SES shim
   compiles to programs.
 
-## Release 0.10.4 (28-September-2020)
+# 0.10.4 (2020-09-28)
 
 - When converting each of [these data properties](src/enablements.js) to
   accessor properties, to suppress the
@@ -264,7 +264,7 @@ all the code you're running under SES.
 - Fixes an exception thrown when calling `lockdown` after just importing
   `ses/lockdown` in all environments.
 
-## Release 0.10.3 (8-September-2020)
+# 0.10.3 (2020-09-08)
 
 - The `ses/lockdown` module and Rollup bundles now include a minimal
   implementation of `Compartment` that supports `evaluate` but not loading
@@ -281,7 +281,7 @@ all the code you're running under SES.
   At this time, the intermediate stacks of the causal chain are lost.
   https://github.com/Agoric/SES-shim/issues/440
 
-## Release 0.10.2 (20-August-2020)
+# 0.10.2 (2020-08-20)
 
 - Adds a `moduleMapHook` option to the `Compartment` constructor options.
   The module map hook can return values for the `moduleMap` for
@@ -290,7 +290,7 @@ all the code you're running under SES.
   This allows for wildcard linkage to other compartments.
 - Fix dependency version for `@agoric/transform-module`.
 
-## Release 0.10.1 (13-August-2020)
+# 0.10.1 (2020-08-13)
 
 - Updates the whitelist to allow a `HandledPromise` global, which is provided
   by `@agoric/eventual-send`, an early implementation of
@@ -300,7 +300,7 @@ all the code you're running under SES.
   A property created by assignment will now be a writable, enumerable,
   configurable data property, as it is for normal assignment.
 
-## Release 0.10.0 (8-August-2020)
+# 0.10.0 (2020-08-08)
 
 - Creates a `ses/lockdown` module that only introduces `lockdown` and `harden`
   to global scope, for a much smaller payload than `ses`, which entrains a
@@ -311,14 +311,14 @@ all the code you're running under SES.
 - Adds support for third-party implementations of a `StaticModuleRecord`
   interface (`{imports, execute}`).
 
-## Release 0.9.1 (16-July-2020)
+# 0.9.1 (2020-07-16)
 
 - The `*Locale*` methods removed in the previous release are now restored
   by aliasing them to their non-locale equivalents. `localeCompare` had no builtin
   non-locale equivalent, so we provide one.
 - Adds a TypeScript definition for `harden`.
 
-## Release 0.9.0 (13-July-2020)
+# 0.9.0 (2020-07-13)
 
 - BREAKING CHANGE: The compartment `evaluate` method no longer accepts an
   `endowments` option.
@@ -342,7 +342,7 @@ all the code you're running under SES.
   modules.
   The global lexicals overshadow the global object.
 
-## Release 0.8.0 (26-May-2020)
+# 0.8.0 (2020-05-26)
 
 - Adds support for modules to Compartments.
 - SES no longer exports anything.
@@ -371,7 +371,7 @@ all the code you're running under SES.
   [#293]: https://github.com/Agoric/SES-shim/issues/293
   [#326]: https://github.com/Agoric/SES-shim/issues/326
 
-## Release 0.7.7 (27-Apr-2020)
+# 0.7.7 (2020-04-27)
 
 - This version decouples lockdown and the Compartment constructor.
   The Compartment constructor is now exported by `ses` (was previously only
@@ -379,12 +379,12 @@ all the code you're running under SES.
   The Compartment constructor will also create "privileged" compartments when
   constructed before lockdown.
 
-## Release 0.7.6 (31-Mar-2020)
+# 0.7.6 (2020-03-31)
 
 Bug fixes.
 This release fixes issues in RegExp and Error taming.
 
-## Release 0.7.4-5 (21-Mar-2020)
+# 0.7.4-5 (2020-03-21)
 
 This release adds Node.js ESM support by upgrading @agoric/make-hardener to a
 hybrid version for most modern module systems.
@@ -393,7 +393,7 @@ hybrid version for most modern module systems.
 
 - upgrade @agoric/make-hardener v0.0.8
 
-## Release 0.7.2-3 (13-Mar-2020)
+# 0.7.2-3 (2020-03-13)
 
 Bug fixes.
 This release addresses an exception observed where locking down fails because
@@ -402,7 +402,7 @@ This is addressed by upgrading @agoric/make-harden to version 0.0.7.
 This release also restores fulls upport for importing SES as CommonJS, Node.js
 ESM, and Node.js emulated ESM with the `esm` package.
 
-## Release 0.7.1 (10-Mar-2020)
+# 0.7.1 (2020-13-10)
 
 SECURITY UPDATE: This complete re-architecture which removes the realm-shim and
 resolve the associatd sandbox escapes related to leaking cross-realm
@@ -410,7 +410,7 @@ intrinsics. All users should update to this version.
 
 See [docs/ses-0.7.md].
 
-## Release 0.6.4 (16-Oct-2019)
+# 0.6.4 (2019-10-16)
 
 SECURITY UPDATE: This release upgrades realms-shim to fix multiple sandbox
 escapes. All users should update to this version.
@@ -421,7 +421,7 @@ Non-security fixes:
 
 - improve documentation
 
-## Release 0.6.3 (02-Oct-2019)
+# 0.6.3 (2019-10-02)
 
 SECURITY UPDATE: This release upgrades realms-shim to fix multiple sandbox
 escapes. All users should update to this version.
@@ -432,14 +432,14 @@ Non-security fixes:
 
 - add `SES.harden` to make hardening available from within the Realm. (#161)
 
-## Release 0.6.2 (25-Sep-2019)
+# 0.6.2 (2019-09-25)
 
 No user-visible changes.
 
 Use realms-shim as a normal package, not a git-submodule. Update eslint
 dependencies.
 
-## Release 0.6.1 (14-Sep-2019)
+# 0.6.1 (2019-19-14)
 
 - SECURITY UPDATE: This release fixes a sandbox escape discovered in the
   realms-shim by GitHub user "XmiliaH", which works by causing an infinite
@@ -447,7 +447,7 @@ dependencies.
   exception object. See https://github.com/Agoric/realms-shim/issues/48 for
   more details.
 
-## Release 0.6.0 (03-Sep-2019)
+# 0.6.0 (2019-09-03)
 
 - Breaking change: `options.transforms` may no longer specify `endow()`
   transforms. Instead, use `rewrite()`, which can now modify endowments.
@@ -465,15 +465,15 @@ dependencies.
   in the new realm. The default gives you SES, but it could be overridden to
   e.g. enforce a Jessie-only environment.
 
-## Release 0.5.3 (24-Jul-2019)
+# 0.5.3 (2019-07-24)
 
 - Re-enable indirect eval. (#131)
 
-## Release 0.5.2 (13-Jul-2019)
+# 0.5.2 (2019-07-13)
 
 Dependency updates only, no user-visible changes.
 
-## Release 0.5.1 (10-Jul-2019)
+# 0.5.1 (2019-07-10)
 
 - The 'realms-shim' module, upon which SES depends, has been split out of the
   TC39 'proposal-realms' repository, and now lives in
@@ -487,7 +487,7 @@ Dependency updates only, no user-visible changes.
 Thanks to Kate Sills, Dan Connolly, Michael Fig, and the ever-dependable
 Dependabot for additional fixes in this release.
 
-## Release 0.5.0 (05-Apr-2019)
+# 0.5.0 (2019-04-05)
 
 INCOMPATIBLE API CHANGE: Starting with this release, the SES package exports
 a single default object (named `SES`, from which you can get the
@@ -524,7 +524,7 @@ Other changes:
 Thanks to Matt Bell, Kate Sills, and Mark Miller for additional fixes in this
 release.
 
-## Release 0.4.0 (20-Feb-2019)
+# 0.4.0 (2019-02-20)
 
 Improve usability.
 
@@ -546,7 +546,7 @@ Improve usability.
 - Include AsyncIteratorPrototype in the set of anonIntrinsics #58
 - use eslint to format all SES code
 
-## Release 0.3.0 (08-Feb-2019)
+# 0.3.0 (2019-02-08)
 
 Improves security and functionality.
 
@@ -585,7 +585,7 @@ It also improves usability:
 
 SES now requires Node.js version 10 or later.
 
-## Release 0.2.0 (18-Jan-2019)
+# 0.2.0 (2019-01-18)
 
 Improves confinement, small API changes.
 
@@ -616,7 +616,7 @@ natural number (a non-negative integer small enough to remain an integer
 inside a Javascript `Number` type). Both are important for defensive
 programming.
 
-## Release 0.1.3 (24-Aug-2018)
+# 0.1.3 (2018-08-24)
 
 Adds Nat and SES.confineExpr.
 
@@ -626,11 +626,11 @@ Adds Nat and SES.confineExpr.
 
 This also updates the challenge page to fix a demo vulnerability (#8).
 
-## Release 0.1.2 (30-Jul-2018)
+# 0.1.2 (2018-07-30)
 
 - npm name is now 'ses'
 - update to current proposal-realms
 
-## Release 0.0.1 (28-Jul-2018)
+# 0.0.1 (2018-07-28)
 
 first preliminary release

--- a/packages/static-module-record/NEWS.md
+++ b/packages/static-module-record/NEWS.md
@@ -1,26 +1,27 @@
+User-visible changes in Static Module Record, née Transform Module:
 
 # Next release
 
-* *BREAKING CHANGE* This package has been renamed `@endo/static-module-record`.
-* *BREAKING CHANGE* This package now only exports a `StaticModuleRecord`
+- *BREAKING CHANGE* This package has been renamed `@endo/static-module-record`.
+- *BREAKING CHANGE* This package now only exports a `StaticModuleRecord`
   constructor, suitable for use with the SES shim `importHook` starting with
   version 0.13.0.
-* *BREAKING*: Removes CommonJS and UMD downgrade compatibility.
+- *BREAKING*: Removes CommonJS and UMD downgrade compatibility.
   Supporting both Node.js ESM and the `node -r esm` shim requires the main
   entry point module to be ESM regardless of environment.
   UMD and CommonJS facets will likely return after all dependees have migrated
   away from depending upon the `esm` JavaScript module emulator.
 
-# v0.4.1 (2020-08-20)
+# 0.4.1 (2020-08-20)
 
-* Removes extraneous dependencies that blocked installation.
+- Removes extraneous dependencies that blocked installation.
 
-# v0.4.0 (2020-08-20)
+# 0.4.0 (2020-08-20)
 
-* This version changes the contract of all functions that receive a Babel
+- This version changes the contract of all functions that receive a Babel
   dependency from accepting an object implementing { transformSync and
   transformFromAstSync } to merely { transform and transformFromAst }.
   The former were exported by `@babel/core`, but we are now using the
   API that surfaces from `@babel/standalone` and our fork
   `@agoric/babel-standalone`.
-* Module static records are now frozen.
+- Module static records are now frozen.

--- a/packages/zip/NEWS.md
+++ b/packages/zip/NEWS.md
@@ -1,3 +1,5 @@
+User-visible changes in Zip:
+
 # Next release
 
 - Initial version.


### PR DESCRIPTION
This mechanical change regularizes the format of NEWS.md across all Endo packages, including the heading level, date format, and bullet kind. The latter are consistent with the new Lerna CHANGELOG format, so it’s easier to update.