### PR TITLE
fix: Make scripts/set-versions suitable for external usage

### DIFF
--- a/scripts/set-versions.sh
+++ b/scripts/set-versions.sh
@@ -7,13 +7,14 @@ set -ueo pipefail
 # This is useful for consistent bulk updates over all packages.
 
 DIR=$(dirname -- "${BASH_SOURCE[0]}")
+
 VERSIONSHASH=$(git hash-object -w --stdin)
 
-cd -- "$DIR/.."
-
-yarn workspaces --json info |
-jq -r '.data | fromjson | .[].location | "\(.)/package.json"' |
-while read PACKAGEJSON; do
+(
+  echo package.json
+  yarn workspaces --json info |
+  jq -r '.data | fromjson | .[].location | "\(.)/package.json"'
+) | while read PACKAGEJSON; do
   PACKAGEJSONHASH=$(
     jq --argfile versions <(git cat-file blob "$VERSIONSHASH") '
       def update(name): if .[name] then {


### PR DESCRIPTION
This change makes it possible to, for example from an Agoric dapp, use `~/endo/scripts/get-versions.sh ~/endo | ~/endo/scripts/set-versions.sh`, to update the versions of Endo dependencies to their most up-to-date versions in a local copy of Endo in the dapp's workspace, including dependencies at the top-level of Endo, or `~/endo/scripts/all-versions.sh ~/endo | ~/endo/scripts/set-versions.sh` (*all-versions*) to sync transitive dependencies.
