### PR TITLE
fix: some tests sensitive to errorTaming

### DIFF
--- a/packages/ses/test/error/test-tame-console-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unfilteredError.js
@@ -4,7 +4,7 @@ import { getPrototypeOf } from '../../src/commons.js';
 
 const originalConsole = console;
 
-lockdown({ stackFiltering: 'verbose' });
+lockdown({ errorTaming: 'safe', stackFiltering: 'verbose' });
 
 const { details: d, quote: q } = assert;
 

--- a/packages/ses/test/error/test-tame-console-unsafe-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unfilteredError.js
@@ -4,7 +4,11 @@ import { getPrototypeOf } from '../../src/commons.js';
 
 const originalConsole = console;
 
-lockdown({ consoleTaming: 'unsafe', stackFiltering: 'verbose' });
+lockdown({
+  errorTaming: 'safe',
+  consoleTaming: 'unsafe',
+  stackFiltering: 'verbose',
+});
 
 const { details: d, quote: q } = assert;
 

--- a/packages/ses/test/error/test-tame-console-unsafe.js
+++ b/packages/ses/test/error/test-tame-console-unsafe.js
@@ -4,7 +4,7 @@ import { getPrototypeOf } from '../../src/commons.js';
 
 const originalConsole = console;
 
-lockdown({ consoleTaming: 'unsafe' });
+lockdown({ errorTaming: 'safe', consoleTaming: 'unsafe' });
 
 const { details: d, quote: q } = assert;
 

--- a/packages/ses/test/error/test-tame-console.js
+++ b/packages/ses/test/error/test-tame-console.js
@@ -4,7 +4,7 @@ import { getPrototypeOf } from '../../src/commons.js';
 
 const originalConsole = console;
 
-lockdown();
+lockdown({ errorTaming: 'safe' });
 
 const { details: d, quote: q } = assert;
 


### PR DESCRIPTION
Some tests assumed that `errorTaming` had its default `'safe'` value by omitting it in their call to `lockdown`. However, I normally run with 
```sh
export LOCKDOWN_ERROR_TAMING=unsafe
```
which overrides that default. That's normally what I want, to see more diagnostics. But these test were testing the contents of the diagnostics with the `'safe'` setting. So I pass the `errorTaming: 'safe'` setting explicitly to their `lockdown`s.