### PR TITLE
fix(eventual-send): stronger (compatible) typing of `E` and `Remote`

### DIFF
--- a/packages/eventual-send/jsconfig.test.json
+++ b/packages/eventual-send/jsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./jsconfig.json",
+  "include": ["test/test-types.js"]
+}

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -13,7 +13,7 @@
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint:types": "tsc -p jsconfig.json",
+    "lint:types": "tsc -p jsconfig.test.json",
     "lint:eslint": "eslint '**/*.js'"
   },
   "repository": {

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -23,7 +23,7 @@ const baseFreezableProxyHandler = {
  * A Proxy handler for E(x).
  *
  * @param {*} x Any value passed to E(x)
- * @param {*} HandledPromise
+ * @param {import('./index').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
 function EProxyHandler(x, HandledPromise) {
@@ -47,7 +47,7 @@ function EProxyHandler(x, HandledPromise) {
  * It is a variant on the E(x) Proxy handler.
  *
  * @param {*} x Any value passed to E.sendOnly(x)
- * @param {*} HandledPromise
+ * @param {import('./index').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
 function EsendOnlyProxyHandler(x, HandledPromise) {
@@ -70,6 +70,10 @@ function EsendOnlyProxyHandler(x, HandledPromise) {
   });
 }
 
+/**
+ * @param {import('./index').HandledPromiseConstructor} HandledPromise
+ * @returns {import('./index').EProxy}
+ */
 export default function makeE(HandledPromise) {
   function E(x) {
     const handler = EProxyHandler(x, HandledPromise);

--- a/packages/eventual-send/test/prepare-test-env-ava.js
+++ b/packages/eventual-send/test/prepare-test-env-ava.js
@@ -3,5 +3,7 @@ import '@endo/lockdown/commit-debug.js';
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';
 
+export * from 'ava';
+
 /** @type {typeof rawTest} */
 export const test = wrapTest(rawTest);

--- a/packages/eventual-send/test/test-types.js
+++ b/packages/eventual-send/test/test-types.js
@@ -1,0 +1,91 @@
+// @ts-check
+import { test } from './prepare-test-env-ava.js';
+
+import { E } from './get-hp.js';
+
+/** @template T @typedef {import('../src/index').ERef<T>} ERef */
+/**
+ * @template Primary
+ * @template [Local=import('../src/index').DataOnly<Primary>]
+ * @typedef {import('@endo/eventual-send').Remote<Primary, Local>} Remote
+ */
+
+/**
+ * @template T
+ * @param {string} _iface
+ * @param {T} value
+ */
+const Far = (_iface, value) => {
+  return /** @type {T & { __Remote__: T }} */ (value);
+};
+
+/**
+ * Check the performance of the legacy ERef type.
+ *
+ * @param {import('./prepare-test-env-ava').ExecutionContext<unknown>} t
+ * @param {ERef<{ bar(): string, baz: number }>} a
+ */
+const foo = async (t, a) => {
+  const { baz } = await a;
+  t.is(baz, 42);
+
+  const bP = E(a).bar(); // bP is a promise for a string
+  t.is(Promise.resolve(bP), bP);
+  t.is(await bP, 'barRet');
+
+  // Should be type error, but isn't.
+  (await a).bar();
+
+  const bazP = E.get(a).baz; // bazP is a promise for a number
+  t.is(Promise.resolve(bazP), bazP);
+  t.is(await bazP, 42);
+
+  // Should be type error, but isn't.
+  const barP = E.get(a).bar;
+  t.is(Promise.resolve(barP), barP);
+  t.is(typeof (await barP), 'function');
+
+  t.is((await a).baz, 42);
+
+  // @ts-expect-error - calling a directly is not typed, but works.
+  a.bar();
+};
+
+/**
+ * Check the performance of Remote<T>.
+ *
+ * @param {import('./prepare-test-env-ava').ExecutionContext<unknown>} t
+ * @param {Remote<{ bar(): string, baz: number }>} a
+ */
+const foo2 = async (t, a) => {
+  const { baz } = await a;
+  t.is(baz, 42);
+
+  const bP = E(a).bar(); // bP is a promise for a string
+  t.is(Promise.resolve(bP), bP);
+  t.is(await bP, 'barRet');
+
+  // @ts-expect-error - awaiting remotes cannot get functions
+  (await a).bar();
+
+  const bazP = E.get(a).baz; // bazP is a promise for a number
+  t.is(Promise.resolve(bazP), bazP);
+  t.is(await bazP, 42);
+
+  // @ts-expect-error - E.get cannot obtain remote functions
+  const barP = E.get(a).bar;
+  t.is(Promise.resolve(barP), barP);
+  t.is(typeof (await barP), 'function');
+
+  t.is((await a).baz, 42);
+
+  // @ts-expect-error - calling a directly is not typed, but works.
+  a.bar();
+};
+
+test('check types', async t => {
+  const f = Far('foo remote', { bar: () => 'barRet', baz: 42 });
+
+  await foo(t, f);
+  await foo2(t, f);
+});

--- a/packages/far/src/index.js
+++ b/packages/far/src/index.js
@@ -2,17 +2,27 @@ export { E } from '@endo/eventual-send';
 export { Far, getInterfaceOf, passStyleOf } from '@endo/marshal';
 
 /**
+ * @template Primary
+ * @template [Local=import('@endo/eventual-send').DataOnly<Primary>]
+ * @typedef {import('@endo/eventual-send').Remote<Primary, Local>} Remote
+ * Declare an object that is potentially a far reference of type Primary whose
+ * near reference has type Local.  This should be used only for arguments and
+ * declarations; the only creators of Remote values are distributed object
+ * creator components like the `Far` or `Remotable` functions.
+ */
+
+/**
  * @template T
  * @typedef {import('@endo/eventual-send').ERef<T>} ERef
- * Declare that `T` can be either a near or far reference.  This should be used
- * only for arguments and declarations; return values should specifically be
- * `Promise<T>` or `T` itself.
+ * Declare that `T` may or may not be a Promise.  This should be used only for
+ * arguments and declarations; return values should specifically be `Promise<T>`
+ * or `T` itself.
  */
 
 /**
  * @template T
  * @typedef {import('@endo/eventual-send').EOnly<T>} EOnly
- * A type that must only be invoked with E.  It supports the `T` interface
- * interface but additionally permits functions to return `PromiseLike`s even if
- * `T` declares them as only synchronous.
+ * Declare a near object that must only be invoked with E, even locally.  It
+ * supports the `T` interface but additionally permits `T`'s methods to return
+ * `PromiseLike`s even if `T` declares them as only synchronous.
  */

--- a/packages/marshal/src/make-far.js
+++ b/packages/marshal/src/make-far.js
@@ -71,6 +71,7 @@ const assertCanBeRemotable = candidate =>
  *
  * // https://github.com/Agoric/agoric-sdk/issues/804
  *
+ * @template T
  * @param {InterfaceSpec} [iface='Remotable'] The interface specification for
  * the remotable. For now, a string iface must be "Remotable" or begin with
  * "Alleged: ", to serve as the alleged name. More general ifaces are not yet
@@ -82,13 +83,13 @@ const assertCanBeRemotable = candidate =>
  * Carol's `iface` as misrepresented by VatA.
  * @param {undefined} [props=undefined] Currently may only be undefined.
  * That plan is that own-properties are copied to the remotable
- * @param {any} [remotable={}] The object used as the remotable
- * @returns {any} remotable, modified for debuggability
+ * @param {T} [remotable={}] The object used as the remotable
+ * @returns {T & { __Remote__: T }} remotable, modified for debuggability
  */
 export const Remotable = (
   iface = 'Remotable',
   props = undefined,
-  remotable = {},
+  remotable = /** @type {T} */ ({}),
 ) => {
   assertIface(iface);
   assert(iface);
@@ -128,7 +129,7 @@ export const Remotable = (
   // COMMITTED!
   // We're committed, so keep the interface for future reference.
   assert(iface !== undefined); // To make TypeScript happy
-  return remotable;
+  return /** @type {T & { __Remote__: T }} */ (remotable);
 };
 harden(Remotable);
 
@@ -138,11 +139,10 @@ harden(Remotable);
  * @template T
  * @param {string} farName This name will be prepended with `Alleged: `
  * for now to form the `Remotable` `iface` argument.
- * @param {T|undefined} [remotable={}] The object used as the remotable
- * @returns {T} remotable, modified for debuggability
+ * @param {T} [remotable={}] The object used as the remotable
  */
 export const Far = (farName, remotable = undefined) => {
-  const r = remotable === undefined ? {} : remotable;
+  const r = remotable === undefined ? /** @type {T} */ ({}) : remotable;
   return Remotable(`Alleged: ${farName}`, undefined, r);
 };
 harden(Far);


### PR DESCRIPTION
First, a little change to propagate types from `@endo/eventual-send`'s `E` to the outside world.

Then, a more ambitious change to instate a proper `Remote<Primary, Local=DataOnly<Primary>>` type that enforces the rules of our distributed object system.  This helps prevent the `(await o).myMethod()` cheat that worked locally but failed when `o` was not the primary remotable.