### PR TITLE
fix(ses-ava): Doc nit

### DIFF
--- a/packages/ses-ava/README.md
+++ b/packages/ses-ava/README.md
@@ -9,7 +9,7 @@ To use this module, create an Ava module wrapper in your target project.
 
 ```js
 import rawTest from 'ava';
-import { wrapTest } from '@agoric/ses-ava';
+import { wrapTest } from '@endo/ses-ava';
 
 const test = wrapTest(rawTest);
 ```


### PR DESCRIPTION
A minor typo missed in renaming `@agoric` to `@endo`.
