### PR TITLE
Bump minimum node 12 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.17.0, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         platform: [ubuntu-latest, windows-latest]
 
     steps:
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.17.0, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -219,7 +219,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.17.0, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         platform: [ubuntu-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "packages/zip"
   ],
   "engines": {
-    "node": ">=12.17.0"
+    "node": ">=12.22.0"
   },
   "devDependencies": {
     "@octokit/core": "^3.4.0",


### PR DESCRIPTION
Typescript ESLint parser (see #1043) requires `node >=12.22`, and we're still testing with an old pinned node version (12.17) which is no longer necessary as `agoric-sdk` has moved on.

Also add node 16.x to the test matrix since `agoric-sdk` now tests on that as well.

Does not drop node 12 entirely as that's a breaking change. Refs #1046 