### PR TITLE
feat(ses): support RedirectStaticModuleInterface without specifying a record

### DIFF
--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -64,9 +64,10 @@ export type FinalStaticModuleType =
   | ThirdPartyStaticModuleInterface;
 
 export interface RedirectStaticModuleInterface {
-  record: FinalStaticModuleType;
   specifier: string;
+  record?: FinalStaticModuleType;
   importMeta?: any;
+  compartment?: Compartment;
 }
 
 export type StaticModuleType =

--- a/packages/ses/test/node.js
+++ b/packages/ses/test/node.js
@@ -65,7 +65,8 @@ export const makeLocator = root => {
 
 const wrapImporterWithMeta = (importer, importMeta) => async specifier => {
   const moduleRecord = await importer(specifier);
-  return { record: moduleRecord, importMeta };
+  // return a RedirectStaticModuleInterface with an explicit record
+  return { specifier, record: moduleRecord, importMeta };
 };
 
 // makeNodeImporter conveniently curries makeImporter with a Node.js style

--- a/packages/ses/test/test-import.js
+++ b/packages/ses/test/test-import.js
@@ -443,6 +443,7 @@ test('module alias', async t => {
     for (const candidate of candidates) {
       // eslint-disable-next-line no-await-in-loop
       const record = await wrappedImportHook(candidate).catch(_ => undefined);
+      // return a RedirectStaticModuleInterface with an explicit record
       if (record !== undefined) {
         return { record, specifier };
       }
@@ -502,6 +503,7 @@ test('import reflexive module alias', async t => {
       // eslint-disable-next-line no-await-in-loop
       const record = await wrappedImportHook(candidate).catch(_ => undefined);
       if (record !== undefined) {
+        // return a RedirectStaticModuleInterface with an explicit record
         return { record, specifier };
       }
     }


### PR DESCRIPTION
allow `importHook` to return an alias record that `ses/src/module-load.js` can attempt to import
this allows `importHook` to resolve to something that may be provided by a different part of the import phase, like the `moduleMapHook`