### PR TITLE
feat(bundle-source): Add JSON cache mode

### DIFF
--- a/packages/bundle-source/NEWS.md
+++ b/packages/bundle-source/NEWS.md
@@ -1,3 +1,14 @@
+# Next release
+
+- Adds a `--cache-json` mode that:
+  - Generates `.json` bundle files in JSON format.
+  - Generates `-json-meta.json` meta files in JSON format.
+- Adds a `--cache-js` mode that should replace `--to`:
+  - Generates `.js` bundle files in JSON format.
+    Adds a UNIX newline absent when using `--to`.
+  - Generates `-json-meta.json` meta files in JSON format instead of
+    `-meta.js`.
+
 # v2.1.4 (2022-04-14)
 
 - Adds a `bundle-source` command line tool that supports build caching.

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -37,7 +37,6 @@
     "source-map": "^0.7.3"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.40",
     "@endo/lockdown": "^0.1.19",
     "@endo/ses-ava": "^0.2.31",
     "ava": "^3.12.1",


### PR DESCRIPTION
- Adds a `--cache-json` mode that:
  - Generates `.json` bundle files in JSON format.
  - Generates `-json-meta.json` meta files in JSON format.
- Adds a `--cache-js` mode that should replace `--to`:
  - Generates `.js` bundle files in JSON format.
    Adds a UNIX newline absent when using `--to`.
  - Generates `-json-meta.json` meta files in JSON format instead of
    `-meta.js`.

