### PR TITLE
chore(release): publish

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/base64@0.2.0...@endo/base64@0.2.1) (2021-06-06)
+
+
+### Bug Fixes
+
+* Fix some stray packaging mistakes ([0eb9297](https://github.com/endojs/endo/commit/0eb9297b1fc9753c235c53d746aa7d7994781216))
+
+
+
 ## 0.2.0 (2021-06-02)
 
 

--- a/packages/base64/NEWS.md
+++ b/packages/base64/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in base64:
 
+# 0.2.1 (2021-06-05)
+
+- Packaging fixes.
+
 # 0.2.0 (2021-06-01)
 
 - *BREAKING*: Removes CommonJS and UMD downgrade compatibility.

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Transcodes base64",
   "keywords": [
     "base64",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.0...@endo/cjs-module-analyzer@0.2.1) (2021-06-06)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ## 0.2.0 (2021-06-02)
 
 

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",
@@ -29,7 +29,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.3.0...@endo/compartment-mapper@0.3.1) (2021-06-06)
+
+**Note:** Version bump only for package @endo/compartment-mapper
+
+
+
+
+
 ## 0.3.0 (2021-06-02)
 
 

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -38,13 +38,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/cjs-module-analyzer": "^0.2.0",
-    "@endo/static-module-record": "^0.5.0",
-    "@endo/zip": "^0.2.0",
-    "ses": "^0.13.0"
+    "@endo/cjs-module-analyzer": "^0.2.1",
+    "@endo/static-module-record": "^0.5.1",
+    "@endo/zip": "^0.2.1",
+    "ses": "^0.13.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/endo/CHANGELOG.md
+++ b/packages/endo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.1](https://github.com/endojs/endo/compare/@endo/endo@0.1.0...@endo/endo@0.1.1) (2021-06-06)
+
+**Note:** Version bump only for package @endo/endo
+
+
+
+
+
 ## 0.1.0 (2021-06-02)
 
 

--- a/packages/endo/package.json
+++ b/packages/endo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/endo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Endo runs Node.js packaged applications in a sandbox",
   "keywords": [
@@ -28,11 +28,11 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/compartment-mapper": "^0.3.0",
-    "ses": "^0.13.0"
+    "@endo/compartment-mapper": "^0.3.1",
+    "ses": "^0.13.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.8](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.7...@endo/eslint-config@0.3.8) (2021-06-06)
+
+**Note:** Version bump only for package @endo/eslint-config
+
+
+
+
+
 ### 0.3.7 (2021-06-02)
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-config",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Endo style rules",
   "keywords": [
     "endo",
@@ -24,7 +24,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/eslint-plugin": "^0.3.3"
+    "@endo/eslint-plugin": "^0.3.4"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^4.18.0",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.4](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.3...@endo/eslint-plugin@0.3.4) (2021-06-06)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ### 0.3.3 (2021-06-02)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Endo-specific ESLint plugin",
   "keywords": [
     "eslint",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/netstring@0.2.0...@endo/netstring@0.2.1) (2021-06-06)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ## 0.2.0 (2021-06-02)
 
 

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,7 +32,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.0...@endo/ses-ava@0.2.1) (2021-06-06)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ## 0.2.0 (2021-06-02)
 
 

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -32,10 +32,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.13.0"
+    "ses": "^0.13.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.0.1](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.0...ses-integration-test@2.0.1) (2021-06-06)
+
+
+### Bug Fixes
+
+* Fix some stray packaging mistakes ([0eb9297](https://github.com/Agoric/SES-shim/commit/0eb9297b1fc9753c235c53d746aa7d7994781216))
+
+
+
 ## 2.0.0 (2021-06-02)
 
 

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,10 +30,10 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.13.0"
+    "ses": "^0.13.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.13.1](https://github.com/endojs/endo/compare/ses@0.13.0...ses@0.13.1) (2021-06-06)
+
+
+### Bug Fixes
+
+* **ses:** Export hardener types properly ([0d2e8f0](https://github.com/endojs/endo/commit/0d2e8f0570d7de06b54b4faee56f487bbf7aeb8b))
+
+
+
 ## 0.13.0 (2021-06-02)
 
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,8 +1,9 @@
 User-visible changes in SES:
 
-# Next release
+# 0.2.1 (2021-06-05)
 
 - Fixes type exports for `harden`.
+- Packaging fixes.
 
 # 0.13.0 (2021-06-01)
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Secure ECMAScript",
   "keywords": [
     "confinement",
@@ -42,10 +42,10 @@
     "test:platform-compatability": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.3.0",
-    "@endo/eslint-config": "^0.3.7",
-    "@endo/static-module-record": "^0.5.0",
-    "@endo/test262-runner": "^0.1.1",
+    "@endo/compartment-mapper": "^0.3.1",
+    "@endo/eslint-config": "^0.3.8",
+    "@endo/static-module-record": "^0.5.1",
+    "@endo/test262-runner": "^0.1.2",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.1](https://github.com/endojs/endo/compare/@endo/static-module-record@0.5.0...@endo/static-module-record@0.5.1) (2021-06-06)
+
+**Note:** Version bump only for package @endo/static-module-record
+
+
+
+
+
 ## 0.5.0 (2021-06-02)
 
 

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -38,8 +38,8 @@
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
-    "@endo/eslint-config": "^0.3.7",
-    "@endo/ses-ava": "^0.2.0",
+    "@endo/eslint-config": "^0.3.8",
+    "@endo/ses-ava": "^0.2.1",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",
@@ -49,7 +49,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "ses": "^0.13.0",
+    "ses": "^0.13.1",
     "typescript": "^4.0.5"
   },
   "files": [

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.1](https://github.com/endojs/endo/compare/@endo/syrup@0.1.0...@endo/syrup@0.1.1) (2021-06-06)
+
+**Note:** Version bump only for package @endo/syrup
+
+
+
+
+
 ## 0.1.0 (2021-06-02)
 
 

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.2](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.1...@endo/test262-runner@0.1.2) (2021-06-06)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### 0.1.1 (2021-06-02)
 
 

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Test262 Runner",
   "author": "Agoric",
@@ -17,7 +17,7 @@
     "test262-parser": "^2.2.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "sinon": "8.0.4"
   },
   "ava": {

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/zip@0.2.0...@endo/zip@0.2.1) (2021-06-06)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ## 0.2.0 (2021-06-02)
 
 

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",
@@ -35,7 +35,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.7",
+    "@endo/eslint-config": "^0.3.8",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",


### PR DESCRIPTION
## Packages that have NEWS.md updates

```diff
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/base64@0.2.0...@endo/base64@0.2.1) (2021-06-06)
+
+
+### Bug Fixes
+
+* Fix some stray packaging mistakes ([0eb9297](https://github.com/endojs/endo/commit/0eb9297b1fc9753c235c53d746aa7d7994781216))
+
+
+
 ## 0.2.0 (2021-06-02)
 
 
--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.0.1](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.0...ses-integration-test@2.0.1) (2021-06-06)
+
+
+### Bug Fixes
+
+* Fix some stray packaging mistakes ([0eb9297](https://github.com/Agoric/SES-shim/commit/0eb9297b1fc9753c235c53d746aa7d7994781216))
+
+
+
 ## 2.0.0 (2021-06-02)
 
 
--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.13.1](https://github.com/endojs/endo/compare/ses@0.13.0...ses@0.13.1) (2021-06-06)
+
+
+### Bug Fixes
+
+* **ses:** Export hardener types properly ([0d2e8f0](https://github.com/endojs/endo/commit/0d2e8f0570d7de06b54b4faee56f487bbf7aeb8b))
+
+
+
 ## 0.13.0 (2021-06-02)
 
 
```
