### PR TITLE
Fix safe promise checks

### DIFF
--- a/packages/marshal/test/test-passStyleOf.js
+++ b/packages/marshal/test/test-passStyleOf.js
@@ -45,14 +45,14 @@ test('some passStyleOf rejections', t => {
   prbad2.extra = 'unexpected own property';
   harden(prbad2);
   t.throws(() => passStyleOf(prbad2), {
-    message: /{pr} - Must not have any own properties: \["extra"\]/,
+    message: /\[Promise\]" - Must not have any own properties: \["extra"\]/,
   });
 
   const prbad3 = Promise.resolve();
   Object.defineProperty(prbad3, 'then', { value: () => 'bad then' });
   harden(prbad3);
   t.throws(() => passStyleOf(prbad3), {
-    message: /{pr} - Must not have any own properties: \["then"\]/,
+    message: /\[Promise\]" - Must not have any own properties: \["then"\]/,
   });
 
   const thenable1 = harden({ then: () => 'thenable' });


### PR DESCRIPTION
Refs https://github.com/endojs/endo/pull/1250#pullrequestreview-1082870845

The checks introduced in #1250 are not compatible with the async_hooks repair (https://github.com/endojs/endo/pull/1115). This PR fixes that in the narrowest way by allowing these symbols only if the repair is enabled and their value has the expected shape.