### PR TITLE
Static module record: error with module url on transform fail

### DIFF
--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -32,7 +32,16 @@ const makeCreateStaticRecord = transformSource =>
       // Comment out the shebang lines.
       moduleSource = `//${moduleSource}`;
     }
-    const scriptSource = transformSource(moduleSource, sourceOptions);
+    let scriptSource;
+    try {
+      scriptSource = transformSource(moduleSource, sourceOptions);
+    } catch (err) {
+      const moduleLocation = url ? JSON.stringify(url) : '<unknown>';
+      throw new SyntaxError(
+        `Error transforming source in ${moduleLocation}: ${err.message}`,
+        { cause: err },
+      );
+    }
 
     let preamble = sourceOptions.importDecls.join(',');
     if (preamble !== '') {


### PR DESCRIPTION
before:
```
TypeError#1: Cannot read properties of undefined (reading 'forEach')
```

after:
```
SyntaxError#1: Error transforming source in "file:///home/xyz/Development/metamask-extension4/node_modules/immer/dist/immer.esm.js": Cannot read properties of undefined (reading 'forEach')
```