### PR TITLE
feat(ses): Add permits for at methods

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in SES:
 
+# Next version
+
+- Adds permits for `Array.prototype.at` and `String.prototype.at` which are
+  Stage 3 proposals for ECMA 262.
+
 # 0.14.0 (2021-07-22)
 
 - *BREAKING*: Any precompiled static module records from prior versions

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -769,6 +769,10 @@ export const whitelist = {
     trimRight: fn,
     // See https://github.com/Moddable-OpenSource/moddable/issues/523
     compare: false,
+
+    // Stage 3:
+    // https://tc39.es/proposal-relative-indexing-method/
+    at: fn,
   },
 
   '%StringIteratorPrototype%': {
@@ -857,6 +861,10 @@ export const whitelist = {
     of: fn,
     prototype: '%ArrayPrototype%',
     '@@species': getter,
+
+    // Stage 3:
+    // https://tc39.es/proposal-relative-indexing-method/
+    at: fn,
   },
 
   '%ArrayPrototype%': {


### PR DESCRIPTION
Array and String prototype `at` methods are a Stage 3 proposal for
ECMA 262 and are appearing in implementations.

Fixes #854
