### PR TITLE
chore: release

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.10](https://github.com/endojs/endo/compare/@endo/base64@0.2.9...@endo/base64@0.2.10) (2021-11-02)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/base64@0.2.8...@endo/base64@0.2.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Transcodes base64",
   "keywords": [
     "base64",
@@ -37,7 +37,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.10](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.9...@endo/cjs-module-analyzer@0.2.10) (2021-11-02)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.8...@endo/cjs-module-analyzer@0.2.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",
@@ -30,7 +30,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.5](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.4...@endo/compartment-mapper@0.5.5) (2021-11-02)
+
+**Note:** Version bump only for package @endo/compartment-mapper
+
+
+
+
+
 ### [0.5.4](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.3...@endo/compartment-mapper@0.5.4) (2021-10-15)
 
 **Note:** Version bump only for package @endo/compartment-mapper

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -40,13 +40,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/cjs-module-analyzer": "^0.2.9",
-    "@endo/static-module-record": "^0.6.4",
-    "@endo/zip": "^0.2.9",
-    "ses": "^0.14.4"
+    "@endo/cjs-module-analyzer": "^0.2.10",
+    "@endo/static-module-record": "^0.6.5",
+    "@endo/zip": "^0.2.10",
+    "ses": "^0.15.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/endo/CHANGELOG.md
+++ b/packages/endo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.10](https://github.com/endojs/endo/compare/@endo/endo@0.1.9...@endo/endo@0.1.10) (2021-11-02)
+
+**Note:** Version bump only for package @endo/endo
+
+
+
+
+
 ### [0.1.9](https://github.com/endojs/endo/compare/@endo/endo@0.1.8...@endo/endo@0.1.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/endo

--- a/packages/endo/package.json
+++ b/packages/endo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/endo",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "description": "Endo runs Node.js packaged applications in a sandbox",
   "keywords": [
@@ -30,11 +30,11 @@
   },
   "dependencies": {
     "@agoric/babel-standalone": "^7.14.3",
-    "@endo/compartment-mapper": "^0.5.4",
-    "ses": "^0.14.4"
+    "@endo/compartment-mapper": "^0.5.5",
+    "ses": "^0.15.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.17](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.16...@endo/eslint-config@0.3.17) (2021-11-02)
+
+**Note:** Version bump only for package @endo/eslint-config
+
+
+
+
+
 ### [0.3.16](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.15...@endo/eslint-config@0.3.16) (2021-10-15)
 
 **Note:** Version bump only for package @endo/eslint-config

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-config",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Endo style rules",
   "keywords": [
     "endo",
@@ -24,7 +24,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/eslint-plugin": "^0.3.12",
+    "@endo/eslint-plugin": "^0.3.13",
     "@jessie.js/eslint-plugin": "^0.1.1"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.13](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.12...@endo/eslint-plugin@0.3.13) (2021-11-02)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ### [0.3.12](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.11...@endo/eslint-plugin@0.3.12) (2021-10-15)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Endo-specific ESLint plugin",
   "keywords": [
     "eslint",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.10](https://github.com/endojs/endo/compare/@endo/netstring@0.2.9...@endo/netstring@0.2.10) (2021-11-02)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/netstring@0.2.8...@endo/netstring@0.2.9) (2021-10-15)
 
 

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -33,7 +33,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.10](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.9...@endo/ses-ava@0.2.10) (2021-11-02)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.8...@endo/ses-ava@0.2.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -33,10 +33,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.14.4"
+    "ses": "^0.15.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.9...ses-integration-test@3.0.0) (2021-11-02)
+
+
+### ⚠ BREAKING CHANGES
+
+* **ses:** Withdraw support for muli-lockdown (#921)
+
+### Features
+
+* **ses:** Read lockdown options from environment ([#871](https://github.com/Agoric/SES-shim/issues/871)) ([789d639](https://github.com/Agoric/SES-shim/commit/789d639c25c6882153a8090f4bd74d350bb29721))
+
+
+### Bug Fixes
+
+* **ses:** Withdraw support for muli-lockdown ([#921](https://github.com/Agoric/SES-shim/issues/921)) ([99752b0](https://github.com/Agoric/SES-shim/commit/99752b046c2a3e2d866559bb9d58f625eb94b1a8)), closes [#814](https://github.com/Agoric/SES-shim/issues/814)
+
+
+
 ### [2.0.9](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.8...ses-integration-test@2.0.9) (2021-10-15)
 
 **Note:** Version bump only for package ses-integration-test

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "2.0.9",
+  "version": "3.0.0",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,10 +30,10 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.14.4"
+    "ses": "^0.15.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses-types-test/CHANGELOG.md
+++ b/packages/ses-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.7](https://github.com/endojs/endo/compare/@endo/ses-types-test@0.1.6...@endo/ses-types-test@0.1.7) (2021-11-02)
+
+**Note:** Version bump only for package @endo/ses-types-test
+
+
+
+
+
 ### [0.1.6](https://github.com/endojs/endo/compare/@endo/ses-types-test@0.1.5...@endo/ses-types-test@0.1.6) (2021-10-15)
 
 **Note:** Version bump only for package @endo/ses-types-test

--- a/packages/ses-types-test/package.json
+++ b/packages/ses-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-types-test",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "description": "TypeScript validation for SES types.",
   "keywords": [],
@@ -25,10 +25,10 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "ses": "^0.14.4"
+    "ses": "^0.15.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.15.0](https://github.com/endojs/endo/compare/ses@0.14.4...ses@0.15.0) (2021-11-02)
+
+
+### ⚠ BREAKING CHANGES
+
+* **ses:** Withdraw support for muli-lockdown (#921)
+* **ses:** Domain taming safe by default (#917)
+
+### Features
+
+* **ses:** Read lockdown options from environment ([#871](https://github.com/endojs/endo/issues/871)) ([789d639](https://github.com/endojs/endo/commit/789d639c25c6882153a8090f4bd74d350bb29721))
+
+
+### Bug Fixes
+
+* **ses:** Domain taming safe by default ([#917](https://github.com/endojs/endo/issues/917)) ([7039276](https://github.com/endojs/endo/commit/7039276ef91a2de2b048c91085a7557c8830f677))
+* **ses:** Withdraw support for muli-lockdown ([#921](https://github.com/endojs/endo/issues/921)) ([99752b0](https://github.com/endojs/endo/commit/99752b046c2a3e2d866559bb9d58f625eb94b1a8)), closes [#814](https://github.com/endojs/endo/issues/814)
+
+
+
 ### [0.14.4](https://github.com/endojs/endo/compare/ses@0.14.3...ses@0.14.4) (2021-10-15)
 
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in SES:
 
-# Next release
+# 0.15.0 (2021-11-02)
 
 - *BREAKING CHANGE*: The lockdown option `domainTaming` is now `safe` by
   default, which will break any application that depends transtively on the

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.14.4",
+  "version": "0.15.0",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",
@@ -59,10 +59,10 @@
     "test:platform-compatability": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.5.4",
-    "@endo/eslint-config": "^0.3.16",
-    "@endo/static-module-record": "^0.6.4",
-    "@endo/test262-runner": "^0.1.10",
+    "@endo/compartment-mapper": "^0.5.5",
+    "@endo/eslint-config": "^0.3.17",
+    "@endo/static-module-record": "^0.6.5",
+    "@endo/test262-runner": "^0.1.11",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.5](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.4...@endo/static-module-record@0.6.5) (2021-11-02)
+
+**Note:** Version bump only for package @endo/static-module-record
+
+
+
+
+
 ### [0.6.4](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.3...@endo/static-module-record@0.6.4) (2021-10-15)
 
 **Note:** Version bump only for package @endo/static-module-record

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
-    "@endo/eslint-config": "^0.3.16",
-    "@endo/ses-ava": "^0.2.9",
+    "@endo/eslint-config": "^0.3.17",
+    "@endo/ses-ava": "^0.2.10",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",
@@ -51,7 +51,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "ses": "^0.14.4",
+    "ses": "^0.15.0",
     "typescript": "^4.0.5"
   },
   "files": [

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.10](https://github.com/endojs/endo/compare/@endo/syrup@0.1.9...@endo/syrup@0.1.10) (2021-11-02)
+
+**Note:** Version bump only for package @endo/syrup
+
+
+
+
+
 ### [0.1.9](https://github.com/endojs/endo/compare/@endo/syrup@0.1.8...@endo/syrup@0.1.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/syrup

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",
@@ -37,7 +37,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.11](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.10...@endo/test262-runner@0.1.11) (2021-11-02)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.9...@endo/test262-runner@0.1.10) (2021-10-15)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "Test262 Runner",
   "author": "Agoric",
@@ -17,7 +17,7 @@
     "test262-parser": "^2.2.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "sinon": "8.0.4"
   },
   "ava": {

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.10](https://github.com/endojs/endo/compare/@endo/zip@0.2.9...@endo/zip@0.2.10) (2021-11-02)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/zip@0.2.8...@endo/zip@0.2.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/zip

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.16",
+    "@endo/eslint-config": "^0.3.17",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",


### PR DESCRIPTION
This release includes two breaking changes for SES.  All other packages depending on SES get a version bump.
