### PR TITLE
chore(import-bundle): Not yet TypeScriptable

### DIFF
--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,3 +1,7 @@
+// XXX Omit from typecheck for TypeScript packages depending upon
+// import-bundle.
+// TODO https://github.com/endojs/endo/issues/1254
+// @ts-nocheck
 /* global globalThis */
 /// <reference types="ses"/>
 


### PR DESCRIPTION
In order to obviate a patch in Agoric SDK, this change marks `importBundle` as explicitly not yet ready to be mechanically verified by TypeScript.