### PR TITLE
fix(marshal)!: assertPure wrong but unused

### DIFF
--- a/packages/marshal/src/typeGuards.js
+++ b/packages/marshal/src/typeGuards.js
@@ -99,26 +99,6 @@ const assertRemotable = (
 };
 harden(assertRemotable);
 
-const assertPure = (pureData, optNameOfData = 'Allegedly pure data') => {
-  const passStyle = passStyleOf(pureData);
-  switch (passStyle) {
-    case 'copyArray':
-    case 'copyRecord':
-    case 'tagged': {
-      return true;
-    }
-    default: {
-      if (!isObject(pureData)) {
-        return true;
-      }
-      assert.fail(
-        X`${q(optNameOfData)} ${pureData} must be pure, not a ${q(passStyle)}`,
-      );
-    }
-  }
-};
-harden(assertPure);
-
 export {
   assertRecord,
   assertCopyArray,
@@ -126,5 +106,4 @@ export {
   isRemotable,
   isRecord,
   isCopyArray,
-  assertPure,
 };

--- a/packages/marshal/src/typeGuards.js
+++ b/packages/marshal/src/typeGuards.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import { isObject } from './helpers/passStyle-helpers.js';
 import { passStyleOf } from './passStyleOf.js';
 
 /** @typedef {import('./types.js').Passable} Passable */


### PR DESCRIPTION
At https://github.com/endojs/endo/commit/f08cad99aa715aa36f78dfd67b9f581cdd22bb3c#diff-d0d534331f6e24715174998494ab6eb7a9349c7e50aba59661267824001fb871 I added a function `assertPure` to marshal which is obviously wrong and dangerous. It is also exported from marshal. Fortunately no one uses it, so this PR deletes it.

There is a use of `assertPure` in agoric-sdk, which is wrong because `assertPure` is wrong. But it is using its own copy so removing it from endo has no effect on it. There do not seem to be any other uses.

Reviewers, deleting this is technically a non-compat change. Please let me know if you think we need to do the deprecation dance in order to get rid of it. If we do, we should also fix the deprecated one since it would still be exported, and it is still dangerously wrong.

See https://github.com/Agoric/agoric-sdk/pull/5876