### PR TITLE
refactor(ses): Avoid use of receiver object `this` in scope handler

### DIFF
--- a/packages/ses/src/make-evaluate-factory.js
+++ b/packages/ses/src/make-evaluate-factory.js
@@ -46,9 +46,10 @@ export const makeEvaluateFactory = (constants = []) => {
   // - keywords like 'function' which are reserved keywords, and cannot be
   //   used as a variables, so they is not part to the optimizer.
   // - when 'eval' is looked up in the proxy, and it's the first time it is
-  //   looked up after useUnsafeEvaluator is turned on, the proxy returns the
-  //   eval intrinsic, and flips useUnsafeEvaluator back to false. Any reference
-  //   to 'eval' in that string will get the tamed evaluator.
+  //   looked up after allowNextEvalToBeUnsafe is turned on, the proxy returns
+  //   the powerful, unsafe eval intrinsic, and flips allowNextEvalToBeUnsafe
+  //   back to false. Any reference to 'eval' in that string will get the tamed
+  //   evaluator.
 
   // TODO https://github.com/endojs/endo/issues/816
   // The optimizer currently runs under sloppy mode, and although we doubt that

--- a/packages/ses/test/test-scope-handler.js
+++ b/packages/ses/test/test-scope-handler.js
@@ -17,7 +17,10 @@ test('scopeHandler - has trap', t => {
 
   const globalObject = { foo: {} };
   const endowments = { foobar: {} };
-  const handler = createScopeHandler(globalObject, endowments);
+  const { scopeHandler: handler } = createScopeHandler(
+    globalObject,
+    endowments,
+  );
 
   t.is(handler.has(null, Symbol.unscopables), false);
   t.is(handler.has(null, 'arguments'), false);
@@ -37,7 +40,11 @@ test('scopeHandler - has trap in sloppyGlobalsMode', t => {
   const globalObject = {};
   const endowments = {};
   const options = { sloppyGlobalsMode: true };
-  const handler = createScopeHandler(globalObject, endowments, options);
+  const { scopeHandler: handler } = createScopeHandler(
+    globalObject,
+    endowments,
+    options,
+  );
 
   globalThis.bar = {};
 
@@ -58,7 +65,10 @@ test('scopeHandler - get trap', t => {
 
   const globalObject = { foo: {} };
   const endowments = { foobar: {} };
-  const handler = createScopeHandler(globalObject, endowments);
+  const { scopeHandler: handler } = createScopeHandler(
+    globalObject,
+    endowments,
+  );
 
   globalThis.bar = {};
 
@@ -79,7 +89,10 @@ test('scopeHandler - get trap - accessors on endowments', t => {
 
   const globalObject = { foo: {} };
   const endowments = {};
-  const handler = createScopeHandler(globalObject, endowments);
+  const { scopeHandler: handler } = createScopeHandler(
+    globalObject,
+    endowments,
+  );
 
   Object.defineProperties(endowments, {
     foo: {
@@ -98,7 +111,10 @@ test('scopeHandler - set trap', t => {
 
   const globalObject = { foo: {} };
   const endowments = { foobar: {} };
-  const handler = createScopeHandler(globalObject, endowments);
+  const { scopeHandler: handler } = createScopeHandler(
+    globalObject,
+    endowments,
+  );
 
   globalThis.bar = {};
 
@@ -137,19 +153,23 @@ test('scopeHandler - set trap', t => {
   delete globalThis.bar;
 });
 
-test('scopeHandler - get trap - useUnsafeEvaluator', t => {
+test('scopeHandler - get trap - reset allow next unsafe eval', t => {
   t.plan(7);
 
   const globalObject = { eval: {} };
-  const handler = createScopeHandler(globalObject);
+  const {
+    scopeHandler: handler,
+    resetOneUnsafeEvalNext,
+    admitOneUnsafeEvalNext,
+  } = createScopeHandler(globalObject);
 
-  t.is(handler.useUnsafeEvaluator, false);
+  t.is(resetOneUnsafeEvalNext(), false);
   t.is(handler.get(null, 'eval'), globalObject.eval);
   t.is(handler.get(null, 'eval'), globalObject.eval); // repeat
 
-  handler.useUnsafeEvaluator = true;
+  admitOneUnsafeEvalNext();
   t.is(handler.get(null, 'eval'), FERAL_EVAL);
-  t.is(handler.useUnsafeEvaluator, false);
+  t.is(resetOneUnsafeEvalNext(), false);
   t.is(handler.get(null, 'eval'), globalObject.eval);
   t.is(handler.get(null, 'eval'), globalObject.eval); // repeat
 });
@@ -160,7 +180,7 @@ test('scopeHandler - throw only for unsupported traps', t => {
   sinon.stub(console, 'error').callsFake();
 
   const globalObject = {};
-  const handler = createScopeHandler(globalObject);
+  const { scopeHandler: handler } = createScopeHandler(globalObject);
 
   ['has', 'get', 'set', 'getPrototypeOf'].forEach(trap =>
     t.notThrows(() => handler[trap]),


### PR DESCRIPTION
As discussed at Sestival 2021, an week-long Agoric/MetaMask Red Team event, the audit-ability of the scope proxy would be improved if there were no incidental state on the scope proxy handler which might collide with the namespace of handlers as used by Proxy and no suspicious use of `this`. This change replaces this boolean flag on the handler object with a controller object with named methods for the intended behaviors.

This includes on incidental behavior change that is a precaution redundant with the revocation of the proxy—checking whether the flag to allow one unsafe eval to pass through the proxy itself resets the flag.