### PR TITLE
fix: unserialize makes copyRecords without problematic assign semantics

### DIFF
--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -300,16 +300,15 @@ export const makeDecodeFromCapData = ({
       // primitives pass through
       return jsonEncoded;
     }
-    // Assertions of the above to narrow the type.
-    assert(isObject(jsonEncoded));
-    if (hasQClass(jsonEncoded)) {
+    if (isArray(jsonEncoded)) {
+      return jsonEncoded.map(encodedVal => decodeFromCapData(encodedVal));
+    } else if (hasQClass(jsonEncoded)) {
       const qclass = jsonEncoded[QCLASS];
       assert.typeof(
         qclass,
         'string',
         X`invalid qclass typeof ${q(typeof qclass)}`,
       );
-      assert(!isArray(jsonEncoded));
       switch (qclass) {
         // Encoding of primitives not handled by JSON
         case 'undefined': {
@@ -424,18 +423,17 @@ export const makeDecodeFromCapData = ({
           assert.fail(X`unrecognized ${q(QCLASS)} ${q(qclass)}`, TypeError);
         }
       }
-    } else if (isArray(jsonEncoded)) {
-      const result = [];
-      const { length } = jsonEncoded;
-      for (let i = 0; i < length; i += 1) {
-        result[i] = decodeFromCapData(jsonEncoded[i]);
-      }
-      return result;
     } else {
       assert(typeof jsonEncoded === 'object' && jsonEncoded !== null);
-      const toDecEntry = ([name, subEnc]) => [name, decodeFromCapData(subEnc)];
-      const decEntries = entries(jsonEncoded).map(toDecEntry);
-      return fromEntries(decEntries);
+      const decodeEntry = ([name, encodedVal]) => {
+        typeof name === 'string' ||
+          assert.fail(
+            X`Property ${q(name)} of ${jsonEncoded} must be a string`,
+          );
+        return [name, decodeFromCapData(encodedVal)];
+      };
+      const decodedEntries = entries(jsonEncoded).map(decodeEntry);
+      return fromEntries(decodedEntries);
     }
   };
   return harden(decodeFromCapData);

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -34,6 +34,7 @@ const {
   getOwnPropertyDescriptors,
   defineProperties,
   is,
+  entries,
   fromEntries,
   freeze,
 } = Object;
@@ -432,16 +433,9 @@ export const makeDecodeFromCapData = ({
       return result;
     } else {
       assert(typeof jsonEncoded === 'object' && jsonEncoded !== null);
-      const result = {};
-      for (const name of ownKeys(jsonEncoded)) {
-        assert.typeof(
-          name,
-          'string',
-          X`Property ${name} of ${jsonEncoded} must be a string`,
-        );
-        result[name] = decodeFromCapData(jsonEncoded[name]);
-      }
-      return result;
+      const toDecEntry = ([name, subEnc]) => [name, decodeFromCapData(subEnc)];
+      const decEntries = entries(jsonEncoded).map(toDecEntry);
+      return fromEntries(decEntries);
     }
   };
   return harden(decodeFromCapData);

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -471,7 +471,7 @@ export const makeDecodeFromSmallcaps = ({
           return result;
         }
 
-        const toDecEntry = ([encodedName, subEnc]) => {
+        const decodeEntry = ([encodedName, encodedVal]) => {
           typeof encodedName === 'string' ||
             assert.fail(
               X`Property name ${q(
@@ -487,10 +487,10 @@ export const makeDecodeFromSmallcaps = ({
             assert.fail(
               X`Decoded property name ${name} from ${encoding} must be a string`,
             );
-          return [name, decodeFromSmallcaps(subEnc)];
+          return [name, decodeFromSmallcaps(encodedVal)];
         };
-        const decEntries = entries(encoding).map(toDecEntry);
-        return fromEntries(decEntries);
+        const decodedEntries = entries(encoding).map(decodeEntry);
+        return fromEntries(decodedEntries);
       }
       default: {
         assert.fail(

--- a/packages/marshal/test/test-marshal-capdata.js
+++ b/packages/marshal/test/test-marshal-capdata.js
@@ -381,7 +381,7 @@ test('records', t => {
   shouldThrow(['nonenumStringData', 'enumStringData'], REC_ONLYENUM);
 });
 
-test('proto problems', t => {
+test('capdata proto problems', t => {
   function convertValToSlot(_val) {
     return 'slot';
   }
@@ -389,20 +389,19 @@ test('proto problems', t => {
   function convertSlotToVal(_slot) {
     return exampleAlice;
   }
-  const { serialize: ser, unserialize: unser } = makeMarshal(
+  const { serialize: toCapData, unserialize: fromCapData } = makeMarshal(
     convertValToSlot,
     convertSlotToVal,
     {
       serializeBodyFormat: 'capdata',
     },
   );
-
   const wrongProto = harden({ ['__proto__']: exampleAlice });
-  const wrongProtoEnc = ser(wrongProto);
-  t.deepEqual(wrongProtoEnc, {
+  const wrongProtoCapData = toCapData(wrongProto);
+  t.deepEqual(wrongProtoCapData, {
     body: '{"__proto__":{"@qclass":"slot","iface":"Alleged: Alice","index":0}}',
     slots: ['slot'],
   });
   // Fails before https://github.com/endojs/endo/issues/1303 fix
-  t.deepEqual(unser(wrongProtoEnc), wrongProto);
+  t.deepEqual(fromCapData(wrongProtoCapData), wrongProto);
 });

--- a/packages/marshal/test/test-marshal-smallcaps.js
+++ b/packages/marshal/test/test-marshal-smallcaps.js
@@ -398,3 +398,28 @@ test('smallcaps encoding examples', t => {
     'hilbert property names',
   );
 });
+
+test('smallcaps proto problems', t => {
+  function convertValToSlot(_val) {
+    return 'slot';
+  }
+  const exampleAlice = Far('Alice', {});
+  function convertSlotToVal(_slot) {
+    return exampleAlice;
+  }
+  const { serialize: toSmallcaps, unserialize: fromSmallcaps } = makeMarshal(
+    convertValToSlot,
+    convertSlotToVal,
+    {
+      serializeBodyFormat: 'smallcaps',
+    },
+  );
+  const wrongProto = harden({ ['__proto__']: exampleAlice });
+  const wrongProtoSmallcaps = toSmallcaps(wrongProto);
+  t.deepEqual(wrongProtoSmallcaps, {
+    body: '#{"__proto__":"$0.Alleged: Alice"}',
+    slots: ['slot'],
+  });
+  // Fails before https://github.com/endojs/endo/issues/1303 fix
+  t.deepEqual(fromSmallcaps(wrongProtoSmallcaps), wrongProto);
+});


### PR DESCRIPTION
fixes #1303 

Includes new test cases that I did see fail before the code was fixed.