### PR TITLE
Retore edits from agoric-sdk #4304

### DIFF
--- a/packages/marshal/src/helpers/error.js
+++ b/packages/marshal/src/helpers/error.js
@@ -52,7 +52,7 @@ export const ErrorHelper = harden({
       return check(false, X`Error expected: ${candidate}`);
     }
     const proto = getPrototypeOf(candidate);
-    const { name } = candidate;
+    const { name } = proto;
     const EC = getErrorConstructor(name);
     if (!EC || EC.prototype !== proto) {
       const note = X`Errors must inherit from an error class .prototype ${candidate}`;
@@ -62,6 +62,7 @@ export const ErrorHelper = harden({
     }
 
     const {
+      // Must allow `cause`, `errors`
       message: mDesc,
       // Allow but ignore only extraneous own `stack` property.
       stack: _optStackDesc,

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -83,6 +83,7 @@ export function makeMarshal(
     function serializeSlot(val, iface = undefined) {
       let slotIndex;
       if (slotMap.has(val)) {
+        // TODO assert that it's the same iface as before
         slotIndex = slotMap.get(val);
         assert.typeof(slotIndex, 'number');
         iface = undefined;
@@ -94,6 +95,7 @@ export function makeMarshal(
         slotMap.set(val, slotIndex);
       }
 
+      // TODO explore removing this special case
       if (iface === undefined) {
         return harden({
           [QCLASS]: 'slot',
@@ -117,6 +119,8 @@ export function makeMarshal(
      * @returns {Encoding}
      */
     const encodeError = err => {
+      // Must encode `cause`, `errors`.
+      // nested non-passable errors must be ok from here.
       if (errorTagging === 'on') {
         // We deliberately do not share the stack, but it would
         // be useful to log the stack locally so someone who has
@@ -285,6 +289,8 @@ export function makeMarshal(
       if (valMap.has(index)) {
         return valMap.get(index);
       }
+      // TODO SECURITY HAZARD: must enfoce that remotable vs promise
+      // is according to the encoded string.
       const slot = slots[Number(Nat(index))];
       const val = convertSlotToVal(slot, iface);
       valMap.set(index, val);
@@ -385,6 +391,7 @@ export function makeMarshal(
           }
 
           case 'error': {
+            // Must decode `cause` and `errors` properties
             const { name, message, errorId } = rawTree;
             assert.typeof(
               name,


### PR DESCRIPTION
Restore edits from https://github.com/Agoric/agoric-sdk/pull/4304 to the marshal package.

Fixes https://github.com/Agoric/agoric-sdk/issues/4312 again ;)

Have recognition of passable Error obtain name from prototype, skipping any own name property on the error instance.

Note several of the places we need to revisit when we admit error.cause and error.errors.

Inline TODOs reminding us to revisit issues identified by zestival

