### PR TITLE
fix: retire deprecated "@@asyncIterator" sending only

### DIFF
--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -341,7 +341,8 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
             assert(match !== null);
             const suffix = match[1];
             assert(Symbol[suffix] === sym);
-            return out.next(`Symbol[${quote(suffix)}]`);
+            assert(identPattern.test(suffix));
+            return out.next(`Symbol.${suffix}`);
           }
           return out.next(`Symbol.for(${quote(registeredName)})`);
         }

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -212,15 +212,6 @@ export const makeMarshal = (
         case 'symbol': {
           assertPassableSymbol(val);
           const name = /** @type {string} */ (nameForPassableSymbol(val));
-          if (name === '@@asyncIterator') {
-            // Deprectated qclass. TODO make conditional
-            // on environment variable. Eventually remove, but only after
-            // confident that all supported receivers understand
-            // `[QCLASS]: 'symbol'`.
-            return harden({
-              [QCLASS]: '@@asyncIterator',
-            });
-          }
           return harden({
             [QCLASS]: 'symbol',
             name,

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -140,6 +140,8 @@ export {};
  *                                       payload: Encoding
  *           }
  * } EncodingUnion
+ * Note that the '@@asyncIterator' encoding is deprecated. Use 'symbol' instead.
+ *
  * @typedef {{ [index: string]: Encoding,
  *             '@qclass'?: undefined
  * }} EncodingRecord

--- a/packages/marshal/test/test-marshal-justin.js
+++ b/packages/marshal/test/test-marshal-justin.js
@@ -32,9 +32,8 @@ export const jsonPairs = harden([
   ['{"@qclass":"-Infinity"}', '-Infinity'],
   ['{"@qclass":"bigint","digits":"4"}', '4n'],
   ['{"@qclass":"bigint","digits":"9007199254740993"}', '9007199254740993n'],
-  ['{"@qclass":"@@asyncIterator"}', 'Symbol.asyncIterator'],
-  // ['{"@qclass":"symbol","name":"@@asyncIterator"}', 'Symbol.asyncIterator'],
-  ['{"@qclass":"symbol","name":"@@match"}', 'Symbol["match"]'],
+  ['{"@qclass":"symbol","name":"@@asyncIterator"}', 'Symbol.asyncIterator'],
+  ['{"@qclass":"symbol","name":"@@match"}', 'Symbol.match'],
   ['{"@qclass":"symbol","name":"foo"}', 'Symbol.for("foo")'],
   ['{"@qclass":"symbol","name":"@@@@foo"}', 'Symbol.for("@@foo")'],
 

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -46,9 +46,8 @@ export const roundTripPairs = harden([
   // Does not fit into a number
   [9007199254740993n, { '@qclass': 'bigint', digits: '9007199254740993' }],
 
-  // Well known symbols, deprecated encoding
-  [Symbol.asyncIterator, { '@qclass': '@@asyncIterator' }],
   // Well known symbols
+  [Symbol.asyncIterator, { '@qclass': 'symbol', name: '@@asyncIterator' }],
   [Symbol.match, { '@qclass': 'symbol', name: '@@match' }],
   // Registered symbols
   [Symbol.for('foo'), { '@qclass': 'symbol', name: 'foo' }],


### PR DESCRIPTION
We first had a special marshal encoding special case for `Symbol.asyncIterator`. Over 4 months ago we introduced general symbol handling. But we kept sending the special case in case there were non-updated receivers, and kept understanding the special case on reception in case there were non-updated senders.

These four months is enough to give us confidence that there are no longer only receivers that do not understand the new symbol encoding. So this PR retires the code for sending the special case. Once we're confident that there are no senders older than this PR we'll be able to update the receivers too.