### PR TITLE
fix: parse positive bigints correctly despite XS parsing them wrong

### DIFF
--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -399,7 +399,9 @@ export const makeDecodeFromSmallcaps = ({
               }
             }
           }
-          case '+':
+          case '+': {
+            return BigInt(encoding.slice(1));
+          }
           case '-': {
             return BigInt(encoding);
           }


### PR DESCRIPTION
Fixes: #1309