### PR TITLE
refactor(ses): Consolidate declarations of uncurryThis and related functionality into commons.js

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -67,7 +67,13 @@ export const defineProperty = (object, prop, descriptor) => {
   return result;
 };
 
-export const { apply, construct, get: reflectGet, set: reflectSet } = Reflect;
+export const {
+  apply,
+  construct,
+  get: reflectGet,
+  ownKeys,
+  set: reflectSet,
+} = Reflect;
 
 export const { isArray, prototype: arrayPrototype } = Array;
 export const { prototype: mapPrototype } = Map;

--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -44,11 +44,12 @@
 // of the whitelist.
 
 import { whitelist, FunctionInstance, isAccessorPermit } from './whitelist.js';
-import { getPrototypeOf, getOwnPropertyDescriptor } from './commons.js';
-
-const { apply, ownKeys } = Reflect;
-const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
-const hasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty);
+import {
+  getPrototypeOf,
+  getOwnPropertyDescriptor,
+  objectHasOwnProperty,
+  ownKeys,
+} from './commons.js';
 
 /**
  * asStringPropertyName()
@@ -140,7 +141,7 @@ export default function whitelistIntrinsics(
         // Assert: the permit is the name of an intrinsic.
         // Assert: the property value is equal to that intrinsic.
 
-        if (hasOwnProperty(intrinsics, permit)) {
+        if (objectHasOwnProperty(intrinsics, permit)) {
           if (value !== intrinsics[permit]) {
             throw new TypeError(`Does not match whitelist ${path}`);
           }
@@ -175,7 +176,7 @@ export default function whitelistIntrinsics(
     const desc = getOwnPropertyDescriptor(obj, prop);
 
     // Is this a value property?
-    if (hasOwnProperty(desc, 'value')) {
+    if (objectHasOwnProperty(desc, 'value')) {
       if (isAccessorPermit(permit)) {
         throw new TypeError(`Accessor expected at ${path}`);
       }
@@ -195,13 +196,13 @@ export default function whitelistIntrinsics(
    */
   function getSubPermit(obj, permit, prop) {
     const permitProp = prop === '__proto__' ? '--proto--' : prop;
-    if (hasOwnProperty(permit, permitProp)) {
+    if (objectHasOwnProperty(permit, permitProp)) {
       return permit[permitProp];
     }
 
     if (typeof obj === 'function') {
       markVirtualizedNativeFunction(obj);
-      if (hasOwnProperty(FunctionInstance, permitProp)) {
+      if (objectHasOwnProperty(FunctionInstance, permitProp)) {
         return FunctionInstance[permitProp];
       }
     }


### PR DESCRIPTION
Some functions that appear as though they should be exported from `commons.js` were declared in `whitelist-intrinsics.js`. `objectHasOwnProperty` and `ownKeys` (from `Reflect`) are now imported from `commons.js` instead of declared in `whitelist-intrinsics.js`. As a consequence, `uncurryThis` is no longer used in `whitelist-intrinsics.js`, and that function is completely removed from that file. `ownKeys` is added as an export of `commons.js` along with the other properties of `Reflect` exported from that file.