### PR TITLE
test(check-bundle): Cover invalid archive error with location diagnostic

### DIFF
--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -44,6 +44,7 @@
     "@endo/bundle-source": "^2.2.0",
     "@endo/eslint-config": "^0.4.10",
     "@endo/init": "^0.5.41",
+    "@endo/zip": "^0.2.25",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/check-bundle/src/json.js
+++ b/packages/check-bundle/src/json.js
@@ -1,5 +1,8 @@
 // @ts-check
 
+// For enquoting strings
+const q = JSON.stringify;
+
 /**
  * Parses JSON and, if necessary, throws exceptions that include the location
  * of the offending file.
@@ -12,7 +15,7 @@ export const parseLocatedJson = (source, location) => {
     return JSON.parse(source);
   } catch (error) {
     if (error instanceof SyntaxError) {
-      throw new SyntaxError(`Cannot parse JSON from ${location}, ${error}`);
+      throw new SyntaxError(`Cannot parse JSON from ${q(location)}, ${error}`);
     }
     throw error;
   }

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -205,7 +205,9 @@ export const parseArchive = async (
   const unseen = new Set(archive.files.keys());
   assert(
     unseen.size >= 2,
-    `Archive failed sanity check: should contain at least a compartment map file and one module file.`,
+    `Archive failed sanity check: should contain at least a compartment map file and one module file in ${q(
+      archiveLocation,
+    )}`,
   );
 
   /**
@@ -240,7 +242,7 @@ export const parseArchive = async (
     compartmentMapText,
     'compartment-map.json',
   );
-  assertCompartmentMap(compartmentMap);
+  assertCompartmentMap(compartmentMap, archiveLocation);
 
   const {
     compartments,


### PR DESCRIPTION
This change improves an error diagnostic that has become common when we introduced a cache that sometimes vended out corrupt bundles.
