### PR TITLE
Fix CI to actually run type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.17.0, 12.x, 14.x]
+        node-version: [12.x, 14.x]
         platform: [ubuntu-latest, windows-latest]
 
     steps:
@@ -170,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.17.0, 12.x, 14.x]
+        node-version: [12.x, 14.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -219,7 +219,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.17.0, 12.x, 14.x]
+        node-version: [12.x, 14.x]
         platform: [ubuntu-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "packages/zip"
   ],
   "engines": {
-    "node": ">=12.17.0"
+    "node": ">=12.22.0"
   },
   "devDependencies": {
     "@octokit/core": "^3.4.0",

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -33,7 +33,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "devDependencies": {

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -26,7 +26,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "exit 0"
   },
   "dependencies": {

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -36,7 +36,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "dependencies": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -30,7 +30,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "dependencies": {

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -40,7 +40,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "dependencies": {

--- a/packages/lp32/reader.js
+++ b/packages/lp32/reader.js
@@ -15,7 +15,7 @@ const { details: X, quote: q } = assert;
  * @param {number} [opts.maxMessageLength] - defaults to 1MB
  * @param {boolean=} [opts.littleEndian]
  * @param {number=} [opts.initialCapacity]
- * @returns {import('@endo/stream').Reader<Uint8Array, undefined>}
+ * @returns {import('@endo/stream').Reader<Uint8Array, void>}
  */
 async function* makeLp32Iterator(
   reader,
@@ -79,7 +79,7 @@ async function* makeLp32Iterator(
  * @param {Object} [opts]
  * @param {string=} [opts.name]
  * @param {number=} [opts.capacity]
- * @returns {import('@endo/stream').Reader<Uint8Array, undefined>} reader
+ * @returns {import('@endo/stream').Reader<Uint8Array, void>} reader
  */
 export const makeLp32Reader = (reader, opts) => {
   return harden(makeLp32Iterator(reader, opts));

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -29,7 +29,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "dependencies": {

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -30,7 +30,7 @@
     "lint-check": "yarn lint",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava",
     "test:xs": "exit 0"
   },

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -29,7 +29,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "dependencies": {

--- a/packages/ses-types-test/package.json
+++ b/packages/ses-types-test/package.json
@@ -21,7 +21,7 @@
     "lint": "yarn lint:types && yarn lint:ts",
     "lint-fix": "eslint --fix . --ext .ts",
     "lint:ts": "eslint . --ext .ts",
-    "lint:types": "tsc --build tsconfig.json",
+    "lint:types": "tsc -p tsconfig.json",
     "test": "yarn lint:types"
   },
   "dependencies": {

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -52,7 +52,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "prepublish": "yarn run clean && yarn build",
     "qt": "ava",
     "test": "yarn build && ava",

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -29,7 +29,7 @@
     "build": "exit 0",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "lint:js": "eslint .",
     "lint-fix": "eslint --fix .",
     "test": "ava"

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -35,7 +35,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "dependencies": {

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -21,7 +21,7 @@
     "lint": "yarn lint:types && yarn lint:ts",
     "lint-fix": "eslint --fix . --ext .ts",
     "lint:ts": "eslint . --ext .ts",
-    "lint:types": "tsc --build tsconfig.json",
+    "lint:types": "tsc -p tsconfig.json",
     "test": "yarn lint:types"
   },
   "dependencies": {

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -34,7 +34,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "dependencies": {

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -33,7 +33,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "devDependencies": {

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -30,7 +30,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "devDependencies": {

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -32,7 +32,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",
-    "lint:types": "tsc --build jsconfig.json",
+    "lint:types": "tsc -p jsconfig.json",
     "test": "ava"
   },
   "devDependencies": {

--- a/scripts/repackage.sh
+++ b/scripts/repackage.sh
@@ -82,7 +82,7 @@ NEWPKGJSONHASH=$(
       "build": "exit 0",
       "test": "ava",
       "lint": "yarn lint:types && yarn lint:js",
-      "lint:types": "tsc --build jsconfig.json",
+      "lint:types": "tsc -p jsconfig.json",
       "lint:js": "eslint .",
       "lint-fix": "eslint --fix .",
     }) | to_entries | sort_by(.key) | from_entries,


### PR DESCRIPTION
Run lint type checks with `-p` instead of `--build`. Closes #1058 
Fix a type issue that arose in `lp32`

Remove Node 12.17 from the CI matrix. Bump minimum node version to `12.22` as that will be the minimum version supported by the upcoming TS 4.5 change (see #1043)