### PR TITLE
feat(stream): Add stream library

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "packages/ses-integration-test",
     "packages/ses-types-test",
     "packages/static-module-record",
+    "packages/stream",
     "packages/syrup",
     "packages/test262-runner",
     "packages/test262-runner",

--- a/packages/stream/LICENSE
+++ b/packages/stream/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/stream/README.md
+++ b/packages/stream/README.md
@@ -1,0 +1,61 @@
+# Endo Streams
+
+Endo models streams as hardened async iterators.
+Async iterators are sufficient to model back-pressure or pacing
+since they are channel messages both from producer to consumer
+and consumer to producer.
+Streams are therefore symmetric.
+The same stream type serves for both a reader and a writer.
+
+## Writing
+
+To write to a stream, give a value to the next method.
+
+```js
+// ...
+await writer.next(value);
+```
+
+Awaiting the returned promise slows the writer to match the pace of the reader.
+
+## Reading
+
+To read from a string, await the value returned by the next method.
+
+```js
+for await (const value of reader) {
+  // ...
+}
+```
+
+## Pipe
+
+The `makePipe` function returns an entangled pair of streams.
+Use one as a reader and the other as a writer.
+Pipes are useful for mocking streams in tests.
+
+```js
+const [writer, reader] = makePipe();
+```
+
+Pipes use `makeStream` and `makeQueue`.
+`makeQueue` creates an async promise queue: a collection type like a queue
+except that `get` returns a promise and `put` accepts a promise, so `get` can
+be called before `put`.
+An async queue ensures that the promises returned by `get` and accepted by
+`put` are matched respectively, but provides no guarantee about the order in
+which promises settle.
+A stream is consequently a pair of queues that transport iteration results,
+one to send messages forward and another to receive acknowledgements.
+
+## Hardening
+
+This library depends on Hardened JavaScript.
+The environment must be locked down before initializing this library.
+All of the exported functions and the streams they produce are hardened.
+
+This implementation of streams ensures that iteration results are shallowly
+frozen.
+The user is responsible for hardening the transported values if that is their
+intent.
+Some values like array buffers cannot be frozen.

--- a/packages/stream/index.d.ts
+++ b/packages/stream/index.d.ts
@@ -1,0 +1,2 @@
+export { makeQueue, makeStream, makePipe } from './index.js';
+export type { Stream, Reader, Writer, AsyncQueue } from './index.js';

--- a/packages/stream/index.js
+++ b/packages/stream/index.js
@@ -1,0 +1,147 @@
+/* `makeQueue`, `makeStream`, and `makePipe` are utilities for creating async
+ * iterator "streams". A Stream is compatible with AsyncIterator and Generator
+ * but differ in that every method and argument of both is required.
+ * For example, streams always have `return` and `throw` for closing the write
+ * side.
+ * The `Stream` interface is symmetric, but a stream that sends data and
+ * receives undefined is conventionally a `Writer` whereas a stream that
+ * receives data and sends undefined is conventionally a `Reader`.
+ */
+
+// @ts-check
+/// <reference types="ses"/>
+
+/**
+ * @template T
+ * @typedef {{
+ *   resolve(value?: T | Promise<T>): void,
+ *   reject(error: Error): void,
+ *   promise: Promise<T>
+ * }} PromiseKit
+ */
+
+/**
+ * @template T
+ * @returns {PromiseKit<T>}
+ */
+const makePromiseKit = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  assert(resolve !== undefined);
+  assert(reject !== undefined);
+  return harden({ promise, resolve, reject });
+};
+
+/**
+ * @template T
+ * @typedef {{
+ *   put(value: T | Promise<T>): void,
+ *   get(): Promise<T>
+ * }} AsyncQueue
+ */
+
+/**
+ * @template T
+ * @returns {AsyncQueue<T>}
+ */
+export const makeQueue = () => {
+  let { promise: tailPromise, resolve: tailResolve } = makePromiseKit();
+  return {
+    put(value) {
+      const { resolve, promise } = makePromiseKit();
+      tailResolve(Object.freeze({ value, promise }));
+      tailResolve = resolve;
+    },
+    get() {
+      const promise = tailPromise.then(next => next.value);
+      tailPromise = tailPromise.then(next => next.promise);
+      return harden(promise);
+    },
+  };
+};
+harden(makeQueue);
+
+/**
+ * @template T
+ * @template U
+ * @template V
+ * @typedef {{
+ *   next(value: U): Promise<IteratorResult<T>>,
+ *   return(value: V): Promise<IteratorResult<T>>,
+ *   throw(error: Error): Promise<IteratorResult<T>>,
+ *   [Symbol.asyncIterator](): Stream<T, U, V>
+ * }} Stream
+ */
+
+/**
+ * @template T
+ * @template V
+ * @typedef {Stream<T, undefined, V>} Reader
+ */
+
+/**
+ * @template U
+ * @template V
+ * @typedef {Stream<undefined, U, V>} Writer
+ */
+
+/**
+ * @template T
+ * @template U
+ * @template V
+ * @param {AsyncQueue<IteratorResult<T>>} acks
+ * @param {AsyncQueue<IteratorResult<U>>} data
+ * @returns {Stream<T, U, V>}
+ */
+export const makeStream = (acks, data) => {
+  const stream = harden({
+    /**
+     * @param {U} value
+     */
+    next(value) {
+      // Note the shallow freeze since value is not guaranteed to be freezable
+      // (typed arrays are not).
+      data.put(Object.freeze({ value, done: false }));
+      return acks.get();
+    },
+    /**
+     * @param {V} value
+     */
+    return(value) {
+      data.put(Object.freeze({ value, done: true }));
+      return acks.get();
+    },
+    /**
+     * @param {Error} error
+     */
+    throw(error) {
+      data.put(harden(Promise.reject(error)));
+      return acks.get();
+    },
+    [Symbol.asyncIterator]() {
+      return stream;
+    },
+  });
+  return stream;
+};
+harden(makeStream);
+
+/**
+ * @template T
+ * @template U
+ * @template TReturn
+ * @template UReturn
+ * @returns {[Stream<T, U, TReturn>, Stream<U, T, UReturn>]}
+ */
+export const makePipe = () => {
+  const data = makeQueue();
+  const acks = makeQueue();
+  const reader = makeStream(data, acks);
+  const writer = makeStream(acks, data);
+  return harden([reader, writer]);
+};
+harden(makePipe);

