### PR TITLE
test: Coverage enforcement ETOOBOLD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.17.0, 12.x, 14.x]
+        node-version: [14.x]
 
     steps:
 

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 90 --functions 100 --branches 75 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint:js": "eslint '**/*.js'",

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 95 --functions 100 --branches 70 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint:js": "eslint '**/*.js'",

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 90 --functions 90 --branches 75 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint:js": "eslint '**/*.js'",

--- a/packages/endo/package.json
+++ b/packages/endo/package.json
@@ -20,7 +20,7 @@
   "type": "module",
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 95 --functions 95 --branches 95 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint:js": "eslint '**/*.js'",

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 85 --functions 80 --branches 55 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint:js": "eslint '**/*.js'",

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 95 --functions 95 --branches 95 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint:js": "eslint '**/*.js'",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "node scripts/bundle.js",
     "clean": "rm -rf dist",
-    "cover": "c8 --check-coverage --lines 80 --functions 76 --branches 77 ava",
+    "cover": "c8 ava",
     "demo": "http-server -o /demos",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 85 --functions 95 --branches 85 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint:types": "tsc --build jsconfig.json",
     "lint:js": "eslint '**/*.js'",

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 85 --functions 100 --branches 75 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint:js": "eslint '**/*.js'",

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "cover": "c8 --check-coverage --lines 92 --functions 86 --branches 81 ava",
+    "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint:js": "eslint '**/*.js'",


### PR DESCRIPTION
Enforcing coverage, as predicted, is too bold at this stage. The only practical mitigation at this point is to adjust the coverage numbers, since the reports produce vast lists of lines that are all opportunities to improve coverage, many of which would have to be reevaluated at every juncture where coverage was not sufficient. Coverage enforcement is only really practical when the thresholds are 100% and checks apply only to code we have not expressly opted out of coverage. 

It’s also moderately infuriating that the coverage is not as high on Node.js 12 as it is on 14, so debugging coverage failures involves checking on all supported Node.js versions. That could perhaps be mitigated by reducing the CI version matrix to just the youngest supported version.