### PR TITLE
fix(ses): Fix {} error reports

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -9,6 +9,9 @@ User-visible changes in SES:
   Now it is possible to write libraries that are usable both in JS and SES,
   which can know whether to harden their API by the presence of harden in
   global scope.
+- Adds `errorTrapping` lockdown option and by default traps uncaught exceptions
+  and logs them back with their original stack traces.
+  These would previously appear as mysterios `{}` lines in Node.js.
 
 # 0.13.4 (2021-06-19)
 

--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -18,6 +18,7 @@ export interface LockdownOptions {
   regExpTaming?: 'safe' | 'unsafe';
   localeTaming?: 'safe' | 'unsafe';
   consoleTaming?: 'safe' | 'unsafe';
+  errorTrapping?: 'platform' | 'exit' | 'abort' | 'report';
   errorTaming?: 'safe' | 'unsafe';
   dateTaming?: 'safe' | 'unsafe'; // deprecated
   mathTaming?: 'safe' | 'unsafe'; // deprecated

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* global process, window */
 
 import { loggedErrorHandler as defaultHandler } from './assert.js';
 import { makeCausalConsole } from './console.js';
@@ -37,5 +38,34 @@ export const tameConsole = (
     };
   }
   const causalConsole = makeCausalConsole(originalConsole, loggedErrorHandler);
