### PR TITLE
Add missing assert.raise

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -3,6 +3,9 @@ User-visible changes in SES:
 # Next release
 
 - Fixes the type assertions for `assert` and `assert.string`.
+- Adds an `assert.raise(reason)` operation for directly causing the
+  termination action associated with this `assert` object with a
+  provided reason (normally an error).
 
 # 0.13.4 (2021-06-19)
 
@@ -53,7 +56,7 @@ User-visible changes in SES:
   mistake.  Most useful as `overrideTaming: 'severe', overrideDebug:
   ['constructor']`.
 - We reopened Safari bug
-  [Object.defineProperties triggering a setter](https://bugs.webkit.org/show_bug.cgi?id=222538#c17) 
+  [Object.defineProperties triggering a setter](https://bugs.webkit.org/show_bug.cgi?id=222538#c17)
   when we found that it was causing an infinite recursion initializing SES
   on Safari.
 - We revised an error message to include the error tag of a new error

--- a/packages/ses/src/error/fatal-assert.js
+++ b/packages/ses/src/error/fatal-assert.js
@@ -11,17 +11,29 @@ let abandon;
 // found on Node. It should also sniff for a vat terminating function expected
 // to be found within the start compartment of SwingSet vats. What else?
 if (typeof process === 'object') {
+  /**
+   * @param {number=} exitCode
+   * @returns {never}
+   */
   abandon = process.abort || process.exit;
 }
 let raise;
 if (typeof abandon === 'function') {
-  /** @param {Error} reason */
+  // eslint apparently doesn't understand `never`.
+  /* eslint-disable jsdoc/require-returns-check */
+  /**
+   * @param {Error} reason
+   * @returns {never}
+   */
+  /* eslint-enable jsdoc/require-returns-check */
   raise = reason => {
     // Check `console` each time `raise` is called.
     if (typeof console === 'object' && typeof console.error === 'function') {
       console.error('Failed because:', reason);
     }
-    abandon(1);
+    // abandon itself should never return. The `throw` is to make
+    // TypeScript happy.
+    throw abandon(1);
   };
 }
 

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -234,7 +234,7 @@
  * that prevents execution from reaching the following throw. However, if
  * `optRaise` returns normally, which would be unusual, the throw following
  * `optRaise(reason)` would still happen. Thus, `makeAssert` return an
- * `assert` for which `assert.raise` is guaranteed to return `never`
+ * `assert` for which `assert.raise` is guaranteed to `never` return
  * whether on not the `optRaise` argument does.
  *
  * @param {Raise=} optRaise

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -211,9 +211,11 @@
  * like a transaction, vat, or process, call `makeAssert` with a `Raise`
  * callback, where that callback actually performs that larger termination.
  * If possible, the callback should also report its `reason` parameter as
- * the alleged reason for the termination.
+ * the alleged reason for the termination. A `Raise` function should
+ * never return.
  *
  * @param {Error} reason
+ * @returns {never}
  */
 
 /**
@@ -231,7 +233,9 @@
  * engage in even more violent termination behavior, like terminating the vat,
  * that prevents execution from reaching the following throw. However, if
  * `optRaise` returns normally, which would be unusual, the throw following
- * `optRaise(reason)` would still happen.
+ * `optRaise(reason)` would still happen. Thus, `makeAssert` return an
+ * `assert` for which `assert.raise` is guaranteed to return `never`
+ * whether on not the `optRaise` argument does.
  *
  * @param {Raise=} optRaise
  * @param {boolean=} unredacted
@@ -281,6 +285,7 @@
  * @typedef { BaseAssert & {
  *   typeof: AssertTypeof,
  *   error: AssertMakeError,
+ *   raise: Raise,
  *   fail: AssertFail,
  *   equal: AssertEqual,
  *   string: AssertString,

--- a/packages/ses/test/error/test-makeAssert.js
+++ b/packages/ses/test/error/test-makeAssert.js
@@ -1,0 +1,86 @@
+import test from 'ava';
+import { throwsAndLogs } from './throws-and-logs.js';
+import { assert } from '../../src/error/assert.js';
+
+const { details: d, makeAssert } = assert;
+
+const goodRaise = reason => {
+  console.error('raising', reason);
+  throw reason;
+};
+
+// A bad raise function because it returns.
+const doesNotThrow = reason => {
+  console.error('not throwing', reason);
+};
+
+const throwsRelated = reason => {
+  const err = assert.error(d`replaces ${reason}`);
+  console.error('throws something else', err);
+  throw err;
+};
+
+const reenterAssert = reason => {
+  console.error('about to fail');
+  assert.fail(d`replaces ${reason}`);
+};
+
+const testError = URIError('test error');
+
+const challenges = [
+  [undefined, /test error/, [['log', 'Caught', URIError]]],
+  [
+    goodRaise,
+    /test error/,
+    [
+      ['error', 'raising', URIError],
+      ['log', 'Caught', URIError],
+    ],
+  ],
+  [
+    doesNotThrow,
+    /test error/,
+    [
+      ['error', 'not throwing', URIError],
+      ['log', 'Caught', URIError],
+    ],
+  ],
+  [
+    throwsRelated,
+    /replaces/,
+    [
+      ['error', 'throws something else', Error],
+      ['log', 'Caught', Error],
+    ],
+  ],
+  [
+    reenterAssert,
+    /replaces/,
+    [
+      ['error', 'about to fail'],
+      ['log', 'Caught', Error],
+    ],
+  ],
+];
+
+for (const [optRaise, regexp, goldenLog] of challenges) {
+  const testName = optRaise ? optRaise.name : 'noRaise';
+  const testAssert = makeAssert(optRaise);
+  test(`makeAssert of ${testName}`, t => {
+    throwsAndLogs(t, () => testAssert.raise(testError), regexp, goldenLog);
+  });
+}
+
+test('makeAssert reenters same assert', t => {
+  const reenterSameAssert = reason => {
+    console.error('about to reenter', reason);
+    // eslint-disable-next-line no-use-before-define
+    testAssert.fail(d`replaces ${reason}`);
+  };
+  const testAssert = makeAssert(reenterSameAssert);
+  throwsAndLogs(t, () => testAssert.raise(testError), /replaces/, [
+    ['error', 'about to reenter', URIError],
+    ['error', 'Failed to raise. Just throwing', Error],
+    ['log', 'Caught', Error],
+  ]);
+});

--- a/packages/ses/test/error/throws-and-logs.js
+++ b/packages/ses/test/error/throws-and-logs.js
@@ -10,11 +10,11 @@ import {
 const { quote: q } = assert;
 
 // For our internal debugging purposes
-const internalDebugConsole = console;
+// const internalDebugConsole = console;
 
 const compareLogs = freeze((t, log, goldenLog) => {
   // For our internal debugging purposes
-  internalDebugConsole.log('LOG', log);
+  // internalDebugConsole.log('LOG', log);
 
   t.is(log.length, goldenLog.length, 'wrong log length');
   log.forEach((logRecord, i) => {

--- a/packages/ses/test/error/throws-and-logs.js
+++ b/packages/ses/test/error/throws-and-logs.js
@@ -10,11 +10,11 @@ import {
 const { quote: q } = assert;
 
 // For our internal debugging purposes
-// const internalDebugConsole = console;
+const internalDebugConsole = console;
 
 const compareLogs = freeze((t, log, goldenLog) => {
   // For our internal debugging purposes
-  // internalDebugConsole.log('LOG', log);
+  internalDebugConsole.log('LOG', log);
 
   t.is(log.length, goldenLog.length, 'wrong log length');
   log.forEach((logRecord, i) => {
@@ -31,7 +31,10 @@ const compareLogs = freeze((t, log, goldenLog) => {
         (typeof goldenEntry === 'function' &&
           getPrototypeOf(goldenEntry) === Error)
       ) {
-        t.assert(logEntry instanceof goldenEntry, 'not the right error');
+        t.assert(
+          logEntry instanceof goldenEntry,
+          `not the right error: ${logEntry.name} vs ${goldenEntry.name}`,
+        );
       } else {
         // tap uses `===` instead of `Object.is`.
         // Assuming ava does the right thing, switch back to this when


### PR DESCRIPTION
Currently, https://github.com/Agoric/agoric-sdk/pull/3287 is unnecessarily awkward because, for an `assert` whose termination action is something other than throwing, `assert` does not provide any way to invoke that termination action with a provided error object. This PR adds an `assert.raise(reason)` action to address that.

A previously unnoticed hazard is that if the provided termination action calls into the same `assert` object in a way that provokes the same termination action, we get an infinite recursion rather than the termination we wanted. This PR adds a mechanism to detect that. Unfortunately, having detected that, there's no way to reliably enable the intended termination action since the function is broken. Instead, we just throw the reason after logging that we had to do that.