### PR TITLE
add __makeScopeProxy__ to Compartment.prototype

### DIFF
--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -27,7 +27,7 @@ import { load } from './module-load.js';
 import { link } from './module-link.js';
 import { getDeferredExports } from './module-proxy.js';
 import { assert } from './error/assert.js';
-import { compartmentEvaluate } from './compartment-evaluate.js';
+import { compartmentEvaluate, makeScopeProxy } from './compartment-evaluate.js';
 
 const { quote: q } = assert;
 
@@ -118,6 +118,18 @@ export const CompartmentPrototype = {
   __isKnownScopeProxy__(value) {
     const { knownScopeProxies } = weakmapGet(privateFields, this);
     return weaksetHas(knownScopeProxies, value);
+  },
+
+  /**
+   * @param {Object} [options]
+   * @param {boolean} [options.sloppyGlobalsMode]
+   * @param {Object} [options.__moduleShimLexicals__]
+   */
+  /* eslint-disable-next-line no-underscore-dangle */
+  __makeScopeProxy__(options = {}) {
+    const compartmentFields = weakmapGet(privateFields, this);
+    const scopeProxy = makeScopeProxy(compartmentFields, options);
+    return { scopeProxy };
   },
 
   module(specifier) {

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -1341,6 +1341,7 @@ export const whitelist = {
     // Should this be proposed?
     toString: fn,
     __isKnownScopeProxy__: fn,
+    __makeScopeProxy__: fn,
     import: asyncFn,
     load: asyncFn,
     importNow: fn,

--- a/packages/ses/test/test-compartment-instance.js
+++ b/packages/ses/test/test-compartment-instance.js
@@ -29,6 +29,7 @@ test('Compartment instance', t => {
     Reflect.ownKeys(Object.getPrototypeOf(c)).sort(),
     [
       '__isKnownScopeProxy__',
+      '__makeScopeProxy__',
       'constructor',
       'evaluate',
       'globalThis',

--- a/packages/ses/test/test-compartment-make-scope-proxy.js
+++ b/packages/ses/test/test-compartment-make-scope-proxy.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-underscore-dangle */
+import test from 'ava';
+import '../index.js';
+
+lockdown();
+
+test('compartment main use case exploded', t => {
+  function power(a) {
+    return a + 1;
+  }
+
+  const c1 = new Compartment({ power });
+  const { scopeProxy: scopeProxy1 } = c1.__makeScopeProxy__();
+  const power1 = scopeProxy1.power;
+  const attenuatedPower = arg => {
+    if (arg <= 0) {
+      throw new TypeError('only positive numbers');
+    }
+    return power1(arg);
+  };
+
+  const c2 = new Compartment({ power: attenuatedPower });
+  const { scopeProxy: scopeProxy2 } = c2.__makeScopeProxy__();
+  const power2 = scopeProxy2.power;
+  const use = arg => {
+    return power2(arg);
+  };
+
+  t.is(use(1), 2);
+  t.throws(() => use(-1), { instanceOf: TypeError });
+});

--- a/packages/ses/test/test-compartment-prototype.js
+++ b/packages/ses/test/test-compartment-prototype.js
@@ -16,6 +16,7 @@ test('Compartment prototype', t => {
     Reflect.ownKeys(Compartment.prototype).sort(),
     [
       '__isKnownScopeProxy__',
+      '__makeScopeProxy__',
       'constructor',
       'evaluate',
       'globalThis',


### PR DESCRIPTION
this allows the ses shim consumer to construct compartments normally and then run code wrapped in the magic lines of code so that they execute as if they were in the compartment but without use of `eval`. This enables ses/endo like behavior in environments where eval is not allowed such a restrictive CSP environments like "WebExtension Manifest v3 Background Service Workers"

prolly some better factoring to be had here