### PR TITLE
XS `Base64.decode` returns an `ArrayBuffer`, not `Uint8Array`

### DIFF
--- a/packages/base64/src/decode.js
+++ b/packages/base64/src/decode.js
@@ -60,5 +60,18 @@ const jsDecodeBase64 = (string, name = '<unknown>') => {
   return data.subarray(0, j);
 };
 
+// The XS Base64.decode function is faster, but might return ArrayBuffer (not
+// Uint8Array).  Adapt it to our needs.
+const adaptDecoder = nativeDecodeBase64 => (...args) => {
+  const decoded = nativeDecodeBase64(...args);
+  if (decoded instanceof Uint8Array) {
+    return decoded;
+  }
+  return new Uint8Array(decoded);
+};
+
+/** @type {typeof jsDecodeBase64} */
 export const decodeBase64 =
-  globalThis.Base64 !== undefined ? globalThis.Base64.decode : jsDecodeBase64;
+  globalThis.Base64 !== undefined
+    ? adaptDecoder(globalThis.Base64.decode)
+    : jsDecodeBase64;

--- a/packages/base64/src/encode.js
+++ b/packages/base64/src/encode.js
@@ -62,5 +62,6 @@ const jsEncodeBase64 = data => {
   return string;
 };
 
+/** @type {typeof jsEncodeBase64} */
 export const encodeBase64 =
   globalThis.Base64 !== undefined ? globalThis.Base64.encode : jsEncodeBase64;


### PR DESCRIPTION
This PR includes some changes I needed to do in order to debug trying to `ZipWriter.write(name, decodeBase64(str))`.

The solution is simple; just wrap the XS native decoder.
