### PR TITLE
test(compartment-mapper): Failing test for CommonJS namespace exports

### DIFF
--- a/packages/compartment-mapper/test/fixtures-0/node_modules/app/main.js
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/app/main.js
@@ -1,5 +1,7 @@
 /* global globalProperty, globalLexical */
 
+import 'esmcjs';
+
 import typemodule from 'typemodule';
 import typecommon from 'typecommon';
 import typehybrid from 'typehybrid';

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/app/package.json
@@ -8,7 +8,8 @@
     "brooke": "^1.0.0",
     "clarke": "^1.0.0",
     "danny": "^1.0.0",
-    "evan": "^1.0.0"
+    "evan": "^1.0.0",
+    "esmcjs": "^1.0.0"
   },
   "devDependencies": {
     "typecommon": "^1.0.0",

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/esmcjs/index.mjs
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/esmcjs/index.mjs
@@ -1,0 +1,12 @@
+import defaultAsName from './module-exports-assigned-object.cjs';
+import * as namespaceAsName from './module-exports-assigned-object.cjs';
+// import { name } from './module-exports-assigned-object.cjs'; // Not expected to work, does not work on Node.js
+if (defaultAsName.name !== 42) {
+  throw new Error(`Assigning to module exports should be equivalent to exporting a default`);
+}
+if (namespaceAsName.default.name !== 42) {
+  throw new Error(`Assigning to module exports should be equivalent to exporting a default on the namespace object`);
+}
+if (namespaceAsName.name !== undefined) {
+  throw new Error(`Assigning to module exports should not replace the properties of the namespace object`);
+}

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/esmcjs/module-exports-assigned-object.cjs
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/esmcjs/module-exports-assigned-object.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 42,
+};

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/esmcjs/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/esmcjs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "esmcjs",
+  "main": "./index.mjs"
+}


### PR DESCRIPTION
This change adds a failing test for the expected behavior for importing names, particularly default vs `*`, from a CommonJS module into an ESM.