### PR TITLE
fix(ses)!: Domain taming safe by default

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,6 +2,15 @@ User-visible changes in SES:
 
 # Next release
 
+- *BREAKING CHANGE*: The lockdown option `domainTaming` is now `safe` by
+  default, which will break any application that depends transtively on the
+  Node.js `domain` module.
+  Notably, [standard-things/esm](https://github.com/standard-things/esm)
+  uses domains and so SES will not support `node -r esm` going forward.
+
+  This protects against the unhardened `domain` property appearing on shared
+  objects like callbacks and promises.
+  This overcomes the last *known* obstacle toward object capability containment.
 - Lockdown will now read options from the environment as defined by the Node.js
   `process.env` parameter space.
 - *BREAKING CHANGE*: It may no longer be safe to call `lockdown` more than once

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -132,8 +132,7 @@ export const repairIntrinsics = (options = {}) => {
     consoleTaming = getenv('LOCKDOWN_CONSOLE_TAMING', 'safe'),
     overrideTaming = getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate'),
     stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise'),
-    // TODO domainTaming should change to safe-by-default in the next breaking relase.
-    domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'unsafe'),
+    domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe'),
     overrideDebug = arrayFilter(
       stringSplit(getenv('LOCKDOWN_OVERRIDE_DEBUG', ''), ','),
       /** @param {string} debugName */

--- a/packages/ses/test/test-package.js
+++ b/packages/ses/test/test-package.js
@@ -9,10 +9,12 @@ const table = {
     args: ['test.cjs'],
     code: 0,
   },
-  resm: {
-    args: ['-r', 'esm', 'test.js'],
-    code: 0,
-  },
+  // SES can no longer support node -r esm because it entrains the Node.js
+  // domain module.
+  // resm: {
+  //   args: ['-r', 'esm', 'test.js'],
+  //   code: 0,
+  // },
   esm: {
     args: ['test.mjs'],
     code: 0,


### PR DESCRIPTION
*BREAKING CHANGE*: The lockdown option `domainTaming` is now `safe` by default, which will break any application that depends transtively on the Node.js `domain` module.  This protects against the unhardened `domain` property appearing on shared objects like callbacks and promises.

This change may need to wait until no more Agoric dapps depend on `-r esm`, since landing this would cut Agoric off from receiving new patches or features from new releases of SES off of `master`. That could force us into the much more labor intensive situation of making back-ports, which would not benefit from the lerna monorepo tooling. cc @michaelfig