### PR TITLE
feat(ses): Reveal harden only after lockdown

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -3,6 +3,12 @@ User-visible changes in SES:
 # Next release
 
 - Fixes the type assertions for `assert` and `assert.string`.
+- Reveals `harden` only after `lockdown`. Harden was never usable before
+  lockdown because it would render the environment irreparable.
+  Calling `harden` before `lockdown` previously threw an exception.
+  Now it is possible to write libraries that are usable both in JS and SES,
+  which can know whether to harden their API by the presence of harden in
+  global scope.
 
 # 0.13.4 (2021-06-19)
 

--- a/packages/ses/index.js
+++ b/packages/ses/index.js
@@ -18,7 +18,7 @@ import { assign } from './src/commons.js';
 import { tameFunctionToString } from './src/tame-function-tostring.js';
 import { getGlobalIntrinsics } from './src/intrinsics.js';
 import { getAnonymousIntrinsics } from './src/get-anonymous-intrinsics.js';
-import { makeLockdown, harden } from './src/lockdown-shim.js';
+import { makeLockdown } from './src/lockdown-shim.js';
 import {
   makeCompartmentConstructor,
   CompartmentPrototype,
@@ -43,7 +43,6 @@ const Compartment = makeCompartmentConstructor(
 );
 
 assign(globalThis, {
-  harden,
   lockdown: makeLockdown(
     makeCompartmentConstructor,
     CompartmentPrototype,

--- a/packages/ses/test/test-harden-before-lockdown.js
+++ b/packages/ses/test/test-harden-before-lockdown.js
@@ -1,0 +1,10 @@
+import test from 'ava';
+import '../index.js';
+
+test('harden must not exist before lockdown', t => {
+  t.assert(typeof harden === 'undefined');
+});
+
+test('harden must not exist before lockdown in compartments', t => {
+  t.assert(new Compartment().evaluate('typeof harden') === 'undefined');
+});


### PR DESCRIPTION
Reveals `harden` only after `lockdown`. Harden was never usable before lockdown because it would render the environment ireparable.  Calling `harden` before `lockdown` previously threw an exception.  Now it is possible to write libraries that are usable both in JS and SES, which can know whether to harden their API by the presence of harden in global scope.

Fixes #787
