### PR TITLE
fix(marshal): remove ambient types, generate declarations from JSDoc

### DIFF
--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -1,6 +1,9 @@
 // @ts-check
 /// <reference types="ses"/>
 
+/** @template Slot @typedef {import('@endo/marshal').ConvertValToSlot<Slot>} ConvertValToSlot */
+/** @template Slot @typedef {import('@endo/marshal').ConvertSlotToVal<Slot>} ConvertSlotToVal */
+
 // Your app may need to `import '@endo/eventual-send/shim.js'` to get HandledPromise
 
 // This logic was mostly lifted from @agoric/swingset-vat liveSlots.js

--- a/packages/captp/src/types.js
+++ b/packages/captp/src/types.js
@@ -17,7 +17,7 @@
  */
 
 /**
- * @typedef {[boolean, CapData<CapTPSlot>]} TrapCompletion The head of the pair
+ * @typedef {[boolean, import('@endo/marshal').CapData<CapTPSlot>]} TrapCompletion The head of the pair
  * is the `isRejected` value indicating whether the sync call was an exception,
  * and tail of the pair is the serialized fulfillment value or rejection reason.
  * (The fulfillment value is a non-thenable.  The rejection reason is normally

--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,5 +1,17 @@
 User-visible changes in `@endo/marshal`:
 
+# Next release
+
+Switch from ambient to exported types.
+Include type declarations (`.d.ts`) generated from JSDoc to avoid requiring
+dependents to parse `.js` files in their `node_modules`.
+
+In order to use the types from `@endo/marshal` you now need to import them
+explicitly. For example, to make them available in scope, use the following:
+- JSDoc: `/** @typedef {import('@endo/marshal').PassStyle} PassStyle */`
+- TypeScript: `import type { PassStyle } from '@endo/marshal'`
+
+
 # v0.5.3 (2021-01-27)
 
 Includes TypeScript definitions in published artifact.

--- a/packages/marshal/exported.js
+++ b/packages/marshal/exported.js
@@ -1,1 +1,0 @@
-import './src/types.js';

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -39,3 +39,6 @@ export {
   isRecord,
   isCopyArray,
 } from './src/typeGuards.js';
+
+// eslint-disable-next-line import/export
+export * from './src/types.js';

--- a/packages/marshal/jsconfig.build.json
+++ b/packages/marshal/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -9,6 +9,9 @@
   },
   "scripts": {
     "build": "exit 0",
+    "clean": "tsc --build jsconfig.build.json --clean",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "yarn clean",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
@@ -47,9 +50,11 @@
   "files": [
     "LICENSE*",
     "SECURITY*",
+    "NEWS*",
     "src",
     "*.js",
-    "*.ts"
+    "*.ts",
+    "*.map"
   ],
   "eslintConfig": {
     "extends": [

--- a/packages/marshal/src/deeplyFulfilled.js
+++ b/packages/marshal/src/deeplyFulfilled.js
@@ -3,14 +3,13 @@
 /// <reference types="ses"/>
 
 import { E } from '@endo/eventual-send';
-/**
- * @template T
- * @typedef {import('@endo/eventual-send').ERef<T>} ERef
- */
 import { isPromise } from '@endo/promise-kit';
 import { getTag, isObject } from './helpers/passStyle-helpers.js';
 import { makeTagged } from './makeTagged.js';
 import { passStyleOf } from './passStyleOf.js';
+
+/** @typedef {import('./types.js').Passable} Passable */
+/** @template T @typedef {import('@endo/eventual-send').ERef<T>} ERef */
 
 const { details: X, quote: q } = assert;
 const { ownKeys } = Reflect;

--- a/packages/marshal/src/helpers/copyArray.js
+++ b/packages/marshal/src/helpers/copyArray.js
@@ -2,8 +2,6 @@
 
 /// <reference types="ses"/>
 
-import '../types.js';
-import './internal-types.js';
 import { assertChecker, checkNormalProperty } from './passStyle-helpers.js';
 
 const { details: X } = assert;
@@ -13,7 +11,7 @@ const { isArray, prototype: arrayPrototype } = Array;
 
 /**
  *
- * @type {PassStyleHelper}
+ * @type {import('./internal-types.js').PassStyleHelper}
  */
 export const CopyArrayHelper = harden({
   styleName: 'copyArray',

--- a/packages/marshal/src/helpers/copyRecord.js
+++ b/packages/marshal/src/helpers/copyRecord.js
@@ -8,9 +8,6 @@ import {
   checkNormalProperty,
 } from './passStyle-helpers.js';
 
-import '../types.js';
-import './internal-types.js';
-
 const { details: X } = assert;
 const { ownKeys } = Reflect;
 const {
@@ -21,7 +18,7 @@ const {
 
 /**
  *
- * @type {PassStyleHelper}
+ * @type {import('./internal-types.js').PassStyleHelper}
  */
 export const CopyRecordHelper = harden({
   styleName: 'copyRecord',

--- a/packages/marshal/src/helpers/error.js
+++ b/packages/marshal/src/helpers/error.js
@@ -2,9 +2,9 @@
 
 /// <reference types="ses"/>
 
-import '../types.js';
-import './internal-types.js';
 import { assertChecker } from './passStyle-helpers.js';
+
+/** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
 
 const { details: X } = assert;
 const { getPrototypeOf, getOwnPropertyDescriptors } = Object;

--- a/packages/marshal/src/helpers/internal-types.js
+++ b/packages/marshal/src/helpers/internal-types.js
@@ -2,6 +2,12 @@
 
 /// <reference path="../extra-types.d.ts" />
 
+export {};
+
+/** @typedef {import('../types.js').Checker} Checker */
+/** @typedef {import('../types.js').PassStyle} PassStyle */
+/** @typedef {import('../types.js').PassStyleOf} PassStyleOf */
+
 /**
  * The PassStyleHelper are only used to make a `passStyleOf` function.
  * Thus, it should not depend on an ambient one. Rather, each helper should be

--- a/packages/marshal/src/helpers/passStyle-helpers.js
+++ b/packages/marshal/src/helpers/passStyle-helpers.js
@@ -2,8 +2,8 @@
 
 /// <reference types="ses"/>
 
-import '../types.js';
-import './internal-types.js';
+/** @typedef {import('../types.js').Checker} Checker */
+/** @typedef {import('../types.js').PassStyle} PassStyle */
 
 const { details: X, quote: q } = assert;
 const {

--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -2,8 +2,6 @@
 
 /// <reference types="ses"/>
 
-import '../types.js';
-import './internal-types.js';
 import {
   assertChecker,
   canBeMethod,
@@ -14,6 +12,12 @@ import {
   getTag,
 } from './passStyle-helpers.js';
 import { getEnvironmentOption } from './environment-options.js';
+
+/** @typedef {import('../types.js').Checker} Checker */
+/** @typedef {import('../types.js').InterfaceSpec} InterfaceSpec */
+/** @typedef {import('../types.js').MarshalGetInterfaceOf} MarshalGetInterfaceOf */
+/** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
+/** @typedef {import('../types.js').Remotable} Remotable */
 
 const { details: X, quote: q } = assert;
 const { ownKeys } = Reflect;

--- a/packages/marshal/src/helpers/tagged.js
+++ b/packages/marshal/src/helpers/tagged.js
@@ -9,16 +9,13 @@ import {
   checkNormalProperty,
 } from './passStyle-helpers.js';
 
-import '../types.js';
-import './internal-types.js';
-
 const { details: X } = assert;
 const { ownKeys } = Reflect;
 const { getPrototypeOf, prototype: objectPrototype } = Object;
 
 /**
  *
- * @type {PassStyleHelper}
+ * @type {import('./internal-types.js').PassStyleHelper}
  */
 export const TaggedHelper = harden({
   styleName: 'tagged',

--- a/packages/marshal/src/make-far.js
+++ b/packages/marshal/src/make-far.js
@@ -10,6 +10,8 @@ import {
 } from './helpers/remotable.js';
 import { pureCopy } from './pureCopy.js';
 
+/** @typedef {import('./types.js').InterfaceSpec} InterfaceSpec */
+
 const { quote: q, details: X } = assert;
 
 const { prototype: functionPrototype } = Function;

--- a/packages/marshal/src/make-far.js
+++ b/packages/marshal/src/make-far.js
@@ -83,8 +83,8 @@ const assertCanBeRemotable = candidate =>
  * Carol's `iface` as misrepresented by VatA.
  * @param {undefined} [props=undefined] Currently may only be undefined.
  * That plan is that own-properties are copied to the remotable
- * @param {object} [remotable={}] The object used as the remotable
- * @returns {object} remotable, modified for debuggability
+ * @param {any} [remotable={}] The object used as the remotable
+ * @returns {any} remotable, modified for debuggability
  */
 export const Remotable = (
   iface = 'Remotable',

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -5,10 +5,11 @@
 import { Nat } from '@endo/nat';
 import { QCLASS } from './marshal.js';
 
-import './types.js';
 import { getErrorConstructor } from './helpers/error.js';
 import { isObject } from './helpers/passStyle-helpers.js';
 import { AtAtPrefixPattern, passableSymbolForName } from './helpers/symbol.js';
+
+/** @typedef {import('./types.js').Encoding} Encoding */
 
 const { ownKeys } = Reflect;
 const { isArray } = Array;

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -3,15 +3,15 @@
 
 import { makeMarshal } from './marshal.js';
 
-import './types.js';
+/** @typedef {import('./types.js').OnlyData} OnlyData */
 
 const { details: X } = assert;
 
-/** @type {ConvertValToSlot<any>} */
+/** @type {import('./types.js').ConvertValToSlot<any>} */
 const doNotConvertValToSlot = val =>
   assert.fail(X`Marshal's stringify rejects presences and promises ${val}`);
 
