### PR TITLE
Lint to disallow SES polymorphic calls

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-polymorphic-call.js
+++ b/packages/eslint-plugin/lib/rules/no-polymorphic-call.js
@@ -1,0 +1,52 @@
+"use strict"
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "disallow polymorphic function calls e.g.: 'array.slice()'",
+            category: "Possible Security Errors",
+            recommended: true,
+            url:
+                "https://github.com/endojs/endo/blob/master/packages/eslint-plugin/lib/rules/no-polymorphic-call.js",
+        },
+        type: "problem",
+        fixable: null,
+        schema: [],
+        supported: true,
+    },
+    create (context) {
+        return {
+          CallExpression(node) {
+            if (node.callee.type !== 'MemberExpression') {
+              return
+            }
+            const reportHint = prepareMemberExpressionHint(node.callee)
+            context.report(node, `Polymorphic call: "${reportHint}". May be vulnerable to corruption or trap`)
+          }
+        }
+    },
+}
+
+function prepareMemberExpressionHint (node) {
+  const { object, property, computed } = node
+  let objectHint
+  let propertyHint
+  if (object.type === 'Identifier') {
+    objectHint = object.name
+  } else if (object.type === 'MemberExpression') {
+    objectHint = prepareMemberExpressionHint(object)
+  } else {
+    objectHint = `[[${object.type}]]`
+  }
+  if (property.type === 'Identifier') {
+    if (computed) {
+      propertyHint = `[${property.name}]`
+    } else {
+      propertyHint = property.name
+    }
+  } else {
+    propertyHint = `[[${property.type}]]`
+  }
+  return `${objectHint}.${propertyHint}`
+}

--- a/packages/ses/index.js
+++ b/packages/ses/index.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { globalThis, Error, assign } from './src/commons.js';
+import { globalThis, TypeError, assign } from './src/commons.js';
 import { tameFunctionToString } from './src/tame-function-tostring.js';
 import { getGlobalIntrinsics } from './src/intrinsics.js';
 import { getAnonymousIntrinsics } from './src/get-anonymous-intrinsics.js';
@@ -29,7 +29,7 @@ function getThis() {
 }
 
 if (getThis()) {
-  throw new Error(`SES failed to initialize, sloppy mode (SES_NO_SLOPPY)`);
+  throw new TypeError(`SES failed to initialize, sloppy mode (SES_NO_SLOPPY)`);
 }
 
 const markVirtualizedNativeFunction = tameFunctionToString();

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -143,7 +143,7 @@
         "parseInt",
         "unescape"
       ],