--- a/packages/stream/jsconfig.json
+++ b/packages/stream/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.js", "index.d.ts"]
+}

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@endo/stream",
+  "version": "0.1.0",
+  "description": "Foundation for async iterators as streams",
+  "keywords": ["endo", "stream", "async", "iterator", "pipe", "promise"],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/stream#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "module": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "cover": "c8 ava",
+    "lint": "yarn lint:types && yarn lint:js",
+    "lint-fix": "eslint --fix .",
+    "lint:js": "eslint .",
+    "lint:types": "tsc --build jsconfig.json",
+    "test": "ava"
+  },
+  "dependencies": {
+    "ses": "^0.15.3"
+  },
+  "devDependencies": {
+    "@endo/eslint-config": "^0.3.20",
+    "@endo/ses-ava": "^0.2.13",
+    "@typescript-eslint/parser": "^4.18.0",
+    "ava": "^3.12.1",
+    "babel-eslint": "^10.0.3",
+    "c8": "^7.7.3",
+    "eslint": "^7.23.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-prettier": "^6.9.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-jsdoc": "^30.4.2",
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1",
+    "typescript": "^4.0.5"
+  },
+  "files": [
+    "LICENSE*",
+    "index.d.ts",
+    "index.js"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@endo"
+    ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "timeout": "2m"
+  }
+}

--- a/packages/stream/test/lockdown.js
+++ b/packages/stream/test/lockdown.js
@@ -1,0 +1,1 @@
+lockdown();

--- a/packages/stream/test/test-stream.js
+++ b/packages/stream/test/test-stream.js
@@ -1,0 +1,60 @@
+import 'ses';
+import './lockdown.js';
+
+import rawTest from 'ava';
+import { wrapTest } from '@endo/ses-ava';
+import { makePipe } from '../index.js';
+
+const test = wrapTest(rawTest);
+
+test('stream', async t => {
+  const [consumeFrom, produceTo] = makePipe();
+
+  const order = [10, 20, 30];
+
+  const makeProducer = async () => {
+    for (const expected of order) {
+      // eslint-disable-next-line no-await-in-loop
+      const { done, value: actual } = await produceTo.next(expected);
+      t.is(done, false);
+      t.is(actual, expected);
+    }
+    const { done, value: actual } = await produceTo.return('.');
+    t.is(done, true);
+    t.is(actual, '!');
+  };
+
+  const makeConsumer = async () => {
+    for (const expected of order) {
+      // eslint-disable-next-line no-await-in-loop
+      const { done, value: actual } = await consumeFrom.next(expected);
+      t.is(done, false);
+      t.is(expected, actual);
+    }
+    const { done, value: actual } = await consumeFrom.return('!');
+    t.is(done, true);
+    t.is(actual, '.');
+  };
+
+  await Promise.all([makeProducer(), makeConsumer()]);
+});
+
+test('stream terminated with cause', async t => {
+  const [consumeFrom, produceTo] = makePipe();
+
+  const makeProducer = async () => {
+    await produceTo.throw(new Error('Exit early'));
+  };
+
+  const makeConsumer = async () => {
+    try {
+      for await (const _ of consumeFrom) {
+        t.fail();
+      }
+    } catch (error) {
+      t.is(error.message, 'Exit early');
+    }
+  };
+
+  await Promise.all([makeProducer(), makeConsumer()]);
+});


### PR DESCRIPTION
Adds a small stream library that provides a foundation for streaming with async iterators. The types are a bit more rigid than AsyncIterator in order to mesh better in TypeScript.

The library includes a reductive makePromiseKit since the AsyncQueue requires a “soft” object and doesn’t require much else that `@agoric/promise-kit` might provide, but nevertheless, I took a cue from attempting to use `@agoric/promise-kit` and implemented the library atop hardened JavaScript.