### PR TITLE
fix(compartment-mapper): Relax schema check for name and label

### DIFF
--- a/packages/compartment-mapper/README.md
+++ b/packages/compartment-mapper/README.md
@@ -386,6 +386,8 @@ type CompartmentName = string;
 // to modules in other compartments, or to built-in modules.
 type Compartment = {
   location: Location,
+  name?: string,
+  label?: string,
   modules: ModuleMap,
   parsers: ParserMap,
   types: ModuleParserMap,

--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -329,16 +329,20 @@ const assertCompartment = (allegedCompartment, path, url) => {
     'string',
     `${path}.location in ${q(url)} must be string, got ${q(location)}`,
   );
-  assert.typeof(
-    name,
-    'string',
-    `${path}.name in ${q(url)} must be string, got ${q(name)}`,
-  );
-  assert.typeof(
-    label,
-    'string',
-    `${path}.label in ${q(url)} must be string, got ${q(label)}`,
-  );
+  if (name !== undefined) {
+    assert.typeof(
+      name,
+      'string',
+      `${path}.name in ${q(url)} must be string, got ${q(name)}`,
+    );
+  }
+  if (label !== undefined) {
+    assert.typeof(
+      label,
+      'string',
+      `${path}.label in ${q(url)} must be string, got ${q(label)}`,
+    );
+  }
 
   assertModules(modules, path, url);
   assertParsers(parsers, path, url);


### PR DESCRIPTION
The name and label properties of a compartment map should be optional.
This change relaxes the schema validator for compartment maps.

