### PR TITLE
feat(daemon): Add worker with lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
         platform: [ubuntu-latest, windows-latest]
 
     steps:
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -211,7 +211,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -259,7 +259,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
         platform: [ubuntu-latest]
 
     steps:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,9 +24,13 @@
     "test": "exit 0"
   },
   "dependencies": {
+    "@agoric/babel-standalone": "^7.14.3",
     "@endo/compartment-mapper": "^0.6.5",
     "@endo/daemon": "^0.1.4",
     "@endo/where": "^0.1.4",
+    "@endo/eventual-send": "^0.14.4",
+    "@endo/lockdown": "^0.1.5",
+    "ses": "^0.15.7",
     "commander": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -1,4 +1,11 @@
 /* global process */
+
+// Establish a perimeter:
+import '@agoric/babel-standalone';
+import 'ses';
+import '@endo/eventual-send/shim.js';
+import '@endo/lockdown/commit.js';
+
 import fs from 'fs';
 import path from 'path';
 import url from 'url';

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -12,7 +12,7 @@ import url from 'url';
 import crypto from 'crypto';
 
 import { Command } from 'commander';
-import { start, stop, restart, clean } from '@endo/daemon';
+import { start, stop, restart, clean, reset } from '@endo/daemon';
 import { whereEndoState, whereEndoSock, whereEndoCache } from '@endo/where';
 import {
   mapLocation,
@@ -81,6 +81,10 @@ export const main = async rawArgs => {
 
   program.command('clean').action(async _cmd => {
     await clean();
+  });
+
+  program.command('reset').action(async _cmd => {
+    await reset();
   });
 
   program

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -1,11 +1,12 @@
 /* global process */
 import fs from 'fs';
+import path from 'path';
 import url from 'url';
 import crypto from 'crypto';
 
 import { Command } from 'commander';
 import { start, stop, restart, clean } from '@endo/daemon';
-import { whereEndo, whereEndoSock, whereEndoLog } from '@endo/where';
+import { whereEndoState, whereEndoSock, whereEndoCache } from '@endo/where';
 import {
   mapLocation,
   hashLocation,
@@ -25,9 +26,10 @@ const packageDescriptorPath = url.fileURLToPath(
   new URL('../package.json', import.meta.url),
 );
 
-const endoPath = whereEndo(process.platform, process.env);
+const statePath = whereEndoState(process.platform, process.env);
 const sockPath = whereEndoSock(process.platform, process.env);
-const logPath = whereEndoLog(process.platform, process.env);
+const cachePath = whereEndoCache(process.platform, process.env);
+const logPath = path.join(cachePath, 'endo.log');
 
 export const main = async rawArgs => {
   const program = new Command();
@@ -40,16 +42,22 @@ export const main = async rawArgs => {
   const packageDescriptor = JSON.parse(packageDescriptorBytes);
   program.name(packageDescriptor.name).version(packageDescriptor.version);
 
-  program.command('where').action(async _cmd => {
-    console.log(endoPath);
+  const where = program.command('where');
+
+  where.command('state').action(async _cmd => {
+    console.log(statePath);
   });
 
-  program.command('wheresock').action(async _cmd => {
+  where.command('sock').action(async _cmd => {
     console.log(sockPath);
   });
 
-  program.command('wherelog').action(async _cmd => {
+  where.command('log').action(async _cmd => {
     console.log(logPath);
+  });
+
+  where.command('cache').action(async _cmd => {
+    console.log(cachePath);
   });
 
   program.command('start').action(async _cmd => {

--- a/packages/daemon/daemon.js
+++ b/packages/daemon/daemon.js
@@ -50,23 +50,23 @@ export const main = async () => {
     console.error('Endo exiting');
   });
 
-  if (process.argv.length < 4) {
+  if (process.argv.length < 5) {
     throw new Error(
-      `daemon.js requires arguments [sockPath] [endoPath], got ${process.argv.join(
+      `daemon.js requires arguments [sockPath] [statePath] [cachePath], got ${process.argv.join(
         ', ',
       )}`,
     );
   }
 
   const sockPath = process.argv[2];
-  const endoPath = process.argv[3];
+  const statePath = process.argv[3];
   const cachePath = process.argv[4];
 
-  const locator = { sockPath, endoPath, cachePath };
+  const locator = { sockPath, statePath, cachePath };
 
   const endoFacets = makeEndoFacets(locator);
 
-  await fs.promises.mkdir(endoPath, { recursive: true });
+  await fs.promises.mkdir(statePath, { recursive: true });
 
   const server = net.createServer();
 

--- a/packages/daemon/daemon.js
+++ b/packages/daemon/daemon.js
@@ -60,8 +60,9 @@ export const main = async () => {
 
   const sockPath = process.argv[2];
   const endoPath = process.argv[3];
+  const cachePath = process.argv[4];
 
-  const locator = { sockPath, endoPath };
+  const locator = { sockPath, endoPath, cachePath };
 
   const endoFacets = makeEndoFacets(locator);
 

--- a/packages/daemon/index.d.ts
+++ b/packages/daemon/index.d.ts
@@ -1,5 +1,5 @@
 type Locator = {
-  endoPath: string;
+  statePath: string;
   cachePath: string;
   sockPath: string;
 };

--- a/packages/daemon/index.d.ts
+++ b/packages/daemon/index.d.ts
@@ -1,6 +1,6 @@
 type Locator = {
   endoPath: string;
-  logPath: string;
+  cachePath: string;
   sockPath: string;
 };
 export async function start(locator?: Locator);

--- a/packages/daemon/index.d.ts
+++ b/packages/daemon/index.d.ts
@@ -8,3 +8,9 @@ export async function stop(locator?: Locator);
 export async function restart(locator?: Locator);
 export async function terminate(locator?: Locator);
 export async function clean(locator?: Locator);
+export async function makeEndoClient<TBootstrap>(
+  name: string,
+  sockPath: string,
+  cancelled: Promise<void>,
+  bootstrap?: TBootstrap,
+);

--- a/packages/daemon/index.d.ts
+++ b/packages/daemon/index.d.ts
@@ -6,5 +6,5 @@ type Locator = {
 export async function start(locator?: Locator);
 export async function stop(locator?: Locator);
 export async function restart(locator?: Locator);
-export async function shutdown(locator?: Locator);
+export async function terminate(locator?: Locator);
 export async function clean(locator?: Locator);

--- a/packages/daemon/index.d.ts
+++ b/packages/daemon/index.d.ts
@@ -8,6 +8,7 @@ export async function stop(locator?: Locator);
 export async function restart(locator?: Locator);
 export async function terminate(locator?: Locator);
 export async function clean(locator?: Locator);
+export async function reset(locator?: Locator);
 export async function makeEndoClient<TBootstrap>(
   name: string,
   sockPath: string,

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -24,13 +24,13 @@ const defaultLocator = {
 
 const endoDaemonPath = url.fileURLToPath(new URL('src/daemon.js', import.meta.url));
 
-export const shutdown = async (locator = defaultLocator) => {
+export const terminate = async (locator = defaultLocator) => {
   const { getBootstrap, finalize } = await makeEndoClient(
     'harbinger',
     locator.sockPath,
   );
   const bootstrap = getBootstrap();
-  await E(E.get(bootstrap).privateFacet).shutdown(locator);
+  await E(E.get(bootstrap).privateFacet).terminate(locator);
   finalize();
 };
 
@@ -93,12 +93,12 @@ export const clean = async (locator = defaultLocator) => {
 
 export const restart = async (locator = defaultLocator) => {
   if (restart) {
-    await shutdown(locator).catch(() => {});
+    await terminate(locator).catch(() => {});
     await clean(locator);
   }
   return start(locator);
 };
 
 export const stop = async (locator = defaultLocator) => {
-  return shutdown(locator).catch(() => {});
+  return terminate(locator).catch(() => {});
 };

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -10,13 +10,18 @@ import { E } from '@endo/eventual-send';
 import { whereEndoState, whereEndoSock, whereEndoCache } from '@endo/where';
 import { makeEndoClient } from './src/client.js';
 
+// Reexports:
+export { makeEndoClient } from './src/client.js';
+
 const defaultLocator = {
   statePath: whereEndoState(process.platform, process.env),
   sockPath: whereEndoSock(process.platform, process.env),
   cachePath: whereEndoCache(process.platform, process.env),
 };
 
-const endoDaemonPath = url.fileURLToPath(new URL('src/daemon.js', import.meta.url));
+const endoDaemonPath = url.fileURLToPath(
+  new URL('src/daemon.js', import.meta.url),
+);
 
 export const terminate = async (locator = defaultLocator) => {
   const { getBootstrap, finalize } = await makeEndoClient(
@@ -24,7 +29,7 @@ export const terminate = async (locator = defaultLocator) => {
     locator.sockPath,
   );
   const bootstrap = getBootstrap();
-  await E(E.get(bootstrap).privateFacet).terminate(locator);
+  await E(E.get(bootstrap).privateFacet).terminate();
   finalize();
 };
 

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -1,12 +1,6 @@
 // @ts-check
 /* global process */
 
-// Establish a perimeter:
-import '@agoric/babel-standalone';
-import 'ses';
-import '@endo/eventual-send/shim.js';
-import '@endo/lockdown/commit.js';
-
 import url from 'url';
 import popen from 'child_process';
 import fs from 'fs';

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -13,11 +13,11 @@ import fs from 'fs';
 import path from 'path';
 
 import { E } from '@endo/eventual-send';
-import { whereEndo, whereEndoSock, whereEndoCache } from '@endo/where';
+import { whereEndoState, whereEndoSock, whereEndoCache } from '@endo/where';
 import { makeEndoClient } from './src/client.js';
 
 const defaultLocator = {
-  endoPath: whereEndo(process.platform, process.env),
+  statePath: whereEndoState(process.platform, process.env),
   sockPath: whereEndoSock(process.platform, process.env),
   cachePath: whereEndoCache(process.platform, process.env),
 };
@@ -35,17 +35,28 @@ export const shutdown = async (locator = defaultLocator) => {
 };
 
 export const start = async (locator = defaultLocator) => {
-  await fs.promises.mkdir(locator.endoPath, { recursive: true });
+  const cachePathCreated = fs.promises.mkdir(locator.cachePath, {
+    recursive: true,
+  });
+  const statePathCreated = fs.promises.mkdir(locator.statePath, {
+    recursive: true,
+  });
+
+  await cachePathCreated;
   const logPath = path.join(locator.cachePath, 'endo.log');
+
+  await statePathCreated;
   const output = fs.openSync(logPath, 'a');
+
   const child = popen.fork(
     endoDaemonPath,
-    [locator.sockPath, locator.endoPath, locator.cachePath],
+    [locator.sockPath, locator.statePath, locator.cachePath],
     {
       detached: true,
       stdio: ['ignore', output, output, 'ipc'],
     },
   );
+
   return new Promise((resolve, reject) => {
     child.on('error', (/** @type {Error} */ cause) => {
       reject(

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -22,7 +22,7 @@ const defaultLocator = {
   cachePath: whereEndoCache(process.platform, process.env),
 };
 
-const endoDaemonPath = url.fileURLToPath(new URL('daemon.js', import.meta.url));
+const endoDaemonPath = url.fileURLToPath(new URL('src/daemon.js', import.meta.url));
 
 export const shutdown = async (locator = defaultLocator) => {
   const { getBootstrap, finalize } = await makeEndoClient(

--- a/packages/daemon/jsconfig.json
+++ b/packages/daemon/jsconfig.json
@@ -7,5 +7,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node"
   },
-  "include": ["src/**/*.js", "index.d.ts"]
+  "include": ["**/*.js", "**/*.ts"]
 }

--- a/packages/daemon/src/client.js
+++ b/packages/daemon/src/client.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import net from 'net';
-import { makeCapTPWithConnection } from './connection.js';
+import { makeNodeNetstringCapTP } from './connection.js';
 
 /**
  * @template TBootstrap
@@ -15,5 +15,5 @@ export const makeEndoClient = async (name, sockPath, bootstrap) => {
     conn.on('connect', resolve);
     conn.on('error', reject);
   });
-  return makeCapTPWithConnection(name, conn, bootstrap);
+  return makeNodeNetstringCapTP(name, conn, conn, bootstrap);
 };

--- a/packages/daemon/src/client.js
+++ b/packages/daemon/src/client.js
@@ -7,13 +7,14 @@ import { makeNodeNetstringCapTP } from './connection.js';
  * @template TBootstrap
  * @param {string} name
  * @param {string} sockPath
+ * @param {Promise<void>} cancelled
  * @param {TBootstrap=} bootstrap
  */
-export const makeEndoClient = async (name, sockPath, bootstrap) => {
+export const makeEndoClient = async (name, sockPath, cancelled, bootstrap) => {
   const conn = net.connect(sockPath);
   await new Promise((resolve, reject) => {
     conn.on('connect', resolve);
     conn.on('error', reject);
   });
-  return makeNodeNetstringCapTP(name, conn, conn, bootstrap);
+  return makeNodeNetstringCapTP(name, conn, conn, cancelled, bootstrap);
 };

--- a/packages/daemon/src/connection.js
+++ b/packages/daemon/src/connection.js
@@ -57,16 +57,17 @@ const bytesToMessage = bytes => {
 /**
  * @template TBootstrap
  * @param {string} name
- * @param {import('net').Socket} conn
+ * @param {import('stream').Writable} nodeWriter
+ * @param {import('stream').Readable} nodeReader
  * @param {TBootstrap} bootstrap
  */
-export const makeCapTPWithConnection = (name, conn, bootstrap) => {
+export const makeNodeNetstringCapTP = (name, nodeWriter, nodeReader, bootstrap) => {
   const writer = mapWriter(
-    makeNetstringWriter(makeNodeWriter(conn)),
+    makeNetstringWriter(makeNodeWriter(nodeWriter)),
     messageToBytes,
   );
   const reader = mapReader(
-    makeNetstringReader(makeNodeReader(conn)),
+    makeNetstringReader(makeNodeReader(nodeReader)),
     bytesToMessage,
   );
   return makeCapTPWithStreams(name, writer, reader, bootstrap);

--- a/packages/daemon/src/connection.js
+++ b/packages/daemon/src/connection.js
@@ -61,7 +61,12 @@ const bytesToMessage = bytes => {
  * @param {import('stream').Readable} nodeReader
  * @param {TBootstrap} bootstrap
  */
-export const makeNodeNetstringCapTP = (name, nodeWriter, nodeReader, bootstrap) => {
+export const makeNodeNetstringCapTP = (
+  name,
+  nodeWriter,
+  nodeReader,
+  bootstrap,
+) => {
   const writer = mapWriter(
     makeNetstringWriter(makeNodeWriter(nodeWriter)),
     messageToBytes,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -13,7 +13,7 @@ import fs from 'fs';
 import { Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 
-import { makeCapTPWithConnection } from './src/connection.js';
+import { makeCapTPWithConnection } from './connection.js';
 
 const { quote: q } = assert;
 
@@ -25,7 +25,7 @@ const sinkError = error => {
 };
 
 /**
- * @param {import('./index.js').Locator} locator
+ * @param {import('../index.js').Locator} locator
  */
 const makeEndoFacets = locator => {
   const publicFacet = Far('Endo public facet', {});

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -12,8 +12,7 @@ import net from 'net';
 import fs from 'fs';
 import { Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
-
-import { makeCapTPWithConnection } from './connection.js';
+import { makeNodeNetstringCapTP } from './connection.js';
 
 const { quote: q } = assert;
 
@@ -88,7 +87,7 @@ export const main = async () => {
     process.exit(-1);
   });
   server.on('connection', conn => {
-    const { drained } = makeCapTPWithConnection('Endo', conn, endoFacets);
+    const { drained } = makeNodeNetstringCapTP('Endo', conn, conn, endoFacets);
     drained.catch(sinkError);
   });
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -102,7 +102,7 @@ const makeEndoFacets = locator => {
 
   const privateFacet = Far('EndoPrivateFacet', {
     async terminate() {
-      console.error('Endo received terminate request');
+      console.error('Endo daemon received terminate request');
       cancel(new Error('Terminate'));
     },
     async makeWorker() {
@@ -119,9 +119,9 @@ const makeEndoFacets = locator => {
 };
 
 export const main = async () => {
-  console.error(`Endo starting on PID ${process.pid}`);
+  console.error(`Endo daemon starting on PID ${process.pid}`);
   process.once('exit', () => {
-    console.error(`Endo stopping on PID ${process.pid}`);
+    console.error(`Endo daemon stopping on PID ${process.pid}`);
   });
 
   if (process.argv.length < 5) {
@@ -155,7 +155,7 @@ export const main = async () => {
     },
     () => {
       console.log(
-        `Endo listening on ${q(sockPath)} ${new Date().toISOString()}`,
+        `Endo daemon listening on ${q(sockPath)} ${new Date().toISOString()}`,
       );
       // Inform parent that we have an open unix domain socket, if we were
       // spawned with IPC.
@@ -169,6 +169,9 @@ export const main = async () => {
     process.exit(-1);
   });
   server.on('connection', conn => {
+    console.error(
+      `Endo daemon received connection ${new Date().toISOString()}`,
+    );
     const { closed } = makeNodeNetstringCapTP(
       'Endo',
       conn,

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -1,0 +1,71 @@
+// @ts-check
+/// <reference types="ses"/>
+/* global process */
+
+// Establish a perimeter:
+import '@agoric/babel-standalone';
+import 'ses';
+import '@endo/eventual-send/shim.js';
+import '@endo/lockdown/commit.js';
+
+import fs from 'fs';
+
+import { Far } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+import { makeNodeNetstringCapTP } from './connection.js';
+
+/** @param {Error} error */
+const sinkError = error => {
+  console.error(error);
+};
+
+const { promise: cancelled, reject: cancel } = makePromiseKit();
+
+const makeWorkerFacet = () => {
+  return Far('EndoWorkerFacet', {
+    async shutdown() {
+      console.error('Endo worker received shutdown request');
+      cancel(new Error('Shutdown'));
+    },
+  });
+};
+
+export const main = async () => {
+  process.once('exit', () => {
+    console.error('Endo Worker exiting');
+  });
+
+  if (process.argv.length < 2) {
+    throw new Error(
+      `worker.js requires arguments [uuid] [workerCachePath], got ${process.argv.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  // const uuid = process.argv[2];
+  // const workerCachePath = process.argv[3];
+
+  // @ts-ignore This is in fact how you open a file descriptor.
+  const reader = fs.createReadStream(null, { fd: 3 });
+  // @ts-ignore This is in fact how you open a file descriptor.
+  const writer = fs.createWriteStream(null, { fd: 3 });
+
+  const workerFacet = makeWorkerFacet();
+
+  const { drained, finalize } = makeNodeNetstringCapTP(
+    'Endo',
+    writer,
+    reader,
+    workerFacet,
+  );
+
+  cancelled.catch(async () => {
+    finalize();
+    writer.close();
+  });
+
+  drained.catch(sinkError);
+};
+
+main().catch(sinkError);

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -23,16 +23,17 @@ const { promise: cancelled, reject: cancel } = makePromiseKit();
 
 const makeWorkerFacet = () => {
   return Far('EndoWorkerFacet', {
-    async shutdown() {
-      console.error('Endo worker received shutdown request');
-      cancel(new Error('Shutdown'));
+    async terminate() {
+      console.error('Endo worker received terminate request');
+      cancel(new Error('terminate'));
     },
   });
 };
 
 export const main = async () => {
+  console.error('Endo worker started');
   process.once('exit', () => {
-    console.error('Endo Worker exiting');
+    console.error('Endo worker exiting');
   });
 
   if (process.argv.length < 2) {

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -53,19 +53,15 @@ export const main = async () => {
 
   const workerFacet = makeWorkerFacet();
 
-  const { drained, finalize } = makeNodeNetstringCapTP(
+  const { closed } = makeNodeNetstringCapTP(
     'Endo',
     writer,
     reader,
+    cancelled,
     workerFacet,
   );
 
-  cancelled.catch(async () => {
-    finalize();
-    writer.close();
-  });
-
-  drained.catch(sinkError);
+  closed.catch(sinkError);
 };
 
 main().catch(sinkError);

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -12,7 +12,14 @@ import url from 'url';
 import path from 'path';
 import { E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
-import { start, stop, restart, clean, makeEndoClient } from '../index.js';
+import {
+  start,
+  stop,
+  restart,
+  clean,
+  reset,
+  makeEndoClient,
+} from '../index.js';
 
 const { raw } = String;
 
@@ -30,6 +37,7 @@ const locator = {
 test.serial('lifecycle', async t => {
   const { resolve: cancel, promise: cancelled } = makePromiseKit();
 
+  await reset(locator);
   await clean(locator);
   await start(locator);
   await stop(locator);

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -11,6 +11,7 @@ import test from 'ava';
 import url from 'url';
 import path from 'path';
 import { E } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
 import { start, stop, restart, clean, makeEndoClient } from '../index.js';
 
 const { raw } = String;
@@ -27,20 +28,23 @@ const locator = {
 };
 
 test.serial('lifecycle', async t => {
+  const { resolve: cancel, promise: cancelled } = makePromiseKit();
+
   await clean(locator);
   await start(locator);
   await stop(locator);
   await restart(locator);
 
-  const { getBootstrap, finalize, drained } = await makeEndoClient(
+  const { getBootstrap, closed } = await makeEndoClient(
     'client',
     locator.sockPath,
+    cancelled,
   );
   const bootstrap = getBootstrap();
   const worker = await E(E.get(bootstrap).privateFacet).makeWorker();
   await E(E.get(worker).actions).terminate();
-  finalize();
-  await drained;
+  cancel();
+  await closed;
 
   await stop(locator);
   t.pass();

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -10,12 +10,12 @@ const { raw } = String;
 const dirname = url.fileURLToPath(new URL('.', import.meta.url)).toString();
 
 const locator = {
-  endoPath: path.join(dirname, 'endo'),
+  statePath: path.join(dirname, 'endo'),
+  cachePath: dirname,
   sockPath:
     process.platform === 'win32'
       ? raw`\\?\pipe\endo-test.sock`
       : path.join(dirname, 'endo.sock'),
-  cachePath: dirname,
 };
 
 test.serial('lifecycle', async t => {

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -15,7 +15,7 @@ const locator = {
     process.platform === 'win32'
       ? raw`\\?\pipe\endo-test.sock`
       : path.join(dirname, 'endo.sock'),
-  logPath: path.join(dirname, 'endo.log'),
+  cachePath: dirname,
 };
 
 test.serial('lifecycle', async t => {

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -55,5 +55,6 @@ test.serial('lifecycle', async t => {
   await closed;
 
   await stop(locator);
+
   t.pass();
 });

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -1,21 +1,29 @@
 // @ts-check
 /* global process */
+
+// Establish a perimeter:
+import '@agoric/babel-standalone';
+import 'ses';
+import '@endo/eventual-send/shim.js';
+import '@endo/lockdown/commit-debug.js';
+
 import test from 'ava';
 import url from 'url';
 import path from 'path';
-import { start, stop, restart, clean } from '../index.js';
+import { E } from '@endo/far';
+import { start, stop, restart, clean, makeEndoClient } from '../index.js';
 
 const { raw } = String;
 
-const dirname = url.fileURLToPath(new URL('.', import.meta.url)).toString();
+const dirname = url.fileURLToPath(new URL('..', import.meta.url)).toString();
 
 const locator = {
-  statePath: path.join(dirname, 'endo'),
-  cachePath: dirname,
+  statePath: path.join(dirname, 'tmp/state'),
+  cachePath: path.join(dirname, 'tmp/cache'),
   sockPath:
     process.platform === 'win32'
       ? raw`\\?\pipe\endo-test.sock`
-      : path.join(dirname, 'endo.sock'),
+      : path.join(dirname, 'tmp/endo.sock'),
 };
 
 test.serial('lifecycle', async t => {
@@ -23,6 +31,17 @@ test.serial('lifecycle', async t => {
   await start(locator);
   await stop(locator);
   await restart(locator);
+
+  const { getBootstrap, finalize, drained } = await makeEndoClient(
+    'client',
+    locator.sockPath,
+  );
+  const bootstrap = getBootstrap();
+  const worker = await E(E.get(bootstrap).privateFacet).makeWorker();
+  await E(E.get(worker).actions).terminate();
+  finalize();
+  await drained;
+
   await stop(locator);
   t.pass();
 });

--- a/packages/stream/index.js
+++ b/packages/stream/index.js
@@ -133,15 +133,15 @@ export const pump = async (writer, reader, primer) => {
       promise,
       result => {
         if (result.done) {
-          return E(writer).return(result.value);
+          return writer.return(result.value);
         } else {
           // Behold: mutual recursion.
           // eslint-disable-next-line no-use-before-define
-          return tock(E(writer).next(result.value));
+          return tock(writer.next(result.value));
         }
       },
       (/** @type {Error} */ error) => {
-        return E(writer).throw(error);
+        return writer.throw(error);
       },
     );
   /** @param {Promise<IteratorResult<TWrite, TWriteReturn>>} promise */
@@ -150,16 +150,16 @@ export const pump = async (writer, reader, primer) => {
       promise,
       result => {
         if (result.done) {
-          return E(reader).return(result.value);
+          return reader.return(result.value);
         } else {
-          return tick(E(reader).next(result.value));
+          return tick(reader.next(result.value));
         }
       },
       (/** @type {Error} */ error) => {
-        return E(reader).throw(error);
+        return reader.throw(error);
       },
     );
-  await tick(E(reader).next(primer));
+  await tick(reader.next(primer));
   return undefined;
 };
 harden(pump);
@@ -243,19 +243,19 @@ export const mapWriter = (writer, transform) => {
      * @param {TIn} value
      */
     async next(value) {
-      return E(writer).next(transform(value));
+      return writer.next(transform(value));
     },
     /**
      * @param {Error} error
      */
     async throw(error) {
-      return E(writer).throw(error);
+      return writer.throw(error);
     },
     /**
      * @param {undefined} value
      */
     async return(value) {
-      return E(writer).return(value);
+      return writer.return(value);
     },
     [Symbol.asyncIterator]() {
       return transformedWriter;

--- a/packages/stream/test/test-pump.js
+++ b/packages/stream/test/test-pump.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* global process */
 
 import '@endo/init';
 
@@ -91,19 +90,7 @@ test('pump with error', async (/** @type {import('ava').ExecutionContext} */ t) 
     }
   }
 
-  try {
-    await pump(prime(target()), source());
-  } catch (error) {
-    // In Node.js 12, the error thrown on the last line of the `source`
-    // generator does not propagate to the promise returned by `pump`.
-    // In Node.js 14, the error does propagate.
-    // We do not assert here so that the plan number is valid in either
-    // version.
-    const major = +process.version.split('.')[0].slice(1);
-    if (major >= 14) {
-      t.fail();
-    }
-  }
+  await pump(prime(target()), source());
 });
 
 test('pump iterator protocol happy', async (/** @type {import('ava').ExecutionContext} */ t) => {

--- a/packages/where/index.d.ts
+++ b/packages/where/index.d.ts
@@ -1,1 +1,1 @@
-export { whereEndo, whereEndoSock, whereEndoLog } from './types.js';
+export { whereEndoState, whereEndoSock, whereEndoCache } from './types.js';

--- a/packages/where/index.js
+++ b/packages/where/index.js
@@ -9,7 +9,7 @@ const { raw } = String;
 /**
  * @param {{[name: string]: string}} env
  */
-const whereEndoWindows = env => {
+const whereEndoStateWindows = env => {
   // Favoring local app data over roaming app data since I don't expect to be
   // able to listen on one host and connect on another.
   if (env.LOCALAPPDATA !== undefined) {
@@ -28,11 +28,11 @@ const whereEndoWindows = env => {
 };
 
 /**
- * @type {typeof import('./types.js').whereEndo}
+ * @type {typeof import('./types.js').whereEndoState}
  */
-export const whereEndo = (platform, env) => {
+export const whereEndoState = (platform, env) => {
   if (platform === 'win32') {
-    return whereEndoWindows(env);
+    return whereEndoStateWindows(env);
   } else if (platform === 'darwin') {
     if (env.HOME !== undefined) {
       return `${env.HOME}/Library/Application Support/Endo`;
@@ -72,19 +72,19 @@ export const whereEndoSock = (platform, env) => {
 };
 
 /**
- * @type {typeof import('./types.js').whereEndoLog}
+ * @type {typeof import('./types.js').whereEndoCache}
  */
-export const whereEndoLog = (platform, env) => {
+export const whereEndoCache = (platform, env) => {
   if (platform === 'win32') {
-    return `${whereEndoWindows(env)}\\endo.log`;
+    return `${whereEndoStateWindows(env)}`;
   } else if (platform === 'darwin') {
     if (env.HOME !== undefined) {
-      return `${env.HOME}/Library/Caches/Endo/endo.log`;
+      return `${env.HOME}/Library/Caches/Endo`;
     }
   } else if (env.XDG_CACHE_HOME !== undefined) {
-    return `${env.XDG_CACHE_HOME}/endo/endo.log`;
+    return `${env.XDG_CACHE_HOME}/endo`;
   } else if (env.HOME !== undefined) {
-    return `${env.HOME}/.cache/endo/endo.log`;
+    return `${env.HOME}/.cache/endo`;
   }
-  return 'endo.log';
+  return '';
 };

--- a/packages/where/test/test-where-endo-cache.js
+++ b/packages/where/test/test-where-endo-cache.js
@@ -1,69 +1,69 @@
 import test from 'ava';
-import { whereEndoLog } from '../index.js';
+import { whereEndoCache } from '../index.js';
 
 test('windows', t => {
   t.is(
-    whereEndoLog('win32', {
+    whereEndoCache('win32', {
       LOCALAPPDATA: 'C:\\Users\\Alice\\AppData\\Local',
       APPDATA: 'C:\\Users\\Alice\\AppData',
       USERPROFILE: 'C:\\Users\\Alice',
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
-    'C:\\Users\\Alice\\AppData\\Local\\Endo\\endo.log',
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
   );
   t.is(
-    whereEndoLog('win32', {
+    whereEndoCache('win32', {
       APPDATA: 'C:\\Users\\Alice\\AppData',
       USERPROFILE: 'C:\\Users\\Alice',
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
-    'C:\\Users\\Alice\\AppData\\Endo\\endo.log',
+    'C:\\Users\\Alice\\AppData\\Endo',
   );
   t.is(
-    whereEndoLog('win32', {
+    whereEndoCache('win32', {
       USERPROFILE: 'C:\\Users\\Alice',
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
-    'C:\\Users\\Alice\\AppData\\Endo\\endo.log',
+    'C:\\Users\\Alice\\AppData\\Endo',
   );
   t.is(
-    whereEndoLog('win32', {
+    whereEndoCache('win32', {
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
-    'C:\\Users\\Alice\\AppData\\Endo\\endo.log',
+    'C:\\Users\\Alice\\AppData\\Endo',
   );
-  t.is(whereEndoLog('win32', {}), '.\\endo.log');
+  t.is(whereEndoCache('win32', {}), '.');
 });
 
 test('darwin', t => {
   t.is(
-    whereEndoLog('darwin', {
+    whereEndoCache('darwin', {
       HOME: '/Users/alice',
     }),
-    '/Users/alice/Library/Caches/Endo/endo.log',
+    '/Users/alice/Library/Caches/Endo',
   );
-  t.is(whereEndoLog('darwin', {}), 'endo.log');
+  t.is(whereEndoCache('darwin', {}), '');
 });
 
 test('linux', t => {
   t.is(
-    whereEndoLog('linux', {
+    whereEndoCache('linux', {
       XDG_CACHE_HOME: '/var/cache/users/alice',
       USER: 'alice',
       HOME: '/Users/alice',
     }),
-    '/var/cache/users/alice/endo/endo.log',
+    '/var/cache/users/alice/endo',
   );
   t.is(
-    whereEndoLog('linux', {
+    whereEndoCache('linux', {
       USER: 'alice',
       HOME: '/Users/alice',
     }),
-    '/Users/alice/.cache/endo/endo.log',
+    '/Users/alice/.cache/endo',
   );
-  t.is(whereEndoLog('linux', {}), 'endo.log');
+  t.is(whereEndoCache('linux', {}), '');
 });

--- a/packages/where/test/test-where-endo-state.js
+++ b/packages/where/test/test-where-endo-state.js
@@ -1,9 +1,9 @@
 import test from 'ava';
-import { whereEndo } from '../index.js';
+import { whereEndoState } from '../index.js';
 
 test('windows', t => {
   t.is(
-    whereEndo('win32', {
+    whereEndoState('win32', {
       LOCALAPPDATA: 'C:\\Users\\Alice\\AppData\\Local',
       APPDATA: 'C:\\Users\\Alice\\AppData',
       USERPROFILE: 'C:\\Users\\Alice',
@@ -13,7 +13,7 @@ test('windows', t => {
     'C:\\Users\\Alice\\AppData\\Local\\Endo',
   );
   t.is(
-    whereEndo('win32', {
+    whereEndoState('win32', {
       APPDATA: 'C:\\Users\\Alice\\AppData',
       USERPROFILE: 'C:\\Users\\Alice',
       HOMEDRIVE: 'C:\\',
@@ -22,7 +22,7 @@ test('windows', t => {
     'C:\\Users\\Alice\\AppData\\Endo',
   );
   t.is(
-    whereEndo('win32', {
+    whereEndoState('win32', {
       USERPROFILE: 'C:\\Users\\Alice',
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
@@ -30,38 +30,38 @@ test('windows', t => {
     'C:\\Users\\Alice\\AppData\\Endo',
   );
   t.is(
-    whereEndo('win32', {
+    whereEndoState('win32', {
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
     'C:\\Users\\Alice\\AppData\\Endo',
   );
-  t.is(whereEndo('win32', {}), '.');
+  t.is(whereEndoState('win32', {}), '.');
 });
 
 test('darwin', t => {
   t.is(
-    whereEndo('darwin', {
+    whereEndoState('darwin', {
       HOME: '/Users/alice',
     }),
     '/Users/alice/Library/Application Support/Endo',
   );
-  t.is(whereEndo('darwin', {}), 'endo');
+  t.is(whereEndoState('darwin', {}), 'endo');
 });
 
 test('linux', t => {
   t.is(
-    whereEndo('linux', {
+    whereEndoState('linux', {
       XDG_CONFIG_DIR: '/Users/alice/.config2',
       HOME: '/Users/alice',
     }),
     '/Users/alice/.config2/endo',
   );
   t.is(
-    whereEndo('linux', {
+    whereEndoState('linux', {
       HOME: '/Users/alice',
     }),
     '/Users/alice/.config/endo',
   );
-  t.is(whereEndo('linux', {}), 'endo');
+  t.is(whereEndoState('linux', {}), 'endo');
 });

--- a/packages/where/types.d.ts
+++ b/packages/where/types.d.ts
@@ -1,4 +1,4 @@
-export function whereEndo(
+export function whereEndoState(
   platform: string,
   env: { [name: string]: string },
 ): string;
@@ -6,7 +6,7 @@ export function whereEndoSock(
   platform: string,
   env: { [name: string]: string },
 ): string;
-export function whereEndoLog(
+export function whereEndoCache(
   platform: string,
   env: { [name: string]: string },
 ): string;


### PR DESCRIPTION
This change takes a number of steps toward spawning a worker which currently does nothing except support graceful termination. Commits are individually reviewable.

Refs #1036

The first change reverts eventual-messages for streams. #1028 because this unexpectedly causes data-lock for the Endo daemon. This might be because of a layering issue: the stream in question is carrying CapTP. It might be possible to recover the feature manually, but was probably unwise to lean on eventual-send anyway, on account of the layering.

The subsequent commits each make some surgical change necessary to explore outward to endo daemon workers.

In subsequent changes, this initial worker will grow the ability to run arbitrary programs under hardened JavaScript with limited access to user powers. But first, each new worker will need to initialize some plugins that provide those powers.