### PR TITLE
fix(netstring): Explicitly export types

### DIFF
--- a/packages/netstring/index.d.ts
+++ b/packages/netstring/index.d.ts
@@ -1,1 +1,2 @@
-export * from './src/main.js';
+export { netstringReader, nestringWriter } from './index.js';
+export type { Stream } from './stream.js';

--- a/packages/netstring/reader.js
+++ b/packages/netstring/reader.js
@@ -8,7 +8,7 @@ const decoder = new TextDecoder();
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} input
  * @param {string=} name
  * @param {number=} capacity
- * @returns {AsyncGenerator<Uint8Array, Uint8Array, unknown>} input
+ * @returns {import('./stream.js').Stream<Uint8Array, undefined, undefined>} input
  */
 export async function* netstringReader(
   input,
@@ -67,5 +67,4 @@ export async function* netstringReader(
       `Unexpected dangling message at offset ${offset} of ${name}`,
     );
   }
-  return new Uint8Array(0);
 }

--- a/packages/netstring/stream.js
+++ b/packages/netstring/stream.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+export const moduleOnlyExportsTypes = true;
+
+/**
+ * Stream satisfies AsyncGenerator, and no arguments are optional.
+ *
+ * @template GetType
+ * @template GiveType
+ * @template FinaType
+ * @typedef {{
+ *   next(value: GiveType): Promise<IteratorResult<GetType>>,
+ *   return(value: FinaType): Promise<IteratorResult<GetType>>,
+ *   throw(error: Error): Promise<IteratorResult<GetType>>,
+ *   [Symbol.asyncIterator](): Stream<GetType, GiveType, FinaType>
+ * }} Stream
+ */

--- a/packages/netstring/test/test-netstring.js
+++ b/packages/netstring/test/test-netstring.js
@@ -90,6 +90,7 @@ test('round-trip varying messages', async t => {
   const [input, output] = pipe();
 
   const producer = (async () => {
+    /** @type {import('../stream.js').Stream<void, Uint8Array, undefined>} */
     const w = netstringWriter(output);
     for (let i = 0; i < array.length; i += 1) {
       // eslint-disable-next-line no-await-in-loop
@@ -101,6 +102,7 @@ test('round-trip varying messages', async t => {
   })();
 
   const consumer = (async () => {
+    /** @type {import('../stream.js').Stream<Uint8Array, Uint8Array, undefined>} */
     const r = netstringReader(input);
     let i = 0;
     for await (const message of r) {

--- a/packages/netstring/writer.js
+++ b/packages/netstring/writer.js
@@ -6,20 +6,8 @@ const COMMA = ','.charCodeAt(0);
 const encoder = new TextEncoder();
 
 /**
- * @template T
- * @template U
- * @template V
- * @typedef {{
- *   next(value: U): Promise<IteratorResult<T>>,
- *   return(value: V): Promise<IteratorResult<T>>,
- *   throw(error: Error): Promise<IteratorResult<T>>,
- *   [Symbol.asyncIterator](): Stream<T, U, V>
- * }} Stream
- */
-
-/**
- * @param {Stream<void, Uint8Array, void>} output
- * @returns {Stream<void, Uint8Array, void>}
+ * @param {import('./stream.js').Stream<void, Uint8Array, undefined>} output
+ * @returns {import('./stream.js').Stream<void, Uint8Array, undefined>}
  */
 export function netstringWriter(output) {
   const scratch = new Uint8Array(8);


### PR DESCRIPTION
The type definitions for netstring must be explicit for lint to pass in
dependees.

Blocks https://github.com/Agoric/agoric-sdk/pull/2978 (which landed prematurely and will need to be reconstructed with the next published version of netstring)