### PR TITLE
perf(marshal): Skip unnecessary assert.details calls

### DIFF
--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -258,7 +258,7 @@ export const makeEncodeToCapData = ({
     }
   };
   const encodeToCapData = passable => {
-    if (ErrorHelper.canBeValid(passable, x => x)) {
+    if (ErrorHelper.canBeValid(passable)) {
       // We pull out this special case to accommodate errors that are not
       // valid Passables. For example, because they're not frozen.
       // The special case can only ever apply at the root, and therefore

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -282,7 +282,7 @@ export const makeEncodeToSmallcaps = ({
     }
   };
   const encodeToSmallcaps = passable => {
-    if (ErrorHelper.canBeValid(passable, x => x)) {
+    if (ErrorHelper.canBeValid(passable)) {
       // We pull out this special case to accommodate errors that are not
       // valid Passables. For example, because they're not frozen.
       // The special case can only ever apply at the root, and therefore

--- a/packages/marshal/src/helpers/copyArray.js
+++ b/packages/marshal/src/helpers/copyArray.js
@@ -17,15 +17,13 @@ export const CopyArrayHelper = harden({
   styleName: 'copyArray',
 
   canBeValid: (candidate, check) =>
-    isArray(candidate) || check(false, X`Array expected: ${candidate}`),
+    isArray(candidate) ||
+    (!!check && check(false, X`Array expected: ${candidate}`)),
 
   assertValid: (candidate, passStyleOfRecur) => {
     CopyArrayHelper.canBeValid(candidate, assertChecker);
-    assert(
-      getPrototypeOf(candidate) === arrayPrototype,
-      X`Malformed array: ${candidate}`,
-      TypeError,
-    );
+    getPrototypeOf(candidate) === arrayPrototype ||
+      assert.fail(X`Malformed array: ${candidate}`, TypeError);
     // Since we're already ensured candidate is an array, it should not be
     // possible for the following test to fail
     checkNormalProperty(candidate, 'length', false, assertChecker);
@@ -33,12 +31,9 @@ export const CopyArrayHelper = harden({
     for (let i = 0; i < len; i += 1) {
       checkNormalProperty(candidate, i, true, assertChecker);
     }
-    assert(
-      // +1 for the 'length' property itself.
-      ownKeys(candidate).length === len + 1,
-      X`Arrays must not have non-indexes: ${candidate}`,
-      TypeError,
-    );
+    // +1 for the 'length' property itself.
+    ownKeys(candidate).length === len + 1 ||
+      assert.fail(X`Arrays must not have non-indexes: ${candidate}`, TypeError);
     // Recursively validate that each member is passable.
     candidate.every(v => !!passStyleOfRecur(v));
   },

--- a/packages/marshal/src/helpers/copyRecord.js
+++ b/packages/marshal/src/helpers/copyRecord.js
@@ -24,10 +24,10 @@ export const CopyRecordHelper = harden({
   styleName: 'copyRecord',
 
   canBeValid: (candidate, check) => {
-    const reject = details => check(false, details);
+    const reject = !!check && (details => check(false, details));
     const proto = getPrototypeOf(candidate);
     if (proto !== objectPrototype && proto !== null) {
-      return reject(X`Unexpected prototype for: ${candidate}`);
+      return reject && reject(X`Unexpected prototype for: ${candidate}`);
     }
     const descs = getOwnPropertyDescriptors(candidate);
     const descKeys = ownKeys(descs);
@@ -35,14 +35,20 @@ export const CopyRecordHelper = harden({
     for (const descKey of descKeys) {
       if (typeof descKey !== 'string') {
         // Pass by copy
-        return reject(
-          X`Records can only have string-named own properties: ${candidate}`,
+        return (
+          (reject &&
+          reject(
+            X`Records can only have string-named own properties: ${candidate}`,
+          ))
         );
       }
       const desc = descs[descKey];
       if (canBeMethod(desc.value)) {
-        return reject(
-          X`Records cannot contain non-far functions because they may be methods of an implicit Remotable: ${candidate}`,
+        return (
+          (reject &&
+          reject(
+            X`Records cannot contain non-far functions because they may be methods of an implicit Remotable: ${candidate}`,
+          ))
         );
       }
     }

--- a/packages/marshal/src/helpers/error.js
+++ b/packages/marshal/src/helpers/error.js
@@ -35,8 +35,8 @@ harden(getErrorConstructor);
  * complaints as notes on the error.
  *
  * To resolve this, such a malformed error object will still pass
- * `canBeValid(err, x => x)` so marshal can use this for top
- * level error to report from, even if it would not actually validate.
+ * `canBeValid` so marshal can use this for top level error to report from,
+ * even if it would not actually validate.
  * Instead, the diagnostics that `assertError` would have reported are
  * attached as notes to the malformed error. Thus, a malformed
  * error is passable by itself, but not as part of a passable structure.
@@ -47,10 +47,10 @@ export const ErrorHelper = harden({
   styleName: 'error',
 
   canBeValid: (candidate, check) => {
-    const reject = details => check(false, details);
+    const reject = !!check && (details => check(false, details));
     // TODO: Need a better test than instanceof
     if (!(candidate instanceof Error)) {
-      return reject(X`Error expected: ${candidate}`);
+      return reject && reject(X`Error expected: ${candidate}`);
     }
     const proto = getPrototypeOf(candidate);
     const { name } = proto;
@@ -58,7 +58,7 @@ export const ErrorHelper = harden({
     if (!EC || EC.prototype !== proto) {
       const note = X`Errors must inherit from an error class .prototype ${candidate}`;
       // Only terminate if check throws
-      reject(note);
+      reject && reject(note);
       assert.note(candidate, note);
     }
 
@@ -72,20 +72,20 @@ export const ErrorHelper = harden({
     if (ownKeys(restDescs).length >= 1) {
       const note = X`Passed Error has extra unpassed properties ${restDescs}`;
       // Only terminate if check throws
-      reject(note);
+      reject && reject(note);
       assert.note(candidate, note);
     }
     if (mDesc) {
       if (typeof mDesc.value !== 'string') {
         const note = X`Passed Error "message" ${mDesc} must be a string-valued data property.`;
         // Only terminate if check throws
-        reject(note);
+        reject && reject(note);
         assert.note(candidate, note);
       }
       if (mDesc.enumerable) {
         const note = X`Passed Error "message" ${mDesc} must not be enumerable`;
         // Only terminate if check throws
-        reject(note);
+        reject && reject(note);
         assert.note(candidate, note);
       }
     }

--- a/packages/marshal/src/helpers/internal-types.js
+++ b/packages/marshal/src/helpers/internal-types.js
@@ -23,7 +23,7 @@ export {};
  *
  * @property {PassStyle} styleName
  *
- * @property {(candidate: any, check: Checker) => boolean} canBeValid
+ * @property {(candidate: any, check?: Checker) => boolean} canBeValid
  * If `canBeValid` returns true, then the candidate would
  * definitely not be valid for any of the other helpers.
  * `assertValid` still needs to be called to determine if it

--- a/packages/marshal/src/helpers/passStyle-helpers.js
+++ b/packages/marshal/src/helpers/passStyle-helpers.js
@@ -60,7 +60,7 @@ harden(assertChecker);
  * @param {Object} candidate
  * @param {string|number|symbol} propertyName
  * @param {boolean} shouldBeEnumerable
- * @param {Checker} check
+ * @param {Checker} [check]
  * @returns {boolean}
  */
 export const checkNormalProperty = (
@@ -69,27 +69,32 @@ export const checkNormalProperty = (
   shouldBeEnumerable,
   check,
 ) => {
-  const reject = details => check(false, details);
+  const reject = !!check && (details => check(false, details));
   const desc = getOwnPropertyDescriptor(candidate, propertyName);
   if (desc === undefined) {
-    return reject(X`${q(propertyName)} property expected: ${candidate}`);
+    return (
+      reject && reject(X`${q(propertyName)} property expected: ${candidate}`)
+    );
   }
   return (
     (hasOwnPropertyOf(desc, 'value') ||
-      reject(
-        X`${q(propertyName)} must not be an accessor property: ${candidate}`,
-      )) &&
+      (reject &&
+        reject(
+          X`${q(propertyName)} must not be an accessor property: ${candidate}`,
+        ))) &&
     (shouldBeEnumerable
       ? desc.enumerable ||
-        reject(
-          X`${q(propertyName)} must be an enumerable property: ${candidate}`,
-        )
+        (reject &&
+          reject(
+            X`${q(propertyName)} must be an enumerable property: ${candidate}`,
+          ))
       : !desc.enumerable ||
-        reject(
-          X`${q(
-            propertyName,
-          )} must not be an enumerable property: ${candidate}`,
-        ))
+        (reject &&
+          reject(
+            X`${q(
+              propertyName,
+            )} must not be an enumerable property: ${candidate}`,
+          )))
   );
 };
 harden(checkNormalProperty);
@@ -100,30 +105,33 @@ harden(getTag);
 /**
  * @param {{ [PASS_STYLE]: string }} tagRecord
  * @param {PassStyle} passStyle
- * @param {Checker} check
+ * @param {Checker} [check]
  * @returns {boolean}
  */
 export const checkTagRecord = (tagRecord, passStyle, check) => {
-  const reject = details => check(false, details);
+  const reject = !!check && (details => check(false, details));
   return (
     (isObject(tagRecord) ||
-      reject(X`A non-object cannot be a tagRecord: ${tagRecord}`)) &&
+      (reject &&
+        reject(X`A non-object cannot be a tagRecord: ${tagRecord}`))) &&
     (isFrozen(tagRecord) ||
-      reject(X`A tagRecord must be frozen: ${tagRecord}`)) &&
+      (reject && reject(X`A tagRecord must be frozen: ${tagRecord}`))) &&
     (!isArray(tagRecord) ||
-      reject(X`An array cannot be a tagRecords: ${tagRecord}`)) &&
+      (reject && reject(X`An array cannot be a tagRecords: ${tagRecord}`))) &&
     checkNormalProperty(tagRecord, PASS_STYLE, false, check) &&
     (tagRecord[PASS_STYLE] === passStyle ||
-      reject(
-        X`Expected ${q(passStyle)}, not ${q(
-          tagRecord[PASS_STYLE],
-        )}: ${tagRecord}`,
-      )) &&
+      (reject &&
+        reject(
+          X`Expected ${q(passStyle)}, not ${q(
+            tagRecord[PASS_STYLE],
+          )}: ${tagRecord}`,
+        ))) &&
     checkNormalProperty(tagRecord, Symbol.toStringTag, false, check) &&
     (typeof getTag(tagRecord) === 'string' ||
-      reject(
-        X`A [Symbol.toStringTag]-named property must be a string: ${tagRecord}`,
-      ))
+      (reject &&
+        reject(
+          X`A [Symbol.toStringTag]-named property must be a string: ${tagRecord}`,
+        )))
   );
 };
 harden(checkTagRecord);

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -161,7 +161,7 @@ const makePassStyleOf = passStyleHelpers => {
             return /** @type {PassStyle} */ (passStyleTag);
           }
           for (const helper of passStyleHelpers) {
-            if (helper.canBeValid(inner, x => x)) {
+            if (helper.canBeValid(inner)) {
               helper.assertValid(inner, passStyleOfRecur);
               return helper.styleName;
             }


### PR DESCRIPTION
Ref 11d9f976944b4faaea06037252cfd54e3dd91c37

A modest but significant speedup, especially for big invalid input:

<details><summary>ad hoc analysis</summary>

```sh
$ node --input-type=module -e '
  import Benchmark from "benchmark";
  import "../init/index.js";
  import { makeTagged } from "./src/makeTagged.js";
  import { makeMarshal } from "./src/marshal.js";
  const { serialize } = makeMarshal(x => x, x => x, { errorTagging: "off", serializeBodyFormat: "smallcaps" });
  const rProto = Object.defineProperties({}, { [Symbol.for("passStyle")]: { value: "remotable" }, [Symbol.toStringTag]: { value: "Remotable" } });
  const inputs = [
    undefined,
    "foo",
    true,
    33,
    33n,
    Symbol.for("foo"),
    Symbol.iterator,
    null,
    Promise.resolve(null),
    [3, 4],
    { foo: 3 },
    { then: "non-function then ok" },
    makeTagged("unknown", undefined),
    Error("ok"),
  ].map(v => harden(v));
  const badInputs = [
    Symbol("unique"),
    {},
    harden(Object.setPrototypeOf(Promise.resolve(), { __proto__: Promise.prototype })),
    harden(Object.assign(Promise.resolve(), { extra: "unexpected own property" })),
    harden(Object.defineProperties(Promise.resolve(), { then: { value: () => "bad then" } })),
    harden({ then: () => "thenable" }),
  ];
  let result;
  (new Benchmark.Suite())
    .add("valid inputs", () => {
      for (const v of inputs) result = serialize(v);
    })
    .add("invalid inputs", () => {
      let caught;
      for (const v of badInputs) {
        caught = undefined;
        try {
          result = serialize(v);
        } catch (err) {
          caught = err;
        } finally {
          if (!caught) throw new Error(`unexpected acceptance: ${v}`);
        }
      }
    })
    .add("big input", () => {
      const input = Array(999).fill().map(() => [...inputs]).concat(Object.create(rProto));
      result = serialize(harden(input));
    })
    .add("big invalid input", () => {
      const input = Array(999).fill().map(() => [...inputs]).concat(Object.create(rProto, { own: {} }));
      let caught;
      caught = undefined;
      try {
        result = serialize(harden(input));
      } catch (err) {
        caught = err;
      }
      if (!caught) throw new Error(`unexpected acceptance`);
    })
    .on("cycle", evt => console.log(String(evt.target)))
    .on("complete", () => result)
    .run({ async: true })
'
```

</details>

before:
```
valid inputs x 5,179 ops/sec ±1.26% (87 runs sampled)
invalid inputs x 2,507 ops/sec ±1.30% (83 runs sampled)
big input x 14.41 ops/sec ±2.08% (37 runs sampled)
big invalid input x 49.72 ops/sec ±3.46% (65 runs sampled)
```
after:
```
valid inputs x 5,908 ops/sec ±1.18% (88 runs sampled)
invalid inputs x 2,565 ops/sec ±1.13% (90 runs sampled)
big input x 14.85 ops/sec ±2.01% (40 runs sampled)
big invalid input x 59.31 ops/sec ±1.16% (61 runs sampled)
```