### PR TITLE
chore: Update Lerna configuration

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,8 @@
     "version": {
       "message": "chore(release): publish",
       "conventionalCommits": true,
-      "preid": "dev"
+      "preid": "dev",
+      "changelogPreset": "conventionalcommits"
     }
   },
   "packages": [

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,13 @@
 {
+  "command": {
+    "version": {
+      "message": "chore(release): publish",
+      "conventionalCommits": true,
+      "preid": "dev"
+    }
+  },
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@typescript-eslint/parser": "^4.25.0",
+    "conventional-changelog-conventionalcommits": "^4.6.0",
     "patch-package": "^6.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4017,6 +4017,15 @@ conventional-changelog-angular@^5.0.3:
     compare-func "^2.0.0"
     q "^1.5.1"
 
+conventional-changelog-conventionalcommits@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz#7fc17211dbca160acf24687bd2fdd5fd767750eb"
+  integrity sha512-sj9tj3z5cnHaSJCYObA9nISf7eq/YjscLPoq6nmew4SiOjxqL2KRpK20fjnjVbpNDjJ2HR3MoVcWKXwbVvzS0A==
+  dependencies:
+    compare-func "^2.0.0"
+    lodash "^4.17.15"
+    q "^1.5.1"
+
 conventional-changelog-core@^3.1.6:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.2.3.tgz#b31410856f431c847086a7dcb4d2ca184a7d88fb"


### PR DESCRIPTION
This change parallels https://github.com/Agoric/agoric-sdk/pull/3230 and configures Lerna to behave consistently with the npm semantics of `^0` dependencies, both for recommending versions and building a change log based on conventional commits.