### PR TITLE
fix(compartment-mapper): Export types properly

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes to the compartment mapper:
 
+# Next release
+
+- Vends types out properly for ReadFn and CanonicalFn in particular.
+
 # 0.4.0 (2021-06-16)
 
 - *BREAKING*: When constructing an archive, the creator must provide a record

--- a/packages/compartment-mapper/jsconfig.json
+++ b/packages/compartment-mapper/jsconfig.json
@@ -7,5 +7,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node"
   },
-  "include": ["src/**/*.js", "index.d.ts"]
+  "include": ["src/**/*.js", "test/**/*.js", "index.d.ts"]
 }

--- a/packages/compartment-mapper/src/node-powers.js
+++ b/packages/compartment-mapper/src/node-powers.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import './types.js';
+
 /**
  * @param {typeof import('fs')} fs
  * @returns {ReadPowers}


### PR DESCRIPTION
Although this lint check locally works fine, it fails two dependency edges up from here.

Refs: https://github.com/Agoric/agoric-sdk/pull/3346
