### PR TITLE
fix: decodeToJustin accepts slot backrefs

### DIFF
--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -24,8 +24,8 @@ export { Remotable, Far, ToFarFunction } from './src/make-far.js';
 
 export { QCLASS, makeMarshal } from './src/marshal.js';
 export { stringify, parse } from './src/marshal-stringify.js';
-// Works, but not yet used
-// export { decodeToJustin } from './src/marshal-justin.js';
+
+export { decodeToJustin } from './src/marshal-justin.js';
 
 export {
   assertRecord,

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -182,7 +182,9 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
           const { index, iface } = rawTree;
           assert.typeof(index, 'number');
           Nat(index);
-          assert.typeof(iface, 'string');
+          if (iface !== undefined) {
+            assert.typeof(iface, 'string');
+          }
           return;
         }
         case 'hilbert': {
@@ -356,8 +358,12 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
         case 'slot': {
           let { index, iface } = rawTree;
           index = Number(Nat(index));
-          iface = quote(iface);
-          return out.next(`getSlotVal(${index},${iface})`);
+          if (iface === undefined) {
+            return out.next(`slot(${index})`);
+          } else {
+            iface = quote(iface);
+            return out.next(`slot(${index},${iface})`);
+          }
         }
 
         case 'hilbert': {


### PR DESCRIPTION
Fixes #1185 

As of https://github.com/Agoric/agoric-sdk/pull/5401 we'll use `decodeToJustin`, so export it as we always expected to.

Take @dtribble 's suggestion to rename `getSlotVal` to simply `slot`.