### PR TITLE
fix: Remove defunct workspace packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "packages/endo",
     "packages/eslint-config",
     "packages/eslint-plugin",
-    "packages/harden",
-    "packages/make-hardener",
-    "packages/make-importer",
     "packages/netstring",
     "packages/ses",
     "packages/ses-ava",
@@ -20,7 +17,6 @@
     "packages/syrup",
     "packages/test262-runner",
     "packages/test262-runner",
-    "packages/transform-module",
     "packages/zip"
   ],
   "engines": {


### PR DESCRIPTION
These packages are no longer in the repository and need to be garbage collected for tooling.
