### PR TITLE
feat(ses): Detect corrupted feral eval early

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes in SES:
 
 - Fixes the type definition for assert.error so that the final options bag,
   which may include `errorName`, checks correctly in TypeScript.
+- Lockdown will now throw an error if code running before SES initialization
+  replaced `eval`.
 
 # 0.15.2 (2021-12-08)
 

--- a/packages/ses/error-codes/SES_DIRECT_EVAL.md
+++ b/packages/ses/error-codes/SES_DIRECT_EVAL.md
@@ -1,0 +1,9 @@
+# SES cannot initialize unless 'eval' is the original intrinsic 'eval', suitable for direct-eval (dynamically scoped eval) (`SES_DIRECT_EVAL`)
+
+The SES Hardened JavaScript shim captures the `eval` function when it is
+initialized.
+The `eval` function it finds must be the original `eval` because SES uses its
+dynamic scope to implement its isolated eval. 
+
+If you see this error, something running before `ses` initialized, most likely
+another instance of `ses`, has replaced `eval` with something else.

--- a/packages/ses/test/test-evalability.js
+++ b/packages/ses/test/test-evalability.js
@@ -1,0 +1,7 @@
+import test from 'ava';
+import './unevalability.js';
+import '../index.js';
+
+test('lockdown must throw if dynamic eval is unavailable at initialization time', t => {
+  t.throws(() => lockdown({ errorTaming: 'unsafe' }));
+});

--- a/packages/ses/test/unevalability.js
+++ b/packages/ses/test/unevalability.js
@@ -1,0 +1,7 @@
+/* global globalThis */
+// This is a fixture for test-evalability.js which ensures that dynamic
+// eval is available at the time of SES initialization.
+// eslint-disable-next-line no-eval
+const originalEval = eval;
+// eslint-disable-next-line no-eval
+globalThis.eval = source => originalEval(source);


### PR DESCRIPTION
- test(ses): Test dynamic eval detection
- feat(ses): Check early for dynamic evalability

Fixes #343
