### PR TITLE
fix(console): close over severity for error note callbacks

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -158,7 +158,9 @@ export const typedArrayPrototype = getPrototypeOf(Uint8Array.prototype);
  * which only lives at
  * http://web.archive.org/web/20160805225710/http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
  *
- * @param {(thisArg: Object, ...args: any[]) => any} fn
+ * @template {Function} F
+ * @param {F} fn
+ * returns {(thisArg: ThisParameterType<F>, ...args: Parameters<F>) => ReturnType<F>}
  */
 export const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
 
@@ -205,6 +207,7 @@ export const stringStartsWith = uncurryThis(stringPrototype.startsWith);
 export const iterateString = uncurryThis(stringPrototype[iteratorSymbol]);
 //
 export const weakmapDelete = uncurryThis(weakmapPrototype.delete);
+/** @type {<K, V>(thisArg: WeakMap<K, V>, ...args: Parameters<WeakMap<K,V>['get']>) => ReturnType<WeakMap<K,V>['get']>} */
 export const weakmapGet = uncurryThis(weakmapPrototype.get);
 export const weakmapHas = uncurryThis(weakmapPrototype.has);
 export const weakmapSet = uncurryThis(weakmapPrototype.set);

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -254,8 +254,8 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
 
   const errorsLogged = new WeakSet();
 
-  /** @type {NoteCallback} */
-  const noteCallback = (severity, error, noteLogArgs) => {
+  /** @type {(severity: LogSeverity) => NoteCallback} */
+  const makeNoteCallback = severity => (error, noteLogArgs) => {
     const subErrors = [];
     // Annotation arrived after the error has already been logged,
     // so just log the annotation immediately, rather than remembering it.
@@ -275,7 +275,10 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     weaksetAdd(errorsLogged, error);
     const subErrors = [];
     const messageLogArgs = takeMessageLogArgs(error);
-    const noteLogArgsArray = takeNoteLogArgsArray(error, noteCallback);
+    const noteLogArgsArray = takeNoteLogArgsArray(
+      error,
+      makeNoteCallback(severity),
+    );
     // Show the error's most informative error message
     if (messageLogArgs === undefined) {
       // If there is no message log args, then just show the message that

--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -13,7 +13,6 @@
 /**
  * @callback NoteCallback
  *
- * @param {'error' | 'warn' | 'info' | 'log' | 'debug'} severity
  * @param {Error} error
  * @param {LogArgs} noteLogArgs
  * @returns {void}


### PR DESCRIPTION
This fix is required as my existing attempt at severity propagation caused exceptions in actual use.

I improved the commons typing around WeakMaps a little bit to help find this problem.
