### PR TITLE
chore: Synchronize internal versions

### DIFF
--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@agoric/babel-standalone": "^7.14.3",
     "@endo/eventual-send": "^0.14.0",
-    "@endo/lockdown": "^0.1.0"
+    "@endo/lockdown": "^0.1.1"
   },
   "files": [
     "*.js",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -35,11 +35,11 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "ses": "^0.15.1"
+    "ses": "^0.15.3"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.6",
-    "@endo/ses-ava": "^0.2.11",
+    "@endo/eslint-config": "^0.3.20",
+    "@endo/ses-ava": "^0.2.13",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -2,7 +2,13 @@
   "name": "@endo/stream-node",
   "version": "0.1.0",
   "description": "Uint8Array async iterator adapters for Node.js streams",
-  "keywords": ["stream", "node", "async", "iterator", "promise"],
+  "keywords": [
+    "stream",
+    "node",
+    "async",
+    "iterator",
+    "promise"
+  ],
   "author": "Endo contributors",
   "license": "Apache-2.0",
   "homepage": "https://github.com/endojs/endo/tree/master/packages/stream-node#readme",

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -54,4 +54,3 @@
     "singleQuote": true
   }
 }
-

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -2,7 +2,14 @@
   "name": "@endo/stream",
   "version": "0.1.0",
   "description": "Foundation for async iterators as streams",
-  "keywords": ["endo", "stream", "async", "iterator", "pipe", "promise"],
+  "keywords": [
+    "endo",
+    "stream",
+    "async",
+    "iterator",
+    "pipe",
+    "promise"
+  ],
   "author": "Endo contributors",
   "license": "Apache-2.0",
   "homepage": "https://github.com/endojs/endo/tree/master/packages/stream#readme",

--- a/scripts/all-versions.sh
+++ b/scripts/all-versions.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+jq '
+  ((.dependencies // {}), (.devDependencies // {}))
+  | to_entries[]
+' packages/*/package.json \
+| jq --slurp '
+  group_by(.key)[] |
+  {
+    key: [.[] | .key][0],
+    value: ([
+      .[] |
+      .value |
+      (capture("[^0-9]*(?<major>[0-9]+).(?<minor>[0-9]+).(?<patch>[0-9]+)") // {}) |
+      [(.major | tonumber), (.minor | tonumber), (.patch | tonumber)]
+    ] | sort | last | "^\(.[0]).\(.[1]).\(.[2])")
+  }
+' | jq --slurp 'from_entries'
+

--- a/scripts/get-versions.sh
+++ b/scripts/get-versions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ueo pipefail
+
+# Gather a map of the versions from this or another workspace.
+WORKDIR=${1:-.}
+
+cd -- "$WORKDIR"
+yarn workspaces --json info |
+jq -r '.data | fromjson | .[].location | "\(.)/package.json"' |
+xargs jq '{key: .name, value: "^\(.version)"}' |
+jq --slurp from_entries

--- a/scripts/set-versions.sh
+++ b/scripts/set-versions.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -ueo pipefail
+
+# Accepts a dependency version map on stdin and updates all of the
+# package.jsons in this workspace such that, if they depend on one of the named
+# dependencies, it uses the version from the map.
+# This is useful for consistent bulk updates over all packages.
+
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
+VERSIONSHASH=$(git hash-object -w --stdin)
+
+cd -- "$DIR/.."
+
+yarn workspaces --json info |
+jq -r '.data | fromjson | .[].location | "\(.)/package.json"' |
+while read PACKAGEJSON; do
+  PACKAGEJSONHASH=$(
+    jq --argfile versions <(git cat-file blob "$VERSIONSHASH") '
+      def update(name): if .[name] then {
+        (name): [
+          .[name] |
+          to_entries[] |
+          {
+            key: .key,
+            value: ($versions[.key] // .value)
+          }
+        ] | from_entries
+      } else {} end;
+
+      . +
+      update("dependencies") +
+      update("devDependencies") +
+      update("peerDependencies")
+    ' "$PACKAGEJSON" |
+    git hash-object -w --stdin
+  )
+  git cat-file blob "$PACKAGEJSONHASH" > "$PACKAGEJSON"
+done

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ueo pipefail
+
+# Synchronizes dependencies from this workspace with the last-published
+# versions of this or another workspace, designated by the path to the work of
+# that workspace.
+# This is specifically useful for syncing the versions published from the
+# Endo workspace repository.
+
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
+
+"$DIR/get-versions.sh" "$@" | "$DIR/set-versions.sh"


### PR DESCRIPTION
This change adds some scripts we can use to keep dependency versions in sync
across packages, then applies them to our current setup.
The get, set, and sync scripts are borrowed from Agoric SDK.
The all script is new.

- chore: Add version synchronization scripts
- chore: Synchronize versions
- chore: Update yarn.lock
