### PR TITLE
Implement and shim `atob` and `btoa`

### DIFF
--- a/packages/base64/NEWS.md
+++ b/packages/base64/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in base64:
 
+- Export `atob.js`, `btoa.js` for compatibility with the Web and Node.js APIs of
+  the same name.  Also add `shim.js` to install them on `globalThis.atob` and
+  `globalThis.btoa` if they are missing.
+
 # 0.2.8 (2021-09-18)
 
 - Use native `Base64.encode` or `Base64.decode` if available in global scope.

--- a/packages/base64/atob.js
+++ b/packages/base64/atob.js
@@ -1,0 +1,10 @@
+import { decodeBase64 } from './decode.js';
+
+/**
+ * @param {string} encodedData a binary string containing base64-encoded data
+ * @returns {string} an ASCII string containing decoded data from `encodedData`
+ */
+export const atob = encodedData => {
+  const buf = decodeBase64(encodedData);
+  return String.fromCharCode(...buf);
+};

--- a/packages/base64/btoa.js
+++ b/packages/base64/btoa.js
@@ -1,0 +1,17 @@
+import { encodeBase64 } from './encode.js';
+
+/**
+ * @param {string} stringToEncode the binary string to encode
+ * @returns {string} an ASCII string containing the base64 representation of `stringToEncode`
+ */
+export const btoa = stringToEncode => {
+  const bytes = stringToEncode.split('').map(char => {
+    const b = char.charCodeAt(0);
+    if (b > 0xff) {
+      throw new Error(`btoa: character out of range: ${char}`);
+    }
+    return b;
+  });
+  const buf = new Uint8Array(bytes);
+  return encodeBase64(buf);
+};

--- a/packages/base64/index.js
+++ b/packages/base64/index.js
@@ -1,2 +1,4 @@
 export { encodeBase64 } from './src/encode.js';
 export { decodeBase64 } from './src/decode.js';
