### PR TITLE
feat: add evalTaming option

### DIFF
--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -378,10 +378,14 @@ Security audit is NOT performed on this option and you SHOULD NEVER use it in pr
 
 Strongly suggest to use [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) when you have use cases like this.
 
+This option only applies to the start compartment. Child compartment will always use value `"safeEval"`.
+
 ```js
-lockdown(); // evalTaming defaults to 'safe'
+lockdown(); // evalTaming defaults to 'safeEval'
 // or
-lockdown({ evalTaming: 'unsafe' });
+lockdown({ evalTaming: 'noEval' }); // disallowing calling eval like there is a CSP limitation.
+// or
+lockdown({ evalTaming: 'unsafeEval' });
 // !!!! DO NOT USE IT IN PRODUCTION WITH "unsafe-eval" in CSP or even no CSP !!!!
 ```
 

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -392,10 +392,8 @@ This option may be useful for web pages with a Content Security Policy
 that excludes `unsafe-eval` or browser extension environments with similar
 restrictions, or development-mode bundling systems that use `eval`.
 In these cases, SES cannot be responsible for maintaining the isolation of
-guest code.
-Using [Trusted
-Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types)
-in combination with `"unsafe"` `evalTaming` may help maintain isolation.
+guest code. If you're going to use `eval`, [Trusted
+Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) may help maintain security.
 
 The `"noEval"` option emulates a Content Security Policy that excludes
 `unsafe-eval` by replacing all evaluators with functions that throw an
@@ -415,7 +413,7 @@ lockdown({ evalTaming: 'unsafeEval' });
 **Background**: The error stacks shown by many JavaScript engines are
 voluminous.
 They contain many stack frames of functions in the infrastructure, that is
