### PR TITLE
docs: One less SES acronym explainer

### DIFF
--- a/packages/ses/docs/secure-coding-guide.md
+++ b/packages/ses/docs/secure-coding-guide.md
@@ -1,6 +1,6 @@
 # Secure Coding Guidelines under SES
 
-SES (Secure EcmaScript) is a JavaScript-based programming environment that
+SES is a JavaScript-based programming environment that
 makes it easier to write *defensively consistent* programs. We define
 **defensive consistency** as a program (or function, or service.. something
 written in code) that provides correct service to its correctly-behaving


### PR DESCRIPTION
We are moving in general toward not explaining the origin of the SES acronym.

*Requires squash*