### PR TITLE
Best effort assert printing

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -94,7 +94,7 @@ const DetailsTokenProto = freeze({
       return '[Not a DetailsToken]';
     }
     return getMessageString(hiddenDetails);
-  }
+  },
 });
 freeze(DetailsTokenProto.toString);
 

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -193,7 +193,7 @@ const makeError = (
   }
   const hiddenDetails = hiddenDetailsMap.get(optDetails);
   if (hiddenDetails === undefined) {
-    throw new Error(`unrecognized details ${optDetails}`);
+    throw new Error(`unrecognized details ${quote(optDetails)}`);
   }
   const messageString = getMessageString(hiddenDetails);
   const error = new ErrorConstructor(messageString);
@@ -243,7 +243,7 @@ const note = (error, detailsNote) => {
   }
   const hiddenDetails = hiddenDetailsMap.get(detailsNote);
   if (hiddenDetails === undefined) {
-    throw new Error(`unrecognized details ${detailsNote}`);
+    throw new Error(`unrecognized details ${quote(detailsNote)}`);
   }
   const logArgs = getLogArgs(hiddenDetails);
   const callbacks = hiddenNoteCallbackArrays.get(error);

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -77,7 +77,7 @@ const getMessageString = ({ template, args }) => {
 
 /**
  * Give detailsTokens a toString behavior. To minimize the overhead of
- * creating new detailsTokens, which is crucial, we do this with an
+ * creating new detailsTokens, we do this with an
  * inherited `this` sensitive `toString` method, even though we normally
  * avoid `this` sensitivity. To protect the method from inappropriate
  * `this` application, it does something interesting only for objects

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -90,10 +90,8 @@ freeze(redactedDetails);
  * @type {DetailsTag}
  */
 const unredactedDetails = (template, ...args) => {
-  const detailsToken = freeze({ __proto__: null });
   args = args.map(arg => (declassifiers.has(arg) ? arg : quote(arg)));
-  hiddenDetailsMap.set(detailsToken, { template, args });
-  return detailsToken;
+  return redactedDetails(template, ...args);
 };
 freeze(unredactedDetails);
 export { unredactedDetails };

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -118,7 +118,17 @@ const bestEffortStringify = (payload, spaces = undefined) => {
       }
     }
   };
-  return JSON.stringify(payload, replacer, spaces);
+  try {
+    return JSON.stringify(payload, replacer, spaces);
+  } catch (_err) {
+    // Don't do anything more fancy here if there is any
+    // chance that might throw, unless you surround that
+    // with another try-catch-recovery. For example,
+    // the caught thing might be a proxy or other exotic
+    // object rather than an error. The proxy might throw
+    // whenever it is possible for it to.
+    return '[Something that failed to stringify]';
+  }
 };
 freeze(bestEffortStringify);
 export { bestEffortStringify };

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -426,10 +426,11 @@ test('q as best efforts stringify', t => {
     },
     2 ** 54,
     { superTagged, subTagged, subTaggedNonEmpty },
+    { __proto__: null },
   ];
   t.is(
     `${q(challenges)}`,
-    '["[Promise]","[Function foo]","[[hilbert]]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"NaN":"[NaN]","Infinity":"[Infinity]","neg":"[-Infinity]"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":"[Tagged]"}]',
+    '["[Promise]","[Function foo]","[[hilbert]]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"NaN":"[NaN]","Infinity":"[Infinity]","neg":"[-Infinity]"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":"[Tagged]"},{}]',
   );
   t.is(
     `${q(challenges, '  ')}`,
@@ -457,7 +458,8 @@ test('q as best efforts stringify', t => {
     "superTagged": "[Tagged]",
     "subTagged": "[Tagged]",
     "subTaggedNonEmpty": "[Tagged]"
-  }
+  },
+  {}
 ]`,
   );
 });
@@ -467,4 +469,24 @@ test('printing detailsToken', t => {
   t.throws(() => assert.error({ __proto__: null }), {
     message: 'unrecognized details {}',
   });
+});
+
+test('q tolerates always throwing exotic', t => {
+
+  /**
+   * alwaysThrowHandler
+   * This is an object that throws if any propery is called. It's used as
+   * a proxy handler which throws on any trap called.
+   * It's made from a proxy with a get trap that throws. It's safe to
+   * create one and share it between all scopeHandlers.
+   */
+  const alwaysThrowHandler = new Proxy({ __proto__: null }, {
+    get(_shadow, _prop) {
+      throw Error('Always throw');
+    },
+  });
+
+  const alwaysThrowProxy = new Proxy({ __proto__: null }, alwaysThrowHandler);
+
+  t.is(`${q(alwaysThrowProxy)}`, '[Something that failed to stringify]');
 });

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -472,7 +472,6 @@ test('printing detailsToken', t => {
 });
 
 test('q tolerates always throwing exotic', t => {
-
   /**
    * alwaysThrowHandler
    * This is an object that throws if any propery is called. It's used as
@@ -480,11 +479,14 @@ test('q tolerates always throwing exotic', t => {
    * It's made from a proxy with a get trap that throws. It's safe to
    * create one and share it between all scopeHandlers.
    */
-  const alwaysThrowHandler = new Proxy({ __proto__: null }, {
-    get(_shadow, _prop) {
-      throw Error('Always throw');
+  const alwaysThrowHandler = new Proxy(
+    { __proto__: null },
+    {
+      get(_shadow, _prop) {
+        throw Error('Always throw');
+      },
     },
-  });
+  );
 
   const alwaysThrowProxy = new Proxy({ __proto__: null }, alwaysThrowHandler);
 

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -461,3 +461,10 @@ test('q as best efforts stringify', t => {
 ]`,
   );
 });
+
+// See https://github.com/endojs/endo/issues/729
+test('printing detailsToken', t => {
+  t.throws(() => assert.error({ __proto__: null }), {
+    message: 'unrecognized details {}',
+  });
+});

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -474,10 +474,9 @@ test('printing detailsToken', t => {
 test('q tolerates always throwing exotic', t => {
   /**
    * alwaysThrowHandler
-   * This is an object that throws if any propery is called. It's used as
+   * This is an object that throws if any propery is read. It's used as
    * a proxy handler which throws on any trap called.
-   * It's made from a proxy with a get trap that throws. It's safe to
-   * create one and share it between all scopeHandlers.
+   * It's made from a proxy with a get trap that throws.
    */
   const alwaysThrowHandler = new Proxy(
     { __proto__: null },
@@ -488,6 +487,11 @@ test('q tolerates always throwing exotic', t => {
     },
   );
 
+  /**
+   * A proxy that throws on any trap, i.e., the proxy throws whenever in can
+   * throw. Potentially useful in many other tests. TODO put somewhere reusable
+   * by other tests.
+   */
   const alwaysThrowProxy = new Proxy({ __proto__: null }, alwaysThrowHandler);
 
   t.is(`${q(alwaysThrowProxy)}`, '[Something that failed to stringify]');


### PR DESCRIPTION
Fixes #729 

@dckc I should still take your suggestion to give detailsTokens their own `toString` method. However, that solves less of the problem. For example, the test case added in this PR would still fail. Instead, where the `assert` module itself stringifies something directly, not through `details`, it would now stringify the `quote` of it. IOW, it would use `bestEffortStringify`.

Since I don't yet know how to reproduce #729, I'll start with this PR, and take your suggestion later after we see if this PR solves your problem.