### PR TITLE
WIP: make many multiline asserts into ifs

### DIFF
--- a/packages/captp/src/atomics.js
+++ b/packages/captp/src/atomics.js
@@ -23,10 +23,11 @@ const STATUS_FLAG_REJECT = 4;
  * @param {SharedArrayBuffer} transferBuffer the backing buffer
  */
 const splitTransferBuffer = transferBuffer => {
-  assert(
-    transferBuffer.byteLength >= MIN_TRANSFER_BUFFER_LENGTH,
-    X`Transfer buffer of ${transferBuffer.byteLength} bytes is smaller than MIN_TRANSFER_BUFFER_LENGTH ${MIN_TRANSFER_BUFFER_LENGTH}`,
-  );
+  if (!(transferBuffer.byteLength >= MIN_TRANSFER_BUFFER_LENGTH)) {
+    assert.fail(
+      X`Transfer buffer of ${transferBuffer.byteLength} bytes is smaller than MIN_TRANSFER_BUFFER_LENGTH ${MIN_TRANSFER_BUFFER_LENGTH}`,
+    );
+  }
   const lenbuf = new BigUint64Array(transferBuffer, 0, 1);
 
   // The documentation says that this needs to be an Int32Array for use with
@@ -40,10 +41,11 @@ const splitTransferBuffer = transferBuffer => {
     X`Internal error; actual overhead ${overheadLength} of bytes is not TRANSFER_OVERHEAD_LENGTH ${TRANSFER_OVERHEAD_LENGTH}`,
   );
   const databuf = new Uint8Array(transferBuffer, overheadLength);
-  assert(
-    databuf.byteLength >= MIN_DATA_BUFFER_LENGTH,
-    X`Transfer buffer of size ${transferBuffer.byteLength} only supports ${databuf.byteLength} data bytes; need at least ${MIN_DATA_BUFFER_LENGTH}`,
-  );
+  if (!(databuf.byteLength >= MIN_DATA_BUFFER_LENGTH)) {
+    assert.fail(
+      X`Transfer buffer of size ${transferBuffer.byteLength} only supports ${databuf.byteLength} data bytes; need at least ${MIN_DATA_BUFFER_LENGTH}`,
+    );
+  }
   return harden({ statusbuf, lenbuf, databuf });
 };
 

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -64,10 +64,11 @@ export const makeCapTP = (
   // encounter deadlock.  Without a lot more bookkeeping, we can't detect it for
   // more general networks of CapTPs, but we are conservative for at least this
   // one case.
-  assert(
-    !(trapHost && trapGuest),
-    X`CapTP ${ourId} can only be one of either trapGuest or trapHost`,
-  );
+  if (trapHost && trapGuest) {
+    assert.fail(
+      X`CapTP ${ourId} can only be one of either trapGuest or trapHost`,
+    );
+  }
 
   const disconnectReason = id =>
     Error(`${JSON.stringify(id)} connection closed`);
@@ -391,10 +392,11 @@ export const makeCapTP = (
         });
       };
       if (trap) {
-        assert(
-          exportedTrapHandlers.has(val),
-          X`Refused Trap(${val}) because target was not registered with makeTrapHandler`,
-        );
+        if (!exportedTrapHandlers.has(val)) {
+          assert.fail(
+            X`Refused Trap(${val}) because target was not registered with makeTrapHandler`,
+          );
+        }
         assert.typeof(
           trapHost,
           'function',
@@ -607,10 +609,9 @@ export const makeCapTP = (
 
     // Create the Trap proxy maker.
     const makeTrapImpl = implMethod => (target, ...implArgs) => {
-      assert(
-        Promise.resolve(target) !== target,
-        X`Trap(${target}) target cannot be a promise`,
-      );
+      if (!(Promise.resolve(target) !== target)) {
+        assert.fail(X`Trap(${target}) target cannot be a promise`);
+      }
 
       const slot = valToSlot.get(target);
       assert(
@@ -685,10 +686,11 @@ export const makeCapTP = (
       });
 
       const value = unserialize(serialized);
-      assert(
-        !isThenable(value),
-        X`Trap(${target}) reply cannot be a Thenable; have ${value}`,
-      );
+      if (isThenable(value)) {
+        assert.fail(
+          X`Trap(${target}) reply cannot be a Thenable; have ${value}`,
+        );
+      }
 
       if (isException) {
         throw value;

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -12,10 +12,9 @@ const { details: X } = assert;
 // use cases that don't involve voluntary participation by oldSrc.
 
 function milageTransform(oldSrc) {
-  assert(
-    oldSrc.indexOf('getOdometer') === -1,
-    X`forbidden access to 'getOdometer' in oldSrc`,
-  );
+  if (!(oldSrc.indexOf('getOdometer') === -1)) {
+    assert.fail(X`forbidden access to 'getOdometer' in oldSrc`);
+  }
   return oldSrc.replace(/addMilage\(\)/g, 'getOdometer().add(1)');
 }
 

--- a/packages/marshal/src/helpers/symbol.js
+++ b/packages/marshal/src/helpers/symbol.js
@@ -38,11 +38,13 @@ export const isPassableSymbol = sym =>
   (typeof Symbol.keyFor(sym) === 'string' || wellKnownSymbolNames.has(sym));
 harden(isPassableSymbol);
 
-export const assertPassableSymbol = sym =>
-  assert(
-    isPassableSymbol(sym),
-    X`Only registered symbols or well-known symbols are passable: ${q(sym)}`,
-  );
+export const assertPassableSymbol = sym => {
+  if (!isPassableSymbol(sym)) {
+    assert.fail(
+      X`Only registered symbols or well-known symbols are passable: ${q(sym)}`,
+    );
+  }
+};
 harden(assertPassableSymbol);
 
 /**

--- a/packages/marshal/src/helpers/tagged.js
+++ b/packages/marshal/src/helpers/tagged.js
@@ -38,10 +38,9 @@ export const TaggedHelper = harden({
       ...rest
     } = candidate;
 
-    assert(
-      ownKeys(rest).length === 0,
-      X`Unexpected properties on Remotable Proto ${ownKeys(rest)}`,
-    );
+    if (!(ownKeys(rest).length === 0)) {
+      assert.fail(X`Unexpected properties on Remotable Proto ${ownKeys(rest)}`);
+    }
 
     checkNormalProperty(candidate, 'payload', 'string', true, assertChecker);
 

--- a/packages/marshal/src/make-far.js
+++ b/packages/marshal/src/make-far.js
@@ -38,15 +38,17 @@ const makeRemotableProto = (remotable, iface) => {
     if (oldProto === null) {
       oldProto = objectPrototype;
     }
-    assert(
-      oldProto === objectPrototype || oldProto === null,
-      X`For now, remotables cannot inherit from anything unusual, in ${remotable}`,
-    );
+    if (!(oldProto === objectPrototype || oldProto === null)) {
+      assert.fail(
+        X`For now, remotables cannot inherit from anything unusual, in ${remotable}`,
+      );
+    }
   } else if (typeof remotable === 'function') {
-    assert(
-      oldProto !== null,
-      X`Original function must not inherit from null: ${remotable}`,
-    );
+    if (!(oldProto !== null)) {
+      assert.fail(
+        X`Original function must not inherit from null: ${remotable}`,
+      );
+    }
     assert(
       oldProto === functionPrototype ||
         getPrototypeOf(oldProto) === functionPrototype,

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -189,10 +189,9 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
         }
         case 'hilbert': {
           const { original, rest } = rawTree;
-          assert(
-            'original' in rawTree,
-            X`Invalid Hilbert Hotel encoding ${rawTree}`,
-          );
+          if (!('original' in rawTree)) {
+            assert.fail(X`Invalid Hilbert Hotel encoding ${rawTree}`);
+          }
           prepare(original);
           if ('rest' in rawTree) {
             assert.typeof(
@@ -228,10 +227,9 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
             'string',
             X`invalid error name typeof ${q(typeof name)}`,
           );
-          assert(
-            getErrorConstructor(name) !== undefined,
-            X`Must be the name of an Error constructor ${name}`,
-          );
+          if (!(getErrorConstructor(name) !== undefined)) {
+            assert.fail(X`Must be the name of an Error constructor ${name}`);
+          }
           assert.typeof(
             message,
             'string',

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -69,10 +69,11 @@ export const makeMarshal = (
   } = {},
 ) => {
   assert.typeof(marshalName, 'string');
-  assert(
-    errorTagging === 'on' || errorTagging === 'off',
-    X`The errorTagging option can only be "on" or "off" ${errorTagging}`,
-  );
+  if (!(errorTagging === 'on' || errorTagging === 'off')) {
+    assert.fail(
+      X`The errorTagging option can only be "on" or "off" ${errorTagging}`,
+    );
+  }
   const nextErrorId = () => {
     errorIdNum += 1;
     return `error:${marshalName}#${errorIdNum}`;
@@ -427,25 +428,24 @@ export const makeMarshal = (
 
           case 'hilbert': {
             const { original, rest } = rawTree;
-            assert(
-              'original' in rawTree,
-              X`Invalid Hilbert Hotel encoding ${rawTree}`,
-            );
+            if (!('original' in rawTree)) {
+              assert.fail(X`Invalid Hilbert Hotel encoding ${rawTree}`);
+            }
             // Don't harden since we're not done mutating it
             const result = { [QCLASS]: fullRevive(original) };
             if ('rest' in rawTree) {
-              assert(
-                rest !== undefined,
-                X`Rest encoding must not be undefined`,
-              );
+              if (!(rest !== undefined)) {
+                assert.fail(X`Rest encoding must not be undefined`);
+              }
               const restObj = fullRevive(rest);
               // TODO really should assert that `passStyleOf(rest)` is
               // `'copyRecord'` but we'd have to harden it and it is too
               // early to do that.
-              assert(
-                !(QCLASS in restObj),
-                X`Rest must not contain its own definition of ${q(QCLASS)}`,
-              );
+              if (QCLASS in restObj) {
+                assert.fail(
+                  X`Rest must not contain its own definition of ${q(QCLASS)}`,
+                );
+              }
               defineProperties(result, getOwnPropertyDescriptors(restObj));
             }
             return result;
@@ -492,10 +492,9 @@ export const makeMarshal = (
       'string',
       X`unserialize() given non-capdata (.body is ${data.body}, not string)`,
     );
-    assert(
-      isArray(data.slots),
-      X`unserialize() given non-capdata (.slots are not Array)`,
-    );
+    if (!(isArray(data.slots))) {
+      assert.fail(X`unserialize() given non-capdata (.slots are not Array)`);
+    }
     const rawTree = harden(JSON.parse(data.body));
     const fullRevive = makeFullRevive(data.slots);
     const result = harden(fullRevive(rawTree));

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -52,10 +52,9 @@ const makeHelperTable = passStyleHelpers => {
     HelperTable[styleName] = helper;
   }
   for (const styleName of ownKeys(HelperTable)) {
-    assert(
-      HelperTable[styleName] !== undefined,
-      X`missing helper for ${q(styleName)}`,
-    );
+    if (!(HelperTable[styleName] !== undefined)) {
+      assert.fail(X`missing helper for ${q(styleName)}`);
+    }
   }
 
   return harden(HelperTable);
@@ -109,10 +108,9 @@ const makePassStyleOf = passStyleHelpers => {
           // @ts-ignore TypeScript doesn't know that `get` after `has` is safe
           return passStyleMemo.get(inner);
         }
-        assert(
-          !inProgress.has(inner),
-          X`Pass-by-copy data cannot be cyclic ${inner}`,
-        );
+        if (inProgress.has(inner)) {
+          assert.fail(X`Pass-by-copy data cannot be cyclic ${inner}`);
+        }
         inProgress.add(inner);
       }
       // eslint-disable-next-line no-use-before-define
@@ -145,26 +143,25 @@ const makePassStyleOf = passStyleHelpers => {
           if (inner === null) {
             return 'null';
           }
-          assert(
-            isFrozen(inner),
-            X`Cannot pass non-frozen objects like ${inner}. Use harden()`,
-          );
+          if (!(isFrozen(inner))) {
+            assert.fail(
+              X`Cannot pass non-frozen objects like ${inner}. Use harden()`,
+            );
+          }
           if (isPromise(inner)) {
             assertSafePromise(inner);
             return 'promise';
           }
-          assert(
-            typeof inner.then !== 'function',
-            X`Cannot pass non-promise thenables`,
-          );
+          if (!(typeof inner.then !== 'function')) {
+            assert.fail(X`Cannot pass non-promise thenables`);
+          }
           const passStyleTag = inner[PASS_STYLE];
           if (passStyleTag !== undefined) {
             assert.typeof(passStyleTag, 'string');
             const helper = HelperTable[passStyleTag];
-            assert(
-              helper !== undefined,
-              X`Unrecognized PassStyle: ${q(passStyleTag)}`,
-            );
+            if (!(helper !== undefined)) {
+              assert.fail(X`Unrecognized PassStyle: ${q(passStyleTag)}`);
+            }
             helper.assertValid(inner, passStyleOfRecur);
             return /** @type {PassStyle} */ (passStyleTag);
           }

--- a/packages/ses/src/environment-options.js
+++ b/packages/ses/src/environment-options.js
@@ -107,10 +107,14 @@ export const makeEnvironmentCaptor = aGlobal => {
         }
       }
     }
-    assert(
-      setting === undefined || typeof setting === 'string',
-      X`Environment option value ${q(setting)}, if present, must be a string.`,
-    );
+    if (!(setting === undefined || typeof setting === 'string')) {
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      assert.fail(
+        X`Environment option value ${q(
+          setting,
+        )}, if present, must be a string.`,
+      );
+    }
     return setting;
   };
   freeze(getEnvironmentOption);

--- a/packages/stream-node/reader.js
+++ b/packages/stream-node/reader.js
@@ -15,10 +15,11 @@ const { details: X, quote: q } = assert;
  * @returns {import('@endo/stream').Reader<Uint8Array>}
  */
 export const makeNodeReader = input => {
-  assert(
-    !input.readableObjectMode,
-    X`Cannot convert Node.js object mode Reader to AsyncIterator<Uint8Array>`,
-  );
+  if (input.readableObjectMode) {
+    assert.fail(
+      X`Cannot convert Node.js object mode Reader to AsyncIterator<Uint8Array>`,
+    );
+  }
   assert(
     input.readableEncoding === null,
     X`Cannot convert Node.js Reader with readableEncoding ${q(

--- a/packages/stream-node/writer.js
+++ b/packages/stream-node/writer.js
@@ -17,10 +17,11 @@ const { details: X } = assert;
  * @returns {import('@endo/stream').Writer<Uint8Array>}
  */
 export const makeNodeWriter = writer => {
-  assert(
-    !writer.writableObjectMode,
-    X`Cannot convert Node.js object mode Writer to AsyncIterator<undefined, Uint8Array>`,
-  );
+  if (writer.writableObjectMode) {
+    assert.fail(
+      X`Cannot convert Node.js object mode Writer to AsyncIterator<undefined, Uint8Array>`,
+    );
+  }
 
   const finalIteration = new Promise((resolve, reject) => {
     const finalize = () => {


### PR DESCRIPTION
Same as https://github.com/Agoric/agoric-sdk/pull/6019 , but for Endo

When tracing code in the debugger, I'm always surprised about how many steps it takes to walk through an assert is I single step all the way. For multiline `assert(` calls, the `if` form with an `assert.fail(` is about the same number of lines, sometimes a bit more, sometimes a bit less. (Altogether, this PR is a net increase in lines of code, though https://github.com/Agoric/agoric-sdk/pull/6019 is a net reduction.) It is *less* readable than the simple `assert(` because of the inversion of the condition. But it does skip all the 
```js
X`...${q(expr)}...`
```
in the success case, which is the only case where we might care about performance. Would it make a significant difference? A difference big enough to pay the cost of reduced readability? We won't know until we measure. Hence this WIP draft PR.