### PR TITLE
fix(ses): Prevent hypothetical stack bumping for unsafe eval

### DIFF
--- a/packages/ses/src/compartment-evaluate.js
+++ b/packages/ses/src/compartment-evaluate.js
@@ -55,7 +55,7 @@ export const provideCompartmentEvaluator = (compartmentFields, options) => {
 
     ({ safeEvaluate } = makeSafeEvaluator({
       globalObject,
-      localObject,
+      globalLexicals: localObject,
       globalTransforms,
       sloppyGlobalsMode,
       knownScopeProxies,

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -283,7 +283,7 @@ export const makeCompartmentConstructor = (
     const knownScopeProxies = new WeakSet();
     const { safeEvaluate } = makeSafeEvaluator({
       globalObject,
-      localObject: globalLexicals,
+      globalLexicals,
       globalTransforms,
       sloppyGlobalsMode: false,
       knownScopeProxies,

--- a/packages/ses/src/make-safe-evaluator.js
+++ b/packages/ses/src/make-safe-evaluator.js
@@ -16,8 +16,6 @@ import { assert } from './error/assert.js';
 
 const { details: d } = assert;
 
-// TODO: rename localObject to scopeObject
-
 /**
  * makeSafeEvaluator()
  * Build the low-level operation used by all evaluators:
@@ -25,14 +23,14 @@ const { details: d } = assert;
  *
  * @param {Object} options
  * @param {Object} options.globalObject
- * @param {Object} [options.localObject]
+ * @param {Object} [options.globalLexicals]
  * @param {Array<Transform>} [options.globalTransforms]
  * @param {bool} [options.sloppyGlobalsMode]
  * @param {WeakSet} [options.knownScopeProxies]
  */
 export const makeSafeEvaluator = ({
   globalObject,
-  localObject = {},
+  globalLexicals = {},
   globalTransforms = [],
   sloppyGlobalsMode = false,
   knownScopeProxies = new WeakSet(),
@@ -41,7 +39,7 @@ export const makeSafeEvaluator = ({
     scopeHandler,
     admitOneUnsafeEvalNext,
     resetOneUnsafeEvalNext,
-  } = createScopeHandler(globalObject, localObject, {
+  } = createScopeHandler(globalObject, globalLexicals, {
     sloppyGlobalsMode,
   });
   const { proxy: scopeProxy, revoke: revokeScopeProxy } = proxyRevocable(
@@ -56,7 +54,7 @@ export const makeSafeEvaluator = ({
   let evaluate;
   const makeEvaluate = () => {
     if (!evaluate) {
-      const constants = getScopeConstants(globalObject, localObject);
+      const constants = getScopeConstants(globalObject, globalLexicals);
       const evaluateFactory = makeEvaluateFactory(constants);
       evaluate = apply(evaluateFactory, scopeProxy, []);
     }

--- a/packages/ses/src/make-safe-evaluator.js
+++ b/packages/ses/src/make-safe-evaluator.js
@@ -35,13 +35,13 @@ export const makeSafeEvaluator = ({
   sloppyGlobalsMode = false,
   knownScopeProxies = new WeakSet(),
 } = {}) => {
-  const {
-    scopeHandler,
-    admitOneUnsafeEvalNext,
-    resetOneUnsafeEvalNext,
-  } = createScopeHandler(globalObject, globalLexicals, {
-    sloppyGlobalsMode,
-  });
+  const { scopeHandler, scopeController } = createScopeHandler(
+    globalObject,
+    globalLexicals,
+    {
+      sloppyGlobalsMode,
+    },
+  );
   const { proxy: scopeProxy, revoke: revokeScopeProxy } = proxyRevocable(
     immutableObject,
     scopeHandler,
@@ -76,7 +76,7 @@ export const makeSafeEvaluator = ({
       mandatoryTransforms,
     ]);
 
-    admitOneUnsafeEvalNext();
+    scopeController.allowNextEvalToBeUnsafe = true;
     let err;
     try {
       // Ensure that "this" resolves to the safe global.
@@ -86,13 +86,15 @@ export const makeSafeEvaluator = ({
       err = e;
       throw e;
     } finally {
-      if (resetOneUnsafeEvalNext()) {
+      const unsafeEvalWasStillExposed = scopeController.allowNextEvalToBeUnsafe;
+      scopeController.allowNextEvalToBeUnsafe = false;
+      if (unsafeEvalWasStillExposed) {
         // Barring a defect in the SES shim, the scope proxy should allow the
         // powerful, unsafe  `eval` to be used by `evaluate` exactly once, as the
         // very first name that it attempts to access from the lexical scope.
-        // A defect in the SES shim could throw an exception after our call to
-        // `admitOneUnsafeEvalNext()` and before `evaluate` calls `eval`
-        // internally.
+        // A defect in the SES shim could throw an exception after we set
+        // `scopeController.allowNextEvalToBeUnsafe` and before `evaluate`
+        // calls `eval` internally.
         // If we get here, SES is very broken.
         // This condition is one where this vat is now hopelessly confused, and
         // the vat as a whole should be aborted.

--- a/packages/ses/test/test-make-evaluate-factory.js
+++ b/packages/ses/test/test-make-evaluate-factory.js
@@ -5,12 +5,18 @@ test('Intrinsics - values', t => {
   t.plan(2);
 
   t.is(
-    makeEvaluateFactory().toString(),
-    "function anonymous(\n) {\n\n    with (this) {\n      \n      return function() {\n        'use strict';\n        return eval(arguments[0]);\n      };\n    }\n  \n}",
+    makeEvaluateFactory()
+      .toString()
+      .replace(/\s/g, ' ')
+      .replace(/ +/g, ' '),
+    "function anonymous( ) { with (this) { return function() { 'use strict'; return eval(arguments[0]); }; } }",
   );
 
   t.is(
-    makeEvaluateFactory(['foot']).toString(),
-    "function anonymous(\n) {\n\n    with (this) {\n      const {foot} = this;\n      return function() {\n        'use strict';\n        return eval(arguments[0]);\n      };\n    }\n  \n}",
+    makeEvaluateFactory(['foot'])
+      .toString()
+      .replace(/\s/g, ' ')
+      .replace(/ +/g, ' '),
+    "function anonymous( ) { with (this) { const {foot} = this; return function() { 'use strict'; return eval(arguments[0]); }; } }",
   );
 });

--- a/packages/ses/test/test-make-evaluator.js
+++ b/packages/ses/test/test-make-evaluator.js
@@ -3,7 +3,7 @@ import './lockdown-safe.js';
 import test from 'ava';
 import { makeSafeEvaluator } from '../src/make-safe-evaluator.js';
 
-test('safeEvaluate - default (non-sloppy, no localObject)', t => {
+test('safeEvaluate - default (non-sloppy, no globalLexicals)', t => {
   t.plan(6);
 
   const globalObject = { abc: 123 };
@@ -55,7 +55,7 @@ test('safeEvaluate - endowments', t => {
   const endowments = { abc: 123 };
   const { safeEvaluate: endowedEvaluate } = makeSafeEvaluator({
     globalObject,
-    localObject: endowments,
+    globalLexicals: endowments,
   });
   const { safeEvaluate: evaluate } = makeSafeEvaluator({ globalObject });
 
@@ -94,7 +94,7 @@ test('safeEvaluate - transforms - rewrite source', t => {
 
   const { safeEvaluate: evaluate } = makeSafeEvaluator({
     globalObject,
-    localObject: endowments,
+    globalLexicals: endowments,
     globalTransforms,
   });
 

--- a/packages/ses/test/test-scope-handler.js
+++ b/packages/ses/test/test-scope-handler.js
@@ -89,16 +89,15 @@ test('scopeHandler - has trap guards eval with its life', t => {
 
   const {
     scopeHandler: handler,
-    resetOneUnsafeEvalNext,
-    admitOneUnsafeEvalNext,
+    scopeController: controller,
   } = createScopeHandler(globalObject);
 
-  admitOneUnsafeEvalNext();
+  controller.allowNextEvalToBeUnsafe = true;
   guardDown = true;
   t.is(handler.has(null, 'eval'), true);
   t.is(handler.get(null, 'eval'), FERAL_EVAL);
 
-  resetOneUnsafeEvalNext();
+  controller.allowNextEvalToBeUnsafe = false;
   guardDown = false;
   t.is(handler.has(null, 'eval'), false, `global object doesn't have eval`);
   t.is(handler.get(null, 'eval'), undefined);
@@ -200,23 +199,22 @@ test('scopeHandler - set trap', t => {
   delete globalThis.bar;
 });
 
-test('scopeHandler - get trap - reset allow next unsafe eval', t => {
+test('scopeHandler - get trap - clear allow next unsafe eval', t => {
   t.plan(7);
 
   const globalObject = { eval: {} };
   const {
     scopeHandler: handler,
-    resetOneUnsafeEvalNext,
-    admitOneUnsafeEvalNext,
+    scopeController: controller,
   } = createScopeHandler(globalObject);
 
-  t.is(resetOneUnsafeEvalNext(), false);
+  t.is(controller.allowNextEvalToBeUnsafe, false);
   t.is(handler.get(null, 'eval'), globalObject.eval);
   t.is(handler.get(null, 'eval'), globalObject.eval); // repeat
 
-  admitOneUnsafeEvalNext();
+  controller.allowNextEvalToBeUnsafe = true;
   t.is(handler.get(null, 'eval'), FERAL_EVAL);
-  t.is(resetOneUnsafeEvalNext(), false);
+  t.is(controller.allowNextEvalToBeUnsafe, false);
   t.is(handler.get(null, 'eval'), globalObject.eval);
   t.is(handler.get(null, 'eval'), globalObject.eval); // repeat
 });


### PR DESCRIPTION
- refactor(ses): Make evaluate factory validation less sensitive to white space
- refactor(ses): Rename localObject to globalLexicals
- fix(ses): Prevent hypothetical stack bumping for unsafe eval

Fixes #956
Fixes #840 (drive by fix)