### PR TITLE
feat(compartment-mapper): Developer dependencies

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -6,6 +6,8 @@ User-visible changes to the compartment mapper:
   of exit modules. Unlike import functions, the values of the exit module
   record are ignored.
   Any omitted exit module will cause an exception during archive creation.
+- Adds a `dev` option to archive and import workflows to include the
+  `devDependencies` of the entry package (but not other packages).
 - Fixes a missing file in the published assets for
   `@endo/compartment-mapper/node-powers.js`.
 

--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -144,7 +144,7 @@ const addSourcesToArchive = async (archive, sources) => {
  * @returns {Promise<Uint8Array>}
  */
 export const makeArchive = async (powers, moduleLocation, options) => {
-  const { moduleTransforms, modules = {} } = options || {};
+  const { moduleTransforms, modules = {}, dev = false } = options || {};
   const { read } = unpackReadPowers(powers);
   const {
     packageLocation,
@@ -166,6 +166,7 @@ export const makeArchive = async (powers, moduleLocation, options) => {
     tags,
     packageDescriptor,
     moduleSpecifier,
+    { dev },
   );
 
   const {

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -26,7 +26,7 @@ export const parserForLanguage = {
  * @returns {Promise<Application>}
  */
 export const loadLocation = async (readPowers, moduleLocation, options) => {
-  const { moduleTransforms = {} } = options || {};
+  const { moduleTransforms = {}, dev = false } = options || {};
 
   const { read } = unpackReadPowers(readPowers);
 
@@ -49,6 +49,7 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
     tags,
     packageDescriptor,
     moduleSpecifier,
+    { dev },
   );
 
   /** @type {ExecuteFn} */

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -229,4 +229,5 @@
  * @typedef {Object} ArchiveOptions
  * @property {ModuleTransforms} [moduleTransforms]
  * @property {Record<string, any>} [modules]
+ * @property {boolean} [dev]
  */

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/app/package.json
@@ -8,7 +8,9 @@
     "brooke": "^1.0.0",
     "clarke": "^1.0.0",
     "danny": "^1.0.0",
-    "evan": "^1.0.0",
+    "evan": "^1.0.0"
+  },
+  "devDependencies": {
     "typecommon": "^1.0.0",
     "typemodule": "^1.0.0",
     "typehybrid": "^1.0.0",

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/app/index.js
@@ -1,0 +1,1 @@
+import 'direct';

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "app",
+  "type": "module",
+  "devDependencies": {
+    "direct": "^1.0.0"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/direct/index.js
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/direct/index.js
@@ -1,0 +1,1 @@
+import 'indirect';

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/direct/package.json
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/direct/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "direct",
+  "type": "module",
+  "devDependencies": {
+    "indirect": "^1.0.0"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/indirect/index.js
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/indirect/index.js
@@ -1,0 +1,1 @@
+export default 'immaterial';

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/indirect/package.json
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/indirect/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "indirect",
+  "type": "module"
+}


### PR DESCRIPTION
The import and archive functions now accepta `dev` flag that indicates that the `devDependencies` of the entry module's package should be included in the compartment graph.  This must be passed explicitly and is off by default since that will be the norm for applications.

This is the bug of the day blocking https://github.com/Agoric/agoric-sdk/pull/3273

In furtherance of https://github.com/Agoric/agoric-sdk/issues/2684