### PR TITLE
feat(eventual-send): De-risk track-turns

### DIFF
--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -15,8 +15,17 @@ let hiddenPriorError;
 let hiddenCurrentTurn = 0;
 let hiddenCurrentEvent = 0;
 
+// TODO Use environment-options.js currently in ses/src after factoring it out
+// to a new package.
+const env = globalThis?.process?.env;
+
 // Turn on if you seem to be losing error logging at the top of the event loop
-const VERBOSE = false;
+const VERBOSE = (env?.DEBUG ?? '').split(':').includes('track-turns');
+
+// Track-turns is disabled by default and can be enabled by an environment
+// option. We intend to change the default after verifying that having
+// the feature enabled in production does not cause memory to leak.
+const ENABLED = env?.TRACK_TURNS === 'enabled';
 
 // We hoist these functions out of trackTurns() to discourage the
 // closures from holding onto 'args' or 'func' longer than necessary,
@@ -83,7 +92,7 @@ const wrapFunction = (func, sendingError, X) => (...args) => {
  * @returns {T}
  */
 export const trackTurns = funcs => {
-  if (typeof globalThis === 'undefined' || !globalThis.assert) {
+  if (!ENABLED || typeof globalThis === 'undefined' || !globalThis.assert) {
     return funcs;
   }
   const { details: X } = assert;

--- a/packages/eventual-send/test/prepare-test-env-ava.js
+++ b/packages/eventual-send/test/prepare-test-env-ava.js
@@ -1,3 +1,5 @@
+/* global process */
+
 import '@endo/lockdown/commit-debug.js';
 
 import { wrapTest } from '@endo/ses-ava';
@@ -7,3 +9,5 @@ export * from 'ava';
 
 /** @type {typeof rawTest} */
 export const test = wrapTest(rawTest);
+
+process.env.TRACK_TURNS = 'enabled';


### PR DESCRIPTION
This change includes work from myself and @warner.

1. Reduces the closure retention of functions wrapped for tracking event-loop turns.
2. Supports a DEBUG=track-turns flag that enables verbose logging, previously only available by editing track-turns.js
3. Supports a TRACK_TURNS=enabled flag that enables the feature. The intention is to reverse the flag’s polarity when we are confident that the feature can be used in production without retaining memory indefinitely.

Fixes #1245