### PR TITLE
fix(compartment-mapper): allow transforms to run on unknown languages

### DIFF
--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -95,12 +95,7 @@ const makeExtensionParser = (
     ) {
       language = languageForModuleSpecifier[specifier];
     } else {
-      if (!has(languageForExtension, extension)) {
-        throw new Error(
-          `Cannot parse module ${specifier} at ${location}, no parser configured for extension ${extension}`,
-        );
-      }
-      language = languageForExtension[extension];
+      language = languageForExtension[extension] || extension;
     }
 
     if (has(moduleTransforms, language)) {

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -76,14 +76,14 @@ const extensionImpliesLanguage = extension => extension !== 'js';
  * the type of a module is implied by package.json and should not be inferred
  * from its extension.
  * @param {Record<string, ParserImplementation>} parserForLanguage
- * @param {ModuleTransforms} transforms
+ * @param {ModuleTransforms} moduleTransforms
  * @returns {ParseFn}
  */
 const makeExtensionParser = (
   languageForExtension,
   languageForModuleSpecifier,
   parserForLanguage,
-  transforms,
+  moduleTransforms,
 ) => {
   return async (bytes, specifier, location, packageLocation, options) => {
     let language;
@@ -103,8 +103,8 @@ const makeExtensionParser = (
       language = languageForExtension[extension];
     }
 
-    if (has(transforms, language)) {
-      ({ bytes, parser: language } = await transforms[language](
+    if (has(moduleTransforms, language)) {
+      ({ bytes, parser: language } = await moduleTransforms[language](
         bytes,
         specifier,
         location,
@@ -127,14 +127,14 @@ const makeExtensionParser = (
  * @param {Record<string, string>} languageForModuleSpecifier - In a rare case, the type of a module
  * is implied by package.json and should not be inferred from its extension.
  * @param {Record<string, ParserImplementation>} parserForLanguage
- * @param {ModuleTransforms} transforms
+ * @param {ModuleTransforms} moduleTransforms
  * @returns {ParseFn}
  */
 export const mapParsers = (
   languageForExtension,
   languageForModuleSpecifier,
   parserForLanguage,
-  transforms = {},
+  moduleTransforms = {},
 ) => {
   const languageForExtensionEntries = [];
   const problems = [];
@@ -152,7 +152,7 @@ export const mapParsers = (
     fromEntries(languageForExtensionEntries),
     languageForModuleSpecifier,
     parserForLanguage,
-    transforms,
+    moduleTransforms,
   );
 };
 

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/language-unknown/README.md
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/language-unknown/README.md
@@ -1,0 +1,1 @@
+This package covers the behavior of a package that has modules in a language unknown to compartment-mapper and must be handled via a transform.

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/language-unknown/main.xyz
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/language-unknown/main.xyz
@@ -1,0 +1,3 @@
+!! this module is in an unknown language that must be converted by a ModuleTransform
+
+provide lambda(a, b): a add b

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/language-unknown/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/language-unknown/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "language-unknown",
+  "exports": "./main.xyz",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}


### PR DESCRIPTION
this allowed me to add transforms for typescript files, that transform them into cjs modules.

The extension is used when the language is unknown. It still enforces that there is a parser for the language as a result of the transformations.

```js
const moduleTransforms = {
  // ...
    'extension:ts': async (bytes, specifier, location, packageLocation) => {
      let parserLanguage = 'cjs'
      const moduleRecord = {
        file: location.toString(),
        source: bytes.toString(),
      }
      await runMetaMaskTransforms(moduleRecord)
      const transformedSource = Buffer.from(moduleRecord.source, 'utf8')
      return { bytes: transformedSource, parser: parserLanguage }
    },
 }
 ```