### PR TITLE
Avoid buffer copies in netstring

### DIFF
--- a/packages/daemon/src/connection.js
+++ b/packages/daemon/src/connection.js
@@ -71,7 +71,7 @@ export const makeNodeNetstringCapTP = (
   bootstrap,
 ) => {
   const writer = mapWriter(
-    makeNetstringWriter(makeNodeWriter(nodeWriter)),
+    makeNetstringWriter(makeNodeWriter(nodeWriter), { chunked: true }),
     messageToBytes,
   );
   const reader = mapReader(

--- a/packages/netstring/reader.js
+++ b/packages/netstring/reader.js
@@ -95,7 +95,7 @@ async function* makeNetstringIterator(input, { name = '<unknown>' } = {}) {
           lengthBuffer = [];
           yield data;
         } else if (buffer.length) {
-          dataBuffer ??= new Uint8Array(remainingDataLength);
+          dataBuffer = dataBuffer || new Uint8Array(remainingDataLength);
           dataBuffer.set(buffer, dataBuffer.length - remainingDataLength);
           remainingDataLength -= buffer.length;
           buffer = buffer.subarray(buffer.length);

--- a/packages/netstring/reader.js
+++ b/packages/netstring/reader.js
@@ -95,8 +95,12 @@ async function* makeNetstringIterator(input, { name = '<unknown>' } = {}) {
           lengthBuffer = [];
           yield data;
         } else if (buffer.length) {
-          dataBuffer = dataBuffer || new Uint8Array(remainingDataLength);
-          dataBuffer.set(buffer, dataBuffer.length - remainingDataLength);
+          if (!dataBuffer && buffer.length === remainingDataLength) {
+            dataBuffer = buffer;
+          } else {
+            dataBuffer = dataBuffer || new Uint8Array(remainingDataLength);
+            dataBuffer.set(buffer, dataBuffer.length - remainingDataLength);
+          }
           remainingDataLength -= buffer.length;
           buffer = buffer.subarray(buffer.length);
         }

--- a/packages/netstring/reader.js
+++ b/packages/netstring/reader.js
@@ -2,67 +2,109 @@
 /// <reference types="ses"/>
 
 const COLON = ':'.charCodeAt(0);
-
-const decoder = new TextDecoder();
+const COMMA = ','.charCodeAt(0);
+const ZERO = '0'.charCodeAt(0);
+const NINE = '9'.charCodeAt(0);
 
 /**
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} input
  * @param {Object} [opts]
  * @param {string} [opts.name]
- * @param {number} [opts.capacity]
  */
-async function* makeNetstringIterator(
-  input,
-  { name = '<unknown>', capacity = 1024 } = {},
-) {
-  let length = 0;
-  let buffer = new Uint8Array(capacity);
+async function* makeNetstringIterator(input, { name = '<unknown>' } = {}) {
+  // byte offset of data consumed so far in the input stream
   let offset = 0;
 
-  for await (const chunk of input) {
-    if (length + chunk.byteLength >= capacity) {
-      while (length + chunk.byteLength >= capacity) {
-        capacity *= 2;
-      }
-      const replacement = new Uint8Array(capacity);
-      replacement.set(buffer, 0);
-      buffer = replacement;
-    }
-    buffer.set(chunk, length);
-    length += chunk.byteLength;
+  // The iterator can be in 2 states: waiting for the length, or waiting for the data
+  // - When waiting for the length, the lengthBuffer is an array containing
+  //   digits charCodes for the length prefix
+  // - When waiting for the data, the dataBuffer is either:
+  //   - null to indicate no data has been received yet.
+  //   - A newly allocated buffer large enough to accommodate the whole expected data.
+  //   In either case, remainingDataLength contains the length of the data to read.
+  //   If the whole data is received in one chunk, no copy is made.
+  /** @type {number[] | null} */
+  let lengthBuffer = [];
+  /** @type {Uint8Array | null} */
+  let dataBuffer = null;
+  let remainingDataLength = -1;
 
-    let drained = false;
-    while (!drained && length > 0) {
-      const colon = buffer.indexOf(COLON);
-      if (colon === 0) {
-        throw new Error(
-          `Expected number before colon at offset ${offset} of ${name}`,
-        );
-      } else if (colon > 0) {
-        const prefixBytes = buffer.subarray(0, colon);
-        const prefixString = decoder.decode(prefixBytes);
-        const contentLength = +prefixString;
-        if (Number.isNaN(contentLength)) {
-          throw new Error(
-            `Invalid netstring prefix length ${prefixString} at offset ${offset} of ${name}`,
-          );
+  for await (const chunk of input) {
+    let buffer = chunk;
+
+    while (buffer.length) {
+      // Waiting for full length prefix
+      if (lengthBuffer) {
+        let i = 0;
+        while (i < buffer.length) {
+          const c = buffer[i];
+          i += 1;
+          if (c >= ZERO && c <= NINE) {
+            lengthBuffer.push(c);
+          } else if (c === COLON && lengthBuffer.length) {
+            lengthBuffer.push(c);
+            break;
+          } else {
+            throw new Error(
+              `Invalid netstring length prefix ${JSON.stringify(
+                String.fromCharCode(...lengthBuffer, c),
+              )} at offset ${offset} of ${name}`,
+            );
+          }
         }
-        const messageLength = colon + contentLength + 2;
-        if (messageLength <= length) {
-          yield buffer.subarray(colon + 1, colon + 1 + contentLength);
-          buffer.copyWithin(0, messageLength);
-          length -= messageLength;
-          offset += messageLength;
-        } else {
-          drained = true;
+
+        buffer = buffer.subarray(i);
+
+        if (lengthBuffer[lengthBuffer.length - 1] === COLON) {
+          lengthBuffer.pop();
+          const prefix = String.fromCharCode(...lengthBuffer);
+          remainingDataLength = +prefix;
+          if (Number.isNaN(remainingDataLength)) {
+            throw new Error(
+              `Invalid netstring prefix length ${prefix} at offset ${offset} of ${name}`,
+            );
+          }
+          offset += lengthBuffer.length + 1;
+          lengthBuffer = null;
         }
-      } else {
-        drained = true;
+      }
+
+      // Waiting for data
+      if (!lengthBuffer) {
+        if (buffer.length > remainingDataLength) {
+          const remainingData = buffer.subarray(0, remainingDataLength);
+          const data = dataBuffer
+            ? (dataBuffer.set(
+                remainingData,
+                dataBuffer.length - remainingDataLength,
+              ),
+              dataBuffer)
+            : remainingData;
+          dataBuffer = null;
+          offset += data.length;
+          if (buffer[remainingDataLength] !== COMMA) {
+            throw new Error(
+              `Invalid netstring separator "${String.fromCharCode(
+                buffer[remainingDataLength],
+              )} at offset ${offset} of ${name}`,
+            );
+          }
+          offset += 1;
+          buffer = buffer.subarray(remainingDataLength + 1);
+          remainingDataLength = -1;
+          lengthBuffer = [];
+          yield data;
+        } else if (buffer.length) {
+          dataBuffer ??= new Uint8Array(remainingDataLength);
+          dataBuffer.set(buffer, dataBuffer.length - remainingDataLength);
+          remainingDataLength -= buffer.length;
+          buffer = buffer.subarray(buffer.length);
+        }
       }
     }
   }
 
-  if (length > 0) {
+  if (!lengthBuffer) {
     throw new Error(
       `Unexpected dangling message at offset ${offset} of ${name}`,
     );
@@ -75,7 +117,6 @@ async function* makeNetstringIterator(
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} input
  * @param {Object} [opts]
  * @param {string} [opts.name]
- * @param {number} [opts.capacity]
  * @returns {import('@endo/stream').Reader<Uint8Array, undefined>} input
  */
 export const makeNetstringReader = (input, opts) => {
@@ -87,14 +128,13 @@ harden(makeNetstringReader);
 /**
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} input
  * @param {string=} name
- * @param {number=} capacity
+ * @param {number=} _capacity
  * @returns {import('@endo/stream').Stream<Uint8Array, undefined>} input
  */
-export const netstringReader = (input, name, capacity) => {
+export const netstringReader = (input, name, _capacity) => {
   return harden(
     makeNetstringIterator(input, {
       name,
-      capacity,
     }),
   );
 };

--- a/packages/netstring/test/test-netstring.js
+++ b/packages/netstring/test/test-netstring.js
@@ -159,6 +159,20 @@ const concurrentWrites = async (t, opts) => {
 test('concurrent writes', concurrentWrites);
 test('concurrent writes (chunked)', concurrentWrites, { chunked: true });
 
+const chunkedWrite = async (t, opts) => {
+  const { array, writer } = makeArrayWriter(opts);
+  const strChunks = ['hello', ' ', 'world'];
+  await writer.next(strChunks.map(strChunk => encoder.encode(strChunk)));
+  await writer.return();
+
+  t.deepEqual(
+    [encoder.encode(strChunks.join(''))],
+    await read(makeNetstringReader(array)),
+  );
+};
+test('chunked write', chunkedWrite);
+test('chunked write (chunked)', chunkedWrite, { chunked: true });
+
 const varyingMessages = async (t, opts) => {
   const array = ['', 'A', 'hello'];
 

--- a/packages/netstring/test/test-netstring.js
+++ b/packages/netstring/test/test-netstring.js
@@ -64,7 +64,7 @@ test(
 test(
   'read messages divided over chunk boundaries',
   readChunkedMessage,
-  ['5:hel', 'lo,5:world,8:good ', 'bye,'],
+  ['5:hello', ',5:world,8:good ', 'bye,'],
   ['hello', 'world', 'good bye'],
 );
 

--- a/packages/netstring/test/test-netstring.js
+++ b/packages/netstring/test/test-netstring.js
@@ -25,7 +25,6 @@ const readChunkedMessage = async (t, chunkStrings, expectedDataStrings) => {
     chunkStrings.map(chunkString => encoder.encode(chunkString)),
     {
       name: '<unknown>',
-      capacity: 1,
     },
   );
   const array = await read(r);
@@ -93,13 +92,9 @@ const readErroneousChunkedMessage = async (t, chunkStrings) => {
   return t.throwsAsync(() => read(r));
 };
 
-test.failing('fails reading invalid prefix', readErroneousChunkedMessage, [
-  '1.0:A,',
-]);
+test('fails reading invalid prefix', readErroneousChunkedMessage, ['1.0:A,']);
 test('fails reading incomplete data', readErroneousChunkedMessage, ['5:hello']);
-test.failing('fails reading invalid separator', readErroneousChunkedMessage, [
-  '0:~',
-]);
+test('fails reading invalid separator', readErroneousChunkedMessage, ['0:~']);
 test('fails reading no colon', readErroneousChunkedMessage, ['1A,']);
 
 function delay(ms) {

--- a/packages/netstring/test/test-netstring.js
+++ b/packages/netstring/test/test-netstring.js
@@ -82,12 +82,10 @@ test(
   ['hello world'],
 );
 
-const readErroneousChunkedMessage = async (t, chunkStrings) => {
+const readErroneousChunkedMessage = async (t, chunkStrings, opts) => {
   const r = makeNetstringReader(
     chunkStrings.map(chunkString => encoder.encode(chunkString)),
-    {
-      name: '<unknown>',
-    },
+    opts,
   );
   return t.throwsAsync(() => read(r));
 };
@@ -99,6 +97,19 @@ test('fails reading no colon', readErroneousChunkedMessage, ['1A,']);
 test('fails reading empty prefix before colon', readErroneousChunkedMessage, [
   ':,',
 ]);
+
+test(
+  'fails reading too long prefix',
+  readErroneousChunkedMessage,
+  ['11:hello world,'],
+  { maxMessageLength: 9 },
+);
+test(
+  'fails reading if message length over max ',
+  readErroneousChunkedMessage,
+  ['11:hello world,'],
+  { maxMessageLength: 10 },
+);
 
 function delay(ms) {
   return new Promise(resolve => {

--- a/packages/netstring/test/test-netstring.js
+++ b/packages/netstring/test/test-netstring.js
@@ -96,6 +96,9 @@ test('fails reading invalid prefix', readErroneousChunkedMessage, ['1.0:A,']);
 test('fails reading incomplete data', readErroneousChunkedMessage, ['5:hello']);
 test('fails reading invalid separator', readErroneousChunkedMessage, ['0:~']);
 test('fails reading no colon', readErroneousChunkedMessage, ['1A,']);
+test('fails reading empty prefix before colon', readErroneousChunkedMessage, [
+  ':,',
+]);
 
 function delay(ms) {
   return new Promise(resolve => {

--- a/packages/netstring/writer.js
+++ b/packages/netstring/writer.js
@@ -9,6 +9,13 @@ const getLengthPrefixCharCodes = length =>
   [...`${length | 0}:`].map(char => char.charCodeAt(0));
 
 /**
+ * Create a writer stream which wraps messages into a netstring encoding and
+ * writes them to an output writer stream.
+ *
+ * This transform can be zero-copy, if the output stream supports consecutive
+ * writes without waiting, aka if it can gracefully handle writes if full or
+ * closed. In that case the by default off `chunked` mode can be enabled.
+ *
  * @param {import('@endo/stream').Writer<Uint8Array, undefined>} output
  * @param {object} [opts]
  * @param {boolean} [opts.chunked]

--- a/packages/netstring/writer.js
+++ b/packages/netstring/writer.js
@@ -16,6 +16,9 @@ const getLengthPrefixCharCodes = length =>
  * writes without waiting, aka if it can gracefully handle writes if full or
  * closed. In that case the by default off `chunked` mode can be enabled.
  *
+ * Accepts the message as an array of buffers in case the producer would like
+ * to avoid pre-concatenating them.
+ *
  * @param {import('@endo/stream').Writer<Uint8Array, undefined>} output
  * @param {object} [opts]
  * @param {boolean} [opts.chunked]

--- a/packages/stream-node/test/test-stream-node.js
+++ b/packages/stream-node/test/test-stream-node.js
@@ -61,7 +61,12 @@ test('stream to and from Node.js reader/writer', async (/** @type {import('ava')
         child.send({});
       }
       // eslint-disable-next-line no-await-in-loop
-      await nextP;
+      const { done } = await nextP;
+
+      if (done) {
+        t.log('done');
+        return;
+      }
 
       i = j;
       chunkLength *= 2;
@@ -107,7 +112,11 @@ test('stream write error (EPIPE due to exit)', async (/** @type {import('ava').E
       t.log('->', i, j);
 
       // eslint-disable-next-line no-await-in-loop
-      await writer.next(scratch.subarray(i, j));
+      const { done } = await writer.next(scratch.subarray(i, j));
+      if (done) {
+        t.log('done');
+        return;
+      }
 
       i = j;
       chunkLength *= 2;

--- a/packages/stream-node/writer.js
+++ b/packages/stream-node/writer.js
@@ -26,7 +26,7 @@ export const makeNodeWriter = writer => {
     const finalize = () => {
       // eslint-disable-next-line no-use-before-define
       cleanup();
-      resolve({ done: true, value: undefined });
+      resolve(harden({ done: true, value: undefined }));
     };
     const error = err => {
       // eslint-disable-next-line no-use-before-define
@@ -45,6 +45,8 @@ export const makeNodeWriter = writer => {
     writer.on('close', finalize);
   });
 
+  const nonFinalIterationResult = harden({ done: false, value: undefined });
+
   /** @type {import('@endo/stream').Writer<Uint8Array>} */
   const nodeWriter = harden({
     /** @param {Uint8Array} value */
@@ -53,11 +55,13 @@ export const makeNodeWriter = writer => {
         finalIteration,
         new Promise(resolve => {
           if (!writer.write(value)) {
-            writer.once('drain', resolve);
+            writer.once('drain', () => {
+              resolve(nonFinalIterationResult);
+            });
           } else {
-            resolve(undefined);
+            resolve(nonFinalIterationResult);
           }
-        }).then(() => ({ done: false, value: undefined })),
+        }),
       ]);
     },
     async return() {

--- a/packages/stream-node/writer.js
+++ b/packages/stream-node/writer.js
@@ -57,7 +57,7 @@ export const makeNodeWriter = writer => {
           } else {
             resolve(undefined);
           }
-        }),
+        }).then(() => ({ done: false, value: undefined })),
       ]);
     },
     async return() {


### PR DESCRIPTION
Rewrite the reader and writer of the netstring stream transform to avoid buffer copies and allocations as much as possible.
- The reader delays allocation of a buffer until the length prefix is parsed.
- The reader re-uses the input buffer if the whole data is a subset of the incoming chunk
  - possible point of improvement is to handle the trailing separator (comma) in a separate chunk, as may happen went sent chunked in the first place
- The writer can output in chunked mode, where the prefix, data and separator are sent to the output as separate writes/next calls.
- The writer can handle an array of buffers as input for producers which would otherwise concatenate their data.
- The writer no longer re-uses an internal buffer for its output as a consumer that doesn't fully process the buffer (e.g. caches it) before resolving would get corrupted data. While Node.js stream sinks should be safe since our adapter doesn't resolve until drain / write completion, not all sinks may be as robust.

Fix a bug discovered in node-stream where the writer's `next` didn't return an iterator result.