### PR TITLE
fix(eventual-send): use `!Object.is(a, b)` instead of `a !== b` for NaNs

### DIFF
--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -26,6 +26,7 @@ const {
   getPrototypeOf,
   setPrototypeOf,
   isFrozen,
+  is: objectIs,
 } = Object;
 
 const { apply, construct } = Reflect;
@@ -93,7 +94,7 @@ export const makeHandledPromise = () => {
     if (presence) {
       // Presences are final, so it is ok to propagate
       // this upstream.
-      while (target !== p) {
+      while (!objectIs(target, p)) {
         const parent = forwardedPromiseToPromise.get(target);
         forwardedPromiseToPromise.delete(target);
         promiseToPendingHandler.delete(target);
@@ -104,7 +105,7 @@ export const makeHandledPromise = () => {
       // We propagate p and remove all other pending handlers
       // upstream.
       // Note that everything except presences is covered here.
-      while (target !== p) {
+      while (!objectIs(target, p)) {
         const parent = forwardedPromiseToPromise.get(target);
         forwardedPromiseToPromise.set(target, p);
         promiseToPendingHandler.delete(target);
@@ -237,7 +238,7 @@ export const makeHandledPromise = () => {
           targetP = presenceToPromise.get(value);
         }
         // Ensure our data structure is a proper tree (avoid cycles).
-        if (targetP && targetP !== handledP) {
+        if (targetP && !objectIs(targetP, handledP)) {
           forwardedPromiseToPromise.set(handledP, targetP);
         } else {
           forwardedPromiseToPromise.delete(handledP);


### PR DESCRIPTION
We need to be more defensive in the `HandledPromise` innards or else we get the following if `NaN` is shortened:

```
TypeError#18: Invalid value used as weak map key
  at WeakMap.set (<anonymous>)
  at shorten (file:///Users/michael/agoric/agoric-sdk/node_modules/@endo/eventual-send/src/handled-promise.js:114:35)
  at handledResolve (file:///Users/michael/agoric/agoric-sdk/node_modules/@endo/eventual-send/src/handled-promise.js:232:17)
  at resolveHandled (file:///Users/michael/agoric/agoric-sdk/node_modules/@endo/eventual-send/src/handled-promise.js:380:9)
  at win (file:///Users/michael/agoric/agoric-sdk/node_modules/@endo/eventual-send/src/handled-promise.js:510:11)
  at file:///Users/michael/agoric/agoric-sdk/node_modules/@endo/eventual-send/src/handled-promise.js:528:20
  at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
