### PR TITLE
feat(endo): Initial daemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "packages/bundle-source",
     "packages/captp",
     "packages/cjs-module-analyzer",
+    "packages/cli",
     "packages/compartment-mapper",
+    "packages/daemon",
     "packages/endo",
     "packages/eslint-config",
     "packages/eslint-plugin",
@@ -31,6 +33,7 @@
     "packages/syrup",
     "packages/test262-runner",
     "packages/test262-runner",
+    "packages/where",
     "packages/zip"
   ],
   "engines": {

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,5 @@
+# Endo CLI
+
+The Endo command line is a user interface for managing the Endo application
+runner (daemon).
+This includes managing the lifecycle of the daemon process.

--- a/packages/cli/bin/endo
+++ b/packages/cli/bin/endo
@@ -1,0 +1,1 @@
+endo.cjs

--- a/packages/cli/bin/endo.cjs
+++ b/packages/cli/bin/endo.cjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+(async () => {
+  const { main } = await import('../src/endo.js');
+  await main(process.argv.slice(2));
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/cli/bin/endo.cmd
+++ b/packages/cli/bin/endo.cmd
@@ -1,0 +1,1 @@
+    @node %~dp0\endo.cjs %*

--- a/packages/cli/jsconfig.json
+++ b/packages/cli/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.js", "index.d.ts"]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@endo/cli",
+  "version": "0.1.0",
+  "description": "Endo command line interface",
+  "keywords": [],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/cli#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "exports": {},
+  "scripts": {
+    "build": "exit 0",
+    "lint": "yarn lint:types && yarn lint:js",
+    "lint-fix": "eslint --fix .",
+    "lint:js": "eslint .",
+    "lint:types": "tsc --build jsconfig.json",
+    "test": "exit 0"
+  },
+  "dependencies": {
+    "commander": "^5.0.0",
+    "@endo/daemon": "^0.1.0",
+    "@endo/where": "^0.1.0"
+  },
+  "devDependencies": {
+    "@endo/eslint-config": "^0.3.20",
+    "ava": "^3.12.1",
+    "babel-eslint": "^10.0.3",
+    "eslint": "^7.23.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-prettier": "^6.9.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1",
+    "typescript": "^4.0.5"
+  },
+  "files": [
+    "LICENSE*",
+    "index.d.ts",
+    "index.js",
+    "src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@endo"
+    ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "timeout": "2m"
+  }
+}

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -1,0 +1,68 @@
+/* global process */
+import url from 'url';
+import rawFs from 'fs';
+
+import { Command } from 'commander';
+import { start, stop, restart, clean } from '@endo/daemon';
+import { whereEndo, whereEndoSock, whereEndoLog } from '@endo/where';
+
+const fs = rawFs.promises;
+
+const packageDescriptorPath = url.fileURLToPath(
+  new URL('../package.json', import.meta.url),
+);
+
+const endoPath = whereEndo(process.platform, process.env);
+const sockPath = whereEndoSock(process.platform, process.env);
+const logPath = whereEndoLog(process.platform, process.env);
+
+export const main = async rawArgs => {
+  const program = new Command();
+
+  program.storeOptionsAsProperties(false);
+
+  const packageDescriptorBytes = await fs.readFile(packageDescriptorPath);
+  const packageDescriptor = JSON.parse(packageDescriptorBytes);
+  program.name(packageDescriptor.name).version(packageDescriptor.version);
+
+  program.command('where').action(async _cmd => {
+    console.log(endoPath);
+  });
+
+  program.command('wheresock').action(async _cmd => {
+    console.log(sockPath);
+  });
+
+  program.command('wherelog').action(async _cmd => {
+    console.log(logPath);
+  });
+
+  program.command('start').action(async _cmd => {
+    await start();
+  });
+
+  program.command('stop').action(async _cmd => {
+    await stop();
+  });
+
+  program.command('restart').action(async _cmd => {
+    await restart();
+  });
+
+  program.command('clean').action(async _cmd => {
+    await clean();
+  });
+
+  // Throw an error instead of exiting directly.
+  program.exitOverride();
+
+  try {
+    await program.parse(rawArgs, { from: 'user' });
+  } catch (e) {
+    if (e && e.name === 'CommanderError') {
+      return e.exitCode;
+    }
+    throw e;
+  }
+  return 0;
+};

--- a/packages/daemon/LICENSE
+++ b/packages/daemon/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -1,0 +1,16 @@
+# Endo Daemon
+
+This package provides the Endo daemon and controller.
+The controller manages the Endo daemon lifecycle.
+
+The Endo daemon is a persistent host for managing guest programs in hardened
+JavaScript worker processes.
+The daemon communicates through a Unix domain socket or named pipe associated
+with the user, and manages per-user storage and compute access.
+
+Over that channel, the daemon communicates in CapTP over netstring message
+envelopes.
+The bootstrap object has public and private facets.
+All access over the public facet are mediate on the private facet.
+So, for example, a request for a handle would be posed on the public facet, and
+the user would be obliged to answer on the private facet.

--- a/packages/daemon/daemon.js
+++ b/packages/daemon/daemon.js
@@ -1,0 +1,88 @@
+// @ts-check
+/// <reference types="ses"/>
+/* global process */
+
+// Establish a perimeter:
+import '@agoric/babel-standalone';
+import 'ses';
+import '@endo/eventual-send/shim.js';
+import '@endo/lockdown/commit.js';
+
+import net from 'net';
+import fs from 'fs';
+import { Far } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+
+import { makeCapTPWithConnection } from './src/connection.js';
+
+const { quote: q } = assert;
+
+const { promise: cancelled, reject: cancel } = makePromiseKit();
+
+/** @param {Error} error */
+const sinkError = error => {
+  console.error(error);
+};
+
+const publicFacet = Far('Endo public facet', {});
+
+const privateFacet = Far('Endo private facet', {
+  async shutdown() {
+    console.error('Endo received shutdown request');
+    cancel(new Error('Shutdown'));
+  },
+});
+
+const bootstrap = harden({
+  publicFacet,
+  privateFacet,
+});
+
+export const main = async () => {
+  process.once('exit', () => {
+    console.error('Endo exiting');
+  });
+
+  if (process.argv.length < 4) {
+    throw new Error(
+      `daemon.js requires arguments [sockPath] [endoPath], got ${process.argv.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  const sockPath = process.argv[2];
+  const endoPath = process.argv[3];
+
+  await fs.promises.mkdir(endoPath, { recursive: true });
+
+  const server = net.createServer();
+
+  server.listen(
+    {
+      path: sockPath,
+    },
+    () => {
+      console.log(`Listening on ${q(sockPath)} ${new Date().toISOString()}`);
+      // Inform parent that we have an open unix domain socket, if we were
+      // spawned with IPC.
+      if (process.send) {
+        process.send({ type: 'listening', path: sockPath });
+      }
+    },
+  );
+  server.on('error', error => {
+    sinkError(error);
+    process.exit(-1);
+  });
+  server.on('connection', conn => {
+    const { drained } = makeCapTPWithConnection('Endo', conn, bootstrap);
+    drained.catch(sinkError);
+  });
+
+  cancelled.catch(() => {
+    server.close();
+  });
+};
+
+main().catch(sinkError);

--- a/packages/daemon/index.d.ts
+++ b/packages/daemon/index.d.ts
@@ -1,0 +1,10 @@
+type Locator = {
+  endoPath: string,
+  logPath: string,
+  sockPath: string,
+};
+export async function start(locator?: Locator);
+export async function stop(locator?: Locator);
+export async function restart(locator?: Locator);
+export async function shutdown(locator?: Locator);
+export async function clean(locator?: Locator);

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -1,0 +1,93 @@
+// @ts-check
+/* global process */
+
+// Establish a perimeter:
+import '@agoric/babel-standalone';
+import 'ses';
+import '@endo/eventual-send/shim.js';
+import '@endo/lockdown/commit.js';
+
+import url from 'url';
+import popen from 'child_process';
+import fs from 'fs';
+
+import { E } from '@endo/eventual-send';
+import { whereEndo, whereEndoSock, whereEndoLog } from '@endo/where';
+import { makeEndoClient } from './src/client.js';
+
+export { makeEndoClient } from './src/client.js';
+
+const defaultLocator = {
+  endoPath: whereEndo(process.platform, process.env),
+  sockPath: whereEndoSock(process.platform, process.env),
+  logPath: whereEndoLog(process.platform, process.env),
+};
+
+const endoDaemonPath = url.fileURLToPath(new URL('daemon.js', import.meta.url));
+
+export const shutdown = async (locator = defaultLocator) => {
+  const { getBootstrap, finalize } = await makeEndoClient(
+    'harbinger',
+    locator.sockPath,
+  );
+  const bootstrap = getBootstrap();
+  await E(E.get(bootstrap).privateFacet).shutdown(locator);
+  finalize();
+};
+
+export const start = async (locator = defaultLocator) => {
+  await fs.promises.mkdir(locator.endoPath, { recursive: true });
+  const output = fs.openSync(locator.logPath, 'a');
+  const child = popen.fork(
+    endoDaemonPath,
+    [locator.sockPath, locator.endoPath],
+    {
+      detached: true,
+      stdio: ['ignore', output, output, 'ipc'],
+    },
+  );
+  return new Promise((resolve, reject) => {
+    child.on('error', (/** @type {Error} */ cause) => {
+      reject(
+        new Error(
+          `Daemon exited prematurely with error ${cause.message}, see (${locator.logPath})`,
+        ),
+      );
+    });
+    child.on('exit', (/** @type {number?} */ code) => {
+      reject(
+        new Error(
+          `Daemon exited prematurely with code (${code}), see (${locator.logPath})`,
+        ),
+      );
+    });
+    child.on('message', _message => {
+      child.disconnect();
+      child.unref();
+      resolve();
+    });
+  });
+};
+
+export const clean = async (locator = defaultLocator) => {
+  if (process.platform !== 'win32') {
+    await fs.promises.unlink(locator.sockPath).catch(error => {
+      if (error.code === 'ENOENT') {
+        return;
+      }
+      throw error;
+    });
+  }
+};
+
+export const restart = async (locator = defaultLocator) => {
+  if (restart) {
+    await shutdown(locator).catch(() => {});
+    await clean(locator);
+  }
+  return start(locator);
+};
+
+export const stop = async (locator = defaultLocator) => {
+  return shutdown(locator).catch(() => {});
+};

--- a/packages/daemon/jsconfig.json
+++ b/packages/daemon/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.js", "index.d.ts"]
+}

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@endo/daemon",
+  "version": "0.1.0",
+  "description": "Endo daemon",
+  "keywords": [
+    "endo",
+    "daemon"
+  ],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/daemon#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "module": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "cover": "c8 ava",
+    "lint": "yarn lint:types && yarn lint:js",
+    "lint-fix": "eslint --fix .",
+    "lint:js": "eslint .",
+    "lint:types": "tsc --build jsconfig.json",
+    "test": "ava"
+  },
+  "dependencies": {
+    "@agoric/babel-standalone": "^7.14.3",
+    "@endo/captp": "^1.10.8",
+    "@endo/eventual-send": "^0.14.0",
+    "@endo/far": "^0.1.1",
+    "@endo/lockdown": "^0.1.1",
+    "@endo/netstring": "^0.2.13",
+    "@endo/promise-kit": "^0.2.29",
+    "@endo/stream": "^0.1.0",
+    "@endo/stream-node": "^0.1.0",
+    "@endo/where": "^0.1.0",
+    "ses": "^0.15.3"
+  },
+  "devDependencies": {
+    "@endo/eslint-config": "^0.3.20",
+    "ava": "^3.12.1",
+    "babel-eslint": "^10.0.3",
+    "c8": "^7.7.3",
+    "eslint": "^7.23.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-prettier": "^6.9.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1",
+    "typescript": "^4.0.5"
+  },
+  "files": [
+    "LICENSE*",
+    "index.d.ts",
+    "index.js",
+    "src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@endo"
+    ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "timeout": "2m"
+  }
+}

--- a/packages/daemon/src/client.js
+++ b/packages/daemon/src/client.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+import net from 'net';
+import { makeCapTPWithConnection } from './connection.js';
+
+/**
+ * @template TBootstrap
+ * @param {string} name
+ * @param {string} sockPath
+ * @param {TBootstrap=} bootstrap
+ */
+export const makeEndoClient = async (name, sockPath, bootstrap) => {
+  const conn = net.connect(sockPath);
+  await new Promise((resolve, reject) => {
+    conn.on('connect', resolve);
+    conn.on('error', reject);
+  });
+  return makeCapTPWithConnection(name, conn, bootstrap);
+};

--- a/packages/daemon/src/connection.js
+++ b/packages/daemon/src/connection.js
@@ -1,0 +1,73 @@
+// @ts-check
+
+import { makeCapTP } from '@endo/captp';
+import { mapWriter, mapReader } from '@endo/stream';
+import { makeNetstringReader, makeNetstringWriter } from '@endo/netstring';
+import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+/**
+ * @template TBootstrap
+ * @param {string} name
+ * @param {import('@endo/stream').Stream<unknown, any, unknown, unknown>} writer
+ * @param {import('@endo/stream').Stream<any, undefined, undefined, undefined>} reader
+ * @param {TBootstrap} bootstrap
+ */
+const makeCapTPWithStreams = (name, writer, reader, bootstrap) => {
+  /** @param {any} message */
+  const send = message => {
+    return writer.next(message);
+  };
+
+  // TODO cancellation context
+  const { dispatch, getBootstrap, abort } = makeCapTP(name, send, bootstrap);
+
+  const drained = (async () => {
+    for await (const message of reader) {
+      dispatch(message);
+    }
+  })();
+
+  return {
+    getBootstrap,
+    drained,
+    finalize() {
+      abort();
+      return writer.return(undefined);
+    },
+  };
+};
+
+/** @param {any} message */
+const messageToBytes = message => {
+  const text = JSON.stringify(message);
+  const bytes = textEncoder.encode(text);
+  return bytes;
+};
+
+/** @param {Uint8Array} bytes */
+const bytesToMessage = bytes => {
+  const text = textDecoder.decode(bytes);
+  const message = JSON.parse(text);
+  return message;
+};
+
+/**
+ * @template TBootstrap
+ * @param {string} name
+ * @param {import('net').Socket} conn
+ * @param {TBootstrap} bootstrap
+ */
+export const makeCapTPWithConnection = (name, conn, bootstrap) => {
+  const writer = mapWriter(
+    makeNetstringWriter(makeNodeWriter(conn)),
+    messageToBytes,
+  );
+  const reader = mapReader(
+    makeNetstringReader(makeNodeReader(conn)),
+    bytesToMessage,
+  );
+  return makeCapTPWithStreams(name, writer, reader, bootstrap);
+};

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -1,0 +1,28 @@
+// @ts-check
+/* global process */
+import test from 'ava';
+import url from 'url';
+import path from 'path';
+import { start, stop, restart, clean } from '../index.js';
+
+const { raw } = String;
+
+const dirname = url.fileURLToPath(new URL('.', import.meta.url)).toString();
+
+const locator = {
+  endoPath: path.join(dirname, 'endo'),
+  sockPath:
+    process.platform === 'win32'
+      ? raw`\\?\pipe\endo-test.sock`
+      : path.join(dirname, 'endo.sock'),
+  logPath: path.join(dirname, 'endo.log'),
+};
+
+test.serial('lifecycle', async t => {
+  await clean(locator);
+  await start(locator);
+  await stop(locator);
+  await restart(locator);
+  await stop(locator);
+  t.pass();
+});

--- a/packages/stream-types-test/validation.ts
+++ b/packages/stream-types-test/validation.ts
@@ -60,7 +60,13 @@ async () => {
 };
 
 async () => {
+  const [reader, writer]: [Reader<number>, Writer<number>] = makePipe<number>();
+  const r: Reader<number> = mapReader<number>(reader, (n: number) => n + 1);
+  const w: Writer<number> = mapWriter<number>(writer, (n: number) => n - 1);
+};
+
+async () => {
   const [reader, writer]: [Stream<number, string>, Stream<string, number>] = makePipe<number, string>();
-  const r: Stream<string> = mapReader<number, string>(reader, (n: number) => String.fromCharCode(n));
-  const w: Stream<unknown, string> = mapWriter<string, number>(writer, (value: string) => value.charCodeAt(0));
+  const r: Stream<string, string> = mapReader<number, string, string>(reader, (n: number) => String.fromCharCode(n));
+  const w: Stream<string, string> = mapWriter<string, number, string>(writer, (value: string) => value.charCodeAt(0));
 };

--- a/packages/stream/index.d.ts
+++ b/packages/stream/index.d.ts
@@ -5,9 +5,9 @@ export function makeQueue<TValue>(): AsyncQueue<TValue>;
 
 export function makeStream<
   TRead,
-  TWrite = unknown,
-  TReadReturn = unknown,
-  TWriteReturn = unknown,
+  TWrite = undefined,
+  TReadReturn = undefined,
+  TWriteReturn = undefined,
 >(
   acks: AsyncQueue<IteratorResult<TRead, TReadReturn>>,
   data: AsyncQueue<IteratorResult<TWrite, TWriteReturn>>,
@@ -15,9 +15,9 @@ export function makeStream<
 
 export function makePipe<
   TRead,
-  TWrite = unknown,
-  TReadReturn = unknown,
-  TWriteReturn = unknown,
+  TWrite = undefined,
+  TReadReturn = undefined,
+  TWriteReturn = undefined,
 >(): [
   Stream<TRead, TWrite, TReadReturn, TWriteReturn>,
   Stream<TWrite, TRead, TWriteReturn, TReadReturn>,
@@ -25,10 +25,10 @@ export function makePipe<
 
 export function mapReader<
   TReadIn,
-  TReadOut,
-  TReadReturn = unknown,
-  TWrite = unknown,
-  TWriteReturn = unknown,
+  TReadOut = TReadIn,
+  TWrite = undefined,
+  TReadReturn = undefined,
+  TWriteReturn = undefined,
 >(
   reader: Stream<TReadIn, TWrite, TReadReturn, TWriteReturn>,
   transform: (value: TReadIn) => TReadOut,
@@ -36,10 +36,10 @@ export function mapReader<
 
 export function mapWriter<
   TWriteIn,
-  TWriteOut,
-  TWriteReturn = unknown,
-  TRead = unknown,
-  TReadReturn = unknown,
+  TWriteOut = TWriteIn,
+  TRead = undefined,
+  TReadReturn = undefined,
+  TWriteReturn = undefined,
 >(
   writer: Stream<TRead, TWriteOut, TReadReturn, TWriteReturn>,
   transform: (value: TWriteIn) => TWriteOut,

--- a/packages/stream/types.d.ts
+++ b/packages/stream/types.d.ts
@@ -8,10 +8,10 @@ export interface AsyncQueue<TValue> {
 // Stream does not make the mistake of conflating the read and write return
 // types.
 export interface Stream<
-TRead,
-TWrite = unknown,
-TReadReturn = unknown,
-TWriteReturn = unknown,
+  TRead,
+  TWrite = undefined,
+  TReadReturn = undefined,
+  TWriteReturn = undefined,
 > {
   next(value: TWrite): Promise<IteratorResult<TRead, TReadReturn>>,
   return(value: TWriteReturn): Promise<IteratorResult<TRead, TReadReturn>>,
@@ -19,5 +19,5 @@ TWriteReturn = unknown,
   [Symbol.asyncIterator](): Stream<TRead, TWrite, TReadReturn, TWriteReturn>,
 }
 
-export type Reader<TRead, TReadReturn = undefined> = Stream<TRead, unknown, TReadReturn, unknown>;
-export type Writer<TWrite, TWriteReturn = undefined> = Stream<unknown, TWrite, unknown, TWriteReturn>;
+export type Reader<TRead, TReadReturn = undefined> = Stream<TRead, undefined, TReadReturn, undefined>;
+export type Writer<TWrite, TWriteReturn = undefined> = Stream<undefined, TWrite, undefined, TWriteReturn>;

--- a/packages/where/LICENSE
+++ b/packages/where/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/where/README.md
+++ b/packages/where/README.md
@@ -1,0 +1,6 @@
+# Where is Endo?
+
+This package provides a utility for finding the user files and Unix domain
+socket or Windows named pipe for the Endo daemon.
+The Endo user directory stores the per-user runtime data for Endo,
+including logs and other application storage.

--- a/packages/where/index.d.ts
+++ b/packages/where/index.d.ts
@@ -1,0 +1,1 @@
+export { whereEndo, whereEndoSock, whereEndoLog } from './types.js';

--- a/packages/where/index.js
+++ b/packages/where/index.js
@@ -1,0 +1,90 @@
+// @ts-check
+
+/* Infers the rendezvous path for the endo.sock file and apps from the platform
+ * and environment.
+ */
+
+const { raw } = String;
+
+/**
+ * @param {{[name: string]: string}} env
+ */
+const whereEndoWindows = env => {
+  // Favoring local app data over roaming app data since I don't expect to be
+  // able to listen on one host and connect on another.
+  if (env.LOCALAPPDATA !== undefined) {
+    return `${env.LOCALAPPDATA}\\Endo`;
+  }
+  if (env.APPDATA !== undefined) {
+    return `${env.APPDATA}\\Endo`;
+  }
+  if (env.USERPROFILE !== undefined) {
+    return `${env.USERPROFILE}\\AppData\\Endo`;
+  }
+  if (env.HOMEDRIVE !== undefined && env.HOMEPATH !== undefined) {
+    return `${env.HOMEDRIVE}${env.HOMEPATH}\\AppData\\Endo`;
+  }
+  return '.';
+};
+
+/**
+ * @type {typeof import('./types.js').whereEndo}
+ */
+export const whereEndo = (platform, env) => {
+  if (platform === 'win32') {
+    return whereEndoWindows(env);
+  } else if (platform === 'darwin') {
+    if (env.HOME !== undefined) {
+      return `${env.HOME}/Library/Application Support/Endo`;
+    }
+  } else {
+    if (env.XDG_CONFIG_DIR !== undefined) {
+      return `${env.XDG_CONFIG_DIR}/endo`;
+    }
+    if (env.HOME !== undefined) {
+      return `${env.HOME}/.config/endo`;
+    }
+  }
+  return 'endo';
+};
+
+/**
+ * @type {typeof import('./types.js').whereEndoSock}
+ */
+export const whereEndoSock = (platform, env) => {
+  if (platform === 'win32') {
+    // Named pipes have a special place in Windows (and in our ashen hearts).
+    if (env.USERNAME !== undefined) {
+      return `\\\\?\\pipe\\${env.USERNAME}-Endo\\endo.pipe`;
+    } else {
+      return raw`\\?\pipe\Endo\endo.pipe`;
+    }
+  } else if (platform === 'darwin') {
+    if (env.HOME !== undefined) {
+      return `${env.HOME}/Library/Application Support/Endo/endo.sock`;
+    }
+  } else if (env.XDG_RUNTIME_DIR !== undefined) {
+    return `${env.XDG_RUNTIME_DIR}/endo/endo.sock`;
+  } else if (env.USER !== undefined) {
+    return `/tmp/endo-${env.USER}/endo.sock`;
+  }
+  return 'endo.sock';
+};
+
+/**
+ * @type {typeof import('./types.js').whereEndoLog}
+ */
+export const whereEndoLog = (platform, env) => {
+  if (platform === 'win32') {
+    return `${whereEndoWindows(env)}\\endo.log`;
+  } else if (platform === 'darwin') {
+    if (env.HOME !== undefined) {
+      return `${env.HOME}/Library/Caches/Endo/endo.log`;
+    }
+  } else if (env.XDG_CACHE_HOME !== undefined) {
+    return `${env.XDG_CACHE_HOME}/endo/endo.log`;
+  } else if (env.HOME !== undefined) {
+    return `${env.HOME}/.cache/endo/endo.log`;
+  }
+  return 'endo.log';
+};

--- a/packages/where/jsconfig.json
+++ b/packages/where/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noEmit": true,
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.js", "index.d.ts"]
+}

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@endo/where",
+  "version": "0.1.0",
+  "private": null,
+  "description": "Description forthcoming.",
+  "keywords": [],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/where#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "module": "./index.js",
+  "browser": null,
+  "unpkg": null,
+  "types": "./index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "cover": "c8 ava",
+    "lint": "yarn lint:types && yarn lint:js",
+    "lint-fix": "eslint --fix .",
+    "lint:js": "eslint .",
+    "lint:types": "tsc --build jsconfig.json",
+    "test": "ava"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@endo/eslint-config": "^0.3.20",
+    "ava": "^3.12.1",
+    "babel-eslint": "^10.0.3",
+    "c8": "^7.7.3",
+    "eslint": "^7.23.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-prettier": "^6.9.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1",
+    "typescript": "^4.0.5"
+  },
+  "files": [
+    "*.js",
+    "*.ts",
+    "LICENSE*",
+    "index.d.ts",
+    "index.js",
+    "src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@endo"
+    ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "timeout": "2m"
+  }
+}

--- a/packages/where/test/test-where-endo-log.js
+++ b/packages/where/test/test-where-endo-log.js
@@ -1,0 +1,69 @@
+import test from 'ava';
+import { whereEndoLog } from '../index.js';
+
+test('windows', t => {
+  t.is(
+    whereEndoLog('win32', {
+      LOCALAPPDATA: 'C:\\Users\\Alice\\AppData\\Local',
+      APPDATA: 'C:\\Users\\Alice\\AppData',
+      USERPROFILE: 'C:\\Users\\Alice',
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo\\endo.log',
+  );
+  t.is(
+    whereEndoLog('win32', {
+      APPDATA: 'C:\\Users\\Alice\\AppData',
+      USERPROFILE: 'C:\\Users\\Alice',
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Endo\\endo.log',
+  );
+  t.is(
+    whereEndoLog('win32', {
+      USERPROFILE: 'C:\\Users\\Alice',
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Endo\\endo.log',
+  );
+  t.is(
+    whereEndoLog('win32', {
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Endo\\endo.log',
+  );
+  t.is(whereEndoLog('win32', {}), '.\\endo.log');
+});
+
+test('darwin', t => {
+  t.is(
+    whereEndoLog('darwin', {
+      HOME: '/Users/alice',
+    }),
+    '/Users/alice/Library/Caches/Endo/endo.log',
+  );
+  t.is(whereEndoLog('darwin', {}), 'endo.log');
+});
+
+test('linux', t => {
+  t.is(
+    whereEndoLog('linux', {
+      XDG_CACHE_HOME: '/var/cache/users/alice',
+      USER: 'alice',
+      HOME: '/Users/alice',
+    }),
+    '/var/cache/users/alice/endo/endo.log',
+  );
+  t.is(
+    whereEndoLog('linux', {
+      USER: 'alice',
+      HOME: '/Users/alice',
+    }),
+    '/Users/alice/.cache/endo/endo.log',
+  );
+  t.is(whereEndoLog('linux', {}), 'endo.log');
+});

--- a/packages/where/test/test-where-endo-sock.js
+++ b/packages/where/test/test-where-endo-sock.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import { whereEndoSock } from '../index.js';
+
+test('windows', t => {
+  t.is(
+    whereEndoSock('win32', {
+      USERNAME: 'alice',
+    }),
+    '\\\\?\\pipe\\alice-Endo\\endo.pipe',
+  );
+  t.is(whereEndoSock('win32', {}), '\\\\?\\pipe\\Endo\\endo.pipe');
+});
+
+test('darwin', t => {
+  t.is(
+    whereEndoSock('darwin', {
+      HOME: '/Users/alice',
+    }),
+    '/Users/alice/Library/Application Support/Endo/endo.sock',
+  );
+  t.is(whereEndoSock('darwin', {}), 'endo.sock');
+});
+
+test('linux', t => {
+  t.is(
+    whereEndoSock('linux', {
+      XDG_RUNTIME_DIR: '/var/run/user/alice',
+      USER: 'alice',
+    }),
+    '/var/run/user/alice/endo/endo.sock',
+  );
+  t.is(
+    whereEndoSock('linux', {
+      USER: 'alice',
+    }),
+    '/tmp/endo-alice/endo.sock',
+  );
+  t.is(whereEndoSock('linux', {}), 'endo.sock');
+});

--- a/packages/where/test/test-where-endo.js
+++ b/packages/where/test/test-where-endo.js
@@ -1,0 +1,67 @@
+import test from 'ava';
+import { whereEndo } from '../index.js';
+
+test('windows', t => {
+  t.is(
+    whereEndo('win32', {
+      LOCALAPPDATA: 'C:\\Users\\Alice\\AppData\\Local',
+      APPDATA: 'C:\\Users\\Alice\\AppData',
+      USERPROFILE: 'C:\\Users\\Alice',
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+  );
+  t.is(
+    whereEndo('win32', {
+      APPDATA: 'C:\\Users\\Alice\\AppData',
+      USERPROFILE: 'C:\\Users\\Alice',
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Endo',
+  );
+  t.is(
+    whereEndo('win32', {
+      USERPROFILE: 'C:\\Users\\Alice',
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Endo',
+  );
+  t.is(
+    whereEndo('win32', {
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Endo',
+  );
+  t.is(whereEndo('win32', {}), '.');
+});
+
+test('darwin', t => {
+  t.is(
+    whereEndo('darwin', {
+      HOME: '/Users/alice',
+    }),
+    '/Users/alice/Library/Application Support/Endo',
+  );
+  t.is(whereEndo('darwin', {}), 'endo');
+});
+
+test('linux', t => {
+  t.is(
+    whereEndo('linux', {
+      XDG_CONFIG_DIR: '/Users/alice/.config2',
+      HOME: '/Users/alice',
+    }),
+    '/Users/alice/.config2/endo',
+  );
+  t.is(
+    whereEndo('linux', {
+      HOME: '/Users/alice',
+    }),
+    '/Users/alice/.config/endo',
+  );
+  t.is(whereEndo('linux', {}), 'endo');
+});

--- a/packages/where/types.d.ts
+++ b/packages/where/types.d.ts
@@ -1,0 +1,4 @@
+export function whereEndo(platform: string, env: {[name: string]: string}): string;
+export function whereEndoSock(platform: string, env: {[name: string]: string}): string;
+export function whereEndoLog(platform: string, env: {[name: string]: string}): string;
+


### PR DESCRIPTION
This is a starting point for the Endo daemon.

The Endo daemon is a per-user background process that communicates with its
user over a Unix domain socket (eventually also a named pipe on Windows).

This change includes three new packages:
- where: Identifies the user-specific location of runtime files for Endo.
  Having a separate package for this allows multiple packages to rendezvous,
  which will eventually include demo packages.
- daemon: The daemon process and controller API.
- cli: A command line for the controller API.

The factoring allows for the daemon to be eventually be operated from an Endo
Browser application, instead of or in addition to the CLI.

As of this change, the Endo daemon has no interesting API, except a private
(user only) method to shut down the daemon.
The daemon will eventually be able to manage child worker processes,
some of which will persist and restart when Endo restarts.

The Endo UI will be implemented in terms of the daemon's private facet,
so this is where the browser or CLI will find methods for observing and
responding to requests from Endo applications.
