### PR TITLE
fix(promise-kit): Publish code

### DIFF
--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -55,8 +55,8 @@
   "files": [
     "LICENSE*",
     "NEWS.md",
-    "index.d.ts",
-    "src/"
+    "index.js",
+    "index.d.ts"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The current published version does not include the code (index.js).
This change ensures it will get picked up next time.
