### PR TITLE
fix(ses): Remove superfluous tick in module loader

### DIFF
--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -54,7 +54,7 @@ const resolveAll = (imports, resolveHook, fullReferrerSpecifier) => {
   return freeze(resolvedImports);
 };
 
-const loadRecord = async (
+const loadRecord = (
   compartmentPrivateFields,
   moduleAliases,
   compartment,
@@ -192,7 +192,7 @@ const loadWithoutErrorAnnotation = async (
         importMeta,
       } = staticModuleRecord;
 
-      const aliasRecord = await loadRecord(
+      const aliasRecord = loadRecord(
         compartmentPrivateFields,
         moduleAliases,
         aliasCompartment,


### PR DESCRIPTION
This removes a superfluous and possibly dangerous await in the module loader. Delimiting the event could cause a race to write to the module memo.

Fixes #1394 