+export { btoa } from './btoa.js';
+export { atob } from './atob.js';

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -22,8 +22,11 @@
   "module": "./index.js",
   "exports": {
     ".": "./index.js",
+    "./atob.js": "./atob.js",
+    "./btoa.js": "./btoa.js",
     "./encode.js": "./encode.js",
     "./decode.js": "./decode.js",
+    "./shim.js": "./shim.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/base64/shim.js
+++ b/packages/base64/shim.js
@@ -1,0 +1,12 @@
+/* global globalThis */
+// @ts-check
+import { atob } from './atob.js';
+import { btoa } from './btoa.js';
+
+if (globalThis.atob === undefined) {
+  globalThis.atob = atob;
+}
+
+if (globalThis.btoa === undefined) {
+  globalThis.btoa = btoa;
+}

--- a/packages/base64/test/capture-atob-btoa.js
+++ b/packages/base64/test/capture-atob-btoa.js
@@ -1,0 +1,3 @@
+/* global globalThis */
+const { atob: origAtob, btoa: origBtoa } = globalThis;
+export { origAtob as atob, origBtoa as btoa };

--- a/packages/base64/test/test-main.js
+++ b/packages/base64/test/test-main.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import { atob as origAtob, btoa as origBtoa } from './capture-atob-btoa.js';
 import { encodeBase64, decodeBase64, atob, btoa } from '../index.js';
 
 function stringToBytes(string) {
@@ -28,6 +29,8 @@ test('bytes conversions', t => {
     t.is(bytesToString(decodeBase64(outp)), inp, `${outp} decodes`);
     t.is(btoa(inp), outp, `${inp} encodes with btoa`);
     t.is(atob(outp), inp, `${outp} decodes with atob`);
+    origBtoa && t.is(origBtoa(inp), outp, `${inp} encodes with origBtoa`);
+    origAtob && t.is(origAtob(outp), inp, `${outp} decodes with origAtob`);
   }
   const inputs = [
     'a',
@@ -43,6 +46,10 @@ test('bytes conversions', t => {
       str,
       `${str} round trips`,
     );
+    origBtoa &&
+      t.is(atob(origBtoa(str)), str, `${str} round trips with atob(origBtoa)`);
+    origAtob &&
+      t.is(origAtob(btoa(str)), str, `${str} round trips with origAtob(btoa)`);
     t.is(atob(btoa(str)), str, `${str} round trips with atob(btoa)`);
   }
 });

--- a/packages/base64/test/test-main.js
+++ b/packages/base64/test/test-main.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { encodeBase64, decodeBase64 } from '../index.js';
+import { encodeBase64, decodeBase64, atob, btoa } from '../index.js';
 
 function stringToBytes(string) {
   const data = new Uint8Array(string.length);
@@ -26,6 +26,8 @@ test('bytes conversions', t => {
   for (const [inp, outp] of insouts) {
     t.is(encodeBase64(stringToBytes(inp)), outp, `${inp} encodes`);
     t.is(bytesToString(decodeBase64(outp)), inp, `${outp} decodes`);
+    t.is(btoa(inp), outp, `${inp} encodes with btoa`);
+    t.is(atob(outp), inp, `${outp} decodes with atob`);
   }
   const inputs = [
     'a',
@@ -41,5 +43,6 @@ test('bytes conversions', t => {
       str,
       `${str} round trips`,
     );
+    t.is(atob(btoa(str)), str, `${str} round trips with atob(btoa)`);
   }
 });

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -27,6 +27,8 @@ export async function importBundle(bundle, options = {}) {
     TextDecoder,
     URL: globalThis.URL, // Absent only in XSnap
     Base64: globalThis.Base64, // Present only in XSnap
+    atob: globalThis.atob,
+    btoa: globalThis.btoa,
     ...optEndowments,
   };
 

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@endo/eventual-send": "^0.15.3",
+    "@endo/base64": "^0.2.25",
     "@endo/lockdown": "^0.1.13"
   },
   "files": [

--- a/packages/init/pre.js
+++ b/packages/init/pre.js
@@ -1,3 +1,6 @@
 // Generic preamble for all shims.
 
+import '@endo/lockdown';
+import '@endo/base64/shim.js';
+
 export * from '@endo/lockdown';

--- a/packages/init/src/pre-node.js
+++ b/packages/init/src/pre-node.js
@@ -1,4 +1,6 @@
 // Node preamble for all shims.
 
 import './node-async_hooks-patch.js';
-import '@endo/lockdown';
+
+// eslint-disable-next-line import/export
+export * from '../pre.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,11 +1816,6 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-2.0.0.tgz#6d8f8ad9db3b75a39115f5def2654df8bed39f28"
-  integrity sha512-J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw==
-
 "@octokit/openapi-types@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-6.0.0.tgz#7da8d7d5a72d3282c1a3ff9f951c8133a707480d"
@@ -2546,7 +2541,7 @@ ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -5046,7 +5041,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2, es-abstract@^1.18.2, es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
+es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
   integrity sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==
@@ -6025,7 +6020,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.0, get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -6341,7 +6336,7 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-bigints@^1.0.1, has-bigints@^1.0.2:
+has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
@@ -6992,7 +6987,7 @@ is-buffer@^1.1.0, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.3, is-callable@^1.2.4:
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
@@ -7016,7 +7011,7 @@ is-color-stop@^1.0.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.1.0, is-core-module@^2.2.0, is-core-module@^2.8.0, is-core-module@^2.8.1:
+is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
@@ -7148,7 +7143,7 @@ is-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
   integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
 
-is-negative-zero@^2.0.1, is-negative-zero@^2.0.2:
+is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
@@ -7234,7 +7229,7 @@ is-reference@^1.1.2, is-reference@^1.2.1:
   dependencies:
     "@types/estree" "*"
 
-is-regex@^1.0.4, is-regex@^1.1.3, is-regex@^1.1.4:
+is-regex@^1.0.4, is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
@@ -7278,7 +7273,7 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
-is-string@^1.0.5, is-string@^1.0.6, is-string@^1.0.7:
+is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
   integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
@@ -8890,7 +8885,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.10.3, object-inspect@^1.12.0, object-inspect@^1.9.0:
+object-inspect@^1.12.0, object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
@@ -8913,7 +8908,7 @@ object-is@^1.0.1:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
 
-object-keys@^1.0.12, object-keys@^1.0.6, object-keys@^1.1.1:
+object-keys@^1.0.6, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -11571,7 +11566,7 @@ string.prototype.trim@~1.2.1:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
 
-string.prototype.trimend@^1.0.4, string.prototype.trimend@^1.0.5:
+string.prototype.trimend@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
   integrity sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==
@@ -11580,7 +11575,7 @@ string.prototype.trimend@^1.0.4, string.prototype.trimend@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
 
-string.prototype.trimstart@^1.0.4, string.prototype.trimstart@^1.0.5:
+string.prototype.trimstart@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
   integrity sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==
@@ -12384,7 +12379,7 @@ umd@^3.0.0:
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.3.tgz#aa9fe653c42b9097678489c01000acb69f0b26cf"
   integrity sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==
 
-unbox-primitive@^1.0.1, unbox-primitive@^1.0.2:
+unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
   integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==


### PR DESCRIPTION
These are useful and standard Web/Node.js APIs for Base64 support.

At least `protobufjs` relies on having them in the global scope (Web-compatible) when `Buffer` is unavailable.
