### PR TITLE
chore(ses): Advance Node.js compatibility test from version 10 to 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,10 +349,10 @@ jobs:
     - name: 'build'
       run: yarn run build
 
-    - name: 'switch to node v10'
+    - name: 'switch to node v12'
       uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '12.x'
 
     - name: Echo node version
       run: node --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,8 +305,8 @@ jobs:
       run: cd packages/ses-integration-test && yarn test:pre-release
 
 
-  platform-compatability-test:
-    name: platform-compatability-test
+  platform-compatibility-test:
+    name: platform-compatibility-test
 
 # begin macro
 
@@ -357,5 +357,5 @@ jobs:
     - name: Echo node version
       run: node --version
 
-    - name: Run yarn test:platform-compatability
-      run: cd packages/ses && yarn test:platform-compatability
+    - name: Run yarn test:platform-compatibility
+      run: cd packages/ses && yarn test:platform-compatibility

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -56,7 +56,7 @@
     "prepublish": "yarn run clean && yarn build",
     "qt": "ava",
     "test": "tsd && ava",
-    "test:platform-compatability": "node test/package/test.cjs"
+    "test:platform-compatibility": "node test/package/test.cjs"
   },
   "devDependencies": {
     "@endo/compartment-mapper": "^0.7.13",


### PR DESCRIPTION
Per #1306, we have an invalid `Object.fromEntries` shim that is only needed before Node.js 12 and analogous browsers. This change raises the _tested_ lockdown compatibility floor up to Node.js 12.

- fix(ses): Fix incompatible spelling
- chore(ses): Advance lowest supported Node.js compatibility test from 10 to 12
