### PR TITLE
fix(nat): declare `allegedNum` as `unknown`, then assert

### DIFF
--- a/packages/nat/src/index.js
+++ b/packages/nat/src/index.js
@@ -26,12 +26,15 @@
  * within range of [integers safely representable in
  * floating point](https://tc39.es/ecma262/#sec-number.issafeinteger).
  *
- * @param {any} allegedNum
+ * @param {unknown} allegedNum
  * @returns {boolean}
  */
 function isNat(allegedNum) {
   if (typeof allegedNum === 'bigint') {
     return allegedNum >= 0;
+  }
+  if (typeof allegedNum !== 'number') {
+    return false;
   }
 
   return Number.isSafeInteger(allegedNum) && allegedNum >= 0;
@@ -47,7 +50,7 @@ function isNat(allegedNum) {
  * non-negative integer, `Nat` throws a `RangeError`.
  * Otherwise, it is converted to a bigint if necessary and returned.
  *
- * @param {bigint | number} allegedNum
+ * @param {unknown} allegedNum
  * @returns {bigint}
  */
 function Nat(allegedNum) {


### PR DESCRIPTION
This change is necessary to allow callers to use `Nat` on data whose type they are unsure of.
