### PR TITLE
feat(static-module-record): add support for import.meta

### DIFF
--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -332,9 +332,7 @@ ${importsCellSetter(__liveExportMap__, index)}\
     onceVar: {
 ${importsCellSetter(__fixedExportMap__, index)}\
     },
-    importMeta: {
-      url: '${packageLocation}'\
-    },
+    importMeta: {},
   });
 `,
   ),

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -332,7 +332,7 @@ ${importsCellSetter(__liveExportMap__, index)}\
     onceVar: {
 ${importsCellSetter(__fixedExportMap__, index)}\
     },
-    meta: {
+    importMeta: {
       url: '${packageLocation}'\
     },
   });

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -332,7 +332,7 @@ ${importsCellSetter(__liveExportMap__, index)}\
     onceVar: {
 ${importsCellSetter(__fixedExportMap__, index)}\
     },
-    metaVar: {
+    meta: {
       url: '${packageLocation}'\
     },
   });

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -332,6 +332,9 @@ ${importsCellSetter(__liveExportMap__, index)}\
     onceVar: {
 ${importsCellSetter(__fixedExportMap__, index)}\
     },
+    metaVar: {
+      url: '${packageLocation}'\
+    },
   });
 `,
   ),

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -419,7 +419,9 @@ A compiled static module record has the following shape:
       exports to notifier functions.
       A notifier function accepts an update function and registers
       to receive updates for the value exported by the other module.
-    - `importMeta` is a null-prototype object with keys transferred from `meta` property in the envelope returned by importHook and/or mutated by calling `importMetaHook(importMeta)`
+    - `importMeta` is a null-prototype object with keys transferred from `importMeta`
+      property in the envelope returned by importHook and/or mutated by
+      calling `importMetaHook(moduleSpecifier, importMeta)`
     - `liveVar` is a record that maps names exported by this module
       to a function that may be called to initialize or update
       the corresponding value in another module.

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -412,13 +412,14 @@ A compiled static module record has the following shape:
   an initialization record and initializes the module.
   This property distinguishes this type of module record.
   The name implies a future record type that supports top-level await.
-  - An initialization record has the properties `imports`, `liveVar`, and
+  - An initialization record has the properties `imports`, `liveVar`, `importMeta` and
     `onceVar`.
     - `imports` is a function that accepts a map from partial import
       module specifiers to maps from names that the corresponding module
       exports to notifier functions.
       A notifier function accepts an update function and registers
       to receive updates for the value exported by the other module.
+    - `importMeta` is a null-prototype object with keys transferred from `meta` property in the envelope returned by importHook and/or mutated by calling `importMetaHook(importMeta)`
     - `liveVar` is a record that maps names exported by this module
       to a function that may be called to initialize or update
       the corresponding value in another module.

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -215,6 +215,7 @@ export const makeCompartmentConstructor = (
       resolveHook,
       importHook,
       moduleMapHook,
+      importMetaHook,
     } = options;
     const globalTransforms = [...transforms, ...__shimTransforms__];
 
