### PR TITLE
fix: prepare for far classes

### DIFF
--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -68,16 +68,22 @@ harden(assertIface);
  * @returns {boolean}
  */
 const checkRemotableProtoOf = (original, check = x => x) => {
-  /**
-   * TODO: It would be nice to typedef this shape, but we can't declare a type
-   * with PASS_STYLE from JSDoc.
-   *
-   * @type {{ [PASS_STYLE]: string,
-   *          [Symbol.toStringTag]: string,
-   *        }}
-   */
+  // A valid remotable object must inherit from a "tag record" -- a
+  // plain-object prototype consisting of only
+  // a suitable `PASS_STYLE` property and a suitable `Symbol.toStringTag`
+  // property. The remotable could inherit directly from such a tag record, or
+  // it could inherit from another valid remotable, that therefore itself
+  // inherits directly or indirectly from such a tag record.
+  //
+  // TODO: It would be nice to typedef this shape, but we can't declare a type
+  // with PASS_STYLE from JSDoc.
+  //
+  // @type {{ [PASS_STYLE]: string,
+  //          [Symbol.toStringTag]: string,
+  //        }}
+  //
   const proto = getPrototypeOf(original);
-  const protoProto = getPrototypeOf(proto);
+  const protoProto = proto === null ? null : getPrototypeOf(proto);
   if (
     typeof original === 'object' &&
     proto !== objectPrototype &&

--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -77,6 +77,18 @@ const checkRemotableProtoOf = (original, check = x => x) => {
    *        }}
    */
   const proto = getPrototypeOf(original);
+  const protoProto = getPrototypeOf(proto);
+  if (
+    typeof original === 'object' &&
+    proto !== objectPrototype &&
+    protoProto !== objectPrototype
+  ) {
+    return (
+      // eslint-disable-next-line no-use-before-define
+      RemotableHelper.canBeValid(proto, check) && checkRemotable(proto, check)
+    );
+  }
+
   if (
     !(
       check(
@@ -94,8 +106,6 @@ const checkRemotableProtoOf = (original, check = x => x) => {
   ) {
     return false;
   }
-
-  const protoProto = getPrototypeOf(proto);
 
   if (typeof original === 'object') {
     if (

--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -87,7 +87,8 @@ const checkRemotableProtoOf = (original, check = x => x) => {
   if (
     typeof original === 'object' &&
     proto !== objectPrototype &&
-    protoProto !== objectPrototype
+    protoProto !== objectPrototype &&
+    protoProto !== null
   ) {
     return (
       // eslint-disable-next-line no-use-before-define

--- a/packages/marshal/test/test-passStyleOf.js
+++ b/packages/marshal/test/test-passStyleOf.js
@@ -66,23 +66,32 @@ test('some passStyleOf rejections', t => {
   });
 });
 
+/**
+ * For testing purposes, makes a TagRecond-like object with
+ * non-enumerable PASS_STYLE and Symbol.toStringTag properties.
+ * A valid Remotable must inherit from a valid TagRecord
+ *
+ * @param {string} [tag]
+ * @param {object|null} [proto]
+ */
+const makeTagishRecord = (tag = 'Remotable', proto = undefined) => {
+  return Object.create(proto === undefined ? Object.prototype : proto, {
+    [PASS_STYLE]: { value: 'remotable' },
+    [Symbol.toStringTag]: { value: tag },
+  });
+};
+
 test('passStyleOf testing remotables', t => {
   t.is(passStyleOf(Far('foo', {})), 'remotable');
   t.is(passStyleOf(Far('foo', () => 'far function')), 'remotable');
 
-  const tagRecord1 = Object.create(Object.prototype, {
-    [PASS_STYLE]: { value: 'remotable' },
-    [Symbol.toStringTag]: { value: 'Alleged: manually constructed' },
-  });
+  const tagRecord1 = makeTagishRecord('Alleged: manually constructed');
   const farObj1 = harden({
     __proto__: tagRecord1,
   });
   t.is(passStyleOf(farObj1), 'remotable');
 
-  const tagRecord2 = Object.create(Object.prototype, {
-    [PASS_STYLE]: { value: 'remotable' },
-    [Symbol.toStringTag]: { value: 'Alleged: tagRecord not hardened' },
-  });
+  const tagRecord2 = makeTagishRecord('Alleged: tagRecord not hardened');
   const farObj2 = Object.freeze({
     __proto__: tagRecord2,
   });
@@ -91,29 +100,20 @@ test('passStyleOf testing remotables', t => {
   });
 
   const tagRecord3 = Object.freeze(
-    Object.create(Object.prototype, {
-      [PASS_STYLE]: { value: 'remotable' },
-      [Symbol.toStringTag]: { value: 'Alleged: both manually frozen' },
-    }),
+    makeTagishRecord('Alleged: both manually frozen'),
   );
   const farObj3 = Object.freeze({
     __proto__: tagRecord3,
   });
   t.is(passStyleOf(farObj3), 'remotable');
 
-  const tagRecord4 = Object.create(Object.prototype, {
-    [PASS_STYLE]: { value: 'remotable' },
-    [Symbol.toStringTag]: { value: 'Remotable' },
-  });
+  const tagRecord4 = makeTagishRecord('Remotable');
   const farObj4 = harden({
     __proto__: tagRecord4,
   });
   t.is(passStyleOf(farObj4), 'remotable');
 
-  const tagRecord5 = Object.create(Object.prototype, {
-    [PASS_STYLE]: { value: 'remotable' },
-    [Symbol.toStringTag]: { value: 'Not alleging' },
-  });
+  const tagRecord5 = makeTagishRecord('Not alleging');
   const farObj5 = harden({
     __proto__: tagRecord5,
   });
@@ -121,10 +121,7 @@ test('passStyleOf testing remotables', t => {
     message: /For now, iface "Not alleging" must be "Remotable" or begin with "Alleged: "; unimplemented/,
   });
 
-  const tagRecord6 = Object.create(Object.prototype, {
-    [PASS_STYLE]: { value: 'remotable' },
-    [Symbol.toStringTag]: { value: 'Alleged: manually constructed' },
-  });
+  const tagRecord6 = makeTagishRecord('Alleged: manually constructed');
   const farObjProto6 = harden({
     __proto__: tagRecord6,
   });
@@ -175,30 +172,41 @@ test('passStyleOf testing remotables', t => {
     message: 'For now, remotables cannot inherit from anything unusual, in {}',
   });
 
-  const tagRecordA = Object.create(Object.prototype, {
-    __proto__: null,
+  const tagRecordA1 = Object.create(null, {
     [PASS_STYLE]: { value: 'remotable' },
     [Symbol.toStringTag]: { value: 'Alleged: null grandproto is fine' },
   });
-  const farObjProtoA = harden({
-    __proto__: tagRecordA,
+  const farObjProtoA1 = harden({
+    __proto__: tagRecordA1,
   });
-  const farObjA = harden({
-    __proto__: farObjProtoA,
+  const farObjA1 = harden({
+    __proto__: farObjProtoA1,
   });
-  t.is(passStyleOf(farObjA), 'remotable');
+  t.is(passStyleOf(farObjA1), 'remotable');
+
+  const tagRecordA2 = Object.create(null, {
+    [PASS_STYLE]: { value: 'remotable' },
+    [Symbol.toStringTag]: { value: 'Alleged: null grandproto is fine' },
+  });
+  const farObjA2 = harden({
+    __proto__: tagRecordA2,
+  });
+  t.is(passStyleOf(farObjA2), 'remotable');
+
+  const tagRecordA3 = makeTagishRecord(
+    'Alleged: null grandproto is fine',
+    null,
+  );
+  const farObjA3 = harden({
+    __proto__: tagRecordA3,
+  });
+  t.is(passStyleOf(farObjA3), 'remotable');
 
   t.throws(() => passStyleOf(Object.prototype), {
     message: 'cannot serialize Remotables with accessors like "toString" in {}',
   });
 
-  const fauxTagRecordB = Object.create(
-    {},
-    {
-      [PASS_STYLE]: { value: 'remotable' },
-      [Symbol.toStringTag]: { value: 'Alleged: manually constructed' },
-    },
-  );
+  const fauxTagRecordB = makeTagishRecord('Alleged: manually constructed', {});
   const farObjProtoB = harden({
     __proto__: fauxTagRecordB,
   });

--- a/packages/marshal/test/test-passStyleOf.js
+++ b/packages/marshal/test/test-passStyleOf.js
@@ -118,7 +118,6 @@ test('passStyleOf testing remotables', t => {
     message: /For now, iface "Not alleging" must be "Remotable" or begin with "Alleged: "; unimplemented/,
   });
 
-  // We need this to succeed to enable far classes
   const tagRecord6 = Object.create(Object.prototype, {
     [PASS_STYLE]: { value: 'remotable' },
     [Symbol.toStringTag]: { value: 'Alleged: manually constructed' },
@@ -129,7 +128,5 @@ test('passStyleOf testing remotables', t => {
   const farObj6 = harden({
     __proto__: farObjProto6,
   });
-  t.throws(() => passStyleOf(farObj6), {
-    message: /"\[Symbol\(passStyle\)\]" property expected: "\[Alleged: manually constructed\]"/,
-  });
+  t.is(passStyleOf(farObj6), 'remotable');
 });


### PR DESCRIPTION
In order to support https://github.com/Agoric/agoric-sdk/pull/5970 , we need to allow at least one level of remotable inheritance. Currently supported in agoric-sdk as a patch. TODO after this is merged and agoric-sdk updated to depend on it, remove the patch.