### PR TITLE
fix: workaround leak through promise resolvers

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -5,6 +5,7 @@
 // Establish a perimeter:
 import 'ses';
 import '@endo/eventual-send/shim.js';
+import '@endo/promise-kit/shim.js';
 import '@endo/lockdown/commit.js';
 
 import crypto from 'crypto';

--- a/packages/init/NEWS.md
+++ b/packages/init/NEWS.md
@@ -1,4 +1,8 @@
 
+# Next release
+
+Patch `Promise.race` to use a non-leaky implementation.
+
 # v0.5.30 (2022-01-21)
 
 The `@endo/init` package exists so the "main" of production code can

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@endo/base64": "^0.2.26",
     "@endo/eventual-send": "^0.15.4",
+    "@endo/promise-kit": "^0.2.42",
     "@endo/lockdown": "^0.1.14"
   },
   "files": [

--- a/packages/init/pre.js
+++ b/packages/init/pre.js
@@ -2,5 +2,6 @@
 
 import '@endo/lockdown';
 import '@endo/base64/shim.js';
+import '@endo/promise-kit/shim.js';
 
 export * from '@endo/lockdown';

--- a/packages/promise-kit/NEWS.md
+++ b/packages/promise-kit/NEWS.md
@@ -3,6 +3,7 @@ User-visible changes in `@endo/promise-kit`:
 # Next release
 
 Add a `racePromises` export which implements a non-leaky race algorithm.
+Add a `/shim.js` entrypoint which replaces `Promise.race` with the same non-leaky version.
 
 # v0.2.31 (2022-01-25)
 

--- a/packages/promise-kit/NEWS.md
+++ b/packages/promise-kit/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `@endo/promise-kit`:
 
+# Next release
+
+Add a `racePromises` export which implements a non-leaky race algorithm.
+
 # v0.2.31 (2022-01-25)
 
 This change fixes the package such that the code is included in the published

--- a/packages/promise-kit/index.js
+++ b/packages/promise-kit/index.js
@@ -79,11 +79,11 @@ harden(isPromise);
  * Unlike `Promise.race` it cleans up after itself so a non-resolved value doesn't hold onto
  * the result promise.
  *
- * @template {readonly unknown[] | []} T
- * @param {T} values An array of Promises.
- * @returns {Promise<Awaited<T[number]>>} A new Promise.
+ * @template T
+ * @param {Iterable<T>} values An iterable of Promises.
+ * @returns {Promise<Awaited<T>>} A new Promise.
  */
 export function racePromises(values) {
-  return harden(memoRace(values));
+  return harden(memoRace.call(BestPipelinablePromise, values));
 }
 harden(racePromises);

--- a/packages/promise-kit/index.js
+++ b/packages/promise-kit/index.js
@@ -3,6 +3,8 @@
 
 /// <reference types="ses"/>
 
+import { memoRace } from './src/memo-race.js';
+
 /** @type {PromiseConstructor} */
 const BestPipelinablePromise = globalThis.HandledPromise || Promise;
 
@@ -69,3 +71,19 @@ export function isPromise(maybePromise) {
   return Promise.resolve(maybePromise) === maybePromise;
 }
 harden(isPromise);
+
+/**
+ * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
+ * or rejected.
+ *
+ * Unlike `Promise.race` it cleans up after itself so a non-resolved value doesn't hold onto
+ * the result promise.
+ *
+ * @template {readonly unknown[] | []} T
+ * @param {T} values An array of Promises.
+ * @returns {Promise<Awaited<T[number]>>} A new Promise.
+ */
+export function racePromises(values) {
+  return harden(memoRace(values));
+}
+harden(racePromises);

--- a/packages/promise-kit/index.js
+++ b/packages/promise-kit/index.js
@@ -5,32 +5,12 @@
 
 import { memoRace } from './src/memo-race.js';
 
+export * from './src/is-promise.js';
+// eslint-disable-next-line import/export
+export * from './src/types.js';
+
 /** @type {PromiseConstructor} */
 const BestPipelinablePromise = globalThis.HandledPromise || Promise;
-
-/**
- * @template T
- * @typedef {Object} PromiseKit A reified Promise
- * @property {(value: ERef<T>) => void} resolve
- * @property {(reason: any) => void} reject
- * @property {Promise<T>} promise
- */
-
-/**
- * PromiseRecord is deprecated in favor of PromiseKit.
- *
- * @template T
- * @typedef {PromiseKit<T>} PromiseRecord
- */
-
-/**
- * @template T
- * @typedef {T | PromiseLike<T>} ERef
- * A reference of some kind for to an object of type T. It may be a direct
- * reference to a local T. It may be a local presence for a remote T. It may
- * be a promise for a local or remote T. Or it may even be a thenable
- * (a promise-like non-promise with a "then" method) for a T.
- */
 
 /**
  * Needed to prevent type errors where functions are detected to be undefined.
@@ -43,10 +23,10 @@ const NOOP_INITIALIZER = harden(() => {});
  * and rejecting it.
  *
  * @template T
- * @returns {PromiseKit<T>}
+ * @returns {import('./src/types.js').PromiseKit<T>}
  */
 export function makePromiseKit() {
-  /** @type {(value: ERef<T>) => void} */
+  /** @type {(value: import('./src/types.js').ERef<T>) => void} */
   let resolve = NOOP_INITIALIZER;
   /** @type {(reason: unknown) => void} */
   let reject = NOOP_INITIALIZER;
@@ -60,17 +40,6 @@ export function makePromiseKit() {
   return harden({ promise, resolve, reject });
 }
 harden(makePromiseKit);
-
-/**
- * Determine if the argument is a Promise.
- *
- * @param {any} maybePromise The value to examine
- * @returns {maybePromise is Promise} Whether it is a promise
- */
-export function isPromise(maybePromise) {
-  return Promise.resolve(maybePromise) === maybePromise;
-}
-harden(isPromise);
 
 /**
  * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -20,6 +20,7 @@
   "module": "./index.js",
   "exports": {
     ".": "./index.js",
+    "./shim.js": "./shim.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/promise-kit/shim.js
+++ b/packages/promise-kit/shim.js
@@ -1,0 +1,4 @@
+import { memoRace } from './src/memo-race.js';
+
+// Unconditionally replace with a non-leaking version
+Promise.race = memoRace;

--- a/packages/promise-kit/src/is-promise.js
+++ b/packages/promise-kit/src/is-promise.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+/**
+ * Determine if the argument is a Promise.
+ *
+ * @param {unknown} maybePromise The value to examine
+ * @returns {maybePromise is Promise} Whether it is a promise
+ */
+export function isPromise(maybePromise) {
+  return Promise.resolve(maybePromise) === maybePromise;
+}
+harden(isPromise);

--- a/packages/promise-kit/src/memo-race.js
+++ b/packages/promise-kit/src/memo-race.js
@@ -34,7 +34,7 @@ const isObject = value => Object(value) === value;
 /**
  * @template [T=any]
  * @typedef {object} Deferred
- * @property {(value?: import("../index.js").ERef<T> ) => void} resolve
+ * @property {(value?: import("./types.js").ERef<T> ) => void} resolve
  * @property {(err?: any ) => void} reject
  */
 

--- a/packages/promise-kit/src/memo-race.js
+++ b/packages/promise-kit/src/memo-race.js
@@ -104,41 +104,51 @@ const getMemoRecord = value => {
   return record;
 };
 
-/**
- * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
- * or rejected.
- *
- * Unlike `Promise.race` it cleans up after itself so a non-resolved value doesn't hold onto
- * the result promise.
- *
- * @template {readonly unknown[] | []} T
- * @param {T} values An array of Promises.
- * @returns {Promise<Awaited<T[number]>>} A new Promise.
- */
-export const memoRace = values => {
-  let deferred;
-  const result = new Promise((resolve, reject) => {
-    deferred = { resolve, reject };
-    for (const value of values) {
-      const { settled, deferreds } = getMemoRecord(value);
-      if (settled) {
-        // If the contender is settled (including primitives), it is safe
-        // to call `Promise.resolve(value).then` on it.
-        Promise.resolve(value).then(resolve, reject);
-      } else {
-        deferreds.add(deferred);
+const { race } = {
+  /**
+   * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
+   * or rejected.
+   *
+   * Unlike `Promise.race` it cleans up after itself so a non-resolved value doesn't hold onto
+   * the result promise.
+   *
+   * @template T
+   * @template {PromiseConstructor} [P=PromiseConstructor]
+   * @this {P}
+   * @param {Iterable<T>} values An iterable of Promises.
+   * @returns {Promise<Awaited<T>>} A new Promise.
+   */
+  race(values) {
+    let deferred;
+    /** @type {T[]} */
+    const cachedValues = [];
+    const C = this;
+    const result = new C((resolve, reject) => {
+      deferred = { resolve, reject };
+      for (const value of values) {
+        cachedValues.push(value);
+        const { settled, deferreds } = getMemoRecord(value);
+        if (settled) {
+          // If the contender is settled (including primitives), it is safe
+          // to call `Promise.resolve(value).then` on it.
+          C.resolve(value).then(resolve, reject);
+        } else {
+          deferreds.add(deferred);
+        }
       }
-    }
-  });
+    });
 
-  // The finally callback executes when any value settles, preventing any of
-  // the unresolved values from retaining a reference to the resolved value.
-  return result.finally(() => {
-    for (const value of values) {
-      const { deferreds } = getMemoRecord(value);
-      if (deferreds) {
-        deferreds.delete(deferred);
+    // The finally callback executes when any value settles, preventing any of
+    // the unresolved values from retaining a reference to the resolved value.
+    return result.finally(() => {
+      for (const value of cachedValues) {
+        const { deferreds } = getMemoRecord(value);
+        if (deferreds) {
+          deferreds.delete(deferred);
+        }
       }
-    }
-  });
+    });
+  },
 };
+
+export { race as memoRace };

--- a/packages/promise-kit/src/memo-race.js
+++ b/packages/promise-kit/src/memo-race.js
@@ -1,0 +1,99 @@
+/* eslint-disable */
+/*
+Authored by Brian Kim:
+https://github.com/nodejs/node/issues/17469#issuecomment-685216777
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+*/
+
+function isPrimitive(value) {
+  return (
+    value === null || (typeof value !== 'object' && typeof value !== 'function')
+  );
+}
+
+// Keys are the values passed to race, values are a record of data containing a
+// set of deferreds and whether the value has settled.
+/** @type {WeakMap<object, {deferreds: Set<Deferred>, settled: boolean}>} */
+const wm = new WeakMap();
+function safeRace(contenders) {
+  let deferred;
+  const result = new Promise((resolve, reject) => {
+    deferred = { resolve, reject };
+    for (const contender of contenders) {
+      if (isPrimitive(contender)) {
+        // If the contender is a primitive, attempting to use it as a key in the
+        // weakmap would throw an error. Luckily, it is safe to call
+        // `Promise.resolve(contender).then` on a primitive value multiple times
+        // because the promise fulfills immediately.
+        Promise.resolve(contender).then(resolve, reject);
+        continue;
+      }
+
+      let record = wm.get(contender);
+      if (record === undefined) {
+        record = { deferreds: new Set([deferred]), settled: false };
+        wm.set(contender, record);
+        // This call to `then` happens once for the lifetime of the value.
+        Promise.resolve(contender).then(
+          value => {
+            for (const { resolve } of record.deferreds) {
+              resolve(value);
+            }
+
+            record.deferreds.clear();
+            record.settled = true;
+          },
+          err => {
+            for (const { reject } of record.deferreds) {
+              reject(err);
+            }
+
+            record.deferreds.clear();
+            record.settled = true;
+          },
+        );
+      } else if (record.settled) {
+        // If the value has settled, it is safe to call
+        // `Promise.resolve(contender).then` on it.
+        Promise.resolve(contender).then(resolve, reject);
+      } else {
+        record.deferreds.add(deferred);
+      }
+    }
+  });
+
+  // The finally callback executes when any value settles, preventing any of
+  // the unresolved values from retaining a reference to the resolved value.
+  return result.finally(() => {
+    for (const contender of contenders) {
+      if (!isPrimitive(contender)) {
+        const record = wm.get(contender);
+        record.deferreds.delete(deferred);
+      }
+    }
+  });
+}

--- a/packages/promise-kit/src/promise-executor-kit.js
+++ b/packages/promise-kit/src/promise-executor-kit.js
@@ -1,0 +1,56 @@
+// @ts-check
+
+/// <reference types="ses"/>
+
+/**
+ * @template T
+ * @callback PromiseExecutor The promise executor
+ * @param {(value: import('./types.js').ERef<T>) => void} resolve
+ * @param {(reason: any) => void} reject
+ */
+
+/**
+ * makeReleasingExecutorKit() builds resolve/reject functions which drop references
+ * to the resolve/reject functions gathered from an executor to be used with a
+ * promise constructor.
+ *
+ * @template T
+ * @returns {Pick<import('./types.js').PromiseKit<T>, 'resolve' | 'reject'> & { executor: PromiseExecutor<T>}}
+ */
+export const makeReleasingExecutorKit = () => {
+  /** @type {null | undefined | ((value: import('./types.js').ERef<T>) => void)} */
+  let internalResolve;
+  /** @type {null | undefined | ((reason: unknown) => void)} */
+  let internalReject;
+
+  /** @param {import('./types.js').ERef<T>} value */
+  const resolve = value => {
+    if (internalResolve) {
+      internalResolve(value);
+      internalResolve = null;
+      internalReject = null;
+    } else {
+      assert(internalResolve === null);
+    }
+  };
+
+  /** @param {unknown} reason */
+  const reject = reason => {
+    if (internalReject) {
+      internalReject(reason);
+      internalResolve = null;
+      internalReject = null;
+    } else {
+      assert(internalReject === null);
+    }
+  };
+
+  const executor = (res, rej) => {
+    assert(internalResolve === undefined && internalReject === undefined);
+    internalResolve = res;
+    internalReject = rej;
+  };
+
+  return { resolve, reject, executor };
+};
+harden(makeReleasingExecutorKit);

--- a/packages/promise-kit/src/types.js
+++ b/packages/promise-kit/src/types.js
@@ -1,0 +1,25 @@
+/**
+ * @template T
+ * @typedef {object} PromiseKit A reified Promise
+ * @property {(value: ERef<T>) => void} resolve
+ * @property {(reason: any) => void} reject
+ * @property {Promise<T>} promise
+ */
+
+/**
+ * PromiseRecord is deprecated in favor of PromiseKit.
+ *
+ * @template T
+ * @typedef {PromiseKit<T>} PromiseRecord
+ */
+
+/**
+ * @template T
+ * @typedef {T | PromiseLike<T>} ERef
+ * A reference of some kind for to an object of type T. It may be a direct
+ * reference to a local T. It may be a local presence for a remote T. It may
+ * be a promise for a local or remote T. Or it may even be a thenable
+ * (a promise-like non-promise with a "then" method) for a T.
+ */
+
+export {};

--- a/packages/promise-kit/test/test-promise-kit.js
+++ b/packages/promise-kit/test/test-promise-kit.js
@@ -1,8 +1,26 @@
+/* globals globalThis, FinalizationRegistry, setImmediate */
+
 import 'ses';
 import './lockdown.js';
 import rawTest from 'ava';
 import { wrapTest } from '@endo/ses-ava';
-import { isPromise, makePromiseKit } from '../index.js';
+
+import v8 from 'node:v8';
+import vm from 'node:vm';
+
+import { isPromise, makePromiseKit, racePromises } from '../index.js';
+
+/** @type {() => void} */
+let engineGC;
+if (typeof globalThis.gc !== 'function') {
+  // Node.js v8 wizardry.
+  v8.setFlagsFromString('--expose_gc');
+  engineGC = vm.runInNewContext('gc');
+  // Hide the gc global from new contexts/workers.
+  v8.setFlagsFromString('--no-expose_gc');
+} else {
+  engineGC = globalThis.gc;
+}
 
 const test = wrapTest(rawTest);
 
@@ -15,4 +33,70 @@ test('makePromiseKit', async t => {
 
 test('isPromise', t => {
   t.assert(isPromise(Promise.resolve()));
+});
+
+/** @type {FinalizationRegistry<() => void>} */
+const fr = new FinalizationRegistry(held => {
+  held();
+});
+
+const forever = new Promise(() => {});
+
+function testRacePromise(t, candidate) {
+  t.plan(2);
+  const collected = makePromiseKit();
+  let bothResults;
+
+  let targetWasCollected = false;
+
+  collected.promise.then(() => {
+    targetWasCollected = true;
+  });
+
+  (() => {
+    const raced = racePromises([forever, candidate]);
+    const result = Promise.resolve(candidate);
+
+    bothResults = Promise.allSettled([raced, result]);
+    fr.register(raced, collected.resolve);
+  })();
+
+  return bothResults
+    .then(([val1, val2]) => {
+      t.deepEqual(val1, val2);
+    })
+    .then(() => {
+      const sentinelCollected = new Promise(resolve => {
+        fr.register({}, resolve);
+      });
+
+      new Promise(resolve => {
+        setImmediate(resolve);
+      }).then(engineGC);
+
+      return sentinelCollected;
+    })
+    .then(() => {})
+    .then(() => {
+      if (targetWasCollected) {
+        t.pass();
+      } else {
+        t.fail('Raced promise leaked');
+      }
+    });
+}
+
+test('racePromise: resolved', testRacePromise, Promise.resolve());
+test(
+  'racePromise: rejected',
+  testRacePromise,
+  Promise.reject(new Error('Test')),
+);
+test('racePromise: primitive', testRacePromise, -0);
+test('racePromise: object', testRacePromise, {});
+test('racePromise: thenable', testRacePromise, {
+  internal: Promise.resolve(),
+  then(res, rej) {
+    return this.internal.then(res, rej);
+  },
 });


### PR DESCRIPTION
The investigation into https://github.com/Agoric/agoric-sdk/issues/5507 lead us into discovering a leak caused by promises, in particular when using [`Promise.race` with a long pending promise](https://github.com/nodejs/node/issues/17469). The root cause really seem that the promise resolve functions hold onto the promise strongly (instead of just an internal record representing the reactions registered on the promise), and through that, the result of said promise. `Promise.race` is implemented as adding the result's promise's resolver functions to each of the contenders reactions, causing the long pending promise to keep the raced result alive.

This PR re-implements `Promise.race` based on the solution in https://github.com/nodejs/node/issues/17469#issuecomment-685216777. It also updates `makePromiseKit` to return resolvers that will sever their hold on the original resolvers (and thus the promise) once called. That latter approach, while simpler, is not sufficient for `Promise.race` as reactions would keep queueing on the long pending promise (engines are not sufficiently smart to realize a reaction is a native resolver that has become inert).

Finally it installs the new race implementation as a `Promise.race` vetted shim in `@endo/init`.

(I'm half considering re-writing promises in userland with proper support for short-circuiting, which would avoid most of these issues, but the few spec places creating primordial promises would damper that. A long term solution might be to rewrite the spec  with proper short-circuiting, maybe as part of [tc39/proposal-faster-promise-adoption](https://github.com/tc39/proposal-faster-promise-adoption))