### PR TITLE
fix(ses): Defend integrity of intrinsics

### DIFF
--- a/packages/ses/index.js
+++ b/packages/ses/index.js
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* global globalThis */
-
-import { assign } from './src/commons.js';
+import { globalThis, Error, assign } from './src/commons.js';
 import { tameFunctionToString } from './src/tame-function-tostring.js';
 import { getGlobalIntrinsics } from './src/intrinsics.js';
 import { getAnonymousIntrinsics } from './src/get-anonymous-intrinsics.js';

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -84,6 +84,73 @@
   "eslintConfig": {
     "extends": [
       "@endo"
+    ],
+    "rules": {
+      "no-restricted-globals": [
+        "error",
+        "Array",
+        "ArrayBuffer",
+        "Atomics",
+        "BigInt",
+        "BigInt64Array",
+        "BigUint64Array",
+        "Boolean",
+        "DataView",
+        "Date",
+        "Error",
+        "EvalError",
+        "Float32Array",
+        "Float64Array",
+        "Function",
+        "HandledPromise",
+        "Int16Array",
+        "Int32Array",
+        "Int8Array",
+        "JSON",
+        "Map",
+        "Math",
+        "Number",
+        "Object",
+        "Promise",
+        "Proxy",
+        "RangeError",
+        "ReferenceError",
+        "Reflect",
+        "RegExp",
+        "Set",
+        "SharedArrayBuffer",
+        "String",
+        "Symbol",
+        "SyntaxError",
+        "TypeError",
+        "URIError",
+        "Uint16Array",
+        "Uint32Array",
+        "Uint8Array",
+        "Uint8ClampedArray",
+        "WeakMap",
+        "WeakSet",
+        "decodeURI",
+        "decodeURIComponent",
+        "encodeURI",
+        "encodeURIComponent",
+        "escape",
+        "eval",
+        "globalThis",
+        "isFinite",
+        "isNaN",
+        "parseFloat",
+        "parseInt",
+        "unescape"
+      ]
+    },
+    "overrides": [
+      {
+        "files": ["test/**/*.js", "demos/**/*.js"],
+        "rules": {
+          "no-restricted-globals": "off"
+        }
+      }
     ]
   },
   "prettier": {

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -1,3 +1,6 @@
+/* global globalThis */
+/* eslint-disable no-restricted-globals */
+
 /**
  * commons.js
  * Declare shorthand functions. Sharing these declarations across modules
@@ -8,6 +11,37 @@
  * modifies Object to change what 'assign' points to, the Compartment shim
  * would be corrupted.
  */
+
+// We cannot use globalThis as the local name since it would capture the
+// lexical name.
+const universalThis = globalThis;
+export { universalThis as globalThis };
+
+export const {
+  Array,
+  Date,
+  Float32Array,
+  JSON,
+  Map,
+  Math,
+  Object,
+  Promise,
+  Proxy,
+  Reflect,
+  RegExp,
+  Set,
+  String,
+  WeakMap,
+  WeakSet,
+} = globalThis;
+
+export const {
+  Error,
+  RangeError,
+  ReferenceError,
+  SyntaxError,
+  TypeError,
+} = globalThis;
 
 export const {
   assign,
@@ -27,6 +61,15 @@ export const {
   setPrototypeOf,
   values,
 } = Object;
+
+export const {
+  species: speciesSymbol,
+  toStringTag: toStringTagSymbol,
+  iterator: iteratorSymbol,
+  matchAll: matchAllSymbol,
+} = Symbol;
+
+export const { stringify: stringifyJson } = JSON;
 
 // At time of this writing, we still support Node 10 which doesn't have
 // `Object.fromEntries`. If it is absent, this should be an adequate
@@ -71,7 +114,11 @@ export const {
   apply,
   construct,
   get: reflectGet,
+  getOwnPropertyDescriptor: reflectGetOwnPropertyDescriptor,
+  has: reflectHas,
+  isExtensible: reflectIsExtensible,
   ownKeys,
+  preventExtensions: reflectPreventExtensions,
   set: reflectSet,
 } = Reflect;
 
@@ -83,6 +130,7 @@ export const { prototype: setPrototype } = Set;
 export const { prototype: stringPrototype } = String;
 export const { prototype: weakmapPrototype } = WeakMap;
 export const { prototype: weaksetPrototype } = WeakSet;
+export const { prototype: functionPrototype } = Function;
 
 /**
  * uncurryThis()
@@ -103,24 +151,40 @@ export const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
 
 export const objectHasOwnProperty = uncurryThis(objectPrototype.hasOwnProperty);
 //
+export const arrayForEach = uncurryThis(arrayPrototype.forEach);
 export const arrayFilter = uncurryThis(arrayPrototype.filter);
 export const arrayJoin = uncurryThis(arrayPrototype.join);
 export const arrayPush = uncurryThis(arrayPrototype.push);
 export const arrayPop = uncurryThis(arrayPrototype.pop);
 export const arrayIncludes = uncurryThis(arrayPrototype.includes);
 //
+export const mapSet = uncurryThis(mapPrototype.set);
+export const mapGet = uncurryThis(mapPrototype.get);
+export const mapHas = uncurryThis(mapPrototype.has);
+//
+export const setAdd = uncurryThis(setPrototype.add);
+export const setForEach = uncurryThis(setPrototype.forEach);
+export const setHas = uncurryThis(setPrototype.has);
+//
 export const regexpTest = uncurryThis(regexpPrototype.test);
 //
+export const stringEndsWith = uncurryThis(stringPrototype.endsWith);
+export const stringIncludes = uncurryThis(stringPrototype.includes);
 export const stringMatch = uncurryThis(stringPrototype.match);
 export const stringSearch = uncurryThis(stringPrototype.search);
 export const stringSlice = uncurryThis(stringPrototype.slice);
 export const stringSplit = uncurryThis(stringPrototype.split);
+export const stringStartsWith = uncurryThis(stringPrototype.startsWith);
 //
 export const weakmapGet = uncurryThis(weakmapPrototype.get);
 export const weakmapSet = uncurryThis(weakmapPrototype.set);
 export const weakmapHas = uncurryThis(weakmapPrototype.has);
 //
 export const weaksetAdd = uncurryThis(weaksetPrototype.add);
+export const weaksetSet = uncurryThis(weaksetPrototype.set);
+export const weaksetHas = uncurryThis(weaksetPrototype.has);
+//
+export const functionToString = uncurryThis(functionPrototype.toString);
 
 /**
  * getConstructorOf()
@@ -135,4 +199,34 @@ export const getConstructorOf = fn =>
  * immutableObject
  * An immutable (frozen) exotic object and is safe to share.
  */
-export const immutableObject = freeze({ __proto__: null });
+export const immutableObject = freeze(create(null));
+
+/**
+ * isObject tests whether a value is an object.
+ * Today, this is equivalent to:
+ *
+ *   const isObject = value => {
+ *     if (value === null) return false;
+ *     const type = typeof value;
+ *     return type === 'object' || type === 'function';
+ *   };
+ *
+ * But this is not safe in the face of possible evolution of the language, for
+ * example new types or semantics of records and tuples.
+ * We use this implementation despite the unnecessary allocation implied by
+ * attempting to box a primitive.
+ *
+ * @param {any} value
+ */
+export const isObject = value => Object(value) === value;
+
+// The original unsafe untamed eval function, which must not escape.
+// Sample at module initialization time, which is before lockdown can
+// repair it.  Use it only to build powerless abstractions.
+// eslint-disable-next-line no-eval
+export const FERAL_EVAL = eval;
+
+// The original unsafe untamed Function constructor, which must not escape.
+// Sample at module initialization time, which is before lockdown can
+// repair it.  Use it only to build powerless abstractions.
+export const FERAL_FUNCTION = Function;

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -4,11 +4,18 @@
 // @ts-check
 
 import {
+  Error,
+  Set,
+  String,
+  TypeError,
   defineProperty,
-  getOwnPropertyNames,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
+  getOwnPropertyNames,
+  isObject,
   objectHasOwnProperty,
+  ownKeys,
+  setHas,
 } from './commons.js';
 
 import {
@@ -16,12 +23,6 @@ import {
   moderateEnablements,
   severeEnablements,
 } from './enablements.js';
-
-const { ownKeys } = Reflect;
-
-function isObject(obj) {
-  return obj !== null && typeof obj === 'object';
-}
 
 /**
  * For a special set of properties defined in the `enablement` whitelist,
@@ -97,7 +98,7 @@ export default function enablePropertyOverrides(
         configurable: false,
       });
 
-      const isDebug = debugProperties.has(prop);
+      const isDebug = setHas(debugProperties, prop);
 
       function setter(newValue) {
         if (obj === this) {

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -1,6 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 // @ts-check
-/* global globalThis */
 
 // To ensure that this module operates without special privilege, it should
 // not reference the free variable `console` except for its own internal
@@ -12,7 +11,18 @@
 // of `console.js`. However, for code that does not have such access, this
 // module should not be observably impure.
 
-import { freeze, is, assign } from '../commons.js';
+import {
+  Error,
+  RangeError,
+  TypeError,
+  WeakMap,
+  assign,
+  freeze,
+  globalThis,
+  is,
+  weakmapGet,
+  weakmapSet,
+} from '../commons.js';
 import { an, bestEffortStringify } from './stringify-utils.js';
 import './types.js';
 import './internal-types.js';
@@ -189,13 +199,13 @@ const errorTags = new WeakMap();
  * @returns {string}
  */
 const tagError = (err, optErrorName = err.name) => {
-  let errorTag = errorTags.get(err);
+  let errorTag = weakmapGet(errorTags, err);
   if (errorTag !== undefined) {
     return errorTag;
   }
   errorTagNum += 1;
   errorTag = `${optErrorName}#${errorTagNum}`;
-  errorTags.set(err, errorTag);
+  weakmapSet(errorTags, err, errorTag);
   return errorTag;
 };
 

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -5,7 +5,15 @@
 // debugging purposes in the declaration of `internalDebugConsole`, which is
 // normally commented out.
 
-import { defineProperty, freeze, fromEntries } from '../commons.js';
+import {
+  Error,
+  WeakSet,
+  defineProperty,
+  freeze,
+  fromEntries,
+  weaksetAdd,
+  weaksetHas,
+} from '../commons.js';
 import './types.js';
 import './internal-types.js';
 
@@ -258,11 +266,11 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
    * @param {Error} error
    */
   const logError = error => {
-    if (errorsLogged.has(error)) {
+    if (weaksetHas(errorsLogged, error)) {
       return;
     }
     const errorTag = tagError(error);
-    errorsLogged.add(error);
+    weaksetAdd(errorsLogged, error);
     const subErrors = [];
     const messageLogArgs = takeMessageLogArgs(error);
     const noteLogArgsArray = takeNoteLogArgsArray(error, noteCallback);

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -1,6 +1,18 @@
 // @ts-check
 
-import { freeze } from '../commons.js';
+import {
+  Error,
+  Set,
+  String,
+  freeze,
+  is,
+  setAdd,
+  setHas,
+  stringStartsWith,
+  stringIncludes,
+  stringifyJson,
+  toStringTagSymbol,
+} from '../commons.js';
 
 /**
  * Prepend the correct indefinite article onto a noun, typically a typeof
@@ -11,7 +23,7 @@ import { freeze } from '../commons.js';
  */
 const an = str => {
   str = `${str}`;
-  if (str.length >= 1 && 'aeiouAEIOU'.includes(str[0])) {
+  if (str.length >= 1 && stringIncludes('aeiouAEIOU', str[0])) {
     return `an ${str}`;
   }
   return `a ${str}`;
@@ -54,14 +66,14 @@ const bestEffortStringify = (payload, spaces = undefined) => {
         if (val === null) {
           return null;
         }
-        if (seenSet.has(val)) {
+        if (setHas(seenSet, val)) {
           return '[Seen]';
         }
-        seenSet.add(val);
+        setAdd(seenSet, val);
         if (val instanceof Error) {
           return `[${val.name}: ${val.message}]`;
         }
-        if (Symbol.toStringTag in val) {
+        if (toStringTagSymbol in val) {
           // For the built-ins that have or inherit a `Symbol.toStringTag`-named
           // property, most of them inherit the default `toString` method,
           // which will print in a similar manner: `"[object Foo]"` vs
@@ -83,7 +95,7 @@ const bestEffortStringify = (payload, spaces = undefined) => {
           // purely in terms of JavaScript concepts. That's some of the
           // motivation for choosing that representation of remotables
           // and their remote presences in the first place.
-          return `[${val[Symbol.toStringTag]}]`;
+          return `[${val[toStringTagSymbol]}]`;
         }
         return val;
       }
@@ -91,7 +103,7 @@ const bestEffortStringify = (payload, spaces = undefined) => {
         return `[Function ${val.name || '<anon>'}]`;
       }
       case 'string': {
-        if (val.startsWith('[')) {
+        if (stringStartsWith(val, '[')) {
           return `[${val}]`;
         }
         return val;
@@ -104,7 +116,7 @@ const bestEffortStringify = (payload, spaces = undefined) => {
         return `[${val}n]`;
       }
       case 'number': {
-        if (Object.is(val, NaN)) {
+        if (is(val, NaN)) {
           return '[NaN]';
         } else if (val === Infinity) {
           return '[Infinity]';
@@ -119,7 +131,7 @@ const bestEffortStringify = (payload, spaces = undefined) => {
     }
   };
   try {
-    return JSON.stringify(payload, replacer, spaces);
+    return stringifyJson(payload, replacer, spaces);
   } catch (_err) {
     // Don't do anything more fancy here if there is any
     // chance that might throw, unless you surround that

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -1,6 +1,6 @@
 // @ts-check
-/* global globalThis */
 
+import { Error, globalThis } from '../commons.js';
 import { loggedErrorHandler as defaultHandler } from './assert.js';
 import { makeCausalConsole } from './console.js';
 import './types.js';

--- a/packages/ses/src/error/tame-error-constructor.js
+++ b/packages/ses/src/error/tame-error-constructor.js
@@ -1,4 +1,5 @@
 import {
+  Error,
   apply,
   construct,
   defineProperties,
@@ -43,6 +44,7 @@ export default function tameErrorConstructor(
     typeof OriginalError.captureStackTrace === 'function' ? 'v8' : 'unknown';
 
   const makeErrorConstructor = (_ = {}) => {
+    // eslint-disable-next-line no-shadow
     const ResultError = function Error(...rest) {
       let error;
       if (new.target === undefined) {

--- a/packages/ses/src/evaluate.js
+++ b/packages/ses/src/evaluate.js
@@ -1,7 +1,13 @@
 // Portions adapted from V8 - Copyright 2016 the V8 project authors.
 // https://github.com/v8/v8/blob/master/src/builtins/builtins-function.cc
 
-import { apply, immutableObject, proxyRevocable } from './commons.js';
+import {
+  WeakSet,
+  apply,
+  immutableObject,
+  proxyRevocable,
+  weaksetAdd,
+} from './commons.js';
 import { getScopeConstants } from './scope-constants.js';
 import { createScopeHandler } from './scope-handler.js';
 import { applyTransforms, mandatoryTransforms } from './transforms.js';
@@ -57,7 +63,7 @@ export const performEval = (
   let err;
   try {
     // Ensure that "this" resolves to the safe global.
-    knownScopeProxies.add(scopeProxyRevocable.proxy);
+    weaksetAdd(knownScopeProxies, scopeProxyRevocable.proxy);
     return apply(evaluate, globalObject, [source]);
   } catch (e) {
     // stash the child-code error in hopes of debugging the internal failure

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -1,4 +1,16 @@
-import { getOwnPropertyDescriptor, getPrototypeOf } from './commons.js';
+import {
+  Array,
+  FERAL_FUNCTION,
+  Float32Array,
+  Map,
+  RegExp,
+  Set,
+  String,
+  getOwnPropertyDescriptor,
+  getPrototypeOf,
+  iteratorSymbol,
+  matchAllSymbol,
+} from './commons.js';
 import { InertCompartment } from './compartment-shim.js';
 
 /**
@@ -26,10 +38,7 @@ function makeArguments() {
  * @returns {Object}
  */
 export const getAnonymousIntrinsics = () => {
-  const InertFunction = Function.prototype.constructor;
-
-  const SymbolIterator = (typeof Symbol && Symbol.iterator) || '@@iterator';
-  const SymbolMatchAll = (typeof Symbol && Symbol.matchAll) || '@@matchAll';
+  const InertFunction = FERAL_FUNCTION.prototype.constructor;
 
   // 9.2.4.1 %ThrowTypeError%
 
@@ -39,19 +48,19 @@ export const getAnonymousIntrinsics = () => {
   // 21.1.5.2 The %StringIteratorPrototype% Object
 
   // eslint-disable-next-line no-new-wrappers
-  const StringIteratorObject = new String()[SymbolIterator]();
+  const StringIteratorObject = new String()[iteratorSymbol]();
   const StringIteratorPrototype = getPrototypeOf(StringIteratorObject);
 
   // 21.2.7.1 The %RegExpStringIteratorPrototype% Object
   const RegExpStringIterator =
-    RegExp.prototype[SymbolMatchAll] && new RegExp()[SymbolMatchAll]();
+    RegExp.prototype[matchAllSymbol] && new RegExp()[matchAllSymbol]();
   const RegExpStringIteratorPrototype =
     RegExpStringIterator && getPrototypeOf(RegExpStringIterator);
 
   // 22.1.5.2 The %ArrayIteratorPrototype% Object
 
   // eslint-disable-next-line no-array-constructor
-  const ArrayIteratorObject = new Array()[SymbolIterator]();
+  const ArrayIteratorObject = new Array()[iteratorSymbol]();
   const ArrayIteratorPrototype = getPrototypeOf(ArrayIteratorObject);
 
   // 22.2.1 The %TypedArray% Intrinsic Object
@@ -60,12 +69,12 @@ export const getAnonymousIntrinsics = () => {
 
   // 23.1.5.2 The %MapIteratorPrototype% Object
 
-  const MapIteratorObject = new Map()[SymbolIterator]();
+  const MapIteratorObject = new Map()[iteratorSymbol]();
   const MapIteratorPrototype = getPrototypeOf(MapIteratorObject);
 
   // 23.2.5.2 The %SetIteratorPrototype% Object
 
-  const SetIteratorObject = new Set()[SymbolIterator]();
+  const SetIteratorObject = new Set()[iteratorSymbol]();
   const SetIteratorPrototype = getPrototypeOf(SetIteratorObject);
 
   // 25.1.2 The %IteratorPrototype% Object

--- a/packages/ses/src/get-source-url.js
+++ b/packages/ses/src/get-source-url.js
@@ -1,3 +1,5 @@
+import { RegExp } from './commons.js';
+
 // Captures a key and value of the form #key=value or @key=value
 const sourceMetaEntryRegExp =
   '\\s*[@#]\\s*([a-zA-Z][a-zA-Z0-9]*)\\s*=\\s*([^\\s\\*]*)';

--- a/packages/ses/src/intrinsics.js
+++ b/packages/ses/src/intrinsics.js
@@ -1,13 +1,17 @@
-/* global globalThis */
-
 import {
+  WeakSet,
+  Error,
+  Object,
   defineProperty,
   entries,
   freeze,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
+  globalThis,
+  is,
   objectHasOwnProperty,
   values,
+  arrayFilter,
 } from './commons.js';
 
 import {
@@ -16,6 +20,8 @@ import {
   universalPropertyNames,
   whitelist,
 } from './whitelist.js';
+
+const isFunction = obj => typeof obj === 'function';
 
 // Like defineProperty, but throws if it would modify an existing property.
 // We use this to ensure that two conflicting attempts to define the same
@@ -27,7 +33,7 @@ function initProperty(obj, name, desc) {
   if (objectHasOwnProperty(obj, name)) {
     const preDesc = getOwnPropertyDescriptor(obj, name);
     if (
-      !Object.is(preDesc.value, desc.value) ||
+      !is(preDesc.value, desc.value) ||
       preDesc.get !== desc.get ||
       preDesc.set !== desc.set ||
       preDesc.writable !== desc.writable ||
@@ -111,9 +117,7 @@ export const makeIntrinsicsCollector = () => {
     },
     finalIntrinsics() {
       freeze(intrinsics);
-      pseudoNatives = new WeakSet(
-        values(intrinsics).filter(obj => typeof obj === 'function'),
-      );
+      pseudoNatives = new WeakSet(arrayFilter(values(intrinsics), isFunction));
       return intrinsics;
     },
     isPseudoNative(obj) {

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 // @ts-check
-/* global globalThis */
 
-import { keys } from './commons.js';
+import { globalThis, is, keys, ownKeys } from './commons.js';
 import { makeHardener } from './make-hardener.js';
 import { makeIntrinsicsCollector } from './intrinsics.js';
 import whitelistIntrinsics from './whitelist-intrinsics.js';
@@ -147,7 +146,7 @@ export const repairIntrinsics = (
 
   // Assert that only supported options were passed.
   // Use Reflect.ownKeys to reject symbol-named properties as well.
-  const extraOptionsNames = Reflect.ownKeys(extraOptions);
+  const extraOptionsNames = ownKeys(extraOptions);
   assert(
     extraOptionsNames.length === 0,
     d`lockdown(): non supported option ${q(extraOptionsNames)}`,
@@ -201,13 +200,13 @@ export const repairIntrinsics = (
    */
   const seemsToBeLockedDown = () => {
     return (
-      Function.prototype.constructor !== Function &&
+      globalThis.Function.prototype.constructor !== globalThis.Function &&
       typeof globalThis.harden === 'function' &&
       typeof globalThis.lockdown === 'function' &&
-      Date.prototype.constructor !== Date &&
-      typeof Date.now === 'function' &&
+      globalThis.Date.prototype.constructor !== globalThis.Date &&
+      typeof globalThis.Date.now === 'function' &&
       // @ts-ignore
-      Object.is(Date.prototype.constructor.now(), NaN)
+      is(globalThis.Date.prototype.constructor.now(), NaN)
     );
   };
 

--- a/packages/ses/src/make-evaluate-factory.js
+++ b/packages/ses/src/make-evaluate-factory.js
@@ -1,9 +1,4 @@
-import { arrayJoin } from './commons.js';
-
-// The original unsafe untamed Function constructor, which must not escape.
-// Sample at module initialization time, which is before lockdown can
-// repair it. Use it only to build powerless abstractions.
-const FERAL_FUNCTION = Function;
+import { FERAL_FUNCTION, arrayJoin } from './commons.js';
 
 /**
  * buildOptimizer()

--- a/packages/ses/src/make-function-constructor.js
+++ b/packages/ses/src/make-function-constructor.js
@@ -1,4 +1,5 @@
 import {
+  FERAL_FUNCTION,
   arrayJoin,
   arrayPop,
   defineProperties,
@@ -6,11 +7,6 @@ import {
 } from './commons.js';
 import { performEval } from './evaluate.js';
 import { assert } from './error/assert.js';
-
-// The original unsafe untamed Function constructor, which must not escape.
-// Sample at module initialization time, which is before lockdown can
-// repair it.  Use it only to build powerless abstractions.
-const FERAL_FUNCTION = Function;
 
 /*
  * makeFunctionConstructor()
@@ -64,7 +60,7 @@ export const makeFunctionConstructor = (globaObject, options = {}) => {
     // Ensure that any function created in any evaluator in a realm is an
     // instance of Function in any evaluator of the same realm.
     prototype: {
-      value: Function.prototype,
+      value: FERAL_FUNCTION.prototype,
       writable: false,
       enumerable: false,
       configurable: false,
@@ -73,11 +69,11 @@ export const makeFunctionConstructor = (globaObject, options = {}) => {
 
   // Assert identity of Function.__proto__ accross all compartments
   assert(
-    getPrototypeOf(Function) === Function.prototype,
+    getPrototypeOf(FERAL_FUNCTION) === FERAL_FUNCTION.prototype,
     'Function prototype is the same accross compartments',
   );
   assert(
-    getPrototypeOf(newFunction) === Function.prototype,
+    getPrototypeOf(newFunction) === FERAL_FUNCTION.prototype,
     'Function constructor prototype is the same accross compartments',
   );
 

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -1,8 +1,19 @@
+import { assert } from './error/assert.js';
 import { getDeferredExports } from './module-proxy.js';
-import { create, entries, keys, freeze, defineProperty } from './commons.js';
+import {
+  Error,
+  ReferenceError,
+  SyntaxError,
+  TypeError,
+  create,
+  defineProperty,
+  entries,
+  freeze,
+  isArray,
+  keys,
+} from './commons.js';
 
-// q, for enquoting strings in error messages.
-const q = JSON.stringify;
+const { quote: q } = assert;
 
 export const makeThirdPartyModuleInstance = (
   compartmentPrivateFields,
@@ -23,7 +34,7 @@ export const makeThirdPartyModuleInstance = (
 
   if (staticModuleRecord.exports) {
     if (
-      !Array.isArray(staticModuleRecord.exports) ||
+      !isArray(staticModuleRecord.exports) ||
       staticModuleRecord.exports.some(name => typeof name !== 'string')
     ) {
       throw new TypeError(

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -6,7 +6,14 @@
 // module's "imports" with the more specific "resolvedImports" as inferred from
 // the particular compartment's "resolveHook".
 
-import { create, values, freeze } from './commons.js';
+import {
+  Promise,
+  TypeError,
+  ReferenceError,
+  create,
+  values,
+  freeze,
+} from './commons.js';
 import { assert } from './error/assert.js';
 
 const { details: d, quote: q } = assert;

--- a/packages/ses/src/module-proxy.js
+++ b/packages/ses/src/module-proxy.js
@@ -11,10 +11,21 @@
 // and eventually connecting it to to the proxied exports.
 
 import { makeAlias } from './module-load.js';
-import { create, freeze } from './commons.js';
+import {
+  Proxy,
+  TypeError,
+  create,
+  freeze,
+  ownKeys,
+  reflectGet,
+  reflectGetOwnPropertyDescriptor,
+  reflectHas,
+  reflectIsExtensible,
+  reflectPreventExtensions,
+} from './commons.js';
+import { assert } from './error/assert.js';
 
-// q, as in quote, for error messages.
-const q = JSON.stringify;
+const { quote: q } = assert;
 
 // `deferExports` creates a module's exports proxy, proxied exports, and
 // activator.
@@ -51,7 +62,7 @@ export const deferExports = () => {
             )} of module exports namespace, the module has not yet begun to execute`,
           );
         }
-        return Reflect.get(proxiedExports, name, receiver);
+        return reflectGet(proxiedExports, name, receiver);
       },
       set(_target, name, _value) {
         throw new TypeError(
@@ -66,7 +77,7 @@ export const deferExports = () => {
             )}, the module has not yet begun to execute`,
           );
         }
-        return Reflect.has(proxiedExports, name);
+        return reflectHas(proxiedExports, name);
       },
       deleteProperty(_target, name) {
         throw new TypeError(
@@ -79,8 +90,7 @@ export const deferExports = () => {
             'Cannot enumerate keys, the module has not yet begun to execute',
           );
         }
-        // return Object.keys(proxiedExports);
-        return Reflect.ownKeys(proxiedExports);
+        return ownKeys(proxiedExports);
       },
       getOwnPropertyDescriptor(_target, name) {
         if (!active) {
@@ -90,7 +100,7 @@ export const deferExports = () => {
             )}, the module has not yet begun to execute`,
           );
         }
-        return Reflect.getOwnPropertyDescriptor(proxiedExports, name);
+        return reflectGetOwnPropertyDescriptor(proxiedExports, name);
       },
       preventExtensions(_target) {
         if (!active) {
@@ -98,7 +108,7 @@ export const deferExports = () => {
             'Cannot prevent extensions of module exports namespace, the module has not yet begun to execute',
           );
         }
-        return Reflect.preventExtensions(proxiedExports);
+        return reflectPreventExtensions(proxiedExports);
       },
       isExtensible() {
         if (!active) {
@@ -106,7 +116,7 @@ export const deferExports = () => {
             'Cannot check extensibility of module exports namespace, the module has not yet begun to execute',
           );
         }
-        return Reflect.isExtensible(proxiedExports);
+        return reflectIsExtensible(proxiedExports);
       },
       getPrototypeOf(_target) {
         return null;

--- a/packages/ses/src/scope-constants.js
+++ b/packages/ses/src/scope-constants.js
@@ -84,7 +84,7 @@ const keywords = [
  * Note: \w is equivalent [a-zA-Z_0-9]
  * See 11.6.1 Identifier Names
  */
-const identifierPattern = new RegExp('^[a-zA-Z_$][\\w$]*$');
+const identifierPattern = /^[a-zA-Z_$][\w$]*$/;
 
 /**
  * isValidIdentifierName()

--- a/packages/ses/src/scope-handler.js
+++ b/packages/ses/src/scope-handler.js
@@ -1,7 +1,10 @@
-/* global globalThis */
-
 import {
+  Error,
+  FERAL_EVAL,
+  Proxy,
+  String,
   getOwnPropertyDescriptor,
+  globalThis,
   immutableObject,
   reflectGet,
   reflectSet,
@@ -9,12 +12,6 @@ import {
 import { assert } from './error/assert.js';
 
 const { details: d, quote: q } = assert;
-
-// The original unsafe untamed eval function, which must not escape.
-// Sample at module initialization time, which is before lockdown can
-// repair it.  Use it only to build powerless abstractions.
-// eslint-disable-next-line no-eval
-const FERAL_EVAL = eval;
 
 /**
  * alwaysThrowHandler
@@ -162,7 +159,7 @@ export const createScopeHandler = (
 
     getOwnPropertyDescriptor(_target, prop) {
       // Coerce with `String` in case prop is a symbol.
-      const quotedProp = JSON.stringify(String(prop));
+      const quotedProp = q(String(prop));
       console.warn(
         `getOwnPropertyDescriptor trap on scopeHandler for ${quotedProp}`,
         new Error().stack,

--- a/packages/ses/src/tame-date-constructor.js
+++ b/packages/ses/src/tame-date-constructor.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { defineProperties } from './commons.js';
+import { Error, Date, apply, construct, defineProperties } from './commons.js';
 
 export default function tameDateConstructor(dateTaming = 'safe') {
   if (dateTaming !== 'safe' && dateTaming !== 'unsafe') {
@@ -34,13 +34,15 @@ export default function tameDateConstructor(dateTaming = 'safe') {
   const makeDateConstructor = ({ powers = 'none' } = {}) => {
     let ResultDate;
     if (powers === 'original') {
+      // eslint-disable-next-line no-shadow
       ResultDate = function Date(...rest) {
         if (new.target === undefined) {
-          return Reflect.apply(OriginalDate, undefined, rest);
+          return apply(OriginalDate, undefined, rest);
         }
-        return Reflect.construct(OriginalDate, rest, new.target);
+        return construct(OriginalDate, rest, new.target);
       };
     } else {
+      // eslint-disable-next-line no-shadow
       ResultDate = function Date(...rest) {
         if (new.target === undefined) {
           return 'Invalid Date';
@@ -48,7 +50,7 @@ export default function tameDateConstructor(dateTaming = 'safe') {
         if (rest.length === 0) {
           rest = [NaN];
         }
-        return Reflect.construct(OriginalDate, rest, new.target);
+        return construct(OriginalDate, rest, new.target);
       };
     }
 

--- a/packages/ses/src/tame-function-constructors.js
+++ b/packages/ses/src/tame-function-constructors.js
@@ -1,4 +1,11 @@
-import { defineProperties, getPrototypeOf, setPrototypeOf } from './commons.js';
+import {
+  FERAL_FUNCTION,
+  SyntaxError,
+  TypeError,
+  defineProperties,
+  getPrototypeOf,
+  setPrototypeOf,
+} from './commons.js';
 
 // This module replaces the original `Function` constructor, and the original
 // `%GeneratorFunction%`, `%AsyncFunction%` and `%AsyncGeneratorFunction%`,
@@ -38,7 +45,7 @@ import { defineProperties, getPrototypeOf, setPrototypeOf } from './commons.js';
 export default function tameFunctionConstructors() {
   try {
     // Verify that the method is not callable.
-    (0, Function.prototype.constructor)('return 1');
+    FERAL_FUNCTION.prototype.constructor('return 1');
   } catch (ignore) {
     // Throws, no need to patch.
     return {};
@@ -58,7 +65,7 @@ export default function tameFunctionConstructors() {
   function repairFunction(name, intrinsicName, declaration) {
     let FunctionInstance;
     try {
-      // eslint-disable-next-line no-eval
+      // eslint-disable-next-line no-eval, no-restricted-globals
       FunctionInstance = (0, eval)(declaration);
     } catch (e) {
       if (e instanceof SyntaxError) {
@@ -95,8 +102,8 @@ export default function tameFunctionConstructors() {
 
     // Reconstructs the inheritance among the new tamed constructors
     // to mirror the original specified in normal JS.
-    if (InertConstructor !== Function.prototype.constructor) {
-      setPrototypeOf(InertConstructor, Function.prototype.constructor);
+    if (InertConstructor !== FERAL_FUNCTION.prototype.constructor) {
+      setPrototypeOf(InertConstructor, FERAL_FUNCTION.prototype.constructor);
     }
 
     newIntrinsics[intrinsicName] = InertConstructor;

--- a/packages/ses/src/tame-function-tostring.js
+++ b/packages/ses/src/tame-function-tostring.js
@@ -1,4 +1,13 @@
-import { defineProperty, apply, freeze, weaksetAdd } from './commons.js';
+import {
+  WeakSet,
+  defineProperty,
+  freeze,
+  functionPrototype,
+  functionToString,
+  stringEndsWith,
+  weaksetAdd,
+  weaksetHas,
+} from './commons.js';
 
 const nativeSuffix = ') { [native code] }';
 
@@ -16,14 +25,12 @@ export const tameFunctionToString = () => {
   if (markVirtualizedNativeFunction === undefined) {
     const virtualizedNativeFunctions = new WeakSet();
 
-    const originalFunctionToString = Function.prototype.toString;
-
     const tamingMethods = {
       toString() {
-        const str = apply(originalFunctionToString, this, []);
+        const str = functionToString(this, []);
         if (
-          str.endsWith(nativeSuffix) ||
-          !virtualizedNativeFunctions.has(this)
+          stringEndsWith(str, nativeSuffix) ||
+          !weaksetHas(virtualizedNativeFunctions, this)
         ) {
           return str;
         }
@@ -31,7 +38,7 @@ export const tameFunctionToString = () => {
       },
     };
 
-    defineProperty(Function.prototype, 'toString', {
+    defineProperty(functionPrototype, 'toString', {
       value: tamingMethods.toString,
     });
 

--- a/packages/ses/src/tame-locale-methods.js
+++ b/packages/ses/src/tame-locale-methods.js
@@ -1,4 +1,11 @@
-import { getOwnPropertyNames, defineProperty } from './commons.js';
+import {
+  Error,
+  Object,
+  String,
+  TypeError,
+  getOwnPropertyNames,
+  defineProperty,
+} from './commons.js';
 import { assert } from './error/assert.js';
 
 const { details: d, quote: q } = assert;

--- a/packages/ses/src/tame-math-object.js
+++ b/packages/ses/src/tame-math-object.js
@@ -1,4 +1,10 @@
-import { create, getOwnPropertyDescriptors } from './commons.js';
+import {
+  Error,
+  Math,
+  create,
+  getOwnPropertyDescriptors,
+  objectPrototype,
+} from './commons.js';
 
 export default function tameMathObject(mathTaming = 'safe') {
   if (mathTaming !== 'safe' && mathTaming !== 'unsafe') {
@@ -11,7 +17,7 @@ export default function tameMathObject(mathTaming = 'safe') {
     originalMath,
   );
 
-  const sharedMath = create(Object.prototype, otherDescriptors);
+  const sharedMath = create(objectPrototype, otherDescriptors);
 
   return {
     '%InitialMath%': initialMath,

--- a/packages/ses/src/tame-regexp-constructor.js
+++ b/packages/ses/src/tame-regexp-constructor.js
@@ -1,10 +1,16 @@
-import { defineProperties, getOwnPropertyDescriptor } from './commons.js';
+import {
+  Error,
+  RegExp as OriginalRegExp,
+  construct,
+  defineProperties,
+  getOwnPropertyDescriptor,
+  speciesSymbol,
+} from './commons.js';
 
 export default function tameRegExpConstructor(regExpTaming = 'safe') {
   if (regExpTaming !== 'safe' && regExpTaming !== 'unsafe') {
     throw new Error(`unrecognized regExpTaming ${regExpTaming}`);
   }
-  const OriginalRegExp = RegExp;
   const RegExpPrototype = OriginalRegExp.prototype;
 
   const makeRegExpConstructor = (_ = {}) => {
@@ -13,7 +19,7 @@ export default function tameRegExpConstructor(regExpTaming = 'safe') {
       if (new.target === undefined) {
         return OriginalRegExp(...rest);
       }
-      return Reflect.construct(OriginalRegExp, rest, new.target);
+      return construct(OriginalRegExp, rest, new.target);
     };
 
     defineProperties(ResultRegExp, {
@@ -24,10 +30,7 @@ export default function tameRegExpConstructor(regExpTaming = 'safe') {
         enumerable: false,
         configurable: false,
       },
-      [Symbol.species]: getOwnPropertyDescriptor(
-        OriginalRegExp,
-        Symbol.species,
-      ),
+      [speciesSymbol]: getOwnPropertyDescriptor(OriginalRegExp, speciesSymbol),
     });
     return ResultRegExp;
   };

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -1,6 +1,12 @@
 // @ts-check
 
-import { stringSearch, stringSlice, stringSplit } from './commons.js';
+import {
+  RegExp,
+  SyntaxError,
+  stringSearch,
+  stringSlice,
+  stringSplit,
+} from './commons.js';
 import { getSourceURL } from './get-source-url.js';
 
 /**

--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -45,8 +45,12 @@
 
 import { whitelist, FunctionInstance, isAccessorPermit } from './whitelist.js';
 import {
-  getPrototypeOf,
+  Error,
+  TypeError,
+  arrayIncludes,
   getOwnPropertyDescriptor,
+  getPrototypeOf,
+  isObject,
   objectHasOwnProperty,
   ownKeys,
 } from './commons.js';
@@ -89,7 +93,7 @@ export default function whitelistIntrinsics(
    * Validate the object's [[prototype]] against a permit.
    */
   function whitelistPrototype(path, obj, protoName) {
-    if (obj !== Object(obj)) {
+    if (!isObject(obj)) {
       throw new TypeError(`Object expected: ${path}, ${obj}, ${protoName}`);
     }
     const proto = getPrototypeOf(obj);
@@ -153,7 +157,7 @@ export default function whitelistIntrinsics(
         // Assert: the property value type is equal to that primitive.
 
         // eslint-disable-next-line no-lonely-if
-        if (primitives.includes(permit)) {
+        if (arrayIncludes(primitives, permit)) {
           // eslint-disable-next-line valid-typeof
           if (typeof value !== permit) {
             throw new TypeError(

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * @file Exports {@code whitelist}, a recursively defined
  * JSON record enumerating all intrinsics and their properties


### PR DESCRIPTION
In order for the SES shim to faithfully approximate the intended behavior of SES as implemented by engines, it must capture all of the intrinsics it uses and avoid dynamic dispatch on any object that might be modified after SES initialization. After lockdown, the shared intrinsics are immutable, but all execution between initialization and lockdown in the privileged start compartment could alter the intrinsics and compromise the correctness of SES. Also, SES may depend upon free but unshared intrinsics (though I can think of no example).

This is not a security vulnerability because SES provides no guarantees against interference from code running in the start compartment, only code running in child compartments. This change does address a weakness in the SES shim’s integrity against accidental mutation to the shared platform.