### PR TITLE
refactor(stream): Stand on promise-kit dependency

### DIFF
--- a/packages/stream/index.js
+++ b/packages/stream/index.js
@@ -12,6 +12,7 @@
 /// <reference types="ses"/>
 
 import { E } from '@endo/eventual-send';
+import { makePromiseKit } from '@endo/promise-kit';
 
 /**
  * @template T
@@ -26,22 +27,6 @@ import { E } from '@endo/eventual-send';
 // a value one promises not to alter from a value one must not alter,
 // making it useless.
 const freeze = /** @type {<T>(v: T | Readonly<T>) => T} */ (Object.freeze);
-
-/**
- * @template T
- * @returns {PromiseKit<T>}
- */
-const makePromiseKit = () => {
-  let resolve;
-  let reject;
-  const promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  assert(resolve !== undefined);
-  assert(reject !== undefined);
-  return harden({ promise, resolve, reject });
-};
 
 /**
  * @template T

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@endo/eventual-send": "^0.15.3",
+    "@endo/promise-kit": "^0.2.41",
     "ses": "^0.15.15"
   },
   "devDependencies": {


### PR DESCRIPTION
This refactor is merely deduplication of makePromiseKit in the stream library.
Since writing stream, we moved promise kit to Endo, simplified, and committed to hardened-only streams.
