### PR TITLE
feat(bundle-source): CLI tool with caching

### DIFF
--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -4,6 +4,9 @@
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",
+  "bin": {
+    "bundle-source": "./src/tool.js"
+  },
   "scripts": {
     "build": "exit 0",
     "test": "ava",

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -21,6 +21,7 @@
     "@babel/traverse": "^7.17.3",
     "@endo/base64": "^0.2.24",
     "@endo/compartment-mapper": "^0.7.4",
+    "@endo/init": "^0.5.40",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "acorn": "^8.2.4",

--- a/packages/bundle-source/src/is-entrypoint.js
+++ b/packages/bundle-source/src/is-entrypoint.js
@@ -1,0 +1,7 @@
+// Detect if this is run as a script.
+import url from 'url';
+import process from 'process';
+
+// FIXME: Should maybe be exported by '@endo/something'?
+export const isEntrypoint = href =>
+  String(href) === url.pathToFileURL(process.argv[1] ?? '/').href;

--- a/packages/bundle-source/src/is-entrypoint.js
+++ b/packages/bundle-source/src/is-entrypoint.js
@@ -1,7 +1,9 @@
 // Detect if this is run as a script.
 import url from 'url';
 import process from 'process';
+import fs from 'fs';
 
 // FIXME: Should maybe be exported by '@endo/something'?
 export const isEntrypoint = href =>
-  String(href) === url.pathToFileURL(process.argv[1] ?? '/').href;
+  String(href) ===
+  url.pathToFileURL(fs.realpathSync(process.argv[1]) ?? '/').href;

--- a/packages/bundle-source/src/tool.js
+++ b/packages/bundle-source/src/tool.js
@@ -10,7 +10,7 @@ import bundleSource from './index.js';
 const { details: X, quote: q } = assert;
 
 const USAGE =
-  'bundle-source dest/ module1.js bundleName1 module2.js bundleName2 ...';
+  'bundle-source --to dest/ module1.js bundleName1 module2.js bundleName2 ...';
 
 export const makeFileReader = (fileName, { fs, path }) => {
   const make = there => makeFileReader(there, { fs, path });
@@ -175,8 +175,8 @@ export const makeBundleCache = (wr, cwd, readPowers) => {
 };
 
 export const main = async (args, { fs, url, crypto, path }) => {
-  const [dest, ...pairs] = args;
-  if (!(dest && pairs.length > 0 && pairs.length % 2 === 0)) {
+  const [to, dest, ...pairs] = args;
+  if (!(to === '--to' && dest && pairs.length > 0 && pairs.length % 2 === 0)) {
     throw Error(USAGE);
   }
 

--- a/packages/bundle-source/src/tool.js
+++ b/packages/bundle-source/src/tool.js
@@ -109,7 +109,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
       bundleFileName,
       bundleTime,
       contents,
-      moduleSource: { relative: moduleRef },
+      moduleSource: { absolute: moduleSource },
     } = meta;
     assert.equal(bundleFileName, toBundleName(targetName));
     const { mtime: actualBundleTime } = await wr
@@ -117,7 +117,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
       .neighbor(bundleFileName)
       .stat();
     assert.equal(actualBundleTime.toISOString(), bundleTime);
-    const moduleRd = wr.readOnly().neighbor(moduleRef);
+    const moduleRd = wr.readOnly().neighbor(moduleSource);
     const actualTimes = await Promise.all(
       contents.map(async ({ relativePath }) => {
         const itemRd = moduleRd.neighbor(relativePath);

--- a/packages/bundle-source/src/tool.js
+++ b/packages/bundle-source/src/tool.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 import '@endo/init';
-import { ZipReader } from '@endo/zip';
-import { decodeBase64 } from '@endo/base64';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
 
 import { isEntrypoint } from './is-entrypoint.js';
@@ -34,13 +32,6 @@ export const makeFileWriter = (fileName, { fs, path }) => {
     neighbor: ref => make(path.resolve(fileName, ref)),
     mkdir: opts => fs.promises.mkdir(fileName, opts),
   });
-};
-
-export const exploreBundle = async endoZipBase64 => {
-  const zip = new ZipReader(new Uint8Array(decodeBase64(endoZipBase64)));
-  for await (const [name, _entry] of zip.files.entries()) {
-    console.log({ name });
-  }
 };
 
 export const makeBundleCache = (wr, cwd, readPowers, opts) => {
@@ -203,7 +194,7 @@ export const main = async (args, { fs, url, crypto, path }) => {
   const cache = makeBundleCache(destWr, cwd, readPowers);
 
   for (let ix = 0; ix < pairs.length; ix += 2) {
-    const [bundleRoot, bundleName] = pairs.slice(ix);
+    const [bundleRoot, bundleName] = pairs.slice(ix, ix + 2);
 
     // eslint-disable-next-line no-await-in-loop
     await cache.validateOrAdd(bundleRoot, bundleName, console.log);

--- a/packages/bundle-source/src/tool.js
+++ b/packages/bundle-source/src/tool.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+import '@endo/init';
+import { ZipReader } from '@endo/zip';
+import { decodeBase64 } from '@endo/base64';
+import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
+
+import { isEntrypoint } from './is-entrypoint.js';
+import bundleSource from './index.js';
+
+const { details: X, quote: q } = assert;
+
+const USAGE =
+  'bundle-source dest/ module1.js bundleName1 module2.js bundleName2 ...';
+
+export const makeFileReader = (fileName, { fs, path }) => {
+  const make = there => makeFileReader(there, { fs, path });
+  return harden({
+    toString: () => fileName,
+    readText: () => fs.promises.readFile(fileName, 'utf-8'),
+    neighbor: ref => make(path.resolve(fileName, ref)),
+    stat: () => fs.promises.stat(fileName),
+    absolute: () => path.normalize(fileName),
+    relative: there => path.relative(fileName, there),
+  });
+};
+
+export const makeFileWriter = (fileName, { fs, path }) => {
+  const make = there => makeFileWriter(there, { fs, path });
+  return harden({
+    toString: () => fileName,
+    writeText: txt => fs.promises.writeFile(fileName, txt),
+    readOnly: () => makeFileReader(fileName, { fs, path }),
+    neighbor: ref => make(path.resolve(fileName, ref)),
+    mkdir: opts => fs.promises.mkdir(fileName, opts),
+  });
+};
+
+export const exploreBundle = async endoZipBase64 => {
+  const zip = new ZipReader(new Uint8Array(decodeBase64(endoZipBase64)));
+  for await (const [name, _entry] of zip.files.entries()) {
+    console.log({ name });
+  }
+};
+
+export const makeBundleCache = (wr, cwd, readPowers) => {
+  const add = async (rootPath, targetName) => {
+    console.log(`${wr}`, 'add:', targetName, 'from', rootPath);
+    const srcRd = cwd.neighbor(rootPath);
+
+    const modTimeByPath = new Map();
+
+    const loggedRead = async loc => {
+      if (!loc.match(/\bpackage.json$/)) {
+        try {
+          const itemRd = cwd.neighbor(new URL(loc).pathname);
+          const ref = srcRd.relative(itemRd.absolute());
+          const { mtime } = await itemRd.stat();
+          modTimeByPath.set(ref, mtime);
+          // console.log({ loc, mtime, ref });
+        } catch (oops) {
+          console.error(oops);
+        }
+      }
+      return readPowers.read(loc);
+    };
+    const bundle = await bundleSource(
+      rootPath,
+      {},
+      { ...readPowers, read: loggedRead },
+    );
+
+    const { moduleFormat } = bundle;
+    assert.equal(moduleFormat, 'endoZipBase64');
+
+    const code = `export default ${JSON.stringify(bundle)};`;
+    await wr.mkdir({ recursive: true });
+    const bundleFileName = `bundle-${targetName}.js`;
+    const bundleWr = wr.neighbor(bundleFileName);
+    await bundleWr.writeText(code);
+    const { mtime: bundleTime } = await bundleWr.readOnly().stat();
+
+    const meta = {
+      bundleFileName,
+      bundleTime: bundleTime.toISOString(),
+      moduleSource: {
+        relative: bundleWr.readOnly().relative(srcRd.absolute()),
+        absolute: srcRd.absolute(),
+      },
+      contents: [...modTimeByPath.entries()].map(([relativePath, mtime]) => ({
+        relativePath,
+        mtime: mtime.toISOString(),
+      })),
+    };
+
+    await wr
+      .neighbor(`bundle-${targetName}-meta.json`)
+      .writeText(JSON.stringify(meta, null, 2));
+    console.log(
+      `${wr}`,
+      'bundled',
+      modTimeByPath.size,
+      'files in',
+      bundleFileName,
+      'at',
+      bundleTime,
+    );
+  };
+
+  const validate = async targetName => {
+    const metaRd = wr.readOnly().neighbor(`bundle-${targetName}-meta.json`);
+    let txt;
+    try {
+      txt = await metaRd.readText();
+    } catch (ioErr) {
+      assert.fail(
+        X`${q(targetName)}: cannot read bundle metadata: ${q(ioErr)}`,
+      );
+    }
+    const meta = JSON.parse(txt);
+    const {
+      bundleFileName,
+      bundleTime,
+      contents,
+      moduleSource: { relative: moduleRef },
+    } = meta;
+    assert.equal(bundleFileName, `bundle-${targetName}.js`);
+    const { mtime: actualBundleTime } = await wr
+      .readOnly()
+      .neighbor(bundleFileName)
+      .stat();
+    assert.equal(actualBundleTime.toISOString(), bundleTime);
+    const moduleRd = wr.readOnly().neighbor(moduleRef);
+    const actualTimes = await Promise.all(
+      contents.map(async ({ relativePath }) => {
+        const itemRd = moduleRd.neighbor(relativePath);
+        const { mtime } = await itemRd.stat();
+        return { relativePath, mtime: mtime.toISOString() };
+      }),
+    );
+    const outOfDate = actualTimes.filter(({ mtime }) => mtime > bundleTime);
+    assert(
+      outOfDate.length === 0,
+      X`out of date: ${q(outOfDate)}. ${q(targetName)} bundled at ${q(
+        bundleTime,
+      )}`,
+    );
+    console.log(
+      `${wr}`,
+      `bundle-${targetName}.js`,
+      'valid:',
+      contents.length,
+      'files bundled at',
+      bundleTime,
+    );
+  };
+
+  const validateOrAdd = async (rootPath, targetName) => {
+    let valid = false;
+    try {
+      await validate(targetName);
+      valid = true;
+    } catch (invalid) {
+      console.warn(invalid.message);
+    }
+    if (!valid) {
+      await add(rootPath, targetName);
+    }
+  };
+
+  return harden({
+    add,
+    validate,
+    validateOrAdd,
+  });
+};
+
+export const main = async (args, { fs, url, crypto, path }) => {
+  const [dest, ...pairs] = args;
+  if (!(dest && pairs.length > 0 && pairs.length % 2 === 0)) {
+    throw Error(USAGE);
+  }
+
+  const readPowers = makeReadPowers({ fs, url, crypto });
+  const cwd = makeFileReader('', { fs, path });
+  const destWr = makeFileWriter(dest, { fs, path });
+  const cache = makeBundleCache(destWr, cwd, readPowers);
+
+  for (let ix = 0; ix < pairs.length; ix += 2) {
+    const [bundleRoot, bundleName] = pairs.slice(ix);
+
+    // eslint-disable-next-line no-await-in-loop
+    await cache.validateOrAdd(bundleRoot, bundleName);
+  }
+};
+
+if (isEntrypoint(import.meta.url)) {
+  /* global process */
+  main(process.argv.slice(2), {
+    fs: await import('fs'),
+    path: await import('path'),
+    url: await import('url'),
+    crypto: await import('crypto'),
+  }).catch(console.error);
+}


### PR DESCRIPTION
cc @warner , @turadg  ref https://github.com/Agoric/agoric-sdk/issues/3609

demo:

```
$ rm -rf /tmp/d
$ bundle-source /tmp/d demo/dir1/index.js demo1 demo/circular/a.js circular
"demo1": cannot read bundle metadata: "[Error: ENOENT: no such file or directory, open '/tmp/d/bundle-demo1-meta.json']"
/tmp/d add: demo1 from demo/dir1/index.js
/tmp/d bundled 3 files in bundle-demo1.js at 2022-04-14T19:19:34.185Z
"circular": cannot read bundle metadata: "[Error: ENOENT: no such file or directory, open '/tmp/d/bundle-circular-meta.json']"
/tmp/d add: circular from demo/circular/a.js
/tmp/d bundled 2 files in bundle-circular.js at 2022-04-14T19:19:34.293Z

$ bundle-source /tmp/d demo/dir1/index.js demo1 demo/circular/a.js circular
/tmp/d bundle-demo1.js valid: 3 files bundled at 2022-04-14T19:19:34.185Z
/tmp/d bundle-circular.js valid: 2 files bundled at 2022-04-14T19:19:34.293Z

$ touch demo/circular/a.js 
$ bundle-source /tmp/d demo/dir1/index.js demo1 demo/circular/a.js circular
/tmp/d bundle-demo1.js valid: 3 files bundled at 2022-04-14T19:19:34.185Z
out of date: [{"relativePath":"","mtime":"2022-04-14T19:36:01.708Z"}]. "circular" bundled at "2022-04-14T19:19:34.293Z"
/tmp/d add: circular from demo/circular/a.js
/tmp/d bundled 2 files in bundle-circular.js at 2022-04-14T19:36:07.308Z

$ time bundle-source /tmp/d ~/projects/agoric/agoric-sdk/packages/run-protocol/src/vaultFactory/vaultFactory.js vaultFactory
"vaultFactory": cannot read bundle metadata: "[Error: ENOENT: no such file or directory, open '/tmp/d/bundle-vaultFactory-meta.json']"
/tmp/d add: vaultFactory from /home/connolly/projects/agoric/agoric-sdk/packages/run-protocol/src/vaultFactory/vaultFactory.js
(Error#1)
Error#1: ENOENT: no such file or directory, stat '/home/connolly/projects/agoric/agoric-sdk/packages/governance/src/exported'

(Error#2)
Error#2: ENOENT: no such file or directory, stat '/home/connolly/projects/agoric/agoric-sdk/packages/governance/src/types'

/tmp/d bundled 126 files in bundle-vaultFactory.js at 2022-04-14T19:19:51.681Z

real    0m2.314s
user    0m3.506s
sys     0m0.184s

$ time bundle-source /tmp/d ~/projects/agoric/agoric-sdk/packages/run-protocol/src/vaultFactory/vaultFactory.js vaultFactory
/tmp/d bundle-vaultFactory.js valid: 126 files bundled at 2022-04-14T19:19:51.681Z

real    0m0.403s
user    0m0.422s
sys     0m0.038s
```
