### PR TITLE
fix(console): direct error output to the current severity

### DIFF
--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -13,6 +13,7 @@
 /**
  * @callback NoteCallback
  *
+ * @param {'error' | 'warn' | 'info' | 'log' | 'debug'} severity
  * @param {Error} error
  * @param {LogArgs} noteLogArgs
  * @returns {void}

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -29,8 +29,8 @@ test('throwsAndLogs with data', t => {
     [
       ['error', 'what', obj],
       ['log', 'Caught', '(TypeError#1)'],
-      ['debug', 'TypeError#1:', 'foo'],
-      ['debug', 'stack of TypeError\n'],
+      ['log', 'TypeError#1:', 'foo'],
+      ['log', 'stack of TypeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -64,8 +64,8 @@ test('assert', t => {
     /Check failed/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['debug', 'Error#1:', 'Check failed'],
-      ['debug', 'stack of Error\n'],
+      ['log', 'Error#1:', 'Check failed'],
+      ['log', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -110,14 +110,14 @@ test('causal tree', t => {
     /because/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['debug', 'Error#1:', 'because', '(Error#2)'],
-      ['debug', 'stack of Error\n'],
+      ['log', 'Error#1:', 'because', '(Error#2)'],
+      ['log', 'stack of Error\n'],
       ['group', 'Nested error under Error#1'],
-      ['debug', 'Error#2:', 'synful', '(SyntaxError#3)'],
-      ['debug', 'stack of Error\n'],
+      ['log', 'Error#2:', 'synful', '(SyntaxError#3)'],
+      ['log', 'stack of Error\n'],
       ['group', 'Nested error under Error#2'],
-      ['debug', 'SyntaxError#3:', 'foo'],
-      ['debug', 'stack of SyntaxError\n'],
+      ['log', 'SyntaxError#3:', 'foo'],
+      ['log', 'stack of SyntaxError\n'],
       ['groupEnd'],
       ['groupEnd'],
     ],
@@ -202,8 +202,8 @@ test('assert equals', t => {
     /Expected \(a number\) is same as \(a number\)/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['debug', 'RangeError#1:', 'Expected', 5, 'is same as', 6],
-      ['debug', 'stack of RangeError\n'],
+      ['log', 'RangeError#1:', 'Expected', 5, 'is same as', 6],
+      ['log', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -216,8 +216,8 @@ test('assert equals', t => {
     /foo/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['debug', 'RangeError#1:', 'foo'],
-      ['debug', 'stack of RangeError\n'],
+      ['log', 'RangeError#1:', 'foo'],
+      ['log', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -240,8 +240,8 @@ test('assert equals', t => {
     /Expected \(a number\) is same as \(a number\)/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['debug', 'RangeError#1:', 'Expected', -0, 'is same as', 0],
-      ['debug', 'stack of RangeError\n'],
+      ['log', 'RangeError#1:', 'Expected', -0, 'is same as', 0],
+      ['log', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -280,8 +280,8 @@ test('assert error default', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', 'stack of Error\n'],
+      ['log', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
+      ['log', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -307,8 +307,8 @@ test('assert error explicit', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(URIError#1)'],
-      ['debug', 'URIError#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', 'stack of URIError\n'],
+      ['log', 'URIError#1:', '<', 'bar', ',', 'baz', '>'],
+      ['log', 'stack of URIError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -336,8 +336,8 @@ test('assert error named', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Foo-Err#2)'],
-      ['debug', 'Foo-Err#2:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', 'stack of URIError\n'],
+      ['log', 'Foo-Err#2:', '<', 'bar', ',', 'baz', '>'],
+      ['log', 'stack of URIError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -356,8 +356,8 @@ test('assert q', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', 'stack of Error\n'],
+      ['log', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
+      ['log', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );

--- a/packages/ses/test/test-console-error-trap.js
+++ b/packages/ses/test/test-console-error-trap.js
@@ -27,12 +27,12 @@ const exitAssertions = (t, expectedCode, altExpectedCode = expectedCode) => {
       'stderr should not have a second error marker',
     );
     t.assert(
-      stdout.includes('Error#1: Shibboleth'),
-      'stdout should contain error message',
+      stderr.includes('Error#1: Shibboleth'),
+      'stderr should contain error message',
     );
     t.assert(
-      !stdout.includes('Error#2'),
-      'stdout should not contain second error message',
+      !stderr.includes('Error#2'),
+      'stderr should not contain second error message',
     );
     t.end();
   };
@@ -78,12 +78,12 @@ test.cb('errors reveal their stacks with errorTrapping: report', t => {
       'stderr should have a second error marker',
     );
     t.assert(
-      stdout.includes('Error#1: Shibboleth'),
-      'stdout should contain error message',
+      stderr.includes('Error#1: Shibboleth'),
+      'stderr should contain error message',
     );
     t.assert(
-      stdout.includes('Error#2: I am once again'),
-      'stdout should contain second error message',
+      stderr.includes('Error#2: I am once again'),
+      'stderr should contain second error message',
     );
     t.end();
   });

--- a/packages/ses/test/test-console-rejection-trap.js
+++ b/packages/ses/test/test-console-rejection-trap.js
@@ -14,7 +14,13 @@ const exitAssertions = (t, expectedCode, altExpectedCode = expectedCode) => {
     // depending on the platform. Truncation normalizes both of these to the
     // same expected code.
     // eslint-disable-next-line no-bitwise
-    const code = err && err.code === null ? null : (err?.code ?? 0) & 0xff;
+    let code;
+    if (err && err.code === null) {
+      code = null;
+    } else {
+      // eslint-disable-next-line no-bitwise
+      code = ((err && err.code) || 0) & 0xff;
+    }
     t.log({ stdout, stderr, code, expectedCode, altExpectedCode });
     t.assert(
       code === expectedCode || code === altExpectedCode,
@@ -33,12 +39,12 @@ const exitAssertions = (t, expectedCode, altExpectedCode = expectedCode) => {
       'failed stderr should not have a second error marker',
     );
     t.assert(
-      stdout.includes('Error#1: Shibboleth'),
-      'stdout should contain error message',
+      stderr.includes('Error#1: Shibboleth'),
+      'stderr should contain error message',
     );
     t.assert(
-      code === 0 || !stdout.includes('Error#2'),
-      'failed stdout should not contain second error message',
+      code === 0 || !stderr.includes('Error#2'),
+      'failed stderr should not contain second error message',
     );
     t.end();
   };
@@ -59,8 +65,13 @@ test.cb(
   t => {
     t.plan(4);
     exec('node none.js', { cwd }, (err, stdout, stderr) => {
-      // eslint-disable-next-line no-bitwise
-      const code = err && err.code === null ? null : (err?.code ?? 0) & 0xff;
+      let code;
+      if (err && err.code === null) {
+        code = null;
+      } else {
+        // eslint-disable-next-line no-bitwise
+        code = ((err && err.code) || 0) & 0xff;
+      }
       t.log({ stdout, stderr, code });
 
       t.assert(code === 0 || code === 1, 'exit code is expected');
@@ -75,8 +86,8 @@ test.cb(
         'if Node 16, exit 1 and print the rejection code',
       );
       t.assert(
-        !stdout.includes('Error#') && !stderr.includes('Error#'),
-        'stdout should not contain SES errors',
+        !stderr.includes('Error#') && !stderr.includes('Error#'),
+        'stderr should not contain SES errors',
       );
       t.end();
     });


### PR DESCRIPTION
This fixes a longstanding problem where if you did a `console[level](...args_with_some_error)`, then the error output would not necessarily go to `level`.  Now it does.
