### PR TITLE
refactor(marshal): Increase internal consistency

### DIFF
--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -298,10 +298,10 @@ const decodeTagged = (encoded, decodePassable) => {
 
 /**
  * @param {EncodeOptions} encodeOptions
- * @returns {(passable: Passable) => string}
- *
  * encodeOptions is actually optional, but not marked as such to work around
  * https://github.com/microsoft/TypeScript/issues/50286
+ *
+ * @returns {(passable: Passable) => string}
  */
 export const makeEncodePassable = ({
   encodeRemotable = (rem, _) => Fail`remotable unexpected: ${rem}`,

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -297,16 +297,12 @@ const decodeTagged = (encoded, decodePassable) => {
  */
 
 /**
- * @param {EncodeOptions} [encodeOptions]
+ * @param {EncodeOptions} encodeOptions
  * @returns {(passable: Passable) => string}
+ *
+ * encodeOptions is actually optional, but not marked as such to work around
+ * https://github.com/microsoft/TypeScript/issues/50286
  */
-// `yarn lint` complains here but not for equivalent code in agoric-sdk.
-// Also, vscode does not complain. Hence we're using at-ts-ignore rather than
-// at-ts-expect-error. Using at-ts-ignore should also generate a complaint
-// that we should be using at-expect-error, where we would normally need
-// to suppress that error as well. However, perhaps that second error currently
-// happens only in agoric-sdk, but not yet in endo. TODO figure out and fix.
-// @ts-ignore
 export const makeEncodePassable = ({
   encodeRemotable = (rem, _) => Fail`remotable unexpected: ${rem}`,
   encodePromise = (prom, _) => Fail`promise unexpected: ${prom}`,

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -86,10 +86,10 @@ const dontEncodeErrorToCapData = err => Fail`error object unexpected: ${err}`;
 
 /**
  * @param {EncodeToCapDataOptions} encodeOptions
- * @returns {(passable: Passable) => Encoding}
- *
  * encodeOptions is actually optional, but not marked as such to work around
  * https://github.com/microsoft/TypeScript/issues/50286
+ *
+ * @returns {(passable: Passable) => Encoding}
  */
 export const makeEncodeToCapData = ({
   encodeRemotableToCapData = dontEncodeRemotableToCapData,

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -87,6 +87,9 @@ const dontEncodeErrorToCapData = err => Fail`error object unexpected: ${err}`;
 /**
  * @param {EncodeToCapDataOptions} encodeOptions
  * @returns {(passable: Passable) => Encoding}
+ *
+ * encodeOptions is actually optional, but not marked as such to work around
+ * https://github.com/microsoft/TypeScript/issues/50286
  */
 export const makeEncodeToCapData = ({
   encodeRemotableToCapData = dontEncodeRemotableToCapData,

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -134,30 +134,26 @@ export const makeEncodeToCapData = ({
     // JSON, and some must be encoded as [QCLASS] composites.
     const passStyle = passStyleOf(passable);
     switch (passStyle) {
-      case 'null': {
-        return null;
+      case 'null':
+      case 'boolean':
+      case 'string': {
+        // pass through to JSON
+        return passable;
       }
       case 'undefined': {
         return { [QCLASS]: 'undefined' };
       }
-      case 'string':
-      case 'boolean': {
-        return passable;
-      }
       case 'number': {
+        // Special-case numbers with no digit-based representation.
         if (Number.isNaN(passable)) {
           return { [QCLASS]: 'NaN' };
-        }
-        if (is(passable, -0)) {
-          return 0;
-        }
-        if (passable === Infinity) {
+        } else if (passable === Infinity) {
           return { [QCLASS]: 'Infinity' };
-        }
-        if (passable === -Infinity) {
+        } else if (passable === -Infinity) {
           return { [QCLASS]: '-Infinity' };
         }
-        return passable;
+        // Pass through everything else, replacing -0 with 0.
+        return is(passable, -0) ? 0 : passable;
       }
       case 'bigint': {
         return {

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -112,7 +112,7 @@ export const makeEncodeToCapData = ({
    * copyRecord property ordering, differs from canonical-JSON as a whole
    * in that the other record properties are visited in the order in which
    * they are literally written below. TODO perhaps we should indeed switch
-   * to a canonical JSON encoder, and not delicatetly depend on the order
+   * to a canonical JSON encoder, and not delicately depend on the order
    * in which these object literals are written.
    *
    * Readers must not care about this order anyway. We impose this requirement

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -113,6 +113,9 @@ const dontEncodeErrorToSmallcaps = err =>
 /**
  * @param {EncodeToSmallcapsOptions} encodeOptions
  * @returns {(passable: Passable) => SmallcapsEncoding}
+ *
+ * encodeOptions is actually optional, but not marked as such to work around
+ * https://github.com/microsoft/TypeScript/issues/50286
  */
 export const makeEncodeToSmallcaps = ({
   encodeRemotableToSmallcaps = dontEncodeRemotableToSmallcaps,

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -132,14 +132,13 @@ export const makeEncodeToSmallcaps = ({
    * not symbols, we can canonically sort the names first.
    * JSON.stringify will then visit these in that sorted order.
    *
-   * SmallcapsEncoding with a canonical-JSON encoder would also solve
-   * this canonicalness
+   * Encoding with a canonical-JSON encoder would also solve this canonicalness
    * problem in a more modular and encapsulated manner. Note that the
    * actual order produced here, though it agrees with canonical-JSON on
    * copyRecord property ordering, differs from canonical-JSON as a whole
    * in that the other record properties are visited in the order in which
    * they are literally written below. TODO perhaps we should indeed switch
-   * to a canonical JSON encoder, and not delicatetly depend on the order
+   * to a canonical JSON encoder, and not delicately depend on the order
    * in which these object literals are written.
    *
    * Readers must not care about this order anyway. We impose this requirement

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -112,10 +112,10 @@ const dontEncodeErrorToSmallcaps = err =>
 
 /**
  * @param {EncodeToSmallcapsOptions} encodeOptions
- * @returns {(passable: Passable) => SmallcapsEncoding}
- *
  * encodeOptions is actually optional, but not marked as such to work around
  * https://github.com/microsoft/TypeScript/issues/50286
+ *
+ * @returns {(passable: Passable) => SmallcapsEncoding}
  */
 export const makeEncodeToSmallcaps = ({
   encodeRemotableToSmallcaps = dontEncodeRemotableToSmallcaps,
@@ -131,7 +131,7 @@ export const makeEncodeToSmallcaps = ({
     const message = encoding['#error'];
     (typeof message === 'string' &&
       (!startsSpecial(message) || message.startsWith('!'))) ||
-      Fail`internal: Error encoding must string message: ${q(message)}`;
+      Fail`internal: Error encoding must have string message: ${q(message)}`;
   };
 
   /**

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -177,36 +177,29 @@ export const makeEncodeToSmallcaps = ({
         // All other strings pass through to JSON
         return passable;
       }
-      case 'symbol': {
-        // At the smallcaps level, we prefix symbol names with `%`.
-        // By "symbol name", we mean according to `nameForPassableSymbol`
-        // which does some further escaping. See comment on that function.
-        assertPassableSymbol(passable);
-        const name = /** @type {string} */ (nameForPassableSymbol(passable));
-        return `%${name}`;
-      }
       case 'undefined': {
         return '#undefined';
       }
       case 'number': {
+        // Special-case numbers with no digit-based representation.
         if (Number.isNaN(passable)) {
           return '#NaN';
-        }
-        if (is(passable, -0)) {
-          return 0;
-        }
-        if (passable === Infinity) {
+        } else if (passable === Infinity) {
           return '#Infinity';
-        }
-        if (passable === -Infinity) {
+        } else if (passable === -Infinity) {
           return '#-Infinity';
         }
-        // All other numbers pass through to JSON
-        return passable;
+        // Pass through everything else, replacing -0 with 0.
+        return is(passable, -0) ? 0 : passable;
       }
       case 'bigint': {
         const str = String(passable);
         return passable < 0n ? str : `+${str}`;
+      }
+      case 'symbol': {
+        assertPassableSymbol(passable);
+        const name = /** @type {string} */ (nameForPassableSymbol(passable));
+        return `%${name}`;
       }
       case 'copyRecord': {
         // Currently copyRecord allows only string keys so this will

--- a/packages/marshal/src/helpers/copyRecord.js
+++ b/packages/marshal/src/helpers/copyRecord.js
@@ -26,9 +26,9 @@ export const CopyRecordHelper = harden({
       );
     }
 
-    for (const key of ownKeys(candidate)) {
-      const valid =
-        (typeof key === 'string' ||
+    return ownKeys(candidate).every(key => {
+      return (
+        ((typeof key === 'string' ||
           (!!reject &&
             reject(
               X`Records can only have string-named properties: ${candidate}`,
@@ -38,12 +38,9 @@ export const CopyRecordHelper = harden({
             reject(
               // TODO: Update message now that there is no such thing as "implicit Remotable".
               X`Records cannot contain non-far functions because they may be methods of an implicit Remotable: ${candidate}`,
-            )));
-      if (!valid) {
-        return false;
-      }
-    }
-    return true;
+            ))))
+      );
+    });
   },
 
   assertValid: (candidate, passStyleOfRecur) => {
@@ -52,6 +49,8 @@ export const CopyRecordHelper = harden({
       checkNormalProperty(candidate, name, true, assertChecker);
     }
     // Recursively validate that each member is passable.
-    values(candidate).every(v => !!passStyleOfRecur(v));
+    for (const val of values(candidate)) {
+      passStyleOfRecur(val);
+    }
   },
 });

--- a/packages/marshal/src/helpers/error.js
+++ b/packages/marshal/src/helpers/error.js
@@ -4,7 +4,7 @@ import { assertChecker } from './passStyle-helpers.js';
 
 /** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
 
-const { details: X } = assert;
+const { details: X, Fail } = assert;
 const { getPrototypeOf, getOwnPropertyDescriptors } = Object;
 const { ownKeys } = Reflect;
 
@@ -59,9 +59,7 @@ export const ErrorHelper = harden({
     const { name } = proto;
     const EC = getErrorConstructor(name);
     (EC && EC.prototype === proto) ||
-      assert.fail(
-        X`Errors must inherit from an error class .prototype ${candidate}`,
-      );
+      Fail`Errors must inherit from an error class .prototype ${candidate}`;
 
     const {
       // Must allow `cause`, `errors`
@@ -71,14 +69,12 @@ export const ErrorHelper = harden({
       ...restDescs
     } = getOwnPropertyDescriptors(candidate);
     ownKeys(restDescs).length < 1 ||
-      assert.fail(X`Passed Error has extra unpassed properties ${restDescs}`);
+      Fail`Passed Error has extra unpassed properties ${restDescs}`;
     if (mDesc) {
       typeof mDesc.value === 'string' ||
-        assert.fail(
-          X`Passed Error "message" ${mDesc} must be a string-valued data property.`,
-        );
+        Fail`Passed Error "message" ${mDesc} must be a string-valued data property.`;
       !mDesc.enumerable ||
-        assert.fail(X`Passed Error "message" ${mDesc} must not be enumerable`);
+        Fail`Passed Error "message" ${mDesc} must not be enumerable`;
     }
     return true;
   },


### PR DESCRIPTION
* Fix typos
* Work around [microsoft/TypeScript#50286](https://github.com/microsoft/TypeScript/issues/50286) without `@ts-ignore`
* Increase similarity between encodeTo{CapData,Smallcaps}
* DRY out encodeToSmallcaps
* Use more standard patterns in helpers
* Move detailed ErrorHelper checks from canBeValid to assertValid
* Update ErrorHelper to use `assert.Fail`