### PR TITLE
fix: fail template

### DIFF
--- a/packages/captp/src/atomics.js
+++ b/packages/captp/src/atomics.js
@@ -1,6 +1,6 @@
 /// <reference types="ses"/>
 
-const { details: X } = assert;
+const { details: X, Fail } = assert;
 
 // This is a pathological minimum, but exercised by the unit test.
 export const MIN_DATA_BUFFER_LENGTH = 1;
@@ -23,9 +23,7 @@ const STATUS_FLAG_REJECT = 4;
  */
 const splitTransferBuffer = transferBuffer => {
   transferBuffer.byteLength >= MIN_TRANSFER_BUFFER_LENGTH ||
-    assert.fail(
-      X`Transfer buffer of ${transferBuffer.byteLength} bytes is smaller than MIN_TRANSFER_BUFFER_LENGTH ${MIN_TRANSFER_BUFFER_LENGTH}`,
-    );
+    Fail`Transfer buffer of ${transferBuffer.byteLength} bytes is smaller than MIN_TRANSFER_BUFFER_LENGTH ${MIN_TRANSFER_BUFFER_LENGTH}`;
   const lenbuf = new BigUint64Array(transferBuffer, 0, 1);
 
   // The documentation says that this needs to be an Int32Array for use with
@@ -40,9 +38,7 @@ const splitTransferBuffer = transferBuffer => {
   );
   const databuf = new Uint8Array(transferBuffer, overheadLength);
   databuf.byteLength >= MIN_DATA_BUFFER_LENGTH ||
-    assert.fail(
-      X`Transfer buffer of size ${transferBuffer.byteLength} only supports ${databuf.byteLength} data bytes; need at least ${MIN_DATA_BUFFER_LENGTH}`,
-    );
+    Fail`Transfer buffer of size ${transferBuffer.byteLength} only supports ${databuf.byteLength} data bytes; need at least ${MIN_DATA_BUFFER_LENGTH}`;
   return harden({ statusbuf, lenbuf, databuf });
 };
 

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -14,7 +14,7 @@ import './types.js';
 
 export { E };
 
