### PR TITLE
fix(compartment-mapper): Reduce pre-cjs dependence on URL

### DIFF
--- a/packages/compartment-mapper/src/parse-pre-cjs.js
+++ b/packages/compartment-mapper/src/parse-pre-cjs.js
@@ -6,6 +6,16 @@ const { freeze } = Object;
 
 const textDecoder = new TextDecoder();
 
+const urlParent = location => new URL('./', location).toString();
+const pathParent = path => {
+  const index = path.lastIndexOf('/');
+  if (index > 0) {
+    return path.slice(0, index);
+  }
+  return '/';
+};
+const locationParent = typeof URL !== 'undefined' ? urlParent : pathParent;
+
 /** @type {import('./types.js').ParseFn} */
 export const parsePreCjs = async (
   bytes,
@@ -49,7 +59,7 @@ export const parsePreCjs = async (
       moduleExports,
       module,
       location, // __filename
-      new URL('./', location).toString(), // __dirname
+      locationParent(location), // __dirname
     );
   };
 


### PR DESCRIPTION
Precompiled CommonJS should work under XSnap but XSnap does not provide a URL global. The URL global is prohibitively expensive to shim or verily even provide as a native binding. Instead, we relax the coupling on that platform with a very weak version of its behavior that should be sufficient for the purposes of computing `__dirname`.