### PR TITLE
fix(ses): Ignore Array unscopable findLast{,Index}

### DIFF
--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -929,6 +929,9 @@ export const whitelist = {
       // Failed tc39 proposal
       // Seen on FF Nightly 88.0a1
       at: false,
+      // See https://github.com/tc39/proposal-array-find-from-last
+      findLast: 'boolean',
+      findLastIndex: 'boolean',
     },
     // Failed tc39 proposal
     // Seen on FF Nightly 88.0a1


### PR DESCRIPTION
Silences warnings on the latest XS.
