### PR TITLE
WIP: smallcaps, see what breaks

### DIFF
--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -58,7 +58,8 @@ export const makeMarshal = (
       console.log('Temporary logging of sent error', err),
     // Default to 'capdata' because it was implemented first.
     // Sometimes, ontogeny does recapitulate phylogeny ;)
-    serializeBodyFormat = 'capdata',
+    // See what breaks if defaulting to `'smallcaps'`.
+    serializeBodyFormat = 'smallcaps',
   } = {},
 ) => {
   assert.typeof(marshalName, 'string');


### PR DESCRIPTION
Starts from https://github.com/endojs/endo/pull/1282 by changing only the default choice from the capData encoding to the smallcaps encoding, in order to see what breaks under CI.
