### PR TITLE
feat(compartment-mapper): bundle throws on encountering deferredError

### DIFF
--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -82,8 +82,13 @@ const sortedModules = (
 
     const resolve = compartmentResolvers[compartmentName];
     const source = compartmentSources[compartmentName][moduleSpecifier];
-    if (source) {
-      const { record, parser } = source;
+    if (source !== undefined) {
+      const { record, parser, deferredError } = source;
+      if (deferredError) {
+        throw new Error(
+          `Cannot bundle: encountered deferredError ${deferredError}`,
+        );
+      }
       if (record) {
         const { imports = [], reexports = [] } =
           /** @type {PrecompiledStaticModuleInterface} */ (record);


### PR DESCRIPTION
commonjs loader will sometimes set `deferredError` on the module record. the bundler should throw when it encounters this instead of failing due to other properties being missing