+
+  // Attach platform-specific error traps such that any error that bottoms out
+  // an event will get unwrapped by the causal console, revealing the error
+  // stack to the console for debugging.
+
+  // Node.js
+  if (
+    typeof process === 'object' &&
+    process !== null &&
+    typeof process.on === 'function' &&
+    typeof process.exit === 'function'
+  ) {
+    process.on('uncaughtException', error => {
+      causalConsole.error(error);
+      process.exit(process.exitCode || -1);
+    });
+  }
+
+  // Web
+  if (
+    typeof window === 'object' &&
+    window !== null &&
+    typeof window.addEventListener === 'function'
+  ) {
+    window.addEventListener('error', event => {
+      causalConsole.error(event.error);
+    });
+  }
+
   return { console: causalConsole };
 };

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -116,6 +116,7 @@ export const repairIntrinsics = (
     dateTaming = 'safe', // deprecated
     errorTaming = 'safe',
     mathTaming = 'safe', // deprecated
+    errorTrapping = 'platform',
     regExpTaming = 'safe',
     localeTaming = 'safe',
     consoleTaming = 'safe',
@@ -228,7 +229,11 @@ export const repairIntrinsics = (
   if (errorTaming !== 'unsafe') {
     optGetStackString = intrinsics['%InitialGetStackString%'];
   }
-  const consoleRecord = tameConsole(consoleTaming, optGetStackString);
+  const consoleRecord = tameConsole(
+    consoleTaming,
+    errorTrapping,
+    optGetStackString,
+  );
   globalThis.console = /** @type {Console} */ (consoleRecord.console);
 
   if (errorTaming === 'unsafe' && globalThis.assert === assert) {

--- a/packages/ses/test/console-error-trap/abort-lockdown.js
+++ b/packages/ses/test/console-error-trap/abort-lockdown.js
@@ -1,0 +1,1 @@
+lockdown({ errorTrapping: 'abort' });

--- a/packages/ses/test/console-error-trap/abort.js
+++ b/packages/ses/test/console-error-trap/abort.js
@@ -1,0 +1,3 @@
+import '../../index.js';
+import './abort-lockdown.js';
+import './hazard.js';

--- a/packages/ses/test/console-error-trap/default-lockdown.js
+++ b/packages/ses/test/console-error-trap/default-lockdown.js
@@ -1,0 +1,1 @@
+lockdown();

--- a/packages/ses/test/console-error-trap/default.js
+++ b/packages/ses/test/console-error-trap/default.js
@@ -1,3 +1,3 @@
 import '../../index.js';
-import '../lockdown-unsafe.js';
+import './default-lockdown.js';
 import './hazard.js';

--- a/packages/ses/test/console-error-trap/exit-code-lockdown.js
+++ b/packages/ses/test/console-error-trap/exit-code-lockdown.js
@@ -1,0 +1,3 @@
+/* global process */
+process.exitCode = 127;
+lockdown({ errorTrapping: 'exit' });

--- a/packages/ses/test/console-error-trap/exit-code.js
+++ b/packages/ses/test/console-error-trap/exit-code.js
@@ -1,0 +1,3 @@
+import '../../index.js';
+import './exit-code-lockdown.js';
+import './hazard.js';

--- a/packages/ses/test/console-error-trap/exit-lockdown.js
+++ b/packages/ses/test/console-error-trap/exit-lockdown.js
@@ -1,0 +1,1 @@
+lockdown({ errorTrapping: 'exit' });

--- a/packages/ses/test/console-error-trap/exit.js
+++ b/packages/ses/test/console-error-trap/exit.js
@@ -1,0 +1,3 @@
+import '../../index.js';
+import './exit-lockdown.js';
+import './hazard.js';

--- a/packages/ses/test/console-error-trap/hazard.js
+++ b/packages/ses/test/console-error-trap/hazard.js
@@ -1,1 +1,5 @@
+/* global setImmediate */
+setImmediate(() => {
+  throw new Error('I am once again throwing an error');
+});
 throw new Error('Shibboleth');

--- a/packages/ses/test/console-error-trap/hazard.js
+++ b/packages/ses/test/console-error-trap/hazard.js
@@ -1,0 +1,1 @@
+throw new Error('Shibboleth');

--- a/packages/ses/test/console-error-trap/index.html
+++ b/packages/ses/test/console-error-trap/index.html
@@ -1,0 +1,8 @@
+<!-- This is a demonstration page for manual verification of errorTrapping
+  behavior on the web. -->
+<meta charset="utf-8">
+<script src="../../dist/ses.umd.js"></script>
+<script>
+  lockdown();
+  throw new Error("Blorp");
+</script>

--- a/packages/ses/test/console-error-trap/index.js
+++ b/packages/ses/test/console-error-trap/index.js
@@ -1,0 +1,3 @@
+import '../../index.js';
+import '../lockdown-unsafe.js';
+import './hazard.js';

--- a/packages/ses/test/console-error-trap/platform-lockdown.js
+++ b/packages/ses/test/console-error-trap/platform-lockdown.js
@@ -1,0 +1,1 @@
+lockdown({ errorTrapping: 'platform' });

--- a/packages/ses/test/console-error-trap/platform.js
+++ b/packages/ses/test/console-error-trap/platform.js
@@ -1,0 +1,3 @@
+import '../../index.js';
+import './platform-lockdown.js';
+import './hazard.js';

--- a/packages/ses/test/console-error-trap/report-lockdown.js
+++ b/packages/ses/test/console-error-trap/report-lockdown.js
@@ -1,0 +1,1 @@
+lockdown({ errorTrapping: 'report' });

--- a/packages/ses/test/console-error-trap/report.js
+++ b/packages/ses/test/console-error-trap/report.js
@@ -1,0 +1,3 @@
+import '../../index.js';
+import './report-lockdown.js';
+import './hazard.js';

--- a/packages/ses/test/test-console-error-trap.js
+++ b/packages/ses/test/test-console-error-trap.js
@@ -1,0 +1,24 @@
+import test from 'ava';
+import { exec } from 'child_process';
+import { dirname, join } from 'path';
+
+const cwd = join(
+  dirname(new URL(import.meta.url).pathname),
+  'console-error-trap',
+);
+
+test.cb('errors reveal their stacks', t => {
+  t.plan(3);
+  exec('node index.js', { cwd }, (err, stdout, stderr) => {
+    t.assert(err, 'exit code should be non-zero');
+    t.assert(
+      stderr.includes('(Error#1)'),
+      'stderr should have an error marker',
+    );
+    t.assert(
+      stdout.includes('Error#1: Shibboleth'),
+      'stdout should contain error message',
+    );
+    t.end();
+  });
+});

--- a/packages/ses/test/test-console-error-trap.js
+++ b/packages/ses/test/test-console-error-trap.js
@@ -7,17 +7,79 @@ const cwd = join(
   'console-error-trap',
 );
 
-test.cb('errors reveal their stacks', t => {
-  t.plan(3);
-  exec('node index.js', { cwd }, (err, stdout, stderr) => {
-    t.assert(err, 'exit code should be non-zero');
+const exitAssertions = (t, expectedCode, altExpectedCode = expectedCode) => {
+  return (err, stdout, stderr) => {
+    t.log({ stdout, stderr });
+    t.assert(
+      err.code === expectedCode || err.code === altExpectedCode,
+      'exit error code',
+    );
     t.assert(
       stderr.includes('(Error#1)'),
       'stderr should have an error marker',
     );
     t.assert(
+      !stderr.includes('(Error#2)'),
+      'stderr should not have a second error marker',
+    );
+    t.assert(
       stdout.includes('Error#1: Shibboleth'),
       'stdout should contain error message',
+    );
+    t.assert(
+      !stdout.includes('Error#2'),
+      'stdout should not contain second error message',
+    );
+    t.end();
+  };
+};
+
+test.cb('errors reveal their stacks', t => {
+  t.plan(5);
+  exec('node default.js', { cwd }, exitAssertions(t, 255));
+});
+
+test.cb('errors reveal their stacks with errorTrapping: platform', t => {
+  t.plan(5);
+  exec('node platform.js', { cwd }, exitAssertions(t, 255));
+});
+
+test.cb('errors reveal their stacks with errorTrapping: exit', t => {
+  t.plan(5);
+  exec('node exit.js', { cwd }, exitAssertions(t, 255));
+});
+
+test.cb('errors reveal their stacks with errorTrapping: exit with code', t => {
+  t.plan(5);
+  exec('node exit-code.js', { cwd }, exitAssertions(t, 127));
+});
+
+test.cb('errors reveal their stacks with errorTrapping: abort', t => {
+  t.plan(5);
+  // Mac exits with null, Linux exits with code 134
+  exec('node abort.js', { cwd }, exitAssertions(t, null, 134));
+});
+
+test.cb('errors reveal their stacks with errorTrapping: report', t => {
+  t.plan(5);
+  exec('node report.js', { cwd }, (err, stdout, stderr) => {
+    t.log({ stdout, stderr });
+    t.is(err, null);
+    t.assert(
+      stderr.includes('(Error#1)'),
+      'stderr should have an error marker',
+    );
+    t.assert(
+      stderr.includes('(Error#2)'),
+      'stderr should have a second error marker',
+    );
+    t.assert(
+      stdout.includes('Error#1: Shibboleth'),
+      'stdout should contain error message',
+    );
+    t.assert(
+      stdout.includes('Error#2: I am once again'),
+      'stdout should contain second error message',
     );
     t.end();
   });


### PR DESCRIPTION
Errors are reported as `{}` when they are caught by Node.js or the web runtime because their stacks are censored. They must be caught with a platform hook and passed to the tamed console to reveal their stack. 

- test(ses): Test error output on Node.js (a failing test)
- fix(ses): Trap and report errors (fixes failing test)

Must be merged to keep the left traversal on git bisectable with passing tests.

Fixes #769
