### PR TITLE
feat(ses): uncurryThis uses bind

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,11 @@
 User-visible changes in SES:
 
+# Next release
+
+- Fixes the unhandled promise rejection logic to report unhandled rejections
+  when the promise is collected. Because of a bug it previously only reported
+  at process exit.
+
 # v0.15.18 (2022-08-23)
 
 - Removes the `__allowUnsafeMonkeyPatching__` option to lockdown. As the name
@@ -45,7 +51,7 @@ User-visible changes in SES:
 
 # 0.15.0 (2021-11-02)
 
-- *BREAKING CHANGE*: The lockdown option `domainTaming` is now `safe` by
+- _BREAKING CHANGE_: The lockdown option `domainTaming` is now `safe` by
   default, which will break any application that depends transtively on the
   Node.js `domain` module.
   Notably, [standard-things/esm](https://github.com/standard-things/esm)
@@ -53,10 +59,11 @@ User-visible changes in SES:
 
   This protects against the unhardened `domain` property appearing on shared
   objects like callbacks and promises.
-  This overcomes the last *known* obstacle toward object capability containment.
+  This overcomes the last _known_ obstacle toward object capability containment.
+
 - Lockdown will now read options from the environment as defined by the Node.js
   `process.env` parameter space.
-- *BREAKING CHANGE*: Lockdown may no longer be called more than once.
+- _BREAKING CHANGE_: Lockdown may no longer be called more than once.
   Lockdown no longer returns a boolean to indicate whether it was effective
   (true) or redundant (false). Instead, Lockdown will return undefined for
   its first invocation or throw an error otherwise.
@@ -102,7 +109,7 @@ User-visible changes in SES:
 
 # 0.14.0 (2021-07-22)
 
-- *BREAKING*: Any precompiled static module records from prior versions
+- _BREAKING_: Any precompiled static module records from prior versions
   will not load in this version of SES or beyond. The format of the preamble
   has been changed to admit the possibility of a variable named `Map` declared
   in the scope of a module.
@@ -119,8 +126,7 @@ User-visible changes in SES:
 
 # 0.13.4 (2021-06-19)
 
-- Adds more TypeScript definitions, importable with `/// <reference
-  types="ses"/>`, covering `harden`, `lockdown`, `assert`, and `Compartment`,
+- Adds more TypeScript definitions, importable with `/// <reference types="ses"/>`, covering `harden`, `lockdown`, `assert`, and `Compartment`,
   and many types importable with `import('ses')` notation.
 - Adds descriptive detail to module system link error messages and fixes the
   reported exports for one.
@@ -132,25 +138,25 @@ User-visible changes in SES:
 
 # 0.13.0 (2021-06-01)
 
-- *BREAKING CHANGE* The `ses/lockdown` module is again just `ses`.
+- _BREAKING CHANGE_ The `ses/lockdown` module is again just `ses`.
   Instead of having a light 43KB `ses/lockdown` and a heavy 3.1MB `ses`, there
   is just a 52KB `ses` that has everything except `StaticModuleRecord`.
   For this release, there remains a `ses/lockdown` alias to `ses`.
-- *BREAKING CHANGE* Third-party static module interface implementations *must*
+- _BREAKING CHANGE_ Third-party static module interface implementations _must_
   now explicitly list their exported names.
   For CommonJS, this implies using a heuristic static analysis of `exports`
   changes.
   Consequently, third-party modules can now participate in linkage with ESM
   including support for `export * from './spec.cjs'` and also named imports
   like `import * from './spec.cjs'`.
-- *BREAKING CHANGE* The `StaticModuleRecord` constructor has been removed in
+- _BREAKING CHANGE_ The `StaticModuleRecord` constructor has been removed in
   favor of a duck-type for compiled static module records that is intrinsic to
   the shim and may be emulated by a third-party `StaticModuleRecord`
   constructor.
   The constructor must perform the module analysis and transform the source,
   and present this duck-type to the Compartment `importHook`.
   This relieves SES of a dependency on Babel and simplifies its API.
-- *BREAKING CHANGE* The UMD distribution of SES must have the UTF-8 charset.
+- _BREAKING CHANGE_ The UMD distribution of SES must have the UTF-8 charset.
   The prior versions were accidentally ASCII, so SES would have worked
   in any web page, regardless of the charset.
   To remedy this, be sure to include `<head><meta charset="utf-8"></head>` in
@@ -163,8 +169,7 @@ User-visible changes in SES:
 - Fix: `new Compartment(null, null, options)` no longer throws.
 - New lockdown option: `overrideDebug: [...props]` to detect where a property
   assignment needs to be turned into a `defineProperty` to avoid the override
-  mistake.  Most useful as `overrideTaming: 'severe', overrideDebug:
-  ['constructor']`.
+  mistake. Most useful as `overrideTaming: 'severe', overrideDebug: ['constructor']`.
 - We reopened Safari bug
   [Object.defineProperties triggering a setter](https://bugs.webkit.org/show_bug.cgi?id=222538#c17)
   when we found that it was causing an infinite recursion initializing SES
@@ -237,18 +242,17 @@ User-visible changes in SES:
 
   The purpose of the `details` template literal tag (often spelled `X` or `d`) together with the `quote` function (often spelled `q`) is to redact data from the error messages carried by error instances. With this release, the same `{errorTaming: 'unsafe'}` would suppress that redaction as well, so that all substitution values would act like they've been quoted. IOW, with this setting
 
-   ```js
-   assert(false, X`literal part ${secretData} with ${q(publicData)}.`);
-   ```
+  ```js
+  assert(false, X`literal part ${secretData} with ${q(publicData)}.`);
+  ```
 
   acts like
 
-   ```js
-   assert(false, X`literal part ${q(secretData)} with ${q(publicData)}.`);
-   ```
+  ```js
+  assert(false, X`literal part ${q(secretData)} with ${q(publicData)}.`);
+  ```
 
-   Note that the information rendered by the SES shim `console` object always includes all the unredacted data independent of the setting of `errorTaming`.
-
+  Note that the information rendered by the SES shim `console` object always includes all the unredacted data independent of the setting of `errorTaming`.
 
 # 0.12.3 (2021-03-01)
 

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -155,7 +155,7 @@ const { bind } = functionPrototype;
  * which only lives at
  * http://web.archive.org/web/20160805225710/http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
  *
- * @type {(fn: (this: any, ...args: any[]) => any) => ((thisArg: any, ...args: any[]) => any)}
+ * @type {<F extends (this: any, ...args: any[]) => any>(fn: F) => ((thisArg: ThisParameterType<F>, ...args: Parameters<F>) => ReturnType<F>)}
  */
 export const uncurryThis = bind.bind(bind.call); // eslint-disable-line @endo/no-polymorphic-call
 
@@ -165,8 +165,10 @@ export const arrayFilter = uncurryThis(arrayPrototype.filter);
 export const arrayForEach = uncurryThis(arrayPrototype.forEach);
 export const arrayIncludes = uncurryThis(arrayPrototype.includes);
 export const arrayJoin = uncurryThis(arrayPrototype.join);
+/** @type {<T, U>(thisArg: readonly T[], callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]} */
 export const arrayMap = uncurryThis(arrayPrototype.map);
 export const arrayPop = uncurryThis(arrayPrototype.pop);
+/** @type {<T>(thisArg: T[], ...items: T[]) => number} */
 export const arrayPush = uncurryThis(arrayPrototype.push);
 export const arraySlice = uncurryThis(arrayPrototype.slice);
 export const arraySome = uncurryThis(arrayPrototype.some);
@@ -194,9 +196,16 @@ export const stringEndsWith = uncurryThis(stringPrototype.endsWith);
 export const stringIncludes = uncurryThis(stringPrototype.includes);
 export const stringIndexOf = uncurryThis(stringPrototype.indexOf);
 export const stringMatch = uncurryThis(stringPrototype.match);
+/**
+ * @type {
+ *   ((thisArg: string, searchValue: { [Symbol.replace](string: string, replaceValue: string): string; }, replaceValue: string) => string) |
+ *   ((thisArg: string, searchValue: { [Symbol.replace](string: string, replacer: (substring: string, ...args: any[]) => string): string; }, replacer: (substring: string, ...args: any[]) => string) => string)
+ * }
+ */
 export const stringReplace = uncurryThis(stringPrototype.replace);
 export const stringSearch = uncurryThis(stringPrototype.search);
 export const stringSlice = uncurryThis(stringPrototype.slice);
+/** @type {(thisArg: string, splitter: string | RegExp | { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number) => string[]} */
 export const stringSplit = uncurryThis(stringPrototype.split);
 export const stringStartsWith = uncurryThis(stringPrototype.startsWith);
 export const iterateString = uncurryThis(stringPrototype[iteratorSymbol]);
@@ -216,6 +225,7 @@ export const functionToString = uncurryThis(functionPrototype.toString);
 const { all } = Promise;
 export const promiseAll = promises => apply(all, Promise, [promises]);
 export const promiseCatch = uncurryThis(promisePrototype.catch);
+/** @type {<T, TResult1 = T, TResult2 = never>(thisArg: T, onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null) => Promise<TResult1 | TResult2>} */
 export const promiseThen = uncurryThis(promisePrototype.then);
 //
 export const finalizationRegistryRegister =

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -145,24 +145,19 @@ export const { prototype: promisePrototype } = Promise;
 
 export const typedArrayPrototype = getPrototypeOf(Uint8Array.prototype);
 
+const { bind } = functionPrototype;
 /**
  * uncurryThis()
- * This form of uncurry uses Reflect.apply()
- *
- * The original uncurry uses:
- * const bind = Function.prototype.bind;
- * const uncurryThis = bind.bind(bind.call);
+ * Equivalent of: fn => (thisArg, ...args) => apply(fn, thisArg, args)
  *
  * See those reference for a complete explanation:
  * http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
  * which only lives at
  * http://web.archive.org/web/20160805225710/http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
  *
- * @template {Function} F
- * @param {F} fn
- * returns {(thisArg: ThisParameterType<F>, ...args: Parameters<F>) => ReturnType<F>}
+ * @type {(fn: (this: any, ...args: any[]) => any) => ((thisArg: any, ...args: any[]) => any)}
  */
-export const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
+export const uncurryThis = bind.bind(bind.call); // eslint-disable-line @endo/no-polymorphic-call
 
 export const objectHasOwnProperty = uncurryThis(objectPrototype.hasOwnProperty);
 //

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -154,7 +154,10 @@ export const CompartmentPrototype = {
       () => {
         // The namespace box is a contentious design and likely to be a breaking
         // change in an appropriately numbered future version.
-        const namespace = compartmentImportNow(this, specifier);
+        const namespace = compartmentImportNow(
+          /** @type {Compartment} */ (this),
+          specifier,
+        );
         return { namespace };
       },
     );
@@ -177,7 +180,7 @@ export const CompartmentPrototype = {
 
     assertModuleHooks(this);
 
-    return compartmentImportNow(this, specifier);
+    return compartmentImportNow(/** @type {Compartment} */ (this), specifier);
   },
 };
 

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -322,9 +322,9 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     const levelMethod = (...logArgs) => {
       const subErrors = [];
       const argTags = extractErrorArgs(logArgs, subErrors);
-      // @ts-ignore
       // eslint-disable-next-line @endo/no-polymorphic-call
       baseConsole[level](...argTags);
+      // @ts-expect-error ConsoleProp vs LogSeverity mismatch
       logSubErrors(level, subErrors);
     };
     defineProperty(levelMethod, 'name', { value: level });

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -19,7 +19,7 @@ import {
 /**
  * Joins English terms with commas and an optional conjunction.
  *
- * @param {string[]} terms
+ * @param {(string | StringablePayload)[]} terms
  * @param {"and" | "or"} conjunction
  */
 export const enJoin = (terms, conjunction) => {

--- a/packages/ses/src/error/unhandled-rejection.js
+++ b/packages/ses/src/error/unhandled-rejection.js
@@ -63,7 +63,7 @@ export const makeRejectionHandlers = reportReason => {
    * @param {ReasonId} heldReasonId
    */
   const finalizeDroppedPromise = heldReasonId => {
-    if (mapHas(idToReason)) {
+    if (mapHas(idToReason, heldReasonId)) {
       const reason = mapGet(idToReason, heldReasonId);
       removeReasonId(heldReasonId);
       reportReason(reason);


### PR DESCRIPTION
From micro benchmarks, it looks like the bind form is 2x on v8 JIT, 1.5x on v8 jitless, and 1.3x on xsnap.

While looking at this I found a bug in the type definition, which when fixing, uncovered a couple real bugs (including one in the unhandled rejection logic).