### PR TITLE
fix(ses): Fix mistaken this binding example

### DIFF
--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -252,7 +252,7 @@ The `importHook` accepts a full specifier and asynchronously returns a
 
 ```js
 import 'ses';
-import { StaticModuleRecord } from '@endo/static-module-record`;
+import { StaticModuleRecord } from '@endo/static-module-record';
 
 const c1 = new Compartment({}, {}, {
   name: "first compartment",

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -212,9 +212,15 @@ For example, the `Function` constructor in one compartment creates functions
 that evaluate in the global scope of that compartment.
 
 ```js
-const f = new Function("return this");
-f() === globalThis
-// true
+const c1 = new Compartment();
+const f1 = new c.globalThis.Function('return globalThis');
+f1() === c1.globalThis; // true
+
+const c2 = new Compartment();
+const f2 = new c.globalThis.Function('return globalThis');
+f2() === c2.globalThis; // true
+
+f1() === f2(); // false
 ```
 
 Lockdown prepares for compartments with separate globals by freezing


### PR DESCRIPTION
The example in question claims that the per-compartment `Function` constructor arranges for `this` to be bound to its particular `globalThis`. However, because compartments only reveal strict mode functions, `this` is `undefined`. So, to support the claim documented above the example, we amend the example to grab `globalThis` from the scope of the function body.
