### PR TITLE
fix: delete broken objectFromEntries

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -66,6 +66,7 @@ export const {
   preventExtensions,
   setPrototypeOf,
   values,
+  fromEntries,
 } = Object;
 
 export const {
@@ -80,22 +81,6 @@ export const {
 export const { isInteger } = Number;
 
 export const { stringify: stringifyJson } = JSON;
-
-// At time of this writing, we still support Node 10 which doesn't have
-// `Object.fromEntries`. If it is absent, this should be an adequate
-// replacement.
-// By the terminology of https://ponyfoo.com/articles/polyfills-or-ponyfills
-// it is a ponyfill rather than a polyfill or shim because we do not
-// install it on `Object`.
-const objectFromEntries = entryPairs => {
-  const result = {};
-  for (const [prop, val] of entryPairs) {
-    result[prop] = val;
-  }
-  return result;
-};
-
-export const fromEntries = Object.fromEntries || objectFromEntries;
 
 // Needed only for the Safari bug workaround below
 const { defineProperty: originalDefineProperty } = Object;


### PR DESCRIPTION
commons.js contains its own ponyFill (aka shim, polyfill) of `Object.fromEntries` because it was relevant at the time. It no longer is. Fortunately it was dead code anyway because it was only exported (as `fromEntries`) when on a platform on which it is absent. Thus deleting it causes no transition cost. We can avoid the deprecation dance. By this criteria of course, fixing this is also low priority.

The reason to bother getting rid of it is that it uses assignment semantics to initialize the object it creates and returns. The resulting problems explained at https://github.com/endojs/endo/issues/1303 this has some terrible problems do apply to this code as well.