### PR TITLE
feat(compartment-mapper)!: Required exits on archives

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -2,6 +2,10 @@ User-visible changes to the compartment mapper:
 
 # Next release
 
+- *BREAKING*: When constructing an archive, the creator must provide a record
+  of exit modules. Unlike import functions, the values of the exit module
+  record are ignored.
+  Any omitted exit module will cause an exception during archive creation.
 - Fixes a missing file in the published assets for
   `@endo/compartment-mapper/node-powers.js`.
 

--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -140,12 +140,11 @@ const addSourcesToArchive = async (archive, sources) => {
 /**
  * @param {ReadFn | ReadPowers} powers
  * @param {string} moduleLocation
- * @param {Object} [options]
- * @param {ModuleTransforms} [options.moduleTransforms]
+ * @param {ArchiveOptions} [options]
  * @returns {Promise<Uint8Array>}
  */
 export const makeArchive = async (powers, moduleLocation, options) => {
-  const { moduleTransforms } = options || {};
+  const { moduleTransforms, modules = {} } = options || {};
   const { read } = unpackReadPowers(powers);
   const {
     packageLocation,
@@ -186,6 +185,7 @@ export const makeArchive = async (powers, moduleLocation, options) => {
   // Induce importHook to record all the necessary modules to import the given module specifier.
   const compartment = assemble(compartmentMap, {
     resolve,
+    modules,
     makeImportHook,
     moduleTransforms,
     parserForLanguage,

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -303,7 +303,7 @@ export const link = (
       parserForLanguage,
       moduleTransforms,
     );
-    const importHook = makeImportHook(location, parse);
+    const importHook = makeImportHook(location, parse, exitModules);
     const moduleMapHook = makeModuleMapHook(
       compartments,
       compartmentName,

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -146,6 +146,7 @@
  * @callback ImportHookMaker
  * @param {string} packageLocation
  * @param {ParseFn} parse
+ * @param {Record<string, Object>} exitModules
  * @returns {ImportHook}
  */
 
@@ -168,7 +169,7 @@
  * @property {Object} [globalLexicals]
  * @property {Array<Transform>} [transforms]
  * @property {Array<Transform>} [__shimTransforms__]
- * @property {Record<string, string>} [modules]
+ * @property {Record<string, Object>} [modules]
  * @property {typeof Compartment.prototype.constructor} [Compartment]
  */
 
@@ -227,4 +228,5 @@
 /**
  * @typedef {Object} ArchiveOptions
  * @property {ModuleTransforms} [moduleTransforms]
+ * @property {Record<string, any>} [modules]
  */

--- a/packages/compartment-mapper/test/test-main.js
+++ b/packages/compartment-mapper/test/test-main.js
@@ -132,7 +132,9 @@ test('makeArchive / parseArchive', async t => {
   t.plan(fixtureAssertionCount);
   await setup();
 
-  const archive = await makeArchive(readPowers, fixture);
+  const archive = await makeArchive(readPowers, fixture, {
+    modules,
+  });
   const application = await parseArchive(archive);
   const { namespace } = await application.import({
     globals,
@@ -148,7 +150,9 @@ test('makeArchive / parseArchive with a prefix', async t => {
   await setup();
 
   // Zip files support an arbitrary length prefix.
-  const archive = await makeArchive(readPowers, fixture);
+  const archive = await makeArchive(readPowers, fixture, {
+    modules,
+  });
   const prefixArchive = new Uint8Array(archive.length + 10);
   prefixArchive.set(archive, 10);
 
@@ -177,7 +181,9 @@ test('writeArchive / loadArchive', async t => {
     archive = content;
   };
 
-  await writeArchive(fakeWrite, readPowers, 'app.agar', fixture);
+  await writeArchive(fakeWrite, readPowers, 'app.agar', fixture, {
+    modules,
+  });
   const application = await loadArchive(fakeRead, 'app.agar');
   const { namespace } = await application.import({
     globals,
@@ -203,7 +209,9 @@ test('writeArchive / importArchive', async t => {
     archive = content;
   };
 
-  await writeArchive(fakeWrite, readPowers, 'app.agar', fixture);
+  await writeArchive(fakeWrite, readPowers, 'app.agar', fixture, {
+    modules,
+  });
   const { namespace } = await importArchive(fakeRead, 'app.agar', {
     globals,
     globalLexicals,


### PR DESCRIPTION
Upon creating a new archive, the user will now be required to provide a
modules record (with meaningless values) to denote what dependencies are
expected to be provided by the importer.