-      "@endo/no-polymorphic-call": "warn"
+      "@endo/no-polymorphic-call": "error"
     },
     "overrides": [
       {

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -142,16 +142,19 @@
         "parseFloat",
         "parseInt",
         "unescape"
-      ]
+      ],
+      "@endo/no-polymorphic-call": "warn"
     },
     "overrides": [
       {
         "files": [
           "test/**/*.js",
-          "demos/**/*.js"
+          "demos/**/*.js",
+          "scripts/**/*.js"
         ],
         "rules": {
-          "no-restricted-globals": "off"
+          "no-restricted-globals": "off",
+          "@endo/no-polymorphic-call": "off"
         }
       }
     ]

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -102,7 +102,7 @@ export const defineProperty = (object, prop, descriptor) => {
   const result = originalDefineProperty(object, prop, descriptor);
   if (result !== object) {
     throw TypeError(
-      `Please report that the original defineProperty silently failed to set ${JSON.stringify(
+      `Please report that the original defineProperty silently failed to set ${stringifyJson(
         String(prop),
       )}. (SES_DEFINE_PROPERTY_FAILED_SILENTLY)`,
     );
@@ -131,6 +131,7 @@ export const { prototype: stringPrototype } = String;
 export const { prototype: weakmapPrototype } = WeakMap;
 export const { prototype: weaksetPrototype } = WeakSet;
 export const { prototype: functionPrototype } = Function;
+export const { prototype: promisePrototype } = Promise;
 
 /**
  * uncurryThis()
@@ -151,40 +152,58 @@ export const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
 
 export const objectHasOwnProperty = uncurryThis(objectPrototype.hasOwnProperty);
 //
-export const arrayForEach = uncurryThis(arrayPrototype.forEach);
 export const arrayFilter = uncurryThis(arrayPrototype.filter);
-export const arrayJoin = uncurryThis(arrayPrototype.join);
-export const arrayPush = uncurryThis(arrayPrototype.push);
-export const arrayPop = uncurryThis(arrayPrototype.pop);
+export const arrayForEach = uncurryThis(arrayPrototype.forEach);
 export const arrayIncludes = uncurryThis(arrayPrototype.includes);
+export const arrayJoin = uncurryThis(arrayPrototype.join);
+export const arrayMap = uncurryThis(arrayPrototype.map);
+export const arrayPop = uncurryThis(arrayPrototype.pop);
+export const arrayPush = uncurryThis(arrayPrototype.push);
+export const arraySlice = uncurryThis(arrayPrototype.slice);
+export const arraySome = uncurryThis(arrayPrototype.some);
+export const arraySort = uncurryThis(arrayPrototype.sort);
+export const iterateArray = uncurryThis(arrayPrototype[iteratorSymbol]);
 //
 export const mapSet = uncurryThis(mapPrototype.set);
 export const mapGet = uncurryThis(mapPrototype.get);
 export const mapHas = uncurryThis(mapPrototype.has);
+export const iterateMap = uncurryThis(mapPrototype[iteratorSymbol]);
 //
 export const setAdd = uncurryThis(setPrototype.add);
 export const setForEach = uncurryThis(setPrototype.forEach);
 export const setHas = uncurryThis(setPrototype.has);
+export const iterateSet = uncurryThis(setPrototype[iteratorSymbol]);
 //
 export const regexpTest = uncurryThis(regexpPrototype.test);
+export const regexpExec = uncurryThis(regexpPrototype.exec);
+export const matchAllRegExp = uncurryThis(regexpPrototype[matchAllSymbol]);
 //
 export const stringEndsWith = uncurryThis(stringPrototype.endsWith);
 export const stringIncludes = uncurryThis(stringPrototype.includes);
+export const stringIndexOf = uncurryThis(stringPrototype.indexOf);
 export const stringMatch = uncurryThis(stringPrototype.match);
+export const stringReplace = uncurryThis(stringPrototype.replace);
 export const stringSearch = uncurryThis(stringPrototype.search);
 export const stringSlice = uncurryThis(stringPrototype.slice);
 export const stringSplit = uncurryThis(stringPrototype.split);
 export const stringStartsWith = uncurryThis(stringPrototype.startsWith);
+export const iterateString = uncurryThis(stringPrototype[iteratorSymbol]);
 //
+export const weakmapDelete = uncurryThis(weakmapPrototype.delete);
 export const weakmapGet = uncurryThis(weakmapPrototype.get);
-export const weakmapSet = uncurryThis(weakmapPrototype.set);
 export const weakmapHas = uncurryThis(weakmapPrototype.has);
+export const weakmapSet = uncurryThis(weakmapPrototype.set);
 //
 export const weaksetAdd = uncurryThis(weaksetPrototype.add);
-export const weaksetSet = uncurryThis(weaksetPrototype.set);
+export const weaksetGet = uncurryThis(weaksetPrototype.get);
 export const weaksetHas = uncurryThis(weaksetPrototype.has);
 //
 export const functionToString = uncurryThis(functionPrototype.toString);
+//
+const { all } = Promise;
+export const promiseAll = promises => apply(all, Promise, [promises]);
+export const promiseCatch = uncurryThis(promisePrototype.catch);
+export const promiseThen = uncurryThis(promisePrototype.then);
 
 /**
  * getConstructorOf()

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -28,7 +28,7 @@ export const {
   Promise,
   Proxy,
   Reflect,
-  RegExp,
+  RegExp: FERAL_REG_EXP,
   Set,
   String,
   WeakMap,
@@ -36,7 +36,10 @@ export const {
 } = globalThis;
 
 export const {
-  Error,
+  // The feral Error constructor is safe for internal use, but must not be
+  // revealed to post-lockdown code in any compartment including the start
+  // compartment since in V8 at least it bears stack inspection capabilities.
+  Error: FERAL_ERROR,
   RangeError,
   ReferenceError,
   SyntaxError,
@@ -238,6 +241,19 @@ export const immutableObject = freeze(create(null));
  * @param {any} value
  */
 export const isObject = value => Object(value) === value;
+
+/**
+ * isError tests whether an object inherits from the intrinsic
+ * `Error.prototype`.
+ * We capture the original error constructor as FERAL_ERROR to provide a clear
+ * signal for reviewers that we are handling an object with excess authority,
+ * like stack trace inspection, that we are carefully hiding from client code.
+ * Checking instanceof happens to be safe, but to avoid uttering FERAL_ERROR
+ * for such a trivial case outside commons.js, we provide a utility function.
+ *
+ * @param {any} value
+ */
+export const isError = value => value instanceof FERAL_ERROR;
 
 // The original unsafe untamed eval function, which must not escape.
 // Sample at module initialization time, which is before lockdown can

--- a/packages/ses/src/compartment-evaluate.js
+++ b/packages/ses/src/compartment-evaluate.js
@@ -1,0 +1,72 @@
+/// <reference types="ses">
+import {
+  TypeError,
+  arrayPush,
+  create,
+  defineProperties,
+  getOwnPropertyDescriptors,
+} from './commons.js';
+import {
+  evadeHtmlCommentTest,
+  evadeImportExpressionTest,
+  rejectSomeDirectEvalExpressions,
+} from './transforms.js';
+import { performEval } from './evaluate.js';
+
+export const compartmentEvaluate = (compartmentFields, source, options) => {
+  // Perform this check first to avoid unecessary sanitizing.
+  // TODO Maybe relax string check and coerce instead:
+  // https://github.com/tc39/proposal-dynamic-code-brand-checks
+  if (typeof source !== 'string') {
+    throw new TypeError('first argument of evaluate() must be a string');
+  }
+
+  // Extract options, and shallow-clone transforms.
+  const {
+    transforms = [],
+    sloppyGlobalsMode = false,
+    __moduleShimLexicals__ = undefined,
+    __evadeHtmlCommentTest__ = false,
+    __evadeImportExpressionTest__ = false,
+    __rejectSomeDirectEvalExpressions__ = true, // Note default on
+  } = options;
+  const localTransforms = [...transforms];
+  if (__evadeHtmlCommentTest__ === true) {
+    arrayPush(localTransforms, evadeHtmlCommentTest);
+  }
+  if (__evadeImportExpressionTest__ === true) {
+    arrayPush(localTransforms, evadeImportExpressionTest);
+  }
+  if (__rejectSomeDirectEvalExpressions__ === true) {
+    arrayPush(localTransforms, rejectSomeDirectEvalExpressions);
+  }
+
+  let { globalTransforms } = compartmentFields;
+  const { globalObject, globalLexicals, knownScopeProxies } = compartmentFields;
+
+  let localObject = globalLexicals;
+  if (__moduleShimLexicals__ !== undefined) {
+    // When using `evaluate` for ESM modules, as should only occur from the
+    // module-shim's module-instance.js, we do not reveal the SES-shim's
+    // module-to-program translation, as this is not standardizable behavior.
+    // However, the `localTransforms` will come from the `__shimTransforms__`
+    // Compartment option in this case, which is a non-standardizable escape
+    // hatch so programs designed specifically for the SES-shim
+    // implementation may opt-in to use the same transforms for `evaluate`
+    // and `import`, at the expense of being tightly coupled to SES-shim.
+    globalTransforms = undefined;
+
+    localObject = create(null, getOwnPropertyDescriptors(globalLexicals));
+    defineProperties(
+      localObject,
+      getOwnPropertyDescriptors(__moduleShimLexicals__),
+    );
+  }
+
+  return performEval(source, globalObject, localObject, {
+    globalTransforms,
+    localTransforms,
+    sloppyGlobalsMode,
+    knownScopeProxies,
+  });
+};

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -3,7 +3,6 @@
 /// <reference types="ses">
 
 import {
-  Error,
   Map,
   ReferenceError,
   TypeError,
@@ -265,7 +264,7 @@ export const makeCompartmentConstructor = (
       identifier => !isValidIdentifierName(identifier),
     );
     if (invalidNames.length) {
-      throw new Error(
+      throw new TypeError(
         `Cannot create compartment with invalid names for global lexicals: ${arrayJoin(
           invalidNames,
           ', ',

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -8,6 +8,7 @@ import {
   Set,
   String,
   TypeError,
+  arrayForEach,
   defineProperty,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
@@ -112,6 +113,7 @@ export default function enablePropertyOverrides(
           this[prop] = newValue;
         } else {
           if (isDebug) {
+            // eslint-disable-next-line @endo/no-polymorphic-call
             console.error(new Error(`Override property ${prop}`));
           }
           defineProperty(this, prop, {
@@ -148,7 +150,7 @@ export default function enablePropertyOverrides(
     // TypeScript does not allow symbols to be used as indexes because it
     // cannot recokon types of symbolized properties.
     // @ts-ignore
-    ownKeys(descs).forEach(prop => enable(path, obj, prop, descs[prop]));
+    arrayForEach(ownKeys(descs), prop => enable(path, obj, prop, descs[prop]));
   }
 
   function enableProperties(path, obj, plan) {

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -4,7 +4,6 @@
 // @ts-check
 
 import {
-  Error,
   Set,
   String,
   TypeError,
@@ -114,7 +113,7 @@ export default function enablePropertyOverrides(
         } else {
           if (isDebug) {
             // eslint-disable-next-line @endo/no-polymorphic-call
-            console.error(new Error(`Override property ${prop}`));
+            console.error(new TypeError(`Override property ${prop}`));
           }
           defineProperty(this, prop, {
             value: newValue,
@@ -196,7 +195,7 @@ export default function enablePropertyOverrides(
       break;
     }
     default: {
-      throw new Error(`unrecognized overrideTaming ${overrideTaming}`);
+      throw new TypeError(`unrecognized overrideTaming ${overrideTaming}`);
     }
   }
 

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -12,7 +12,6 @@
 // module should not be observably impure.
 
 import {
-  Error,
   RangeError,
   TypeError,
   WeakMap,
@@ -24,6 +23,7 @@ import {
   freeze,
   globalThis,
   is,
+  isError,
   stringIndexOf,
   stringReplace,
   stringSlice,
@@ -85,7 +85,7 @@ const getMessageString = ({ template, args }) => {
     let argStr;
     if (weakmapHas(declassifiers, arg)) {
       argStr = `${arg}`;
-    } else if (arg instanceof Error) {
+    } else if (isError(arg)) {
       argStr = `(${an(arg.name)})`;
     } else {
       argStr = `(${an(typeof arg)})`;
@@ -226,7 +226,7 @@ const tagError = (err, optErrorName = err.name) => {
  */
 const makeError = (
   optDetails = redactedDetails`Assert failed`,
-  ErrorConstructor = Error,
+  ErrorConstructor = globalThis.Error,
   { errorName = undefined } = {},
 ) => {
   if (typeof optDetails === 'string') {
@@ -236,7 +236,7 @@ const makeError = (
   }
   const hiddenDetails = weakmapGet(hiddenDetailsMap, optDetails);
   if (hiddenDetails === undefined) {
-    throw new Error(`unrecognized details ${quote(optDetails)}`);
+    throw new TypeError(`unrecognized details ${quote(optDetails)}`);
   }
   const messageString = getMessageString(hiddenDetails);
   const error = new ErrorConstructor(messageString);
@@ -286,7 +286,7 @@ const note = (error, detailsNote) => {
   }
   const hiddenDetails = weakmapGet(hiddenDetailsMap, detailsNote);
   if (hiddenDetails === undefined) {
-    throw new Error(`unrecognized details ${quote(detailsNote)}`);
+    throw new TypeError(`unrecognized details ${quote(detailsNote)}`);
   }
   const logArgs = getLogArgs(hiddenDetails);
   const callbacks = weakmapGet(hiddenNoteCallbackArrays, error);
@@ -365,7 +365,7 @@ const makeAssert = (optRaise = undefined, unredacted = false) => {
   /** @type {AssertFail} */
   const fail = (
     optDetails = details`Assert failed`,
-    ErrorConstructor = Error,
+    ErrorConstructor = globalThis.Error,
   ) => {
     const reason = makeError(optDetails, ErrorConstructor);
     if (optRaise !== undefined) {
@@ -382,7 +382,7 @@ const makeAssert = (optRaise = undefined, unredacted = false) => {
   function baseAssert(
     flag,
     optDetails = details`Check failed`,
-    ErrorConstructor = Error,
+    ErrorConstructor = globalThis.Error,
   ) {
     if (!flag) {
       throw fail(optDetails, ErrorConstructor);

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -6,7 +6,6 @@
 // normally commented out.
 
 import {
-  Error,
   WeakSet,
   arrayFilter,
   arrayMap,
@@ -14,6 +13,7 @@ import {
   defineProperty,
   freeze,
   fromEntries,
+  isError,
   stringEndsWith,
   weaksetAdd,
   weaksetHas,
@@ -197,7 +197,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
    */
   const extractErrorArgs = (logArgs, subErrorsSink) => {
     const argTags = arrayMap(logArgs, arg => {
-      if (arg instanceof Error) {
+      if (isError(arg)) {
         arrayPush(subErrorsSink, arg);
         return `(${tagError(arg)})`;
       }

--- a/packages/ses/src/error/fatal-assert.js
+++ b/packages/ses/src/error/fatal-assert.js
@@ -18,7 +18,9 @@ if (typeof abandon === 'function') {
   /** @param {Error} reason */
   raise = reason => {
     // Check `console` each time `raise` is called.
+    // eslint-disable-next-line no-restricted-globals
     if (typeof console === 'object' && typeof console.error === 'function') {
+      // eslint-disable-next-line @endo/no-polymorphic-call, no-restricted-globals
       console.error('Failed because:', reason);
     }
     abandon(1);

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -1,11 +1,11 @@
 // @ts-check
 
 import {
-  Error,
   Set,
   String,
   freeze,
   is,
+  isError,
   setAdd,
   setHas,
   stringStartsWith,
@@ -70,7 +70,7 @@ const bestEffortStringify = (payload, spaces = undefined) => {
           return '[Seen]';
         }
         setAdd(seenSet, val);
-        if (val instanceof Error) {
+        if (isError(val)) {
           return `[${val.name}: ${val.message}]`;
         }
         if (toStringTagSymbol in val) {

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -6,6 +6,7 @@ import { makeCausalConsole } from './console.js';
 import './types.js';
 import './internal-types.js';
 
+// eslint-disable-next-line no-restricted-globals
 const originalConsole = console;
 
 /**
@@ -54,11 +55,16 @@ export const tameConsole = (
 
   // Node.js
   if (errorTrapping !== 'none' && globalThis.process !== undefined) {
+    // eslint-disable-next-line @endo/no-polymorphic-call
     globalThis.process.on('uncaughtException', error => {
+      // causalConsole is born frozen so not vulnerable to method tampering.
+      // eslint-disable-next-line @endo/no-polymorphic-call
       causalConsole.error(error);
       if (errorTrapping === 'platform' || errorTrapping === 'exit') {
+        // eslint-disable-next-line @endo/no-polymorphic-call
         globalThis.process.exit(globalThis.process.exitCode || -1);
       } else if (errorTrapping === 'abort') {
+        // eslint-disable-next-line @endo/no-polymorphic-call
         globalThis.process.abort();
       }
     });
@@ -66,9 +72,13 @@ export const tameConsole = (
 
   // Browser
   if (errorTrapping !== 'none' && globalThis.window !== undefined) {
+    // eslint-disable-next-line @endo/no-polymorphic-call
     globalThis.window.addEventListener('error', event => {
+      // eslint-disable-next-line @endo/no-polymorphic-call
       event.preventDefault();
+      // eslint-disable-next-line @endo/no-polymorphic-call
       const stackString = loggedErrorHandler.getStackString(event.error);
+      // eslint-disable-next-line @endo/no-polymorphic-call
       causalConsole.error(stackString);
       if (errorTrapping === 'exit' || errorTrapping === 'abort') {
         globalThis.window.location.href = `about:blank`;

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { Error, globalThis } from '../commons.js';
+import { TypeError, globalThis } from '../commons.js';
 import { loggedErrorHandler as defaultHandler } from './assert.js';
 import { makeCausalConsole } from './console.js';
 import './types.js';
@@ -25,7 +25,7 @@ export const tameConsole = (
   optGetStackString = undefined,
 ) => {
   if (consoleTaming !== 'safe' && consoleTaming !== 'unsafe') {
-    throw new Error(`unrecognized consoleTaming ${consoleTaming}`);
+    throw new TypeError(`unrecognized consoleTaming ${consoleTaming}`);
   }
 
   if (consoleTaming === 'unsafe') {

--- a/packages/ses/src/error/tame-error-constructor.js
+++ b/packages/ses/src/error/tame-error-constructor.js
@@ -42,6 +42,7 @@ export default function tameErrorConstructor(
 
   const platform =
     typeof OriginalError.captureStackTrace === 'function' ? 'v8' : 'unknown';
+  const { captureStackTrace: originalCaptureStackTrace } = OriginalError;
 
   const makeErrorConstructor = (_ = {}) => {
     // eslint-disable-next-line no-shadow
@@ -54,7 +55,7 @@ export default function tameErrorConstructor(
       }
       if (platform === 'v8') {
         // TODO Likely expensive!
-        OriginalError.captureStackTrace(error, ResultError);
+        apply(originalCaptureStackTrace, OriginalError, [error, ResultError]);
       }
       return error;
     };

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -1,5 +1,4 @@
 import {
-  Array,
   FERAL_FUNCTION,
   Float32Array,
   Map,
@@ -8,8 +7,13 @@ import {
   String,
   getOwnPropertyDescriptor,
   getPrototypeOf,
-  iteratorSymbol,
+  iterateArray,
+  iterateMap,
+  iterateSet,
+  iterateString,
+  matchAllRegExp,
   matchAllSymbol,
+  regexpPrototype,
 } from './commons.js';
 import { InertCompartment } from './compartment-shim.js';
 
@@ -48,19 +52,19 @@ export const getAnonymousIntrinsics = () => {
   // 21.1.5.2 The %StringIteratorPrototype% Object
 
   // eslint-disable-next-line no-new-wrappers
-  const StringIteratorObject = new String()[iteratorSymbol]();
+  const StringIteratorObject = iterateString(new String());
   const StringIteratorPrototype = getPrototypeOf(StringIteratorObject);
 
   // 21.2.7.1 The %RegExpStringIteratorPrototype% Object
   const RegExpStringIterator =
-    RegExp.prototype[matchAllSymbol] && new RegExp()[matchAllSymbol]();
+    regexpPrototype[matchAllSymbol] && matchAllRegExp(new RegExp());
   const RegExpStringIteratorPrototype =
     RegExpStringIterator && getPrototypeOf(RegExpStringIterator);
 
   // 22.1.5.2 The %ArrayIteratorPrototype% Object
 
   // eslint-disable-next-line no-array-constructor
-  const ArrayIteratorObject = new Array()[iteratorSymbol]();
+  const ArrayIteratorObject = iterateArray([]);
   const ArrayIteratorPrototype = getPrototypeOf(ArrayIteratorObject);
 
   // 22.2.1 The %TypedArray% Intrinsic Object
@@ -69,12 +73,12 @@ export const getAnonymousIntrinsics = () => {
 
   // 23.1.5.2 The %MapIteratorPrototype% Object
 
-  const MapIteratorObject = new Map()[iteratorSymbol]();
+  const MapIteratorObject = iterateMap(new Map());
   const MapIteratorPrototype = getPrototypeOf(MapIteratorObject);
 
   // 23.2.5.2 The %SetIteratorPrototype% Object
 
-  const SetIteratorObject = new Set()[iteratorSymbol]();
+  const SetIteratorObject = iterateSet(new Set());
   const SetIteratorPrototype = getPrototypeOf(SetIteratorObject);
 
   // 25.1.2 The %IteratorPrototype% Object

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -2,7 +2,6 @@ import {
   FERAL_FUNCTION,
   Float32Array,
   Map,
-  RegExp,
   Set,
   String,
   getOwnPropertyDescriptor,
@@ -57,7 +56,7 @@ export const getAnonymousIntrinsics = () => {
 
   // 21.2.7.1 The %RegExpStringIteratorPrototype% Object
   const RegExpStringIterator =
-    regexpPrototype[matchAllSymbol] && matchAllRegExp(new RegExp());
+    regexpPrototype[matchAllSymbol] && matchAllRegExp(/./);
   const RegExpStringIteratorPrototype =
     RegExpStringIterator && getPrototypeOf(RegExpStringIterator);
 

--- a/packages/ses/src/get-source-url.js
+++ b/packages/ses/src/get-source-url.js
@@ -1,4 +1,4 @@
-import { RegExp } from './commons.js';
+import { RegExp, regexpExec, stringSlice } from './commons.js';
 
 // Captures a key and value of the form #key=value or @key=value
 const sourceMetaEntryRegExp =
@@ -24,11 +24,11 @@ export const getSourceURL = src => {
   // So, we sublimate the comments out of the source until no source or no
   // comments remain.
   while (src.length > 0) {
-    const match = sourceMetaEntriesRegExp.exec(src);
+    const match = regexpExec(sourceMetaEntriesRegExp, src);
     if (match === null) {
       break;
     }
-    src = src.slice(0, src.length - match[0].length);
+    src = stringSlice(src, 0, src.length - match[0].length);
 
     // We skip $0 since it contains the entire match.
     // The match contains four capture groups,

--- a/packages/ses/src/get-source-url.js
+++ b/packages/ses/src/get-source-url.js
@@ -1,4 +1,4 @@
-import { RegExp, regexpExec, stringSlice } from './commons.js';
+import { FERAL_REG_EXP, regexpExec, stringSlice } from './commons.js';
 
 // Captures a key and value of the form #key=value or @key=value
 const sourceMetaEntryRegExp =
@@ -9,7 +9,7 @@ const sourceMetaEntryRegExp =
 // On account of the mechanics of regular expressions, scanning from the end
 // does not allow us to capture every pair, so getSourceURL must capture and
 // trim until there are no matching comments.
-const sourceMetaEntriesRegExp = new RegExp(
+const sourceMetaEntriesRegExp = new FERAL_REG_EXP(
   `(?:\\s*//${sourceMetaEntryRegExp}|/\\*${sourceMetaEntryRegExp}\\s*\\*/)\\s*$`,
 );
 

--- a/packages/ses/src/intrinsics.js
+++ b/packages/ses/src/intrinsics.js
@@ -1,6 +1,6 @@
 import {
-  Error,
   Object,
+  TypeError,
   WeakSet,
   arrayFilter,
   defineProperty,
@@ -41,7 +41,7 @@ function initProperty(obj, name, desc) {
       preDesc.enumerable !== desc.enumerable ||
       preDesc.configurable !== desc.configurable
     ) {
-      throw new Error(`Conflicting definitions of ${name}`);
+      throw new TypeError(`Conflicting definitions of ${name}`);
     }
   }
   defineProperty(obj, name, desc);
@@ -93,22 +93,22 @@ export const makeIntrinsicsCollector = () => {
       }
       const permit = whitelist[name];
       if (typeof permit !== 'object') {
-        throw new Error(`Expected permit object at whitelist.${name}`);
+        throw new TypeError(`Expected permit object at whitelist.${name}`);
       }
       const namePrototype = permit.prototype;
       if (!namePrototype) {
-        throw new Error(`${name}.prototype property not whitelisted`);
+        throw new TypeError(`${name}.prototype property not whitelisted`);
       }
       if (
         typeof namePrototype !== 'string' ||
         !objectHasOwnProperty(whitelist, namePrototype)
       ) {
-        throw new Error(`Unrecognized ${name}.prototype whitelist entry`);
+        throw new TypeError(`Unrecognized ${name}.prototype whitelist entry`);
       }
       const intrinsicPrototype = intrinsic.prototype;
       if (objectHasOwnProperty(intrinsics, namePrototype)) {
         if (intrinsics[namePrototype] !== intrinsicPrototype) {
-          throw new Error(`Conflicting bindings of ${namePrototype}`);
+          throw new TypeError(`Conflicting bindings of ${namePrototype}`);
         }
         // eslint-disable-next-line no-continue
         continue;
@@ -127,7 +127,7 @@ export const makeIntrinsicsCollector = () => {
 
   const isPseudoNative = obj => {
     if (!pseudoNatives) {
-      throw new Error(
+      throw new TypeError(
         'isPseudoNative can only be called after finalIntrinsics',
       );
     }

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -206,11 +206,13 @@ export const repairIntrinsics = (
       globalThis.Date.prototype.constructor !== globalThis.Date &&
       typeof globalThis.Date.now === 'function' &&
       // @ts-ignore
+      // eslint-disable-next-line @endo/no-polymorphic-call
       is(globalThis.Date.prototype.constructor.now(), NaN)
     );
   };
 
   if (seemsToBeLockedDown()) {
+    // eslint-disable-next-line @endo/no-polymorphic-call
     console.log('Seems to already be locked down. Skipping second lockdown');
     return alreadyHardenedIntrinsics;
   }
@@ -218,24 +220,26 @@ export const repairIntrinsics = (
   /**
    * 1. TAME powers & gather intrinsics first.
    */
-  const intrinsicsCollector = makeIntrinsicsCollector();
+  const {
+    addIntrinsics,
+    completePrototypes,
+    finalIntrinsics,
+  } = makeIntrinsicsCollector();
 
-  intrinsicsCollector.addIntrinsics({ harden });
+  addIntrinsics({ harden });
 
-  intrinsicsCollector.addIntrinsics(tameFunctionConstructors());
+  addIntrinsics(tameFunctionConstructors());
 
-  intrinsicsCollector.addIntrinsics(tameDateConstructor(dateTaming));
-  intrinsicsCollector.addIntrinsics(
-    tameErrorConstructor(errorTaming, stackFiltering),
-  );
-  intrinsicsCollector.addIntrinsics(tameMathObject(mathTaming));
-  intrinsicsCollector.addIntrinsics(tameRegExpConstructor(regExpTaming));
+  addIntrinsics(tameDateConstructor(dateTaming));
+  addIntrinsics(tameErrorConstructor(errorTaming, stackFiltering));
+  addIntrinsics(tameMathObject(mathTaming));
+  addIntrinsics(tameRegExpConstructor(regExpTaming));
 
-  intrinsicsCollector.addIntrinsics(getAnonymousIntrinsics());
+  addIntrinsics(getAnonymousIntrinsics());
 
-  intrinsicsCollector.completePrototypes();
+  completePrototypes();
 
-  const intrinsics = intrinsicsCollector.finalIntrinsics();
+  const intrinsics = finalIntrinsics();
 
   // Wrap console unless suppressed.
   // At the moment, the console is considered a host power in the start

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -1,7 +1,6 @@
 import { assert } from './error/assert.js';
 import { getDeferredExports } from './module-proxy.js';
 import {
-  Error,
   ReferenceError,
   SyntaxError,
   TypeError,
@@ -175,7 +174,7 @@ export const makeModuleInstance = (
         // init with initValue of a declared const binding, and return
         // it.
         if (!tdz) {
-          throw new Error(
+          throw new TypeError(
             `Internal: binding ${q(localName)} already initialized`,
           );
         }

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -14,9 +14,9 @@ import {
   makeThirdPartyModuleInstance,
 } from './module-instance.js';
 import {
-  Error,
   Map,
   ReferenceError,
+  TypeError,
   entries,
   isArray,
   isObject,
@@ -163,7 +163,7 @@ export const instantiate = (
       resolvedImports,
     );
   } else {
-    throw new Error(
+    throw new TypeError(
       `importHook must return a static module record, got ${q(
         staticModuleRecord,
       )}`,

--- a/packages/ses/src/module-proxy.js
+++ b/packages/ses/src/module-proxy.js
@@ -16,12 +16,16 @@ import {
   TypeError,
   create,
   freeze,
+  mapGet,
+  mapHas,
+  mapSet,
   ownKeys,
   reflectGet,
   reflectGetOwnPropertyDescriptor,
   reflectHas,
   reflectIsExtensible,
   reflectPreventExtensions,
+  weakmapSet,
 } from './commons.js';
 import { assert } from './error/assert.js';
 
@@ -155,10 +159,14 @@ export const getDeferredExports = (
   specifier,
 ) => {
   const { deferredExports } = compartmentPrivateFields;
-  if (!deferredExports.has(specifier)) {
+  if (!mapHas(deferredExports, specifier)) {
     const deferred = deferExports();
-    moduleAliases.set(deferred.exportsProxy, makeAlias(compartment, specifier));
-    deferredExports.set(specifier, deferred);
+    weakmapSet(
+      moduleAliases,
+      deferred.exportsProxy,
+      makeAlias(compartment, specifier),
+    );
+    mapSet(deferredExports, specifier, deferred);
   }
-  return deferredExports.get(specifier);
+  return mapGet(deferredExports, specifier);
 };

--- a/packages/ses/src/scope-constants.js
+++ b/packages/ses/src/scope-constants.js
@@ -1,4 +1,5 @@
 import {
+  arrayFilter,
   arrayIncludes,
   getOwnPropertyDescriptor,
   getOwnPropertyNames,
@@ -152,18 +153,20 @@ export const getScopeConstants = (globalObject, localObject = {}) => {
   const localNames = getOwnPropertyNames(localObject);
 
   // Collect all valid & immutable identifiers from the endowments.
-  const localConstants = localNames.filter(
+  const localConstants = arrayFilter(
+    localNames,
     name =>
       isValidIdentifierName(name) && isImmutableDataProperty(localObject, name),
   );
 
   // Collect all valid & immutable identifiers from the global that
   // are also not present in the endwoments (immutable or not).
-  const globalConstants = globalNames.filter(
+  const globalConstants = arrayFilter(
+    globalNames,
     name =>
       // Can't define a constant: it would prevent a
       // lookup on the endowments.
-      !localNames.includes(name) &&
+      !arrayIncludes(localNames, name) &&
       isValidIdentifierName(name) &&
       isImmutableDataProperty(globalObject, name),
   );

--- a/packages/ses/src/scope-handler.js
+++ b/packages/ses/src/scope-handler.js
@@ -28,6 +28,7 @@ const alwaysThrowHandler = new Proxy(
   immutableObject,
   freeze({
     get(_shadow, prop) {
+      // eslint-disable-next-line @endo/no-polymorphic-call
       assert.fail(
         d`Please report unexpected scope handler trap: ${q(String(prop))}`,
       );
@@ -174,6 +175,7 @@ export const createScopeHandler = (
     getOwnPropertyDescriptor(_target, prop) {
       // Coerce with `String` in case prop is a symbol.
       const quotedProp = q(String(prop));
+      // eslint-disable-next-line @endo/no-polymorphic-call
       console.warn(
         `getOwnPropertyDescriptor trap on scopeHandler for ${quotedProp}`,
         new Error().stack,

--- a/packages/ses/src/scope-handler.js
+++ b/packages/ses/src/scope-handler.js
@@ -1,8 +1,8 @@
 import {
-  Error,
   FERAL_EVAL,
   Proxy,
   String,
+  TypeError,
   create,
   freeze,
   getOwnPropertyDescriptor,
@@ -178,7 +178,7 @@ export const createScopeHandler = (
       // eslint-disable-next-line @endo/no-polymorphic-call
       console.warn(
         `getOwnPropertyDescriptor trap on scopeHandler for ${quotedProp}`,
-        new Error().stack,
+        new TypeError().stack,
       );
       return undefined;
     },

--- a/packages/ses/src/tame-date-constructor.js
+++ b/packages/ses/src/tame-date-constructor.js
@@ -1,10 +1,16 @@
 // @ts-check
 
-import { Error, Date, apply, construct, defineProperties } from './commons.js';
+import {
+  Date,
+  TypeError,
+  apply,
+  construct,
+  defineProperties,
+} from './commons.js';
 
 export default function tameDateConstructor(dateTaming = 'safe') {
   if (dateTaming !== 'safe' && dateTaming !== 'unsafe') {
-    throw new Error(`unrecognized dateTaming ${dateTaming}`);
+    throw new TypeError(`unrecognized dateTaming ${dateTaming}`);
   }
   const OriginalDate = Date;
   const DatePrototype = OriginalDate.prototype;

--- a/packages/ses/src/tame-function-constructors.js
+++ b/packages/ses/src/tame-function-constructors.js
@@ -45,6 +45,7 @@ import {
 export default function tameFunctionConstructors() {
   try {
     // Verify that the method is not callable.
+    // eslint-disable-next-line @endo/no-polymorphic-call
     FERAL_FUNCTION.prototype.constructor('return 1');
   } catch (ignore) {
     // Throws, no need to patch.

--- a/packages/ses/src/tame-locale-methods.js
+++ b/packages/ses/src/tame-locale-methods.js
@@ -3,8 +3,9 @@ import {
   Object,
   String,
   TypeError,
-  getOwnPropertyNames,
   defineProperty,
+  getOwnPropertyNames,
+  regexpExec,
 } from './commons.js';
 import { assert } from './error/assert.js';
 
@@ -53,7 +54,7 @@ export default function tameLocaleMethods(intrinsics, localeTaming = 'safe') {
     const intrinsic = intrinsics[intrinsicName];
     if (intrinsic === Object(intrinsic)) {
       for (const methodName of getOwnPropertyNames(intrinsic)) {
-        const match = localePattern.exec(methodName);
+        const match = regexpExec(localePattern, methodName);
         if (match) {
           assert(
             typeof intrinsic[methodName] === 'function',

--- a/packages/ses/src/tame-locale-methods.js
+++ b/packages/ses/src/tame-locale-methods.js
@@ -1,5 +1,4 @@
 import {
-  Error,
   Object,
   String,
   TypeError,
@@ -40,7 +39,7 @@ const nonLocaleCompare = tamedMethods.localeCompare;
 
 export default function tameLocaleMethods(intrinsics, localeTaming = 'safe') {
   if (localeTaming !== 'safe' && localeTaming !== 'unsafe') {
-    throw new Error(`unrecognized dateTaming ${localeTaming}`);
+    throw new TypeError(`unrecognized localeTaming ${localeTaming}`);
   }
   if (localeTaming === 'unsafe') {
     return;

--- a/packages/ses/src/tame-math-object.js
+++ b/packages/ses/src/tame-math-object.js
@@ -1,6 +1,6 @@
 import {
-  Error,
   Math,
+  TypeError,
   create,
   getOwnPropertyDescriptors,
   objectPrototype,
@@ -8,7 +8,7 @@ import {
 
 export default function tameMathObject(mathTaming = 'safe') {
   if (mathTaming !== 'safe' && mathTaming !== 'unsafe') {
-    throw new Error(`unrecognized mathTaming ${mathTaming}`);
+    throw new TypeError(`unrecognized mathTaming ${mathTaming}`);
   }
   const originalMath = Math;
   const initialMath = originalMath; // to follow the naming pattern

--- a/packages/ses/src/tame-regexp-constructor.js
+++ b/packages/ses/src/tame-regexp-constructor.js
@@ -1,6 +1,6 @@
 import {
-  Error,
-  RegExp as OriginalRegExp,
+  FERAL_REG_EXP,
+  TypeError,
   construct,
   defineProperties,
   getOwnPropertyDescriptor,
@@ -9,17 +9,17 @@ import {
 
 export default function tameRegExpConstructor(regExpTaming = 'safe') {
   if (regExpTaming !== 'safe' && regExpTaming !== 'unsafe') {
-    throw new Error(`unrecognized regExpTaming ${regExpTaming}`);
+    throw new TypeError(`unrecognized regExpTaming ${regExpTaming}`);
   }
-  const RegExpPrototype = OriginalRegExp.prototype;
+  const RegExpPrototype = FERAL_REG_EXP.prototype;
 
   const makeRegExpConstructor = (_ = {}) => {
     // RegExp has non-writable static properties we need to omit.
     const ResultRegExp = function RegExp(...rest) {
       if (new.target === undefined) {
-        return OriginalRegExp(...rest);
+        return FERAL_REG_EXP(...rest);
       }
-      return construct(OriginalRegExp, rest, new.target);
+      return construct(FERAL_REG_EXP, rest, new.target);
     };
 
     defineProperties(ResultRegExp, {
@@ -30,7 +30,7 @@ export default function tameRegExpConstructor(regExpTaming = 'safe') {
         enumerable: false,
         configurable: false,
       },
-      [speciesSymbol]: getOwnPropertyDescriptor(OriginalRegExp, speciesSymbol),
+      [speciesSymbol]: getOwnPropertyDescriptor(FERAL_REG_EXP, speciesSymbol),
     });
     return ResultRegExp;
   };

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -3,6 +3,7 @@
 import {
   RegExp,
   SyntaxError,
+  stringReplace,
   stringSearch,
   stringSlice,
   stringSplit,
@@ -97,7 +98,7 @@ export const rejectHtmlComments = src => {
  */
 export const evadeHtmlCommentTest = src => {
   const replaceFn = match => (match[0] === '<' ? '< ! --' : '-- >');
-  return src.replace(htmlCommentPattern, replaceFn);
+  return stringReplace(src, htmlCommentPattern, replaceFn);
 };
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -163,7 +164,7 @@ export const rejectImportExpressions = src => {
  */
 export const evadeImportExpressionTest = src => {
   const replaceFn = (_, p1, p2) => `${p1}__import__${p2}`;
-  return src.replace(importPattern, replaceFn);
+  return stringReplace(src, importPattern, replaceFn);
 };
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import {
-  RegExp,
+  FERAL_REG_EXP,
   SyntaxError,
   stringReplace,
   stringSearch,
@@ -34,7 +34,7 @@ function getLineNumber(src, pattern) {
 
 // /////////////////////////////////////////////////////////////////////////////
 
-const htmlCommentPattern = new RegExp(`(?:${'<'}!--|--${'>'})`, 'g');
+const htmlCommentPattern = new FERAL_REG_EXP(`(?:${'<'}!--|--${'>'})`, 'g');
 
 /**
  * Conservatively reject the source text if it may contain text that some
@@ -103,7 +103,10 @@ export const evadeHtmlCommentTest = src => {
 
 // /////////////////////////////////////////////////////////////////////////////
 
-const importPattern = new RegExp('(^|[^.])\\bimport(\\s*(?:\\(|/[/*]))', 'g');
+const importPattern = new FERAL_REG_EXP(
+  '(^|[^.])\\bimport(\\s*(?:\\(|/[/*]))',
+  'g',
+);
 
 /**
  * Conservatively reject the source text if it may contain a dynamic
@@ -169,7 +172,10 @@ export const evadeImportExpressionTest = src => {
 
 // /////////////////////////////////////////////////////////////////////////////
 
-const someDirectEvalPattern = new RegExp('(^|[^.])\\beval(\\s*\\()', 'g');
+const someDirectEvalPattern = new FERAL_REG_EXP(
+  '(^|[^.])\\beval(\\s*\\()',
+  'g',
+);
 
 /**
  * Heuristically reject some text that seems to contain a direct eval

--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -46,6 +46,7 @@
 import { whitelist, FunctionInstance, isAccessorPermit } from './whitelist.js';
 import {
   Error,
+  String,
   TypeError,
   arrayIncludes,
   getOwnPropertyDescriptor,
@@ -53,6 +54,7 @@ import {
   isObject,
   objectHasOwnProperty,
   ownKeys,
+  stringSlice,
 } from './commons.js';
 
 /**
@@ -67,7 +69,7 @@ function asStringPropertyName(path, prop) {
   }
 
   if (typeof prop === 'symbol') {
-    return `@@${prop.toString().slice(14, -1)}`;
+    return `@@${stringSlice(String(prop), 14, -1)}`;
   }
 
   throw new TypeError(`Unexpected property name type ${path} ${prop}`);
@@ -244,14 +246,17 @@ export default function whitelistIntrinsics(
           // This call to `console.log` is intentional. It is not a vestige
           // of a debugging attempt. See the comment at top of file for an
           // explanation.
+          // eslint-disable-next-line @endo/no-polymorphic-call
           console.log(`Removing ${subPath}`);
         }
         try {
           delete obj[prop];
         } catch (err) {
           if (prop in obj) {
+            // eslint-disable-next-line @endo/no-polymorphic-call
             console.error(`failed to delete ${subPath}`, err);
           } else {
+            // eslint-disable-next-line @endo/no-polymorphic-call
             console.error(`deleting ${subPath} threw`, err);
           }
           throw err;

--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -45,7 +45,6 @@
 
 import { whitelist, FunctionInstance, isAccessorPermit } from './whitelist.js';
 import {
-  Error,
   String,
   TypeError,
   arrayIncludes,
@@ -116,7 +115,9 @@ export default function whitelistIntrinsics(
     }
 
     // We can't clean [[prototype]], therefore abort.
-    throw new Error(`Unexpected intrinsic ${path}.__proto__ at ${protoName}`);
+    throw new TypeError(
+      `Unexpected intrinsic ${path}.__proto__ at ${protoName}`,
+    );
   }
 
   /*


### PR DESCRIPTION
[edit kriskowal 2021-07-15]

This adds an eslint plugin that @kumavis authored for us to help us validate that SES shim captures all of the behavior of intrinsics that it needs during initialization in order to provide a faithful emulation of a native SES implementation, to the extent that’s possible and given that SES runs before any intrinsic is altered away from specified behavior.

Then follows changes by me to get SES shim to obey the lint rule.

@erights and I concluded that console and assert should in general be bound late and their methods dispatched dynamically.

Some compartment code moved around to prevent alteration of the Compartment prototype from affecting the behavior of “native” compartment methods.