-const { details: X } = assert;
+const { details: X, Fail } = assert;
 
 /**
  * @param {any} maybeThenable
@@ -61,9 +61,7 @@ export const makeCapTP = (
   // more general networks of CapTPs, but we are conservative for at least this
   // one case.
   !(trapHost && trapGuest) ||
-    assert.fail(
-      X`CapTP ${ourId} can only be one of either trapGuest or trapHost`,
-    );
+    Fail`CapTP ${ourId} can only be one of either trapGuest or trapHost`;
 
   const disconnectReason = id =>
     Error(`${JSON.stringify(id)} connection closed`);
@@ -390,9 +388,7 @@ export const makeCapTP = (
       };
       if (trap) {
         exportedTrapHandlers.has(val) ||
-          assert.fail(
-            X`Refused Trap(${val}) because target was not registered with makeTrapHandler`,
-          );
+          Fail`Refused Trap(${val}) because target was not registered with makeTrapHandler`;
         assert.typeof(
           trapHost,
           'function',
@@ -478,9 +474,7 @@ export const makeCapTP = (
         } catch (e) {
           cleanup();
           if (!e) {
-            assert.fail(
-              X`trapGuest expected trapHost AsyncIterator(${questionID}) to be done, but it wasn't`,
-            );
+            Fail`trapGuest expected trapHost AsyncIterator(${questionID}) to be done, but it wasn't`;
           }
           assert.note(e, X`trapHost AsyncIterator(${questionID}) threw`);
           throw e;
@@ -606,18 +600,17 @@ export const makeCapTP = (
     // Create the Trap proxy maker.
     const makeTrapImpl = implMethod => (target, ...implArgs) => {
       Promise.resolve(target) !== target ||
-        assert.fail(X`Trap(${target}) target cannot be a promise`);
+        Fail`Trap(${target}) target cannot be a promise`;
 
       const slot = valToSlot.get(target);
       // TypeScript confused about `||` control flow so use `if` instead
       // https://github.com/microsoft/TypeScript/issues/50739
       if (!(slot && slot[1] === '-')) {
-        assert.fail(X`Trap(${target}) target was not imported`);
+        Fail`Trap(${target}) target was not imported`;
       }
+      // @ts-expect-error TypeScript confused by `Fail` too?
       slot[0] === 't' ||
-        assert.fail(
-          X`Trap(${target}) imported target was not created with makeTrapHandler`,
-        );
+        Fail`Trap(${target}) imported target was not created with makeTrapHandler`;
 
       // Send a "trap" message.
       lastQuestionID += 1;
@@ -642,7 +635,7 @@ export const makeCapTP = (
           break;
         }
         default: {
-          assert.fail(X`Internal error; unrecognized implMethod ${implMethod}`);
+          Fail`Internal error; unrecognized implMethod ${implMethod}`;
         }
       }
 
@@ -650,6 +643,7 @@ export const makeCapTP = (
       // messages over the current CapTP data channel.
       const [isException, serialized] = trapGuest({
         trapMethod: implMethod,
+        // @ts-expect-error TypeScript confused by `Fail` too?
         slot,
         trapArgs: implArgs,
         startTrap: () => {
@@ -683,9 +677,7 @@ export const makeCapTP = (
 
       const value = unserialize(serialized);
       !isThenable(value) ||
-        assert.fail(
-          X`Trap(${target}) reply cannot be a Thenable; have ${value}`,
-        );
+        Fail`Trap(${target}) reply cannot be a Thenable; have ${value}`;
 
       if (isException) {
         throw value;

--- a/packages/captp/test/traplib.js
+++ b/packages/captp/test/traplib.js
@@ -6,7 +6,7 @@ import { E, makeCapTP } from '../src/captp.js';
 
 import { makeAtomicsTrapGuest, makeAtomicsTrapHost } from '../src/atomics.js';
 
-const { details: X } = assert;
+const { details: X, Fail } = assert;
 
 export const createHostBootstrap = makeTrapHandler => {
   // Create a remotable that has a syncable return value.
@@ -74,7 +74,7 @@ const createGuestBootstrap = (Trap, other) => {
           } catch (e) {
             return;
           }
-          assert.fail(X`Thunk did not throw: ${ret}`);
+          Fail`Thunk did not throw: ${ret}`;
         },
       };
       await runTrapTests(mockT, Trap, other, unwrapsPromises);

--- a/packages/captp/test/worker.js
+++ b/packages/captp/test/worker.js
@@ -6,13 +6,13 @@ import '@endo/init/debug.js';
 import { parentPort } from 'worker_threads';
 import { makeGuest, makeHost } from './traplib.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 let dispatch;
 parentPort.addListener('message', obj => {
   switch (obj.type) {
     case 'TEST_INIT': {
-      assert(!dispatch, X`Internal error; duplicate initialization`);
+      !dispatch || Fail`Internal error; duplicate initialization`;
       const { transferBuffer, isGuest } = obj;
       const initFn = isGuest ? makeGuest : makeHost;
       const ret = initFn(o => parentPort.postMessage(o), transferBuffer);

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -2,7 +2,7 @@
 // @ts-nocheck
 
 // NOTE: We can't import these because they're not in scope before lockdown.
-// import { assert, details as X } from '@agoric/assert';
+// import { assert, details as X, Fail } from '@agoric/assert';
 
 // WARNING: Global Mutable State!
 // This state is communicated to `assert` that makes it available to the

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -5,7 +5,7 @@ import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
 import { decodeBase64 } from '@endo/base64';
 import { wrapInescapableCompartment } from './compartment-wrapper.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 // importBundle takes the output of bundle-source, and returns a namespace
 // object (with .default, and maybe other properties for named exports)
@@ -82,7 +82,7 @@ export async function importBundle(bundle, options = {}) {
     // `filePrefix` and the relative import path of each module.
     endowments.nestedEvaluate = src => c.evaluate(src);
   } else {
-    assert.fail(X`unrecognized moduleFormat '${moduleFormat}'`);
+    Fail`unrecognized moduleFormat '${moduleFormat}'`;
   }
 
   c = new CompartmentToUse(endowments, {}, { transforms });

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -15,10 +15,7 @@ function check(t, c, n) {
   t.throws(
     () => new Con(),
     {
-      // Temporarily tolerate Endo behavior before and after
-      // https://github.com/endojs/endo/pull/822
-      // TODO Simplify once depending on SES post #822
-      message: /Not available|Function\.prototype\.constructor is not a valid constructor\./,
+      message: 'Function.prototype.constructor is not a valid constructor.',
     },
     `${n} .constructor is tamed`,
   );

--- a/packages/marshal/src/dot-membrane.js
+++ b/packages/marshal/src/dot-membrane.js
@@ -12,7 +12,7 @@ import { passStyleOf } from './passStyleOf.js';
 
 const { fromEntries } = Object;
 const { ownKeys } = Reflect;
-const { details: X } = assert;
+const { Fail } = assert;
 
 // TODO(erights): Add Converter type
 /** @param {any} [mirrorConverter] */
