### PR TITLE
fix: Support default conditions and avoid SES double bundle

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -6,6 +6,8 @@ User-visible changes to the compartment mapper:
   `package.json`: When the compartment mapper encounters such a package, every
   module in that package with `.js` extension including the referenced module
   will be treated an ESM, as if it had the `.mjs` extension.
+- Ensures that the `"endo"`, `"import"`, and `"default"` tags (Node.js
+  conditions) are respected in `package.json` `"exports"` conditions.
 
 # v0.7.0 (2022-03-01)
 

--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -203,6 +203,9 @@ const digestLocation = async (powers, moduleLocation, options) => {
 
   /** @type {Set<string>} */
   const tags = new Set();
+  tags.add('endo');
+  tags.add('import');
+  tags.add('default');
 
   const packageDescriptor = parseLocatedJson(
     packageDescriptorText,

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -364,6 +364,8 @@ const graphPackages = async (
 
   tags = new Set(tags || []);
   tags.add('import');
+  tags.add('default');
+  tags.add('endo');
 
   if (packageDescriptor === undefined) {
     throw new Error(

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -35,11 +35,11 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/ses.umd.js",
+      "import": "./index.js",
       "require": "./dist/ses.cjs"
     },
     "./lockdown": {
-      "import": "./dist/ses.umd.js",
+      "import": "./index.js",
       "require": "./dist/ses.cjs"
     },
     "./package.json": "./package.json"
@@ -55,7 +55,7 @@
     "lint:types": "tsc -p jsconfig.json",
     "prepublish": "yarn run clean && yarn build",
     "qt": "ava",
-    "test": "yarn build && ava",
+    "test": "ava",
     "test:platform-compatability": "node test/package/test.cjs"
   },
   "devDependencies": {

--- a/packages/ses/package.json.md
+++ b/packages/ses/package.json.md
@@ -98,6 +98,9 @@ The variations differ only in file name extension.
 
 Node.js and other tools will use this file when importing `ses` as an ESM.
 (JavaScript module).
+We have in the past experimented with using the precompiled bundle of SES here
+(`./dist/ses.cjs`), but found that this interacted poorly with Endo,
+because an Endo bundle contains symbols that SES censors.
 
 ## "require": "./dist/ses.cjs",
 

--- a/packages/ses/package.json.md
+++ b/packages/ses/package.json.md
@@ -99,8 +99,8 @@ The variations differ only in file name extension.
 Node.js and other tools will use this file when importing `ses` as an ESM.
 (JavaScript module).
 We have in the past experimented with using the precompiled bundle of SES here
-(`./dist/ses.cjs`), but found that this interacted poorly with Endo,
-because an Endo bundle contains symbols that SES censors.
+(`./dist/ses.cjs` or `./dist/ses.umd.js`), but found that this interacted
+poorly with Endo, because an Endo bundle contains identifiers that SES censors.
 
 ## "require": "./dist/ses.cjs",
 


### PR DESCRIPTION
Refs https://github.com/endojs/endo/issues/1123

- fix(ses): Do not bundle modules for use as modules
- fix(endo): Ensure conditions include default, import, and endo
