### PR TITLE
fix(ses): Export hardener types properly

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in SES:
 
+# Next release
+
+- Fixes type exports for `harden`.
+
 # 0.13.0 (2021-06-01)
 
 - *BREAKING CHANGE* The `ses/lockdown` module is again just `ses`.

--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -2,7 +2,7 @@
 /**
  * Transitively freeze an object.
  */
-import type { Hardener } from '@agoric/make-hardener';
+import type { Hardener } from './src/make-hardener';
 import type { CompartmentConstructor } from './src/compartment-shim';
 import type { Lockdown } from './src/lockdown-shim';
 import type { StaticModuleRecord } from './module-shim';


### PR DESCRIPTION
In the removal of the consolidation of the `@agoric/make-hardener` package into SES, the SES type definition needed this update.