@@ -104,7 +104,7 @@ const makeConverter = (mirrorConverter = undefined) => {
         break;
       }
       default: {
-        assert.fail(X`internal: Unrecognized passStyle ${passStyle}`);
+        Fail`internal: Unrecognized passStyle ${passStyle}`;
       }
     }
     mineToYours.set(mine, yours);

--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -19,7 +19,7 @@ import {
 /** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
 /** @typedef {import('../types.js').Remotable} Remotable */
 
-const { details: X, quote: q } = assert;
+const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
 const { isArray } = Array;
 const {
@@ -74,7 +74,7 @@ harden(assertIface);
 const checkRemotableProtoOf = (original, check) => {
   const reject = !!check && (details => check(false, details));
   isObject(original) ||
-    assert.fail(X`Remotables must be objects or functions: ${original}`);
+    Fail`Remotables must be objects or functions: ${original}`;
 
   // A valid remotable object must inherit from a "tag record" -- a
   // plain-object prototype consisting of only

--- a/packages/marshal/src/helpers/symbol.js
+++ b/packages/marshal/src/helpers/symbol.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { details: X, quote: q } = assert;
+const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
 
 /**
@@ -40,9 +40,7 @@ harden(isPassableSymbol);
 
 export const assertPassableSymbol = sym =>
   isPassableSymbol(sym) ||
-  assert.fail(
-    X`Only registered symbols or well-known symbols are passable: ${q(sym)}`,
-  );
+  Fail`Only registered symbols or well-known symbols are passable: ${q(sym)}`;
 harden(assertPassableSymbol);
 
 /**
@@ -114,7 +112,7 @@ export const passableSymbolForName = name => {
       if (typeof sym === 'symbol') {
         return sym;
       }
-      assert.fail(X`Reserved for well known symbol ${q(suffix)}: ${q(name)}`);
+      Fail`Reserved for well known symbol ${q(suffix)}: ${q(name)}`;
     }
   }
   return Symbol.for(name);

--- a/packages/marshal/src/helpers/tagged.js
+++ b/packages/marshal/src/helpers/tagged.js
@@ -10,7 +10,7 @@ import {
   checkPassStyle,
 } from './passStyle-helpers.js';
 
-const { details: X } = assert;
+const { Fail } = assert;
 const { ownKeys } = Reflect;
 const { getOwnPropertyDescriptors } = Object;
 
@@ -37,9 +37,7 @@ export const TaggedHelper = harden({
       ...restDescs
     } = getOwnPropertyDescriptors(candidate);
     (ownKeys(restDescs).length === 0) ||
-      assert.fail(
-        X`Unexpected properties on tagged record ${ownKeys(restDescs)}`,
-      );
+      Fail`Unexpected properties on tagged record ${ownKeys(restDescs)}`;
 
     checkNormalProperty(candidate, 'payload', true, assertChecker);
 

--- a/packages/marshal/src/make-far.js
+++ b/packages/marshal/src/make-far.js
@@ -12,7 +12,7 @@ import {
 /** @typedef {import('./types.js').InterfaceSpec} InterfaceSpec */
 /** @template L,R @typedef {import('@endo/eventual-send').RemotableBrand<L, R>} RemotableBrand */
 
-const { quote: q, details: X } = assert;
+const { quote: q, details: X, Fail } = assert;
 
 const { prototype: functionPrototype } = Function;
 const {
@@ -39,21 +39,17 @@ const makeRemotableProto = (remotable, iface) => {
       oldProto = objectPrototype;
     }
     oldProto === objectPrototype ||
-      assert.fail(
-        X`For now, remotables cannot inherit from anything unusual, in ${remotable}`,
-      );
+      Fail`For now, remotables cannot inherit from anything unusual, in ${remotable}`;
   } else if (typeof remotable === 'function') {
     oldProto !== null ||
-      assert.fail(
-        X`Original function must not inherit from null: ${remotable}`,
-      );
+      Fail`Original function must not inherit from null: ${remotable}`;
     assert(
       oldProto === functionPrototype ||
         getPrototypeOf(oldProto) === functionPrototype,
       X`Far functions must originally inherit from Function.prototype, in ${remotable}`,
     );
   } else {
-    assert.fail(X`unrecognized typeof ${remotable}`);
+    Fail`unrecognized typeof ${remotable}`;
   }
   return harden(
     create(oldProto, {

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -14,7 +14,7 @@ import { AtAtPrefixPattern, passableSymbolForName } from './helpers/symbol.js';
 const { ownKeys } = Reflect;
 const { isArray } = Array;
 const { stringify: quote } = JSON;
-const { quote: q, details: X } = assert;
+const { quote: q, details: X, Fail } = assert;
 
 /**
  * @typedef {Object} Indenter
@@ -190,7 +190,7 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
         case 'hilbert': {
           const { original, rest } = rawTree;
           'original' in rawTree ||
-            assert.fail(X`Invalid Hilbert Hotel encoding ${rawTree}`);
+            Fail`Invalid Hilbert Hotel encoding ${rawTree}`;
           prepare(original);
           if ('rest' in rawTree) {
             assert.typeof(
@@ -199,12 +199,9 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
               X`Rest ${rest} encoding must be an object`,
             );
             assert(rest !== null, X`Rest ${rest} encoding must not be null`);
-            !isArray(rest) ||
-              assert.fail(X`Rest ${rest} encoding must not be an array`);
+            !isArray(rest) || Fail`Rest ${rest} encoding must not be an array`;
             !(QCLASS in rest) ||
-              assert.fail(
-                X`Rest encoding ${rest} must not contain ${q(QCLASS)}`,
-              );
+              Fail`Rest encoding ${rest} must not contain ${q(QCLASS)}`;
             const names = ownKeys(rest);
             for (const name of names) {
               assert.typeof(
@@ -225,7 +222,7 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
             X`invalid error name typeof ${q(typeof name)}`,
           );
           getErrorConstructor(name) !== undefined ||
-            assert.fail(X`Must be the name of an Error constructor ${name}`);
+            Fail`Must be the name of an Error constructor ${name}`;
           assert.typeof(
             message,
             'string',

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -5,22 +5,23 @@ import { makeMarshal } from './marshal.js';
 
 /** @typedef {import('./types.js').Passable} Passable */
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 /** @type {import('./types.js').ConvertValToSlot<any>} */
 const doNotConvertValToSlot = val =>
-  assert.fail(X`Marshal's stringify rejects presences and promises ${val}`);
+  Fail`Marshal's stringify rejects presences and promises ${val}`;
 
 /** @type {import('./types.js').ConvertSlotToVal<any>} */
 const doNotConvertSlotToVal = (slot, _iface) =>
-  assert.fail(X`Marshal's parse must not encode any slots ${slot}`);
+  Fail`Marshal's parse must not encode any slots ${slot}`;
 
 const badArrayHandler = harden({
   get: (_target, name, _receiver) => {
     if (name === 'length') {
       return 0;
     }
-    assert.fail(X`Marshal's parse must not encode any slot positions ${name}`);
+    // `throw` is noop since `Fail` throws. But linter confused
+    throw Fail`Marshal's parse must not encode any slot positions ${name}`;
   },
 });
 

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -29,7 +29,7 @@ import { hasOwnPropertyOf } from './helpers/passStyle-helpers.js';
 /** @typedef {import('./types.js').Remotable} Remotable */
 
 const { isArray } = Array;
-const { details: X, quote: q } = assert;
+const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
 
 /** @type {ConvertValToSlot<any>} */
@@ -64,9 +64,7 @@ export const makeMarshal = (
   assert.typeof(marshalName, 'string');
   errorTagging === 'on' ||
     errorTagging === 'off' ||
-    assert.fail(
-      X`The errorTagging option can only be "on" or "off" ${errorTagging}`,
-    );
+    Fail`The errorTagging option can only be "on" or "off" ${errorTagging}`;
   const nextErrorId = () => {
     errorIdNum += 1;
     return `error:${marshalName}#${errorIdNum}`;
@@ -227,9 +225,8 @@ export const makeMarshal = (
         slots,
       });
     } else {
-      assert.fail(
-        X`Unrecognized serializeBodyFormat: ${q(serializeBodyFormat)}`,
-      );
+      // The `throw` is a noop since `Fail` throws. Added for confused linters.
+      throw Fail`Unrecognized serializeBodyFormat: ${q(serializeBodyFormat)}`;
     }
   };
 
@@ -244,7 +241,7 @@ export const makeMarshal = (
     const decodeSlotCommon = slotData => {
       const { iface = undefined, index, ...rest } = slotData;
       ownKeys(rest).length === 0 ||
-        assert.fail(X`unexpected encoded slot properties ${q(ownKeys(rest))}`);
+        Fail`unexpected encoded slot properties ${q(ownKeys(rest))}`;
       if (valMap.has(index)) {
         return valMap.get(index);
       }
@@ -264,7 +261,7 @@ export const makeMarshal = (
     const decodeErrorCommon = (errData, decodeRecur) => {
       const { errorId = undefined, message, name, ...rest } = errData;
       ownKeys(rest).length === 0 ||
-        assert.fail(X`unexpected encoded error properties ${q(ownKeys(rest))}`);
+        Fail`unexpected encoded error properties ${q(ownKeys(rest))}`;
       // TODO Must decode `cause` and `errors` properties
       // capData does not transform strings. The calls to `decodeRecur`
       // are for reuse by other encodings that do, such as smallcaps.
@@ -272,9 +269,9 @@ export const makeMarshal = (
       const dMessage = decodeRecur(message);
       const dErrorId = errorId && decodeRecur(errorId);
       typeof dName === 'string' ||
-        assert.fail(X`invalid error name typeof ${q(typeof dName)}`);
+        Fail`invalid error name typeof ${q(typeof dName)}`;
       typeof dMessage === 'string' ||
-        assert.fail(X`invalid error message typeof ${q(typeof dMessage)}`);
+        Fail`invalid error message typeof ${q(typeof dMessage)}`;
       const EC = getErrorConstructor(dName) || Error;
       // errorId is a late addition so be tolerant of its absence.
       const errorName =
@@ -323,7 +320,7 @@ export const makeMarshal = (
     const decodeErrorFromSmallcaps = (encoding, decodeRecur) => {
       const { '#error': message, ...restErrData } = encoding;
       !hasOwnPropertyOf(restErrData, 'message') ||
-        assert.fail(X`unexpected encoded error property ${q('message')}`);
+        Fail`unexpected encoded error property ${q('message')}`;
       return decodeErrorCommon({ message, ...restErrData }, decodeRecur);
     };
 
@@ -342,11 +339,9 @@ export const makeMarshal = (
   const unserialize = data => {
     const { body, slots } = data;
     typeof body === 'string' ||
-      assert.fail(
-        X`unserialize() given non-capdata (.body is ${body}, not string)`,
-      );
+      Fail`unserialize() given non-capdata (.body is ${body}, not string)`;
     isArray(data.slots) ||
-      assert.fail(X`unserialize() given non-capdata (.slots are not Array)`);
+      Fail`unserialize() given non-capdata (.slots are not Array)`;
     const { reviveFromCapData, reviveFromSmallcaps } = makeFullRevive(slots);
     let result;
     // JSON cannot begin with a '#', so this is an unambiguous signal.

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -26,7 +26,7 @@ import { assertSafePromise } from './helpers/safe-promise.js';
 
 /** @typedef {Exclude<PassStyle, PrimitiveStyle | "promise">} HelperPassStyle */
 
-const { details: X, quote: q } = assert;
+const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
 const { isFrozen } = Object;
 
@@ -57,7 +57,7 @@ const makeHelperTable = passStyleHelpers => {
   }
   for (const styleName of ownKeys(HelperTable)) {
     HelperTable[styleName] !== undefined ||
-      assert.fail(X`missing helper for ${q(styleName)}`);
+      Fail`missing helper for ${q(styleName)}`;
   }
 
   return harden(HelperTable);
@@ -112,7 +112,7 @@ const makePassStyleOf = passStyleHelpers => {
           return passStyleMemo.get(inner);
         }
         (!inProgress.has(inner)) ||
-          assert.fail(X`Pass-by-copy data cannot be cyclic ${inner}`);
+          Fail`Pass-by-copy data cannot be cyclic ${inner}`;
         inProgress.add(inner);
       }
       // eslint-disable-next-line no-use-before-define
@@ -159,13 +159,13 @@ const makePassStyleOf = passStyleHelpers => {
             return 'promise';
           }
           (typeof inner.then !== 'function') ||
-            assert.fail(X`Cannot pass non-promise thenables`);
+            Fail`Cannot pass non-promise thenables`;
           const passStyleTag = inner[PASS_STYLE];
           if (passStyleTag !== undefined) {
             assert.typeof(passStyleTag, 'string');
             const helper = HelperTable[passStyleTag];
             (helper !== undefined) ||
-              assert.fail(X`Unrecognized PassStyle: ${q(passStyleTag)}`);
+              Fail`Unrecognized PassStyle: ${q(passStyleTag)}`;
             helper.assertValid(inner, passStyleOfRecur);
             return /** @type {PassStyle} */ (passStyleTag);
           }
@@ -180,11 +180,9 @@ const makePassStyleOf = passStyleHelpers => {
         }
         case 'function': {
           (isFrozen(inner)) ||
-            assert.fail(
-              X`Cannot pass non-frozen objects like ${inner}. Use harden()`,
-            );
+            Fail`Cannot pass non-frozen objects like ${inner}. Use harden()`;
           (typeof inner.then !== 'function') ||
-            assert.fail(X`Cannot pass non-promise thenables`);
+            Fail`Cannot pass non-promise thenables`;
           remotableHelper.assertValid(inner, passStyleOfRecur);
           return 'remotable';
         }

--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -195,6 +195,7 @@ export interface Assert {
     template: TemplateStringsArray | string[],
     ...args: any
   ): DetailsToken;
+  Fail(template: TemplateStringsArray | string[], ...args: any): never;
   quote(payload: any, spaces?: string | number): ToStringable;
   makeAssert: MakeAssert;
 }

--- a/packages/ses/src/environment-options.js
+++ b/packages/ses/src/environment-options.js
@@ -5,7 +5,7 @@
 import { arrayPush, freeze } from './commons.js';
 import { assert } from './error/assert.js';
 
-const { details: X, quote: q } = assert;
+const { details: X, Fail, quote: q } = assert;
 
 /**
  * JavaScript module semantics resists attempts to parameterize a module's
@@ -110,11 +110,9 @@ export const makeEnvironmentCaptor = aGlobal => {
     setting === undefined ||
       typeof setting === 'string' ||
       // eslint-disable-next-line @endo/no-polymorphic-call
-      assert.fail(
-        X`Environment option value ${q(
-          setting,
-        )}, if present, must be a string.`,
-      );
+      Fail`Environment option value ${q(
+        setting,
+      )}, if present, must be a string.`;
     return setting;
   };
   freeze(getEnvironmentOption);

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -375,6 +375,9 @@ const makeAssert = (optRaise = undefined, unredacted = false) => {
   };
   freeze(fail);
 
+  /** @type {FailTag} */
+  const Fail = (template, ...args) => fail(details(template, ...args));
+
   // Don't freeze or export `baseAssert` until we add methods.
   // TODO If I change this from a `function` function to an arrow
   // function, I seem to get type errors from TypeScript. Why?
@@ -433,6 +436,7 @@ const makeAssert = (optRaise = undefined, unredacted = false) => {
     string: assertString,
     note,
     details,
+    Fail,
     quote,
     makeAssert,
   });

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -262,6 +262,60 @@
 
 /**
  * @typedef {(template: TemplateStringsArray | string[], ...args: any) => never} FailTag
+ * The `Fail` tamplate tag supports replacing patterns like
+ * ```js
+ * assert(cond, X`...complaint...`);
+ * ```
+ * or
+ * ```js
+ * cond || assert.fail(X`...complaint...`);
+ * ```
+ * with patterns like
+ * ```js
+ * cond || Fail`...complaint...`;
+ * ```
+ *
+ * However, due to [weakness in current
+ * TypeScript](https://github.com/microsoft/TypeScript/issues/51426), the `||`
+ * patterns are not as powerful as the `assert(...)` call at enabling static
+ * reasoning. Of the `||`, again due to weaknesses in current TypeScript,
+ * the
+ * ```js
+ * cond || Fail`...complaint...`
+ * ```
+ * pattern is not as powerful as the
+ * ```js
+ * cond || assert.fail(X`...complaint...`);
+ * ```
+ * at enabling static resoning. Despite these problems, we do not want to
+ * return to the
+ * ```js
+ * assert(cond, X`...complaint...`)
+ * ```
+ * style because of the substantial overhead in
+ * evaluating the `X` template in the typical `true` case where it is not
+ * needed. And we do not want to return to the
+ * ```js
+ * assert.fail(X`...complaint...`)`
+ * ```
+ * because of the verbosity and loss of readability. Instead, until/unless
+ * https://github.com/microsoft/TypeScript/issues/51426 is fixed, for those
+ * new-style assertions where this loss of static reasoning is a problem,
+ * instead express the assertion as
+ * ```js
+ *   if (!cond) {
+ *     Fail`...complaint...`;
+ *   }
+ * ```
+ * or, if needed,
+ * ```js
+ *   if (!cond) {
+ *     // `throw` is noop since `Fail` throws. But linter confused
+ *     throw Fail`...complaint...`;
+ *   }
+ * ```
+ * This avoid the TypeScript bugs that cause the loss of static reasoning,
+ * but with no loss of efficiency and little loss of readability.
  */
 
 /**

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -261,6 +261,10 @@
  */
 
 /**
+ * @typedef {(template: TemplateStringsArray | string[], ...args: any) => never} FailTag
+ */
+
+/**
  * assert that expr is truthy, with an optional details to describe
  * the assertion. It is a tagged template literal like
  * ```js
@@ -286,6 +290,7 @@
  *   string: AssertString,
  *   note: AssertNote,
  *   details: DetailsTag,
+ *   Fail: FailTag,
  *   quote: AssertQuote,
  *   makeAssert: MakeAssert,
  * } } Assert

--- a/packages/static-module-record/test/fixtures/exportheavy.js
+++ b/packages/static-module-record/test/fixtures/exportheavy.js
@@ -1,4 +1,4 @@
-/* eslint-disable */ 
+/* eslint-disable */
 console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
 
 export { mapIterable, filterIterable } from './src/helpers/iter-helpers.js';
@@ -43,7 +43,7 @@ export {
 export * from './src/types.js';
 
 
-const { details: X } = assert;
+const { details: X, Fail } = assert;
 
 // This is a pathological minimum, but exercised by the unit test.
 export const MIN_DATA_BUFFER_LENGTH = 1;

--- a/packages/stream-node/reader.js
+++ b/packages/stream-node/reader.js
@@ -8,7 +8,7 @@
 
 import { mapReader } from '@endo/stream';
 
-const { details: X, quote: q } = assert;
+const { details: X, Fail, quote: q } = assert;
 
 /**
  * @param {import('stream').Readable} input the source Node.js reader
@@ -16,9 +16,7 @@ const { details: X, quote: q } = assert;
  */
 export const makeNodeReader = input => {
   !input.readableObjectMode ||
-    assert.fail(
-      X`Cannot convert Node.js object mode Reader to AsyncIterator<Uint8Array>`,
-    );
+    Fail`Cannot convert Node.js object mode Reader to AsyncIterator<Uint8Array>`;
   assert(
     input.readableEncoding === null,
     X`Cannot convert Node.js Reader with readableEncoding ${q(

--- a/packages/stream-node/writer.js
+++ b/packages/stream-node/writer.js
@@ -5,7 +5,7 @@
 // @ts-check
 /// <reference types="ses"/>
 
-const { details: X } = assert;
+const { Fail } = assert;
 
 /**
  * Adapts a Node.js writable stream to a JavaScript
@@ -18,9 +18,7 @@ const { details: X } = assert;
  */
 export const makeNodeWriter = writer => {
   !writer.writableObjectMode ||
-    assert.fail(
-      X`Cannot convert Node.js object mode Writer to AsyncIterator<undefined, Uint8Array>`,
-    );
+    Fail`Cannot convert Node.js object mode Writer to AsyncIterator<undefined, Uint8Array>`;
 
   const finalIteration = new Promise((resolve, reject) => {
     const finalize = () => {


### PR DESCRIPTION
See https://github.com/Agoric/agoric-sdk/pull/6482

Prior to this PR, our new assertion style let to many statements of the form
```js
condition || assert.fail(X`...`);
```
with this PR, we can now write
```js
condition || Fail`...`;
```
which is more compact and more readable.