### PR TITLE
fix(static-module-record): Revert recast

### DIFF
--- a/packages/static-module-record/NEWS.md
+++ b/packages/static-module-record/NEWS.md
@@ -1,5 +1,11 @@
 User-visible changes in Static Module Record, née Transform Module:
 
+# Next release
+
+- Reverts a prior change that would have greatly improved the preservation of
+  line and column numbers, but resulted in a number of programs failing to
+  compile.
+
 # 0.6.3 (2021-09-18)
 
 - Silences a Babel code generation warning regarding deoptimized styling by

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -35,10 +35,7 @@
     "test": "ava"
   },
   "dependencies": {
-    "@agoric/babel-standalone": "^7.14.3",
-    "@agoric/recast": "^0.20.6",
-    "@babel/traverse": "^7.10.4",
-    "@babel/types": "^7.10.4"
+    "@agoric/babel-standalone": "^7.14.3"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -48,7 +48,9 @@ const prependReplacements = (replacements, node) => {
 };
 
 const displayAsExport = node => {
-  node.loc.prependText = '/*EX*/ ';
+  if (node.loc) {
+    node.loc.prependText = '/*EX*/ ';
+  }
   return node;
 };
 

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -1,7 +1,3 @@
-import * as recastCJS from '@agoric/recast';
-import traverseCJS from '@babel/traverse';
-import typesCJS from '@babel/types';
-
 import * as h from './hidden.js';
 import makeModulePlugins from './babelPlugin.js';
 
@@ -43,7 +39,6 @@ const makeTransformSource = babel =>
       'throwExpressions',
       'logicalAssignment',
       'classPrivateMethods',
-      'classPrivateProperties',
       // 'v8intrinsic', // we really don't want people to rely on platform powers
       'partialApplication',
       ['decorators', { decoratorsBeforeExport: false }],
@@ -53,30 +48,29 @@ const makeTransformSource = babel =>
     const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
     // TODO top-level-await https://github.com/endojs/endo/issues/306
     const allowAwaitOutsideFunction = false;
-    const recast = recastCJS.default || recastCJS;
-    const ast = recast.parse(code, {
-      parser: {
-        parse: source =>
-          babel.transform(source, {
-            parserOpts: {
-              allowAwaitOutsideFunction,
-              tokens: true,
-              plugins: parserPlugins,
-            },
-            plugins: [analyzePlugin],
-            ast: true,
-            code: false,
-          }).ast,
+    babel.transform(code, {
+      parserOpts: {
+        allowAwaitOutsideFunction,
+        plugins: parserPlugins,
       },
+      generatorOpts: {
+        retainLines: true,
+        compact: false,
+      },
+      plugins: [analyzePlugin],
+      ast: false,
+      code: false,
     });
-    const traverse = traverseCJS.default || traverseCJS;
-    const types = typesCJS.default || typesCJS;
-    traverse(ast, transformPlugin({ types }).visitor);
-    ({ code } = recast.print(ast, {
-      wrapColumn: Infinity,
-      reuseWhitespace: true,
-      includeComments: true,
-      retainLines: true,
+    ({ code } = babel.transform(code, {
+      parserOpts: {
+        allowAwaitOutsideFunction,
+        plugins: parserPlugins,
+      },
+      generatorOpts: {
+        retainLines: true,
+        compact: false,
+      },
+      plugins: [transformPlugin],
     }));
 
     // console.log(`transformed to`, output.code);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,16 +7,6 @@
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.14.3.tgz#1bf201417481d37d2797dd3283590dcbef775b4d"
   integrity sha512-Rdlxts19kvxHsqTjTrhGJv0yKgCyjCSVgXoLBZf9dZ7lyo/j+6xFQBiWjP03bXve3X74wUvA1QU55wVey8DEiQ==
 
-"@agoric/recast@^0.20.6":
-  version "0.20.6"
-  resolved "https://registry.yarnpkg.com/@agoric/recast/-/recast-0.20.6.tgz#38f7130dc87d410a1eaa1d82de2b4528732c6228"
-  integrity sha512-pmgM/0g290/lGLmSfzR1/jh6Ij247yZJhJ8gw9180Vg/R7TcW3+pS4Vv9rlx2864ROeLC6GFlICEhFPjwprevw==
-  dependencies:
-    ast-types "0.14.2"
-    esprima "~4.0.0"
-    source-map "~0.6.1"
-    tslib "^2.0.1"
-
 "@ava/babel@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@ava/babel/-/babel-1.0.1.tgz#9f005bc0118eee4639827df798c75b77fa5fe35d"
@@ -2791,13 +2781,6 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
-ast-types@0.14.2:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
-  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
-  dependencies:
-    tslib "^2.0.1"
-
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -5271,7 +5254,15 @@ eslint-import-resolver-node@^0.3.4:
     debug "^2.6.9"
     resolve "^1.13.1"
 
-eslint-module-utils@^2.6.0, eslint-module-utils@^2.6.1:
+eslint-module-utils@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
+  integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
+  dependencies:
+    debug "^2.6.9"
+    pkg-dir "^2.0.0"
+
+eslint-module-utils@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz#b51be1e473dd0de1c5ea638e22429c2490ea8233"
   integrity sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==
@@ -12526,11 +12517,6 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.21.0"


### PR DESCRIPTION
This change reverts two changes that turned out to not be backward compatible as advertised.  My intent is to publish a patch to unbreak the upgrade path for existing installations and then later restore these changes either in a subsequent patch or a major bump.

These are surgical reverts for a portion of the changes that were released, not a full roll-back.

- Revert "fix(static-module-record): minimise source changes with `recast`"
- Revert "build(deps): add a patched version of `recast`"
- fix(static-module-record): Account for unlocated nodes in displayAsExport

Please review closely the novel code in the final commit that got the tests passing but was evidently unnecessary when composed with recast.
