### PR TITLE
chore: release

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.24](https://github.com/endojs/endo/compare/@endo/base64@0.2.23...@endo/base64@0.2.24) (2022-04-14)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/base64@0.2.22...@endo/base64@0.2.23) (2022-04-13)
 
 

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Transcodes base64",
   "keywords": [
     "base64",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.1.4](https://github.com/endojs/endo/compare/@endo/bundle-source@2.1.3...@endo/bundle-source@2.1.4) (2022-04-14)
+
+
+### Bug Fixes
+
+* **bundle-source:** Use a github reference instead of a bundled tarball for rollup patch ([1bf0c18](https://github.com/endojs/endo/commit/1bf0c187e04bfe015850a91d51a33074aeebfde4))
+
+
+
 ### [2.1.3](https://github.com/endojs/endo/compare/@endo/bundle-source@2.1.2...@endo/bundle-source@2.1.3) (2022-04-13)
 
 

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",
@@ -19,8 +19,8 @@
     "@agoric/babel-generator": "^7.17.4",
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
-    "@endo/base64": "^0.2.23",
-    "@endo/compartment-mapper": "^0.7.3",
+    "@endo/base64": "^0.2.24",
+    "@endo/compartment-mapper": "^0.7.4",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "acorn": "^8.2.4",
@@ -28,9 +28,9 @@
     "source-map": "^0.7.3"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.39",
-    "@endo/lockdown": "^0.1.11",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/init": "^0.5.40",
+    "@endo/lockdown": "^0.1.12",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.0.6](https://github.com/endojs/endo/compare/@endo/captp@2.0.5...@endo/captp@2.0.6) (2022-04-14)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ### [2.0.5](https://github.com/endojs/endo/compare/@endo/captp@2.0.4...@endo/captp@2.0.5) (2022-04-13)
 
 

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [
@@ -40,16 +40,16 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.39",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/init": "^0.5.40",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.15.1",
-    "@endo/marshal": "^0.6.5",
-    "@endo/nat": "^4.1.10",
-    "@endo/promise-kit": "^0.2.39"
+    "@endo/eventual-send": "^0.15.2",
+    "@endo/marshal": "^0.6.6",
+    "@endo/nat": "^4.1.11",
+    "@endo/promise-kit": "^0.2.40"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.1...@endo/check-bundle@0.2.2) (2022-04-14)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.0...@endo/check-bundle@0.2.1) (2022-04-13)
 
 

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",
@@ -37,13 +37,13 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.23",
-    "@endo/compartment-mapper": "^0.7.3"
+    "@endo/base64": "^0.2.24",
+    "@endo/compartment-mapper": "^0.7.4"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.1.3",
-    "@endo/eslint-config": "^0.4.8",
-    "@endo/init": "^0.5.39",
+    "@endo/bundle-source": "^2.1.4",
+    "@endo/eslint-config": "^0.4.9",
+    "@endo/init": "^0.5.40",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.24](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.23...@endo/cjs-module-analyzer@0.2.24) (2022-04-14)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.22...@endo/cjs-module-analyzer@0.2.23) (2022-04-13)
 
 

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",
@@ -29,7 +29,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.11](https://github.com/endojs/endo/compare/@endo/cli@0.1.10...@endo/cli@0.1.11) (2022-04-14)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/cli@0.1.9...@endo/cli@0.1.10) (2022-04-13)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Endo command line interface",
   "keywords": [],
   "author": "Endo contributors",
@@ -24,16 +24,16 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/compartment-mapper": "^0.7.3",
-    "@endo/daemon": "^0.1.10",
-    "@endo/eventual-send": "^0.15.1",
-    "@endo/lockdown": "^0.1.11",
-    "@endo/where": "^0.2.5",
+    "@endo/compartment-mapper": "^0.7.4",
+    "@endo/daemon": "^0.1.11",
+    "@endo/eventual-send": "^0.15.2",
+    "@endo/lockdown": "^0.1.12",
+    "@endo/where": "^0.2.6",
     "commander": "^5.0.0",
-    "ses": "^0.15.13"
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.7.4](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.3...@endo/compartment-mapper@0.7.4) (2022-04-14)
+
+**Note:** Version bump only for package @endo/compartment-mapper
+
+
+
+
+
 ### [0.7.3](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.2...@endo/compartment-mapper@0.7.3) (2022-04-13)
 
 

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -41,13 +41,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/cjs-module-analyzer": "^0.2.23",
-    "@endo/static-module-record": "^0.7.2",
-    "@endo/zip": "^0.2.23",
-    "ses": "^0.15.13"
+    "@endo/cjs-module-analyzer": "^0.2.24",
+    "@endo/static-module-record": "^0.7.3",
+    "@endo/zip": "^0.2.24",
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.11](https://github.com/endojs/endo/compare/@endo/daemon@0.1.10...@endo/daemon@0.1.11) (2022-04-14)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/daemon@0.1.9...@endo/daemon@0.1.10) (2022-04-13)
 
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Endo daemon",
   "keywords": [
     "endo",
@@ -34,19 +34,19 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/captp": "^2.0.5",
-    "@endo/eventual-send": "^0.15.1",
-    "@endo/far": "^0.2.1",
-    "@endo/lockdown": "^0.1.11",
-    "@endo/netstring": "^0.3.9",
-    "@endo/promise-kit": "^0.2.39",
-    "@endo/stream": "^0.3.8",
-    "@endo/stream-node": "^0.2.9",
-    "@endo/where": "^0.2.5",
-    "ses": "^0.15.13"
+    "@endo/captp": "^2.0.6",
+    "@endo/eventual-send": "^0.15.2",
+    "@endo/far": "^0.2.2",
+    "@endo/lockdown": "^0.1.12",
+    "@endo/netstring": "^0.3.10",
+    "@endo/promise-kit": "^0.2.40",
+    "@endo/stream": "^0.3.9",
+    "@endo/stream-node": "^0.2.10",
+    "@endo/where": "^0.2.6",
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.4.9](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.8...@endo/eslint-config@0.4.9) (2022-04-14)
+
+**Note:** Version bump only for package @endo/eslint-config
+
+
+
+
+
 ### [0.4.8](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.7...@endo/eslint-config@0.4.8) (2022-04-13)
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-config",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Endo style rules",
   "keywords": [
     "endo",
@@ -24,7 +24,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/eslint-plugin": "^0.3.26",
+    "@endo/eslint-plugin": "^0.3.27",
     "@jessie.js/eslint-plugin": "^0.1.1"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.27](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.26...@endo/eslint-plugin@0.3.27) (2022-04-14)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ### [0.3.26](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.25...@endo/eslint-plugin@0.3.26) (2022-04-13)
 
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "description": "Endo-specific ESLint plugin",
   "keywords": [
     "eslint",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.15.2](https://github.com/endojs/endo/compare/@endo/eventual-send@0.15.1...@endo/eventual-send@0.15.2) (2022-04-14)
+
+**Note:** Version bump only for package @endo/eventual-send
+
+
+
+
+
 ### [0.15.1](https://github.com/endojs/endo/compare/@endo/eventual-send@0.15.0...@endo/eventual-send@0.15.1) (2022-04-13)
 
 

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/lockdown": "^0.1.11",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/lockdown": "^0.1.12",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "c8": "^7.7.3",
     "tsd": "^0.19.1"

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/endojs/endo/compare/@endo/far@0.2.1...@endo/far@0.2.2) (2022-04-14)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/far@0.2.0...@endo/far@0.2.1) (2022-04-13)
 
 

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",
@@ -26,12 +26,12 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.15.1",
-    "@endo/marshal": "^0.6.5"
+    "@endo/eventual-send": "^0.15.2",
+    "@endo/marshal": "^0.6.6"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.39",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/init": "^0.5.40",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.44](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.43...@endo/import-bundle@0.2.44) (2022-04-14)
+
+**Note:** Version bump only for package @endo/import-bundle
+
+
+
+
+
 ### [0.2.43](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.42...@endo/import-bundle@0.2.43) (2022-04-13)
 
 

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "load modules created by @endo/bundle-source",
   "type": "module",
   "main": "src/index.js",
