### PR TITLE
errorTrapping type - missing "none" option

### DIFF
--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -18,7 +18,7 @@ export interface LockdownOptions {
   regExpTaming?: 'safe' | 'unsafe';
   localeTaming?: 'safe' | 'unsafe';
   consoleTaming?: 'safe' | 'unsafe';
-  errorTrapping?: 'platform' | 'exit' | 'abort' | 'report';
+  errorTrapping?: 'platform' | 'exit' | 'abort' | 'report' | 'none';
   errorTaming?: 'safe' | 'unsafe';
   dateTaming?: 'safe' | 'unsafe'; // deprecated
   mathTaming?: 'safe' | 'unsafe'; // deprecated


### PR DESCRIPTION
as used here https://github.com/endojs/endo/blob/3a3afddf8828c21dcc58b9c98243b31e2cc99d47/packages/ses/src/error/tame-console.js#L74