### PR TITLE
test(ses): Verify assignability of array length over frozen prototype

### DIFF
--- a/packages/ses/test/test-property-override.js
+++ b/packages/ses/test/test-property-override.js
@@ -32,6 +32,21 @@ test('Can assign "toString" of class prototype', t => {
   t.is(result, 'moo');
 });
 
+test('Can assign "length" of array instance', t => {
+  const c = new Compartment();
+
+  function testContent() {
+    const x = [1, 2, 3];
+    x.length = 1;
+    return x;
+  }
+
+  const result = c.evaluate(`(${testContent})`)();
+  t.is(result.length, 1);
+  t.is(result[0], 1);
+  t.is(result[1], undefined);
+});
+
 test('packages in-the-wild', t => {
   const c = new Compartment();
 


### PR DESCRIPTION
This is a sanity check that seems like a good one to carry forward into test 262 one day. The problem that motivated the sanity check was a hardened array instance. Hardening the prototype of all arrays doesn’t preclude using length assignment to truncate.