### PR TITLE
fix(init): workaround node promise destroyed bug

### DIFF
--- a/packages/init/src/node-async_hooks.js
+++ b/packages/init/src/node-async_hooks.js
@@ -172,7 +172,8 @@ const getAsyncHookSymbolPromiseProtoDesc = (
     if (Object.isExtensible(this)) {
       Object.defineProperty(this, symbol, {
         value,
-        writable: false,
+        // Workaround a Node bug setting the destroyed sentinel multiple times
+        writable: disallowGet,
         configurable: false,
         enumerable: false,
       });


### PR DESCRIPTION
After #1115 landed in agoric-sdk, people stated experiencing errors like `TypeError#1: Cannot assign to read only property 'Symbol(destroyed)' of object '[object Promise]'`

The patch was overzealous and set the property as non-configurable and non-writable. This isn't a problem for the `async_id` and `trigger_async_id` symbols since node tests for their presence before assigning, however it seems node unconditionally set the destroyed symbol, and being an object, the description doesn't match (different value), and the later assignment throws.

I am not quite sure under which circumstances this situation arises, or I'd add a test for it.