### PR TITLE
perf(marshal): Extend new assert style to passStyleOf `check` calls

### DIFF
--- a/packages/marshal/src/helpers/copyArray.js
+++ b/packages/marshal/src/helpers/copyArray.js
@@ -17,7 +17,7 @@ export const CopyArrayHelper = harden({
   styleName: 'copyArray',
 
   canBeValid: (candidate, check) =>
-    check(isArray(candidate), X`Array expected: ${candidate}`),
+    isArray(candidate) || check(false, X`Array expected: ${candidate}`),
 
   assertValid: (candidate, passStyleOfRecur) => {
     CopyArrayHelper.canBeValid(candidate, assertChecker);

--- a/packages/marshal/src/helpers/copyRecord.js
+++ b/packages/marshal/src/helpers/copyRecord.js
@@ -24,9 +24,10 @@ export const CopyRecordHelper = harden({
   styleName: 'copyRecord',
 
   canBeValid: (candidate, check) => {
+    const reject = details => check(false, details);
     const proto = getPrototypeOf(candidate);
     if (proto !== objectPrototype && proto !== null) {
-      return check(false, X`Unexpected prototype for: ${candidate}`);
+      return reject(X`Unexpected prototype for: ${candidate}`);
     }
     const descs = getOwnPropertyDescriptors(candidate);
     const descKeys = ownKeys(descs);
@@ -34,15 +35,13 @@ export const CopyRecordHelper = harden({
     for (const descKey of descKeys) {
       if (typeof descKey !== 'string') {
         // Pass by copy
-        return check(
-          false,
+        return reject(
           X`Records can only have string-named own properties: ${candidate}`,
         );
       }
       const desc = descs[descKey];
       if (canBeMethod(desc.value)) {
-        return check(
-          false,
+        return reject(
           X`Records cannot contain non-far functions because they may be methods of an implicit Remotable: ${candidate}`,
         );
       }

--- a/packages/marshal/src/helpers/error.js
+++ b/packages/marshal/src/helpers/error.js
@@ -47,9 +47,10 @@ export const ErrorHelper = harden({
   styleName: 'error',
 
   canBeValid: (candidate, check) => {
+    const reject = details => check(false, details);
     // TODO: Need a better test than instanceof
     if (!(candidate instanceof Error)) {
-      return check(false, X`Error expected: ${candidate}`);
+      return reject(X`Error expected: ${candidate}`);
     }
     const proto = getPrototypeOf(candidate);
     const { name } = proto;
@@ -57,7 +58,7 @@ export const ErrorHelper = harden({
     if (!EC || EC.prototype !== proto) {
       const note = X`Errors must inherit from an error class .prototype ${candidate}`;
       // Only terminate if check throws
-      check(false, note);
+      reject(note);
       assert.note(candidate, note);
     }
 
@@ -71,20 +72,20 @@ export const ErrorHelper = harden({
     if (ownKeys(restDescs).length >= 1) {
       const note = X`Passed Error has extra unpassed properties ${restDescs}`;
       // Only terminate if check throws
-      check(false, note);
+      reject(note);
       assert.note(candidate, note);
     }
     if (mDesc) {
       if (typeof mDesc.value !== 'string') {
         const note = X`Passed Error "message" ${mDesc} must be a string-valued data property.`;
         // Only terminate if check throws
-        check(false, note);
+        reject(note);
         assert.note(candidate, note);
       }
       if (mDesc.enumerable) {
         const note = X`Passed Error "message" ${mDesc} must not be enumerable`;
         // Only terminate if check throws
-        check(false, note);
+        reject(note);
         assert.note(candidate, note);
       }
     }

--- a/packages/marshal/src/helpers/tagged.js
+++ b/packages/marshal/src/helpers/tagged.js
@@ -24,11 +24,8 @@ export const TaggedHelper = harden({
 
   assertValid: (candidate, passStyleOfRecur) => {
     TaggedHelper.canBeValid(candidate, assertChecker);
-    assert.equal(
-      getPrototypeOf(candidate),
-      objectPrototype,
-      X`Unexpected prototype for: ${candidate}`,
-    );
+    getPrototypeOf(candidate) === objectPrototype ||
+      assert.fail(X`Unexpected prototype for: ${candidate}`);
 
     const {
       [PASS_STYLE]: _passStyle, // checkTagRecord already checked


### PR DESCRIPTION
Ref dc24f2f2c3cac7ce239a64c503493c41a2334315

<details><summary>ad hoc analysis</summary>

```sh
$ node --input-type=module -e '
  import Benchmark from "benchmark";
  import "../init/index.js";
  import { passStyleOf } from "./src/passStyleOf.js";
  import { makeTagged } from "./src/makeTagged.js";
  const inputs = [
    undefined,
    "foo",
    true,
    33,
    33n,
    Symbol.for("foo"),
    Symbol.iterator,
    null,
    Promise.resolve(null),
    [3, 4],
    { foo: 3 },
    { then: "non-function then ok" },
    makeTagged("unknown", undefined),
    Error("ok"),
  ].map(v => harden(v));
  const badInputs = [
    Symbol("unique"),
    {},
    harden(Object.setPrototypeOf(Promise.resolve(), { __proto__: Promise.prototype })),
    harden(Object.assign(Promise.resolve(), { extra: "unexpected own property" })),
    harden(Object.defineProperties(Promise.resolve(), { then: { value: () => "bad then" } })),
    harden({ then: () => "thenable" }),
  ];
  let result;
  (new Benchmark.Suite())
    .add("valid inputs", () => {
      for (const v of inputs) result = passStyleOf(v);
    })
    .add("invalid inputs", () => {
      let caught;
      for (const v of badInputs) {
        caught = undefined;
        try {
          result = passStyleOf(v);
        } catch (err) {
          caught = err;
        } finally {
          if (!caught) throw new Error(`unexpected acceptance: ${v}`);
        }
      }
    })
    .add("big input", () => {
      result = passStyleOf(harden(Array(1000).fill().map(() => [...inputs])));
    })
    .on("cycle", evt => console.log(String(evt.target)))
    .on("complete", () => result)
    .run({ async: true })
'
```

</details>

before:
```
valid inputs x 831,564 ops/sec ±0.71% (91 runs sampled)
invalid inputs x 3,645 ops/sec ±0.86% (88 runs sampled)
big input x 10.31 ops/sec ±3.22% (32 runs sampled)
```
after:
```
valid inputs x 828,877 ops/sec ±0.60% (91 runs sampled)
invalid inputs x 3,780 ops/sec ±0.76% (85 runs sampled)
big input x 66.53 ops/sec ±1.74% (67 runs sampled)
```

(and we could probably get even more improvement by replacing `check` parameters with `reject` to avoid creating the latter functions inline)