### PR TITLE
feat(bundle-source): normalized `getExport` and `nestedEvaluate` pathnames

### DIFF
--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -325,11 +325,8 @@ ${sourceMap}`;
     // This function's source code is inlined in the output bundle.
     // It figures out the exports from a given module filename.
     const nsBundle = {};
-    const nestedEvaluate = _src => {
-      throw Error('need to override nestedEvaluate');
-    };
     function computeExports(filename, exportPowers, exports) {
-      const { require: systemRequire, _log } = exportPowers;
+      const { require: systemRequire, systemEval, _log } = exportPowers;
       // This captures the endowed require.
       const match = filename.match(/^(.*)\/[^/]+$/);
       const thisdir = match ? match[1] : '.';
@@ -399,7 +396,8 @@ ${sourceMap}`;
       }
 
       // log('evaluating', code);
-      return nestedEvaluate(code)(contextRequire, exports);
+      // eslint-disable-next-line no-eval
+      return (systemEval || eval)(code)(contextRequire, exports);
     }
 
     source = `\
@@ -420,7 +418,8 @@ function getExportWithNestedEvaluate(filePrefix) {
 
   // Evaluate the entrypoint recursively, seeding the exports.
   const systemRequire = typeof require === 'undefined' ? undefined : require;
-  return computeExports(entrypoint, { require: systemRequire }, {});
+  const systemEval = typeof nestedEvaluate === 'undefined' ? undefined : nestedEvaluate;
+  return computeExports(entrypoint, { require: systemRequire, systemEval }, {});
 }
 ${sourceMap}`;
   }

--- a/packages/bundle-source/test/sanity.js
+++ b/packages/bundle-source/test/sanity.js
@@ -133,12 +133,8 @@ export function makeSanityTests(stackFiltering) {
 
     const srcMap2 = `(${src2})\n${map2}`;
 
-    const nestedEvaluate = src => {
-      // console.log('========== evaluating', src, '\n=========');
-      return evaluate(src, { nestedEvaluate });
-    };
     // eslint-disable-next-line no-eval
-    const ex2 = nestedEvaluate(srcMap2)();
+    const ex2 = (1, eval)(srcMap2)();
     t.is(ex2.message, `You're great!`, 'exported message matches');
     t.is(
       ex2.encourage('Nick'),


### PR DESCRIPTION
Remove pathname sensitivity from the `getExport` and `nestedEvaluate` bundle formats by trimming the longest common prefix from emitted output names. 

Also, make the `nestedEvaluate` format backwards compatible with `getExport` when evaluating code in the start compartment.
