### PR TITLE
chore: release

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.21](https://github.com/endojs/endo/compare/@endo/base64@0.2.20...@endo/base64@0.2.21) (2022-03-07)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/base64@0.2.19...@endo/base64@0.2.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Transcodes base64",
   "keywords": [
     "base64",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.1.1](https://github.com/endojs/endo/compare/@endo/bundle-source@2.1.0...@endo/bundle-source@2.1.1) (2022-03-07)
+
+**Note:** Version bump only for package @endo/bundle-source
+
+
+
+
+
 ## [2.1.0](https://github.com/endojs/endo/compare/@endo/bundle-source@2.0.7...@endo/bundle-source@2.1.0) (2022-03-02)
 
 

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",
@@ -19,8 +19,8 @@
     "@agoric/babel-generator": "^7.17.4",
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
-    "@endo/base64": "^0.2.20",
-    "@endo/compartment-mapper": "^0.7.0",
+    "@endo/base64": "^0.2.21",
+    "@endo/compartment-mapper": "^0.7.1",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "acorn": "^8.2.4",
@@ -28,9 +28,9 @@
     "source-map": "^0.7.3"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.36",
-    "@endo/lockdown": "^0.1.8",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/init": "^0.5.37",
+    "@endo/lockdown": "^0.1.9",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.0.3](https://github.com/endojs/endo/compare/@endo/captp@2.0.2...@endo/captp@2.0.3) (2022-03-07)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ### [2.0.2](https://github.com/endojs/endo/compare/@endo/captp@2.0.1...@endo/captp@2.0.2) (2022-03-02)
 
 **Note:** Version bump only for package @endo/captp

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [
@@ -40,16 +40,16 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.36",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/init": "^0.5.37",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.14.7",
-    "@endo/marshal": "^0.6.2",
-    "@endo/nat": "^4.1.7",
-    "@endo/promise-kit": "^0.2.36"
+    "@endo/eventual-send": "^0.14.8",
+    "@endo/marshal": "^0.6.3",
+    "@endo/nat": "^4.1.8",
+    "@endo/promise-kit": "^0.2.37"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.2](https://github.com/endojs/endo/compare/@endo/check-bundle@0.1.1...@endo/check-bundle@0.1.2) (2022-03-07)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### 0.1.1 (2022-03-02)
 
 

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",
@@ -37,13 +37,13 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.20",
-    "@endo/compartment-mapper": "^0.7.0"
+    "@endo/base64": "^0.2.21",
+    "@endo/compartment-mapper": "^0.7.1"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.1.0",
-    "@endo/eslint-config": "^0.4.5",
-    "@endo/init": "^0.5.36",
+    "@endo/bundle-source": "^2.1.1",
+    "@endo/eslint-config": "^0.4.6",
+    "@endo/init": "^0.5.37",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.21](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.20...@endo/cjs-module-analyzer@0.2.21) (2022-03-07)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.19...@endo/cjs-module-analyzer@0.2.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",
@@ -29,7 +29,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.8](https://github.com/endojs/endo/compare/@endo/cli@0.1.7...@endo/cli@0.1.8) (2022-03-07)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [0.1.7](https://github.com/endojs/endo/compare/@endo/cli@0.1.6...@endo/cli@0.1.7) (2022-03-02)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Endo command line interface",
   "keywords": [],
   "author": "Endo contributors",
@@ -24,16 +24,16 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/compartment-mapper": "^0.7.0",
-    "@endo/daemon": "^0.1.7",
-    "@endo/eventual-send": "^0.14.7",
-    "@endo/lockdown": "^0.1.8",
-    "@endo/where": "^0.2.2",
+    "@endo/compartment-mapper": "^0.7.1",
+    "@endo/daemon": "^0.1.8",
+    "@endo/eventual-send": "^0.14.8",
+    "@endo/lockdown": "^0.1.9",
+    "@endo/where": "^0.2.3",
     "commander": "^5.0.0",
-    "ses": "^0.15.10"
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.7.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.0...@endo/compartment-mapper@0.7.1) (2022-03-07)
+
+**Note:** Version bump only for package @endo/compartment-mapper
+
+
+
+
+
 ## [0.7.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.7...@endo/compartment-mapper@0.7.0) (2022-03-02)
 
 

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -41,13 +41,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/cjs-module-analyzer": "^0.2.20",
-    "@endo/static-module-record": "^0.6.15",
-    "@endo/zip": "^0.2.20",
-    "ses": "^0.15.10"
+    "@endo/cjs-module-analyzer": "^0.2.21",
+    "@endo/static-module-record": "^0.7.0",
+    "@endo/zip": "^0.2.21",
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.8](https://github.com/endojs/endo/compare/@endo/daemon@0.1.7...@endo/daemon@0.1.8) (2022-03-07)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ### [0.1.7](https://github.com/endojs/endo/compare/@endo/daemon@0.1.6...@endo/daemon@0.1.7) (2022-03-02)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Endo daemon",
   "keywords": [
     "endo",
@@ -34,19 +34,19 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/captp": "^2.0.2",
-    "@endo/eventual-send": "^0.14.7",
-    "@endo/far": "^0.1.8",
-    "@endo/lockdown": "^0.1.8",
-    "@endo/netstring": "^0.3.6",
-    "@endo/promise-kit": "^0.2.36",
-    "@endo/stream": "^0.3.5",
-    "@endo/stream-node": "^0.2.6",
-    "@endo/where": "^0.2.2",
-    "ses": "^0.15.10"
+    "@endo/captp": "^2.0.3",
+    "@endo/eventual-send": "^0.14.8",
+    "@endo/far": "^0.1.9",
+    "@endo/lockdown": "^0.1.9",
+    "@endo/netstring": "^0.3.7",
+    "@endo/promise-kit": "^0.2.37",
+    "@endo/stream": "^0.3.6",
+    "@endo/stream-node": "^0.2.7",
+    "@endo/where": "^0.2.3",
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.4.6](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.5...@endo/eslint-config@0.4.6) (2022-03-07)
+
+**Note:** Version bump only for package @endo/eslint-config
+
+
+
+
+
 ### [0.4.5](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.4...@endo/eslint-config@0.4.5) (2022-03-02)
 
 **Note:** Version bump only for package @endo/eslint-config

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-config",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Endo style rules",
   "keywords": [
     "endo",
@@ -24,7 +24,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/eslint-plugin": "^0.3.23",
+    "@endo/eslint-plugin": "^0.3.24",
     "@jessie.js/eslint-plugin": "^0.1.1"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.24](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.23...@endo/eslint-plugin@0.3.24) (2022-03-07)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ### [0.3.23](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.22...@endo/eslint-plugin@0.3.23) (2022-03-02)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Endo-specific ESLint plugin",
   "keywords": [
     "eslint",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.14.8](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.7...@endo/eventual-send@0.14.8) (2022-03-07)
+
+
+### Features
+
+* **eventual-send:** provide typing for `Remote<Primary, Local>` ([4d28509](https://github.com/endojs/endo/commit/4d285095a6ea1a78f1a3a4696bc822f5e4dfd43f))
+
+
+### Bug Fixes
+
+* **eventual-send:** properly declare `E` to be type `EProxy` ([3bdfdf7](https://github.com/endojs/endo/commit/3bdfdf77440f9ddea9bac1e783aaf015e9bcfa62))
+
+
+
 ### [0.14.7](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.6...@endo/eventual-send@0.14.7) (2022-03-02)
 
 **Note:** Version bump only for package @endo/eventual-send

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/lockdown": "^0.1.8",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/lockdown": "^0.1.9",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.9](https://github.com/endojs/endo/compare/@endo/far@0.1.8...@endo/far@0.1.9) (2022-03-07)
+
+
+### Features
+
+* **far:** export `Remote<Primary, Local>` ([f406cb6](https://github.com/endojs/endo/commit/f406cb6b8658d457fdfda20c71ff844a8eea8112))
+
+
+
 ### [0.1.8](https://github.com/endojs/endo/compare/@endo/far@0.1.7...@endo/far@0.1.8) (2022-03-02)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",
@@ -26,12 +26,12 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.14.7",
-    "@endo/marshal": "^0.6.2"
+    "@endo/eventual-send": "^0.14.8",
+    "@endo/marshal": "^0.6.3"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.36",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/init": "^0.5.37",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.41](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.40...@endo/import-bundle@0.2.41) (2022-03-07)
+
+**Note:** Version bump only for package @endo/import-bundle
+
+
+
+
+
 ### [0.2.40](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.39...@endo/import-bundle@0.2.40) (2022-03-02)
 
 **Note:** Version bump only for package @endo/import-bundle

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "load modules created by @endo/bundle-source",
   "type": "module",
   "main": "src/index.js",
@@ -18,13 +18,13 @@
     "lint": "eslint '**/*.js'"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.20",
-    "@endo/compartment-mapper": "^0.7.0"
+    "@endo/base64": "^0.2.21",
+    "@endo/compartment-mapper": "^0.7.1"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.1.0",
-    "@endo/init": "^0.5.36",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/bundle-source": "^2.1.1",
+    "@endo/init": "^0.5.37",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.37](https://github.com/endojs/endo/compare/@endo/init@0.5.36...@endo/init@0.5.37) (2022-03-07)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [0.5.36](https://github.com/endojs/endo/compare/@endo/init@0.5.35...@endo/init@0.5.36) (2022-03-02)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",
@@ -24,8 +24,8 @@
     "ava": "^3.12.1"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.14.7",
-    "@endo/lockdown": "^0.1.8"
+    "@endo/eventual-send": "^0.14.8",
+    "@endo/lockdown": "^0.1.9"
   },
   "files": [
     "LICENSE*",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.9](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.8...@endo/lockdown@0.1.9) (2022-03-07)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [0.1.8](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.7...@endo/lockdown@0.1.8) (2022-03-02)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
@@ -16,7 +16,7 @@
     "ava": "^3.12.1"
   },
   "dependencies": {
-    "ses": "^0.15.10"
+    "ses": "^0.15.11"
   },
   "files": [
     "LICENSE*",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.7](https://github.com/endojs/endo/compare/@endo/lp32@0.3.6...@endo/lp32@0.3.7) (2022-03-07)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [0.3.6](https://github.com/endojs/endo/compare/@endo/lp32@0.3.5...@endo/lp32@0.3.6) (2022-03-02)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",
@@ -44,13 +44,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.36",
-    "@endo/stream": "^0.3.5",
-    "ses": "^0.15.10"
+    "@endo/init": "^0.5.37",
+    "@endo/stream": "^0.3.6",
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/eslint-config": "^0.4.6",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.3](https://github.com/endojs/endo/compare/@endo/marshal@0.6.2...@endo/marshal@0.6.3) (2022-03-07)
+
+
+### Features
+
+* **marshal:** have `Remotable` create `Remote<T>`-compatible objs ([1ba89ba](https://github.com/endojs/endo/commit/1ba89ba922275f08d3b7b8c82fae0dca31752321))
+
+
+
 ### [0.6.2](https://github.com/endojs/endo/compare/@endo/marshal@0.6.1...@endo/marshal@0.6.2) (2022-03-02)
 
 **Note:** Version bump only for package @endo/marshal

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "marshal",
   "type": "module",
   "main": "index.js",
@@ -37,13 +37,13 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.14.7",
-    "@endo/nat": "^4.1.7",
-    "@endo/promise-kit": "^0.2.36"
+    "@endo/eventual-send": "^0.14.8",
+    "@endo/nat": "^4.1.8",
+    "@endo/promise-kit": "^0.2.37"
   },
   "devDependencies": {
-    "@endo/lockdown": "^0.1.8",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/lockdown": "^0.1.9",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.8](https://github.com/endojs/endo/compare/@endo/nat@4.1.7...@endo/nat@4.1.8) (2022-03-07)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [4.1.7](https://github.com/endojs/endo/compare/@endo/nat@4.1.6...@endo/nat@4.1.7) (2022-03-02)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.7.0",
+    "@endo/compartment-mapper": "^0.7.1",
     "ava": "^3.12.1",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "ses": "^0.15.10"
+    "ses": "^0.15.11"
   },
   "directories": {
     "test": "test"

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.7](https://github.com/endojs/endo/compare/@endo/netstring@0.3.6...@endo/netstring@0.3.7) (2022-03-07)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [0.3.6](https://github.com/endojs/endo/compare/@endo/netstring@0.3.5...@endo/netstring@0.3.6) (2022-03-02)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,12 +32,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.36",
-    "@endo/stream": "^0.3.5",
-    "ses": "^0.15.10"
+    "@endo/init": "^0.5.37",
+    "@endo/stream": "^0.3.6",
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.37](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.36...@endo/promise-kit@0.2.37) (2022-03-07)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [0.2.36](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.35...@endo/promise-kit@0.2.36) (2022-03-02)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "description": "Helper for making promises",
   "keywords": [
     "promise"
@@ -34,11 +34,11 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "ses": "^0.15.10"
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/eslint-config": "^0.4.6",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.21](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.20...@endo/ses-ava@0.2.21) (2022-03-07)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.19...@endo/ses-ava@0.2.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -33,10 +33,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.15.10"
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.11](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.10...ses-integration-test@3.0.11) (2022-03-07)
+
+**Note:** Version bump only for package ses-integration-test
+
+
+
+
+
 ### [3.0.10](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.9...ses-integration-test@3.0.10) (2022-03-02)
 
 **Note:** Version bump only for package ses-integration-test

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,10 +30,10 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.15.10"
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses-types-test/CHANGELOG.md
+++ b/packages/ses-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.18](https://github.com/endojs/endo/compare/@endo/ses-types-test@0.1.17...@endo/ses-types-test@0.1.18) (2022-03-07)
+
+**Note:** Version bump only for package @endo/ses-types-test
+
+
+
+
+
 ### [0.1.17](https://github.com/endojs/endo/compare/@endo/ses-types-test@0.1.16...@endo/ses-types-test@0.1.17) (2022-03-02)
 
 **Note:** Version bump only for package @endo/ses-types-test

--- a/packages/ses-types-test/package.json
+++ b/packages/ses-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-types-test",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "description": "TypeScript validation for SES types.",
   "keywords": [],
@@ -25,10 +25,10 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "ses": "^0.15.10"
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.15.11](https://github.com/endojs/endo/compare/ses@0.15.10...ses@0.15.11) (2022-03-07)
+
+**Note:** Version bump only for package ses
+
+
+
+
+
 ### [0.15.10](https://github.com/endojs/endo/compare/ses@0.15.9...ses@0.15.10) (2022-03-02)
 
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",
@@ -59,10 +59,10 @@
     "test:platform-compatability": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.7.0",
-    "@endo/eslint-config": "^0.4.5",
-    "@endo/static-module-record": "^0.6.15",
-    "@endo/test262-runner": "^0.1.21",
+    "@endo/compartment-mapper": "^0.7.1",
+    "@endo/eslint-config": "^0.4.6",
+    "@endo/static-module-record": "^0.7.0",
+    "@endo/test262-runner": "^0.1.22",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.0](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.15...@endo/static-module-record@0.7.0) (2022-03-07)
+
+
+### ⚠ BREAKING CHANGES
+
+* **static-module-record:** remove dependencies on `@babel/standalone`
+
+### Bug Fixes
+
+* **static-module-record:** remove dependencies on `@babel/standalone` ([1a1d1a4](https://github.com/endojs/endo/commit/1a1d1a4f5a7094f32d3e1edfc620e64065771efa))
+
+
+
 ### [0.6.15](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.14...@endo/static-module-record@0.6.15) (2022-03-02)
 
 

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.6.15",
+  "version": "0.7.0",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -39,12 +39,12 @@
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
     "@babel/types": "^7.17.0",
-    "ses": "^0.15.10"
+    "ses": "^0.15.11"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
-    "@endo/eslint-config": "^0.4.5",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/eslint-config": "^0.4.6",
+    "@endo/ses-ava": "^0.2.21",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.7](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.6...@endo/stream-node@0.2.7) (2022-03-07)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.5...@endo/stream-node@0.2.6) (2022-03-02)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",
@@ -38,13 +38,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.36",
-    "@endo/stream": "^0.3.5",
-    "ses": "^0.15.10"
+    "@endo/init": "^0.5.37",
+    "@endo/stream": "^0.3.6",
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/eslint-config": "^0.4.6",
+    "@endo/ses-ava": "^0.2.21",
     "@typescript-eslint/parser": "^5.10.2",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.18](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.17...@endo/stream-types-test@0.1.18) (2022-03-07)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [0.1.17](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.16...@endo/stream-types-test@0.1.17) (2022-03-02)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],
@@ -25,11 +25,11 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "@endo/stream": "^0.3.5",
-    "ses": "^0.15.10"
+    "@endo/stream": "^0.3.6",
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.6](https://github.com/endojs/endo/compare/@endo/stream@0.3.5...@endo/stream@0.3.6) (2022-03-07)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [0.3.5](https://github.com/endojs/endo/compare/@endo/stream@0.3.4...@endo/stream@0.3.5) (2022-03-02)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",
@@ -38,13 +38,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.14.7",
-    "ses": "^0.15.10"
+    "@endo/eventual-send": "^0.14.8",
+    "ses": "^0.15.11"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
-    "@endo/init": "^0.5.36",
-    "@endo/ses-ava": "^0.2.20",
+    "@endo/eslint-config": "^0.4.6",
+    "@endo/init": "^0.5.37",
+    "@endo/ses-ava": "^0.2.21",
     "@typescript-eslint/parser": "^5.10.2",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.21](https://github.com/endojs/endo/compare/@endo/syrup@0.1.20...@endo/syrup@0.1.21) (2022-03-07)
+
+**Note:** Version bump only for package @endo/syrup
+
+
+
+
+
 ### [0.1.20](https://github.com/endojs/endo/compare/@endo/syrup@0.1.19...@endo/syrup@0.1.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/syrup

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.22](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.21...@endo/test262-runner@0.1.22) (2022-03-07)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.21](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.20...@endo/test262-runner@0.1.21) (2022-03-02)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "description": "Test262 Runner",
   "author": "Agoric",
@@ -17,7 +17,7 @@
     "test262-parser": "^2.2.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "sinon": "8.0.4"
   },
   "ava": {

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.3](https://github.com/endojs/endo/compare/@endo/where@0.2.2...@endo/where@0.2.3) (2022-03-07)
+
+**Note:** Version bump only for package @endo/where
+
+
+
+
+
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/where@0.2.1...@endo/where@0.2.2) (2022-03-02)
 
 **Note:** Version bump only for package @endo/where

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": null,
   "description": "Description forthcoming.",
   "keywords": [],
@@ -34,7 +34,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.21](https://github.com/endojs/endo/compare/@endo/zip@0.2.20...@endo/zip@0.2.21) (2022-03-07)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/zip@0.2.19...@endo/zip@0.2.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/zip

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",
@@ -35,7 +35,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.5",
+    "@endo/eslint-config": "^0.4.6",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",


### PR DESCRIPTION
This will publish the new StaticModuleRecord that does not depend on babel-standalone.
