### PR TITLE
fix(ses): Fix packaging for `@web/dev-server`

### DIFF
--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -21,11 +21,17 @@
   "type": "module",
   "main": "./dist/ses.cjs",
   "module": "./index.js",
-  "types": "./index.d.ts",
   "unpkg": "./dist/ses.umd.js",
+  "types": "./index.d.ts",
   "exports": {
-    ".": "./dist/ses.cjs",
-    "./lockdown": "./dist/ses.cjs",
+    ".": {
+      "import": "./dist/ses.umd.js",
+      "require": "./dist/ses.cjs"
+    },
+    "./lockdown": {
+      "import": "./dist/ses.umd.js",
+      "require": "./dist/ses.cjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
Node.js with ESM support uses the `exports` property to guide an import or require call to the relevant content, trusting that mechanism and ignoring the extension of the file. However, `@web/dev-server` depends on the extension to be consistent. It’s therefore necessary to use the `import` and `require` predicates, even though the referenced files have identical content. This change also makes the packaging more consistent, always using the built SES bundle, not trusting the module system (which may attempt to produce an equivalent module) if that can be avoided.