### PR TITLE
fix(ses): Fix reflexive imports

### DIFF
--- a/packages/compartment-mapper/test/fixtures-cycle-cjs/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-cjs/node_modules/app/index.js
@@ -1,0 +1,1 @@
+require('app');

--- a/packages/compartment-mapper/test/fixtures-cycle-cjs/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cycle-cjs/node_modules/app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "app",
+  "type": "commonjs"
+}

--- a/packages/compartment-mapper/test/fixtures-cycle-mjs/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-mjs/node_modules/app/index.js
@@ -1,0 +1,1 @@
+import 'app';

--- a/packages/compartment-mapper/test/fixtures-cycle-mjs/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cycle-mjs/node_modules/app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "app",
+  "type": "module"
+}

--- a/packages/compartment-mapper/test/test-cycle-cjs.js
+++ b/packages/compartment-mapper/test/test-cycle-cjs.js
@@ -1,0 +1,22 @@
+// import "./ses-lockdown.js";
+import 'ses';
+import fs from 'fs';
+import test from 'ava';
+import { loadLocation } from '../src/import.js';
+import { makeNodeReadPowers } from '../src/node-powers.js';
+
+const readPowers = makeNodeReadPowers(fs);
+const { read } = readPowers;
+
+test('reflexive CommonJS cyclic import', async t => {
+  t.plan(1);
+
+  const fixture = new URL(
+    'fixtures-cycle-cjs/node_modules/app/index.js',
+    import.meta.url,
+  ).toString();
+
+  const application = await loadLocation(read, fixture);
+  await application.import({});
+  t.pass();
+});

--- a/packages/compartment-mapper/test/test-cycle-mjs.js
+++ b/packages/compartment-mapper/test/test-cycle-mjs.js
@@ -1,0 +1,22 @@
+// import "./ses-lockdown.js";
+import 'ses';
+import fs from 'fs';
+import test from 'ava';
+import { loadLocation } from '../src/import.js';
+import { makeNodeReadPowers } from '../src/node-powers.js';
+
+const readPowers = makeNodeReadPowers(fs);
+const { read } = readPowers;
+
+test('reflexive cycle of ESM', async t => {
+  t.plan(1);
+
+  const fixture = new URL(
+    'fixtures-cycle-mjs/node_modules/app/index.js',
+    import.meta.url,
+  ).toString();
+
+  const application = await loadLocation(read, fixture);
+  await application.import({});
+  t.pass();
+});

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -17,6 +17,8 @@ User-visible changes in SES:
   afford a gradual migration.
   Thank you to @dominictarr with [Least Authority](https://leastauthority.com/)
   for devising this feature.
+- Fixes reflexive module imports. Previously, SES would fail to initialize a
+  module graph where a module imported an alias to itself.
 
 # 0.14.1 (2021-08-12)
 

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -40,11 +40,18 @@ export const link = (
   compartment,
   moduleSpecifier,
 ) => {
-  const { moduleRecords } = weakmapGet(compartmentPrivateFields, compartment);
+  const { name: compartmentName, moduleRecords } = weakmapGet(
+    compartmentPrivateFields,
+    compartment,
+  );
 
   const moduleRecord = mapGet(moduleRecords, moduleSpecifier);
   if (moduleRecord === undefined) {
-    throw new ReferenceError(`Missing link to module ${q(moduleSpecifier)}`);
+    throw new ReferenceError(
+      `Missing link to module ${q(moduleSpecifier)} from compartment ${q(
+        compartmentName,
+      )}`,
+    );
   }
 
   // Mutual recursion so there's no confusion about which

--- a/packages/ses/test/test-import.js
+++ b/packages/ses/test/test-import.js
@@ -510,8 +510,10 @@ test('import reflexive module alias', async t => {
 
   const moduleMapHook = specifier => {
     if (specifier === 'self') {
+      // eslint-disable-next-line no-use-before-define
       return compartment.module('./index.js');
     }
+    return undefined;
   };
 
   const compartment = new Compartment(


### PR DESCRIPTION
Previously, SES would stall when attempting to load a module that imported itself through an alias.

- test(ses): Test module reflexive import
- test(compartment-mapper): Add reflexive import tests
- fix(ses): Fix reflexive imports
