### PR TITLE
chore: Migrate lockdown from Agoric SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "packages/endo",
     "packages/eslint-config",
     "packages/eslint-plugin",
+    "packages/lockdown",
     "packages/lp32",
     "packages/netstring",
     "packages/promise-kit",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### 0.1.1 (2021-12-02)
+
+
+### Features
+
+* **install-ses:** provide some composable entrypoints ([8f85868](https://github.com/Agoric/agoric-sdk/commit/8f8586872febaa12857d0833bd19d71dc9aa8134))
+
+
+### Bug Fixes
+
+* **lockdown:** use default `stackFiltering: 'concise'` for debug ([8fa0611](https://github.com/Agoric/agoric-sdk/commit/8fa0611b474d2770fbbae6d0831c47d97fe68c0b))

--- a/packages/lockdown/commit-debug.js
+++ b/packages/lockdown/commit-debug.js
@@ -1,0 +1,79 @@
+// commit-debug.js - debug version of commit.js
+
+// This is like `@agoric/install-ses` but sacrificing safety to optimize
+// for debugging and testing. The difference is only the lockdown options.
+// The setting below are *unsafe* and should not be used in contact with
+// genuinely malicious code.
+
+// See
+// https://github.com/endojs/endo/blob/master/packages/ses/lockdown-options.md
+// for more explanation of these lockdown options.
+
+export * from './pre.js';
+
+lockdown({
+  // The default `{errorTaming: 'safe'}` setting, if possible, redacts the
+  // stack trace info from the error instances, so that it is not available
+  // merely by saying `errorInstance.stack`. However, some tools, such as
+  // Ava, will look for the stack there and become much less useful if it is
+  // missing.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  errorTaming: 'unsafe',
+
+  // The default `{stackFiltering: 'concise'}` setting usually makes for a
+  // better debugging experience, by severely reducing the noisy distractions
+  // of the normal verbose stack traces. Which is why we comment
+  // out the `'verbose'` setting is commented out below. However, some
+  // tools look for the full filename that it expects in order
+  // to fetch the source text for diagnostics,
+  //
+  // Another reason for not commenting it out: The cause
+  // of the bug may be anywhere, so the `'noise'` thrown out by the default
+  // `'concise'` setting may also contain the signal you need. To see it,
+  // uncomment out the following line. But please do not commit it in that
+  // state.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that MUST be fixed before merging.
+  //
+  // stackFiltering: 'verbose',
+
+  // The default `{overrideTaming: 'moderate'}` setting does not hurt the
+  // debugging experience much. But it will introduce noise into, for example,
+  // the vscode debugger's object inspector. During debug and test, if you can
+  // avoid legacy code that needs the `'moderate'` setting, then the `'min'`
+  // setting reduces debugging noise yet further, by turning fewer inherited
+  // properties into accessors.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  overrideTaming: 'min',
+
+  // The default `{consoleTaming: 'safe'}` setting usually makes for a
+  // better debugging experience, by wrapping the original `console` with
+  // the SES replacement `console` that provides more information about
+  // errors, expecially those thrown by the `assert` system. However,
+  // in case the SES `console` is getting in the way, we provide the
+  // `'unsafe'` option for leaving the original `console` in place.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  // consoleTaming: 'unsafe',
+
+  // Domain taming causes lockdown to throw an error if the Node.js domain
+  // module has already been loaded, and causes loading the domain module
+  // to throw an error if it is pulled into the working set later.
+  // This is because domains may add domain properties to promises and other
+  // callbacks and that these domain objects provide a means to escape
+  // containment.
+  // However, our platform still depends on systems like standardthings/esm
+  // which ultimately pull in domains.
+  // For now, we are resigned to leave this hole open, knowing that all
+  // contract code will be run under XS to avoid this vulnerability.
+  domainTaming: 'unsafe',
+});

--- a/packages/lockdown/commit-debug.js
+++ b/packages/lockdown/commit-debug.js
@@ -1,6 +1,6 @@
 // commit-debug.js - debug version of commit.js
 
-// This is like `@agoric/install-ses` but sacrificing safety to optimize
+// This is like `@endo/install-ses` but sacrificing safety to optimize
 // for debugging and testing. The difference is only the lockdown options.
 // The setting below are *unsafe* and should not be used in contact with
 // genuinely malicious code.

--- a/packages/lockdown/commit.js
+++ b/packages/lockdown/commit.js
@@ -1,0 +1,3 @@
+export * from './pre.js';
+
+lockdown();

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@agoric/lockdown",
+  "version": "0.1.1",
+  "description": "wrappers for locking down SES the Agoric way",
+  "type": "module",
+  "main": "pre.js",
+  "scripts": {
+    "build": "exit 0",
+    "test": "exit 0",
+    "test:xs": "exit 0",
+    "lint-check": "yarn lint",
+    "lint-fix": "eslint --fix '**/*.js'",
+    "lint": "eslint '**/*.js'"
+  },
+  "devDependencies": {
+    "ava": "^3.12.1"
+  },
+  "dependencies": {
+    "ses": "^0.15.3"
+  },
+  "files": [
+    "*.js",
+    "src/**.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agoric/agoric-sdk.git"
+  },
+  "author": "Agoric",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Agoric/agoric-sdk/issues"
+  },
+  "homepage": "https://github.com/Agoric/agoric-sdk#readme",
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ]
+  },
+  "eslintConfig": {
+    "extends": [
+      "@agoric"
+    ]
+  },
+  "eslintIgnore": [
+    "bundle-*.js"
+  ],
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@agoric/lockdown",
+  "name": "@endo/lockdown",
   "version": "0.1.1",
-  "description": "wrappers for locking down SES the Agoric way",
+  "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
   "scripts": {
@@ -24,14 +24,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Agoric/agoric-sdk.git"
+    "url": "git+https://github.com/endojs/endo.git"
   },
   "author": "Agoric",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/Agoric/agoric-sdk/issues"
+    "url": "https://github.com/endojs/endo/issues"
   },
