### PR TITLE
fix: restore capdata leniency

### DIFF
--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -413,13 +413,11 @@ export const makeDecodeFromCapData = ({
             jsonEncoded,
             decodeFromCapData,
           );
-          const passStyle = passStyleOf(decoded);
-          if (passStyle === 'remotable' || passStyle === 'promise') {
-            return decoded;
-          }
-          assert.fail(
-            X`internal: decodeRemotableFromCapData option must return a remotable or promise: ${decoded}`,
-          );
+          // BEWARE: capdata does not check that `decoded` is
+          // a promise or a remotable, since that would break some
+          // capdata clients. We are deprecating capdata, and these clients
+          // will need to update before switching to smallcaps.
+          return decoded;
         }
         case 'error': {
           const decoded = decodeErrorFromCapData(

--- a/packages/marshal/test/test-marshal-capdata.js
+++ b/packages/marshal/test/test-marshal-capdata.js
@@ -407,3 +407,23 @@ test('capdata proto problems', t => {
   // Fails before https://github.com/endojs/endo/issues/1303 fix
   t.deepEqual(fromCapData(wrongProtoCapData), wrongProto);
 });
+
+test('capdata slot leniency', t => {
+  const { unserialize: fromCapData } = makeMarshal(
+    undefined,
+    _slot => ({
+      name: 'I should not be in a slot',
+    }),
+    {
+      errorTagging: 'off',
+      serializeBodyFormat: 'capdata',
+    },
+  );
+  t.deepEqual(
+    fromCapData({
+      body: '[{"@qclass":"slot","index":0}]',
+      slots: ['ignored'],
+    }),
+    [{ name: 'I should not be in a slot' }],
+  );
+});


### PR DESCRIPTION
capdata is being deprecated. It exists only to avoid breaking old clients that have not yet updated to smallcaps. However, I accidentally introduced an error check that I did not realize would be a breaking change. This removes that extra check, enabling old code to continue working the old way until it upgrades to smallcaps.
