### PR TITLE
babelPlugin fix proposal and benchmarking setup

### DIFF
--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -47,6 +47,7 @@
     "@endo/ses-ava": "^0.2.25",
     "ava": "^3.12.1",
     "babel-eslint": "^10.0.3",
+    "benchmark": "^2.1.4",
     "c8": "^7.7.3",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -597,10 +597,12 @@ function makeModulePlugins(options) {
           },
         };
       case 1:
-        return { visitor: {
-          ...moduleVisitor(false, true),
-          ...importMetaVisitor,
-        } };
+        return {
+          visitor: {
+            ...moduleVisitor(false, true),
+            ...importMetaVisitor,
+          },
+        };
       default:
         throw TypeError(`Unrecognized module pass ${pass}`);
     }

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -1,48 +1,9 @@
-import * as babelParser from '@babel/parser';
-import babelGenerate from '@agoric/babel-generator';
-import babelTraverse from '@babel/traverse';
-import babelTypes from '@babel/types';
-
-import * as h from './hidden.js';
+import { makeTransformSource } from './transformSource.js';
 import makeModulePlugins from './babelPlugin.js';
 
+import * as h from './hidden.js';
+
 const { freeze } = Object;
-
-const parseBabel = babelParser.default
-  ? babelParser.default.parse
-  : babelParser.parse || babelParser;
-
-const visitorFromPlugin = plugin => plugin({ types: babelTypes }).visitor;
-
-const traverseBabel = babelTraverse.default || babelTraverse;
-const generateBabel = babelGenerate.default || babelGenerate;
-
-const makeTransformSource = (babel = null) => {
-  if (babel !== null) {
-    throw new Error(
-      `transform-analyze.js no longer allows injecting babel; use \`null\``,
-    );
-  }
-
-  const transformSource = (code, sourceOptions = {}) => {
-    // console.log(`transforming`, sourceOptions, code);
-    const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
-
-    const ast = parseBabel(code, { sourceType: sourceOptions.sourceType });
-
-    traverseBabel(ast, visitorFromPlugin(analyzePlugin));
-    traverseBabel(ast, visitorFromPlugin(transformPlugin));
-
-    const { code: transformedCode } = generateBabel(ast, {
-      retainLines: true,
-      compact: true,
-      verbatim: true,
-    });
-    return transformedCode;
-  };
-
-  return transformSource;
-};
 
 const makeCreateStaticRecord = transformSource =>
   function createStaticRecord(moduleSource, url) {
@@ -136,13 +97,13 @@ const makeCreateStaticRecord = transformSource =>
   };
 
 export const makeModuleAnalyzer = babel => {
-  const transformSource = makeTransformSource(babel);
+  const transformSource = makeTransformSource(makeModulePlugins, babel);
   const createStaticRecord = makeCreateStaticRecord(transformSource);
   return ({ string, url }) => createStaticRecord(string, url);
 };
 
 export const makeModuleTransformer = (babel, importer) => {
-  const transformSource = makeTransformSource(babel);
+  const transformSource = makeTransformSource(makeModulePlugins, babel);
   const createStaticRecord = makeCreateStaticRecord(transformSource);
   return {
     rewrite(ss) {

--- a/packages/static-module-record/src/transformSource.js
+++ b/packages/static-module-record/src/transformSource.js
@@ -20,7 +20,6 @@ export const makeTransformSource = (makeModulePlugins, babel = null) => {
   }
 
   const transformSource = (code, sourceOptions = {}) => {
-    // console.log(`transforming`, sourceOptions, code);
     const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
 
     const ast = parseBabel(code, { sourceType: sourceOptions.sourceType });

--- a/packages/static-module-record/src/transformSource.js
+++ b/packages/static-module-record/src/transformSource.js
@@ -1,0 +1,40 @@
+import * as babelParser from '@babel/parser';
+import babelGenerate from '@agoric/babel-generator';
+import babelTraverse from '@babel/traverse';
+import babelTypes from '@babel/types';
+
+const parseBabel = babelParser.default
+  ? babelParser.default.parse
+  : babelParser.parse || babelParser;
+
+const visitorFromPlugin = plugin => plugin({ types: babelTypes }).visitor;
+
+const traverseBabel = babelTraverse.default || babelTraverse;
+const generateBabel = babelGenerate.default || babelGenerate;
+
+export const makeTransformSource = (makeModulePlugins, babel = null) => {
+  if (babel !== null) {
+    throw new Error(
+      `transform-analyze.js no longer allows injecting babel; use \`null\``,
+    );
+  }
+
+  const transformSource = (code, sourceOptions = {}) => {
+    // console.log(`transforming`, sourceOptions, code);
+    const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
+
+    const ast = parseBabel(code, { sourceType: sourceOptions.sourceType });
+
+    traverseBabel(ast, visitorFromPlugin(analyzePlugin));
+    traverseBabel(ast, visitorFromPlugin(transformPlugin));
+
+    const { code: transformedCode } = generateBabel(ast, {
+      retainLines: true,
+      compact: true,
+      verbatim: true,
+    });
+    return transformedCode;
+  };
+
+  return transformSource;
+};

--- a/packages/static-module-record/test/benchmark-babel-plugin.js
+++ b/packages/static-module-record/test/benchmark-babel-plugin.js
@@ -1,0 +1,53 @@
+import Benchmark from 'benchmark';
+import fs from 'fs';
+import url from 'url';
+import { makeTransformSource } from '../src/transformSource.js';
+import makeModulePlugins from '../src/babelPlugin.js';
+
+const suite = new Benchmark.Suite();
+
+const resolveLocal = path => url.fileURLToPath(new URL(path, import.meta.url));
+const cases = [
+  {
+    name: 'small',
+    fixture: fs.readFileSync(resolveLocal('./fixtures/small.js'), 'utf8'),
+  },
+  {
+    name: 'large',
+    fixture: fs.readFileSync(resolveLocal('./fixtures/large.js'), 'utf8'),
+  },
+  {
+    name: 'exportheavy',
+    fixture: fs.readFileSync(resolveLocal('./fixtures/exportheavy.js'), 'utf8'),
+  },
+];
+
+const transformSource = makeTransformSource(makeModulePlugins);
+const freshOptions = () => {
+  return {
+    sourceType: 'module',
+    fixedExportMap: Object.create(null),
+    imports: Object.create(null),
+    exportAlls: [],
+    liveExportMap: Object.create(null),
+    hoistedDecls: [],
+    importSources: Object.create(null),
+    importDecls: [],
+    importMeta: { uttered: false },
+  };
+};
+
+cases.map(testCase =>
+  suite.add(testCase.name, () => {
+    transformSource(testCase.fixture, freshOptions());
+  }),
+);
+
+suite
+  .on('cycle', event => {
+    console.log(String(event.target));
+  })
+  .on('error', event => {
+    console.log(String(event.target), event.target.error);
+  })
+  .run();

--- a/packages/static-module-record/test/fixtures/exportheavy.js
+++ b/packages/static-module-record/test/fixtures/exportheavy.js
@@ -1,0 +1,52 @@
+export { mapIterable, filterIterable } from './src/helpers/iter-helpers.js';
+export {
+  PASS_STYLE,
+  isObject,
+  assertChecker,
+  getTag,
+  hasOwnPropertyOf,
+} from './src/helpers/passStyle-helpers.js';
+
+export { getErrorConstructor, toPassableError } from './src/helpers/error.js';
+export { getInterfaceOf } from './src/helpers/remotable.js';
+
+export {
+  nameForPassableSymbol,
+  passableSymbolForName,
+} from './src/helpers/symbol.js';
+
+export { passStyleOf, assertPassable } from './src/passStyleOf.js';
+
+export { deeplyFulfilled } from './src/deeplyFulfilled.js';
+
+export { makeTagged } from './src/makeTagged.js';
+export { Remotable, Far, ToFarFunction } from './src/make-far.js';
+
+export { QCLASS, makeMarshal } from './src/marshal.js';
+export { stringify, parse } from './src/marshal-stringify.js';
+// Works, but not yet used
+// export { decodeToJustin } from './src/marshal-justin.js';
+
+export {
+  assertRecord,
+  assertCopyArray,
+  assertRemotable,
+  isRemotable,
+  isRecord,
+  isCopyArray,
+} from './src/typeGuards.js';
+
+// eslint-disable-next-line import/export
+export * from './src/types.js';
+
+
+const { details: X } = assert;
+
+// This is a pathological minimum, but exercised by the unit test.
+export const MIN_DATA_BUFFER_LENGTH = 1;
+
+// Calculate how big the transfer buffer needs to be.
+export const TRANSFER_OVERHEAD_LENGTH =
+  BigUint64Array.BYTES_PER_ELEMENT + Int32Array.BYTES_PER_ELEMENT;
+export const MIN_TRANSFER_BUFFER_LENGTH =
+  MIN_DATA_BUFFER_LENGTH + TRANSFER_OVERHEAD_LENGTH;

--- a/packages/static-module-record/test/fixtures/exportheavy.js
+++ b/packages/static-module-record/test/fixtures/exportheavy.js
@@ -1,3 +1,6 @@
+/* eslint-disable */ 
+console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
+
 export { mapIterable, filterIterable } from './src/helpers/iter-helpers.js';
 export {
   PASS_STYLE,

--- a/packages/static-module-record/test/fixtures/large.js
+++ b/packages/static-module-record/test/fixtures/large.js
@@ -1,4 +1,5 @@
-/* eslint max-lines: 0 */
+/* eslint-disable */ 
+console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
 
 import * as h from './hidden.js';
 

--- a/packages/static-module-record/test/fixtures/small.js
+++ b/packages/static-module-record/test/fixtures/small.js
@@ -1,3 +1,5 @@
+/* eslint-disable */ 
+console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
 import * as babelParser from '@babel/parser';
 import babelGenerate from '@agoric/babel-generator';
 import babelTraverse from '@babel/traverse';

--- a/packages/static-module-record/test/fixtures/small.js
+++ b/packages/static-module-record/test/fixtures/small.js
@@ -1,0 +1,42 @@
+import * as babelParser from '@babel/parser';
+import babelGenerate from '@agoric/babel-generator';
+import babelTraverse from '@babel/traverse';
+import babelTypes from '@babel/types';
+
+import makeModulePlugins from './babelPlugin.js';
+
+const parseBabel = babelParser.default
+  ? babelParser.default.parse
+  : babelParser.parse || babelParser;
+
+const visitorFromPlugin = plugin => plugin({ types: babelTypes }).visitor;
+
+const traverseBabel = babelTraverse.default || babelTraverse;
+const generateBabel = babelGenerate.default || babelGenerate;
+
+export const makeTransformSource = (babel = null) => {
+  if (babel !== null) {
+    throw new Error(
+      `transform-analyze.js no longer allows injecting babel; use \`null\``,
+    );
+  }
+
+  const transformSource = (code, sourceOptions = {}) => {
+    // console.log(`transforming`, sourceOptions, code);
+    const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
+
+    const ast = parseBabel(code, { sourceType: sourceOptions.sourceType });
+
+    traverseBabel(ast, visitorFromPlugin(analyzePlugin));
+    traverseBabel(ast, visitorFromPlugin(transformPlugin));
+
+    const { code: transformedCode } = generateBabel(ast, {
+      retainLines: true,
+      compact: true,
+      verbatim: true,
+    });
+    return transformedCode;
+  };
+
+  return transformSource;
+};

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -64,7 +64,7 @@ test('export default', t => {
 function initialize(t, source, options = {}) {
   const { endowments, imports = new Map() } = options;
   const record = new StaticModuleRecord(source);
-  // t.log(record.__syncModuleProgram__);
+  t.log(record.__syncModuleProgram__);
   const liveUpdaters = {};
   const onceUpdaters = {};
   const namespace = {};
@@ -105,7 +105,7 @@ function initialize(t, source, options = {}) {
       };
     },
   );
-
+console.error('>>',record.__syncModuleProgram__)
   const functor = compartment.evaluate(record.__syncModuleProgram__);
 
   /** @type {Map<string, Map<string, Updater>>} */
@@ -560,13 +560,14 @@ test('import for side-effect', t => {
 test('import meta', t => {
   t.notThrows(() => initialize(t, `const a = import.meta.url`));
 });
-test.failing('import meta in export', t => {
+test('import meta in export', t => {
   let namespace = {};
   t.notThrows(() => {
-    namespace = initialize(t, `export const a = 'ok ' + import.meta.url`)
+    namespace = initialize(t, `export const a = 'ok ' + import.meta.url;
+    const unrelated = {b:import.meta.url};`)
       .namespace;
   });
-  t.is(namespace.result, 'ok file://meta.url');
+  t.is(namespace.a, 'ok file://meta.url');
 });
 test('import meta member uttered', t => {
   const record = new StaticModuleRecord(`const a = import.meta.url`);

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -562,9 +562,11 @@ test('import meta', t => {
 test('import meta in export', t => {
   let namespace = {};
   t.notThrows(() => {
-    namespace = initialize(t, `export const a = 'ok ' + import.meta.url;
-    const unrelated = {b:import.meta.url};`)
-      .namespace;
+    namespace = initialize(
+      t,
+      `export const a = 'ok ' + import.meta.url;
+    const unrelated = {b:import.meta.url};`,
+    ).namespace;
   });
   t.is(namespace.a, 'ok file://meta.url');
 });

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -105,7 +105,6 @@ function initialize(t, source, options = {}) {
       };
     },
   );
-console.error('>>',record.__syncModuleProgram__)
   const functor = compartment.evaluate(record.__syncModuleProgram__);
 
   /** @type {Map<string, Map<string, Updater>>} */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,6 +3082,14 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.1.tgz#73540563558687586b52ed217dad6a802ab1549c"
   integrity sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==
 
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  integrity sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -9765,6 +9773,11 @@ pkg-up@^2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
+
+platform@^1.3.3:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
 plur@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Note this PR has been opened against naugtur-import-meta-url branch. I wanted to discuss this commit separately

Working on import.meta I stumbled upon a case where if import.meta is used in an export statement it's not being reached by the visitor. 
This is one of the possible implementations.

Other ideas include:
- calling path.traverse inside rewriteDeclaration, which makes the whole thing take 2x the time
- replacing import.meta in the first ('Analyze') pass, which is controversial.

I think this fix may also fix other issues we didn't discover yet.


_I'm aware this has lint issues and a console.log leftover. I'm setting up the PR to make discussion easier_