### PR TITLE
fix(ses): Include error in trapped error log

### DIFF
--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -77,9 +77,7 @@ export const tameConsole = (
       // eslint-disable-next-line @endo/no-polymorphic-call
       event.preventDefault();
       // eslint-disable-next-line @endo/no-polymorphic-call
-      const stackString = loggedErrorHandler.getStackString(event.error);
-      // eslint-disable-next-line @endo/no-polymorphic-call
-      causalConsole.error(`${event.error.message}\n${stackString}`);
+      causalConsole.error(event.error);
       if (errorTrapping === 'exit' || errorTrapping === 'abort') {
         globalThis.window.location.href = `about:blank`;
       }

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -79,7 +79,7 @@ export const tameConsole = (
       // eslint-disable-next-line @endo/no-polymorphic-call
       const stackString = loggedErrorHandler.getStackString(event.error);
       // eslint-disable-next-line @endo/no-polymorphic-call
-      causalConsole.error(stackString);
+      causalConsole.error(`${event.error.message}\n${stackString}`);
       if (errorTrapping === 'exit' || errorTrapping === 'abort') {
         globalThis.window.location.href = `about:blank`;
       }

--- a/packages/ses/test/test-console-error-trap.js
+++ b/packages/ses/test/test-console-error-trap.js
@@ -27,8 +27,8 @@ const exitAssertions = (t, expectedCode, altExpectedCode = expectedCode) => {
       'stdout should contain error message',
     );
     t.assert(
-      !stdout.includes('Error#2'),
-      'stdout should not contain second error message',
+      !stdout.includes('Error#2: I am once again throwing an error'),
+      'stdout should contain second error message',
     );
     t.end();
   };

--- a/packages/ses/test/test-console-error-trap.js
+++ b/packages/ses/test/test-console-error-trap.js
@@ -27,8 +27,8 @@ const exitAssertions = (t, expectedCode, altExpectedCode = expectedCode) => {
       'stdout should contain error message',
     );
     t.assert(
-      !stdout.includes('Error#2: I am once again throwing an error'),
-      'stdout should contain second error message',
+      !stdout.includes('Error#2'),
+      'stdout should not contain second error message',
     );
     t.end();
   };


### PR DESCRIPTION
Errors caught by the `errorTrapping` feature were being logged with only their stack traces. The error message was omitted.

Now the log for trapped errors includes the error message along with the stack trace.