### PR TITLE
fix(compartment-mapper): Needless genericity considered harmful

### DIFF
--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -45,10 +45,8 @@ const defaultCompartment = Compartment;
 const q = JSON.stringify;
 
 /**
- * @template {string | number} Key
- * @template Value
- * @param {Record<Key, Value>} object
- * @param {Key} key
+ * @param {Record<string, unknown>} object
+ * @param {string} key
  * @returns {boolean}
  */
 const has = (object, key) => apply(hasOwnProperty, object, [key]);


### PR DESCRIPTION
The has utility function in the compartment mapper did not need to be generic.  Because it was generic, at a vast distance down the dependency chain, TypeScript proposed bizarre combinations of types for each of the uses, probably sampling the first ambient type that emitted a valid function, then failed type check in compartment-mapper.