@@ -316,6 +317,7 @@ export const makeCompartmentConstructor = (
       importHook,
       moduleMap,
       moduleMapHook,
+      importMetaHook,
       moduleRecords,
       __shimTransforms__,
       deferredExports,

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -127,14 +127,14 @@ export const makeModuleInstance = (
     compartment,
     moduleSpecifier,
     staticModuleRecord,
-    meta: moduleRecordMeta,
+    importMeta: moduleRecordMeta,
   } = moduleRecord;
   const {
     reexports: exportAlls = [],
     __syncModuleProgram__: functorSource,
     __fixedExportMap__: fixedExportMap = {},
     __liveExportMap__: liveExportMap = {},
-    __usesImportMeta__: usesImportMeta = false,
+    __needsImportMeta__: needsImportMeta = false,
   } = staticModuleRecord;
 
   const compartmentFields = weakmapGet(privateFields, compartment);
@@ -169,8 +169,8 @@ export const makeModuleInstance = (
   if (moduleRecordMeta) {
     assign(importMeta, moduleRecordMeta);
   }
-  if (usesImportMeta && importMetaHook) {
-    importMetaHook(importMeta);
+  if (needsImportMeta && importMetaHook) {
+    importMetaHook(moduleSpecifier, importMeta);
   }
 
   // {_localName_: [{get, set, notify}]} used to merge all the export updaters.

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -165,12 +165,12 @@ export const makeModuleInstance = (
   // both initialize and update live bindings.
   const liveVar = create(null);
 
-  const meta = create(null);
+  const importMeta = create(null);
   if (moduleRecordMeta) {
-    assign(meta, moduleRecordMeta);
+    assign(importMeta, moduleRecordMeta);
   }
   if (usesImportMeta && importMetaHook) {
-    importMetaHook(meta);
+    importMetaHook(importMeta);
   }
 
   // {_localName_: [{get, set, notify}]} used to merge all the export updaters.
@@ -453,7 +453,7 @@ export const makeModuleInstance = (
             imports: freeze(imports),
             onceVar: freeze(onceVar),
             liveVar: freeze(liveVar),
-            meta,
+            importMeta,
           }),
         );
       } catch (e) {

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -158,6 +158,17 @@ export const makeModuleInstance = (
   // both initialize and update live bindings.
   const liveVar = create(null);
 
+  const metaVar = create(null);
+  try {
+    metaVar.url = new URL(
+      moduleSpecifier,
+      compartmentFields.name || '.',
+    ).toString();
+  } catch (e) {
+    metaVar.url = moduleSpecifier;
+    console.error('Wont URL:', moduleSpecifier, compartmentFields.name);
+  }
+
   // {_localName_: [{get, set, notify}]} used to merge all the export updaters.
   const localGetNotify = create(null);
 
@@ -438,6 +449,7 @@ export const makeModuleInstance = (
             imports: freeze(imports),
             onceVar: freeze(onceVar),
             liveVar: freeze(liveVar),
+            metaVar: freeze(metaVar),
           }),
         );
       } catch (e) {

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -321,7 +321,7 @@ export const load = async (
       `Failed to load module ${q(moduleSpecifier)} in package ${q(
         compartmentName,
       )} (${errors.length} underlying failures: ${arrayJoin(
-        arrayMap(errors, error => error.stack),
+        arrayMap(errors, error => error.message),
         ', ',
       )}`,
     );

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -63,6 +63,7 @@ const loadRecord = async (
   pendingJobs,
   moduleLoads,
   errors,
+  meta,
 ) => {
   const { resolveHook, moduleRecords } = weakmapGet(
     compartmentPrivateFields,
@@ -80,6 +81,7 @@ const loadRecord = async (
     staticModuleRecord,
     moduleSpecifier,
     resolvedImports,
+    meta,
   });
 
   // Enqueue jobs to load this module's shallow dependencies.
@@ -181,6 +183,7 @@ const loadWithoutErrorAnnotation = async (
       compartment: aliasCompartment = compartment,
       specifier: aliasSpecifier = moduleSpecifier,
       record: aliasModuleRecord,
+      meta,
     } = staticModuleRecord;
 
     const aliasRecord = await loadRecord(
@@ -192,6 +195,7 @@ const loadWithoutErrorAnnotation = async (
       pendingJobs,
       moduleLoads,
       errors,
+      meta,
     );
     mapSet(moduleRecords, moduleSpecifier, aliasRecord);
     return aliasRecord;
@@ -317,7 +321,7 @@ export const load = async (
       `Failed to load module ${q(moduleSpecifier)} in package ${q(
         compartmentName,
       )} (${errors.length} underlying failures: ${arrayJoin(
-        arrayMap(errors, error => error.message),
+        arrayMap(errors, error => error.stack),
         ', ',
       )}`,
     );

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -63,7 +63,7 @@ const loadRecord = async (
   pendingJobs,
   moduleLoads,
   errors,
-  meta,
+  importMeta,
 ) => {
   const { resolveHook, moduleRecords } = weakmapGet(
     compartmentPrivateFields,
@@ -81,7 +81,7 @@ const loadRecord = async (
     staticModuleRecord,
     moduleSpecifier,
     resolvedImports,
-    meta,
+    importMeta,
   });
 
   // Enqueue jobs to load this module's shallow dependencies.
@@ -183,7 +183,7 @@ const loadWithoutErrorAnnotation = async (
       compartment: aliasCompartment = compartment,
       specifier: aliasSpecifier = moduleSpecifier,
       record: aliasModuleRecord,
-      meta,
+      importMeta,
     } = staticModuleRecord;
 
     const aliasRecord = await loadRecord(
@@ -195,7 +195,7 @@ const loadWithoutErrorAnnotation = async (
       pendingJobs,
       moduleLoads,
       errors,
-      meta,
+      importMeta,
     );
     mapSet(moduleRecords, moduleSpecifier, aliasRecord);
     return aliasRecord;

--- a/packages/ses/test/node.js
+++ b/packages/ses/test/node.js
@@ -63,9 +63,9 @@ export const makeLocator = root => {
   };
 };
 
-const wrapImporterWithMeta = (importer, meta) => async specifier => {
+const wrapImporterWithMeta = (importer, importMeta) => async specifier => {
   const moduleRecord = await importer(specifier);
-  return { record: moduleRecord, meta };
+  return { record: moduleRecord, importMeta };
 };
 
 // makeNodeImporter conveniently curries makeImporter with a Node.js style

--- a/packages/ses/test/node.js
+++ b/packages/ses/test/node.js
@@ -63,10 +63,21 @@ export const makeLocator = root => {
   };
 };
 
+const wrapImporterWithMeta = (importer, meta) => async specifier => {
+  const moduleRecord = await importer(specifier);
+  return { record: moduleRecord, meta };
+};
+
 // makeNodeImporter conveniently curries makeImporter with a Node.js style
 // locator and static file retriever.
-export const makeNodeImporter = sources => compartmentLocation => {
+export const makeNodeImporter = sources => (
+  compartmentLocation,
+  options = {},
+) => {
   const locate = makeLocator(compartmentLocation);
   const retrieve = makeStaticRetriever(sources);
+  if (options.meta) {
+    return wrapImporterWithMeta(makeImporter(locate, retrieve), options.meta);
+  }
   return makeImporter(locate, retrieve);
 };

--- a/packages/ses/test/test-import.js
+++ b/packages/ses/test/test-import.js
@@ -556,3 +556,31 @@ test('child compartments are modular', async t => {
 
   t.is(meaning, 42, 'child compartments have module support');
 });
+
+test.only('import.meta.url points to the module', async t => {
+  t.plan(1);
+
+  const makeImportHook = makeNodeImporter({
+    'https://example.com/index.js': `
+      const myloc = import.meta.url;
+      export default myloc;
+    `,
+  });
+
+  const compartment = new Compartment(
+    { t },
+    {},
+    {
+      name: 'https://example.com',
+      resolveHook: resolveNode,
+      importHook: makeImportHook('https://example.com'),
+    },
+  );
+
+  const {
+    namespace:{
+      default: metaurl
+    }
+  } = await compartment.import('./index.js');
+  t.is(metaurl, 'https://example.com/index.js');
+});

--- a/packages/ses/test/test-import.js
+++ b/packages/ses/test/test-import.js
@@ -602,7 +602,7 @@ test('importMetaHook', async t => {
       name: 'https://example.com',
       resolveHook: resolveNode,
       importHook: makeImportHook('https://example.com'),
-      importMetaHook: meta => {
+      importMetaHook: (_moduleSpecifier, meta) => {
         meta.url = 'https://example.com/index.js';
       },
     },
@@ -632,7 +632,7 @@ test('importMetaHook and meta from record', async t => {
       importHook: makeImportHook('https://example.com', {
         meta: { url: 'https://example.com/index.js' },
       }),
-      importMetaHook: meta => {
+      importMetaHook: (_moduleSpecifier, meta) => {
         meta.url += '?foo';
         meta.isStillMutableHopefully = 1;
       },

--- a/packages/static-module-record/DESIGN.md
+++ b/packages/static-module-record/DESIGN.md
@@ -19,6 +19,7 @@ moduleFunctor({
   imports(importedVariableUpdaters) { /* ... */ },
   liveVar: exportedVariableUpdaters,
   onceVar: exportedConstantEmitters,
+  importMeta: Object.create(null)
 });
 ```
 
@@ -85,6 +86,7 @@ line numbers.
   imports: $h_imports,
   liveVar: $h_live,
   onceVar: $h_once,
+  importMeta: $h_import_meta,
 }) => {
   let foo, bar, fizz, buzz, colour;
   $h_imports(

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -47,6 +47,7 @@
     "@endo/ses-ava": "^0.2.26",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
+    "benchmark": "^2.1.4",
     "c8": "^7.7.3",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -308,8 +308,13 @@ function makeModulePlugins(options) {
       },
     };
 
-    const moduleVisitor = (doAnalyze, doTransform) => ({
-      // We handle all the import and export productions.
+      const moduleVisitor = (doAnalyze, doTransform) => ({
+      MetaProperty(path){
+        if(path.node.meta.name==='import' && doTransform){
+          path.replaceWithMultiple([replace(path.node, t.identifier(h.HIDDEN_META))]);
+        }
+      },
+        // We handle all the import and export productions.
       ImportDeclaration(path) {
         if (doAnalyze) {
           const specs = path.node.specifiers;

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -47,6 +47,7 @@ function makeModulePlugins(options) {
     importDecls,
     importSources,
     liveExportMap,
+    importMetaProperties,
   } = options;
 
   if (sourceType !== 'module') {
@@ -308,13 +309,20 @@ function makeModulePlugins(options) {
       },
     };
 
-      const moduleVisitor = (doAnalyze, doTransform) => ({
-      MetaProperty(path){
-        if(path.node.meta.name==='import' && doTransform){
-          path.replaceWithMultiple([replace(path.node, t.identifier(h.HIDDEN_META))]);
+    const moduleVisitor = (doAnalyze, doTransform) => ({
+      MetaProperty(path) {
+        if (path.node.meta.name === 'import') {
+          if (doAnalyze && path.parentPath.isMemberExpression()) {
+            importMetaProperties.add(path.parentPath.node.property.name);
+          }
+          if (doTransform) {
+            path.replaceWithMultiple([
+              replace(path.node, hiddenIdentifier(h.HIDDEN_META)),
+            ]);
+          }
         }
       },
-        // We handle all the import and export productions.
+      // We handle all the import and export productions.
       ImportDeclaration(path) {
         if (doAnalyze) {
           const specs = path.node.specifiers;

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -47,7 +47,7 @@ function makeModulePlugins(options) {
     importDecls,
     importSources,
     liveExportMap,
-    importMetaProperties,
+    importMeta,
   } = options;
 
   if (sourceType !== 'module') {
@@ -311,9 +311,13 @@ function makeModulePlugins(options) {
 
     const moduleVisitor = (doAnalyze, doTransform) => ({
       MetaProperty(path) {
-        if (path.node.meta.name === 'import') {
-          if (doAnalyze && path.parentPath.isMemberExpression()) {
-            importMetaProperties.add(path.parentPath.node.property.name);
+        if (
+          path.node.meta &&
+          path.node.meta.name === 'import' &&
+          path.node.property.name === 'meta'
+        ) {
+          if (doAnalyze) {
+            importMeta.uttered = true;
           }
           if (doTransform) {
             path.replaceWithMultiple([

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -300,7 +300,7 @@ function makeModulePlugins(options) {
           path.node.meta.name === 'import' &&
           path.node.property.name === 'meta'
         ) {
-          importMeta.uttered = true;
+          importMeta.present = true;
           path.replaceWithMultiple([
             replace(path.node, hiddenIdentifier(h.HIDDEN_META)),
           ]);

--- a/packages/static-module-record/src/hidden.js
+++ b/packages/static-module-record/src/hidden.js
@@ -5,7 +5,9 @@ export const HIDDEN_IMPORT = `${HIDDEN_PREFIX}import`;
 export const HIDDEN_IMPORT_SELF = `${HIDDEN_PREFIX}importSelf`;
 export const HIDDEN_IMPORTS = `${HIDDEN_PREFIX}imports`;
 export const HIDDEN_ONCE = `${HIDDEN_PREFIX}once`;
-export const HIDDEN_META = `${HIDDEN_PREFIX}import_meta`;
+// HIDDEN_META is used to replace `import.meta`. The value fits the original
+// length so it doesn’t displace the column number of following text
+export const HIDDEN_META = `${HIDDEN_PREFIX}___meta`;
 export const HIDDEN_LIVE = `${HIDDEN_PREFIX}live`;
 export const HIDDEN_IDENTIFIERS = [
   HIDDEN_A,

--- a/packages/static-module-record/src/hidden.js
+++ b/packages/static-module-record/src/hidden.js
@@ -5,6 +5,7 @@ export const HIDDEN_IMPORT = `${HIDDEN_PREFIX}import`;
 export const HIDDEN_IMPORT_SELF = `${HIDDEN_PREFIX}importSelf`;
 export const HIDDEN_IMPORTS = `${HIDDEN_PREFIX}imports`;
 export const HIDDEN_ONCE = `${HIDDEN_PREFIX}once`;
+export const HIDDEN_META = `${HIDDEN_PREFIX}meta`;
 export const HIDDEN_LIVE = `${HIDDEN_PREFIX}live`;
 export const HIDDEN_IDENTIFIERS = [
   HIDDEN_A,
@@ -12,5 +13,6 @@ export const HIDDEN_IDENTIFIERS = [
   HIDDEN_IMPORT_SELF,
   HIDDEN_IMPORTS,
   HIDDEN_ONCE,
+  HIDDEN_META,
   HIDDEN_LIVE,
 ];

--- a/packages/static-module-record/src/hidden.js
+++ b/packages/static-module-record/src/hidden.js
@@ -5,7 +5,7 @@ export const HIDDEN_IMPORT = `${HIDDEN_PREFIX}import`;
 export const HIDDEN_IMPORT_SELF = `${HIDDEN_PREFIX}importSelf`;
 export const HIDDEN_IMPORTS = `${HIDDEN_PREFIX}imports`;
 export const HIDDEN_ONCE = `${HIDDEN_PREFIX}once`;
-export const HIDDEN_META = `${HIDDEN_PREFIX}meta`;
+export const HIDDEN_META = `${HIDDEN_PREFIX}import_meta`;
 export const HIDDEN_LIVE = `${HIDDEN_PREFIX}live`;
 export const HIDDEN_IDENTIFIERS = [
   HIDDEN_A,

--- a/packages/static-module-record/src/static-module-record.js
+++ b/packages/static-module-record/src/static-module-record.js
@@ -51,7 +51,7 @@ export function StaticModuleRecord(source, url) {
     liveExportMap,
     fixedExportMap,
     exportAlls,
-    importMetaProperties,
+    importMetaUttered,
   } = analyzeModule({ string: source, url });
   this.imports = freeze([...keys(imports)].sort());
   this.exports = freeze(
@@ -61,8 +61,6 @@ export function StaticModuleRecord(source, url) {
   this.__syncModuleProgram__ = functorSource;
   this.__liveExportMap__ = liveExportMap;
   this.__fixedExportMap__ = fixedExportMap;
-  this.__usesImportMeta__ = importMetaProperties.length > 0;
-  // useful for knowing if resolve or any other expensive features are used
-  this.__usesImportMetaProperties__ = importMetaProperties;
+  this.__usesImportMeta__ = importMetaUttered;
   freeze(this);
 }

--- a/packages/static-module-record/src/static-module-record.js
+++ b/packages/static-module-record/src/static-module-record.js
@@ -51,7 +51,7 @@ export function StaticModuleRecord(source, url) {
     liveExportMap,
     fixedExportMap,
     exportAlls,
-    importMetaUttered,
+    needsImportMeta,
   } = analyzeModule({ string: source, url });
   this.imports = freeze([...keys(imports)].sort());
   this.exports = freeze(
@@ -61,6 +61,6 @@ export function StaticModuleRecord(source, url) {
   this.__syncModuleProgram__ = functorSource;
   this.__liveExportMap__ = liveExportMap;
   this.__fixedExportMap__ = fixedExportMap;
-  this.__usesImportMeta__ = importMetaUttered;
+  this.__needsImportMeta__ = needsImportMeta;
   freeze(this);
 }

--- a/packages/static-module-record/src/static-module-record.js
+++ b/packages/static-module-record/src/static-module-record.js
@@ -51,6 +51,7 @@ export function StaticModuleRecord(source, url) {
     liveExportMap,
     fixedExportMap,
     exportAlls,
+    importMetaProperties,
   } = analyzeModule({ string: source, url });
   this.imports = freeze([...keys(imports)].sort());
   this.exports = freeze(
@@ -60,5 +61,8 @@ export function StaticModuleRecord(source, url) {
   this.__syncModuleProgram__ = functorSource;
   this.__liveExportMap__ = liveExportMap;
   this.__fixedExportMap__ = fixedExportMap;
+  this.__usesImportMeta__ = importMetaProperties.length > 0;
+  // useful for knowing if resolve or any other expensive features are used
+  this.__usesImportMetaProperties__ = importMetaProperties;
   freeze(this);
 }

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -65,7 +65,7 @@ const makeCreateStaticRecord = transformSource =>
       importSources: Object.create(null),
       importDecls: [],
       // enables passing import.meta usage hints up.
-      importMetaProperties: new Set(),
+      importMeta: { uttered: false },
     };
     if (moduleSource.startsWith('#!')) {
       // Comment out the shebang lines.
@@ -114,7 +114,7 @@ const makeCreateStaticRecord = transformSource =>
   imports: ${h.HIDDEN_IMPORTS}, \
   liveVar: ${h.HIDDEN_LIVE}, \
   onceVar: ${h.HIDDEN_ONCE}, \
-  meta: ${h.HIDDEN_META}, \
+  importMeta: ${h.HIDDEN_META}, \
  }) => { \
   ${preamble} \
   ${scriptSource}
@@ -129,9 +129,7 @@ const makeCreateStaticRecord = transformSource =>
       imports: freeze(sourceOptions.imports),
       liveExportMap: freeze(sourceOptions.liveExportMap),
       fixedExportMap: freeze(sourceOptions.fixedExportMap),
-      importMetaProperties: freeze(
-        Array.from(sourceOptions.importMetaProperties),
-      ),
+      importMetaUttered: sourceOptions.importMeta.uttered,
       functorSource,
     });
     return moduleAnalysis;

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -1,48 +1,9 @@
-import * as babelParser from '@babel/parser';
-import babelGenerate from '@agoric/babel-generator';
-import babelTraverse from '@babel/traverse';
-import babelTypes from '@babel/types';
-
-import * as h from './hidden.js';
+import { makeTransformSource } from './transformSource.js';
 import makeModulePlugins from './babelPlugin.js';
 
+import * as h from './hidden.js';
+
 const { freeze } = Object;
-
-const parseBabel = babelParser.default
-  ? babelParser.default.parse
-  : babelParser.parse || babelParser;
-
-const visitorFromPlugin = plugin => plugin({ types: babelTypes }).visitor;
-
-const traverseBabel = babelTraverse.default || babelTraverse;
-const generateBabel = babelGenerate.default || babelGenerate;
-
-const makeTransformSource = (babel = null) => {
-  if (babel !== null) {
-    throw new Error(
-      `transform-analyze.js no longer allows injecting babel; use \`null\``,
-    );
-  }
-
-  const transformSource = (code, sourceOptions = {}) => {
-    // console.log(`transforming`, sourceOptions, code);
-    const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
-
-    const ast = parseBabel(code, { sourceType: sourceOptions.sourceType });
-
-    traverseBabel(ast, visitorFromPlugin(analyzePlugin));
-    traverseBabel(ast, visitorFromPlugin(transformPlugin));
-
-    const { code: transformedCode } = generateBabel(ast, {
-      retainLines: true,
-      compact: true,
-      verbatim: true,
-    });
-    return transformedCode;
-  };
-
-  return transformSource;
-};
 
 const makeCreateStaticRecord = transformSource =>
   function createStaticRecord(moduleSource, url) {
@@ -136,13 +97,13 @@ const makeCreateStaticRecord = transformSource =>
   };
 
 export const makeModuleAnalyzer = babel => {
-  const transformSource = makeTransformSource(babel);
+  const transformSource = makeTransformSource(makeModulePlugins, babel);
   const createStaticRecord = makeCreateStaticRecord(transformSource);
   return ({ string, url }) => createStaticRecord(string, url);
 };
 
 export const makeModuleTransformer = (babel, importer) => {
-  const transformSource = makeTransformSource(babel);
+  const transformSource = makeTransformSource(makeModulePlugins, babel);
   const createStaticRecord = makeCreateStaticRecord(transformSource);
   return {
     rewrite(ss) {

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -113,6 +113,7 @@ const makeCreateStaticRecord = transformSource =>
   imports: ${h.HIDDEN_IMPORTS}, \
   liveVar: ${h.HIDDEN_LIVE}, \
   onceVar: ${h.HIDDEN_ONCE}, \
+  metaVar: ${h.HIDDEN_META}, \
  }) => { \
   ${preamble} \
   ${scriptSource}

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -38,7 +38,6 @@ const makeTransformSource = (babel = null) => {
       compact: true,
       verbatim: true,
     });
-    // console.log(`transformed`, transformedCode);
     return transformedCode;
   };
 
@@ -65,6 +64,8 @@ const makeCreateStaticRecord = transformSource =>
       hoistedDecls: [],
       importSources: Object.create(null),
       importDecls: [],
+      // enables passing import.meta usage hints up.
+      importMetaProperties: new Set(),
     };
     if (moduleSource.startsWith('#!')) {
       // Comment out the shebang lines.
@@ -113,7 +114,7 @@ const makeCreateStaticRecord = transformSource =>
   imports: ${h.HIDDEN_IMPORTS}, \
   liveVar: ${h.HIDDEN_LIVE}, \
   onceVar: ${h.HIDDEN_ONCE}, \
-  metaVar: ${h.HIDDEN_META}, \
+  meta: ${h.HIDDEN_META}, \
  }) => { \
   ${preamble} \
   ${scriptSource}
@@ -123,12 +124,14 @@ const makeCreateStaticRecord = transformSource =>
     if (url) {
       functorSource += `//# sourceURL=${url}\n`;
     }
-
     const moduleAnalysis = freeze({
       exportAlls: freeze(sourceOptions.exportAlls),
       imports: freeze(sourceOptions.imports),
       liveExportMap: freeze(sourceOptions.liveExportMap),
       fixedExportMap: freeze(sourceOptions.fixedExportMap),
+      importMetaProperties: freeze(
+        Array.from(sourceOptions.importMetaProperties),
+      ),
       functorSource,
     });
     return moduleAnalysis;
@@ -198,7 +201,6 @@ export const makeModuleTransformer = (babel, importer) => {
           ? maybeSource.slice(0, -1)
           : maybeSource;
 
-      // console.log(ss.isExpr, `generated`, src, `from`, ast);
       return { ...ss, endowments, src: actualSource };
     },
   };

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -26,7 +26,7 @@ const makeCreateStaticRecord = transformSource =>
       importSources: Object.create(null),
       importDecls: [],
       // enables passing import.meta usage hints up.
-      importMeta: { uttered: false },
+      importMeta: { present: false },
     };
     if (moduleSource.startsWith('#!')) {
       // Comment out the shebang lines.
@@ -90,7 +90,7 @@ const makeCreateStaticRecord = transformSource =>
       imports: freeze(sourceOptions.imports),
       liveExportMap: freeze(sourceOptions.liveExportMap),
       fixedExportMap: freeze(sourceOptions.fixedExportMap),
-      importMetaUttered: sourceOptions.importMeta.uttered,
+      needsImportMeta: sourceOptions.importMeta.present,
       functorSource,
     });
     return moduleAnalysis;

--- a/packages/static-module-record/src/transformSource.js
+++ b/packages/static-module-record/src/transformSource.js
@@ -1,0 +1,39 @@
+import * as babelParser from '@babel/parser';
+import babelGenerate from '@agoric/babel-generator';
+import babelTraverse from '@babel/traverse';
+import babelTypes from '@babel/types';
+
+const parseBabel = babelParser.default
+  ? babelParser.default.parse
+  : babelParser.parse || babelParser;
+
+const visitorFromPlugin = plugin => plugin({ types: babelTypes }).visitor;
+
+const traverseBabel = babelTraverse.default || babelTraverse;
+const generateBabel = babelGenerate.default || babelGenerate;
+
+export const makeTransformSource = (makeModulePlugins, babel = null) => {
+  if (babel !== null) {
+    throw new Error(
+      `transform-analyze.js no longer allows injecting babel; use \`null\``,
+    );
+  }
+
+  const transformSource = (code, sourceOptions = {}) => {
+    const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
+
+    const ast = parseBabel(code, { sourceType: sourceOptions.sourceType });
+
+    traverseBabel(ast, visitorFromPlugin(analyzePlugin));
+    traverseBabel(ast, visitorFromPlugin(transformPlugin));
+
+    const { code: transformedCode } = generateBabel(ast, {
+      retainLines: true,
+      compact: true,
+      verbatim: true,
+    });
+    return transformedCode;
+  };
+
+  return transformSource;
+};

--- a/packages/static-module-record/test/benchmark-babel-plugin.js
+++ b/packages/static-module-record/test/benchmark-babel-plugin.js
@@ -1,0 +1,53 @@
+import Benchmark from 'benchmark';
+import fs from 'fs';
+import url from 'url';
+import { makeTransformSource } from '../src/transformSource.js';
+import makeModulePlugins from '../src/babelPlugin.js';
+
+const suite = new Benchmark.Suite();
+
+const resolveLocal = path => url.fileURLToPath(new URL(path, import.meta.url));
+const cases = [
+  {
+    name: 'small',
+    fixture: fs.readFileSync(resolveLocal('./fixtures/small.js'), 'utf8'),
+  },
+  {
+    name: 'large',
+    fixture: fs.readFileSync(resolveLocal('./fixtures/large.js'), 'utf8'),
+  },
+  {
+    name: 'exportheavy',
+    fixture: fs.readFileSync(resolveLocal('./fixtures/exportheavy.js'), 'utf8'),
+  },
+];
+
+const transformSource = makeTransformSource(makeModulePlugins);
+const freshOptions = () => {
+  return {
+    sourceType: 'module',
+    fixedExportMap: Object.create(null),
+    imports: Object.create(null),
+    exportAlls: [],
+    liveExportMap: Object.create(null),
+    hoistedDecls: [],
+    importSources: Object.create(null),
+    importDecls: [],
+    importMeta: { uttered: false },
+  };
+};
+
+cases.map(testCase =>
+  suite.add(testCase.name, () => {
+    transformSource(testCase.fixture, freshOptions());
+  }),
+);
+
+suite
+  .on('cycle', event => {
+    console.log(String(event.target));
+  })
+  .on('error', event => {
+    console.log(String(event.target), event.target.error);
+  })
+  .run();

--- a/packages/static-module-record/test/benchmark-babel-plugin.js
+++ b/packages/static-module-record/test/benchmark-babel-plugin.js
@@ -33,7 +33,7 @@ const freshOptions = () => {
     hoistedDecls: [],
     importSources: Object.create(null),
     importDecls: [],
-    importMeta: { uttered: false },
+    importMeta: { present: false },
   };
 };
 

--- a/packages/static-module-record/test/fixtures/exportheavy.js
+++ b/packages/static-module-record/test/fixtures/exportheavy.js
@@ -1,0 +1,55 @@
+/* eslint-disable */ 
+console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
+
+export { mapIterable, filterIterable } from './src/helpers/iter-helpers.js';
+export {
+  PASS_STYLE,
+  isObject,
+  assertChecker,
+  getTag,
+  hasOwnPropertyOf,
+} from './src/helpers/passStyle-helpers.js';
+
+export { getErrorConstructor, toPassableError } from './src/helpers/error.js';
+export { getInterfaceOf } from './src/helpers/remotable.js';
+
+export {
+  nameForPassableSymbol,
+  passableSymbolForName,
+} from './src/helpers/symbol.js';
+
+export { passStyleOf, assertPassable } from './src/passStyleOf.js';
+
+export { deeplyFulfilled } from './src/deeplyFulfilled.js';
+
+export { makeTagged } from './src/makeTagged.js';
+export { Remotable, Far, ToFarFunction } from './src/make-far.js';
+
+export { QCLASS, makeMarshal } from './src/marshal.js';
+export { stringify, parse } from './src/marshal-stringify.js';
+// Works, but not yet used
+// export { decodeToJustin } from './src/marshal-justin.js';
+
+export {
+  assertRecord,
+  assertCopyArray,
+  assertRemotable,
+  isRemotable,
+  isRecord,
+  isCopyArray,
+} from './src/typeGuards.js';
+
+// eslint-disable-next-line import/export
+export * from './src/types.js';
+
+
+const { details: X } = assert;
+
+// This is a pathological minimum, but exercised by the unit test.
+export const MIN_DATA_BUFFER_LENGTH = 1;
+
+// Calculate how big the transfer buffer needs to be.
+export const TRANSFER_OVERHEAD_LENGTH =
+  BigUint64Array.BYTES_PER_ELEMENT + Int32Array.BYTES_PER_ELEMENT;
+export const MIN_TRANSFER_BUFFER_LENGTH =
+  MIN_DATA_BUFFER_LENGTH + TRANSFER_OVERHEAD_LENGTH;

--- a/packages/static-module-record/test/fixtures/large.js
+++ b/packages/static-module-record/test/fixtures/large.js
@@ -1,4 +1,5 @@
-/* eslint max-lines: 0 */
+/* eslint-disable */ 
+console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
 
 import * as h from './hidden.js';
 
@@ -84,6 +85,10 @@ function makeModulePlugins(options) {
       node.comments = [...(src.leadingComments || [])];
       t.inheritsComments(node, src);
       return node;
+    };
+
+    const prependReplacements = (replacements, node) => {
+      replacements.unshift(node);
     };
 
     const allowedHiddens = new WeakSet();
@@ -250,7 +255,7 @@ function makeModulePlugins(options) {
 
       // Create the export calls.
       const isConst = decl.kind === 'const';
-      const additions = rewriteVars(
+      const replacements = rewriteVars(
         vids,
         isConst,
         decl.type === 'FunctionDeclaration'
@@ -258,11 +263,43 @@ function makeModulePlugins(options) {
           : !isConst && decl.kind !== 'let',
       );
 
-      if (additions.length > 0) {
-        if (decl.type === 'VariableDeclaration') {
-          rewrittenDecls.add(decl);
+      if (replacements.length > 0) {
+        switch (decl.type) {
+          case 'VariableDeclaration': {
+            // We rewrote the declaration.
+            rewrittenDecls.add(decl);
+            prependReplacements(replacements, decl);
+            break;
+          }
+          case 'FunctionDeclaration': {
+            prependReplacements(replacements, decl);
+            break;
+          }
+          default: {
+            throw TypeError(`Unknown declaration type ${decl.type}`);
+          }
         }
-        path.insertAfter(additions);
+        console.error(decl.declarations[0])
+
+        path.traverse({
+          MetaProperty(pathWithin) {
+            if (
+              pathWithin.node.meta &&
+              pathWithin.node.meta.name === 'import' &&
+              pathWithin.node.property.name === 'meta'
+            ) {
+            console.error('this works')
+              
+                pathWithin.replaceWithMultiple([
+                  replace(pathWithin.node, hiddenIdentifier(h.HIDDEN_META)),
+                ]);
+              
+            }
+          },
+        });
+        console.error(decl.declarations[0])
+
+        path.replaceWithMultiple(replacements);
       }
     };
 
@@ -293,22 +330,24 @@ function makeModulePlugins(options) {
       },
     };
 
-    const importMetaVisitor = {
+    const moduleVisitor = (doAnalyze, doTransform) => ({
       MetaProperty(path) {
         if (
           path.node.meta &&
           path.node.meta.name === 'import' &&
           path.node.property.name === 'meta'
         ) {
-          importMeta.uttered = true;
-          path.replaceWithMultiple([
-            replace(path.node, hiddenIdentifier(h.HIDDEN_META)),
-          ]);
+          if (doAnalyze) {
+            importMeta.uttered = true;
+          }
+          if (doTransform) {
+            console.error('at least I tried')
+            path.replaceWithMultiple([
+              replace(path.node, hiddenIdentifier(h.HIDDEN_META)),
+            ]);
+          }
         }
       },
-    };
-
-    const moduleVisitor = (doAnalyze, doTransform) => ({
       // We handle all the import and export productions.
       ImportDeclaration(path) {
         if (doAnalyze) {
@@ -597,12 +636,7 @@ function makeModulePlugins(options) {
           },
         };
       case 1:
-        return {
-          visitor: {
-            ...moduleVisitor(false, true),
-            ...importMetaVisitor,
-          },
-        };
+        return { visitor: moduleVisitor(false, true) };
       default:
         throw TypeError(`Unrecognized module pass ${pass}`);
     }

--- a/packages/static-module-record/test/fixtures/large.js
+++ b/packages/static-module-record/test/fixtures/large.js
@@ -338,7 +338,7 @@ function makeModulePlugins(options) {
           path.node.property.name === 'meta'
         ) {
           if (doAnalyze) {
-            importMeta.uttered = true;
+            importMeta.present = true;
           }
           if (doTransform) {
             console.error('at least I tried')

--- a/packages/static-module-record/test/fixtures/small.js
+++ b/packages/static-module-record/test/fixtures/small.js
@@ -1,0 +1,44 @@
+/* eslint-disable */ 
+console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
+import * as babelParser from '@babel/parser';
+import babelGenerate from '@agoric/babel-generator';
+import babelTraverse from '@babel/traverse';
+import babelTypes from '@babel/types';
+
+import makeModulePlugins from './babelPlugin.js';
+
+const parseBabel = babelParser.default
+  ? babelParser.default.parse
+  : babelParser.parse || babelParser;
+
+const visitorFromPlugin = plugin => plugin({ types: babelTypes }).visitor;
+
+const traverseBabel = babelTraverse.default || babelTraverse;
+const generateBabel = babelGenerate.default || babelGenerate;
+
+export const makeTransformSource = (babel = null) => {
+  if (babel !== null) {
+    throw new Error(
+      `transform-analyze.js no longer allows injecting babel; use \`null\``,
+    );
+  }
+
+  const transformSource = (code, sourceOptions = {}) => {
+    // console.log(`transforming`, sourceOptions, code);
+    const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
+
+    const ast = parseBabel(code, { sourceType: sourceOptions.sourceType });
+
+    traverseBabel(ast, visitorFromPlugin(analyzePlugin));
+    traverseBabel(ast, visitorFromPlugin(transformPlugin));
+
+    const { code: transformedCode } = generateBabel(ast, {
+      retainLines: true,
+      compact: true,
+      verbatim: true,
+    });
+    return transformedCode;
+  };
+
+  return transformSource;
+};

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -570,13 +570,13 @@ test('import meta in export', t => {
   });
   t.is(namespace.a, 'ok file://meta.url');
 });
-test('import meta member uttered', t => {
+test('import meta member present', t => {
   const record = new StaticModuleRecord(`const a = import.meta.url`);
-  t.is(record.__usesImportMeta__, true);
+  t.is(record.__needsImportMeta__, true);
 });
-test('import meta uttered', t => {
+test('import meta present', t => {
   const record = new StaticModuleRecord(`const a = import.meta`);
-  t.is(record.__usesImportMeta__, true);
+  t.is(record.__needsImportMeta__, true);
 });
 
 test('export names', t => {

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -64,7 +64,7 @@ test('export default', t => {
 function initialize(t, source, options = {}) {
   const { endowments, imports = new Map() } = options;
   const record = new StaticModuleRecord(source);
-  // t.log(record.__syncModuleProgram__);
+  t.log(record.__syncModuleProgram__);
   const liveUpdaters = {};
   const onceUpdaters = {};
   const namespace = {};
@@ -105,7 +105,6 @@ function initialize(t, source, options = {}) {
       };
     },
   );
-
   const functor = compartment.evaluate(record.__syncModuleProgram__);
 
   /** @type {Map<string, Map<string, Updater>>} */
@@ -560,13 +559,16 @@ test('import for side-effect', t => {
 test('import meta', t => {
   t.notThrows(() => initialize(t, `const a = import.meta.url`));
 });
-test.failing('import meta in export', t => {
+test('import meta in export', t => {
   let namespace = {};
   t.notThrows(() => {
-    namespace = initialize(t, `export const a = 'ok ' + import.meta.url`)
-      .namespace;
+    namespace = initialize(
+      t,
+      `export const a = 'ok ' + import.meta.url;
+    const unrelated = {b:import.meta.url};`,
+    ).namespace;
   });
-  t.is(namespace.result, 'ok file://meta.url');
+  t.is(namespace.a, 'ok file://meta.url');
 });
 test('import meta member uttered', t => {
   const record = new StaticModuleRecord(`const a = import.meta.url`);

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -152,7 +152,7 @@ function initialize(t, source, options = {}) {
     imports: updateImports,
     liveVar: liveUpdaters,
     onceVar: onceUpdaters,
-    meta: { url: 'file://meta.url' },
+    importMeta: { url: 'file://meta.url' },
   });
 
   return { record, namespace, log, updaters };
@@ -567,6 +567,14 @@ test.failing('import meta in export', t => {
       .namespace;
   });
   t.is(namespace.result, 'ok file://meta.url');
+});
+test('import meta member uttered', t => {
+  const record = new StaticModuleRecord(`const a = import.meta.url`);
+  t.is(record.__usesImportMeta__, true);
+});
+test('import meta uttered', t => {
+  const record = new StaticModuleRecord(`const a = import.meta`);
+  t.is(record.__usesImportMeta__, true);
 });
 
 test('export names', t => {

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -152,6 +152,7 @@ function initialize(t, source, options = {}) {
     imports: updateImports,
     liveVar: liveUpdaters,
     onceVar: onceUpdaters,
+    metaVar: { url: 'file://meta.url' },
   });
 
   return { record, namespace, log, updaters };
@@ -555,6 +556,17 @@ test('import for side-effect', t => {
   t.deepEqual(record.__fixedExportMap__, {});
   t.deepEqual(record.__liveExportMap__, {});
   t.deepEqual(record.imports, ['module']);
+});
+test('import meta', t => {
+  t.notThrows(() => initialize(t, `const a = import.meta.url`));
+});
+test.failing('import meta in export', t => {
+  let namespace = {};
+  t.notThrows(() => {
+    namespace = initialize(t, `export const a = 'ok ' + import.meta.url`)
+      .namespace;
+  });
+  t.is(namespace.result, 'ok file://meta.url');
 });
 
 test('export names', t => {

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -152,7 +152,7 @@ function initialize(t, source, options = {}) {
     imports: updateImports,
     liveVar: liveUpdaters,
     onceVar: onceUpdaters,
-    metaVar: { url: 'file://meta.url' },
+    meta: { url: 'file://meta.url' },
   });
 
   return { record, namespace, log, updaters };

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -64,7 +64,7 @@ test('export default', t => {
 function initialize(t, source, options = {}) {
   const { endowments, imports = new Map() } = options;
   const record = new StaticModuleRecord(source);
-  t.log(record.__syncModuleProgram__);
+  // t.log(record.__syncModuleProgram__);
   const liveUpdaters = {};
   const onceUpdaters = {};
   const namespace = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9639,13 +9639,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-up@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
-  integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
-  dependencies:
-    find-up "^2.1.0"
-
 platform@^1.3.3:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,6 +3014,14 @@ before-after-hook@^2.0.0, before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.1.tgz#73540563558687586b52ed217dad6a802ab1549c"
   integrity sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==
 
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  integrity sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -9630,6 +9638,18 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
+  dependencies:
+    find-up "^2.1.0"
+
+platform@^1.3.3:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
 plur@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Implemented import.meta according to #291

The actual implementation of exposing import.meta.url to modules loaded by compartment-mapper is going to be a separate PR.