-usually irrelevant to the programmer trying to disagnose a bug. The SES-shim's
+usually irrelevant to the programmer trying to diagnose a bug. The SES-shim's
 `console`, under the default `consoleTaming` option of `'safe'`, is even more
 voluminous&mdash;displaying "deep stack" traces, tracing back through the
 [eventually sent messages](https://github.com/tc39/proposal-eventual-send)

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -369,18 +369,18 @@ the container to exit explicitly, and we highly recommend setting
 
 ## `evalTaming` Options
 
-**Background**: Every compartment including the implied compartment in the
+**Background**: For every compartment including the implied compartment in the
 initial JavaScript realm, there are evaluators `eval` and `Function`.
 The default lockdown behavior isolates all of these evaluators.
 
 Replacing the realm's initial evaluators is not necessary to ensure the
 isolation of guest code because guest code must not run in the initial realm.
 However, replacing these evaluators is the safest and therefore default
-evaluator taming option (`"safe"`) because it may limit the harm that guest code can cause
+evaluator taming option (`"safeEval"`) because it may limit the harm that guest code can cause
 if it escapes its assigned compartment.
 
 However, only the exact `eval` function from the initial realm can be used to
-perform direct-eval, which runs in the caller's scope (dynamic scope).
+perform direct-eval, which runs in the lexical scope in which the direct-eval syntax appears (direct-eval is a special form rather than a function call).
 The SES shim itself uses direct-eval internally to construct an isolated
 evaluator, so replacing the initial `eval` prevents any subsequent program
 from using the same mechanism to isolate a guest program.
@@ -388,7 +388,7 @@ from using the same mechanism to isolate a guest program.
 The `"unsafe"` option for `evalTaming` leaves the original `eval` in place
 for other isolation mechanisms like isolation code generators that work in
 tandem with SES.
-This option may be useful in may for web pages with a Content Security Policy
+This option may be useful for web pages with a Content Security Policy
 that excludes `unsafe-eval` or browser extension environments with similar
 restrictions, or development-mode bundling systems that use `eval`.
 In these cases, SES cannot be responsible for maintaining the isolation of
@@ -397,7 +397,7 @@ Using [Trusted
 Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types)
 in combination with `"unsafe"` `evalTaming` may help maintain isolation.
 
-The `"none"` option emulates a Content Security Policy that excludes
+The `"noEval"` option emulates a Content Security Policy that excludes
 `unsafe-eval` by replacing all evaluators with functions that throw an
 exception, in the initial realm as well as any derived compartment.
 

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -385,9 +385,6 @@ lockdown({ evalTaming: 'unsafe' });
 // !!!! DO NOT USE IT IN PRODUCTION WITH "unsafe-eval" in CSP or even no CSP !!!!
 ```
 
-`Compartment` constructor is not installed when this option is `"unsafe"` because `Compartment` relies on taming the `eval` and `Function`.
-If your production does not allow `eval` and `Function`, `Compartment` shim is actually not usable.
-
 ## `stackFiltering` Options
 
 **Background**: The error stacks shown by many JavaScript engines are

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -377,7 +377,7 @@ The default lockdown behavior isolates all of these evaluators.
 
 Replacing the realm's initial evaluators is not necessary to ensure the
 isolation of guest code because guest code must not run in the start compartment.
-Although the code run in the start compartment is normally referred to as "trusted", we mean only that we assume it was not written maliciously. It may still be buggy, and it may be buggy in a way that is exploitable by malicious guest code. To limit the hard that such vulnerabilities can cause, the default (`"safeEval"`) setting replaces the evaluators of the start compartment with their safe alternatives.
+Although the code run in the start compartment is normally referred to as "trusted", we mean only that we assume it was not written maliciously. It may still be buggy, and it may be buggy in a way that is exploitable by malicious guest code. To limit the harm that such vulnerabilities can cause, the default (`"safeEval"`) setting replaces the evaluators of the start compartment with their safe alternatives.
 
 However, in the shim, only the exact `eval` function from the start compartment can be used to
 perform direct-eval, which runs in the lexical scope in which the direct-eval syntax appears (direct-eval is a special form rather than a function call).

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -369,6 +369,8 @@ the container to exit explicitly, and we highly recommend setting
 
 ## `evalTaming` Options
 
+This option only affects the initial compartment!
+
 **Background**: For every compartment including the implied compartment in the
 initial JavaScript realm, there are evaluators `eval` and `Function`.
 The default lockdown behavior isolates all of these evaluators.
@@ -376,8 +378,7 @@ The default lockdown behavior isolates all of these evaluators.
 Replacing the realm's initial evaluators is not necessary to ensure the
 isolation of guest code because guest code must not run in the initial realm.
 However, replacing these evaluators is the safest and therefore default
-evaluator taming option (`"safeEval"`) because it may limit the harm that guest code can cause
-if it escapes its assigned compartment.
+evaluator taming option (`"safeEval"`) because it may limit the harm that guest code can cause if it escapes its assigned compartment.
 
 However, only the exact `eval` function from the initial realm can be used to
 perform direct-eval, which runs in the lexical scope in which the direct-eval syntax appears (direct-eval is a special form rather than a function call).
@@ -397,7 +398,7 @@ Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Securit
 
 The `"noEval"` option emulates a Content Security Policy that excludes
 `unsafe-eval` by replacing all evaluators with functions that throw an
-exception, in the initial realm as well as any derived compartment.
+exception.
 
 ```js
 lockdown(); // evalTaming defaults to 'safeEval'

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -388,14 +388,15 @@ from using the same mechanism to isolate a guest program.
 The `"unsafeEval"` option for `evalTaming` leaves the original `eval` in place
 for other isolation mechanisms like isolation code generators that work in
 tandem with SES.
-This option may be useful for web pages with a Content Security Policy
-that excludes `unsafe-eval` or browser extension environments with similar
-restrictions, or development-mode bundling systems that use `eval`.
+This option may be useful for web pages with an environment that allows `unsafe-eval`,
+like a development-mode bundling systems that use `eval`
+(for example, [`"eval-source-map"` in webpack](https://webpack.js.org/configuration/devtool/#devtool)).
+
 In these cases, SES cannot be responsible for maintaining the isolation of
 guest code. If you're going to use `eval`, [Trusted
 Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) may help maintain security.
 
-The `"noEval"` option emulates a Content Security Policy that excludes
+The `"noEval"` option emulates a Content Security Policy that disallows
 `unsafe-eval` by replacing all evaluators with functions that throw an
 exception.
 
@@ -404,8 +405,10 @@ lockdown(); // evalTaming defaults to 'safeEval'
 // or
 lockdown({ evalTaming: 'noEval' }); // disallowing calling eval like there is a CSP limitation.
 // or
+
+// Please use this option with caution.
+// You may want to use Trusted Types or Content Security Policy with this option.
 lockdown({ evalTaming: 'unsafeEval' });
-// !!!! DO NOT USE IT IN PRODUCTION WITH "unsafe-eval" in CSP or even no CSP !!!!
 ```
 
 ## `stackFiltering` Options

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -27,7 +27,7 @@ Each option is explained in its own section below.
 | `consoleTaming`  | `'safe'`         | `'unsafe'`     | deep stacks                |
 | `errorTaming`    | `'safe'`         | `'unsafe'`     | `errorInstance.stack`      |
 | `errorTrapping`  | `'platform'`     | `'exit'` `'abort'` `'report'` | handling of uncaught exceptions |
-| `evalTaming`     | `'safe'`         | `'unsafe'`     | `eval` and `Function`. |
+| `evalTaming`     | `'safeEval'`     | `'unsafeEval'` `'noEval'` | `eval` and `Function` of the start compartment. |
 | `stackFiltering` | `'concise'`      | `'verbose'`    | deep stacks signal/noise   |
 | `overrideTaming` | `'moderate'`     | `'min'` or `'severe'` | override mistake antidote  |
 | `overrideDebug`  | `[]`             | array of property names | detect override mistake |

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -386,7 +386,7 @@ The SES shim itself uses direct-eval internally to construct an isolated
 evaluator, so replacing the initial `eval` prevents any subsequent program
 from using the same mechanism to isolate a guest program.
 
-The `"unsafe"` option for `evalTaming` leaves the original `eval` in place
+The `"unsafeEval"` option for `evalTaming` leaves the original `eval` in place
 for other isolation mechanisms like isolation code generators that work in
 tandem with SES.
 This option may be useful for web pages with a Content Security Policy

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -369,18 +369,17 @@ the container to exit explicitly, and we highly recommend setting
 
 ## `evalTaming` Options
 
-This option only affects the initial compartment!
+This option only affects the start compartment!
 
-**Background**: For every compartment including the implied compartment in the
-initial JavaScript realm, there are evaluators `eval` and `Function`.
+**Background**: Every realm has an implicit initial compartment we call the "start compartment". Explicit compartments are made with the `Compartment` constructor.
+For every compartment including the start compartment, there are evaluators `eval` and `Function`.
 The default lockdown behavior isolates all of these evaluators.
 
 Replacing the realm's initial evaluators is not necessary to ensure the
-isolation of guest code because guest code must not run in the initial realm.
-However, replacing these evaluators is the safest and therefore default
-evaluator taming option (`"safeEval"`) because it may limit the harm that guest code can cause if it escapes its assigned compartment.
+isolation of guest code because guest code must not run in the start compartment.
+Although the code run in the start compartment is normally referred to as "trusted", we mean only that we assume it was not written maliciously. It may still be buggy, and it may be buggy in a way that is exploitable by malicious guest code. To limit the hard that such vulnerabilities can cause, the default (`"safeEval"`) setting replaces the evaluators of the start compartment with their safe alternatives.
 
-However, only the exact `eval` function from the initial realm can be used to
+However, in the shim, only the exact `eval` function from the start compartment can be used to
 perform direct-eval, which runs in the lexical scope in which the direct-eval syntax appears (direct-eval is a special form rather than a function call).
 The SES shim itself uses direct-eval internally to construct an isolated
 evaluator, so replacing the initial `eval` prevents any subsequent program

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -371,6 +371,15 @@ the container to exit explicitly, and we highly recommend setting
 
 This option only affects the start compartment!
 
+To disallows eval in the explicit compartments, replace the constructors in the compartment.
+
+```js
+const c = new Compartment()
+c.globalThis.eval = c.globalThis.Function = function() {
+  throw new TypeError()
+}
+```
+
 **Background**: Every realm has an implicit initial compartment we call the "start compartment". Explicit compartments are made with the `Compartment` constructor.
 For every compartment including the start compartment, there are evaluators `eval` and `Function`.
 The default lockdown behavior isolates all of these evaluators.

--- a/packages/ses/error-codes/SES_NO_EVAL.md
+++ b/packages/ses/error-codes/SES_NO_EVAL.md
@@ -1,0 +1,3 @@
+# SES is disallowing eval in the current compartment (`SES_NO_EVAL`)
+
+The SES Hardened JavaScript shim is configured to reject any source evaluation in the current compartment. This is configured in the `lockdown` option.

--- a/packages/ses/error-codes/SES_NO_EVAL.md
+++ b/packages/ses/error-codes/SES_NO_EVAL.md
@@ -1,3 +1,3 @@
 # SES is disallowing eval in the current compartment (`SES_NO_EVAL`)
 
-The SES Hardened JavaScript shim is configured to reject any source evaluation in the current compartment. This is configured in the `lockdown` option.
+The SES Hardened JavaScript shim is configured to reject any source evaluation in the current compartment. This is configured in the `lockdown` option. To mitigate this error, change the [lockdown option `"evalTaming"`](../docs/lockdown.md) from `"noEval"` to either `"safeEval"` (default) or `"unsafeEval"`.

--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -23,6 +23,7 @@ export interface LockdownOptions {
   errorTaming?: 'safe' | 'unsafe';
   dateTaming?: 'safe' | 'unsafe'; // deprecated
   mathTaming?: 'safe' | 'unsafe'; // deprecated
+  evalTaming?: 'safe' | 'unsafe';
   stackFiltering?: 'concise' | 'verbose';
   overrideTaming?: 'moderate' | 'min' | 'severe';
   overrideDebug?: Array<string>;

--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -23,7 +23,7 @@ export interface LockdownOptions {
   errorTaming?: 'safe' | 'unsafe';
   dateTaming?: 'safe' | 'unsafe'; // deprecated
   mathTaming?: 'safe' | 'unsafe'; // deprecated
-  evalTaming?: 'safe' | 'unsafe';
+  evalTaming?: 'safeEval' | 'unsafeEval' | 'noEval';
   stackFiltering?: 'concise' | 'verbose';
   overrideTaming?: 'moderate' | 'min' | 'severe';
   overrideDebug?: Array<string>;

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -272,3 +272,7 @@ export const FERAL_EVAL = eval;
 // Sample at module initialization time, which is before lockdown can
 // repair it.  Use it only to build powerless abstractions.
 export const FERAL_FUNCTION = Function;
+
+export const noEvalEvaluate = () => {
+  throw new TypeError();
+};

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -274,5 +274,7 @@ export const FERAL_EVAL = eval;
 export const FERAL_FUNCTION = Function;
 
 export const noEvalEvaluate = () => {
-  throw new TypeError();
+  throw new TypeError(
+    'Cannot eval with evalTaming set to "noEval" (SES_NO_EVAL)',
+  );
 };

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -297,7 +297,11 @@ export const makeCompartmentConstructor = (
     });
 
     // TODO: maybe add evalTaming to the Compartment constructor 3rd options?
-    setGlobalObjectEvaluators(globalObject, safeEvaluate);
+    setGlobalObjectEvaluators(
+      globalObject,
+      safeEvaluate,
+      markVirtualizedNativeFunction,
+    );
 
     assign(globalObject, endowments);
 

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -189,6 +189,7 @@ defineProperties(InertCompartment, {
  * @param {MakeCompartmentConstructor} targetMakeCompartmentConstructor
  * @param {Record<string, any>} intrinsics
  * @param {(object: Object) => void} markVirtualizedNativeFunction
+ * @param {boolean} noEvalTaming
  * @returns {Compartment['constructor']}
  */
 
@@ -197,6 +198,7 @@ export const makeCompartmentConstructor = (
   targetMakeCompartmentConstructor,
   intrinsics,
   markVirtualizedNativeFunction,
+  noEvalTaming,
 ) => {
   function Compartment(endowments = {}, moduleMap = {}, options = {}) {
     if (new.target === undefined) {
@@ -294,6 +296,7 @@ export const makeCompartmentConstructor = (
       makeCompartmentConstructor: targetMakeCompartmentConstructor,
       safeEvaluate,
       markVirtualizedNativeFunction,
+      noEvalTaming,
     });
 
     assign(globalObject, endowments);

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -23,6 +23,7 @@ import {
 import {
   setGlobalObjectConstantProperties,
   setGlobalObjectMutableProperties,
+  setGlobalObjectEvaluators,
 } from './global-object.js';
 import { isValidIdentifierName } from './scope-constants.js';
 import { sharedGlobalPropertyNames } from './whitelist.js';
@@ -292,10 +293,11 @@ export const makeCompartmentConstructor = (
       intrinsics,
       newGlobalPropertyNames: sharedGlobalPropertyNames,
       makeCompartmentConstructor: targetMakeCompartmentConstructor,
-      safeEvaluate,
       markVirtualizedNativeFunction,
-      evalTaming: 'safeEval',
     });
+
+    // TODO: maybe add evalTaming to the Compartment constructor 3rd options?
+    setGlobalObjectEvaluators(globalObject, safeEvaluate);
 
     assign(globalObject, endowments);
 

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -189,7 +189,6 @@ defineProperties(InertCompartment, {
  * @param {MakeCompartmentConstructor} targetMakeCompartmentConstructor
  * @param {Record<string, any>} intrinsics
  * @param {(object: Object) => void} markVirtualizedNativeFunction
- * @param {boolean} noEvalTaming
  * @returns {Compartment['constructor']}
  */
 
@@ -198,7 +197,6 @@ export const makeCompartmentConstructor = (
   targetMakeCompartmentConstructor,
   intrinsics,
   markVirtualizedNativeFunction,
-  noEvalTaming,
 ) => {
   function Compartment(endowments = {}, moduleMap = {}, options = {}) {
     if (new.target === undefined) {
@@ -296,7 +294,7 @@ export const makeCompartmentConstructor = (
       makeCompartmentConstructor: targetMakeCompartmentConstructor,
       safeEvaluate,
       markVirtualizedNativeFunction,
-      noEvalTaming,
+      evalTaming: 'safeEval',
     });
 
     assign(globalObject, endowments);

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -100,6 +100,16 @@ export const setGlobalObjectMutableProperties = (
  * @param {Function} evaluator
  */
 export const setGlobalObjectEvaluators = (globalObject, evaluator) => {
-  globalObject.eval = makeEvalFunction(evaluator);
-  globalObject.Function = makeFunctionConstructor(evaluator);
+  defineProperty(globalObject, 'eval', {
+    value: makeEvalFunction(evaluator),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+  defineProperty(globalObject, 'Function', {
+    value: makeFunctionConstructor(evaluator),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
 };

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -1,4 +1,10 @@
-import { defineProperty, objectHasOwnProperty, entries } from './commons.js';
+import {
+  defineProperty,
+  objectHasOwnProperty,
+  entries,
+  noEvalEvaluate,
+  TypeError,
+} from './commons.js';
 import { makeEvalFunction } from './make-eval-function.js';
 import { makeFunctionConstructor } from './make-function-constructor.js';
 import { constantProperties, universalPropertyNames } from './whitelist.js';
@@ -32,11 +38,11 @@ export const setGlobalObjectConstantProperties = globalObject => {
  * @param {Object} globalObject
  * @param {Object} param1
  * @param {Object} param1.intrinsics
+ * @param {'safeEval' | 'noEval' | 'unsafeEval'} param1.evalTaming
  * @param {Object} param1.newGlobalPropertyNames
  * @param {Function} param1.makeCompartmentConstructor
  * @param {(string, Object?) => any} param1.safeEvaluate
  * @param {(Object) => void} param1.markVirtualizedNativeFunction
- * @param {boolean} param1.noEvalTaming
  */
 export const setGlobalObjectMutableProperties = (
   globalObject,
@@ -46,7 +52,7 @@ export const setGlobalObjectMutableProperties = (
     makeCompartmentConstructor,
     safeEvaluate,
     markVirtualizedNativeFunction,
-    noEvalTaming,
+    evalTaming,
   },
 ) => {
   for (const [name, intrinsicName] of entries(universalPropertyNames)) {
@@ -71,25 +77,27 @@ export const setGlobalObjectMutableProperties = (
     }
   }
 
-  defineProperty(globalObject, 'globalThis', {
-    value: globalObject,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  });
-
   const perCompartmentGlobals = {
-    eval: makeEvalFunction(safeEvaluate),
-    Function: makeFunctionConstructor(safeEvaluate),
+    globalThis: globalObject,
   };
+
+  if (evalTaming === 'unsafeEval') {
+    // do nothing
+  } else if (evalTaming === 'noEval') {
+    perCompartmentGlobals.eval = makeEvalFunction(noEvalEvaluate);
+    perCompartmentGlobals.Function = makeFunctionConstructor(noEvalEvaluate);
+  } else if (evalTaming === 'safeEval') {
+    perCompartmentGlobals.eval = makeEvalFunction(safeEvaluate);
+    perCompartmentGlobals.Function = makeFunctionConstructor(safeEvaluate);
+  } else {
+    throw new TypeError('Unreachable value');
+  }
 
   perCompartmentGlobals.Compartment = makeCompartmentConstructor(
     makeCompartmentConstructor,
     intrinsics,
     markVirtualizedNativeFunction,
   );
-
-  if (noEvalTaming) return;
 
   // TODO These should still be tamed according to the whitelist before
   // being made available.

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -98,18 +98,31 @@ export const setGlobalObjectMutableProperties = (
  *
  * @param {Object} globalObject
  * @param {Function} evaluator
+ * @param {(Object) => void} markVirtualizedNativeFunction
  */
-export const setGlobalObjectEvaluators = (globalObject, evaluator) => {
-  defineProperty(globalObject, 'eval', {
-    value: makeEvalFunction(evaluator),
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  });
-  defineProperty(globalObject, 'Function', {
-    value: makeFunctionConstructor(evaluator),
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  });
+export const setGlobalObjectEvaluators = (
+  globalObject,
+  evaluator,
+  markVirtualizedNativeFunction,
+) => {
+  {
+    const f = makeEvalFunction(evaluator);
+    markVirtualizedNativeFunction(f);
+    defineProperty(globalObject, 'eval', {
+      value: f,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  {
+    const f = makeFunctionConstructor(evaluator);
+    markVirtualizedNativeFunction(f);
+    defineProperty(globalObject, 'Function', {
+      value: f,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
 };

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -1,9 +1,4 @@
-import {
-  defineProperty,
-  objectHasOwnProperty,
-  entries,
-  noEvalEvaluate,
-} from './commons.js';
+import { defineProperty, objectHasOwnProperty, entries } from './commons.js';
 import { makeEvalFunction } from './make-eval-function.js';
 import { makeFunctionConstructor } from './make-function-constructor.js';
 import { constantProperties, universalPropertyNames } from './whitelist.js';
@@ -27,7 +22,6 @@ export const setGlobalObjectConstantProperties = globalObject => {
   }
 };
 
-const { details: d, quote: q } = assert;
 /**
  * setGlobalObjectMutableProperties()
  * Create new global object using a process similar to ECMA specifications
@@ -38,10 +32,8 @@ const { details: d, quote: q } = assert;
  * @param {Object} globalObject
  * @param {Object} param1
  * @param {Object} param1.intrinsics
- * @param {'safeEval' | 'noEval' | 'unsafeEval'} param1.evalTaming
  * @param {Object} param1.newGlobalPropertyNames
  * @param {Function} param1.makeCompartmentConstructor
- * @param {(string, Object?) => any} param1.safeEvaluate
  * @param {(Object) => void} param1.markVirtualizedNativeFunction
  */
 export const setGlobalObjectMutableProperties = (
@@ -50,9 +42,7 @@ export const setGlobalObjectMutableProperties = (
     intrinsics,
     newGlobalPropertyNames,
     makeCompartmentConstructor,
-    safeEvaluate,
     markVirtualizedNativeFunction,
-    evalTaming,
   },
 ) => {
   for (const [name, intrinsicName] of entries(universalPropertyNames)) {
@@ -81,18 +71,6 @@ export const setGlobalObjectMutableProperties = (
     globalThis: globalObject,
   };
 
-  if (evalTaming === 'unsafeEval') {
-    // do nothing
-  } else if (evalTaming === 'noEval') {
-    perCompartmentGlobals.eval = makeEvalFunction(noEvalEvaluate);
-    perCompartmentGlobals.Function = makeFunctionConstructor(noEvalEvaluate);
-  } else if (evalTaming === 'safeEval') {
-    perCompartmentGlobals.eval = makeEvalFunction(safeEvaluate);
-    perCompartmentGlobals.Function = makeFunctionConstructor(safeEvaluate);
-  } else {
-    assert(false, d`non supported option evalTaming: ${q(evalTaming)}`);
-  }
-
   perCompartmentGlobals.Compartment = makeCompartmentConstructor(
     makeCompartmentConstructor,
     intrinsics,
@@ -112,4 +90,16 @@ export const setGlobalObjectMutableProperties = (
       markVirtualizedNativeFunction(value);
     }
   }
+};
+
+/**
+ * setGlobalObjectEvaluators()
+ * Set the eval and the Function evaluator on the global object with given evalTaming policy.
+ *
+ * @param {Object} globalObject
+ * @param {Function} evaluator
+ */
+export const setGlobalObjectEvaluators = (globalObject, evaluator) => {
+  globalObject.eval = makeEvalFunction(evaluator);
+  globalObject.Function = makeFunctionConstructor(evaluator);
 };

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -3,7 +3,6 @@ import {
   objectHasOwnProperty,
   entries,
   noEvalEvaluate,
-  TypeError,
 } from './commons.js';
 import { makeEvalFunction } from './make-eval-function.js';
 import { makeFunctionConstructor } from './make-function-constructor.js';
@@ -28,6 +27,7 @@ export const setGlobalObjectConstantProperties = globalObject => {
   }
 };
 
+const { details: d, quote: q } = assert;
 /**
  * setGlobalObjectMutableProperties()
  * Create new global object using a process similar to ECMA specifications
@@ -90,7 +90,7 @@ export const setGlobalObjectMutableProperties = (
     perCompartmentGlobals.eval = makeEvalFunction(safeEvaluate);
     perCompartmentGlobals.Function = makeFunctionConstructor(safeEvaluate);
   } else {
-    assert.fail(`Invalid evalTaming setting ${q(evalTaming)}`)
+    assert(false, d`non supported option evalTaming: ${q(evalTaming)}`);
   }
 
   perCompartmentGlobals.Compartment = makeCompartmentConstructor(

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -36,6 +36,7 @@ export const setGlobalObjectConstantProperties = globalObject => {
  * @param {Function} param1.makeCompartmentConstructor
  * @param {(string, Object?) => any} param1.safeEvaluate
  * @param {(Object) => void} param1.markVirtualizedNativeFunction
+ * @param {boolean} param1.noEvalTaming
  */
 export const setGlobalObjectMutableProperties = (
   globalObject,
@@ -45,6 +46,7 @@ export const setGlobalObjectMutableProperties = (
     makeCompartmentConstructor,
     safeEvaluate,
     markVirtualizedNativeFunction,
+    noEvalTaming,
   },
 ) => {
   for (const [name, intrinsicName] of entries(universalPropertyNames)) {
@@ -69,8 +71,16 @@ export const setGlobalObjectMutableProperties = (
     }
   }
 
+  defineProperty(globalObject, 'globalThis', {
+    value: globalObject,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  if (noEvalTaming) return;
+
   const perCompartmentGlobals = {
-    globalThis: globalObject,
     eval: makeEvalFunction(safeEvaluate),
     Function: makeFunctionConstructor(safeEvaluate),
   };

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -78,8 +78,6 @@ export const setGlobalObjectMutableProperties = (
     configurable: true,
   });
 
-  if (noEvalTaming) return;
-
   const perCompartmentGlobals = {
     eval: makeEvalFunction(safeEvaluate),
     Function: makeFunctionConstructor(safeEvaluate),
@@ -90,6 +88,8 @@ export const setGlobalObjectMutableProperties = (
     intrinsics,
     markVirtualizedNativeFunction,
   );
+
+  if (noEvalTaming) return;
 
   // TODO These should still be tamed according to the whitelist before
   // being made available.

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -90,7 +90,7 @@ export const setGlobalObjectMutableProperties = (
     perCompartmentGlobals.eval = makeEvalFunction(safeEvaluate);
     perCompartmentGlobals.Function = makeFunctionConstructor(safeEvaluate);
   } else {
-    throw new TypeError('Unreachable value');
+    assert.fail(`Invalid evalTaming setting ${q(evalTaming)}`)
   }
 
   perCompartmentGlobals.Compartment = makeCompartmentConstructor(

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -164,6 +164,7 @@ export const repairIntrinsics = (options = {}) => {
     overrideTaming = getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate'),
     stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise'),
     domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe'),
+    evalTaming = getenv('LOCKDOWN_COMPARTMENT', 'safe'),
     overrideDebug = arrayFilter(
       stringSplit(getenv('LOCKDOWN_OVERRIDE_DEBUG', ''), ','),
       /** @param {string} debugName */
@@ -332,6 +333,7 @@ export const repairIntrinsics = (options = {}) => {
     makeCompartmentConstructor,
     safeEvaluate,
     markVirtualizedNativeFunction,
+    noEvalTaming: evalTaming === 'unsafe',
   });
 
   /**

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -347,7 +347,9 @@ export const repairIntrinsics = (options = {}) => {
     const { safeEvaluate } = makeSafeEvaluator({ globalObject: globalThis });
     setGlobalObjectEvaluators(globalThis, safeEvaluate);
   } else if (evalTaming === 'unsafeEval') {
-    // Do nothing
+    // Leave eval function and Function constructor of the initial compartment in-tact.
+    // Other compartments will not have access to these evaluators unless a guest program
+    // escapes containment.
   }
 
   /**

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -164,7 +164,7 @@ export const repairIntrinsics = (options = {}) => {
     overrideTaming = getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate'),
     stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise'),
     domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe'),
-    evalTaming = getenv('LOCKDOWN_COMPARTMENT', 'safe'),
+    evalTaming = getenv('LOCKDOWN_COMPARTMENT', 'safeEval'),
     overrideDebug = arrayFilter(
       stringSplit(getenv('LOCKDOWN_OVERRIDE_DEBUG', ''), ','),
       /** @param {string} debugName */
@@ -189,6 +189,13 @@ export const repairIntrinsics = (options = {}) => {
       )}`,
     );
   }