-/** @type {ConvertSlotToVal<any>} */
+/** @type {import('./types.js').ConvertSlotToVal<any>} */
 const doNotConvertSlotToVal = (slot, _iface) =>
   assert.fail(X`Marshal's parse must not encode any slots ${slot}`);
 

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -5,7 +5,6 @@
 import { Nat } from '@endo/nat';
 import { assertPassable, passStyleOf } from './passStyleOf.js';
 
-import './types.js';
 import { getInterfaceOf } from './helpers/remotable.js';
 import { ErrorHelper, getErrorConstructor } from './helpers/error.js';
 import { makeTagged } from './makeTagged.js';
@@ -15,6 +14,15 @@ import {
   nameForPassableSymbol,
   passableSymbolForName,
 } from './helpers/symbol.js';
+
+/** @typedef {import('./types.js').MakeMarshalOptions} MakeMarshalOptions */
+/** @template Slot @typedef {import('./types.js').ConvertSlotToVal<Slot>} ConvertSlotToVal */
+/** @template Slot @typedef {import('./types.js').ConvertValToSlot<Slot>} ConvertValToSlot */
+/** @template Slot @typedef {import('./types.js').Serialize<Slot>} Serialize */
+/** @template Slot @typedef {import('./types.js').Unserialize<Slot>} Unserialize */
+/** @typedef {import('./types.js').Passable} Passable */
+/** @typedef {import('./types.js').InterfaceSpec} InterfaceSpec */
+/** @typedef {import('./types.js').Encoding} Encoding */
 
 const { ownKeys } = Reflect;
 const { isArray } = Array;
