### PR TITLE
fix(ses): Patch leak of globalLexicals thru moduleLexicals

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in SES:
 
+# Next release
+
+- *SECURITY FIX*: Closes a leak for `globalLexicals`, such that a module
+  lexical scope cannot be used to reveal names in global lexical scope.
+
 # v0.17.0 (2022-10-24)
 
 - Previous versions of SES would leak the proxy used to isolate evaluated

--- a/packages/ses/src/make-safe-evaluator.js
+++ b/packages/ses/src/make-safe-evaluator.js
@@ -21,10 +21,12 @@ const { details: d } = assert;
  * @param {Object} [options.globalLexicals]
  * @param {Array<Transform>} [options.globalTransforms]
  * @param {bool} [options.sloppyGlobalsMode]
+ * @param {Object} [options.moduleLexicals]
  */
 export const makeSafeEvaluator = ({
   globalObject,
   globalLexicals = {},
+  moduleLexicals = {},
   globalTransforms = [],
   sloppyGlobalsMode = false,
 } = {}) => {
@@ -36,6 +38,7 @@ export const makeSafeEvaluator = ({
 
   const evaluateContext = freeze({
     evalScope,
+    moduleLexicals,
     globalLexicals,
     globalObject,
     scopeTerminator,

--- a/packages/ses/test/test-compartment.js
+++ b/packages/ses/test/test-compartment.js
@@ -98,3 +98,23 @@ test('main use case', t => {
   t.is(user(1), 2);
   t.throws(() => user(-1), { instanceOf: TypeError });
 });
+
+test.failing('compartment does not leak globalLexicals through moduleLexicals', t => {
+  const compartment = new Compartment(null, null, {
+    globalLexicals: {
+      secret: 'secret',
+    },
+  });
+
+  t.is('secret', compartment.evaluate('secret'));
+
+  const moduleShimLexicals = compartment.evaluate('leakModuleLexicals()', {
+    __moduleShimLexicals__: {
+      leakModuleLexicals() {
+        return this;
+      },
+    },
+  });
+
+  t.not('secret', moduleShimLexicals.secret);
+});

--- a/packages/ses/test/test-compartment.js
+++ b/packages/ses/test/test-compartment.js
@@ -99,7 +99,7 @@ test('main use case', t => {
   t.throws(() => user(-1), { instanceOf: TypeError });
 });
 
-test.failing('compartment does not leak globalLexicals through moduleLexicals', t => {
+test('compartment does not leak globalLexicals through moduleLexicals', t => {
   const compartment = new Compartment(null, null, {
     globalLexicals: {
       secret: 'secret',

--- a/packages/ses/test/test-make-evaluate.js
+++ b/packages/ses/test/test-make-evaluate.js
@@ -19,7 +19,7 @@ const makeObservingProxy = target => {
 };
 
 test('makeEvaluate - optimizer', t => {
-  t.plan(5);
+  t.plan(6);
 
   const globalObjectTarget = Object.create(null, {
     foo: { value: true },
@@ -27,6 +27,7 @@ test('makeEvaluate - optimizer', t => {
     baz: { value: true, writable: true },
   });
   const globalLexicalsTarget = Object.create(null, { foo: { value: false } });
+  const moduleLexicalsTarget = Object.create(null, { qux: { value: false } });
 
   const [globalObject, globalObjectOps] = makeObservingProxy(
     globalObjectTarget,
@@ -34,17 +35,27 @@ test('makeEvaluate - optimizer', t => {
   const [globalLexicals, globalLexicalsOps] = makeObservingProxy(
     globalLexicalsTarget,
   );
+  const [moduleLexicals, moduleLexicalsOps] = makeObservingProxy(
+    moduleLexicalsTarget,
+  );
 
   const scopeTerminator = strictScopeTerminator;
   const evalScopeKit = makeEvalScopeKit();
   const { evalScope } = evalScopeKit;
 
   const evaluate = makeEvaluate(
-    freeze({ scopeTerminator, globalObject, globalLexicals, evalScope }),
+    freeze({
+      scopeTerminator,
+      globalObject,
+      globalLexicals,
+      moduleLexicals,
+      evalScope,
+    }),
   );
 
   t.deepEqual(globalObjectOps, [['get', 'bar']]);
   t.deepEqual(globalLexicalsOps, [['get', 'foo']]);
+  t.deepEqual(moduleLexicalsOps, [['get', 'qux']]);
 
   globalObjectOps.length = 0;
   globalLexicalsOps.length = 0;
@@ -63,13 +74,20 @@ test('makeEvaluate - strict-mode', t => {
 
   const globalObject = Object.create(null);
   const globalLexicals = Object.create(null);
+  const moduleLexicals = Object.create(null);
 
   const scopeTerminator = strictScopeTerminator;
   const evalScopeKit = makeEvalScopeKit();
   const { evalScope } = evalScopeKit;
 
   const evaluate = makeEvaluate(
-    freeze({ scopeTerminator, globalObject, globalLexicals, evalScope }),
+    freeze({
+      scopeTerminator,
+      globalObject,
+      globalLexicals,
+      moduleLexicals,
+      evalScope,
+    }),
   );
 
   evalScopeKit.allowNextEvalToBeUnsafe();

--- a/packages/ses/test/test-scope-constants.js
+++ b/packages/ses/test/test-scope-constants.js
@@ -1,59 +1,95 @@
 import test from 'ava';
 import { getScopeConstants } from '../src/scope-constants.js';
 
-test('getScopeConstants - global object', t => {
+test('getScopeConstants - globalObject', t => {
   t.plan(20);
 
   t.deepEqual(
     getScopeConstants({}),
-    { globalLexicalConstants: [], globalObjectConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalLexicalConstants: [],
+      globalObjectConstants: [],
+    },
     'should return empty if no global',
   );
 
   t.deepEqual(
     getScopeConstants({ foo: true }),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject configurable & writable',
   );
   t.deepEqual(
     getScopeConstants(Object.create(null, { foo: { value: true } })),
-    { globalObjectConstants: ['foo'], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: ['foo'],
+      globalLexicalConstants: [],
+    },
     'should return non configurable & non writable',
   );
   t.deepEqual(
     getScopeConstants(
       Object.create(null, { foo: { value: true, configurable: true } }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject configurable',
   );
   t.deepEqual(
     getScopeConstants(
       Object.create(null, { foo: { value: true, writable: true } }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject writable',
   );
 
   t.deepEqual(
     getScopeConstants(Object.create(null, { foo: { get: () => true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject getter',
   );
   t.deepEqual(
     getScopeConstants(Object.create(null, { foo: { set: () => true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject setter',
   );
 
   t.deepEqual(
     getScopeConstants(Object.create(null, { eval: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject eval',
   );
   t.deepEqual(
     getScopeConstants(Object.create(null, { const: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject reserved keyword',
   );
   t.deepEqual(
@@ -64,7 +100,11 @@ test('getScopeConstants - global object', t => {
         false: { value: true },
       }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject literals (reserved)',
   );
   t.deepEqual(
@@ -74,46 +114,78 @@ test('getScopeConstants - global object', t => {
         arguments: { value: true },
       }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject this and arguments',
   );
   t.deepEqual(
     getScopeConstants(
       Object.create(null, { [Symbol.iterator]: { value: true } }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject symbols',
   );
 
   t.deepEqual(
     getScopeConstants(Object.create(null, { 123: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject leading digit',
   );
   t.deepEqual(
     getScopeConstants(Object.create(null, { '-123': { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject leading dash',
   );
 
   t.deepEqual(
     getScopeConstants(Object.create(null, { _123: { value: true } })),
-    { globalObjectConstants: ['_123'], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: ['_123'],
+      globalLexicalConstants: [],
+    },
     'should return leading underscore',
   );
   t.deepEqual(
     getScopeConstants(Object.create(null, { $123: { value: true } })),
-    { globalObjectConstants: ['$123'], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: ['$123'],
+      globalLexicalConstants: [],
+    },
     'should return leading underscore',
   );
   t.deepEqual(
     getScopeConstants(Object.create(null, { a123: { value: true } })),
-    { globalObjectConstants: ['a123'], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: ['a123'],
+      globalLexicalConstants: [],
+    },
     'should return leading lowercase',
   );
   t.deepEqual(
     getScopeConstants(Object.create(null, { A123: { value: true } })),
-    { globalObjectConstants: ['A123'], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: ['A123'],
+      globalLexicalConstants: [],
+    },
     'should return leading uppercase',
   );
 
@@ -121,7 +193,11 @@ test('getScopeConstants - global object', t => {
     getScopeConstants(
       Object.create(null, { foo: { value: true }, bar: { value: true } }),
     ),
-    { globalObjectConstants: ['foo', 'bar'], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: ['foo', 'bar'],
+      globalLexicalConstants: [],
+    },
     'should return all non configurable & non writable',
   );
   t.deepEqual(
@@ -131,28 +207,44 @@ test('getScopeConstants - global object', t => {
         bar: { value: true, configurable: true },
       }),
     ),
-    { globalObjectConstants: ['foo'], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: ['foo'],
+      globalLexicalConstants: [],
+    },
     'should return only non configurable & non writable',
   );
 });
 
-test('getScopeConstants - local object (endownments)', t => {
+test('getScopeConstants - globalLexicals', t => {
   t.plan(20);
 
   t.deepEqual(
     getScopeConstants({}, {}),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
-    'should return empty if no local',
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
+    'should return empty if no globalLexicals',
   );
 
   t.deepEqual(
     getScopeConstants({}, { foo: true }),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject configurable & writable',
   );
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { foo: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: ['foo'] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: ['foo'],
+    },
     'should return non configurable & non writable',
   );
   t.deepEqual(
@@ -160,7 +252,11 @@ test('getScopeConstants - local object (endownments)', t => {
       {},
       Object.create(null, { foo: { value: true, configurable: true } }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject configurable',
   );
   t.deepEqual(
@@ -168,29 +264,49 @@ test('getScopeConstants - local object (endownments)', t => {
       {},
       Object.create(null, { foo: { value: true, writable: true } }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject writable',
   );
 
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { foo: { get: () => true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject getter',
   );
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { foo: { set: () => true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject setter',
   );
 
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { eval: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject eval',
   );
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { const: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject reserved keyword',
   );
   t.deepEqual(
@@ -202,7 +318,11 @@ test('getScopeConstants - local object (endownments)', t => {
         false: { value: true },
       }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject literals (reserved)',
   );
   t.deepEqual(
@@ -213,7 +333,11 @@ test('getScopeConstants - local object (endownments)', t => {
         arguments: { value: true },
       }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject this and arguments',
   );
   t.deepEqual(
@@ -221,39 +345,67 @@ test('getScopeConstants - local object (endownments)', t => {
       {},
       Object.create(null, { [Symbol.iterator]: { value: true } }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject symbols',
   );
 
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { 123: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject leading digit',
   );
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { '-123': { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: [] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: [],
+    },
     'should reject leading dash',
   );
 
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { _123: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: ['_123'] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: ['_123'],
+    },
     'should return leading underscore',
   );
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { $123: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: ['$123'] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: ['$123'],
+    },
     'should return leading underscore',
   );
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { a123: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: ['a123'] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: ['a123'],
+    },
     'should return leading lowercase',
   );
   t.deepEqual(
     getScopeConstants({}, Object.create(null, { A123: { value: true } })),
-    { globalObjectConstants: [], globalLexicalConstants: ['A123'] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: ['A123'],
+    },
     'should return leading uppercase',
   );
 
@@ -262,7 +414,11 @@ test('getScopeConstants - local object (endownments)', t => {
       {},
       Object.create(null, { foo: { value: true }, bar: { value: true } }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: ['foo', 'bar'] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: ['foo', 'bar'],
+    },
     'should return all non configurable & non writable',
   );
   t.deepEqual(
@@ -273,12 +429,16 @@ test('getScopeConstants - local object (endownments)', t => {
         bar: { value: true, configurable: true },
       }),
     ),
-    { globalObjectConstants: [], globalLexicalConstants: ['foo'] },
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: [],
+      globalLexicalConstants: ['foo'],
+    },
     'should return only non configurable & non writable',
   );
 });
 
-test('getScopeConstants - global and local object', t => {
+test('getScopeConstants - globalObject and globalLexicals', t => {
   t.plan(1);
 
   t.deepEqual(
@@ -286,7 +446,11 @@ test('getScopeConstants - global and local object', t => {
       Object.create(null, { foo: { value: true }, bar: { value: true } }),
       { foo: false },
     ),
-    { globalObjectConstants: ['bar'], globalLexicalConstants: [] },
-    'should only return global contants not hidden by local',
+    {
+      moduleLexicalConstants: [],
+      globalObjectConstants: ['bar'],
+      globalLexicalConstants: [],
+    },
+    'should only return global contants not hidden by global lexicals',
   );
 });


### PR DESCRIPTION
Fixes #912

The global lexicals are intended to provide a namespace that guest code cannot enumerate for arbitrary properties.  By employing a transform for all evaluation in a compartment and also transforming all module code provided to a compartment's import hooks, a host program can introduce a name like `meter` into the global lexical scope of a program and also deny that program access to the lexical name through censorship of the original source.  Previously, a crafted module could use a function in module lexical scope to capture the global lexicals object or the scope proxy.  This change creates another intermediate layer in the safe evaluator that separates the global lexicals from the module lexicals, plugging this leak.

Individually reviewable commits.

- test(ses): Leak globalLexicals through moduleLexicals
- refactor(ses): Decouple moduleLexicals from globalLexicals
- test(ses): Cover moduleLexicals optimizer overshadowing
