### PR TITLE
refactor(ses): Sublimate makeLockdown

### DIFF
--- a/packages/ses/index.js
+++ b/packages/ses/index.js
@@ -16,12 +16,8 @@ import { globalThis, TypeError, assign } from './src/commons.js';
 
 import { tameFunctionToString } from './src/tame-function-tostring.js';
 import { getGlobalIntrinsics } from './src/intrinsics.js';
-import { getAnonymousIntrinsics } from './src/get-anonymous-intrinsics.js';
-import { makeLockdown } from './src/lockdown-shim.js';
-import {
-  makeCompartmentConstructor,
-  CompartmentPrototype,
-} from './src/compartment-shim.js';
+import { lockdown } from './src/lockdown-shim.js';
+import { makeCompartmentConstructor } from './src/compartment-shim.js';
 import { assert } from './src/error/assert.js';
 
 /** getThis returns globalThis in sloppy mode or undefined in strict mode. */
@@ -42,11 +38,7 @@ const Compartment = makeCompartmentConstructor(
 );
 
 assign(globalThis, {
-  lockdown: makeLockdown(
-    makeCompartmentConstructor,
-    CompartmentPrototype,
-    getAnonymousIntrinsics,
-  ),
+  lockdown,
   Compartment,
   assert,
 });

--- a/packages/ses/test/test-lockdown-options.js
+++ b/packages/ses/test/test-lockdown-options.js
@@ -1,16 +1,5 @@
 import test from 'ava';
-import { makeLockdown } from '../src/lockdown-shim.js';
-import { getAnonymousIntrinsics } from '../src/get-anonymous-intrinsics.js';
-import {
-  makeCompartmentConstructor,
-  CompartmentPrototype,
-} from '../src/compartment-shim.js';
-
-const lockdown = makeLockdown(
-  makeCompartmentConstructor,
-  CompartmentPrototype,
-  getAnonymousIntrinsics,
-);
+import { lockdown } from '../src/lockdown-shim.js';
 
 test('lockdown throws with non-recognized options', t => {
   t.throws(


### PR DESCRIPTION
This simplifies away the lockdown maker since we now only make one kind of lockdown.

Fixes #814

Please claim the review and cancel the other reviewer.