### PR TITLE
fix: assert touchups

### DIFF
--- a/packages/captp/src/atomics.js
+++ b/packages/captp/src/atomics.js
@@ -121,7 +121,7 @@ export const makeAtomicsTrapGuest = transferBuffer => {
       // Tell that we are ready for another buffer.
       statusbuf[0] = STATUS_WAITING;
       const { done: itDone } = it.next();
-      assert(!itDone, X`Internal error; it.next() returned done=${itDone}`);
+      !itDone || Fail`Internal error; it.next() returned done=${itDone}`;
 
       // Wait for the host to wake us.
       Atomics.wait(statusbuf, 0, STATUS_WAITING);

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -439,11 +439,11 @@ export const makeCapTP = (
     },
     // Have the host serve more of the reply.
     CTP_TRAP_ITERATE: async obj => {
-      assert(trapHost, X`CTP_TRAP_ITERATE is impossible without a trapHost`);
+      trapHost || Fail`CTP_TRAP_ITERATE is impossible without a trapHost`;
       const { questionID, serialized } = obj;
 
       const resultP = trapIteratorResultP.get(questionID);
-      assert(resultP, X`CTP_TRAP_ITERATE did not expect ${questionID}`);
+      resultP || Fail`CTP_TRAP_ITERATE did not expect ${questionID}`;
 
       const [method, args] = unserialize(serialized);
 

--- a/packages/check-bundle/test/test-check-bundle.js
+++ b/packages/check-bundle/test/test-check-bundle.js
@@ -32,14 +32,14 @@ const computeSha512 = bytes => {
 test('bundle and check get export package', async t => {
   const bundle = await bundleSource(fixture, 'getExport');
   await t.throwsAsync(checkBundle(bundle, computeSha512, 'fixture/main.js'), {
-    message: /checkBundle cannot determine hash of bundle with getExport moduleFormat because it is not necessarily consistent/,
+    message: /checkBundle cannot determine hash of bundle with "getExport" moduleFormat because it is not necessarily consistent/,
   });
 });
 
 test('bundle and check nested evaluate package', async t => {
   const bundle = await bundleSource(fixture, 'nestedEvaluate');
   await t.throwsAsync(checkBundle(bundle, computeSha512, 'fixture/main.js'), {
-    message: /checkBundle cannot determine hash of bundle with nestedEvaluate moduleFormat because it is not necessarily consistent/,
+    message: /checkBundle cannot determine hash of bundle with "nestedEvaluate" moduleFormat because it is not necessarily consistent/,
   });
 });
 

--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -1,6 +1,10 @@
 // @ts-check
 /// <reference types="ses"/>
 
+// TODO Since this file pervasively uses simple template strings rather than
+// template strings tagged with `assert.details` (aka `X`), and since it uses
+// this definition of `q` rather than `assert.quote`, we have not yet
+// converted it to the new `||` assert style.
 const q = JSON.stringify;
 
 const moduleLanguages = [

--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -1,10 +1,10 @@
 // @ts-check
 /// <reference types="ses"/>
 
-// TODO Since this file pervasively uses simple template strings rather than
-// template strings tagged with `assert.details` (aka `X`), and since it uses
-// this definition of `q` rather than `assert.quote`, we have not yet
-// converted it to the new `||` assert style.
+// TODO convert to the new `||` assert style.
+// Deferred because this file pervasively uses simple template strings rather than
+// template strings tagged with `assert.details` (aka `X`), and uses
+// this definition of `q` rather than `assert.quote`
 const q = JSON.stringify;
 
 const moduleLanguages = [

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -29,7 +29,7 @@ import { assertCompartmentMap } from './compartment-map.js';
 
 const DefaultCompartment = Compartment;
 
-const { quote: q, details: d } = assert;
+const { Fail, quote: q } = assert;
 
 const textDecoder = new TextDecoder();
 
@@ -207,12 +207,10 @@ export const parseArchive = async (
 
   // Track all modules that get loaded, all files that are used.
   const unseen = new Set(archive.files.keys());
-  assert(
-    unseen.size >= 2,
-    `Archive failed sanity check: should contain at least a compartment map file and one module file in ${q(
+  unseen.size >= 2 ||
+    Fail`Archive failed sanity check: should contain at least a compartment map file and one module file in ${q(
       archiveLocation,
-    )}`,
-  );
+    )}`;
 
   /**
    * @param {string} path
@@ -280,12 +278,10 @@ export const parseArchive = async (
     });
 
     await compartment.load(moduleSpecifier);
-    assert(
-      unseen.size === 0,
-      d`Archive contains extraneous files: ${q([...unseen])} in ${q(
+    unseen.size === 0 ||
+      Fail`Archive contains extraneous files: ${q([...unseen])} in ${q(
         archiveLocation,
-      )}`,
-    );
+      )}`;
   }
 
   /** @type {ExecuteFn} */

--- a/packages/lp32/reader.js
+++ b/packages/lp32/reader.js
@@ -6,7 +6,7 @@
 
 import { hostIsLittleEndian } from './src/host-endian.js';
 
-const { details: X, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} reader
@@ -48,12 +48,10 @@ async function* makeLp32Iterator(
     let drained = false;
     while (!drained && length >= 4) {
       const messageLength = data.getUint32(0, littleEndian);
-      assert(
-        messageLength <= maxMessageLength,
-        X`Messages on ${q(
-          name,
-        )} must not exceed ${maxMessageLength} bytes in length`,
-      );
+      messageLength <= maxMessageLength ||
+        Fail`Messages on ${q(name)} must not exceed ${q(
+          maxMessageLength,
+        )} bytes in length`;
       const envelopeLength = 4 + messageLength;
       drained = envelopeLength > length;
       if (!drained) {

--- a/packages/lp32/writer.js
+++ b/packages/lp32/writer.js
@@ -3,7 +3,7 @@
 
 import { hostIsLittleEndian } from './src/host-endian.js';
 
-const { details: X, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * @param {import('@endo/stream').Writer<Uint8Array, undefined>} output
@@ -24,12 +24,10 @@ export const makeLp32Writer = (
   const writer = harden({
     /** @param {Uint8Array} message */
     async next(message) {
-      assert(
-        message.byteLength <= maxMessageLength,
-        X`Messages on ${q(
+      message.byteLength <= maxMessageLength ||
+        Fail`Messages on ${q(
           name,
-        )} must not exceed ${maxMessageLength} bytes in length`,
-      );
+        )} must not exceed ${maxMessageLength} bytes in length`;
       const array8 = new Uint8Array(4 + message.byteLength);
       const data = new DataView(array8.buffer);
       data.setUint32(0, message.byteLength, littleEndian);

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -433,9 +433,11 @@ export const makeDecodeFromCapData = ({
           // Don't harden since we're not done mutating it
           const result = { [QCLASS]: decodeFromCapData(original) };
           if (hasOwnPropertyOf(jsonEncoded, 'rest')) {
-            (typeof rest === 'object' &&
+            const isNonEmptyObject =
+              typeof rest === 'object' &&
               rest !== null &&
-              ownKeys(rest).length >= 1) ||
+              ownKeys(rest).length >= 1;
+            isNonEmptyObject ||
               Fail`Rest encoding must be a non-empty object: ${rest}`;
             const restObj = decodeFromCapData(rest);
             // TODO really should assert that `passStyleOf(rest)` is

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -310,12 +310,10 @@ export const makeDecodeFromCapData = ({
   decodePromiseFromCapData = dontDecodeRemotableOrPromiseFromCapData,
   decodeErrorFromCapData = dontDecodeErrorFromCapData,
 } = {}) => {
-  assert(
-    decodeRemotableFromCapData === decodePromiseFromCapData,
-    X`An implementation restriction for now: If either decodeRemotableFromCapData or decodePromiseFromCapData is provided, both must be provided and they must be the same: ${q(
+  decodeRemotableFromCapData === decodePromiseFromCapData ||
+    Fail`An implementation restriction for now: If either decodeRemotableFromCapData or decodePromiseFromCapData is provided, both must be provided and they must be the same: ${q(
       decodeRemotableFromCapData,
-    )} vs ${q(decodePromiseFromCapData)}`,
-  );
+    )} vs ${q(decodePromiseFromCapData)}`;
 
   /**
    * `decodeFromCapData` may rely on `jsonEncoded` being the result of a
@@ -435,12 +433,10 @@ export const makeDecodeFromCapData = ({
           // Don't harden since we're not done mutating it
           const result = { [QCLASS]: decodeFromCapData(original) };
           if (hasOwnPropertyOf(jsonEncoded, 'rest')) {
-            assert(
-              typeof rest === 'object' &&
-                rest !== null &&
-                ownKeys(rest).length >= 1,
-              X`Rest encoding must be a non-empty object: ${rest}`,
-            );
+            (typeof rest === 'object' &&
+              rest !== null &&
+              ownKeys(rest).length >= 1) ||
+              Fail`Rest encoding must be a non-empty object: ${rest}`;
             const restObj = decodeFromCapData(rest);
             // TODO really should assert that `passStyleOf(rest)` is
             // `'copyRecord'` but we'd have to harden it and it is too

--- a/packages/marshal/src/helpers/symbol.js
+++ b/packages/marshal/src/helpers/symbol.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { details: X, Fail, quote: q } = assert;
+const { Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
 
 /**
@@ -12,13 +12,11 @@ const wellKnownSymbolNames = new Map(
       name => typeof name === 'string' && typeof Symbol[name] === 'symbol',
     )
     .filter(name => {
-      assert(
-        // @ts-ignore It doesn't know name cannot be a symbol
-        !name.startsWith('@@'),
-        X`Did not expect Symbol to have a symbol-valued property name starting with "@@" ${q(
+      // @ts-ignore It doesn't know name cannot be a symbol
+      !name.startsWith('@@') ||
+        Fail`Did not expect Symbol to have a symbol-valued property name starting with "@@" ${q(
           name,
-        )}`,
-      );
+        )}`;
       return true;
     })
     // @ts-ignore It doesn't know name cannot be a symbol

--- a/packages/marshal/src/helpers/symbol.js
+++ b/packages/marshal/src/helpers/symbol.js
@@ -12,7 +12,7 @@ const wellKnownSymbolNames = new Map(
       name => typeof name === 'string' && typeof Symbol[name] === 'symbol',
     )
     .filter(name => {
-      // @ts-ignore It doesn't know name cannot be a symbol
+      // @ts-expect-error It doesn't know name cannot be a symbol
       !name.startsWith('@@') ||
         Fail`Did not expect Symbol to have a symbol-valued property name starting with "@@" ${q(
           name,

--- a/packages/marshal/src/make-far.js
+++ b/packages/marshal/src/make-far.js
@@ -12,7 +12,7 @@ import {
 /** @typedef {import('./types.js').InterfaceSpec} InterfaceSpec */
 /** @template L,R @typedef {import('@endo/eventual-send').RemotableBrand<L, R>} RemotableBrand */
 
-const { quote: q, details: X, Fail } = assert;
+const { quote: q, Fail } = assert;
 
 const { prototype: functionPrototype } = Function;
 const {
@@ -43,11 +43,9 @@ const makeRemotableProto = (remotable, iface) => {
   } else if (typeof remotable === 'function') {
     oldProto !== null ||
       Fail`Original function must not inherit from null: ${remotable}`;
-    assert(
-      oldProto === functionPrototype ||
-        getPrototypeOf(oldProto) === functionPrototype,
-      X`Far functions must originally inherit from Function.prototype, in ${remotable}`,
-    );
+    oldProto === functionPrototype ||
+      getPrototypeOf(oldProto) === functionPrototype ||
+      Fail`Far functions must originally inherit from Function.prototype, in ${remotable}`;
   } else {
     Fail`unrecognized typeof ${remotable}`;
   }
@@ -92,20 +90,18 @@ export const Remotable = (
   assert(iface);
   // TODO: When iface is richer than just string, we need to get the allegedName
   // in a different way.
-  assert(props === undefined, X`Remotable props not yet implemented ${props}`);
+  props === undefined || Fail`Remotable props not yet implemented ${props}`;
 
   // Fail fast: check that the unmodified object is able to become a Remotable.
   assertCanBeRemotable(remotable);
 
   // Ensure that the remotable isn't already marked.
-  assert(
-    !(PASS_STYLE in remotable),
-    X`Remotable ${remotable} is already marked as a ${q(
+  !(PASS_STYLE in remotable) ||
+    Fail`Remotable ${remotable} is already marked as a ${q(
       remotable[PASS_STYLE],
-    )}`,
-  );
+    )}`;
   // Ensure that the remotable isn't already frozen.
-  assert(!isFrozen(remotable), X`Remotable ${remotable} is already frozen`);
+  !isFrozen(remotable) || Fail`Remotable ${remotable} is already frozen`;
   const remotableProto = makeRemotableProto(remotable, iface);
 
   // Take a static copy of the enumerable own properties as data properties.

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -198,7 +198,9 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
               'object',
               X`Rest ${rest} encoding must be an object`,
             );
-            assert(rest !== null, X`Rest ${rest} encoding must not be null`);
+            if (rest === null) {
+              throw Fail`Rest ${rest} encoding must not be null`;
+            }
             !isArray(rest) || Fail`Rest ${rest} encoding must not be an array`;
             !(QCLASS in rest) ||
               Fail`Rest encoding ${rest} must not contain ${q(QCLASS)}`;

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -47,12 +47,9 @@ const makeHelperTable = passStyleHelpers => {
   };
   for (const helper of passStyleHelpers) {
     const { styleName } = helper;
-    assert(styleName in HelperTable, X`Unrecognized helper: ${q(styleName)}`);
-    assert.equal(
-      HelperTable[styleName],
-      undefined,
-      X`conflicting helpers for ${q(styleName)}`,
-    );
+    styleName in HelperTable || Fail`Unrecognized helper: ${q(styleName)}`;
+    HelperTable[styleName] === undefined ||
+      Fail`conflicting helpers for ${q(styleName)}`;
     HelperTable[styleName] = helper;
   }
   for (const styleName of ownKeys(HelperTable)) {

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -12,7 +12,7 @@ import {
 /** @typedef {import('./types.js').PassStyle} PassStyle */
 /** @typedef {import('./types.js').RankCover} RankCover */
 
-const { details: X, quote: q } = assert;
+const { Fail, quote: q } = assert;
 const { entries, fromEntries, setPrototypeOf, is } = Object;
 
 /**
@@ -268,7 +268,7 @@ export const makeComparatorKit = (compareRemotables = (_x, _y) => 0) => {
         return comparator(left.payload, right.payload);
       }
       default: {
-        assert.fail(X`Unrecognized passStyle: ${q(leftStyle)}`);
+        throw Fail`Unrecognized passStyle: ${q(leftStyle)}`;
       }
     }
   };
@@ -318,11 +318,9 @@ harden(isRankSorted);
  */
 export const assertRankSorted = (sorted, compare) =>
   isRankSorted(sorted, compare) ||
-  assert.fail(
-    // TODO assert on bug could lead to infinite recursion. Fix.
-    // eslint-disable-next-line no-use-before-define
-    X`Must be rank sorted: ${sorted} vs ${sortByRank(sorted, compare)}`,
-  );
+  // TODO assert on bug could lead to infinite recursion. Fix.
+  // eslint-disable-next-line no-use-before-define
+  Fail`Must be rank sorted: ${sorted} vs ${sortByRank(sorted, compare)}`;
 harden(assertRankSorted);
 
 /**

--- a/packages/marshal/src/typeGuards.js
+++ b/packages/marshal/src/typeGuards.js
@@ -7,7 +7,7 @@ import { passStyleOf } from './passStyleOf.js';
 /** @template T @typedef {import('./types.js').CopyRecord<T>} CopyRecord */
 /** @typedef {import('./types.js').Remotable} Remotable */
 
-const { details: X, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * Check whether the argument is a pass-by-copy array, AKA a "copyArray"
@@ -48,12 +48,10 @@ harden(isRemotable);
 /** @type {AssertArray} */
 const assertCopyArray = (array, optNameOfArray = 'Alleged array') => {
   const passStyle = passStyleOf(array);
-  assert(
-    passStyle === 'copyArray',
-    X`${q(optNameOfArray)} ${array} must be a pass-by-copy array, not ${q(
+  passStyle === 'copyArray' ||
+    Fail`${q(optNameOfArray)} ${array} must be a pass-by-copy array, not ${q(
       passStyle,
-    )}`,
-  );
+    )}`;
 };
 harden(assertCopyArray);
 
@@ -67,12 +65,10 @@ harden(assertCopyArray);
 /** @type {AssertRecord} */
 const assertRecord = (record, optNameOfRecord = 'Alleged record') => {
   const passStyle = passStyleOf(record);
-  assert(
-    passStyle === 'copyRecord',
-    X`${q(optNameOfRecord)} ${record} must be a pass-by-copy record, not ${q(
+  passStyle === 'copyRecord' ||
+    Fail`${q(optNameOfRecord)} ${record} must be a pass-by-copy record, not ${q(
       passStyle,
-    )}`,
-  );
+    )}`;
 };
 harden(assertRecord);
 
@@ -89,12 +85,10 @@ const assertRemotable = (
   optNameOfRemotable = 'Alleged remotable',
 ) => {
   const passStyle = passStyleOf(remotable);
-  assert(
-    passStyle === 'remotable',
-    X`${q(optNameOfRemotable)} ${remotable} must be a remotable, not ${q(
+  passStyle === 'remotable' ||
+    Fail`${q(optNameOfRemotable)} ${remotable} must be a remotable, not ${q(
       passStyle,
-    )}`,
-  );
+    )}`;
 };
 harden(assertRemotable);
 

--- a/packages/ses/index.test-d.ts
+++ b/packages/ses/index.test-d.ts
@@ -81,7 +81,7 @@ d.module('z');
 
 // Assertions
 
-const { quote: q, details: X } = assert;
+const { Fail, quote: q, details: X } = assert;
 
 assert.equal('a', 'b');
 assert.equal('a', 'b', 'equality error');
@@ -206,4 +206,4 @@ expectType<Error>(assert.error(X`details are ${stringable}`, TypeError));
 
 expectType<Error>(assert.error(X`details are ${stringable}`, TypeError, { errorName: 'Nom de plum' }));
 
-expectType<never>(assert.fail(X`details are ${stringable}`));
+expectType<never>(Fail`details are ${stringable}`);

--- a/packages/ses/index.test-d.ts
+++ b/packages/ses/index.test-d.ts
@@ -206,4 +206,7 @@ expectType<Error>(assert.error(X`details are ${stringable}`, TypeError));
 
 expectType<Error>(assert.error(X`details are ${stringable}`, TypeError, { errorName: 'Nom de plum' }));
 
+expectType<never>(assert.fail(X`details are ${stringable}`));
+
+// eslint-disable-next-line no-unreachable
 expectType<never>(Fail`details are ${stringable}`);

--- a/packages/ses/src/environment-options.js
+++ b/packages/ses/src/environment-options.js
@@ -109,7 +109,6 @@ export const makeEnvironmentCaptor = aGlobal => {
     }
     setting === undefined ||
       typeof setting === 'string' ||
-      // eslint-disable-next-line @endo/no-polymorphic-call
       Fail`Environment option value ${q(
         setting,
       )}, if present, must be a string.`;

--- a/packages/ses/src/eval-scope.js
+++ b/packages/ses/src/eval-scope.js
@@ -2,7 +2,7 @@ import { FERAL_EVAL, create, defineProperties, freeze } from './commons.js';
 
 import { assert } from './error/assert.js';
 
-const { details: d } = assert;
+const { Fail } = assert;
 
 // We attempt to frustrate stack bumping attacks on the safe evaluator
 // (`make-safe-evaluator.js`).
@@ -73,10 +73,7 @@ export const makeEvalScopeKit = () => {
     evalScope,
     allowNextEvalToBeUnsafe() {
       if (evalScopeKit.revoked !== null) {
-        // eslint-disable-next-line @endo/no-polymorphic-call
-        assert.fail(
-          d`a handler did not reset allowNextEvalToBeUnsafe ${this.revoked.err}`,
-        );
+        Fail`a handler did not reset allowNextEvalToBeUnsafe ${this.revoked.err}`;
       }
       // Allow next reference to eval produce the unsafe FERAL_EVAL.
       // We avoid defineProperty because it consumes an extra stack frame taming

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -55,7 +55,7 @@ import { makeCompartmentConstructor } from './compartment-shim.js';
 
 /** @typedef {import('../index.js').LockdownOptions} LockdownOptions */
 
-const { details: d, quote: q } = assert;
+const { Fail, details: d, quote: q } = assert;
 
 /** @type {Error=} */
 let priorLockdown;
@@ -191,26 +191,23 @@ export const repairIntrinsics = (options = {}) => {
     );
   }
 
-  assert(
-    evalTaming === 'unsafeEval' ||
-      evalTaming === 'safeEval' ||
-      evalTaming === 'noEval',
-    d`lockdown(): non supported option evalTaming: ${q(evalTaming)}`,
-  );
+  evalTaming === 'unsafeEval' ||
+    evalTaming === 'safeEval' ||
+    evalTaming === 'noEval' ||
+    Fail`lockdown(): non supported option evalTaming: ${q(evalTaming)}`;
 
   // Assert that only supported options were passed.
   // Use Reflect.ownKeys to reject symbol-named properties as well.
   const extraOptionsNames = ownKeys(extraOptions);
-  assert(
-    extraOptionsNames.length === 0,
-    d`lockdown(): non supported option ${q(extraOptionsNames)}`,
-  );
+  extraOptionsNames.length === 0 ||
+    Fail`lockdown(): non supported option ${q(extraOptionsNames)}`;
 
-  assert(
-    priorLockdown === undefined,
-    `Already locked down at ${priorLockdown} (SES_ALREADY_LOCKED_DOWN)`,
-    TypeError,
-  );
+  priorLockdown === undefined ||
+    // eslint-disable-next-line @endo/no-polymorphic-call
+    assert.fail(
+      d`Already locked down at ${priorLockdown} (SES_ALREADY_LOCKED_DOWN)`,
+      TypeError,
+    );
   priorLockdown = new TypeError('Prior lockdown (SES_ALREADY_LOCKED_DOWN)');
   // Tease V8 to generate the stack string and release the closures the stack
   // trace retained:

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -249,7 +249,6 @@ export const repairIntrinsics = (options = {}) => {
   };
 
   if (seemsToBeLockedDown()) {
-    // eslint-disable-next-line @endo/no-polymorphic-call
     throw new TypeError(
       `Already locked down but not by this SES instance (SES_MULTIPLE_INSTANCES)`,
     );

--- a/packages/ses/src/make-function-constructor.js
+++ b/packages/ses/src/make-function-constructor.js
@@ -7,6 +7,8 @@ import {
 } from './commons.js';
 import { assert } from './error/assert.js';
 
+const { Fail } = assert;
+
 /*
  * makeFunctionConstructor()
  * A safe version of the native Function which relies on
@@ -67,14 +69,10 @@ export const makeFunctionConstructor = safeEvaluate => {
   });
 
   // Assert identity of Function.__proto__ accross all compartments
-  assert(
-    getPrototypeOf(FERAL_FUNCTION) === FERAL_FUNCTION.prototype,
-    'Function prototype is the same accross compartments',
-  );
-  assert(
-    getPrototypeOf(newFunction) === FERAL_FUNCTION.prototype,
-    'Function constructor prototype is the same accross compartments',
-  );
+  getPrototypeOf(FERAL_FUNCTION) === FERAL_FUNCTION.prototype ||
+    Fail`Function prototype is the same accross compartments`;
+  getPrototypeOf(newFunction) === FERAL_FUNCTION.prototype ||
+    Fail`Function constructor prototype is the same accross compartments`;
 
   return newFunction;
 };

--- a/packages/ses/src/make-safe-evaluator.js
+++ b/packages/ses/src/make-safe-evaluator.js
@@ -9,7 +9,7 @@ import { applyTransforms, mandatoryTransforms } from './transforms.js';
 import { makeEvaluate } from './make-evaluate.js';
 import { assert } from './error/assert.js';
 
-const { details: d } = assert;
+const { Fail } = assert;
 
 /**
  * makeSafeEvaluator()
@@ -100,8 +100,7 @@ export const makeSafeEvaluator = ({
         evalScopeKit.revoked = { err };
         // TODO A GOOD PLACE TO PANIC(), i.e., kill the vat incarnation.
         // See https://github.com/Agoric/SES-shim/issues/490
-        // eslint-disable-next-line @endo/no-polymorphic-call
-        assert.fail(d`handler did not reset allowNextEvalToBeUnsafe ${err}`);
+        Fail`handler did not reset allowNextEvalToBeUnsafe ${err}`;
       }
     }
   };

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -26,7 +26,7 @@ import {
   weakmapGet,
 } from './commons.js';
 
-const { quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 // `link` creates `ModuleInstances` and `ModuleNamespaces` for a module and its
 // transitive dependencies and connects their imports and exports.
@@ -70,18 +70,14 @@ function validatePrecompiledStaticModuleRecord(
   moduleSpecifier,
 ) {
   const { __fixedExportMap__, __liveExportMap__ } = staticModuleRecord;
-  assert(
-    isObject(__fixedExportMap__),
-    `Property '__fixedExportMap__' of a precompiled module record must be an object, got ${q(
+  isObject(__fixedExportMap__) ||
+    Fail`Property '__fixedExportMap__' of a precompiled module record must be an object, got ${q(
       __fixedExportMap__,
-    )}, for module ${q(moduleSpecifier)}`,
-  );
-  assert(
-    isObject(__liveExportMap__),
-    `Property '__liveExportMap__' of a precompiled module record must be an object, got ${q(
+    )}, for module ${q(moduleSpecifier)}`;
+  isObject(__liveExportMap__) ||
+    Fail`Property '__liveExportMap__' of a precompiled module record must be an object, got ${q(
       __liveExportMap__,
-    )}, for module ${q(moduleSpecifier)}`,
-  );
+    )}, for module ${q(moduleSpecifier)}`;
 }
 
 function isThirdParty(staticModuleRecord) {
@@ -93,40 +89,30 @@ function validateThirdPartyStaticModuleRecord(
   moduleSpecifier,
 ) {
   const { exports } = staticModuleRecord;
-  assert(
-    isArray(exports),
-    `Property 'exports' of a third-party static module record must be an array, got ${q(
+  isArray(exports) ||
+    Fail`Property 'exports' of a third-party static module record must be an array, got ${q(
       exports,
-    )}, for module ${q(moduleSpecifier)}`,
-  );
+    )}, for module ${q(moduleSpecifier)}`;
 }
 
 function validateStaticModuleRecord(staticModuleRecord, moduleSpecifier) {
-  assert(
-    isObject(staticModuleRecord),
-    `Static module records must be of type object, got ${q(
+  isObject(staticModuleRecord) ||
+    Fail`Static module records must be of type object, got ${q(
       staticModuleRecord,
-    )}, for module ${q(moduleSpecifier)}`,
-  );
+    )}, for module ${q(moduleSpecifier)}`;
   const { imports, exports, reexports = [] } = staticModuleRecord;
-  assert(
-    isArray(imports),
-    `Property 'imports' of a static module record must be an array, got ${q(
+  isArray(imports) ||
+    Fail`Property 'imports' of a static module record must be an array, got ${q(
       imports,
-    )}, for module ${q(moduleSpecifier)}`,
-  );
-  assert(
-    isArray(exports),
-    `Property 'exports' of a precompiled module record must be an array, got ${q(
+    )}, for module ${q(moduleSpecifier)}`;
+  isArray(exports) ||
+    Fail`Property 'exports' of a precompiled module record must be an array, got ${q(
       exports,
-    )}, for module ${q(moduleSpecifier)}`,
-  );
-  assert(
-    isArray(reexports),
-    `Property 'reexports' of a precompiled module record must be an array if present, got ${q(
+    )}, for module ${q(moduleSpecifier)}`;
+  isArray(reexports) ||
+    Fail`Property 'reexports' of a precompiled module record must be an array if present, got ${q(
       reexports,
-    )}, for module ${q(moduleSpecifier)}`,
-  );
+    )}, for module ${q(moduleSpecifier)}`;
 }
 
 export const instantiate = (

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -27,7 +27,7 @@ import {
 } from './commons.js';
 import { assert } from './error/assert.js';
 
-const { details: d, quote: q } = assert;
+const { Fail, details: d, quote: q } = assert;
 
 const noop = () => {};
 
@@ -170,12 +170,9 @@ const loadWithoutErrorAnnotation = async (
   const staticModuleRecord = await importHook(moduleSpecifier);
 
   if (staticModuleRecord === null || typeof staticModuleRecord !== 'object') {
-    // eslint-disable-next-line @endo/no-polymorphic-call
-    assert.fail(
-      d`importHook must return a promise for an object, for module ${q(
-        moduleSpecifier,
-      )} in compartment ${q(compartment.name)}`,
-    );
+    Fail`importHook must return a promise for an object, for module ${q(
+      moduleSpecifier,
+    )} in compartment ${q(compartment.name)}`;
   }
 
   if (staticModuleRecord.record !== undefined) {

--- a/packages/ses/src/strict-scope-terminator.js
+++ b/packages/ses/src/strict-scope-terminator.js
@@ -11,7 +11,7 @@ import {
 } from './commons.js';
 import { assert } from './error/assert.js';
 
-const { details: d, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * alwaysThrowHandler
@@ -24,10 +24,7 @@ export const alwaysThrowHandler = new Proxy(
   immutableObject,
   freeze({
     get(_shadow, prop) {
-      // eslint-disable-next-line @endo/no-polymorphic-call
-      assert.fail(
-        d`Please report unexpected scope handler trap: ${q(String(prop))}`,
-      );
+      Fail`Please report unexpected scope handler trap: ${q(String(prop))}`;
     },
   }),
 );

--- a/packages/ses/src/tame-locale-methods.js
+++ b/packages/ses/src/tame-locale-methods.js
@@ -9,7 +9,7 @@ import {
 } from './commons.js';
 import { assert } from './error/assert.js';
 
-const { details: d, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 const localePattern = /^(\w*[a-z])Locale([A-Z]\w*)$/;
 
@@ -31,7 +31,7 @@ const tamedMethods = {
     if (s > that) {
       return 1;
     }
-    assert(s === that, d`expected ${q(s)} and ${q(that)} to compare`);
+    s === that || Fail`expected ${q(s)} and ${q(that)} to compare`;
     return 0;
   },
 
@@ -61,16 +61,12 @@ export default function tameLocaleMethods(intrinsics, localeTaming = 'safe') {
       for (const methodName of getOwnPropertyNames(intrinsic)) {
         const match = regexpExec(localePattern, methodName);
         if (match) {
-          assert(
-            typeof intrinsic[methodName] === 'function',
-            d`expected ${q(methodName)} to be a function`,
-          );
+          typeof intrinsic[methodName] === 'function' ||
+            Fail`expected ${q(methodName)} to be a function`;
           const nonLocaleMethodName = `${match[1]}${match[2]}`;
           const method = intrinsic[nonLocaleMethodName];
-          assert(
-            typeof method === 'function',
-            d`function ${q(nonLocaleMethodName)} not found`,
-          );
+          typeof method === 'function' ||
+            Fail`function ${q(nonLocaleMethodName)} not found`;
           defineProperty(intrinsic, methodName, { value: method });
         }
       }

--- a/packages/stream-node/reader.js
+++ b/packages/stream-node/reader.js
@@ -8,7 +8,7 @@
 
 import { mapReader } from '@endo/stream';
 
-const { details: X, Fail, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * @param {import('stream').Readable} input the source Node.js reader
@@ -17,12 +17,10 @@ const { details: X, Fail, quote: q } = assert;
 export const makeNodeReader = input => {
   !input.readableObjectMode ||
     Fail`Cannot convert Node.js object mode Reader to AsyncIterator<Uint8Array>`;
-  assert(
-    input.readableEncoding === null,
-    X`Cannot convert Node.js Reader with readableEncoding ${q(
+  input.readableEncoding === null ||
+    Fail`Cannot convert Node.js Reader with readableEncoding ${q(
       input.readableEncoding,
-    )} to a AsyncIterator<Uint8Array>`,
-  );
+    )} to a AsyncIterator<Uint8Array>`;
 
   const iterator = input[Symbol.asyncIterator]();
   assert(iterator.return);


### PR DESCRIPTION
Now that https://github.com/endojs/endo/pull/1334 has been merged, this PR converts remaining stragglers in endo from the old `assert(` style to the new `||` style. Convert to `|| Fail...` when possible; otherwise still to `|| assert.fail(X...)`.
