### PR TITLE
chore: Sync TypeScript with Agoric SDK

### DIFF
--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/ses-types-test/package.json
+++ b/packages/ses-types-test/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [],
   "publishConfig": {

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -75,7 +75,7 @@
     "prettier": "^1.19.1",
     "sinon": "8.0.4",
     "terser": "^4.8.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-jsdoc": "^30.4.2",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [],
   "publishConfig": {

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-jsdoc": "^30.4.2",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "*.js",

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12707,10 +12707,10 @@ typescript@^4.0.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
-typescript@^4.0.5:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.2.3:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uglify-js@^3.1.4:
   version "3.13.5"


### PR DESCRIPTION
This syncs the current TypeScript version with Agoric SDK to reduce probability of divergent behavior under lint.

- chore: Sync TypeScript version with Agoric SDK
- chore: Update yarn.lock
