### PR TITLE
refactor(marshal): Simplify checkNormalProperty

### DIFF
--- a/packages/marshal/src/helpers/copyArray.js
+++ b/packages/marshal/src/helpers/copyArray.js
@@ -28,10 +28,10 @@ export const CopyArrayHelper = harden({
     );
     // Since we're already ensured candidate is an array, it should not be
     // possible for the following test to fail
-    checkNormalProperty(candidate, 'length', 'string', false, assertChecker);
+    checkNormalProperty(candidate, 'length', false, assertChecker);
     const len = candidate.length;
     for (let i = 0; i < len; i += 1) {
-      checkNormalProperty(candidate, i, 'number', true, assertChecker);
+      checkNormalProperty(candidate, i, true, assertChecker);
     }
     assert(
       // +1 for the 'length' property itself.

--- a/packages/marshal/src/helpers/copyRecord.js
+++ b/packages/marshal/src/helpers/copyRecord.js
@@ -8,7 +8,7 @@ import {
   checkNormalProperty,
 } from './passStyle-helpers.js';
 
-const { details: X } = assert;
+const { details: X, quote: q } = assert;
 const { ownKeys } = Reflect;
 const {
   getPrototypeOf,
@@ -52,7 +52,11 @@ export const CopyRecordHelper = harden({
   assertValid: (candidate, passStyleOfRecur) => {
     CopyRecordHelper.canBeValid(candidate, assertChecker);
     for (const name of ownKeys(candidate)) {
-      checkNormalProperty(candidate, name, 'string', true, assertChecker);
+      typeof name === 'string' ||
+        assert.fail(
+          X`${q(name)} must be a string-named property: ${candidate}`,
+        );
+      checkNormalProperty(candidate, name, true, assertChecker);
     }
     // Recursively validate that each member is passable.
     Object.values(candidate).every(v => !!passStyleOfRecur(v));

--- a/packages/marshal/src/helpers/passStyle-helpers.js
+++ b/packages/marshal/src/helpers/passStyle-helpers.js
@@ -55,9 +55,10 @@ export const assertChecker = (cond, details) => {
 harden(assertChecker);
 
 /**
+ * Checks for the presence and enumerability of an own data property.
+ *
  * @param {Object} candidate
  * @param {string|number|symbol} propertyName
- * @param {string} nameType
  * @param {boolean} shouldBeEnumerable
  * @param {Checker} check
  * @returns {boolean}
@@ -65,7 +66,6 @@ harden(assertChecker);
 export const checkNormalProperty = (
   candidate,
   propertyName,
-  nameType,
   shouldBeEnumerable,
   check,
 ) => {
@@ -75,14 +75,6 @@ export const checkNormalProperty = (
     return reject(X`${q(propertyName)} property expected: ${candidate}`);
   }
   return (
-    (nameType === undefined ||
-      // eslint-disable-next-line valid-typeof
-      typeof propertyName === nameType ||
-      reject(
-        X`${q(propertyName)} must be a ${q(
-          nameType,
-        )}-named property: ${candidate}`,
-      )) &&
     (hasOwnPropertyOf(desc, 'value') ||
       reject(
         X`${q(propertyName)} must not be an accessor property: ${candidate}`,
@@ -120,20 +112,14 @@ export const checkTagRecord = (tagRecord, passStyle, check) => {
       reject(X`A tagRecord must be frozen: ${tagRecord}`)) &&
     (!isArray(tagRecord) ||
       reject(X`An array cannot be a tagRecords: ${tagRecord}`)) &&
-    checkNormalProperty(tagRecord, PASS_STYLE, 'symbol', false, check) &&
+    checkNormalProperty(tagRecord, PASS_STYLE, false, check) &&
     (tagRecord[PASS_STYLE] === passStyle ||
       reject(
         X`Expected ${q(passStyle)}, not ${q(
           tagRecord[PASS_STYLE],
         )}: ${tagRecord}`,
       )) &&
-    checkNormalProperty(
-      tagRecord,
-      Symbol.toStringTag,
-      'symbol',
-      false,
-      check,
-    ) &&
+    checkNormalProperty(tagRecord, Symbol.toStringTag, false, check) &&
     (typeof getTag(tagRecord) === 'string' ||
       reject(
         X`A [Symbol.toStringTag]-named property must be a string: ${tagRecord}`,

--- a/packages/marshal/src/helpers/tagged.js
+++ b/packages/marshal/src/helpers/tagged.js
@@ -46,7 +46,7 @@ export const TaggedHelper = harden({
         X`Unexpected properties on tagged record ${ownKeys(restDescs)}`,
       );
 
-    checkNormalProperty(candidate, 'payload', 'string', true, assertChecker);
+    checkNormalProperty(candidate, 'payload', true, assertChecker);
 
     // Recursively validate that each member is passable.
     passStyleOfRecur(candidate.payload);


### PR DESCRIPTION
The `nameType` argument is mostly noise and can only fail at one call site, so this PR moves the relevant check to it.