### PR TITLE
fix: tolerate more from async_hooks

### DIFF
--- a/packages/marshal/src/helpers/safe-promise.js
+++ b/packages/marshal/src/helpers/safe-promise.js
@@ -23,25 +23,52 @@ const checkPromiseOwnKeys = (pr, check) => {
     key => typeof key !== 'symbol' || !hasOwnPropertyOf(Promise.prototype, key),
   );
 
+  const checkSafeEnoughKey = key => {
+    const val = pr[key];
+    if (val === undefined || typeof val === 'number') {
+      return true;
+    }
+    if (
+      typeof val === 'object' &&
+      val !== null &&
+      isFrozen(val) &&
+      getPrototypeOf(val) === Object.prototype
+    ) {
+      const subKeys = ownKeys(val);
+      if (subKeys.length === 0) {
+        return true;
+      }
+
+      // At the time of this writing, Node's async_hooks contains the
+      // following code, which we can also safely tolerate
+      //
+      // function destroyTracking(promise, parent) {
+      // trackPromise(promise, parent);
+      //   const asyncId = promise[async_id_symbol];
+      //   const destroyed = { destroyed: false };
+      //   promise[destroyedSymbol] = destroyed;
+      //   registerDestroyHook(promise, asyncId, destroyed);
+      // }
+
+      if (
+        subKeys.length === 1 &&
+        subKeys[0] === 'destroyed' &&
+        val.destroyed === false
+      ) {
+        return true;
+      }
+    }
+    return check(
+      false,
+      X`Unexpected promise own property value: ${pr}.${q(key)} is ${val}`,
+    );
+  };
+
   return (
     check(
       unknownKeys.length === 0,
       X`${pr} - Must not have any own properties: ${q(unknownKeys)}`,
-    ) &&
-    check(
-      keys.filter(key => {
-        const val = pr[key];
-        return !(
-          val === undefined ||
-          typeof val === 'number' ||
-          (typeof val === 'object' &&
-            isFrozen(val) &&
-            getPrototypeOf(val) === Object.prototype &&
-            ownKeys(val).length === 0)
-        );
-      }).length === 0,
-      X`${pr} - async_hooks own keys have unexpected values`,
-    )
+    ) && keys.every(checkSafeEnoughKey)
   );
 };
 

--- a/packages/marshal/src/helpers/safe-promise.js
+++ b/packages/marshal/src/helpers/safe-promise.js
@@ -23,6 +23,13 @@ const checkPromiseOwnKeys = (pr, check) => {
     key => typeof key !== 'symbol' || !hasOwnPropertyOf(Promise.prototype, key),
   );
 
+  if (unknownKeys.length !== 0) {
+    return check(
+      false,
+      X`${pr} - Must not have any own properties: ${q(unknownKeys)}`,
+    );
+  }
+
   const checkSafeEnoughKey = key => {
     const val = pr[key];
     if (val === undefined || typeof val === 'number') {
@@ -60,16 +67,11 @@ const checkPromiseOwnKeys = (pr, check) => {
     }
     return check(
       false,
-      X`Unexpected promise own property value: ${pr}.${q(key)} is ${val}`,
+      X`Node async_hooks added something unexpected to promise: ${pr}.${q(key)} is ${val}`,
     );
   };
 
-  return (
-    check(
-      unknownKeys.length === 0,
-      X`${pr} - Must not have any own properties: ${q(unknownKeys)}`,
-    ) && keys.every(checkSafeEnoughKey)
-  );
+  return keys.every(checkSafeEnoughKey);
 };
 
 /**

--- a/packages/marshal/src/helpers/safe-promise.js
+++ b/packages/marshal/src/helpers/safe-promise.js
@@ -19,6 +19,10 @@ const { ownKeys } = Reflect;
 const checkPromiseOwnKeys = (pr, check) => {
   const keys = ownKeys(pr);
 
+  if (keys.length === 0) {
+    return true;
+  }
+
   const unknownKeys = keys.filter(
     key => typeof key !== 'symbol' || !hasOwnPropertyOf(Promise.prototype, key),
   );
@@ -72,7 +76,7 @@ const checkPromiseOwnKeys = (pr, check) => {
     }
     return check(
       false,
-      X`Node async_hooks added something unexpected to promise: ${pr}.${q(
+      X`Unexpected Node async_hooks additions to promise: ${pr}.${q(
         String(key),
       )} is ${val}`,
     );


### PR DESCRIPTION
Our attempt to safely tolerate Node async_hooks was safe, but missed a case we could handle safely and which is provoked at least by the vscode debugger.

Node's async_hooks currently contains the following code, which we can also safely tolerate

```js
function destroyTracking(promise, parent) {
  trackPromise(promise, parent);
  const asyncId = promise[async_id_symbol];
  const destroyed = { destroyed: false };
  promise[destroyedSymbol] = destroyed;
  registerDestroyHook(promise, asyncId, destroyed);
}
```

However, before this PR we did not know to expect this. I just encountered this failure when trying to debug some of our code in the vscode debugger. The additional record that Node adds here is one we can tolerate safely. This PR's expectations includes this additional record, so that we can safely tolerate it in environments, like the vscode debugger, that provoke it.

Reviews: How do I test this? I have already tried it experimentally on the debugger experience that was blocking me. This code got me past that problem.