### PR TITLE
feat(compartment-mapper): common dependencies

### DIFF
--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -255,6 +255,7 @@ const digestLocation = async (powers, moduleLocation, options) => {
     tags = new Set(),
     captureSourceLocation = undefined,
     searchSuffixes = undefined,
+    commonDependencies = undefined,
   } = options || {};
   const { read, computeSha512 } = unpackReadPowers(powers);
   const {
@@ -278,7 +279,7 @@ const digestLocation = async (powers, moduleLocation, options) => {
     tags,
     packageDescriptor,
     moduleSpecifier,
-    { dev },
+    { dev, commonDependencies },
   );
 
   const {

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -147,6 +147,7 @@ const sortedModules = (
  * @param {boolean} [options.dev]
  * @param {Set<string>} [options.tags]
  * @param {Array<string>} [options.searchSuffixes]
+ * @param {Object} [options.commonDependencies]
  * @returns {Promise<string>}
  */
 export const makeBundle = async (read, moduleLocation, options) => {
@@ -155,6 +156,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
     dev,
     tags: tagsOption,
     searchSuffixes,
+    commonDependencies,
   } = options || {};
   const tags = new Set(tagsOption);
 
@@ -175,7 +177,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
     tags,
     packageDescriptor,
     moduleSpecifier,
-    { dev },
+    { dev, commonDependencies },
   );
 
   const {

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -42,6 +42,7 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
     dev = false,
     tags = new Set(),
     searchSuffixes = undefined,
+    commonDependencies = undefined,
   } = options || {};
 
   const { read } = unpackReadPowers(readPowers);
@@ -63,7 +64,7 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
     tags,
     packageDescriptor,
     moduleSpecifier,
-    { dev },
+    { dev, commonDependencies },
   );
 
   /** @type {ExecuteFn} */

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -312,4 +312,5 @@ export {};
  * @property {Set<string>} [tags]
  * @property {CaptureSourceLocationHook} [captureSourceLocation]
  * @property {Array<string>} [searchSuffixes]
+ * @property {Record<string, string>} [commonDependencies]
  */

--- a/packages/compartment-mapper/test/fixtures-common-deps/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-common-deps/node_modules/app/index.js
@@ -1,0 +1,1 @@
+export { status } from 'common-dep-required';

--- a/packages/compartment-mapper/test/fixtures-common-deps/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-common-deps/node_modules/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  },
+  "dependencies": {
+    "common-dep-required": "0.0.0",
+    "common-dep-target": "0.0.0"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-common-deps/node_modules/common-dep-required/index.js
+++ b/packages/compartment-mapper/test/fixtures-common-deps/node_modules/common-dep-required/index.js
@@ -1,0 +1,1 @@
+export { value as status } from 'unlisted-common-dep';

--- a/packages/compartment-mapper/test/fixtures-common-deps/node_modules/common-dep-required/package.json
+++ b/packages/compartment-mapper/test/fixtures-common-deps/node_modules/common-dep-required/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "common-dep-required",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-common-deps/node_modules/common-dep-target/index.js
+++ b/packages/compartment-mapper/test/fixtures-common-deps/node_modules/common-dep-target/index.js
@@ -1,0 +1,1 @@
+export const value = 101;

--- a/packages/compartment-mapper/test/fixtures-common-deps/node_modules/common-dep-target/package.json
+++ b/packages/compartment-mapper/test/fixtures-common-deps/node_modules/common-dep-target/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "common-dep-target",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/scaffold.js
+++ b/packages/compartment-mapper/test/scaffold.js
@@ -59,6 +59,7 @@ export function scaffold(
     knownFailure = false,
     tags = undefined,
     searchSuffixes = undefined,
+    commonDependencies = undefined,
   } = {},
 ) {
   // wrapping each time allows for convenient use of test.only
@@ -93,6 +94,7 @@ export function scaffold(
       dev: true,
       tags,
       searchSuffixes,
+      commonDependencies,
     });
     const { namespace } = await application.import({
       globals,
@@ -113,6 +115,7 @@ export function scaffold(
       dev: true,
       tags,
       searchSuffixes,
+      commonDependencies,
     });
     return namespace;
   });
@@ -126,6 +129,7 @@ export function scaffold(
       dev: true,
       tags,
       searchSuffixes,
+      commonDependencies,
     });
     const application = await parseArchive(archive, '<unknown>', {
       modules: Object.fromEntries(
@@ -158,6 +162,7 @@ export function scaffold(
         dev: true,
         tags,
         searchSuffixes,
+        commonDependencies,
       });
       const prefixArchive = new Uint8Array(archive.length + 10);
       prefixArchive.set(archive, 10);
@@ -195,6 +200,7 @@ export function scaffold(
       dev: true,
       tags,
       searchSuffixes,
+      commonDependencies,
     });
     const application = await loadArchive(fakeRead, 'app.agar', {
       modules,
@@ -228,6 +234,7 @@ export function scaffold(
       dev: true,
       tags,
       searchSuffixes,
+      commonDependencies,
     });
     const { namespace } = await importArchive(fakeRead, 'app.agar', {
       globals,
@@ -248,6 +255,7 @@ export function scaffold(
         dev: true,
         tags,
         searchSuffixes,
+        commonDependencies,
       });
 
       const archiveBytes = await makeArchive(readPowers, fixture, {
@@ -255,6 +263,7 @@ export function scaffold(
         dev: true,
         tags,
         searchSuffixes,
+        commonDependencies,
       });
 
       const { computeSha512 } = readPowers;
@@ -282,6 +291,7 @@ export function scaffold(
         dev: true,
         tags,
         searchSuffixes,
+        commonDependencies,
       });
 
       const archive = await makeArchive(readPowers, fixture, {
@@ -289,6 +299,7 @@ export function scaffold(
         dev: true,
         tags,
         searchSuffixes,
+        commonDependencies,
       });
 
       const reader = new ZipReader(archive);

--- a/packages/compartment-mapper/test/test-main.js
+++ b/packages/compartment-mapper/test/test-main.js
@@ -255,3 +255,21 @@ scaffold(
     searchSuffixes: ['.abc.js'],
   },
 );
+
+scaffold(
+  'provide commonDependencies',
+  test,
+  new URL(
+    'fixtures-common-deps/node_modules/app/index.js',
+    import.meta.url,
+  ).toString(),
+  (t, { namespace: { status } }) => {
+    t.is(status, 101);
+  },
+  1,
+  {
+    commonDependencies: {
+      'unlisted-common-dep': 'common-dep-target',
+    },
+  },
+);


### PR DESCRIPTION
provides a means of exposing additional dependencies to every package

this is common when a transpiler adds additional dependencies (eg `@babel/runtime`) or when relying on polyfills of node builtins (eg browserify's replacement of `buffer`, etc)

this is somewhat related to `exitModules`, but they can otherwise be treated as normal packages that can be loaded from the file system

see related:
- browserify: `{ builtins: { [name]: location } }`
  see `opts.builtins` https://github.com/browserify/browserify#browserifyfiles--opts
- webpack: `{ resolve: { fallback: { [name]: location } } }`
  see https://webpack.js.org/configuration/resolve/#resolvefallback