+
+  assert(
+    evalTaming === 'unsafeEval' ||
+      evalTaming === 'safeEval' ||
+      evalTaming === 'noEval',
+    d`lockdown(): non supported option evalTaming: ${q(evalTaming)}`,
+  );
 
   // Assert that only supported options were passed.
   // Use Reflect.ownKeys to reject symbol-named properties as well.
@@ -333,7 +340,7 @@ export const repairIntrinsics = (options = {}) => {
     makeCompartmentConstructor,
     safeEvaluate,
     markVirtualizedNativeFunction,
-    noEvalTaming: evalTaming === 'unsafe',
+    evalTaming,
   });
 
   /**

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -164,7 +164,7 @@ export const repairIntrinsics = (options = {}) => {
     overrideTaming = getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate'),
     stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise'),
     domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe'),
-    evalTaming = getenv('LOCKDOWN_COMPARTMENT', 'safeEval'),
+    evalTaming = getenv('LOCKDOWN_EVAL_TAMING', 'safeEval'),
     overrideDebug = arrayFilter(
       stringSplit(getenv('LOCKDOWN_OVERRIDE_DEBUG', ''), ','),
       /** @param {string} debugName */

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -342,10 +342,18 @@ export const repairIntrinsics = (options = {}) => {
   });
 
   if (evalTaming === 'noEval') {
-    setGlobalObjectEvaluators(globalThis, noEvalEvaluate);
+    setGlobalObjectEvaluators(
+      globalThis,
+      noEvalEvaluate,
+      markVirtualizedNativeFunction,
+    );
   } else if (evalTaming === 'safeEval') {
     const { safeEvaluate } = makeSafeEvaluator({ globalObject: globalThis });
-    setGlobalObjectEvaluators(globalThis, safeEvaluate);
+    setGlobalObjectEvaluators(
+      globalThis,
+      safeEvaluate,
+      markVirtualizedNativeFunction,
+    );
   } else if (evalTaming === 'unsafeEval') {
     // Leave eval function and Function constructor of the initial compartment in-tact.
     // Other compartments will not have access to these evaluators unless a guest program

--- a/packages/ses/src/make-eval-function.js
+++ b/packages/ses/src/make-eval-function.js
@@ -1,7 +1,9 @@
-/*
+/**
  * makeEvalFunction()
  * A safe version of the native eval function which relies on
  * the safety of safeEvaluate for confinement.
+ *
+ * @param {Function} safeEvaluate
  */
 export const makeEvalFunction = safeEvaluate => {
   // We use the the concise method syntax to create an eval without a

--- a/packages/ses/test/test-evalTaming-default.js
+++ b/packages/ses/test/test-evalTaming-default.js
@@ -10,4 +10,8 @@ test('safe eval when evalTaming is undefined.', t => {
   t.throws(() => eval('a'));
   // eslint-disable-next-line no-eval
   t.is(eval('1 + 1'), 2);
+
+  // should not throw
+  const compartment = new Compartment();
+  compartment.evaluate('(1, eval)("1 + 1")');
 });

--- a/packages/ses/test/test-evalTaming-default.js
+++ b/packages/ses/test/test-evalTaming-default.js
@@ -1,0 +1,13 @@
+import test from 'ava';
+import '../index.js';
+
+lockdown({});
+
+test('safe eval when evalTaming is undefined.', t => {
+  // eslint-disable-next-line no-unused-vars
+  const a = 0;
+  // eslint-disable-next-line no-eval
+  t.throws(() => eval('a'));
+  // eslint-disable-next-line no-eval
+  t.is(eval('1 + 1'), 2);
+});

--- a/packages/ses/test/test-evalTaming-default.js
+++ b/packages/ses/test/test-evalTaming-default.js
@@ -14,4 +14,6 @@ test('safe eval when evalTaming is undefined.', t => {
   // should not throw
   const compartment = new Compartment();
   compartment.evaluate('(1, eval)("1 + 1")');
+  // eslint-disable-next-line no-eval
+  t.is(eval.toString(), 'function eval() { [native code] }');
 });

--- a/packages/ses/test/test-evalTaming-noEval.js
+++ b/packages/ses/test/test-evalTaming-noEval.js
@@ -6,4 +6,8 @@ lockdown({ evalTaming: 'noEval' });
 test('no eval when evalTaming is noEval.', t => {
   // eslint-disable-next-line no-eval
   t.throws(() => eval('1+1'));
+
+  const compartment = new Compartment();
+  // should not throw
+  compartment.evaluate('(1, eval)("1 + 1")');
 });

--- a/packages/ses/test/test-evalTaming-noEval.js
+++ b/packages/ses/test/test-evalTaming-noEval.js
@@ -10,4 +10,6 @@ test('no eval when evalTaming is noEval.', t => {
   const compartment = new Compartment();
   // should not throw
   compartment.evaluate('(1, eval)("1 + 1")');
+  // eslint-disable-next-line no-eval
+  t.is(eval.toString(), 'function eval() { [native code] }');
 });

--- a/packages/ses/test/test-evalTaming-noEval.js
+++ b/packages/ses/test/test-evalTaming-noEval.js
@@ -1,0 +1,9 @@
+import test from 'ava';
+import '../index.js';
+
+lockdown({ evalTaming: 'noEval' });
+
+test('no eval when evalTaming is noEval.', t => {
+  // eslint-disable-next-line no-eval
+  t.throws(() => eval('1+1'));
+});

--- a/packages/ses/test/test-evalTaming-safeEval.js
+++ b/packages/ses/test/test-evalTaming-safeEval.js
@@ -10,4 +10,6 @@ test('safe eval when evalTaming is safeEval.', t => {
   t.throws(() => eval('a'));
   // eslint-disable-next-line no-eval
   t.is(eval('1 + 1'), 2);
+  // eslint-disable-next-line no-eval
+  t.is(eval.toString(), 'function eval() { [native code] }');
 });

--- a/packages/ses/test/test-evalTaming-safeEval.js
+++ b/packages/ses/test/test-evalTaming-safeEval.js
@@ -1,0 +1,13 @@
+import test from 'ava';
+import '../index.js';
+
+lockdown({ evalTaming: 'safeEval' });
+
+test('safe eval when evalTaming is safeEval.', t => {
+  // eslint-disable-next-line no-unused-vars
+  const a = 0;
+  // eslint-disable-next-line no-eval
+  t.throws(() => eval('a'));
+  // eslint-disable-next-line no-eval
+  t.is(eval('1 + 1'), 2);
+});

--- a/packages/ses/test/test-evalTaming-unsafe.js
+++ b/packages/ses/test/test-evalTaming-unsafe.js
@@ -12,4 +12,6 @@ test('direct eval is possible when evalTaming is unsafe.', t => {
   // should not throw
   const compartment = new Compartment();
   compartment.evaluate('(1, eval)("1 + 1")');
+  // eslint-disable-next-line no-eval
+  t.is(eval.toString(), 'function eval() { [native code] }');
 });

--- a/packages/ses/test/test-evalTaming-unsafe.js
+++ b/packages/ses/test/test-evalTaming-unsafe.js
@@ -8,4 +8,8 @@ test('direct eval is possible when evalTaming is unsafe.', t => {
   const a = 0;
   // eslint-disable-next-line no-eval
   t.is(eval('a'), 0);
+
+  // should not throw
+  const compartment = new Compartment();
+  compartment.evaluate('(1, eval)("1 + 1")');
 });

--- a/packages/ses/test/test-evalTaming-unsafe.js
+++ b/packages/ses/test/test-evalTaming-unsafe.js
@@ -9,7 +9,3 @@ test('direct eval is possible when evalTaming is unsafe.', t => {
   // eslint-disable-next-line no-eval
   t.is(eval('a'), 0);
 });
-
-test('compartment cannot be used when evalTaming is unsafe.', t => {
-  t.is(typeof Compartment, 'undefined');
-});

--- a/packages/ses/test/test-evalTaming-unsafe.js
+++ b/packages/ses/test/test-evalTaming-unsafe.js
@@ -1,0 +1,15 @@
+import test from 'ava';
+import '../index.js';
+
+lockdown({ evalTaming: 'unsafe' });
+
+test('direct eval is possible when evalTaming is unsafe.', t => {
+  // eslint-disable-next-line no-unused-vars
+  const a = 0;
+  // eslint-disable-next-line no-eval
+  t.is(eval('a'), 0);
+});
+
+test('compartment cannot be used when evalTaming is unsafe.', t => {
+  t.is(typeof Compartment, 'undefined');
+});

--- a/packages/ses/test/test-evalTaming-unsafe.js
+++ b/packages/ses/test/test-evalTaming-unsafe.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import '../index.js';
 
-lockdown({ evalTaming: 'unsafe' });
+lockdown({ evalTaming: 'unsafeEval' });
 
 test('direct eval is possible when evalTaming is unsafe.', t => {
   // eslint-disable-next-line no-unused-vars

--- a/packages/ses/test/test-global-object.js
+++ b/packages/ses/test/test-global-object.js
@@ -30,7 +30,11 @@ test('globalObject', t => {
     makeCompartmentConstructor,
     markVirtualizedNativeFunction,
   });
-  setGlobalObjectEvaluators(globalObject, safeEvaluate);
+  setGlobalObjectEvaluators(
+    globalObject,
+    safeEvaluate,
+    markVirtualizedNativeFunction,
+  );
 
   t.truthy(globalObject instanceof Object);
   t.is(Object.getPrototypeOf(globalObject), Object.prototype);

--- a/packages/ses/test/test-global-object.js
+++ b/packages/ses/test/test-global-object.js
@@ -6,6 +6,7 @@ import test from 'ava';
 import {
   setGlobalObjectConstantProperties,
   setGlobalObjectMutableProperties,
+  setGlobalObjectEvaluators,
 } from '../src/global-object.js';
 import { sharedGlobalPropertyNames } from '../src/whitelist.js';
 import { makeCompartmentConstructor } from '../src/compartment-shim.js';
@@ -27,10 +28,9 @@ test('globalObject', t => {
     intrinsics,
     newGlobalPropertyNames: sharedGlobalPropertyNames,
     makeCompartmentConstructor,
-    safeEvaluate,
     markVirtualizedNativeFunction,
-    evalTaming: 'safeEval',
   });
+  setGlobalObjectEvaluators(globalObject, safeEvaluate);
 
   t.truthy(globalObject instanceof Object);
   t.is(Object.getPrototypeOf(globalObject), Object.prototype);

--- a/packages/ses/test/test-global-object.js
+++ b/packages/ses/test/test-global-object.js
@@ -29,6 +29,7 @@ test('globalObject', t => {
     makeCompartmentConstructor,
     safeEvaluate,
     markVirtualizedNativeFunction,
+    evalTaming: 'safeEval',
   });
 
   t.truthy(globalObject instanceof Object);


### PR DESCRIPTION
This PR adds a new option `evalTaming` which defaults to `"safeEval"` (current behavior).

I introduced a new behavior `"unsafeEval"` and `"noEval"`.

This option is for the environment that does not allow `eval` in the production mode but allows it in the development mode for webpack `eval-source-map`.
The current behavior will replace the `eval` constructor and cause the webpack bundle to fail to load.

I have documented this new option and warned any users do not use it unless they have the same situation as us.
