### PR TITLE
fix: tolerate empty func.prototype

### DIFF
--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -285,6 +285,15 @@ export default function whitelistIntrinsics(
           delete obj[prop];
         } catch (err) {
           if (prop in obj) {
+            if (typeof obj === 'function' && prop === 'prototype') {
+              obj.prototype = undefined;
+              if (obj.prototype === undefined) {
+                // eslint-disable-next-line @endo/no-polymorphic-call
+                console.warn(`Tolerating undeletable ${subPath} === undefined`);
+                // eslint-disable-next-line no-continue
+                continue;
+              }
+            }
             // eslint-disable-next-line @endo/no-polymorphic-call
             console.error(`failed to delete ${subPath}`, err);
           } else {

--- a/packages/ses/test/test-tolerate-empty-prototype.js
+++ b/packages/ses/test/test-tolerate-empty-prototype.js
@@ -12,4 +12,14 @@ lockdown();
 
 test('tolerate empty prototype', t => {
   t.assert('prototype' in Array.prototype.push);
+  t.is(Array.prototype.push.prototype, undefined);
+  t.deepEqual(
+    Object.getOwnPropertyDescriptor(Array.prototype.push, 'prototype'),
+    {
+      value: undefined,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    },
+  );
 });

--- a/packages/ses/test/test-tolerate-empty-prototype.js
+++ b/packages/ses/test/test-tolerate-empty-prototype.js
@@ -1,0 +1,15 @@
+import test from 'ava';
+import '../index.js';
+
+// See https://github.com/zloirock/core-js/issues/1092
+const originalPush = Array.prototype.push;
+// eslint-disable-next-line no-extend-native
+Array.prototype.push = function push(...args) {
+  return Reflect.apply(originalPush, this, args);
+};
+
+lockdown();
+
+test('tolerate empty prototype', t => {
+  t.assert('prototype' in Array.prototype.push);
+});


### PR DESCRIPTION
See https://github.com/zloirock/core-js/issues/1092

If a primordial method is whitelisted as `fn`, then it is not supposed to have `prototype` property. However, as explained by https://github.com/zloirock/core-js/issues/1092 , there is some desire to run `core-js` as a vetted shim, i.e., a shim run before `lockdown` that does not break any of the invariants that SES depends on. However, the core-js shim also targets ES5, and there's no good option in ES5 for making a replacement primordial function that does not have an undeletable `prototype` property.

With this PR, our whitelisting, on encountering such a function, instead sets its `prototype` to `undefined` and then checks that it has done so. If so, then it issues a warning but allows the whitelisting to continue. 
