### PR TITLE
doc(ses): Remove confusing reference to vetted-shim module

### DIFF
--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -83,7 +83,6 @@ lexical versions that do not reveal the user locale.
 
 ```js
 import 'ses';
-import 'my-vetted-shim';
 
 lockdown();
 


### PR DESCRIPTION
This documents where a vetted-shim might be imported, but the documentation fails to explain its presence and since SES does not support vetted shims at time of writing there is no suitable explanation to add.