### PR TITLE
feat(compartment-mapper): allow alternate candidateSuffixes

### DIFF
--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -254,6 +254,7 @@ const digestLocation = async (powers, moduleLocation, options) => {
     dev = false,
     tags = new Set(),
     captureSourceLocation = undefined,
+    searchSuffixes = undefined,
   } = options || {};
   const { read, computeSha512 } = unpackReadPowers(powers);
   const {
@@ -295,6 +296,7 @@ const digestLocation = async (powers, moduleLocation, options) => {
     compartments,
     exitModules,
     computeSha512,
+    searchSuffixes,
   );
 
   // Induce importHook to record all the necessary modules to import the given module specifier.

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -146,10 +146,16 @@ const sortedModules = (
  * @param {ModuleTransforms} [options.moduleTransforms]
  * @param {boolean} [options.dev]
  * @param {Set<string>} [options.tags]
+ * @param {Array<string>} [options.searchSuffixes]
  * @returns {Promise<string>}
  */
 export const makeBundle = async (read, moduleLocation, options) => {
-  const { moduleTransforms, dev, tags: tagsOption } = options || {};
+  const {
+    moduleTransforms,
+    dev,
+    tags: tagsOption,
+    searchSuffixes,
+  } = options || {};
   const tags = new Set(tagsOption);
 
   const {
@@ -184,6 +190,9 @@ export const makeBundle = async (read, moduleLocation, options) => {
     packageLocation,
     sources,
     compartments,
+    undefined,
+    undefined,
+    searchSuffixes,
   );
 
   // Induce importHook to record all the necessary modules to import the given module specifier.

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -45,6 +45,9 @@ function getImportsFromRecord(record) {
   return (has(record, 'record') ? record.record.imports : record.imports) || [];
 }
 
+// Node.js default resolution allows for an incomplement specifier that does not include a suffix.
+const nodejsConventionSearchSuffixes = ['.js', '/index.js'];
+
 /**
  * @param {ReadFn|ReadPowers} readPowers
  * @param {string} baseLocation
@@ -52,6 +55,12 @@ function getImportsFromRecord(record) {
  * @param {Record<string, CompartmentDescriptor>} compartmentDescriptors
  * @param {Record<string, any>} exitModules
  * @param {HashFn=} computeSha512
+ * @param {Array<string>} searchSuffixes - Suffixes to search if the unmodified specifier is not found.
+ * Pass [] to emulate Node.js’s strict behavior.
+ * The default handles Node.js’s CommonJS behavior.
+ * Unlike Node.js, the Compartment Mapper lifts CommonJS up, more like a bundler,
+ * and does not attempt to vary the behavior of resolution depending on the
+ * language of the importing module.
  * @returns {ImportHookMaker}
  */
 export const makeImportHookMaker = (
@@ -61,6 +70,7 @@ export const makeImportHookMaker = (
   compartmentDescriptors = Object.create(null),
   exitModules = Object.create(null),
   computeSha512 = undefined,
+  searchSuffixes = nodejsConventionSearchSuffixes,
 ) => {
   // Set of specifiers for modules whose parser is not using heuristics to determine imports
   const strictlyRequired = new Set();
@@ -142,12 +152,13 @@ export const makeImportHookMaker = (
         );
       }
 
-      // Collate candidate locations for the moduleSpecifier per Node.js
-      // conventions.
-      const candidates = [];
+      // Collate candidate locations for the moduleSpecifier,
+      // to support Node.js conventions and similar.
+      const candidates = [moduleSpecifier];
       if (moduleSpecifier !== '.') {
-        candidates.push(moduleSpecifier);
-        candidates.push(`${moduleSpecifier}.js`, `${moduleSpecifier}/index.js`);
+        for (const candidateSuffix of searchSuffixes) {
+          candidates.push(`${moduleSpecifier}${candidateSuffix}`);
+        }
       }
 
       const { read } = unpackReadPowers(readPowers);

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -46,7 +46,17 @@ function getImportsFromRecord(record) {
 }
 
 // Node.js default resolution allows for an incomplement specifier that does not include a suffix.
-const nodejsConventionSearchSuffixes = ['.js', '/index.js'];
+// https://nodejs.org/api/modules.html#all-together
+const nodejsConventionSearchSuffixes = [
+  // LOAD_AS_FILE(X)
+  '.js',
+  '.json',
+  '.node',
+  // LOAD_INDEX(X)
+  '/index.js',
+  '/index.json',
+  '/index.node',
+];
 
 /**
  * @param {ReadFn|ReadPowers} readPowers

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -41,6 +41,7 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
     moduleTransforms = {},
     dev = false,
     tags = new Set(),
+    searchSuffixes = undefined,
   } = options || {};
 
   const { read } = unpackReadPowers(readPowers);
@@ -74,6 +75,9 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
       packageLocation,
       undefined,
       compartmentMap.compartments,
+      undefined,
+      undefined,
+      searchSuffixes,
     );
     const { compartment } = link(compartmentMap, {
       makeImportHook,

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -311,4 +311,5 @@ export {};
  * @property {boolean} [dev]
  * @property {Set<string>} [tags]
  * @property {CaptureSourceLocationHook} [captureSourceLocation]
+ * @property {Array<string>} [searchSuffixes]
  */

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/candidates-custom/index.js
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/candidates-custom/index.js
@@ -1,0 +1,1 @@
+export { fourthPrime } from './util';

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/candidates-custom/package.json
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/candidates-custom/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "canidates-custom",
+  "version": "1.0.0",
+  "description": "uses imports that requires custom canidates",
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/candidates-custom/util.abc.js
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/candidates-custom/util.abc.js
@@ -1,0 +1,1 @@
+export const fourthPrime = 7;

--- a/packages/compartment-mapper/test/scaffold.js
+++ b/packages/compartment-mapper/test/scaffold.js
@@ -58,6 +58,7 @@ export function scaffold(
     shouldFailBeforeArchiveOperations = false,
     knownFailure = false,
     tags = undefined,
+    searchSuffixes = undefined,
   } = {},
 ) {
   // wrapping each time allows for convenient use of test.only
@@ -91,6 +92,7 @@ export function scaffold(
     const application = await loadLocation(readPowers, fixture, {
       dev: true,
       tags,
+      searchSuffixes,
     });
     const { namespace } = await application.import({
       globals,
@@ -110,6 +112,7 @@ export function scaffold(
       Compartment,
       dev: true,
       tags,
+      searchSuffixes,
     });
     return namespace;
   });
@@ -122,6 +125,7 @@ export function scaffold(
       modules,
       dev: true,
       tags,
+      searchSuffixes,
     });
     const application = await parseArchive(archive, '<unknown>', {
       modules: Object.fromEntries(
@@ -153,6 +157,7 @@ export function scaffold(
         modules,
         dev: true,
         tags,
+        searchSuffixes,
       });
       const prefixArchive = new Uint8Array(archive.length + 10);
       prefixArchive.set(archive, 10);
@@ -189,6 +194,7 @@ export function scaffold(
       modules: { builtin: true },
       dev: true,
       tags,
+      searchSuffixes,
     });
     const application = await loadArchive(fakeRead, 'app.agar', {
       modules,
@@ -221,6 +227,7 @@ export function scaffold(
       modules,
       dev: true,
       tags,
+      searchSuffixes,
     });
     const { namespace } = await importArchive(fakeRead, 'app.agar', {
       globals,
@@ -240,12 +247,14 @@ export function scaffold(
         Compartment,
         dev: true,
         tags,
+        searchSuffixes,
       });
 
       const archiveBytes = await makeArchive(readPowers, fixture, {
         modules,
         dev: true,
         tags,
+        searchSuffixes,
       });
 
       const { computeSha512 } = readPowers;
@@ -272,12 +281,14 @@ export function scaffold(
         modules,
         dev: true,
         tags,
+        searchSuffixes,
       });
 
       const archive = await makeArchive(readPowers, fixture, {
         modules,
         dev: true,
         tags,
+        searchSuffixes,
       });
 
       const reader = new ZipReader(archive);

--- a/packages/compartment-mapper/test/test-main.js
+++ b/packages/compartment-mapper/test/test-main.js
@@ -239,3 +239,19 @@ scaffold(
   },
   2,
 );
+
+scaffold(
+  'overwrite searchSuffixes',
+  test,
+  new URL(
+    'fixtures-0/node_modules/candidates-custom/index.js',
+    import.meta.url,
+  ).toString(),
+  (t, { namespace: { fourthPrime } }) => {
+    t.is(fourthPrime, 7);
+  },
+  1,
+  {
+    searchSuffixes: ['.abc.js'],
+  },
+);

--- a/packages/compartment-mapper/test/test-transform.js
+++ b/packages/compartment-mapper/test/test-transform.js
@@ -175,7 +175,6 @@ test('module transforms can be used for extensions where the language is not kno
           .replace('lambda(', '(')
           .replace('): ', ') => ')
           .replace(' add ', ' + ');
-        console.log('done:\n', output);
         const objectBytes = new TextEncoder().encode(output);
         return { bytes: objectBytes, parser: 'mjs' };
       },


### PR DESCRIPTION
allows the specification of alternate suffixes when determining candidates

related to supporting features like typescript where files may import other typescript modules with the extension omitted or browserify's `opts.extensions` https://github.com/browserify/browserify#browserifyfiles--opts