### PR TITLE
feat: HandledPromise hardening

### DIFF
--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -30,15 +30,10 @@ function EProxyHandler(x, HandledPromise) {
   return harden({
     ...baseFreezableProxyHandler,
     get(_target, p, _receiver) {
-      // Harden this Promise because it's our only opportunity to ensure
-      // p1=E(x).foo() is hardened. The Handled Promise API does not (yet)
-      // allow the handler to synchronously influence the promise returned
-      // by the handled methods, so we must freeze it from the outside. See
-      // #95 for details.
-      return (...args) => harden(HandledPromise.applyMethod(x, p, args));
+      return harden((...args) => HandledPromise.applyMethod(x, p, args));
     },
     apply(_target, _thisArg, argArray = []) {
-      return harden(HandledPromise.applyFunction(x, argArray));
+      return HandledPromise.applyFunction(x, argArray);
     },
     has(_target, _p) {
       // We just pretend everything exists.
@@ -88,7 +83,7 @@ export default function makeE(HandledPromise) {
         return true;
       },
       get(_target, prop) {
-        return harden(HandledPromise.get(x, prop));
+        return HandledPromise.get(x, prop);
       },
     });
 


### PR DESCRIPTION
refs: Agoric/agoric-sdk#4362
closes: Agoric/agoric-sdk#4363

## Description

Move hardening around HandledPromises to the shim so that it can't be bypassed with a malicious user-level `E`.

The motivation in Agoric/agoric-sdk#4362 still applies; when we're under SES, we should harden on the boundaries of the system.  HandledPromise's eventual send and eventual get support is such a thing.
