### PR TITLE
fix(compartment-mapper) Increase defineProperty no exports compatibility

### DIFF
--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/defineprop/c.js
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/defineprop/c.js
@@ -1,0 +1,9 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = addComments;
+
+function addComments() {
+}

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/defineprop/example-babeltypes.js
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/defineprop/example-babeltypes.js
@@ -1,0 +1,8 @@
+Object.defineProperty(exports, "addComment", {
+    enumerable: true,
+    get: function () {
+      return _addComment.default;
+    }
+  });
+
+var _addComment = require('./c.js')

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/defineprop/main.js
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/defineprop/main.js
@@ -1,3 +1,4 @@
+const babeltypes = require('./example-babeltypes');
 const curves = require('./example-elliptic');
 const ethereum = require('./example-ethereum-util');
 
@@ -20,4 +21,8 @@ if (curves.p192.name !== 'p192' || curves.secp256k1.name !== 'secp256k1') {
   throw Error(
     `Expected example-elliptic.js exports to contain values: p192,secp256k1 got: ${curves.p192.name},${curves.secp256k1.name}`,
   );
+}
+
+if(!babeltypes.addComment || typeof babeltypes.addComment !== 'function') {
+  throw Error('Expected example-babeltypes.js to export a function called addComment')
 }


### PR DESCRIPTION
… by not trying to create named exports too hard

Initially the idea was to use the same mechanic of promoting fields to named exports for the ones defined with a getter by calling the getter immediately. It ends up producing more harm than good, so I've decided to skip exposing getter-based exports as named exports from cjs. 
For now it seems like an overall improvement in ecosystem compatibility.

*Fedor's contraption* for lazy init now works as expected in cjs. Could even work as named exports if we're lucky, because once the getter is called it propagates the value. It'd need to be required before it's imported though. 

The ability to delegate a named export to a getter would require defining a getter on the exportsProxy or opening more of its internals to parse-cjs. 

It changes our support matrix results:

|  | **endo change** | **node-v12** | **node-v12** | **node-v16** | **esbuild** | **parcel** | **rollup** | **tsc** | **tscInterop** | **webpack** |
|  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |  ---  |
 | [9.cjs](https://github.com/endojs/endo-e2e-tests/blob/main/matrix/table.md#file-9cjs) even | ✔️->❌ | ❌ | ❌ | ❌ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 | [9.cjs](https://github.com/endojs/endo-e2e-tests/blob/main/matrix/table.md#file-9cjs) default | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ | ❌ | ✔️ |
 | [9.cjs](https://github.com/endojs/endo-e2e-tests/blob/main/matrix/table.md#file-9cjs) default.even | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ | ❌ | ✔️ |
| [10.cjs](https://github.com/endojs/endo-e2e-tests/blob/main/matrix/table.md#file-10cjs) even | ✔️->❌ | ❌ | ❌ | ❌ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 | [10.cjs](https://github.com/endojs/endo-e2e-tests/blob/main/matrix/table.md#file-10cjs) default | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ | ✔️ | ✔️ |