@@ -18,13 +18,13 @@
     "lint": "eslint '**/*.js'"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.23",
-    "@endo/compartment-mapper": "^0.7.3"
+    "@endo/base64": "^0.2.24",
+    "@endo/compartment-mapper": "^0.7.4"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.1.3",
-    "@endo/init": "^0.5.39",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/bundle-source": "^2.1.4",
+    "@endo/init": "^0.5.40",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.40](https://github.com/endojs/endo/compare/@endo/init@0.5.39...@endo/init@0.5.40) (2022-04-14)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [0.5.39](https://github.com/endojs/endo/compare/@endo/init@0.5.38...@endo/init@0.5.39) (2022-04-13)
 
 

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "0.5.39",
+  "version": "0.5.40",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",
@@ -24,13 +24,13 @@
     "lint": "eslint '**/*.js'"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.7.3",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/compartment-mapper": "^0.7.4",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.15.1",
-    "@endo/lockdown": "^0.1.11"
+    "@endo/eventual-send": "^0.15.2",
+    "@endo/lockdown": "^0.1.12"
   },
   "files": [
     "LICENSE*",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.12](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.11...@endo/lockdown@0.1.12) (2022-04-14)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [0.1.11](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.10...@endo/lockdown@0.1.11) (2022-04-13)
 
 

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
@@ -16,7 +16,7 @@
     "ava": "^3.12.1"
   },
   "dependencies": {
-    "ses": "^0.15.13"
+    "ses": "^0.15.14"
   },
   "files": [
     "LICENSE*",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.10](https://github.com/endojs/endo/compare/@endo/lp32@0.3.9...@endo/lp32@0.3.10) (2022-04-14)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [0.3.9](https://github.com/endojs/endo/compare/@endo/lp32@0.3.8...@endo/lp32@0.3.9) (2022-04-13)
 
 

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",
@@ -44,13 +44,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.39",
-    "@endo/stream": "^0.3.8",
-    "ses": "^0.15.13"
+    "@endo/init": "^0.5.40",
+    "@endo/stream": "^0.3.9",
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/eslint-config": "^0.4.9",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.6](https://github.com/endojs/endo/compare/@endo/marshal@0.6.5...@endo/marshal@0.6.6) (2022-04-14)
+
+**Note:** Version bump only for package @endo/marshal
+
+
+
+
+
 ### [0.6.5](https://github.com/endojs/endo/compare/@endo/marshal@0.6.4...@endo/marshal@0.6.5) (2022-04-13)
 
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "marshal",
   "type": "module",
   "main": "index.js",
@@ -37,13 +37,13 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.15.1",
-    "@endo/nat": "^4.1.10",
-    "@endo/promise-kit": "^0.2.39"
+    "@endo/eventual-send": "^0.15.2",
+    "@endo/nat": "^4.1.11",
+    "@endo/promise-kit": "^0.2.40"
   },
   "devDependencies": {
-    "@endo/lockdown": "^0.1.11",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/lockdown": "^0.1.12",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "c8": "^7.7.3"
   },

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.11](https://github.com/endojs/endo/compare/@endo/nat@4.1.10...@endo/nat@4.1.11) (2022-04-14)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [4.1.10](https://github.com/endojs/endo/compare/@endo/nat@4.1.9...@endo/nat@4.1.10) (2022-04-13)
 
 

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.7.3",
+    "@endo/compartment-mapper": "^0.7.4",
     "ava": "^3.12.1",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
-    "ses": "^0.15.13"
+    "ses": "^0.15.14"
   },
   "directories": {
     "test": "test"

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.10](https://github.com/endojs/endo/compare/@endo/netstring@0.3.9...@endo/netstring@0.3.10) (2022-04-14)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [0.3.9](https://github.com/endojs/endo/compare/@endo/netstring@0.3.8...@endo/netstring@0.3.9) (2022-04-13)
 
 

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,12 +32,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.39",
-    "@endo/stream": "^0.3.8",
-    "ses": "^0.15.13"
+    "@endo/init": "^0.5.40",
+    "@endo/stream": "^0.3.9",
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.40](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.39...@endo/promise-kit@0.2.40) (2022-04-14)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [0.2.39](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.38...@endo/promise-kit@0.2.39) (2022-04-13)
 
 

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Helper for making promises",
   "keywords": [
     "promise"
@@ -34,11 +34,11 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "ses": "^0.15.13"
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/eslint-config": "^0.4.9",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.24](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.23...@endo/ses-ava@0.2.24) (2022-04-14)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.22...@endo/ses-ava@0.2.23) (2022-04-13)
 
 

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -33,10 +33,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.15.13"
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.14](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.13...ses-integration-test@3.0.14) (2022-04-14)
+
+**Note:** Version bump only for package ses-integration-test
+
+
+
+
+
 ### [3.0.13](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.12...ses-integration-test@3.0.13) (2022-04-13)
 
 

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,10 +30,10 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.15.13"
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.15.14](https://github.com/endojs/endo/compare/ses@0.15.13...ses@0.15.14) (2022-04-14)
+
+**Note:** Version bump only for package ses
+
+
+
+
+
 ### [0.15.13](https://github.com/endojs/endo/compare/ses@0.15.12...ses@0.15.13) (2022-04-13)
 
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.15.13",
+  "version": "0.15.14",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",
@@ -59,10 +59,10 @@
     "test:platform-compatability": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.7.3",
-    "@endo/eslint-config": "^0.4.8",
-    "@endo/static-module-record": "^0.7.2",
-    "@endo/test262-runner": "^0.1.24",
+    "@endo/compartment-mapper": "^0.7.4",
+    "@endo/eslint-config": "^0.4.9",
+    "@endo/static-module-record": "^0.7.3",
+    "@endo/test262-runner": "^0.1.25",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.7.3](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.2...@endo/static-module-record@0.7.3) (2022-04-14)
+
+**Note:** Version bump only for package @endo/static-module-record
+
+
+
+
+
 ### [0.7.2](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.1...@endo/static-module-record@0.7.2) (2022-04-13)
 
 

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -39,12 +39,12 @@
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
     "@babel/types": "^7.17.0",
