### PR TITLE
feat(compartment-mapper): Support reflexive imports

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,11 @@
 User-visible changes to the compartment mapper:
 
+# Next release
+
+- Adds support for reflexive import specifiers, so modules in package named
+  `@example/example` may import `@example/example` from their own modules.
+  This is necessary for parity with Node.js.
+
 # 0.5.0 (2021-07-22)
 
 - The calling convention between SES and StaticModuleRecords has changed and

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/app/main.js
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/app/main.js
@@ -28,3 +28,10 @@ export const receivedGlobalLexical = globalLexical;
 if (!Object.isFrozen(globalThis)) {
   throw new Error('The global object must be frozen in all compartments');
 }
+
+// reflexivity
+import * as app from 'app';
+import * as appMain from 'app/main.js';
+if (app !== appMain) {
+  throw new Error('Import aliases for the reflexive module name should produce identical namespace objects');
+}


### PR DESCRIPTION
In Node.js ESM, a package may import its own name. This is particularly
useful for creating tests and testing examples of usage from a
third-party perspective, and is necessary for feature parity.

Blocks https://github.com/Agoric/agoric-sdk/pull/3273
