### PR TITLE
fix unnecessary memory retention paths

### DIFF
--- a/packages/stream-node/writer.js
+++ b/packages/stream-node/writer.js
@@ -24,11 +24,23 @@ export const makeNodeWriter = writer => {
 
   const finalIteration = new Promise((resolve, reject) => {
     const finalize = () => {
+      // eslint-disable-next-line no-use-before-define
+      cleanup();
       resolve({ done: true, value: undefined });
+    };
+    const error = err => {
+      // eslint-disable-next-line no-use-before-define
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      writer.off('error', error);
+      writer.off('finish', finalize);
+      writer.off('close', finalize);
     };
     // Streams should emit either error or finish and then may emit close.
     // So, watching close is redundant but makes us feel safer.
-    writer.on('error', reject);
+    writer.on('error', error);
     writer.on('finish', finalize);
     writer.on('close', finalize);
   });


### PR DESCRIPTION
While investigating https://github.com/Agoric/agoric-sdk/issues/5447, I found that endo was possibly unnecessarily holding onto memory in a couple places. This PR fixes them:
- SES's v8 Error taming no longer holds onto the raw CallSite stack for error objects after it has created a string for them. It does so by keeping a second WeakMap with the generates stack string, and nulls out the content of the first WeakMap. That way the stack is still processed lazily.
- stream-node possibly held onto the finalResolution promise and other things in context even after the stream closed.