-  "homepage": "https://github.com/Agoric/agoric-sdk#readme",
+  "homepage": "https://github.com/endojs/endo#readme",
   "ava": {
     "files": [
       "test/**/test-*.js"
@@ -39,7 +39,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/lockdown/post.js
+++ b/packages/lockdown/post.js
@@ -1,0 +1,13 @@
+/* global globalThis */
+
+// The post lockdown thunk.
+export default () => {
+  // Even on non-v8, we tame the start compartment's Error constructor so
+  // this assignment is not rejected, even if it does nothing.
+  Error.stackTraceLimit = Infinity;
+
+  harden(TextEncoder);
+  harden(TextDecoder);
+  harden(globalThis.URL); // Absent only on XSnap
+  harden(globalThis.Base64); // Present only on XSnap
+};

--- a/packages/lockdown/pre.js
+++ b/packages/lockdown/pre.js
@@ -1,0 +1,173 @@
+// pre.js - set up the default lockdown function
+/* global globalThis LOCKDOWN_OPTIONS process */
+
+import 'ses';
+import postLockdown from './post.js';
+
+// Export the type definitions, too.
+export * from 'ses';
+
+const rawLockdown = globalThis.lockdown;
+
+/** @type {typeof rawLockdown} */
+export const lockdown = defaultOptions => {
+  // For testing under Ava, and also sometimes for testing and debugging in
+  // general, when safety is not needed, you perhaps want to use
+  // packages/SwingSet/tools/install-ses-debug.js instead of this one.
+  // If you're using a prepare-test-env-ava.js, it is probably already doing that
+  // for you.
+
+  // The`@agoric/import-ses` package exists so the "main" of production code can
+  // start with the following import or its equivalent.
+  // ```js
+  // import '@agoric/install-ses';
+  // ```
+  // But production code must also be tested. Normal ocap discipline of passing
+  // explicit arguments into the `lockdown`
+  // call would require an awkward structuring of start modules, since
+  // the `install-ses` module calls `lockdown` during its initialization,
+  // before any explicit code in the start module gets to run. Even if other code
+  // does get to run first, the `lockdown` call in this module happens during
+  // module initialization, before it can legitimately receive parameters by
+  // explicit parameter passing.
+  //
+  // Instead, for now, `install-ses` violates normal ocap discipline by feature
+  // testing global state for a passed "parameter". This is something that a
+  // module can but normally should not do, during initialization or otherwise.
+  // Initialization is often awkward.
+  //
+  // The `install-ses` module tests, first,
+  // for a JavaScript global named `LOCKDOWN_OPTIONS`, and second, for an
+  // environment
+  // variable named `LOCKDOWN_OPTIONS`. If either is present, its value should be
+  // a JSON encoding of the options bag to pass to the `lockdown` call. If so,
+  // then `install-ses` calls `lockdown` with those options. If there is no such
+  // feature, `install-ses` calls `lockdown` with appropriate settings for
+  // production use.
+
+  let optionsString;
+  if (typeof LOCKDOWN_OPTIONS === 'string') {
+    optionsString = LOCKDOWN_OPTIONS;
+    console.log(
+      `'@agoric/install-ses' sniffed and found a 'LOCKDOWN_OPTIONS' global variable\n`,
+    );
+  } else if (
+    typeof process === 'object' &&
+    typeof process.env.LOCKDOWN_OPTIONS === 'string'
+  ) {
+    optionsString = process.env.LOCKDOWN_OPTIONS;
+    console.log(
+      `'@agoric/install-ses' sniffed and found a 'LOCKDOWN_OPTIONS' environment variable\n`,
+    );
+  }
+
+  if (typeof optionsString === 'string') {
+    let options;
+    try {
+      options = JSON.parse(optionsString);
+    } catch (err) {
+      console.error('Environment variable LOCKDOWN_OPTIONS must be JSON', err);
+      throw err;
+    }
+    if (typeof options !== 'object' || Array.isArray(options)) {
+      const err = new TypeError(
+        'Environment variable LOCKDOWN_OPTIONS must be a JSON object',
+      );
+      console.error('', err, options);
+      throw err;
+    }
+    rawLockdown({
+      ...options,
+      // See comment on domainTaming below.
+      domainTaming: 'unsafe',
+    });
+  } else if (defaultOptions) {
+    rawLockdown({
+      ...defaultOptions,
+      // See comment on domainTaming below.
+      domainTaming: 'unsafe',
+    });
+  } else {
+    rawLockdown({
+      // The default `{errorTaming: 'safe'}` setting, if possible, redacts the
+      // stack trace info from the error instances, so that it is not available
+      // merely by saying `errorInstance.stack`. However, some tools
+      // will look for the stack there and become much less useful if it is
+      // missing. In production, the settings in this file need to preserve
+      // security, so the 'unsafe' setting below MUST always be commented out
+      // except during private development.
+      //
+      // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+      // this may be a development accident that MUST be fixed before merging.
+      //
+      // errorTaming: 'unsafe',
+      //
+      //
+      // The default `{stackFiltering: 'concise'}` setting usually makes for a
+      // better debugging experience, by severely reducing the noisy distractions
+      // of the normal verbose stack traces. Which is why we comment
+      // out the `'verbose'` setting is commented out below. However, some
+      // tools look for the full filename that it expects in order
+      // to fetch the source text for diagnostics,
+      //
+      // Another reason for not commenting it out: The cause
+      // of the bug may be anywhere, so the `'noise'` thrown out by the default
+      // `'concise'` setting may also contain the signal you need. To see it,
+      // uncomment out the following line. But please do not commit it in that
+      // state.
+      //
+      // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+      // this may be a development accident that MUST be fixed before merging.
+      //
+      // stackFiltering: 'verbose',
+      //
+      //
+      // The default `{overrideTaming: 'moderate'}` setting does not hurt the
+      // debugging experience much. But it will introduce noise into, for example,
+      // the vscode debugger's object inspector. During debug and test, if you can
+      // avoid legacy code that needs the `'moderate'` setting, then the `'min'`
+      // setting reduces debugging noise yet further, by turning fewer inherited
+      // properties into accessors.
+      //
+      // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+      // this may be a development accident that MUST be fixed before merging.
+      //
+      // overrideTaming: 'min',
+      //
+      //
+      // The default `{consoleTaming: 'safe'}` setting usually makes for a
+      // better debugging experience, by wrapping the original `console` with
+      // the SES replacement `console` that provides more information about
+      // errors, expecially those thrown by the `assert` system. However,
+      // in case the SES `console` is getting in the way, we provide the
+      // `'unsafe'` option for leaving the original `console` in place.
+      //
+      // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+      // this may be a development accident that MUST be fixed before merging.
+      //
+      // consoleTaming: 'unsafe',
+
+      // Domain taming causes lockdown to throw an error if the Node.js domain
+      // module has already been loaded, and causes loading the domain module
+      // to throw an error if it is pulled into the working set later.
+      // This is because domains may add domain properties to promises and other
+      // callbacks and that these domain objects provide a means to escape
+      // containment.
+      // However, our platform still depends on systems like standardthings/esm
+      // which ultimately pull in domains.
+      // For now, we are resigned to leave this hole open, knowing that all
+      // contract code will be run under XS to avoid this vulnerability.
+      domainTaming: 'unsafe',
+    });
+  }
+
+  // We are now in the "Start Compartment". Our global has all the same
+  // powerful things it had before, but the primordials have changed to make
+  // them safe to use in the arguments of API calls we make into more limited
+  // compartments
+
+  // 'Compartment', 'assert', and 'harden' are now present in our global scope.
+  postLockdown();
+};
+
+globalThis.lockdown = lockdown;

--- a/packages/lockdown/pre.js
+++ b/packages/lockdown/pre.js
@@ -17,10 +17,10 @@ export const lockdown = defaultOptions => {
   // If you're using a prepare-test-env-ava.js, it is probably already doing that
   // for you.
 
-  // The`@agoric/import-ses` package exists so the "main" of production code can
-  // start with the following import or its equivalent.
+  // The `@endo/install-ses` package exists so the "main" of production code
+  // can start with the following import or its equivalent.
   // ```js
-  // import '@agoric/install-ses';
+  // import '@endo/install-ses';
   // ```
   // But production code must also be tested. Normal ocap discipline of passing
   // explicit arguments into the `lockdown`

--- a/packages/lockdown/pre.js
+++ b/packages/lockdown/pre.js
@@ -48,16 +48,16 @@ export const lockdown = defaultOptions => {
   let optionsString;
   if (typeof LOCKDOWN_OPTIONS === 'string') {
     optionsString = LOCKDOWN_OPTIONS;
-    console.log(
-      `'@agoric/install-ses' sniffed and found a 'LOCKDOWN_OPTIONS' global variable\n`,
+    console.warn(
+      `'@endo/lockdown' sniffed and found a 'LOCKDOWN_OPTIONS' global variable\n`,
     );
   } else if (
     typeof process === 'object' &&
     typeof process.env.LOCKDOWN_OPTIONS === 'string'
   ) {
     optionsString = process.env.LOCKDOWN_OPTIONS;
-    console.log(
-      `'@agoric/install-ses' sniffed and found a 'LOCKDOWN_OPTIONS' environment variable\n`,
+    console.warn(
+      `'@endo/install-ses' sniffed and found a 'LOCKDOWN_OPTIONS' environment variable\n`,
     );
   }
 


### PR DESCRIPTION
This uses git subtree to migrate Lockdown from the Agoric SDK repository as part of the greater plan to move Endo dependencies to the Endo repository. Uses the git subtree instructions from #560.

Refs #506