### PR TITLE
fix(compartment-mapper): allow specifier to include period and omit extension

### DIFF
--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -10,7 +10,6 @@
 /** @typedef {import('./types.js').CompartmentDescriptor} CompartmentDescriptor */
 /** @typedef {import('./types.js').ImportHookMaker} ImportHookMaker */
 
-import { parseExtension } from './extension.js';
 import { unpackReadPowers } from './powers.js';
 
 // q, as in quote, for quoting strings in error messages.
@@ -146,12 +145,7 @@ export const makeImportHookMaker = (
         candidates.push('./index.js');
       } else {
         candidates.push(moduleSpecifier);
-        if (parseExtension(moduleSpecifier) === '') {
-          candidates.push(
-            `${moduleSpecifier}.js`,
-            `${moduleSpecifier}/index.js`,
-          );
-        }
+        candidates.push(`${moduleSpecifier}.js`, `${moduleSpecifier}/index.js`);
       }
 
       const { read } = unpackReadPowers(readPowers);

--- a/packages/compartment-mapper/test/fixtures-resolve/node_modules/path-with-dot/dir.with.dot/index.js
+++ b/packages/compartment-mapper/test/fixtures-resolve/node_modules/path-with-dot/dir.with.dot/index.js
@@ -1,0 +1,1 @@
+export const question = '?';

--- a/packages/compartment-mapper/test/fixtures-resolve/node_modules/path-with-dot/main.js
+++ b/packages/compartment-mapper/test/fixtures-resolve/node_modules/path-with-dot/main.js
@@ -1,0 +1,2 @@
+export { question } from './dir.with.dot';
+export { answer } from './module.with.dot';

--- a/packages/compartment-mapper/test/fixtures-resolve/node_modules/path-with-dot/module.with.dot.js
+++ b/packages/compartment-mapper/test/fixtures-resolve/node_modules/path-with-dot/module.with.dot.js
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/packages/compartment-mapper/test/fixtures-resolve/node_modules/path-with-dot/package.json
+++ b/packages/compartment-mapper/test/fixtures-resolve/node_modules/path-with-dot/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {},
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/test-main.js
+++ b/packages/compartment-mapper/test/test-main.js
@@ -167,3 +167,17 @@ test('no transitive dev dependencies', async t => {
     },
   );
 });
+
+scaffold(
+  'fixtures-resolve',
+  test,
+  new URL(
+    'fixtures-resolve/node_modules/path-with-dot/main.js',
+    import.meta.url,
+  ).toString(),
+  (t, { namespace }) => {
+    t.is(namespace.question, '?', 'correct exports');
+    t.is(namespace.answer, 42, 'correct exports');
+  },
+  2,
+);


### PR DESCRIPTION
specifier `./util.thing` may refer to `./util.thing.js`