### PR TITLE
chore: Neutralize test fixtures

### DIFF
--- a/packages/compartment-mapper/test/fixtures-0/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/app/package.json
@@ -15,5 +15,8 @@
     "typemodule": "^1.0.0",
     "typemodule-implied": "^1.0.0",
     "typeparsers": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/avery/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/avery/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "description": "Avery exports a `main` ESM.",
   "type": "module",
-  "main": "./avery.js"
+  "main": "./avery.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/brooke/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/brooke/package.json
@@ -5,5 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./brooke.js"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/builtin/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/builtin/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "exports": {
     ".": "./builtin.js"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/bundle/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/bundle/package.json
@@ -1,5 +1,10 @@
 {
   "name": "bundle",
-  "parsers": {"js": "mjs"},
-  "main": "./main.js"
+  "parsers": {
+    "js": "mjs"
+  },
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/clarke/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/clarke/package.json
@@ -2,5 +2,8 @@
   "name": "clarke",
   "version": "1.0.0",
   "description": "Clarke implicitly exports an index ESM.",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/danny/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/danny/package.json
@@ -5,5 +5,8 @@
   "type": "module",
   "parsers": {
     "js": "mjs"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/esmcjs/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/esmcjs/package.json
@@ -1,4 +1,7 @@
 {
   "name": "esmcjs",
-  "main": "./index.mjs"
+  "main": "./index.mjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/evaluator/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/evaluator/package.json
@@ -1,4 +1,7 @@
 {
   "name": "evaluator",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/typecommon/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/typecommon/package.json
@@ -1,4 +1,7 @@
 {
   "name": "typecommon",
-  "exports": "./main.js"
+  "exports": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/typemodule-implied/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/typemodule-implied/package.json
@@ -1,4 +1,7 @@
 {
   "name": "typemodule-implied",
-  "module": "./main.js"
+  "module": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/typemodule/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/typemodule/package.json
@@ -1,5 +1,8 @@
 {
   "name": "typemodule",
   "type": "module",
-  "exports": "./main.js"
+  "exports": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/typeparsers/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/typeparsers/package.json
@@ -1,5 +1,10 @@
 {
   "name": "typeparsers",
-  "parsers": {"js": "mjs"},
-  "exports": "./main.js"
+  "parsers": {
+    "js": "mjs"
+  },
+  "exports": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-1/node_modules/evan/package.json
+++ b/packages/compartment-mapper/test/fixtures-1/node_modules/evan/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "dependencies": {
     "evankin": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-1/node_modules/evankin/node_modules/evan/package.json
+++ b/packages/compartment-mapper/test/fixtures-1/node_modules/evankin/node_modules/evan/package.json
@@ -1,5 +1,8 @@
 {
   "name": "evan",
   "version": "1.0.0",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-1/node_modules/evankin/package.json
+++ b/packages/compartment-mapper/test/fixtures-1/node_modules/evankin/package.json
@@ -3,5 +3,8 @@
   "type": "module",
   "dependencies": {
     "evan": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-assets/package.json
+++ b/packages/compartment-mapper/test/fixtures-assets/package.json
@@ -3,5 +3,8 @@
   "type": "module",
   "parsers": {
     "uint32": "bytes"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/after-exec/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/after-exec/package.json
@@ -1,4 +1,7 @@
 {
   "name": "after-exec",
-  "exports": "./main.js"
+  "exports": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/app/package.json
@@ -13,5 +13,8 @@
     "nested-file": "^1.0.0",
     "nested-export": "^1.0.0",
     "require-resolve": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/default-difficulties/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/default-difficulties/package.json
@@ -1,4 +1,7 @@
 {
   "name": "default-difficulties",
-  "main": "./index.mjs"
+  "main": "./index.mjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/defineprop/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/defineprop/package.json
@@ -1,4 +1,7 @@
 {
   "name": "defineprop",
-  "exports": "./main.js"
+  "exports": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/exports-shenanigans/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/exports-shenanigans/package.json
@@ -1,4 +1,7 @@
 {
   "name": "exports-shenanigans",
-  "main": "./main.js"
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/interops/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/interops/package.json
@@ -1,4 +1,7 @@
 {
   "name": "interops",
-  "exports": "./main.js"
+  "exports": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/nested-export/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/nested-export/package.json
@@ -18,5 +18,8 @@
       "./this-is-never-reached"
     ],
     "./package.json": "./package.json"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/nested-file/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/nested-file/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "nested-file"
+  "name": "nested-file",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/parser-struggles/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/parser-struggles/package.json
@@ -1,4 +1,7 @@
 {
   "name": "parser-struggles",
-  "main": "./main.js"
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/require-resolve/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/require-resolve/package.json
@@ -5,5 +5,8 @@
     "./package.json": "./package.json",
     "./nested/file.js": "./nested/file.js",
     "./nested/file.js.map": "./nested/file.js.map"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-cthuloops/package.json
+++ b/packages/compartment-mapper/test/fixtures-cthuloops/package.json
@@ -1,5 +1,8 @@
 {
   "name": "cthuloops",
   "version": "1.0.0",
-  "main": "./main.mjs"
+  "main": "./main.mjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cycle-cjs/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cycle-cjs/node_modules/app/package.json
@@ -1,4 +1,7 @@
 {
   "name": "app",
-  "type": "commonjs"
+  "type": "commonjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-cycle-mjs/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cycle-mjs/node_modules/app/package.json
@@ -1,4 +1,7 @@
 {
   "name": "app",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/both/package.json
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/both/package.json
@@ -3,8 +3,11 @@
   "version": "1.0.0",
   "type": "module",
   "main": "./main.js",
-  "dependencies":{
-    "cjs":"^1.0.0",
-    "esm":"^1.0.0"
+  "dependencies": {
+    "cjs": "^1.0.0",
+    "esm": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/package.json
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/catch/package.json
@@ -1,5 +1,8 @@
 {
   "name": "catch",
   "version": "1.0.0",
-  "main": "./main.js"
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/cjs/package.json
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/cjs/package.json
@@ -1,5 +1,8 @@
 {
   "name": "cjs",
   "version": "1.0.0",
-  "main": "./main.js"
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/esm/package.json
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/esm/package.json
@@ -2,5 +2,8 @@
   "name": "esm",
   "version": "1.0.0",
   "type": "module",
-  "main": "./main.js"
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/package.json
+++ b/packages/compartment-mapper/test/fixtures-error-handling/node_modules/what-the-falsy/package.json
@@ -1,5 +1,8 @@
 {
   "name": "what-the-falsy",
   "version": "1.0.0",
-  "main": "./main.js"
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-nested-pkg/node_modules/apackage/afolder/package.json
+++ b/packages/compartment-mapper/test/fixtures-nested-pkg/node_modules/apackage/afolder/package.json
@@ -1,3 +1,6 @@
 {
-    "type": "module"
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-nested-pkg/node_modules/apackage/package.json
+++ b/packages/compartment-mapper/test/fixtures-nested-pkg/node_modules/apackage/package.json
@@ -1,7 +1,10 @@
 {
-    "name": "apackage",
-    "exports": {
-        "./file": "./afolder/file.js",
-        "./file2": "./afolder/anotherfolder/file2.js"
-    }
+  "name": "apackage",
+  "exports": {
+    "./file": "./afolder/file.js",
+    "./file2": "./afolder/anotherfolder/file2.js"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-nested-pkg/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-nested-pkg/node_modules/app/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "apackage": "^1.0.0",
     "bpackage": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-nested-pkg/node_modules/bpackage/package.json
+++ b/packages/compartment-mapper/test/fixtures-nested-pkg/node_modules/bpackage/package.json
@@ -1,5 +1,8 @@
 {
-    "name": "bpackage",
-    "type": "module",
-    "main": "a.cjs"
+  "name": "bpackage",
+  "type": "module",
+  "main": "a.cjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/app/package.json
@@ -3,5 +3,8 @@
   "type": "module",
   "devDependencies": {
     "direct": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/direct/package.json
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/direct/package.json
@@ -3,5 +3,8 @@
   "type": "module",
   "devDependencies": {
     "indirect": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/indirect/package.json
+++ b/packages/compartment-mapper/test/fixtures-no-trans-dev-deps/node_modules/indirect/package.json
@@ -1,4 +1,7 @@
 {
   "name": "indirect",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-retained/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-retained/node_modules/app/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "mk1": "^1.0.0",
     "sweep": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-retained/node_modules/mk1/package.json
+++ b/packages/compartment-mapper/test/fixtures-retained/node_modules/mk1/package.json
@@ -7,5 +7,8 @@
   },
   "dependencies": {
     "mk2": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-retained/node_modules/mk2/package.json
+++ b/packages/compartment-mapper/test/fixtures-retained/node_modules/mk2/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "exports": {
     ".": "./mark.js"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }
-

--- a/packages/compartment-mapper/test/fixtures-retained/node_modules/sweep/package.json
+++ b/packages/compartment-mapper/test/fixtures-retained/node_modules/sweep/package.json
@@ -2,5 +2,8 @@
   "name": "sweep",
   "version": "1.0.0",
   "type": "module",
-  "exports": {}
+  "exports": {},
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-stability/node_modules/a/node_modules/dep/package.json
+++ b/packages/compartment-mapper/test/fixtures-stability/node_modules/a/node_modules/dep/package.json
@@ -2,5 +2,8 @@
   "name": "dep",
   "version": "1.0.0",
   "type": "module",
-  "main": "./dep.js"
+  "main": "./dep.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-stability/node_modules/a/package.json
+++ b/packages/compartment-mapper/test/fixtures-stability/node_modules/a/package.json
@@ -5,5 +5,8 @@
   "main": "./a.js",
   "dependencies": {
     "dep": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-stability/node_modules/b/node_modules/dep/package.json
+++ b/packages/compartment-mapper/test/fixtures-stability/node_modules/b/node_modules/dep/package.json
@@ -2,5 +2,8 @@
   "name": "dep",
   "version": "1.0.0",
   "type": "module",
-  "main": "./dep.js"
+  "main": "./dep.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-stability/node_modules/b/package.json
+++ b/packages/compartment-mapper/test/fixtures-stability/node_modules/b/package.json
@@ -5,5 +5,8 @@
   "main": "./b.js",
   "dependencies": {
     "dep": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-stability/node_modules/dep/package.json
+++ b/packages/compartment-mapper/test/fixtures-stability/node_modules/dep/package.json
@@ -2,5 +2,8 @@
   "name": "dep",
   "version": "1.0.0",
   "type": "module",
-  "main": "./dep.js"
+  "main": "./dep.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-stability/package.json
+++ b/packages/compartment-mapper/test/fixtures-stability/package.json
@@ -7,5 +7,8 @@
     "dep": "^1.0.0",
     "b": "^1.0.0",
     "a": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-symlink/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-symlink/app/package.json
@@ -3,5 +3,8 @@
   "type": "module",
   "dependencies": {
     "symlink": "*"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-symlink/deps/node_modules/symlink-peer/package.json
+++ b/packages/compartment-mapper/test/fixtures-symlink/deps/node_modules/symlink-peer/package.json
@@ -1,4 +1,7 @@
 {
   "name": "symlink-peer",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
 }

--- a/packages/compartment-mapper/test/fixtures-symlink/deps/node_modules/symlink/package.json
+++ b/packages/compartment-mapper/test/fixtures-symlink/deps/node_modules/symlink/package.json
@@ -3,5 +3,8 @@
   "type": "module",
   "dependencies": {
     "symlink-peer": "*"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/test/neutralize.sh
+++ b/packages/compartment-mapper/test/neutralize.sh
@@ -1,0 +1,10 @@
+find fixture* -name 'package.json' | while read FILE; do
+  jq '. + {
+    scripts: (
+      (.scripts // {}) + {
+        preinstall: "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+      }
+    )
+  }' < "$FILE" > "$FILE.neutralized"
+  mv "$FILE.neutralized" "$FILE"
+done


### PR DESCRIPTION
Security researcher @nvk0x pointed out to us that anyone attempting to run `npm install` or `yarn install` in one of the Compartment Mapper test fixtures would be vulnerable to an attacker who had published one of its fake dependencies.  Although this would not occur during normal development of this project, to entirely deny the possibility of such an attack, I've added a preinstall script to each of these fixtures to place a guard rail and preclude such an accident. Thank you to @nvk0x for pointing out the hazard.
