### PR TITLE
fix(eventual-send)!: Disallow using E proxy methods as functions

### DIFF
--- a/packages/eventual-send/NEWS.md
+++ b/packages/eventual-send/NEWS.md
@@ -1,5 +1,11 @@
 User-visible changes in eventual-send:
 
+# Next release
+
+- _BREAKING_: Disallow using E proxy methods as functions.
+  Enforces the `E(x).foo()` calling convention and disallows using as bound
+  methods. Constructs like `const foo = E(x).foo; foo()` now cause a rejection.
+
 # v0.14.2 (2022-01-25)
 
 - Eventual send now hardens arguments and results (values and errors).

--- a/packages/eventual-send/NEWS.md
+++ b/packages/eventual-send/NEWS.md
@@ -2,7 +2,7 @@ User-visible changes in eventual-send:
 
 # Next release
 
-- _BREAKING_: Disallow using E proxy methods as functions.
+- *BREAKING*: Disallow using E proxy methods as functions.
   Enforces the `E(x).foo()` calling convention and disallows using as bound
   methods. Constructs like `const foo = E(x).foo; foo()` now cause a rejection.
 

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -93,8 +93,9 @@ function EsendOnlyProxyHandler(x, HandledPromise) {
           // is not constructable, it also avoids the `function` syntax.
           [p](...args) {
             // Throw since the function returns nothing
-            assert(
-              this === receiver,
+            assert.equal(
+              this,
+              receiver,
               X`Unexpected receiver for "${p}" method of E.sendOnly(${q(x)})`,
             );
             HandledPromise.applyMethodSendOnly(x, p, args);

--- a/packages/eventual-send/test/test-e.js
+++ b/packages/eventual-send/test/test-e.js
@@ -55,6 +55,10 @@ test('E method calls', async t => {
   t.assert(Object.isFrozen(methodProxy));
   const output = await methodProxy.frozenTest({ arg: 123 });
   t.assert(Object.isFrozen(output), 'output is frozen');
+
+  const double = methodProxy.double;
+  await t.throwsAsync(() => double(6));
+  await t.throwsAsync(() => double.call(x, 6));
 });
 
 test('E sendOnly method calls', async t => {
@@ -79,6 +83,14 @@ test('E sendOnly method calls', async t => {
   await testIncrDone;
   t.is(count, 42, 'sendOnly method call variant works');
   await E(counter).frozenTest({ arg: 123 });
+
+  const incr = E.sendOnly(counter).incr;
+  t.throws(() => {
+    incr(42);
+  });
+  t.throws(() => {
+    incr.call(counter, 42);
+  });
 });
 
 test('E call missing method', async t => {


### PR DESCRIPTION
Closes #1253 

I decided to reject with an error instead of using a plain `assert`ion which would have thrown synchronously for an expected "async function". Cannot use a real `async function` of course since that would absorb the `HandledPromise` into a platform `Promise`.

@kriskowal please let me know if I got the dance of breaking change documentation right.

One this is approved, I will incorporate the changed in a patch on `agoric-sdk` along with the fixes from https://github.com/Agoric/agoric-sdk/commit/ab3b5900fd0845b9ed8081f61cadf81704891ba2