### PR TITLE
fix: type of E.when

### DIFF
--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -257,11 +257,11 @@ interface EProxy {
    * E.when(x, res, rej) is equivalent to
    * HandledPromise.resolve(x).then(res, rej)
    */
-  readonly when: <T, U>(
+  readonly when: <T>(
     x: T,
-    onfulfilled?: (value: Awaited<T>) => ERef<U>,
-    onrejected?: (reason: any) => ERef<U>,
-  ) => Promise<U>;
+    onfulfilled?: (value: Awaited<T>) => ERef<T>,
+    onrejected?: (reason: any) => ERef<T>,
+  ) => Promise<Awaited<T>>;
 
   /**
    * E.sendOnly returns a proxy similar to E, but for which the results

--- a/packages/eventual-send/src/index.test-d.ts
+++ b/packages/eventual-send/src/index.test-d.ts
@@ -46,3 +46,15 @@ const foo2 = async (a: FarRef<{ bar(): string; baz: number }>) => {
   // @ts-expect-error - calling directly is valid but not yet in the typedef
   a.bar;
 };
+
+// when
+const aPromise = Promise.resolve('a');
+const onePromise = Promise.resolve(1);
+const remoteString: ERef<string> = Promise.resolve('remote');
+E.when(Promise.all([aPromise, onePromise, remoteString])).then(
+  ([str, num, remote]) => {
+    expectType<string>(str);
+    expectType<number>(num);
+    expectType<string>(remote);
+  },
+);


### PR DESCRIPTION
In using `E.when` I encountered types of `then` parameters as `any`. I added a test case and then a fix.

I don't understand what  `U` was doing (added in https://github.com/endojs/endo/commit/ea0cfad1515be19807878aa1f3a8f311ea91bc9b#diff-619cc2239a7eb4ef05041767e6ab0e4fb069e98ee9d2c83c2d8e1865c475e141R104 ) so I might have missed something.
