### PR TITLE
fix(compartment-mapper): Thread dev option thru bundler

### DIFF
--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -139,10 +139,11 @@ const sortedModules = (
  * @param {string} moduleLocation
  * @param {Object} [options]
  * @param {ModuleTransforms} [options.moduleTransforms]
+ * @param {boolean} [options.dev]
  * @returns {Promise<string>}
  */
 export const makeBundle = async (read, moduleLocation, options) => {
-  const { moduleTransforms } = options || {};
+  const { moduleTransforms, dev } = options || {};
   const {
     packageLocation,
     packageDescriptorText,
@@ -163,6 +164,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
     tags,
     packageDescriptor,
     moduleSpecifier,
+    { dev },
   );
 
   const {


### PR DESCRIPTION
It seems I neglected to thread a flag. This allows `devDependencies` to be incorporated into a bundle.