### PR TITLE
fix(eventual-send): E.resolve safer against constructor attack

### DIFF
--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -365,7 +365,27 @@ export const makeHandledPromise = () => {
     return handledP;
   }
 
-  const isFrozenPromiseThen = p => {
+  /**
+   * If the promise `p` is safe, then during the evaluation of the
+   * expressopns `p.then` and `await p`, `p` cannot mount a reentrancy attack.
+   * Unfortunately, due to limitations of the current JavaScript standard,
+   * it seems impossible to prevent `p` from mounting a reentrancy attack
+   * during the evaluation of `isSafePromise(p)`, and therefore during
+   * operations like `HandledPromise.resolve(p)` that call
+   * `isSafePromise(p)` synchronously.
+   *
+   * The `@endo/marshal` package defines a related notion of a passable
+   * promise, i.e., one for which which `passStyleOf(p) === 'promise'`. All
+   * passable promises are also safe. But not vice versa because the
+   * requirements for a promise to be passable are slightly greater. A safe
+   * promise must not override `then` or `constructor`. A passable promise
+   * must not have any own properties. The requirements are otherwise
+   * identical.
+   *
+   * @param {Promise} p
+   * @returns {boolean}
+   */
+  const isSafePromise = p => {
     return (
       isFrozen(p) &&
       getPrototypeOf(p) === Promise.prototype &&
@@ -415,7 +435,7 @@ export const makeHandledPromise = () => {
       }
       // Prevent any proxy trickery.
       harden(resolvedPromise);
-      if (isFrozenPromiseThen(resolvedPromise)) {
+      if (isSafePromise(resolvedPromise)) {
         // We can use the `resolvedPromise` directly, since it is guaranteed to
         // have a `then` which is actually `Promise.prototype.then`.
         return resolvedPromise;

--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -370,7 +370,8 @@ export const makeHandledPromise = () => {
       isFrozen(p) &&
       getPrototypeOf(p) === Promise.prototype &&
       Promise.resolve(p) === p &&
-      getOwnPropertyDescriptor(p, 'then') === undefined
+      getOwnPropertyDescriptor(p, 'then') === undefined &&
+      getOwnPropertyDescriptor(p, 'constructor') === undefined
     );
   };
 

--- a/packages/eventual-send/test/test-thenable.js
+++ b/packages/eventual-send/test/test-thenable.js
@@ -3,76 +3,75 @@ import { test } from './prepare-test-env-ava.js';
 
 import { E, HandledPromise } from './get-hp.js';
 
-test('E.resolve does not coerce simple promise', async t => {
+const verifySimplePromise = async (t, resolve) => {
   const p = new Promise(_ => {});
-  const p2 = E.resolve(p);
+  const p2 = resolve(p);
   t.is(p, p2, 'simple promise should not coerce');
-});
+};
+test(
+  'E.resolve does not coerce simple promise',
+  verifySimplePromise,
+  E.resolve,
+);
+test(
+  'HandledPromise.resolve does not coerce simple promise',
+  verifySimplePromise,
+  HandledPromise.resolve,
+);
 
-test('HandledPromise.resolve does not coerce simple promise', async t => {
+const verifyThenAttack = async (t, resolve) => {
   const p = new Promise(_ => {});
-  const p2 = HandledPromise.resolve(p);
-  t.is(p, p2, 'simple promise should not coerce');
-});
-
-test('E.resolve protects against "then" attack', async t => {
-  const p = new Promise(_ => {});
+  let getHappened = false;
+  let callHappened = false;
   // Work around the override mistake on SES.
-  Object.defineProperty(p, 'then', { value: (res, _rej) => res('done') });
-  let happened = false;
-  const p2 = E.resolve(p).then(ret => (happened = ret));
+  Object.defineProperty(p, 'then', {
+    get() {
+      getHappened = true;
+      return (res, _rej) => {
+        callHappened = true;
+        res('done');
+      };
+    },
+  });
+  const p2 = resolve(p).then(ret => ret);
   t.not(p, p2, 'an own "then" should cause coercion');
-  t.is(happened, false, `p2 is not yet resolved`);
+  t.is(getHappened, false, `getter not called too early`);
+  t.is(callHappened, false, `then not called too early`);
   t.is(await p2, 'done', `p2 is resolved`);
-});
+  t.is(getHappened, true, `getter not called too early`);
+  t.is(callHappened, true, `then not called too early`);
+};
+test('E.resolve protects against "then" attack', verifyThenAttack, E.resolve);
+test(
+  'HandledPromise.resolve protects against "then" attack',
+  verifyThenAttack,
+  HandledPromise.resolve,
+);
 
-test('HandledPromise.resolve protects against "then" attack', async t => {
+const verifyConstructorAttack = async (t, resolve) => {
   const p = new Promise(_ => {});
-  // Work around the override mistake on SES.
-  Object.defineProperty(p, 'then', { value: (res, _rej) => res('done') });
-  let happened = false;
-  const p2 = HandledPromise.resolve(p).then(ret => (happened = ret));
-  t.not(p, p2, 'an own "then" should cause coercion');
-  t.is(happened, false, `p2 is not yet resolved`);
-  t.is(await p2, 'done', `p2 is resolved`);
-});
-
-test('E.resolve protects against "constructor" attack', async t => {
-  const p = new Promise(_ => {});
-  let happened = false;
+  let getHappened = false;
   // Work around the override mistake on SES.
   Object.defineProperty(p, 'constructor', {
     get() {
-      happened = true;
+      getHappened = true;
       return Promise;
     },
   });
-  const p2 = E.resolve(p);
+  const p2 = resolve(p);
   t.not(p, p2, 'an own "constructor" should cause coercion');
-  // This first 'true' demonstrates our remaining vulnerability to reentrancy.
+  // This 'true' demonstrates our remaining vulnerability to reentrancy.
   // But the fact that p coerced to a fresh p2 means that p2 cannot
   // cause a reentrancy attack
-  t.is(happened, true, `same turn`);
-  await null;
-  t.is(happened, true, `later turn with p still unresolved`);
-});
-
-test('HandledPromise.resolve protects against "constructor" attack', async t => {
-  const p = new Promise(_ => {});
-  let happened = false;
-  // Work around the override mistake on SES.
-  Object.defineProperty(p, 'constructor', {
-    get() {
-      happened = true;
-      return Promise;
-    },
-  });
-  const p2 = HandledPromise.resolve(p);
-  t.not(p, p2, 'an own "constructor" should cause coercion');
-  // This first 'true' demonstrates our remaining vulnerability to reentrancy.
-  // But the fact that p coerced to a fresh p2 means that p2 cannot
-  // cause a reentrancy attack
-  t.is(happened, true, `same turn`);
-  await null;
-  t.is(happened, true, `later turn with p still unresolved`);
-});
+  t.is(getHappened, true, `same turn`);
+};
+test(
+  'E.resolve protects against "constructor" attack',
+  verifyConstructorAttack,
+  E.resolve,
+);
+test(
+  'HandledPromise.resolve protects against "constructor" attack',
+  verifyConstructorAttack,
+  HandledPromise.resolve,
+);

--- a/packages/eventual-send/test/test-thenable.js
+++ b/packages/eventual-send/test/test-thenable.js
@@ -3,22 +3,76 @@ import { test } from './prepare-test-env-ava.js';
 
 import { E, HandledPromise } from './get-hp.js';
 
-test('E.resolve is always asynchronous', async t => {
+test('E.resolve does not coerce simple promise', async t => {
+  const p = new Promise(_ => {});
+  const p2 = E.resolve(p);
+  t.is(p, p2, 'simple promise should not coerce');
+});
+
+test('HandledPromise.resolve does not coerce simple promise', async t => {
+  const p = new Promise(_ => {});
+  const p2 = HandledPromise.resolve(p);
+  t.is(p, p2, 'simple promise should not coerce');
+});
+
+test('E.resolve protects against "then" attack', async t => {
   const p = new Promise(_ => {});
   // Work around the override mistake on SES.
   Object.defineProperty(p, 'then', { value: (res, _rej) => res('done') });
-  let thened = false;
-  const p2 = E.resolve(p).then(ret => (thened = ret));
-  t.is(thened, false, `p2 is not yet resolved`);
+  let happened = false;
+  const p2 = E.resolve(p).then(ret => (happened = ret));
+  t.not(p, p2, 'an own "then" should cause coercion');
+  t.is(happened, false, `p2 is not yet resolved`);
   t.is(await p2, 'done', `p2 is resolved`);
 });
 
-test('HandledPromise.resolve is always asynchronous', async t => {
+test('HandledPromise.resolve protects against "then" attack', async t => {
   const p = new Promise(_ => {});
   // Work around the override mistake on SES.
   Object.defineProperty(p, 'then', { value: (res, _rej) => res('done') });
-  let thened = false;
-  const p2 = HandledPromise.resolve(p).then(ret => (thened = ret));
-  t.is(thened, false, `p2 is not yet resolved`);
+  let happened = false;
+  const p2 = HandledPromise.resolve(p).then(ret => (happened = ret));
+  t.not(p, p2, 'an own "then" should cause coercion');
+  t.is(happened, false, `p2 is not yet resolved`);
   t.is(await p2, 'done', `p2 is resolved`);
+});
+
+test('E.resolve protects against "constructor" attack', async t => {
+  const p = new Promise(_ => {});
+  let happened = false;
+  // Work around the override mistake on SES.
+  Object.defineProperty(p, 'constructor', {
+    get() {
+      happened = true;
+      return Promise;
+    },
+  });
+  const p2 = E.resolve(p);
+  t.not(p, p2, 'an own "constructor" should cause coercion');
+  // This first 'true' demonstrates our remaining vulnerability to reentrancy.
+  // But the fact that p coerced to a fresh p2 means that p2 cannot
+  // cause a reentrancy attack
+  t.is(happened, true, `same turn`);
+  await null;
+  t.is(happened, true, `later turn with p still unresolved`);
+});
+
+test('HandledPromise.resolve protects against "constructor" attack', async t => {
+  const p = new Promise(_ => {});
+  let happened = false;
+  // Work around the override mistake on SES.
+  Object.defineProperty(p, 'constructor', {
+    get() {
+      happened = true;
+      return Promise;
+    },
+  });
+  const p2 = HandledPromise.resolve(p);
+  t.not(p, p2, 'an own "constructor" should cause coercion');
+  // This first 'true' demonstrates our remaining vulnerability to reentrancy.
+  // But the fact that p coerced to a fresh p2 means that p2 cannot
+  // cause a reentrancy attack
+  t.is(happened, true, `same turn`);
+  await null;
+  t.is(happened, true, `later turn with p still unresolved`);
 });


### PR DESCRIPTION
If a genuine promise has an own `constructor` accessor property, the getter can mount a reentrancy attack on `Promise.resolve'. Call this the "constructor" attack. This is similar to the "then" attack of https://github.com/Agoric/agoric-sdk/issues/9 but more obscure.

Currently `HandledPromise.resolve` and its alias `E.resolve` protect against the "then" attack but not the "constructor" attack. This PR fixes `HandledPromise.resolve` and `E.resolve` to provide partial reentrancy defense against the "constructor" attack. The "constructor" getter can still run synchronously during the call. But the mere presence of the `constructor` own property will cause `HandledPromise.resolve` and `E.resolve` to coerce the malicious promise into a fresh benign one that will not cause a reentrancy attack.