### PR TITLE
fix: Fix some stray packaging mistakes

### DIFF
--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -18,10 +18,8 @@
     "url": "https://github.com/endojs/endo/issues"
   },
   "type": "module",
-  "main": "./dist/base64.cjs",
+  "main": "./index.js",
   "module": "./index.js",
-  "browser": "./dist/base64.umd.js",
-  "unpkg": "./dist/base64.umd.js",
   "types": "./index.d.ts",
   "exports": {
     ".": "./index.js",

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -14,7 +14,6 @@
   "bugs": {
     "url": "https://github.com/Agoric/SES-shim/issues"
   },
-  "main": "index.js",
   "scripts": {
     "build": "exit 0",
     "lint": "eslint '**/*.js'",


### PR DESCRIPTION
These are a couple discrepancies I’ve discovered in the packaging of base64 and ses-integration-test, the former revealed through integration testing with Agoric SDK.