### PR TITLE
fix(static-module-record): use `Object.create(null)` to prevent crashes

### DIFF
--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -52,18 +52,18 @@ const makeCreateStaticRecord = transformSource =>
       sourceType: 'module',
       // exportNames of variables that are only initialized and used, but
       // never assigned to.
-      fixedExportMap: {},
+      fixedExportMap: Object.create(null),
       // Record of imported module specifier names to list of importNames.
       // The importName '*' is that module's module namespace object.
-      imports: {},
+      imports: Object.create(null),
       // List of module specifiers that we export all from.
       exportAlls: [],
       // exportNames of variables that are assigned to, or reexported and
       // therefore assumed live. A reexported variable might not have any
       // localName.
-      liveExportMap: {},
+      liveExportMap: Object.create(null),
       hoistedDecls: [],
-      importSources: {},
+      importSources: Object.create(null),
       importDecls: [],
     };
     if (moduleSource.startsWith('#!')) {

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -623,6 +623,26 @@ test('export all', t => {
 
 // TODO cross product let, class, maybe var:
 
+test('Object.hasOwnProperty override mistake should not crash transform', t => {
+  const { __fixedExportMap__ } = new StaticModuleRecord(`
+    const { hasOwnProperty } = Object;
+    export { hasOwnProperty };
+  `);
+  t.deepEqual(__fixedExportMap__, { hasOwnProperty: ['hasOwnProperty'] });
+
+  const { __liveExportMap__ } = new StaticModuleRecord(`
+    let hop = 1;
+    ({ hasOwnProperty: hop } = Object);
+    export { hop as hasOwnProperty };
+  `);
+  t.deepEqual(__liveExportMap__, { hasOwnProperty: ['hop', true] });
+
+  const { imports } = new StaticModuleRecord(`
+    import { hasOwnProperty } from 'hasOwnProperty';
+  `);
+  t.deepEqual(imports, ['hasOwnProperty']);
+});
+
 test('export function should be fixed when not assigned', t => {
   const { __fixedExportMap__, __liveExportMap__ } = new StaticModuleRecord(`
     export function work() {}


### PR DESCRIPTION
Closes #1108.

Avoid assignment of proporties to Object with a prototype.
