### PR TITLE
test: failing test for error taming inside Compartment

### DIFF
--- a/packages/ses/test/error/test-tame-v8-error-unsafe.js
+++ b/packages/ses/test/error/test-tame-v8-error-unsafe.js
@@ -51,6 +51,28 @@ function simulateDepd() {
   return site.name;
 }
 
+test('SES compartment error compatibility', t => {
+  const c1 = new Compartment();
+  const result = c1.evaluate(`
+    function prepareObjectStackTrace(_, stack) {
+      return stack;
+    }
+    const limit = Error.stackTraceLimit;
+    const obj = {};
+    const prep = Error.prepareStackTrace;
+    Error.prepareStackTrace = prepareObjectStackTrace;
+    Error.stackTraceLimit = Math.max(10, limit);
+    // capture the stack
+    Error.captureStackTrace(obj);
+    // slice this function off the top
+    const stack = obj.stack.slice(1);
+    Error.prepareStackTrace = prep;
+    Error.stackTraceLimit = limit;
+    'ok';
+  `);
+  t.is(result, 'ok');
+});
+
 test('Error compatibility - depd', t => {
   // the Start Compartment should support this sort of manipulation
   const name = simulateDepd();


### PR DESCRIPTION
A basic test showing that Error is no longer extensible even if lockdown did leave it at that with errorTaming: 'unsafe'

Test fails with 
```
  TypeError {
    message: 'Cannot add property prepareStackTrace, object is not extensible',
  }
```

Am I missing something obvious? If I am, LavaMoat is also missing it ;) 