@@ -34,14 +42,18 @@ const { details: X, quote: q } = assert;
 const QCLASS = '@qclass';
 export { QCLASS };
 
+/** @type {ConvertValToSlot<any>} */
 const defaultValToSlotFn = x => x;
+/** @type {ConvertSlotToVal<any>} */
 const defaultSlotToValFn = (x, _) => x;
 
 /**
  * @template Slot
- * @type {MakeMarshal<Slot>}
+ * @param {ConvertValToSlot<Slot>} [convertValToSlot]
+ * @param {ConvertSlotToVal<Slot>} [convertSlotToVal]
+ * @param {MakeMarshalOptions} [options]
  */
-export function makeMarshal(
+export const makeMarshal = (
   convertValToSlot = defaultValToSlotFn,
   convertSlotToVal = defaultSlotToValFn,
   {
@@ -55,7 +67,7 @@ export function makeMarshal(
     marshalSaveError = err =>
       console.log('Temporary logging of sent error', err),
   } = {},
-) {
+) => {
   assert.typeof(marshalName, 'string');
   assert(
     errorTagging === 'on' || errorTagging === 'off',
@@ -67,7 +79,6 @@ export function makeMarshal(
   };
 
   /**
-   * @template Slot
    * @type {Serialize<Slot>}
    */
   const serialize = root => {
@@ -482,7 +493,6 @@ export function makeMarshal(
   };
 
   /**
-   * @template Slot
    * @type {Unserialize<Slot>}
    */
   const unserialize = data => {
@@ -507,4 +517,4 @@ export function makeMarshal(
     serialize,
     unserialize,
   });
-}
+};

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -11,9 +11,13 @@ import { TaggedHelper } from './helpers/tagged.js';
 import { RemotableHelper } from './helpers/remotable.js';
 import { ErrorHelper } from './helpers/error.js';
 
-import './types.js';
-import './helpers/internal-types.js';
 import { assertPassableSymbol } from './helpers/symbol.js';
+
+/** @typedef {import('./helpers/internal-types.js').PassStyleHelper} PassStyleHelper */
+/** @typedef {import('./types.js').Passable} Passable */
+/** @typedef {import('./types.js').PassStyle} PassStyle */
+/** @typedef {import('./types.js').PassStyleOf} PassStyleOf */
+/** @typedef {import('./types.js').PrimitiveStyle} PrimitiveStyle */
 
 /** @typedef {Exclude<PassStyle, PrimitiveStyle | "promise">} HelperPassStyle */
 

--- a/packages/marshal/src/pureCopy.js
+++ b/packages/marshal/src/pureCopy.js
@@ -4,6 +4,9 @@ import { getTag } from './helpers/passStyle-helpers.js';
 import { makeTagged } from './makeTagged.js';
 import { passStyleOf } from './passStyleOf.js';
 
+/** @typedef {import('./types.js').OnlyData} OnlyData */
+/** @typedef {import('./types.js').CopyTagged} CopyTagged */
+
 const { is } = Object;
 const { details: X, quote: q } = assert;
 

--- a/packages/marshal/src/typeGuards.js
+++ b/packages/marshal/src/typeGuards.js
@@ -2,6 +2,11 @@
 
 import { passStyleOf } from './passStyleOf.js';
 
+/** @typedef {import('./types.js').Passable} Passable */
+/** @template T @typedef {import('./types.js').CopyArray<T>} CopyArray */
+/** @template T @typedef {import('./types.js').CopyRecord<T>} CopyRecord */
+/** @typedef {import('./types.js').Remotable} Remotable */
+
 const { details: X, quote: q } = assert;
 
 /**

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -3,6 +3,8 @@
 
 /// <reference path="extra-types.d.ts" />
 
+export {};
+
 /**
  * @typedef { "undefined" | "null" |
  *   "boolean" | "number" | "bigint" | "string" | "symbol"
@@ -180,7 +182,7 @@
 
 /**
  * @template Slot
- * @typedef CapData
+ * @typedef {Object} CapData
  * @property {string} body A JSON.stringify of an Encoding
  * @property {Slot[]} slots
  */
@@ -201,22 +203,13 @@
 
 /**
  * @template Slot
- * @typedef Marshal
+ * @typedef {Object} Marshal
  * @property {Serialize<Slot>} serialize
  * @property {Unserialize<Slot>} unserialize
  */
 
 /**
- * @template Slot
- * @callback MakeMarshal
- * @param {ConvertValToSlot<Slot>=} convertValToSlot
- * @param {ConvertSlotToVal<Slot>=} convertSlotToVal
- * @param {MakeMarshalOptions=} options
- * @returns {Marshal<Slot>}
- */
-
-/**
- * @typedef MakeMarshalOptions
+ * @typedef {Object} MakeMarshalOptions
  * @property {'on'|'off'=} errorTagging controls whether serialized errors
  * also carry tagging information, made from `marshalName` and numbers
  * generated (currently by counting) starting at `errorIdNum`. The

--- a/packages/marshal/test/test-marshal-far-obj.js
+++ b/packages/marshal/test/test-marshal-far-obj.js
@@ -59,9 +59,10 @@ test('Remotable/getInterfaceOf', t => {
   t.is(p2.birthYear(2020), 1956, `birthYear() works`);
 
   // Remotables and Fars can be serialized, of course
-  function convertValToSlot(_val) {
+  /** @type {import('../src/types.js').ConvertValToSlot<string>} */
+  const convertValToSlot = _val => {
     return 'slot';
-  }
+  };
   const m = makeMarshal(convertValToSlot);
   t.deepEqual(m.serialize(p2), {
     body: JSON.stringify({


### PR DESCRIPTION
Experiment to remove dependency on ambient types.  The process:

1. Put `export {};` near the top of every JSDoc `types.js` file.  This switches it from an ambient file to a module with exported types.
2. Remove `exported.js` so that ambient type users break hard.
3. Add `export * from './src/types.js';` to `index.js` so that upstream consumers can import types from the package identifier.  Season with eslint-ignores to taste.
4. Remove any `import './types.js';`, `import './internal-types.js';` etc.
5. Add `/** @typedef {import('./types.js').MemberName} MemberName */` or for template types `/** @template T @typedef {import('./types.js').MemberName2<T>} MemberName2 */`. as needed to the top of `.js` sources.
6. Chase any other Typescript errors.
7. Add build step to generate declarations, modify `package.json` to include generated files.
7. In consumers of the package, add JSDoc typedef imports like `/** @typedef {import('@agoric/marshal').MyType} MyType */`, and remove any `import '@agoric/marshal/exported';`.
8. When all cross project dependencies have transitioned to explicitly exported type declarations, remove any `--maxNodeModulesJsDepth` hack that used to be needed with JSDoc ambient type in `node_modules`.
