### PR TITLE
feat(ses): Harden typed arrays

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,15 @@
 User-visible changes in SES:
 
+# Next release
+
+- Harden now gives special treatment to typed arrays.
+  Instead of freezing a typed array, harden will seal it and make all of its
+  non-integer properties non-writable.
+  All of their integer properties will remain writable and non-configurable.
+  TypedArrays are exceedingly unusual because their integer properties are
+  writable and neither freeze nor defineProperty can convert them from writable
+  to non-writable.
+
 # v0.15.3 (2022-01-21)
 
 - Fixes the type definition for assert.error so that the final options bag,

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -73,6 +73,8 @@ export const {
   matchAll: matchAllSymbol,
 } = Symbol;
 
+export const { isInteger } = Number;
+
 export const { stringify: stringifyJson } = JSON;
 
 // At time of this writing, we still support Node 10 which doesn't have
@@ -137,6 +139,8 @@ export const { prototype: weaksetPrototype } = WeakSet;
 export const { prototype: functionPrototype } = Function;
 export const { prototype: promisePrototype } = Promise;
 
+export const typedArrayPrototype = getPrototypeOf(Uint8Array.prototype);
+
 /**
  * uncurryThis()
  * This form of uncurry uses Reflect.apply()
@@ -174,6 +178,7 @@ export const mapHas = uncurryThis(mapPrototype.has);
 export const iterateMap = uncurryThis(mapPrototype[iteratorSymbol]);
 //
 export const setAdd = uncurryThis(setPrototype.add);
+export const setDelete = uncurryThis(setPrototype.delete);
 export const setForEach = uncurryThis(setPrototype.forEach);
 export const setHas = uncurryThis(setPrototype.has);
 export const iterateSet = uncurryThis(setPrototype[iteratorSymbol]);

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -62,6 +62,7 @@ export const {
   keys,
   prototype: objectPrototype,
   seal,
+  preventExtensions,
   setPrototypeOf,
   values,
 } = Object;

--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -39,7 +39,6 @@ import {
   objectHasOwnProperty,
   ownKeys,
   preventExtensions,
-  seal,
   setAdd,
   setForEach,
   setHas,

--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -93,7 +93,8 @@ const freezeTypedArray = array => {
     //
     // TypedArrays are integer-indexed exotic objects, so indexed properties
     // outside the range of 0 to the typed array's length are disallowed.
-    // Assignment to these indexes silently fails.
+    // Assignment to these indexes silently fails and defining an indexed
+    // property throws an error.
     // So, we only need to make non-index properties non-writable and
     // non-configurable.
     // https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects

--- a/packages/ses/test/test-is-typed-array.js
+++ b/packages/ses/test/test-is-typed-array.js
@@ -1,0 +1,53 @@
+/* global BigInt64Array, BigUint64Array */
+// @ts-check
+
+import test from 'ava';
+import '../index.js';
+
+import { isTypedArray } from '../src/make-hardener.js';
+
+// Tests borrowed from https://github.com/inspect-js/is-typed-array
+// https://github.com/inspect-js/is-typed-array/blob/c1ad8eae617870e3b3700dda0ff736a267b7e990/LICENSE
+// MIT license.
+
+test('isTypedArray positive cases', t => {
+  t.assert(isTypedArray(new Int8Array()));
+  t.assert(isTypedArray(new Uint8Array()));
+  t.assert(isTypedArray(new Uint8ClampedArray()));
+  t.assert(isTypedArray(new Int16Array()));
+  t.assert(isTypedArray(new Uint16Array()));
+  t.assert(isTypedArray(new Int32Array()));
+  t.assert(isTypedArray(new Uint32Array()));
+  t.assert(isTypedArray(new Float32Array()));
+  t.assert(isTypedArray(new Float64Array()));
+  t.assert(isTypedArray(new BigInt64Array()));
+  t.assert(isTypedArray(new BigUint64Array()));
+});
+
+test('isTypedArray negative cases', t => {
+  t.assert(!isTypedArray(undefined));
+  t.assert(!isTypedArray(null));
+  t.assert(!isTypedArray(false));
+  t.assert(!isTypedArray(true));
+  t.assert(!isTypedArray([]));
+  t.assert(!isTypedArray({}));
+  t.assert(!isTypedArray(/a/g));
+  t.assert(!isTypedArray(new RegExp('a', 'g')));
+  t.assert(!isTypedArray(new Date()));
+  t.assert(!isTypedArray(42));
+  t.assert(!isTypedArray(NaN));
+  t.assert(!isTypedArray(Infinity));
+  // eslint-disable-next-line no-new-wrappers
+  t.assert(!isTypedArray(new Number(42)));
+  t.assert(!isTypedArray('foo'));
+  t.assert(!isTypedArray(Object('foo')));
+  t.assert(!isTypedArray(function f() {}));
+  t.assert(
+    !isTypedArray(function* g() {
+      yield;
+    }),
+  );
+  t.assert(!isTypedArray(() => {}));
+  t.assert(!isTypedArray([]));
+  t.assert(!isTypedArray(new ArrayBuffer(1)));
+});

--- a/packages/ses/test/test-make-hardener.js
+++ b/packages/ses/test/test-make-hardener.js
@@ -1,3 +1,6 @@
+/* global BigInt64Array, BigUint64Array */
+// @ts-check
+
 import test from 'ava';
 import { makeHardener } from '../src/make-hardener.js';
 
