### PR TITLE
bundle - metamask extension bundling compatibility (unrefined)

### DIFF
--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -72,7 +72,15 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
       __shimTransforms__,
       Compartment,
     } = options;
-    const makeImportHook = makeImportHookMaker(readPowers, packageLocation, undefined, undefined, undefined, undefined, packageDescriptor);
+    const makeImportHook = makeImportHookMaker(
+      readPowers,
+      packageLocation,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      packageDescriptor,
+    );
     const { compartment } = link(compartmentMap, {
       makeImportHook,
       parserForLanguage,

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -72,7 +72,7 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
       __shimTransforms__,
       Compartment,
     } = options;
-    const makeImportHook = makeImportHookMaker(readPowers, packageLocation);
+    const makeImportHook = makeImportHookMaker(readPowers, packageLocation, undefined, undefined, undefined, undefined, packageDescriptor);
     const { compartment } = link(compartmentMap, {
       makeImportHook,
       parserForLanguage,

--- a/packages/compartment-mapper/src/infer-exports.js
+++ b/packages/compartment-mapper/src/infer-exports.js
@@ -23,9 +23,9 @@ function* interpretBrowserExports(name, exports) {
     );
   }
   for (const [key, value] of entries(exports)) {
-    // console.log(`interpretBrowserExports name: ${name} key: ${key}, value: ${value}`);
     // https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module
     if (value === false) {
+      // eslint-disable-next-line no-continue
       continue;
     }
     // https://github.com/defunctzombie/package-browser-field-spec#replace-specific-files---advanced

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -89,20 +89,12 @@ const makeExtensionParser = (
     let language;
     const extension = parseExtension(location);
 
-    let languageSourceHint
     if (
       !extensionImpliesLanguage(extension) &&
       has(languageForModuleSpecifier, specifier)
     ) {
-      languageSourceHint = 'languageForModuleSpecifier'
       language = languageForModuleSpecifier[specifier];
     } else {
-      // if (!has(languageForExtension, extension)) {
-      //   throw new Error(
-      //     `Cannot parse module ${specifier} at ${location}, no parser configured for extension ${extension}`,
-      //   );
-      // }
-      languageSourceHint = 'languageForExtension'
       language = languageForExtension[extension] || extension;
     }
 
@@ -121,10 +113,6 @@ const makeExtensionParser = (
       );
     }
     const { parse } = parserForLanguage[language];
-    // if (specifier === './esm/src/bytes.js') {
-    // if (language === 'mjs') {
-    //   console.log('-- parse', specifier, location, language, languageSourceHint)
-    // }
     return parse(bytes, specifier, location, packageLocation, options);
   };
 };
@@ -219,11 +207,6 @@ const makeModuleMapHook = (
     compartmentDescriptor.retained = true;
 
     const moduleDescriptor = moduleDescriptors[moduleSpecifier];
-    // if (moduleSpecifier === '@noble/hashes/crypto') {
-    //   console.log('moduleMapHook', moduleSpecifier, moduleDescriptor)
-    //   console.log('--moduleDescriptors', Reflect.ownKeys(moduleDescriptors).join('\n'), '\n--scopeDescriptors', Reflect.ownKeys(scopeDescriptors).join('\n'))
-    // }
-
     if (moduleDescriptor !== undefined) {
       const {
         compartment: foreignCompartmentName = compartmentName,
@@ -278,19 +261,12 @@ const makeModuleMapHook = (
     // This might be better with a trie, but only a benchmark on real-world
     // data would tell us whether the additional complexity would translate to
     // better performance, so this is left readable and presumed slow for now.
-    // if (moduleSpecifier === '@noble/hashes/crypto') {
-    //   console.log('@noble/hashes scopes + compartments', scopeDescriptors, compartments)
-    // }
 
     for (const [scopePrefix, scopeDescriptor] of entries(scopeDescriptors)) {
       const foreignModuleSpecifier = trimModuleSpecifierPrefix(
         moduleSpecifier,
         scopePrefix,
       );
-
-      if (moduleSpecifier === '@noble/hashes/crypto') {
-        console.log('scopePrefix', scopePrefix, 'foreignModuleSpecifier', foreignModuleSpecifier, scopeDescriptor)
-      }
 
       if (foreignModuleSpecifier !== undefined) {
         const { compartment: foreignCompartmentName } = scopeDescriptor;
@@ -306,10 +282,6 @@ const makeModuleMapHook = (
               foreignCompartmentName,
             )}`,
           );
-        }
-
-        if (moduleSpecifier === '@noble/hashes/crypto') {
-          console.log('foreignCompartment', foreignCompartmentName)
         }
 
         // The following line is weird.
@@ -382,8 +354,6 @@ export const link = (
       types: languageForModuleSpecifier = Object.create(null),
       scopes = Object.create(null),
     } = compartmentDescriptor;
-    // if (compartmentName === 'file:///home/xyz/Development/metamask-extension4/node_modules/multiformats/')
-      // console.log('-- linking', location, languageForModuleSpecifier)
 
     // Capture the default.
     // The `moduleMapHook` writes back to the compartment map.

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -310,27 +310,43 @@ const graphPackage = async (
     return data;
   };
 
-  Object.assign(result, {
-    name,
-    path: undefined,
-    label: `${name}${version ? `-v${version}` : ''}`,
-    explicit: exports !== undefined,
-    exports: inferExports(packageDescriptor, tags, types),
-    dependencies: dependencyLocations,
-    types,
-    parsers: inferParsers(packageDescriptor, packageLocation),
-  });
+  try {
+    const inferredExports = inferExports(packageDescriptor, tags, types)
+    // if (packageLocation === 'file:///home/xyz/Development/metamask-extension4/node_modules/readable-stream/'){
+    //   console.log(packageLocation, exports);
+    // }
 
-  await Promise.all(
-    values(result.exports).map(async item => {
-      const descriptor = await readDescriptorUpwards(item);
-      if (descriptor && descriptor.type === 'module') {
-        types[item] = 'mjs';
-      }
-    }),
-  );
+    Object.assign(result, {
+      name,
+      path: undefined,
+      label: `${name}${version ? `-v${version}` : ''}`,
+      explicit: exports !== undefined,
+      exports: inferredExports,
+      dependencies: dependencyLocations,
+      types,
+      parsers: inferParsers(packageDescriptor, packageLocation),
+    });
+
+    await Promise.all(
+      values(result.exports).map(async item => {
+        const descriptor = await readDescriptorUpwards(item);
+        if (descriptor && descriptor.type === 'module') {
+          types[item] = 'mjs';
+        }
+      }),
+    );
+
+  } catch (err) {
+    console.error(`Error while processing package ${q(name)} at ${q(packageLocation)}: ${err.stack}`);
+    throw err;
+  }
 
   await Promise.all(children);
+
+  // if (packageLocation === 'file:///home/xyz/Development/metamask-extension4/node_modules/@formatjs/intl-relativetimeformat/'){
+  //   console.log(packageLocation, result);
+  // }
+
   return undefined;
 };
 
@@ -502,6 +518,7 @@ const translateGraph = (
   // package and is a complete list of every external module that the
   // corresponding compartment can import.
   for (const packageLocation of keys(graph).sort()) {
+    const graphLocation = packageLocation
     const { name, path, label, dependencies, parsers, types } = graph[
       packageLocation
     ];
@@ -522,14 +539,22 @@ const translateGraph = (
           module,
         };
       }
+      // if (packageLocation === 'file:///home/xyz/Development/metamask-extension4/node_modules/@formatjs/intl-relativetimeformat/') {
+      //   console.log('digest', explicit, dependencyName);
+      // }
       if (!explicit) {
+        // if (dependencyName === '@noble/hashes') {
+        //   console.log('digest', dependencyName, graphLocation, packageLocation);
+        // } else {
+        //   console.log('digest', dependencyName, graphLocation, packageLocation); 
+        // }
         scopes[dependencyName] = {
           compartment: packageLocation,
         };
       }
     };
     // Support reflexive package imports.
-    digest(name, entryPackageLocation);
+    digest(name, packageLocation);
     // Support external package imports.
     for (const dependencyName of keys(dependencies).sort()) {
       const packageLocation = dependencies[dependencyName];

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -311,11 +311,7 @@ const graphPackage = async (
   };
 
   try {
-    const inferredExports = inferExports(packageDescriptor, tags, types)
-    // if (packageLocation === 'file:///home/xyz/Development/metamask-extension4/node_modules/readable-stream/'){
-    //   console.log(packageLocation, exports);
-    // }
-
+    const inferredExports = inferExports(packageDescriptor, tags, types);
     Object.assign(result, {
       name,
       path: undefined,
@@ -335,17 +331,16 @@ const graphPackage = async (
         }
       }),
     );
-
   } catch (err) {
-    console.error(`Error while processing package ${q(name)} at ${q(packageLocation)}: ${err.stack}`);
+    console.error(
+      `Error while processing package ${q(name)} at ${q(packageLocation)}: ${
+        err.stack
+      }`,
+    );
     throw err;
   }
 
   await Promise.all(children);
-
-  // if (packageLocation === 'file:///home/xyz/Development/metamask-extension4/node_modules/@formatjs/intl-relativetimeformat/'){
-  //   console.log(packageLocation, result);
-  // }
 
   return undefined;
 };
@@ -518,7 +513,6 @@ const translateGraph = (
   // package and is a complete list of every external module that the
   // corresponding compartment can import.
   for (const packageLocation of keys(graph).sort()) {
-    const graphLocation = packageLocation
     const { name, path, label, dependencies, parsers, types } = graph[
       packageLocation
     ];
@@ -539,15 +533,7 @@ const translateGraph = (
           module,
         };
       }
-      // if (packageLocation === 'file:///home/xyz/Development/metamask-extension4/node_modules/@formatjs/intl-relativetimeformat/') {
-      //   console.log('digest', explicit, dependencyName);
-      // }
       if (!explicit) {
-        // if (dependencyName === '@noble/hashes') {
-        //   console.log('digest', dependencyName, graphLocation, packageLocation);
-        // } else {
-        //   console.log('digest', dependencyName, graphLocation, packageLocation); 
-        // }
         scopes[dependencyName] = {
           compartment: packageLocation,
         };

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -76,9 +76,6 @@ const loadRecord = async (
     resolveHook,
     moduleSpecifier,
   );
-  // if (compartmentName.includes('web3-stream-provider')) {
-  //   console.log(compartmentName, resolvedImports)
-  // }
   const moduleRecord = freeze({
     compartment,
     staticModuleRecord,
@@ -124,31 +121,16 @@ const loadWithoutErrorAnnotation = async (
   errors,
   parentSpecifier,
 ) => {
-  const { importHook, moduleMap, moduleMapHook, moduleRecords, name: compartmentName } = weakmapGet(
+  const { importHook, moduleMap, moduleMapHook, moduleRecords } = weakmapGet(
     compartmentPrivateFields,
     compartment,
   );
 
   // Follow moduleMap, or moduleMapHook if present.
   let aliasNamespace = moduleMap[moduleSpecifier];
-  // if (compartmentName === 'file:///home/xyz/Development/metamask-extension4/node_modules/@ethereumjs/util/node_modules/@noble/hashes/' && moduleSpecifier === '@noble/hashes/crypto') {
-  //   // console.log('aliasNamespace', aliasNamespace)
-  //   console.log('noble hashes before moduleMapHook', moduleSpecifier, aliasNamespace)
-  // }
   if (aliasNamespace === undefined && moduleMapHook !== undefined) {
     aliasNamespace = moduleMapHook(moduleSpecifier);
   }
-  // if (compartmentName === 'file:///home/xyz/Development/metamask-extension4/node_modules/@ethereumjs/util/node_modules/@noble/hashes/' && moduleSpecifier === '@noble/hashes/crypto') {
-  //   // console.log('aliasNamespace', aliasNamespace)
-  //   console.log('noble hashes', moduleSpecifier, aliasNamespace)
-  // }
-
-  // if (moduleSpecifier === '@formatjs/intl-relativetimeformat/polyfill') {
-  //   if (moduleSpecifier[0] !== '.' && aliasNamespace === undefined) {
-  //     console.log('aliasRecord missing', JSON.stringify(moduleSpecifier), parentSpecifier, !!aliasNamespace, !!moduleMapHook)
-  //     console.log(Reflect.ownKeys(moduleMap))
-  //   }
-  // }
 
   if (typeof aliasNamespace === 'string') {
     // eslint-disable-next-line @endo/no-polymorphic-call
@@ -160,15 +142,6 @@ const loadWithoutErrorAnnotation = async (
     );
   } else if (aliasNamespace !== undefined) {
     const alias = weakmapGet(moduleAliases, aliasNamespace);
-    // if (compartmentName === 'file:///home/xyz/Development/metamask-extension4/node_modules/@ethereumjs/util/node_modules/@noble/hashes/') {
-    //   // console.log('aliasNamespace', aliasNamespace)
-    //   // console.log('noble hashes', moduleSpecifier, aliasNamespace)
-    //   const { name: aliasCompartmentName } = weakmapGet(
-    //     compartmentPrivateFields,
-    //     alias.compartment,
-    //   )
-    //   console.log('alias', moduleSpecifier, alias, parentSpecifier, aliasCompartmentName)
-    // }
     if (alias === undefined) {
       // eslint-disable-next-line @endo/no-polymorphic-call
       assert.fail(
@@ -188,13 +161,8 @@ const loadWithoutErrorAnnotation = async (
       pendingJobs,
       moduleLoads,
       errors,
-      parentSpecifier
+      parentSpecifier,
     );
-    // if (compartmentName === 'file:///home/xyz/Development/metamask-extension4/node_modules/@ethereumjs/util/node_modules/@noble/hashes/') {
-    //   // console.log('aliasNamespace', aliasNamespace)
-    //   // console.log('noble hashes', moduleSpecifier, aliasNamespace)
-    //   console.log('aliasRecord found', moduleSpecifier, parentSpecifier)
-    // }
     mapSet(moduleRecords, moduleSpecifier, aliasRecord);
     return aliasRecord;
   }
@@ -202,11 +170,6 @@ const loadWithoutErrorAnnotation = async (
   if (mapHas(moduleRecords, moduleSpecifier)) {
     return mapGet(moduleRecords, moduleSpecifier);
   }
-
-  // if (moduleSpecifier[0] !== '.') {
-  //   console.log('aliasRecord missing', JSON.stringify(moduleSpecifier), parentSpecifier)
-  // }
-
 
   const staticModuleRecord = await importHook(moduleSpecifier, parentSpecifier);
 
@@ -259,7 +222,7 @@ const memoizedLoadWithErrorAnnotation = async (
   pendingJobs,
   moduleLoads,
   errors,
-  parentSpecifier
+  parentSpecifier,
 ) => {
   const { name: compartmentName } = weakmapGet(
     compartmentPrivateFields,


### PR DESCRIPTION
hack and slash monkey patching to enable loading and linking of metamask dependency graph

will be split into a handful of small PRs


**to be broken out:**
- [x] **importHook**: support resolution candidates when extension omitted but "." present
https://github.com/endojs/endo/pull/1370
- [x] **infer-exports**: handle browser field more correctly
https://github.com/endojs/endo/pull/1373
- [x] **node-modules/digest**: uses wrong packageLocation
https://github.com/endojs/endo/pull/1372
- [x] **bundler**: handle dev mode https://github.com/endojs/endo/pull/1400
- [x] **link**: fallback to extension as language and dont error until after transform
https://github.com/endojs/endo/pull/1371
- [x] **importHook**: support resolution candidates when '.' in packageDir means main
    which involves threading the packageDescriptor or less
https://github.com/endojs/endo/pull/1374
- [x] **bundler**: handle tags https://github.com/endojs/endo/pull/1404
- [x] **bundler**: handle deferredErrors https://github.com/endojs/endo/pull/1403
- [x] **importHook** allow alternate candidateSuffixes https://github.com/endojs/endo/pull/1405
- [x] **bundler**: handle pre-cjs-json modules https://github.com/endojs/endo/pull/1383
- [x] **bundler**: handle exitModules or "global internal aliases" or "dependency injections" https://github.com/endojs/endo/pull/1406
- [ ] **importHook**: include parentSpecifier for debugging
- [ ] **node-modules/graphPackage**: wrap error for more clarity


getting the loading and linking working also required a number of changes to metamask-extension, including many patches to dependencies' `package.json`s to fix missing or incorrect specified dependencies. some of these may be fixable inside `compartment-mapper`, for example: https://github.com/endojs/endo/issues/1364
see https://github.com/MetaMask/metamask-extension/pull/16520 for the changes necessary in metamask-extension