### PR TITLE
Pure Babel

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,6 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@agoric/babel-standalone": "^7.14.3",
     "@endo/compartment-mapper": "^0.7.0",
     "@endo/daemon": "^0.1.7",
     "@endo/eventual-send": "^0.14.7",

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -1,7 +1,6 @@
 /* global process */
 
 // Establish a perimeter:
-import '@agoric/babel-standalone';
 import 'ses';
 import '@endo/eventual-send/shim.js';
 import '@endo/lockdown/commit.js';

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -34,7 +34,6 @@
     "test": "ava"
   },
   "dependencies": {
-    "@agoric/babel-standalone": "^7.14.3",
     "@endo/captp": "^2.0.2",
     "@endo/eventual-send": "^0.14.7",
     "@endo/far": "^0.1.8",

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -3,7 +3,6 @@
 /* global process, setTimeout */
 
 // Establish a perimeter:
-import '@agoric/babel-standalone';
 import 'ses';
 import '@endo/eventual-send/shim.js';
 import '@endo/lockdown/commit.js';

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -3,7 +3,6 @@
 /* global process */
 
 // Establish a perimeter:
-import '@agoric/babel-standalone';
 import 'ses';
 import '@endo/eventual-send/shim.js';
 import '@endo/lockdown/commit.js';

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -2,7 +2,6 @@
 /* global process */
 
 // Establish a perimeter:
-import '@agoric/babel-standalone';
 import 'ses';
 import '@endo/eventual-send/shim.js';
 import '@endo/lockdown/commit-debug.js';

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -24,7 +24,6 @@
     "ava": "^3.12.1"
   },
   "dependencies": {
-    "@agoric/babel-standalone": "^7.14.3",
     "@endo/eventual-send": "^0.14.7",
     "@endo/lockdown": "^0.1.8"
   },

--- a/packages/init/pre-bundle-source.js
+++ b/packages/init/pre-bundle-source.js
@@ -1,7 +1,7 @@
 // pre-bundle-source.js - initialization to use @endo/bundle-source
+// DEPRECATED: no longer necessary, imports of this module can be replaced with
+//   import '@endo/init';
+// or if further vetted shim initialization is needed:
+//   import '@endo/init/pre.js';
 
 import './pre.js';
-
-// TODO Remove babel-standalone preinitialization
-// https://github.com/endojs/endo/issues/768
-import '@agoric/babel-standalone';

--- a/packages/ses-integration-test/scaffolding/rollup/test-rollup.config.js
+++ b/packages/ses-integration-test/scaffolding/rollup/test-rollup.config.js
@@ -15,12 +15,7 @@ export default [
     ],
     plugins: [
       resolve({
-        only: [
-          'ses',
-          '@agoric/make-hardener',
-          '@agoric/transform-module',
-          '@agoric/babel-standalone',
-        ],
+        only: ['ses', '@agoric/make-hardener', '@agoric/transform-module'],
       }),
       commonjs(),
     ],

--- a/packages/ses/test262/make-importer.js.SKIP
+++ b/packages/ses/test262/make-importer.js.SKIP
@@ -8,12 +8,10 @@ import {
   makeModuleTransformer,
   makeModuleAnalyzer,
 } from '../src/transforms.js';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import * as babelCore from '@babel/core';
 
 import makeImporter, * as mi from '@agoric/make-importer';
 
-const typeAnalyzers = { module: makeModuleAnalyzer(babelCore) };
+const typeAnalyzers = { module: makeModuleAnalyzer() };
 
 test262Runner({
   testDirs: [
@@ -130,7 +128,7 @@ test262Runner({
       analyze: mi.makeTypeAnalyzer(typeAnalyzers),
       rootLinker: mi.makeEvaluateLinker(evaluateProgram),
     });
-    transforms[0] = makeModuleTransformer(babelCore, importer);
+    transforms[0] = makeModuleTransformer(null, importer);
 
     await importer(
       { specifier: testInfo.relativePath, referrer: `${testInfo.rootUrl}/` },

--- a/packages/static-module-record/DESIGN.md
+++ b/packages/static-module-record/DESIGN.md
@@ -12,8 +12,7 @@ record's metadata, evaluate the functor, call the functor with linkage.
 
 ```js
 import { makeModuleAnalyzer } from './src/transform-analyze.js';
-import * as babel from '@agoric/babel-standalone';
-const analyze = makeModuleAnalyzer(babel.default);
+const analyze = makeModuleAnalyzer();
 const moduleAnalysis = analyze(moduleSource);
 const moduleFunctor = evaluateModuleFunctor(moduleAnalysis.functorSource, /* ... */);
 moduleFunctor({

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -35,7 +35,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "@agoric/babel-standalone": "^7.14.3",
+    "@agoric/babel-generator": "^7.17.6",
+    "@babel/parser": "^7.17.3",
+    "@babel/traverse": "^7.17.3",
+    "@babel/types": "^7.17.0",
     "ses": "^0.15.10"
   },
   "devDependencies": {

--- a/packages/static-module-record/src/static-module-record.js
+++ b/packages/static-module-record/src/static-module-record.js
@@ -1,7 +1,5 @@
 /* eslint no-underscore-dangle: ["off"] */
 
-// import babel from '@agoric/babel-standalone';
-import * as babelStar from '@agoric/babel-standalone';
 import { makeModuleAnalyzer } from './transform-analyze.js';
 
 const { freeze, keys } = Object;
@@ -30,7 +28,7 @@ const { freeze, keys } = Object;
 //     babel:     linker error: no export named default
 //     babelStar: exports
 
-const analyzeModule = makeModuleAnalyzer(babelStar.default || babelStar);
+const analyzeModule = makeModuleAnalyzer();
 
 /**
  * StaticModuleRecord captures the effort of parsing and analyzing module text

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,14 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@agoric/babel-standalone@^7.14.3":
+"@agoric/babel-generator@^7.17.6":
   version "7.17.6"
-  resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.17.6.tgz#2d53829242627c472807a0456af91dca6258d90d"
-  integrity sha512-kuxQh+M1gd8gdbX6bvTCU3MMo5KX/CYjwk7FBZ2vkB1v+NYub4+qUYZjT+nLguizGRaMmfBNcLTCqXvepGXviw==
+  resolved "https://registry.yarnpkg.com/@agoric/babel-generator/-/babel-generator-7.17.6.tgz#75ff4629468a481d670b4154bcfade11af6de674"
+  integrity sha512-D2wnk5fGajxMN5SCRSaA/triQGEaEX2Du0EzrRqobuD4wRXjvtF1e7jC1PPOk/RC2bZ8/0fzp0CHOiB7YLwb5w==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
 
 "@ava/babel@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
Remove our reliance on `@agoric/babel-standalone`, and instead compose `@babel/parser`, `@babel/traverse`, and `@agoric/babel-generator`.
