### PR TITLE
chore: release

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.14](https://github.com/endojs/endo/compare/@endo/base64@0.2.13...@endo/base64@0.2.14) (2022-01-23)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/base64@0.2.12...@endo/base64@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Transcodes base64",
   "keywords": [
     "base64",
@@ -37,7 +37,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 2.0.2 (2022-01-23)
+
+
+### Bug Fixes
+
+* **bundle-source:** Support Node.js 12 ([5f64d07](https://github.com/endojs/endo/commit/5f64d07dcfdcab6d1b599047b297c759b85466ea))
+* **bundle-source:** Windows support for tests ([59f3fc1](https://github.com/endojs/endo/commit/59f3fc11f9a0d959f172469caffb86c4749c2fbe))
+
+
+
 ### [2.0.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@2.0.0...@agoric/bundle-source@2.0.1) (2021-12-02)
 
 

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",
@@ -16,17 +16,17 @@
     "lint": "eslint '**/*.js'"
   },
   "devDependencies": {
-    "@endo/lockdown": "^0.1.1",
-    "@endo/init": "^0.5.29",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/init": "^0.5.30",
+    "@endo/lockdown": "^0.1.2",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1"
   },
   "dependencies": {
     "@babel/generator": "^7.14.2",
     "@babel/parser": "^7.14.2",
     "@babel/traverse": "^7.14.2",
-    "@endo/base64": "^0.2.13",
-    "@endo/compartment-mapper": "^0.6.1",
+    "@endo/base64": "^0.2.14",
+    "@endo/compartment-mapper": "^0.6.2",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "acorn": "^8.2.4",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 1.10.9 (2022-01-23)
+
+
+### Bug Fixes
+
+* **captp:** Windows test support ([67c8cc1](https://github.com/endojs/endo/commit/67c8cc1ced1c8be8dc8b795e56198b0dc5da1e7b))
+
+
+
 ### [1.10.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.7...@agoric/captp@1.10.8) (2021-12-22)
 
 **Note:** Version bump only for package @agoric/captp

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [
@@ -36,16 +36,16 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.29",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/init": "^0.5.30",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.14.0",
-    "@endo/marshal": "^0.5.0",
-    "@endo/nat": "^4.1.0",
-    "@endo/promise-kit": "^0.2.29"
+    "@endo/eventual-send": "^0.14.1",
+    "@endo/marshal": "^0.5.1",
+    "@endo/nat": "^4.1.1",
+    "@endo/promise-kit": "^0.2.30"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.14](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.13...@endo/cjs-module-analyzer@0.2.14) (2022-01-23)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.12...@endo/cjs-module-analyzer@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",
@@ -30,7 +30,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### 0.1.1 (2022-01-23)
+
+
+### Features
+
+* **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Endo command line interface",
   "keywords": [],
   "author": "Endo contributors",
@@ -24,12 +24,12 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "commander": "^5.0.0",
-    "@endo/daemon": "^0.1.0",
-    "@endo/where": "^0.1.0"
+    "@endo/daemon": "^0.1.1",
+    "@endo/where": "^0.1.1",
+    "commander": "^5.0.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.1...@endo/compartment-mapper@0.6.2) (2022-01-23)
+
+**Note:** Version bump only for package @endo/compartment-mapper
+
+
+
+
+
 ### [0.6.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.0...@endo/compartment-mapper@0.6.1) (2021-12-14)
 
 **Note:** Version bump only for package @endo/compartment-mapper

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -40,13 +40,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/cjs-module-analyzer": "^0.2.13",
-    "@endo/static-module-record": "^0.6.8",
-    "@endo/zip": "^0.2.13",
-    "ses": "^0.15.3"
+    "@endo/cjs-module-analyzer": "^0.2.14",
+    "@endo/static-module-record": "^0.6.9",
+    "@endo/zip": "^0.2.14",
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### 0.1.1 (2022-01-23)
+
+
+### Features
+
+* **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Endo daemon",
   "keywords": [
     "endo",
@@ -35,19 +35,19 @@
   },
   "dependencies": {
     "@agoric/babel-standalone": "^7.14.3",
-    "@endo/captp": "^1.10.8",
-    "@endo/eventual-send": "^0.14.0",
-    "@endo/far": "^0.1.1",
-    "@endo/lockdown": "^0.1.1",
-    "@endo/netstring": "^0.2.13",
-    "@endo/promise-kit": "^0.2.29",
-    "@endo/stream": "^0.1.0",
-    "@endo/stream-node": "^0.1.0",
-    "@endo/where": "^0.1.0",
-    "ses": "^0.15.3"
+    "@endo/captp": "^1.10.9",
+    "@endo/eventual-send": "^0.14.1",
+    "@endo/far": "^0.1.2",
+    "@endo/lockdown": "^0.1.2",
+    "@endo/netstring": "^0.3.0",
+    "@endo/promise-kit": "^0.2.30",
+    "@endo/stream": "^0.2.0",
+    "@endo/stream-node": "^0.2.0",
+    "@endo/where": "^0.1.1",
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/endo/CHANGELOG.md
+++ b/packages/endo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.14](https://github.com/endojs/endo/compare/@endo/endo@0.1.13...@endo/endo@0.1.14) (2022-01-23)
+
+**Note:** Version bump only for package @endo/endo
+
+
+
+
+
 ### [0.1.13](https://github.com/endojs/endo/compare/@endo/endo@0.1.12...@endo/endo@0.1.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/endo

--- a/packages/endo/package.json
+++ b/packages/endo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/endo",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "description": "Endo runs Node.js packaged applications in a sandbox",
   "keywords": [
@@ -30,11 +30,11 @@
   },
   "dependencies": {
     "@agoric/babel-standalone": "^7.14.3",
-    "@endo/compartment-mapper": "^0.6.1",
-    "ses": "^0.15.3"
+    "@endo/compartment-mapper": "^0.6.2",
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.21](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.20...@endo/eslint-config@0.3.21) (2022-01-23)
+
+**Note:** Version bump only for package @endo/eslint-config
+
+
+
+
+
 ### [0.3.20](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.19...@endo/eslint-config@0.3.20) (2021-12-14)
 
 **Note:** Version bump only for package @endo/eslint-config

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-config",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Endo style rules",
   "keywords": [
     "endo",
@@ -24,7 +24,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/eslint-plugin": "^0.3.16",
+    "@endo/eslint-plugin": "^0.3.17",
     "@jessie.js/eslint-plugin": "^0.1.1"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.17](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.16...@endo/eslint-plugin@0.3.17) (2022-01-23)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ### [0.3.16](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.15...@endo/eslint-plugin@0.3.16) (2021-12-14)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Endo-specific ESLint plugin",
   "keywords": [
     "eslint",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 0.14.1 (2022-01-23)
+
+
+### Bug Fixes
+
+* **eventual-send:** Accommodate TypeScript pickiness difference ([1c86bb0](https://github.com/endojs/endo/commit/1c86bb096c6fc8f4e5dd0220c2309534e8593b52))
+* **eventual-send:** Remove unused files ([309965c](https://github.com/endojs/endo/commit/309965c79c23079cdcf578b91b265c82d7657b09))
+
+
+
 ## [0.14.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.30...@agoric/eventual-send@0.14.0) (2021-12-02)
 
 

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/lockdown": "^0.1.1",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/lockdown": "^0.1.2",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 0.1.2 (2022-01-23)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### 0.1.1 (2021-12-02)
 
 

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",
@@ -26,12 +26,12 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.14.0",
-    "@endo/marshal": "^0.5.0"
+    "@endo/eventual-send": "^0.14.1",
+    "@endo/marshal": "^0.5.1"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.29",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/init": "^0.5.30",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 0.2.34 (2022-01-23)
+
+
+### Bug Fixes
+
+* **import-bundle:** Support windows ([eab39f1](https://github.com/endojs/endo/commit/eab39f1581d341384b2f9c2b5a32b02bd04499a6))
+
+
+
 ### [0.2.33](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.32...@agoric/import-bundle@0.2.33) (2021-12-22)
 
 **Note:** Version bump only for package @agoric/import-bundle

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "load modules created by @endo/bundle-source",
   "type": "module",
   "main": "src/index.js",
@@ -18,13 +18,13 @@
     "lint": "eslint '**/*.js'"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.13",
-    "@endo/compartment-mapper": "^0.6.1"
+    "@endo/base64": "^0.2.14",
+    "@endo/compartment-mapper": "^0.6.2"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.0.1",
-    "@endo/init": "^0.5.29",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/bundle-source": "^2.0.2",
+    "@endo/init": "^0.5.30",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 0.5.30 (2022-01-23)
+
+
+### Features
+
+* **init:** Add explicit exports block ([f9d52ab](https://github.com/endojs/endo/commit/f9d52ab3e97df9965014fe408e7f792738a0b67c))
+
+
+
 ### [0.5.29](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.28...@agoric/install-ses@0.5.29) (2021-12-02)
 
 

--- a/packages/init/NEWS.md
+++ b/packages/init/NEWS.md
@@ -1,4 +1,5 @@
-## Next Release
+
+# v0.5.30 (2022-01-21)
 
 The `@endo/init` package exists so the "main" of production code can
 start with the following import or its equivalent.

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@agoric/babel-standalone": "^7.14.3",
-    "@endo/eventual-send": "^0.14.0",
-    "@endo/lockdown": "^0.1.1"
+    "@endo/eventual-send": "^0.14.1",
+    "@endo/lockdown": "^0.1.2"
   },
   "files": [
     "*.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 0.1.2 (2022-01-23)
+
+
+### Bug Fixes
+
+* **lockdown:** Log to stderr ([960a9ef](https://github.com/endojs/endo/commit/960a9ef79e8e36dd564d01016441119156f2ad08))
+
+
+
 ### 0.1.1 (2021-12-02)
 
 

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
@@ -16,7 +16,7 @@
     "ava": "^3.12.1"
   },
   "dependencies": {
-    "ses": "^0.15.3"
+    "ses": "^0.15.4"
   },
   "files": [
     "*.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.3.0 (2022-01-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* **stream:** Use eventual send
+
+### Features
+
+* **lp32:** Implement Chrome host message protocol ([ce80bc5](https://github.com/endojs/endo/commit/ce80bc53a038e96a5a0bf7c0221da05fe6e4243f))
+* **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",
@@ -44,13 +44,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.29",
-    "@endo/stream": "^0.1.0",
-    "ses": "^0.15.3"
+    "@endo/init": "^0.5.30",
+    "@endo/stream": "^0.2.0",
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/eslint-config": "^0.3.21",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 0.5.1 (2022-01-23)
+
+**Note:** Version bump only for package @endo/marshal
+
+
+
+
+
 ## [0.5.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.28...@agoric/marshal@0.5.0) (2021-12-02)
 
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "marshal",
   "type": "module",
   "main": "index.js",
@@ -34,13 +34,13 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/nat": "^4.1.0",
-    "@endo/eventual-send": "^0.14.0",
-    "@endo/promise-kit": "^0.2.29"
+    "@endo/eventual-send": "^0.14.1",
+    "@endo/nat": "^4.1.1",
+    "@endo/promise-kit": "^0.2.30"
   },
   "devDependencies": {
-    "@endo/lockdown": "^0.1.1",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/lockdown": "^0.1.2",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### 4.1.1 (2022-01-23)
+
+
+### Bug Fixes
+
+* **nat:** Thread Windows read powers ([920d478](https://github.com/endojs/endo/commit/920d478532b0c830962de92a19f02f9be6a8a546))

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",
@@ -23,9 +23,8 @@
     "url": "https://github.com/endojs/endo/issues"
   },
   "homepage": "https://github.com/endojs/endo#readme",
-  "dependencies": {},
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.6.1",
+    "@endo/compartment-mapper": "^0.6.2",
     "ava": "^3.12.1",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",
@@ -33,7 +32,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "ses": "^0.15.3"
+    "ses": "^0.15.4"
   },
   "directories": {
     "test": "test"

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -50,6 +50,9 @@
       "test/**/*.js"
     ]
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "eslintConfig": {
     "extends": [
       "@endo"

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.0](https://github.com/endojs/endo/compare/@endo/netstring@0.2.13...@endo/netstring@0.3.0) (2022-01-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* **stream:** Use eventual send
+* **netstring:** Eject stream library
+
+### Features
+
+* **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
+
+
+### Code Refactoring
+
+* **netstring:** Eject stream library ([31b00c3](https://github.com/endojs/endo/commit/31b00c391fe28c7997c2dfa58dc7d297099edc8a))
+
+
+
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/netstring@0.2.12...@endo/netstring@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/NEWS.md
+++ b/packages/netstring/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to netstring:
 
-# Next release
+# v0.3.0 (2022-01-21)
 
 - *BREAKING*: This package is now hardened and depends on Hardened JavaScript
   and remotable promises (eventual send).

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -33,12 +33,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.29",
-    "@endo/stream": "^0.1.0",
-    "ses": "^0.15.3"
+    "@endo/init": "^0.5.30",
+    "@endo/stream": "^0.2.0",
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "@endo/stream": "^0.1.0",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### 0.2.30 (2022-01-23)
+
+
+### Bug Fixes
+
+* **promise-kit:** SES AVA is a dev dependency ([1579160](https://github.com/endojs/endo/commit/1579160b222cd48308780d008743296ef764f163))
+
+
+
 ### [0.2.29](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.28...@agoric/promise-kit@0.2.29) (2021-12-02)
 
 **Note:** Version bump only for package @agoric/promise-kit

--- a/packages/promise-kit/NEWS.md
+++ b/packages/promise-kit/NEWS.md
@@ -1,18 +1,18 @@
-User-visible changes in @endo/promise-kit:
+User-visible changes in `@endo/promise-kit`:
 
-## Next release
+# v0.2.30 (2022-01-21)
 
 This is the first release of this package under the name `@endo/promise-kit`.
 Prior releases are named `@agoric/promise-kit` or `@agoric/make-promise`.
 
-## Release ????
+# v0.0.4-0.2.30 (unknown)
 
 Created promise-kit to replace produce-promise, renaming `producePromise` to `makePromiseKit`
 
-## Release 0.0.4 (6-Apr-2020)
+# v0.0.4 (6-Apr-2020)
 
 Created produce-promise to replace make-promise.
 
-## Release 0.0.1 (3-Feb-2020)
+# v0.0.1 (3-Feb-2020)
 
 Moved out of ERTP and created new package `@agoric/make-promise`

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "Helper for making promises",
   "keywords": [
     "promise"
@@ -35,11 +35,11 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "ses": "^0.15.3"
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/eslint-config": "^0.3.21",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.14](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.13...@endo/ses-ava@0.2.14) (2022-01-23)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.12...@endo/ses-ava@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -33,10 +33,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.15.3"
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.4](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.3...ses-integration-test@3.0.4) (2022-01-23)
+
+**Note:** Version bump only for package ses-integration-test
+
+
+
+
+
 ### [3.0.3](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.2...ses-integration-test@3.0.3) (2021-12-14)
 
 **Note:** Version bump only for package ses-integration-test

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,10 +30,10 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.15.3"
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses-types-test/CHANGELOG.md
+++ b/packages/ses-types-test/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.11](https://github.com/endojs/endo/compare/@endo/ses-types-test@0.1.10...@endo/ses-types-test@0.1.11) (2022-01-23)
+
+
+### Bug Fixes
+
+* **ses:** Add assert.error options bag to type definition ([#978](https://github.com/endojs/endo/issues/978)) ([ca42997](https://github.com/endojs/endo/commit/ca4299714d5769ea15418612f679abb400ff7e25)), closes [#977](https://github.com/endojs/endo/issues/977)
+
+
+
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/ses-types-test@0.1.9...@endo/ses-types-test@0.1.10) (2021-12-14)
 
 **Note:** Version bump only for package @endo/ses-types-test

--- a/packages/ses-types-test/package.json
+++ b/packages/ses-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-types-test",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "TypeScript validation for SES types.",
   "keywords": [],
@@ -25,10 +25,10 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "ses": "^0.15.3"
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.15.4](https://github.com/endojs/endo/compare/ses@0.15.3...ses@0.15.4) (2022-01-23)
+
+
+### Features
+
+* **ses:** Check early for dynamic evalability ([d0f6f09](https://github.com/endojs/endo/commit/d0f6f099d41edee3f484da5d5094848f72f93084)), closes [#343](https://github.com/endojs/endo/issues/343)
+
+
+### Bug Fixes
+
+* **ses:** Direct eval check should not preclude no-eval under CSP ([#1004](https://github.com/endojs/endo/issues/1004)) ([fc8f9ee](https://github.com/endojs/endo/commit/fc8f9eee5ec703ebc611bc015b94fc8ecb721324))
+* **ses:** Fix mistaken this binding example ([#990](https://github.com/endojs/endo/issues/990)) ([71db876](https://github.com/endojs/endo/commit/71db876ee3d7557f0f19dd995a4e027cc7945c2b))
+* minor wording ([#989](https://github.com/endojs/endo/issues/989)) ([f8d6ff6](https://github.com/endojs/endo/commit/f8d6ff6c63b0c46bcaf93378b61d7286d971fd5f))
+* **ses:** Add assert.error options bag to type definition ([#978](https://github.com/endojs/endo/issues/978)) ([ca42997](https://github.com/endojs/endo/commit/ca4299714d5769ea15418612f679abb400ff7e25)), closes [#977](https://github.com/endojs/endo/issues/977)
+* **ses:** Number.prototype.toLocaleString radix confusion ([#975](https://github.com/endojs/endo/issues/975)) ([6a17595](https://github.com/endojs/endo/commit/6a175953e5c78d2575c2e9e4e72e6b893bcdb631)), closes [#852](https://github.com/endojs/endo/issues/852)
+* **ses:** Remove superfluous error cause on prototypes ([#955](https://github.com/endojs/endo/issues/955)) ([6e50c45](https://github.com/endojs/endo/commit/6e50c4526f457b31e00a783406d175b0088907eb))
+
+
+
 ### [0.15.3](https://github.com/endojs/endo/compare/ses@0.15.2...ses@0.15.3) (2021-12-14)
 
 **Note:** Version bump only for package ses

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in SES:
 
-# Next release
+# v0.15.3 (2022-01-21)
 
 - Fixes the type definition for assert.error so that the final options bag,
   which may include `errorName`, checks correctly in TypeScript.

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",
@@ -59,10 +59,10 @@
     "test:platform-compatability": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.6.1",
-    "@endo/eslint-config": "^0.3.20",
-    "@endo/static-module-record": "^0.6.8",
-    "@endo/test262-runner": "^0.1.14",
+    "@endo/compartment-mapper": "^0.6.2",
+    "@endo/eslint-config": "^0.3.21",
+    "@endo/static-module-record": "^0.6.9",
+    "@endo/test262-runner": "^0.1.15",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.9](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.8...@endo/static-module-record@0.6.9) (2022-01-23)
+
+**Note:** Version bump only for package @endo/static-module-record
+
+
+
+
+
 ### [0.6.8](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.7...@endo/static-module-record@0.6.8) (2021-12-14)
 
 

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
-    "@endo/eslint-config": "^0.3.20",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/eslint-config": "^0.3.21",
+    "@endo/ses-ava": "^0.2.14",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",
@@ -51,7 +51,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "ses": "^0.15.3",
+    "ses": "^0.15.4",
     "typescript": "^4.0.5"
   },
   "files": [

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.2.0 (2022-01-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* **stream:** Use eventual send
+
+### Features
+
+* **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
+* **stream-node:** Add Node.js stream adapters ([834c439](https://github.com/endojs/endo/commit/834c43915e5e80b1c96c2642e4cf01398fd9441d))

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",
@@ -39,13 +39,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.29",
-    "@endo/stream": "^0.1.0",
-    "ses": "^0.15.3"
+    "@endo/init": "^0.5.30",
+    "@endo/stream": "^0.2.0",
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/eslint-config": "^0.3.21",
+    "@endo/ses-ava": "^0.2.14",
     "@typescript-eslint/parser": "^4.18.0",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### 0.1.11 (2022-01-23)
+
+
+### Features
+
+* **stream:** Add mapReader and mapWriter ([c05c2d4](https://github.com/endojs/endo/commit/c05c2d4d5077e303fe54b1b5a5e0a54a8c432795))
+* **stream:** Add pump and prime ([b555147](https://github.com/endojs/endo/commit/b555147ea727eee68f9f08b00912be306f8d8e2a))
+
+
+### Bug Fixes
+
+* **stream:** Default types to undefined ([eba45b6](https://github.com/endojs/endo/commit/eba45b6db4538f84ba86a60f7be5bd940a007f7e))

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],
@@ -25,11 +25,11 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "@endo/stream": "^0.1.0",
-    "ses": "^0.15.3"
+    "@endo/stream": "^0.2.0",
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.2.0 (2022-01-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* **stream:** Use eventual send
+
+### Features
+
+* **stream:** Add mapReader and mapWriter ([c05c2d4](https://github.com/endojs/endo/commit/c05c2d4d5077e303fe54b1b5a5e0a54a8c432795))
+* **stream:** Add pump and prime ([b555147](https://github.com/endojs/endo/commit/b555147ea727eee68f9f08b00912be306f8d8e2a))
+* **stream:** Add stream library ([cc684d8](https://github.com/endojs/endo/commit/cc684d89898ef0abe00511c897865f605b7ddeb3))
+* **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
+
+
+### Bug Fixes
+
+* **stream:** Default types to undefined ([eba45b6](https://github.com/endojs/endo/commit/eba45b6db4538f84ba86a60f7be5bd940a007f7e))

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",
@@ -38,13 +38,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.15.3",
-    "@endo/eventual-send": "^0.14.0"
+    "@endo/eventual-send": "^0.14.1",
+    "ses": "^0.15.4"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
-    "@endo/init": "^0.5.29",
-    "@endo/ses-ava": "^0.2.13",
+    "@endo/eslint-config": "^0.3.21",
+    "@endo/init": "^0.5.30",
+    "@endo/ses-ava": "^0.2.14",
     "@typescript-eslint/parser": "^4.18.0",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.14](https://github.com/endojs/endo/compare/@endo/syrup@0.1.13...@endo/syrup@0.1.14) (2022-01-23)
+
+**Note:** Version bump only for package @endo/syrup
+
+
+
+
+
 ### [0.1.13](https://github.com/endojs/endo/compare/@endo/syrup@0.1.12...@endo/syrup@0.1.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/syrup

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",
@@ -37,7 +37,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.15](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.14...@endo/test262-runner@0.1.15) (2022-01-23)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.14](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.13...@endo/test262-runner@0.1.14) (2021-12-14)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "description": "Test262 Runner",
   "author": "Agoric",
@@ -17,7 +17,7 @@
     "test262-parser": "^2.2.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "sinon": "8.0.4"
   },
   "ava": {

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### 0.1.1 (2022-01-23)
+
+
+### Features
+
+* **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": null,
   "description": "Description forthcoming.",
   "keywords": [],
@@ -33,9 +33,8 @@
     "lint:types": "tsc --build jsconfig.json",
     "test": "ava"
   },
-  "dependencies": {},
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.14](https://github.com/endojs/endo/compare/@endo/zip@0.2.13...@endo/zip@0.2.14) (2022-01-23)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/zip@0.2.12...@endo/zip@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/zip

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.3.20",
+    "@endo/eslint-config": "^0.3.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",


### PR DESCRIPTION
This release includes many new packages. Most are migrations from Agoric SDK.  The remaining packages include initial versions of Endo daemon, its locator, and its CLI, as well as stream libraries needed for Endo Browser and native message host.

The netstring library includes a principled breaking change, which should require no additional programming to integrate in Agoric SDK: all stream libraries now require eventual-send in addition to hardened JavaScript.
