### PR TITLE
Handle user code catching errors from require

### DIFF
--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/README.md
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/README.md
@@ -1,0 +1,1 @@
+Catches the error thrown by require and tries again

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/getmissing.js
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/getmissing.js
@@ -1,0 +1,2 @@
+module.exports = 42;
+require('obviouslymissing');

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/main.js
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/main.js
@@ -1,0 +1,5 @@
+try {
+  const a = require('./getmissing');
+} catch (e) {
+  const a = require('./getmissing');
+}

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/package.json
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "catch",
+  "version": "1.0.0",
+  "main": "./main.js"
+}

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/README.md
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/README.md
@@ -1,0 +1,1 @@
+Throws falsy to trip up error caching mechanisms.

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/main.js
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/main.js
@@ -1,0 +1,5 @@
+try {
+  require('what-the-falsy/throws-falsy')
+} catch (_) {
+  require('what-the-falsy/throws-falsy')
+}

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/package.json
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "what-the-falsy",
+  "version": "1.0.0",
+  "main": "./main.js"
+}

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/throws-falsy.js
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/throws-falsy.js
@@ -1,0 +1,1 @@
+throw (Math.random() > 0.5) ? false : undefined;

--- a/packages/compartment-mapper/test/test-error-handling.js
+++ b/packages/compartment-mapper/test/test-error-handling.js
@@ -81,3 +81,17 @@ scaffold(
     shouldFailBeforeArchiveOperations: false,
   },
 );
+
+scaffold(
+  'fixtures-error-handling / throw falsy',
+  test,
+  fixtureUrl('fixtures-error-handling/node_modules/what-the-falsy/main.js'),
+  assertFixture,
+  fixtureAssertionCount,
+  {
+    onError: (t, { error, _title }) => {
+      t.assert(!error);
+    },
+    shouldFailBeforeArchiveOperations: false,
+  },
+);

--- a/packages/compartment-mapper/test/test-error-handling.js
+++ b/packages/compartment-mapper/test/test-error-handling.js
@@ -67,3 +67,17 @@ scaffold(
     shouldFailBeforeArchiveOperations: true,
   },
 );
+
+scaffold(
+  'fixtures-error-handling / catch',
+  test,
+  fixtureUrl('fixtures-error-handling/node_modules/catch/main.js'),
+  assertFixture,
+  fixtureAssertionCount,
+  {
+    onError: (t, { error, _title }) => {
+      t.regex(error.message, /obviouslymissing/);
+    },
+    shouldFailBeforeArchiveOperations: false,
+  },
+);

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -80,19 +80,25 @@ export const makeThirdPartyModuleInstance = (
   }
 
   let activated = false;
+  let failed = false;
   return freeze({
     notifiers,
     exportsProxy,
     execute() {
-      if (!activated) {
+      if (!activated || failed) {
         activate();
         activated = true;
-        // eslint-disable-next-line @endo/no-polymorphic-call
-        staticModuleRecord.execute(
-          proxiedExports,
-          compartment,
-          resolvedImports,
-        );
+        try {
+          // eslint-disable-next-line @endo/no-polymorphic-call
+          staticModuleRecord.execute(
+            proxiedExports,
+            compartment,
+            resolvedImports,
+          );
+        } catch (err) {
+          failed = true;
+          throw err;
+        }
       }
     },
   });

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -80,12 +80,15 @@ export const makeThirdPartyModuleInstance = (
   }
 
   let activated = false;
-  let failed = false;
+  let errorFromExecute;
   return freeze({
     notifiers,
     exportsProxy,
     execute() {
-      if (!activated || failed) {
+      if (errorFromExecute) {
+        throw errorFromExecute;
+      }
+      if (!activated) {
         activate();
         activated = true;
         try {
@@ -96,7 +99,7 @@ export const makeThirdPartyModuleInstance = (
             resolvedImports,
           );
         } catch (err) {
-          failed = true;
+          errorFromExecute = err;
           throw err;
         }
       }

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -17,6 +17,7 @@ import {
   keys,
   mapGet,
   weakmapGet,
+  reflectHas,
 } from './commons.js';
 import { compartmentEvaluate } from './compartment-evaluate.js';
 
@@ -79,18 +80,19 @@ export const makeThirdPartyModuleInstance = (
     };
   }
 
-  let activated = false;
-  let errorFromExecute;
+  const localState = {
+    activated: false,
+  };
   return freeze({
     notifiers,
     exportsProxy,
     execute() {
-      if (errorFromExecute) {
-        throw errorFromExecute;
+      if (reflectHas(localState, 'errorFromExecute')) {
+        throw localState.errorFromExecute;
       }
-      if (!activated) {
+      if (!localState.activated) {
         activate();
-        activated = true;
+        localState.activated = true;
         try {
           // eslint-disable-next-line @endo/no-polymorphic-call
           staticModuleRecord.execute(
@@ -99,7 +101,7 @@ export const makeThirdPartyModuleInstance = (
             resolvedImports,
           );
         } catch (err) {
-          errorFromExecute = err;
+          localState.errorFromExecute = err;
           throw err;
         }
       }


### PR DESCRIPTION
fixes #1116

I didn't observe negative consequences of calling activate() more than once, but that could be avoided.

ALso, it would be possible to hold on to the error and rethrow it instead of running execute each time, but I think that could get cached higher the dependency chain than needed.