### PR TITLE
fix(marshal): Increase consistency for encoding/decoding CapData

### DIFF
--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -227,17 +227,6 @@ export const makeEncodeToCapData = ({
           )} ${q('slot')}: ${encoded}`,
         );
       }
-      case 'error': {
-        const encoded = encodeErrorToCapData(passable, encodeToCapDataRecur);
-        if (qclassMatches(encoded, 'error')) {
-          return encoded;
-        }
-        assert.fail(
-          X`internal: Error encoding must be an object with ${q(QCLASS)} ${q(
-            'error',
-          )}: ${encoded}`,
-        );
-      }
       case 'promise': {
         const encoded = encodePromiseToCapData(passable, encodeToCapDataRecur);
         if (qclassMatches(encoded, 'slot')) {
@@ -246,6 +235,17 @@ export const makeEncodeToCapData = ({
         assert.fail(
           X`internal: Promise encoding must be an object with ${q(QCLASS)} ${q(
             'slot',
+          )}: ${encoded}`,
+        );
+      }
+      case 'error': {
+        const encoded = encodeErrorToCapData(passable, encodeToCapDataRecur);
+        if (qclassMatches(encoded, 'error')) {
+          return encoded;
+        }
+        assert.fail(
+          X`internal: Error encoding must be an object with ${q(QCLASS)} ${q(
+            'error',
           )}: ${encoded}`,
         );
       }
@@ -396,7 +396,6 @@ export const makeDecodeFromCapData = ({
           const { name } = jsonEncoded;
           return passableSymbolForName(name);
         }
-
         case 'tagged': {
           // Using @ts-ignore rather than @ts-expect-error below because
           // with @ts-expect-error I get a red underline in vscode, but
@@ -406,20 +405,6 @@ export const makeDecodeFromCapData = ({
           const { tag, payload } = jsonEncoded;
           return makeTagged(tag, decodeFromCapData(payload));
         }
-
-        case 'error': {
-          const decoded = decodeErrorFromCapData(
-            jsonEncoded,
-            decodeFromCapData,
-          );
-          if (passStyleOf(decoded) === 'error') {
-            return decoded;
-          }
-          assert.fail(
-            X`internal: decodeErrorFromCapData option must return an error: ${decoded}`,
-          );
-        }
-
         case 'slot': {
           // See note above about how the current encoding cannot reliably
           // distinguish which we should call, so in the non-default case
@@ -436,7 +421,18 @@ export const makeDecodeFromCapData = ({
             X`internal: decodeRemotableFromCapData option must return a remotable or promise: ${decoded}`,
           );
         }
-
+        case 'error': {
+          const decoded = decodeErrorFromCapData(
+            jsonEncoded,
+            decodeFromCapData,
+          );
+          if (passStyleOf(decoded) === 'error') {
+            return decoded;
+          }
+          assert.fail(
+            X`internal: decodeErrorFromCapData option must return an error: ${decoded}`,
+          );
+        }
         case 'hilbert': {
           // Using @ts-ignore rather than @ts-expect-error below because
           // with @ts-expect-error I get a red underline in vscode, but
@@ -467,7 +463,6 @@ export const makeDecodeFromCapData = ({
           }
           return result;
         }
-
         // @ts-expect-error This is the error case we're testing for
         case 'ibid': {
           assert.fail(

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -345,7 +345,7 @@ export const makeDecodeFromCapData = ({
       assert.typeof(
         qclass,
         'string',
-        X`invalid qclass typeof ${q(typeof qclass)}`,
+        X`invalid ${q(QCLASS)} typeof ${q(typeof qclass)}`,
       );
       switch (qclass) {
         // Encoding of primitives not handled by JSON

--- a/packages/marshal/test/test-marshal-capdata.js
+++ b/packages/marshal/test/test-marshal-capdata.js
@@ -290,7 +290,9 @@ test('passStyleOf null is "null"', t => {
 test('mal-formed @qclass', t => {
   const m = makeTestMarshal();
   const uns = body => m.unserialize({ body, slots: [] });
-  t.throws(() => uns('{"@qclass": 0}'), { message: /invalid qclass/ });
+  t.throws(() => uns('{"@qclass": 0}'), {
+    message: /invalid "@qclass" typeof "number"*/,
+  });
 });
 
 test('records', t => {

--- a/packages/marshal/test/test-marshal-stringify.js
+++ b/packages/marshal/test/test-marshal-stringify.js
@@ -52,7 +52,7 @@ test('marshal parse errors', t => {
     message: /Unexpected token X in JSON at position 0*/,
   });
   t.throws(() => parse('{"@qclass":8}'), {
-    message: /invalid qclass typeof "number"*/,
+    message: /invalid "@qclass" typeof "number"*/,
   });
   t.throws(() => parse('{"@qclass":"bogus"}'), {
     message: /unrecognized "@qclass" "bogus"*/,


### PR DESCRIPTION
Should not merge ahead of fixing #1312 unless confirmed safe by @FUDCo.

* Add assertions mirroring Smallcaps
* Consistently order special cases: remotable, promise, error
* Consistently quote "@qclass" in error messages