### PR TITLE
fix(ses): Direct eval check should not preclude no-eval under CSP

### DIFF
--- a/packages/ses/test/no-direct-eval.js
+++ b/packages/ses/test/no-direct-eval.js
@@ -1,7 +1,7 @@
 /* global globalThis */
-// This is a fixture for test-evalability.js which ensures that dynamic
+// This is a fixture for test-no-direct-eval.js which ensures that dynamic
 // eval is available at the time of SES initialization.
 // eslint-disable-next-line no-eval
-const originalEval = eval;
+const indirectEval = eval;
 // eslint-disable-next-line no-eval
-globalThis.eval = source => originalEval(source);
+globalThis.eval = source => indirectEval(source);

--- a/packages/ses/test/no-eval.js
+++ b/packages/ses/test/no-eval.js
@@ -1,0 +1,7 @@
+/* global globalThis */
+// This is a fixture for test-no-eval.js which ensures that eval is unusable at
+// the time of SES initialization.
+// eslint-disable-next-line no-eval
+globalThis.eval = _source => {
+  throw new TypeError('no unsafe-eval, as if by content-security-policy');
+};

--- a/packages/ses/test/test-no-direct-eval.js
+++ b/packages/ses/test/test-no-direct-eval.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import './unevalability.js';
+import './no-direct-eval.js';
 import '../index.js';
 
 test('lockdown must throw if dynamic eval is unavailable at initialization time', t => {

--- a/packages/ses/test/test-no-eval.js
+++ b/packages/ses/test/test-no-eval.js
@@ -1,0 +1,11 @@
+import test from 'ava';
+import './no-eval.js';
+import '../index.js';
+
+// I've manually verified that this is not failing due to the dynamic-eval
+// check in src/lockdown-shim.js, and the remaining issues are captured in
+// https://github.com/endojs/endo/issues/903.
+test.failing('lockdown must not throw when eval is forbidden', t => {
+  lockdown({ errorTaming: 'unsafe' });
+  t.pass();
+});


### PR DESCRIPTION
    This change adds nuance to the code that checks for whether eval is
    direct-eval. We do want to screen environments where eval is indirect.
    But, if eval throws an exception instead, that would indicate a
    content-security-policy that excludes unsafe-eval, and SES should be
    usable for this case in a future version.

    Currently, this case fails for other reasons.
    So this change adds a known-failing test.