@@ -49,11 +52,145 @@ test('harden up prototype chain', t => {
   t.truthy(Object.isFrozen(a));
 });
 
-test('harden() tolerates objects with null prototypes', t => {
+test('harden tolerates objects with null prototypes', t => {
   const h = makeHardener();
   const o = { a: 1 };
   Object.setPrototypeOf(o, null);
   t.is(h(o), o);
   t.truthy(Object.isFrozen(o));
   t.truthy(Object.isFrozen(o.a));
+});
+
+test('harden typed arrays', t => {
+  const typedArrayConstructors = [
+    BigInt64Array,
+    BigUint64Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+  ];
+
+  for (const TypedArray of typedArrayConstructors) {
+    const h = makeHardener();
+    const a = new TypedArray(1);
+
+    t.is(h(a), a, `harden ${TypedArray}`);
+    t.truthy(Object.isSealed(a));
+    t.deepEqual(
+      {
+        value: a[0],
+        writable: true, // Note that indexes of typed arrays are exceptionally writable for hardened objects.
+        configurable: false,
+        enumerable: true,
+      },
+      Object.getOwnPropertyDescriptor(a, '0'),
+    );
+  }
+});
+
+test('harden typed arrays and their expandos', t => {
+  const h = makeHardener();
+  const a = new Uint8Array(1);
+  // @ts-ignore
+  a.x = { y: { z: 10 } };
+
+  t.is(h(a), a);
+  t.truthy(Object.isSealed(a));
+
+  t.deepEqual(
+    {
+      value: 0,
+      writable: true, // Note that indexes of typed arrays are exceptionally writable for hardened objects.
+      configurable: false,
+      enumerable: true,
+    },
+    Object.getOwnPropertyDescriptor(a, '0'),
+  );
+
+  t.deepEqual(
+    {
+      // @ts-ignore
+      value: a.x,
+      writable: false,
+      configurable: false,
+      enumerable: true,
+    },
+    Object.getOwnPropertyDescriptor(a, 'x'),
+  );
+
+  // @ts-ignore
+  t.truthy(Object.isFrozen(a.x));
+  // @ts-ignore
+  t.truthy(Object.isFrozen(a.x.y));
+  // @ts-ignore
+  t.truthy(Object.isFrozen(a.x.y.z));
+});
+
+test('hardening makes writable properties readonly even if non-configurable', t => {
+  const h = makeHardener();
+  const o = {};
+  Object.defineProperty(o, 'x', {
+    value: 10,
+    writable: true,
+    configurable: false,
+    enumerable: false,
+  });
+  h(o);
+  t.deepEqual(
+    {
+      value: 10,
+      writable: false,
+      configurable: false,
+      enumerable: false,
+    },
+    Object.getOwnPropertyDescriptor(o, 'x'),
+  );
+});
+
+test('harden a typed array with a writable non-configurable expando', t => {
+  const h = makeHardener();
+  const a = new Uint8Array(1);
+  Object.defineProperty(a, 'x', {
+    value: 'A',
+    writable: true,
+    configurable: false,
+    enumerable: false,
+  });
+
+  t.is(h(a), a);
+  t.truthy(Object.isSealed(a));
+
+  t.deepEqual(
+    {
+      value: 'A',
+      writable: false,
+      configurable: false,
+      enumerable: false,
+    },
+    Object.getOwnPropertyDescriptor(a, 'x'),
+  );
+});
+
+test('harden depends on invariant: typed arrays have no storage for integer indexes beyond length', t => {
+  const a = new Uint8Array(1);
+  a[1] = 1;
+  t.is(a[1], undefined);
+});
+
+test('harden depends on invariant: typed arrays cannot have integer expandos', t => {
+  const a = new Uint8Array(1);
+  t.throws(() => {
+    Object.defineProperty(a, '1', {
+      value: 'A',
+      writable: true,
+      configurable: false,
+      enumerable: false,
+    });
+  });
 });

--- a/packages/ses/test/test-make-hardener.js
+++ b/packages/ses/test/test-make-hardener.js
@@ -177,6 +177,29 @@ test('harden a typed array with a writable non-configurable expando', t => {
   );
 });
 
+test('harden a typed array subclass', t => {
+  const h = makeHardener();
+
+  class Ooint8Array extends Uint8Array {
+    oo = 'ghosts';
+  }
+
+  const a = new Ooint8Array(1);
+  t.is(h(a), a);
+
+  t.deepEqual(
+    {
+      value: 'ghosts',
+      writable: false,
+      configurable: false,
+      enumerable: true,
+    },
+    Object.getOwnPropertyDescriptor(a, 'oo'),
+  );
+  t.truthy(Object.isFrozen(Ooint8Array.prototype));
+  t.truthy(Object.isFrozen(Object.getPrototypeOf(Ooint8Array.prototype)));
+});
+
 test('harden depends on invariant: typed arrays have no storage for integer indexes beyond length', t => {
   const a = new Uint8Array(1);
   a[1] = 1;


### PR DESCRIPTION

Harden can now handle typed arrays.  Although typed arrays cannot be frozen because their integer properties cannot be made non-writable by any mechanism, these properties are analogous to the entries in a map, which can be hardened.  This change makes harden treat typed arrays as the moral equivalent of a map.  Hardening a typed array seals the object and makes all other properties non-writable and non-configurable.

Fixes #1029
