### PR TITLE
fix: update whitelist with stage 3 and 4 proposals

### DIFF
--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -983,6 +983,9 @@ export const whitelist = {
     // Failed tc39 proposal
     // Seen on FF Nightly 88.0a1
     at: false,
+    // See https://github.com/tc39/proposal-array-find-from-last
+    findLast: fn,
+    findLastIndex: fn,
   },
 
   // The TypedArray Constructors
@@ -1126,7 +1129,7 @@ export const whitelist = {
     transfer: fn,
     resize: fn,
     resizable: getter,
-    maximumByteLength: getter,
+    maxByteLength: getter,
   },
 
   // SharedArrayBuffer Objects

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -425,6 +425,8 @@ export const whitelist = {
     seal: fn,
     setPrototypeOf: fn,
     values: fn,
+    // See https://github.com/tc39/proposal-accessible-object-hasownproperty
+    hasOwn: fn,
   },
 
   '%ObjectPrototype%': {
@@ -922,6 +924,9 @@ export const whitelist = {
     // Failed tc39 proposal
     // Seen on FF Nightly 88.0a1
     at: false,
+    // See https://github.com/tc39/proposal-array-find-from-last
+    findLast: fn,
+    findLastIndex: fn,
   },
 
   '%ArrayIteratorPrototype%': {
@@ -1117,6 +1122,11 @@ export const whitelist = {
     '@@toStringTag': 'string',
     // See https://github.com/Moddable-OpenSource/moddable/issues/523
     concat: false,
+    // See https://github.com/tc39/proposal-resizablearraybuffer
+    transfer: fn,
+    resize: fn,
+    resizable: getter,
+    maximumByteLength: getter,
   },
 
   // SharedArrayBuffer Objects


### PR DESCRIPTION
All of those added by this PR are powerless and purely computational, and so should be enabled by the whitelist (rather than using `false` to acknowledge that they are expected but remove them).