### PR TITLE
fix(ses): Use eslint-disable notation consistently

### DIFF
--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -1,4 +1,4 @@
-/* eslint no-underscore-dangle: ["off"] */
+/* eslint-disable no-underscore-dangle */
 
 // For brevity, in this file, as in module-load.js, the term "moduleRecord"
 // without qualification means "module compartment record".

--- a/packages/ses/test/test-get-source-url.js
+++ b/packages/ses/test/test-get-source-url.js
@@ -1,4 +1,4 @@
-/* eslint max-depth: "off" */
+/* eslint-disable max-depth */
 import test from 'ava';
 import { getSourceURL } from '../src/get-source-url.js';
 

--- a/packages/ses/test/test-property-override.js
+++ b/packages/ses/test/test-property-override.js
@@ -1,4 +1,4 @@
-/* eslint max-classes-per-file: "off" */
+/* eslint-disable max-classes-per-file */
 import test from 'ava';
 import '../index.js';
 


### PR DESCRIPTION
Drive-by notation simplification