### PR TITLE
feat(compartment-mapper): Add hooks for sourceURL

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -5,6 +5,13 @@ User-visible changes to the compartment mapper:
 - Adds source URL suffixes to archives, such that the archive hash remains
   orthogonal to the local directory but has sufficient information that editors
   like VS Code can match the suffix to a file in the IDE workspace.
+- Adds hooks to archive production and consumption for reading and writing
+  source locations, such that other tools yet to be written can use these hooks
+  to provide fully qualified local debug source URLs.
+  Archive creation functions now accept a
+  `captureSourceLocation(compartmentName, moduleSpecifier, sourceLocation)`
+  hook and archive parsing functions accept
+  `computeSourceLocation(compartmentName, moduleSpecifier)`.
 
 # 0.5.1 (2021-08-12)
 

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -56,7 +56,7 @@ export const makeImportHookMaker = (
 ) => {
   // per-assembly:
   /** @type {ImportHookMaker} */
-  const makeImportHook = (packageLocation, packageName, parse) => {
+  const makeImportHook = (packageLocation, _packageName, parse) => {
     // per-compartment:
     packageLocation = resolveLocation(packageLocation, baseLocation);
     const packageSources = sources[packageLocation] || {};
@@ -121,7 +121,6 @@ export const makeImportHookMaker = (
             candidateSpecifier,
             moduleLocation,
             packageLocation,
-            packageName,
           );
           const {
             parser,
@@ -156,6 +155,7 @@ export const makeImportHookMaker = (
           );
           packageSources[candidateSpecifier] = {
             location: packageRelativeLocation,
+            sourceLocation: moduleLocation,
             parser,
             bytes: transformedBytes,
             record,

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -76,7 +76,7 @@ const makeExtensionParser = (
   parserForLanguage,
   transforms,
 ) => {
-  return async (bytes, specifier, location, packageLocation, packageName) => {
+  return async (bytes, specifier, location, packageLocation) => {
     let language;
     if (has(languageForModuleSpecifier, specifier)) {
       language = languageForModuleSpecifier[specifier];
@@ -105,7 +105,7 @@ const makeExtensionParser = (
       );
     }
     const parse = parserForLanguage[language];
-    return parse(bytes, specifier, location, packageLocation, packageName);
+    return parse(bytes, specifier, location, packageLocation);
   };
 };
 

--- a/packages/compartment-mapper/src/parse-archive-cjs.js
+++ b/packages/compartment-mapper/src/parse-archive-cjs.js
@@ -3,7 +3,6 @@
 /** @typedef {import('ses').ThirdPartyStaticModuleInterface} ThirdPartyStaticModuleInterface */
 
 import { analyzeCommonJS } from '@endo/cjs-module-analyzer';
-import { join } from './node-module-specifier.js';
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
@@ -17,20 +16,14 @@ freeze(noopExecute);
 export const parseArchiveCjs = async (
   bytes,
   specifier,
-  _location,
+  location,
   _packageLocation,
-  packageName,
 ) => {
   const source = textDecoder.decode(bytes);
-  const base = packageName
-    .split('/')
-    .slice(-1)
-    .join('/');
-  const sourceLocation = `.../${join(base, specifier)}`;
 
   const { requires: imports, exports, reexports } = analyzeCommonJS(
     source,
-    sourceLocation,
+    location,
   );
 
   const pre = textEncoder.encode(
@@ -38,7 +31,7 @@ export const parseArchiveCjs = async (
       imports,
       exports,
       reexports,
-      source: `(function (require, exports, module, __filename, __dirname) { ${source} //*/\n})\n//# sourceURL=${sourceLocation}`,
+      source: `(function (require, exports, module, __filename, __dirname) { ${source} //*/\n})\n`,
     }),
   );
 

--- a/packages/compartment-mapper/src/parse-archive-mjs.js
+++ b/packages/compartment-mapper/src/parse-archive-mjs.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 import { StaticModuleRecord } from '@endo/static-module-record';
-import { join } from './node-module-specifier.js';
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
@@ -9,18 +8,12 @@ const textDecoder = new TextDecoder();
 /** @type {import('./types.js').ParseFn} */
 export const parseArchiveMjs = async (
   bytes,
-  specifier,
+  _specifier,
   _location,
   _packageLocation,
-  packageName,
 ) => {
   const source = textDecoder.decode(bytes);
-  const base = packageName
-    .split('/')
-    .slice(-1)
-    .join('/');
-  const sourceLocation = `.../${join(base, specifier)}`;
-  const record = new StaticModuleRecord(source, sourceLocation);
+  const record = new StaticModuleRecord(source);
   const pre = textEncoder.encode(JSON.stringify(record));
   return {
     parser: 'pre-mjs-json',

--- a/packages/compartment-mapper/src/parse-pre-cjs.js
+++ b/packages/compartment-mapper/src/parse-pre-cjs.js
@@ -6,15 +6,13 @@ const { freeze } = Object;
 
 const textDecoder = new TextDecoder();
 
-const urlParent = location => new URL('./', location).toString();
-const pathParent = path => {
-  const index = path.lastIndexOf('/');
-  if (index > 0) {
-    return path.slice(0, index);
+const locationParent = location => {
+  const index = location.lastIndexOf('/');
+  if (index >= 0) {
+    return location.slice(0, index);
   }
-  return '/';
+  return location;
 };
-const locationParent = typeof URL !== 'undefined' ? urlParent : pathParent;
 
 /** @type {import('./types.js').ParseFn} */
 export const parsePreCjs = async (

--- a/packages/compartment-mapper/src/parse-pre-mjs.js
+++ b/packages/compartment-mapper/src/parse-pre-mjs.js
@@ -13,6 +13,8 @@ export const parsePreMjs = async (
 ) => {
   const text = textDecoder.decode(bytes);
   const record = parseLocatedJson(text, location);
+  // eslint-disable-next-line no-underscore-dangle
+  record.__syncModuleProgram__ += `//# sourceURL=${location}\n`;
   return {
     parser: 'pre-mjs-json',
     bytes,

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -183,7 +183,6 @@ export const moduleJSDocTypes = true;
  * @param {string} specifier
  * @param {string} location
  * @param {string} packageLocation
- * @param {string} packageName
  * @returns {Promise<{
  *   bytes: Uint8Array,
  *   parser: Language,
@@ -192,8 +191,16 @@ export const moduleJSDocTypes = true;
  */
 
 /**
+ * @callback ComputeSourceLocationHook
+ * @param {string} compartmentName
+ * @param {string} moduleSpecifier
+ * @returns {string|undefined} sourceLocation
+ */
+
+/**
  * @typedef {Object} LoadArchiveOptions
  * @property {string} [expectedSha512]
+ * @property {ComputeSourceLocationHook} [computeSourceLocation]
  */
 
 /**
@@ -246,7 +253,8 @@ export const moduleJSDocTypes = true;
 
 /**
  * @typedef {Object} ModuleSource
- * @property {string} [location]
+ * @property {string} [location] - package relative location
+ * @property {string} [sourceLocation] - fully qualified location
  * @property {Uint8Array} [bytes]
  * @property {string} [sha512] in base16, hex
  * @property {Language} [parser]
@@ -261,8 +269,16 @@ export const moduleJSDocTypes = true;
  */
 
 /**
+ * @callback CaptureSourceLocationHook
+ * @param {string} compartmentName
+ * @param {string} moduleSpecifier
+ * @param {string} sourceLocation
+ */
+
+/**
  * @typedef {Object} ArchiveOptions
  * @property {ModuleTransforms} [moduleTransforms]
  * @property {Record<string, never>} [modules]
  * @property {boolean} [dev]
+ * @property {CaptureSourceLocationHook} [captureSourceLocation]
  */

--- a/packages/compartment-mapper/test/test-source-url-rewrite.js
+++ b/packages/compartment-mapper/test/test-source-url-rewrite.js
@@ -1,0 +1,63 @@
+// @ts-check
+import 'ses';
+import test from 'ava';
+import fs from 'fs';
+import crypto from 'crypto';
+import { parseArchive, makeArchive } from '../index.js';
+import { makeNodeReadPowers } from '../node-powers.js';
+
+const fixtureLocation = new URL(
+  'fixtures-stack/index.js',
+  import.meta.url,
+).toString();
+
+const readPowers = makeNodeReadPowers(fs, crypto);
+
+test('rewrite source url', async t => {
+  const locations = new Map();
+
+  const computeKey = (compartmentName, moduleSpecifier) => {
+    return `${JSON.stringify(compartmentName)},${JSON.stringify(
+      moduleSpecifier,
+    )}`;
+  };
+
+  const archive = await makeArchive(readPowers, fixtureLocation, {
+    /**
+     * @param {string} compartmentName
+     * @param {string} moduleSpecifier
+     * @param {string} location
+     */
+    captureSourceLocation(compartmentName, moduleSpecifier, location) {
+      const key = computeKey(compartmentName, moduleSpecifier);
+      locations.set(key, location);
+    },
+  });
+
+  const app = await parseArchive(archive, '<memory>', {
+    /**
+     * @param {string} compartmentName
+     * @param {string} moduleSpecifier
+     * @returns {string|undefined}
+     */
+    computeSourceLocation(compartmentName, moduleSpecifier) {
+      const key = computeKey(compartmentName, moduleSpecifier);
+      return locations.get(key);
+    },
+  });
+
+  let error;
+  try {
+    await app.import();
+  } catch (_error) {
+    error = _error;
+  }
+
+  t.assert(error);
+  t.log(error.stack);
+  t.assert(
+    error.stack.includes(
+      '/packages/compartment-mapper/test/fixtures-stack/index.js:3:',
+    ),
+  );
+});

--- a/packages/compartment-mapper/test/test-stack.js
+++ b/packages/compartment-mapper/test/test-stack.js
@@ -29,6 +29,7 @@ test('archive stack trace source', async t => {
   }
 
   t.assert(error);
+  t.log(error.stack);
   t.assert(
     error.stack.includes(
       '.../compartment-mapper/test/fixtures-stack/index.js:3:',


### PR DESCRIPTION
Adds hooks to archive production and consumption for reading and writing source locations, such that other tools yet to be written can use these hooks to provide fully qualified local debug source URLs.  Archive creation functions now accept a `captureSourceLocation(compartmentName, moduleSpecifier, sourceLocation)` hook and archive parsing functions accept `computeSourceLocation(compartmentName, moduleSpecifier)`.
