### PR TITLE
fix: trivial changes to make lint happy

### DIFF
--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -467,6 +467,7 @@ const assertEntry = (allegedEntry, url) => {
  * @param {string} [url]
  * @returns {asserts compartmentMap is import('./types.js').CompartmentMapDescriptor}
  */
+
 export const assertCompartmentMap = (
   allegedCompartmentMap,
   url = '<unknown-compartment-map.json>',
@@ -488,5 +489,4 @@ export const assertCompartmentMap = (
   assertTags(tags, url);
   assertEntry(entry, url);
   assertCompartments(compartments, url);
-  return undefined;
 };

--- a/packages/compartment-mapper/src/parse-cjs-shared-export-wrapper.js
+++ b/packages/compartment-mapper/src/parse-cjs-shared-export-wrapper.js
@@ -20,6 +20,7 @@ const noTrailingSlash = path => {
 
 /**
  * Generates values for __filename and __dirname from location
+ *
  * @param {ReadPowers | ReadFn | undefined} readPowers
  * @param {string} location
  * @returns {{

--- a/packages/marshal/src/typeGuards.js
+++ b/packages/marshal/src/typeGuards.js
@@ -49,7 +49,7 @@ harden(isRemotable);
 /** @type {AssertArray} */
 const assertCopyArray = (array, optNameOfArray = 'Alleged array') => {
   const passStyle = passStyleOf(array);
-  return assert(
+  assert(
     passStyle === 'copyArray',
     X`${q(optNameOfArray)} ${array} must be a pass-by-copy array, not ${q(
       passStyle,
@@ -68,7 +68,7 @@ harden(assertCopyArray);
 /** @type {AssertRecord} */
 const assertRecord = (record, optNameOfRecord = 'Alleged record') => {
   const passStyle = passStyleOf(record);
-  return assert(
+  assert(
     passStyle === 'copyRecord',
     X`${q(optNameOfRecord)} ${record} must be a pass-by-copy record, not ${q(
       passStyle,
@@ -90,7 +90,7 @@ const assertRemotable = (
   optNameOfRemotable = 'Alleged remotable',
 ) => {
   const passStyle = passStyleOf(remotable);
-  return assert(
+  assert(
     passStyle === 'remotable',
     X`${q(optNameOfRemotable)} ${remotable} must be a remotable, not ${q(
       passStyle,

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -93,8 +93,8 @@ export const rejectHtmlComments = src => {
  * not change the meaning of the program because it only changes the contents of
  * those comments.
  *
- * @param { string } src
- * @returns { string }
+ * @param {string} src
+ * @returns {string}
  */
 export const evadeHtmlCommentTest = src => {
   const replaceFn = match => (match[0] === '<' ? '< ! --' : '-- >');
@@ -135,8 +135,8 @@ const importPattern = new FERAL_REG_EXP(
  * something like that from something like importnotreally('power.js') which
  * is perfectly safe.
  *
- * @param { string } src
- * @returns { string }
+ * @param {string} src
+ * @returns {string}
  */
 export const rejectImportExpressions = src => {
   const lineNumber = getLineNumber(src, importPattern);
@@ -162,8 +162,8 @@ export const rejectImportExpressions = src => {
  * the meaning of the program, depending on the binding, if any, of the lexical
  * variable `__import__`.
  *
- * @param { string } src
- * @returns { string }
+ * @param {string} src
+ * @returns {string}
  */
 export const evadeImportExpressionTest = src => {
   const replaceFn = (_, p1, p2) => `${p1}__import__${p2}`;
@@ -206,8 +206,8 @@ const someDirectEvalPattern = new FERAL_REG_EXP(
  *
  * Exported for unit tests.
  *
- * @param { string } src
- * @returns { string }
+ * @param {string} src
+ * @returns {string}
  */
 export const rejectSomeDirectEvalExpressions = src => {
   const lineNumber = getLineNumber(src, someDirectEvalPattern);


### PR DESCRIPTION
For some reason, when a newline is placed between a function jsdoc-type declaration and the function itself, ts type checking makes fewer bad rejections while otherwise seeming to stay as accurate. Discovered by accident. I have no idea why.

Also removing extraneous spaces within the outer curlies of jsdoc type decls, as our style is generally to omit them. By omitting them consistently, it is easier to find things with trivial greps.

See https://github.com/Agoric/agoric-sdk/pull/5597