### PR TITLE
fix: import endo/init, not lockdown

### DIFF
--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -42,6 +42,7 @@
     "@endo/promise-kit": "^0.2.48"
   },
   "devDependencies": {
+    "@endo/init": "^0.5.48",
     "@endo/lockdown": "^0.1.20",
     "@endo/ses-ava": "^0.2.32",
     "ava": "^3.12.1",

--- a/packages/marshal/test/prepare-test-env-ava.js
+++ b/packages/marshal/test/prepare-test-env-ava.js
@@ -1,6 +1,4 @@
-import '@endo/lockdown';
-import '@endo/eventual-send/shim.js';
-import '@endo/lockdown/commit-debug.js';
+import '@endo/init/debug.js';
 
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';


### PR DESCRIPTION
Addresses the immediate problem explained at https://github.com/endojs/endo/issues/1298

Does not fix 1098 as it suggests a deeper reform.
