### PR TITLE
fix: typo vs type checker

### DIFF
--- a/packages/ses/src/tame-date-constructor.js
+++ b/packages/ses/src/tame-date-constructor.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { defineProperties } from './commons.js';
 
 export default function tameDateConstructor(dateTaming = 'safe') {
@@ -74,7 +76,7 @@ export default function tameDateConstructor(dateTaming = 'safe') {
     return ResultDate;
   };
   const InitialDate = makeDateConstructor({ powers: 'original' });
-  const SharedDate = makeDateConstructor({ power: 'none' });
+  const SharedDate = makeDateConstructor({ powers: 'none' });
 
   defineProperties(InitialDate, {
     now: {


### PR DESCRIPTION
Fixes #520 

I first added a missing `// @ts-check` at the top and was gratified to see a red underline at the typo, and no where else.