### PR TITLE
fix(compartment-map): Restore test fixture maker and support for exit…

### DIFF
--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -154,7 +154,8 @@ const addSourcesToArchive = async (archive, sources) => {
  * @returns {Promise<Uint8Array>}
  */
 export const makeArchive = async (powers, moduleLocation, options) => {
-  const { moduleTransforms, modules = {}, dev = false } = options || {};
+  const { moduleTransforms, modules: exitModules = {}, dev = false } =
+    options || {};
   const { read } = unpackReadPowers(powers);
   const {
     packageLocation,
@@ -191,15 +192,17 @@ export const makeArchive = async (powers, moduleLocation, options) => {
     packageLocation,
     sources,
     compartments,
+    exitModules,
   );
 
   // Induce importHook to record all the necessary modules to import the given module specifier.
   const compartment = assemble(compartmentMap, {
     resolve,
-    modules,
+    modules: exitModules,
     makeImportHook,
     moduleTransforms,
     parserForLanguage,
+    archiveOnly: true,
   });
   await compartment.load(entryModuleSpecifier);
 

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -189,6 +189,7 @@ export const moduleJSDocTypes = true;
  * @property {AssembleImportHook} makeImportHook
  * @property {ParserForLanguage} parserForLanguage
  * @property {ModuleTransforms} [moduleTransforms]
+ * @property {boolean} [archiveOnly]
  */
 
 /**
@@ -235,6 +236,6 @@ export const moduleJSDocTypes = true;
 /**
  * @typedef {Object} ArchiveOptions
  * @property {ModuleTransforms} [moduleTransforms]
- * @property {Record<string, any>} [modules]
+ * @property {Record<string, never>} [modules]
  * @property {boolean} [dev]
  */

--- a/packages/compartment-mapper/test/app.agar-make.js
+++ b/packages/compartment-mapper/test/app.agar-make.js
@@ -6,6 +6,8 @@
 // The archive may need to be regenerated if the test fixture and assertions
 // have been changed.
 
+/* global process */
+
 import 'ses';
 import fs from 'fs';
 import { writeArchive } from '../archive.js';
@@ -20,4 +22,14 @@ const fixture = new URL(
 ).toString();
 const archiveFixture = new URL('app.agar', import.meta.url).toString();
 
-writeArchive(write, readPowers, archiveFixture, fixture);
+const mitt = err =>
+  process.nextTick(() => {
+    throw err;
+  });
+
+writeArchive(write, readPowers, archiveFixture, fixture, {
+  dev: true,
+  modules: {
+    builtin: true,
+  },
+}).catch(mitt);

--- a/packages/compartment-mapper/test/test-main.js
+++ b/packages/compartment-mapper/test/test-main.js
@@ -187,7 +187,7 @@ test('writeArchive / loadArchive', async t => {
   };
 
   await writeArchive(fakeWrite, readPowers, 'app.agar', fixture, {
-    modules,
+    modules: { builtin: true },
     dev: true,
   });
   const application = await loadArchive(fakeRead, 'app.agar');


### PR DESCRIPTION
… modules from archives


Addresses a regression: archives can be created with a `modules` option for the exit modules of the application. The values of the module map are ignored for the purposes of archiving, so `{ builtin: true }` is acceptable, whereas when passing `modules` to `importLocation` or `importArchive`, the values must be reified module namespace objects.