### PR TITLE
fix: tests use debug settings

### DIFF
--- a/packages/check-bundle/test/test-check-bundle.js
+++ b/packages/check-bundle/test/test-check-bundle.js
@@ -1,6 +1,6 @@
 // @ts-check
 import '@endo/init/pre-bundle-source.js';
-import '@endo/init';
+import '@endo/init/debug.js';
 import test from 'ava';
 import * as fs from 'fs';
 import * as url from 'url';
@@ -76,7 +76,7 @@ test('bundle and check endo zip base64 package absent hash', async t => {
     checkBundle(lightBundle, computeSha512, 'fixture/main.js'),
     {
       message:
-        "checkBundle cannot bundle without the property 'endoZipBase64Sha512', which must be a string, got (a string)",
+        'checkBundle cannot bundle without the property \'endoZipBase64Sha512\', which must be a string, got "undefined"',
     },
   );
 });

--- a/packages/init/test/test-async_hooks.js
+++ b/packages/init/test/test-async_hooks.js
@@ -2,7 +2,7 @@
 
 // Use a package self-reference to go through the "exports" resolution
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@endo/init';
+import '@endo/init/debug.js';
 import test from 'ava';
 import { createHook } from 'async_hooks';
 import { setTimeout } from 'timers';

--- a/packages/lp32/test/test-lp32.js
+++ b/packages/lp32/test/test-lp32.js
@@ -1,7 +1,7 @@
 /* global setTimeout */
 // @ts-check
 
-import '@endo/init';
+import '@endo/init/debug.js';
 
 import rawTest from 'ava';
 import { wrapTest } from '@endo/ses-ava';

--- a/packages/netstring/test/test-netstring.js
+++ b/packages/netstring/test/test-netstring.js
@@ -1,7 +1,7 @@
 /* global setTimeout */
 // @ts-check
 
-import '@endo/init';
+import '@endo/init/debug.js';
 
 import test from 'ava';
 import { makePipe } from '@endo/stream';

--- a/packages/stream-node/test/test-stream-node.js
+++ b/packages/stream-node/test/test-stream-node.js
@@ -1,7 +1,7 @@
 // @ts-check
 /* global setTimeout */
 
-import '@endo/init';
+import '@endo/init/debug.js';
 
 import rawTest from 'ava';
 import { wrapTest } from '@endo/ses-ava';

--- a/packages/stream/test/test-map.js
+++ b/packages/stream/test/test-map.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import '@endo/init';
+import '@endo/init/debug.js';
 
 import rawTest from 'ava';
 import { wrapTest } from '@endo/ses-ava';

--- a/packages/stream/test/test-prime.js
+++ b/packages/stream/test/test-prime.js
@@ -1,7 +1,7 @@
 // @ts-check
 /* eslint-disable require-yield, no-empty-function */
 
-import '@endo/init';
+import '@endo/init/debug.js';
 
 import rawTest from 'ava';
 import { wrapTest } from '@endo/ses-ava';

--- a/packages/stream/test/test-pump.js
+++ b/packages/stream/test/test-pump.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import '@endo/init';
+import '@endo/init/debug.js';
 
 import rawTest from 'ava';
 import { wrapTest } from '@endo/ses-ava';

--- a/packages/stream/test/test-stream.js
+++ b/packages/stream/test/test-stream.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import '@endo/init';
+import '@endo/init/debug.js';
 
 import rawTest from 'ava';
 import { wrapTest } from '@endo/ses-ava';


### PR DESCRIPTION
I normally run with 
```sh
export LOCKDOWN_ERROR_TAMING=unsafe
```
This caused a failure in a test case comparing error messages, that were made more explanatory with this setting. The problem is that our tests were run with a neutral `lockdown` call that was letting this setting be set by the environment variable, but the test itself happened to depend on this option being `'safe'`. I think our best practice should be that `test-*.js` ava test files[1] should use the `@endo/init/debug.js` settings rather than the `@endo/init` settings. Then the error messages during testing will be more informative without endangering info leakage in production.

[1] aside from those whose purpose is to test the lockdown options, or whose purpose is to test that sensitive info in error messages get properly redacted.