### PR TITLE
fix: typedef of E() proxy parameter constraint

### DIFF
--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -234,7 +234,7 @@ interface EProxy {
    * @param x target for method/function call
    * @returns method/function call proxy
    */
-  <T>(x: T): ECallableOrMethods<RemoteFunctions<T>>;
+  <T extends {}>(x: T): ECallableOrMethods<RemoteFunctions<T>>;
 
   /**
    * E.get(x) returns a proxy on which you can get arbitrary properties.
@@ -245,7 +245,7 @@ interface EProxy {
    * @param x target for property get
    * @returns property get proxy
    */
-  readonly get: <T>(x: T) => EGetters<LocalRecord<T>>;
+  readonly get: <T extends {}>(x: T) => EGetters<LocalRecord<T>>;
 
   /**
    * E.resolve(x) converts x to a handled promise. It is

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -234,7 +234,10 @@ interface EProxy {
    * @param x target for method/function call
    * @returns method/function call proxy
    */
-  <T extends {}>(x: T): ECallableOrMethods<RemoteFunctions<T>>;
+  // <T>(x: NonNullable<T>): ECallableOrMethods<RemoteFunctions<T>>;
+  // (undefined): Record<PropertyKey, never>;
+  // (x: null): Record<PropertyKey, never>;
+  <T>(x: NonNullable<T>): ECallableOrMethods<RemoteFunctions<T>>;
 
   /**
    * E.get(x) returns a proxy on which you can get arbitrary properties.
@@ -245,7 +248,7 @@ interface EProxy {
    * @param x target for property get
    * @returns property get proxy
    */
-  readonly get: <T extends {}>(x: T) => EGetters<LocalRecord<T>>;
+  readonly get: <T>(x: T) => EGetters<LocalRecord<T>>;
 
   /**
    * E.resolve(x) converts x to a handled promise. It is

--- a/packages/eventual-send/src/index.test-d.ts
+++ b/packages/eventual-send/src/index.test-d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @endo/no-polymorphic-call, import/no-extraneous-dependencies, no-restricted-globals, prettier/prettier */
 import { expectType } from 'tsd';
+import { Far } from '@endo/marshal';
 import { E } from '../test/get-hp.js';
 import { DataOnly, ERef } from './index.js';
 
@@ -51,13 +52,30 @@ const foo2 = async (a: FarRef<{ bar(): string; baz: number }>) => {
 type SomeRemotable = { someMethod: () => 'hello'; someVal: 'alsoHello' };
 const undefinedCase = () => {
   let ref: SomeRemotable | undefined;
+  // @ts-expect-error can't proxy an undefined value
+  E(ref);
   // @ts-expect-error could be undefined
   E(ref).someMethod();
   // @ts-expect-error optional chaining doesn't work with E()
   E(ref)?.someMethod();
   // @ts-expect-error could be undefined
   E.get(ref);
-  const getters = E.get(ref!);
+  const getters = E.get(ref);
+  expectType < EGetters<SomeRemotable | undefined>(getters);
+  getters.someMethod.then(sayHello => sayHello());
+  getters.someVal;
+};
+const promiseUndefinedCase = () => {
+  let ref: Promise<SomeRemotable | undefined>;
+  // @ts-expect-error can't proxy an undefined value
+  E(ref);
+  // @ts-expect-error could be undefined
+  E(ref).someMethod();
+  // @ts-expect-error optional chaining doesn't work with E()
+  E(ref)?.someMethod();
+  // @ts-expect-error could be undefined
+  E.get(ref);
+  const getters = E.get(ref);
   getters.someMethod.then(sayHello => sayHello());
   getters.someVal;
 };

--- a/packages/eventual-send/src/index.test-d.ts
+++ b/packages/eventual-send/src/index.test-d.ts
@@ -46,3 +46,30 @@ const foo2 = async (a: FarRef<{ bar(): string; baz: number }>) => {
   // @ts-expect-error - calling directly is valid but not yet in the typedef
   a.bar;
 };
+
+// Nullish handling
+type SomeRemotable = { someMethod: () => 'hello'; someVal: 'alsoHello' };
+const undefinedCase = () => {
+  let ref: SomeRemotable | undefined;
+  // @ts-expect-error could be undefined
+  E(ref).someMethod();
+  // @ts-expect-error optional chaining doesn't work with E()
+  E(ref)?.someMethod();
+  // @ts-expect-error could be undefined
+  E.get(ref);
+  const getters = E.get(ref!);
+  getters.someMethod.then(sayHello => sayHello());
+  getters.someVal;
+};
+const nullCase = () => {
+  let ref: SomeRemotable | null;
+  // @ts-expect-error could be null
+  E(ref).someMethod();
+  // @ts-expect-error optional chaining doesn't work with E()
+  E(ref)?.someMethod();
+  // @ts-expect-error could be null
+  E.get(ref);
+  const getters = E.get(ref!);
+  getters.someMethod.then(sayHello => sayHello());
+  getters.someVal;
+};


### PR DESCRIPTION
The following throws `Cannot deliver "getChildNode" to target; typeof target is "undefined"`.
```js
test('childNode on undefined', async () => {
  /** @type {StorageNode | undefined} */
  let parentNode;
  await E(parentNode)?.getChildNode('foo');
});
```

It's tempting to make `E(undefined)` to return `undefined` but the behavior must be consistent with a promised value and `Promise<undefined>` can't be determined before the object returns.

So this solves the case above by updating the type definition to report that it won't work.
