### PR TITLE
refactor: Clean up references to @endo/install-ses

### DIFF
--- a/packages/lockdown/commit-debug.js
+++ b/packages/lockdown/commit-debug.js
@@ -1,6 +1,6 @@
 // commit-debug.js - debug version of commit.js
 
-// This is like `@endo/install-ses` but sacrificing safety to optimize
+// This is like `@endo/init` but sacrificing safety to optimize
 // for debugging and testing. The difference is only the lockdown options.
 // The setting below are *unsafe* and should not be used in contact with
 // genuinely malicious code.

--- a/packages/lockdown/pre.js
+++ b/packages/lockdown/pre.js
@@ -17,32 +17,32 @@ export const lockdown = defaultOptions => {
   // If you're using a prepare-test-env-ava.js, it is probably already doing that
   // for you.
 
-  // The `@endo/install-ses` package exists so the "main" of production code
+  // The `@endo/init` package exists so the "main" of production code
   // can start with the following import or its equivalent.
   // ```js
-  // import '@endo/install-ses';
+  // import '@endo/init';
   // ```
   // But production code must also be tested. Normal ocap discipline of passing
   // explicit arguments into the `lockdown`
   // call would require an awkward structuring of start modules, since
-  // the `install-ses` module calls `lockdown` during its initialization,
+  // the `init` module calls `lockdown` during its initialization,
   // before any explicit code in the start module gets to run. Even if other code
   // does get to run first, the `lockdown` call in this module happens during
   // module initialization, before it can legitimately receive parameters by
   // explicit parameter passing.
   //
-  // Instead, for now, `install-ses` violates normal ocap discipline by feature
+  // Instead, for now, `init` violates normal ocap discipline by feature
   // testing global state for a passed "parameter". This is something that a
   // module can but normally should not do, during initialization or otherwise.
   // Initialization is often awkward.
   //
-  // The `install-ses` module tests, first,
+  // The `init` module tests, first,
   // for a JavaScript global named `LOCKDOWN_OPTIONS`, and second, for an
   // environment
   // variable named `LOCKDOWN_OPTIONS`. If either is present, its value should be
   // a JSON encoding of the options bag to pass to the `lockdown` call. If so,
-  // then `install-ses` calls `lockdown` with those options. If there is no such
-  // feature, `install-ses` calls `lockdown` with appropriate settings for
+  // then `init` calls `lockdown` with those options. If there is no such
+  // feature, `init` calls `lockdown` with appropriate settings for
   // production use.
 
   let optionsString;
@@ -57,7 +57,7 @@ export const lockdown = defaultOptions => {
   ) {
     optionsString = process.env.LOCKDOWN_OPTIONS;
     console.warn(
-      `'@endo/install-ses' sniffed and found a 'LOCKDOWN_OPTIONS' environment variable\n`,
+      `'@endo/lockdown' sniffed and found a 'LOCKDOWN_OPTIONS' environment variable\n`,
     );
   }
 

--- a/packages/marshal/README.md
+++ b/packages/marshal/README.md
@@ -26,7 +26,7 @@ an object with `serialize` and `unserialize` properties. If the callback
 arguments are omitted, they default to the identity function.
 
 ```js
-import '@endo/install-ses';
+import '@endo/init';
 import { makeMarshal } from '@endo/marshal';
 
 const m = makeMarshal();
@@ -40,7 +40,7 @@ console.log(o2); // { a: 1 }
 ## Frozen Objects Only
 
 The entire object graph must be "hardened" (recursively frozen), such as done
-by the `ses` module (installed with `@endo/install-ses`). The serialization
+by the `ses` module (installed with `@endo/init`). The serialization
 function will refuse to marshal any graph that contains a non-frozen object.
 
 ## Beyond JSON


### PR DESCRIPTION
These remaining misnomers are in a layer below the package in question
and did not get caught in the initial migration.