-    "ses": "^0.15.13"
+    "ses": "^0.15.14"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
-    "@endo/eslint-config": "^0.4.8",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/eslint-config": "^0.4.9",
+    "@endo/ses-ava": "^0.2.24",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.10](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.9...@endo/stream-node@0.2.10) (2022-04-14)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.8...@endo/stream-node@0.2.9) (2022-04-13)
 
 

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",
@@ -38,13 +38,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.39",
-    "@endo/stream": "^0.3.8",
-    "ses": "^0.15.13"
+    "@endo/init": "^0.5.40",
+    "@endo/stream": "^0.3.9",
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/eslint-config": "^0.4.9",
+    "@endo/ses-ava": "^0.2.24",
     "@typescript-eslint/parser": "^5.10.2",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.21](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.20...@endo/stream-types-test@0.1.21) (2022-04-14)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [0.1.20](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.19...@endo/stream-types-test@0.1.20) (2022-04-13)
 
 

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],
@@ -25,11 +25,11 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "@endo/stream": "^0.3.8",
-    "ses": "^0.15.13"
+    "@endo/stream": "^0.3.9",
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.9](https://github.com/endojs/endo/compare/@endo/stream@0.3.8...@endo/stream@0.3.9) (2022-04-14)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [0.3.8](https://github.com/endojs/endo/compare/@endo/stream@0.3.7...@endo/stream@0.3.8) (2022-04-13)
 
 

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",
@@ -38,13 +38,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.15.1",
-    "ses": "^0.15.13"
+    "@endo/eventual-send": "^0.15.2",
+    "ses": "^0.15.14"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
-    "@endo/init": "^0.5.39",
-    "@endo/ses-ava": "^0.2.23",
+    "@endo/eslint-config": "^0.4.9",
+    "@endo/init": "^0.5.40",
+    "@endo/ses-ava": "^0.2.24",
     "@typescript-eslint/parser": "^5.10.2",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.24](https://github.com/endojs/endo/compare/@endo/syrup@0.1.23...@endo/syrup@0.1.24) (2022-04-14)
+
+**Note:** Version bump only for package @endo/syrup
+
+
+
+
+
 ### [0.1.23](https://github.com/endojs/endo/compare/@endo/syrup@0.1.22...@endo/syrup@0.1.23) (2022-04-13)
 
 

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.25](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.24...@endo/test262-runner@0.1.25) (2022-04-14)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.24](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.23...@endo/test262-runner@0.1.24) (2022-04-13)
 
 

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "description": "Test262 Runner",
   "author": "Agoric",
@@ -17,7 +17,7 @@
     "test262-parser": "^2.2.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "sinon": "8.0.4"
   },
   "ava": {

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.6](https://github.com/endojs/endo/compare/@endo/where@0.2.5...@endo/where@0.2.6) (2022-04-14)
+
+**Note:** Version bump only for package @endo/where
+
+
+
+
+
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/where@0.2.4...@endo/where@0.2.5) (2022-04-13)
 
 

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": null,
   "description": "Description forthcoming.",
   "keywords": [],
@@ -34,7 +34,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.24](https://github.com/endojs/endo/compare/@endo/zip@0.2.23...@endo/zip@0.2.24) (2022-04-14)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/zip@0.2.22...@endo/zip@0.2.23) (2022-04-13)
 
 

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",
@@ -35,7 +35,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.4.8",
+    "@endo/eslint-config": "^0.4.9",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",


### PR DESCRIPTION
This release fixes a problem with the previous release of bundle-source, pertaining to a patched version of Rollup.
