### PR TITLE
Much prettier module-transformed code and bundles

### DIFF
--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -231,7 +231,19 @@ export const makeBundle = async (read, moduleLocation, options) => {
 
   const bundle = `\
 'use strict';
-(functors => {
+(() => {
+  const functors = [
+${''.concat(
+  ...modules.map(
+    ({ record: { __syncModuleProgram__ } }, i) =>
+      `\
+// === functors[${i}] ===
+${__syncModuleProgram__},
+`,
+  ),
+)}\
+]; // functors end
+
   function cell(name, value = undefined) {
     const observers = [];
     function set(newValue) {
@@ -318,17 +330,7 @@ ${importsCellSetter(__fixedExportMap__, index)}\
 `,
   ),
 )}\
-})([
-${''.concat(
-  ...modules.map(
-    ({ record: { __syncModuleProgram__ } }) =>
-      `\
-${__syncModuleProgram__}
-,
-`,
-  ),
-)}\
-]);
+})();
 `;
 
   return bundle;

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -212,6 +212,23 @@ export const makeBundle = async (read, moduleLocation, options) => {
     );
   }
 
+  const exportsCellRecord = exportMap =>
+    ''.concat(
+      ...Object.keys(exportMap).map(
+        exportName => `\
+      ${exportName}: cell(${q(exportName)}),
+`,
+      ),
+    );
+  const importsCellSetter = (exportMap, index) =>
+    ''.concat(
+      ...Object.entries(exportMap).map(
+        ([exportName, [importName]]) => `\
+      ${importName}: cells[${index}].${exportName}.set,
+`,
+      ),
+    );
+
   const bundle = `\
 'use strict';
 (functors => {
@@ -233,32 +250,27 @@ export const makeBundle = async (read, moduleLocation, options) => {
     return { get, set, observe, enumerable: true };
   }
 
-  const cells = [${''.concat(
-    ...modules.map(
-      ({ record: { __fixedExportMap__, __liveExportMap__ } }) => `{
-        ${''.concat(
-          ...Object.keys(__fixedExportMap__).map(
-            exportName => `${exportName}: cell(${q(exportName)}),\n`,
-          ),
-        )}
-        ${''.concat(
-          ...Object.keys(__liveExportMap__).map(
-            exportName => `${exportName}: cell(${q(exportName)}),\n`,
-          ),
-        )}
-      },`,
-    ),
-  )}];
+  const cells = [
+${''.concat(
+  ...modules.map(
+    ({ record: { __fixedExportMap__, __liveExportMap__ } }) => `\
+    {
+${exportsCellRecord(__fixedExportMap__)}${exportsCellRecord(__liveExportMap__)}\
+    },
+`,
+  ),
+)}\
+  ];
 
-  ${''.concat(
-    ...modules.flatMap(({ index, indexedImports, record: { reexports } }) =>
-      reexports.map(
-        (/* @type {string} */ importSpecifier) => `\
-          Object.defineProperties(cells[${index}], Object.getOwnPropertyDescriptors(cells[${indexedImports[importSpecifier]}]));
-        `,
-      ),
+${''.concat(
+  ...modules.flatMap(({ index, indexedImports, record: { reexports } }) =>
+    reexports.map(
+      importSpecifier => `\
+  Object.defineProperties(cells[${index}], Object.getOwnPropertyDescriptors(cells[${indexedImports[importSpecifier]}]));
+`,
     ),
-  )}
+  ),
+)}\
 
   const namespaces = cells.map(cells => Object.create(null, cells));
 
@@ -266,62 +278,56 @@ export const makeBundle = async (read, moduleLocation, options) => {
     cells[index]['*'] = cell('*', namespaces[index]);
   }
 
-  ${''.concat(
-    ...modules.map(
-      ({
-        index,
-        indexedImports,
-        record: { __liveExportMap__, __fixedExportMap__ },
-      }) => `\
-        functors[${index}]({
-          imports(entries) {
-            const map = new Map(entries);
-            ${''.concat(
-              ...Object.entries(indexedImports).map(
-                ([importName, importIndex]) => `\
-                  for (const [name, observers] of map.get(${q(importName)})) {
-                    const cell = cells[${importIndex}][name];
-                    if (cell === undefined) {
-                      throw new ReferenceError(\`Cannot import name \${name}\`);
-                    }
-                    for (const observer of observers) {
-                      cell.observe(observer);
-                    }
-                  }
-                `,
-              ),
-            )}
-          },
-          liveVar: {
-            ${''.concat(
-              ...Object.entries(__liveExportMap__).map(
-                ([exportName, [importName]]) => `\
-                  ${importName}: cells[${index}].${exportName}.set,
-                `,
-              ),
-            )}
-          },
-          onceVar: {
-            ${''.concat(
-              ...Object.entries(__fixedExportMap__).map(
-                ([exportName, [importName]]) => `\
-                  ${importName}: cells[${index}].${exportName}.set,
-                `,
-              ),
-            )}
-          },
-        });
-      `,
-    ),
-  )}
+  function observeImports(map, importName, importIndex) {
+    for (const [name, observers] of map.get(importName)) {
+      const cell = cells[importIndex][name];
+      if (cell === undefined) {
+        throw new ReferenceError(\`Cannot import name \${name}\`);
+      }
+      for (const observer of observers) {
+        cell.observe(observer);
+      }
+    }
+  }
 
+${''.concat(
+  ...modules.map(
+    ({
+      index,
+      indexedImports,
+      record: { __liveExportMap__, __fixedExportMap__ },
+    }) => `\
+  functors[${index}]({
+    imports(entries) {
+      const map = new Map(entries);
+${''.concat(
+  ...Object.entries(indexedImports).map(
+    ([importName, importIndex]) => `\
+      observeImports(map, ${q(importName)}, ${importIndex});
+`,
+  ),
+)}\
+    },
+    liveVar: {
+${importsCellSetter(__liveExportMap__, index)}\
+    },
+    onceVar: {
+${importsCellSetter(__fixedExportMap__, index)}\
+    },
+  });
+`,
+  ),
+)}\
 })([
-  ${''.concat(
-    ...modules.map(
-      ({ record: { __syncModuleProgram__ } }) =>
-        `${__syncModuleProgram__}\n,\n`,
-    ),
-  )}
+${''.concat(
+  ...modules.map(
+    ({ record: { __syncModuleProgram__ } }) =>
+      `\
+${__syncModuleProgram__}
+,
+`,
+  ),
+)}\
 ]);
 `;
 

--- a/packages/ses/scripts/bundle.js
+++ b/packages/ses/scripts/bundle.js
@@ -1,3 +1,4 @@
+/* global process */
 import '../index.js';
 import fs from 'fs';
 import { makeBundle } from '@endo/compartment-mapper/bundle.js';
@@ -12,7 +13,7 @@ const write = async (target, content) => {
   await fs.promises.writeFile(new URL(location).pathname, content);
 };
 
-(async () => {
+const main = async () => {
   const bundle = await makeBundle(
     read,
     resolve('../index.js', import.meta.url),
@@ -26,7 +27,6 @@ const write = async (target, content) => {
   console.log(`Minified bundle size: ${terse.length} bytes`);
 
   await fs.promises.mkdir('dist', { recursive: true });
-
   await write('dist/ses.cjs', bundle);
   await write('dist/ses.mjs', bundle);
   await write('dist/ses.umd.js', bundle);
@@ -36,4 +36,9 @@ const write = async (target, content) => {
   await write('dist/lockdown.mjs', bundle);
   await write('dist/lockdown.umd.js', bundle);
   await write('dist/lockdown.umd.min.js', terse);
-})();
+};
+
+main().catch(err => {
+  console.error('Error running main:', err);
+  process.exitCode = 1;
+});

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -35,7 +35,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "@agoric/babel-standalone": "^7.14.3"
+    "@agoric/babel-standalone": "^7.14.3",
+    "@agoric/recast": "^0.20.6",
+    "@babel/traverse": "^7.10.4",
+    "@babel/types": "^7.10.4"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -38,20 +38,6 @@ const collectPatternIdentifiers = (path, pattern) => {
   }
 };
 
-const prependReplacements = (replacements, node) => {
-  const lastReplace = replacements[replacements.length - 1];
-  if (lastReplace) {
-    lastReplace.trailingComments = node.trailingComments;
-    node.trailingComments = undefined;
-  }
-  replacements.unshift(node);
-};
-
-const displayAsExport = node => {
-  node.loc.prependText = '/*EX*/ ';
-  return node;
-};
-
 function makeModulePlugins(options) {
   const {
     sourceType,
@@ -89,6 +75,20 @@ function makeModulePlugins(options) {
   const topLevelExported = Object.create(null);
 
   const rewriteModules = pass => ({ types: t }) => {
+    const replace = (
+      src,
+      node = t.expressionStatement(t.identifier('null')),
+    ) => {
+      node.loc = src.loc;
+      node.comments = [...(src.leadingComments || [])];
+      t.inheritsComments(node, src);
+      return node;
+    };
+
+    const prependReplacements = (replacements, node) => {
+      replacements.unshift(node);
+    };
+
     const allowedHiddens = new WeakSet();
     const rewrittenDecls = new WeakSet();
     const hiddenIdentifier = hi => {
@@ -253,7 +253,7 @@ function makeModulePlugins(options) {
 
       // Create the export calls.
       const isConst = decl.kind === 'const';
-      const replace = rewriteVars(
+      const replacements = rewriteVars(
         vids,
         isConst,
         decl.type === 'FunctionDeclaration'
@@ -261,25 +261,23 @@ function makeModulePlugins(options) {
           : !isConst && decl.kind !== 'let',
       );
 
-      if (replace.length > 0) {
+      if (replacements.length > 0) {
         switch (decl.type) {
           case 'VariableDeclaration': {
             // We rewrote the declaration.
             rewrittenDecls.add(decl);
-            prependReplacements(replace, decl);
+            prependReplacements(replacements, decl);
             break;
           }
           case 'FunctionDeclaration': {
-            prependReplacements(replace, decl);
+            prependReplacements(replacements, decl);
             break;
           }
           default: {
             throw TypeError(`Unknown declaration type ${decl.type}`);
           }
         }
-      }
-      if (replace.length > 0) {
-        path.replaceWithMultiple(replace);
+        path.replaceWithMultiple(replacements);
       }
     };
 
@@ -404,7 +402,7 @@ function makeModulePlugins(options) {
           if (decl.id) {
             // Just keep the same declaration and mark it as the default.
             path.replaceWithMultiple([
-              displayAsExport(decl),
+              replace(path.node, decl),
               t.expressionStatement(t.callExpression(callee, [decl.id])),
             ]);
             return;
@@ -412,7 +410,8 @@ function makeModulePlugins(options) {
 
           // const {default: $c_default} = {default: (XXX)}; $h_once.default($c_default);
           path.replaceWithMultiple([
-            displayAsExport(
+            replace(
+              path.node,
               t.variableDeclaration('const', [
                 t.variableDeclarator(
                   t.objectPattern([t.objectProperty(id, cid)]),
@@ -583,7 +582,7 @@ function makeModulePlugins(options) {
           });
         }
         if (doTransform) {
-          path.replaceWithMultiple(decl ? [displayAsExport(decl)] : []);
+          path.replaceWithMultiple(decl ? [replace(path.node, decl)] : []);
         }
       },
     });

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -1,3 +1,7 @@
+import * as recastCJS from '@agoric/recast';
+import traverseCJS from '@babel/traverse';
+import typesCJS from '@babel/types';
+
 import * as h from './hidden.js';
 import makeModulePlugins from './babelPlugin.js';
 
@@ -39,6 +43,7 @@ const makeTransformSource = babel =>
       'throwExpressions',
       'logicalAssignment',
       'classPrivateMethods',
+      'classPrivateProperties',
       // 'v8intrinsic', // we really don't want people to rely on platform powers
       'partialApplication',
       ['decorators', { decoratorsBeforeExport: false }],
@@ -48,29 +53,30 @@ const makeTransformSource = babel =>
     const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
     // TODO top-level-await https://github.com/endojs/endo/issues/306
     const allowAwaitOutsideFunction = false;
-    babel.transform(code, {
-      parserOpts: {
-        allowAwaitOutsideFunction,
-        plugins: parserPlugins,
+    const recast = recastCJS.default || recastCJS;
+    const ast = recast.parse(code, {
+      parser: {
+        parse: source =>
+          babel.transform(source, {
+            parserOpts: {
+              allowAwaitOutsideFunction,
+              tokens: true,
+              plugins: parserPlugins,
+            },
+            plugins: [analyzePlugin],
+            ast: true,
+            code: false,
+          }).ast,
       },
-      generatorOpts: {
-        retainLines: true,
-        compact: false,
-      },
-      plugins: [analyzePlugin],
-      ast: false,
-      code: false,
     });
-    ({ code } = babel.transform(code, {
-      parserOpts: {
-        allowAwaitOutsideFunction,
-        plugins: parserPlugins,
-      },
-      generatorOpts: {
-        retainLines: true,
-        compact: false,
-      },
-      plugins: [transformPlugin],
+    const traverse = traverseCJS.default || traverseCJS;
+    const types = typesCJS.default || typesCJS;
+    traverse(ast, transformPlugin({ types }).visitor);
+    ({ code } = recast.print(ast, {
+      wrapColumn: Infinity,
+      reuseWhitespace: true,
+      includeComments: true,
+      retainLines: true,
     }));
 
     // console.log(`transformed to`, output.code);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,16 @@
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.14.3.tgz#1bf201417481d37d2797dd3283590dcbef775b4d"
   integrity sha512-Rdlxts19kvxHsqTjTrhGJv0yKgCyjCSVgXoLBZf9dZ7lyo/j+6xFQBiWjP03bXve3X74wUvA1QU55wVey8DEiQ==
 
+"@agoric/recast@^0.20.6":
+  version "0.20.6"
+  resolved "https://registry.yarnpkg.com/@agoric/recast/-/recast-0.20.6.tgz#38f7130dc87d410a1eaa1d82de2b4528732c6228"
+  integrity sha512-pmgM/0g290/lGLmSfzR1/jh6Ij247yZJhJ8gw9180Vg/R7TcW3+pS4Vv9rlx2864ROeLC6GFlICEhFPjwprevw==
+  dependencies:
+    ast-types "0.14.2"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tslib "^2.0.1"
+
 "@ava/babel@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@ava/babel/-/babel-1.0.1.tgz#9f005bc0118eee4639827df798c75b77fa5fe35d"
@@ -2781,6 +2791,13 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
+ast-types@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -5254,15 +5271,7 @@ eslint-import-resolver-node@^0.3.4:
     debug "^2.6.9"
     resolve "^1.13.1"
 
-eslint-module-utils@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
-  integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
-  dependencies:
-    debug "^2.6.9"
-    pkg-dir "^2.0.0"
-
-eslint-module-utils@^2.6.1:
+eslint-module-utils@^2.6.0, eslint-module-utils@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz#b51be1e473dd0de1c5ea638e22429c2490ea8233"
   integrity sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==
@@ -12517,6 +12526,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.21.0"


### PR DESCRIPTION
- Use `@agoric/recast` to minimise the changes made to `static-module-record`-transformed code
- Clean up `@endo/compartment-mapper/bundle.js` output to have proper indentation
- Output `functor` sources first, so that the uninteresting linkage machinery appears at the end of the bundle
