### PR TITLE
fix: change unsafe then to E.when

### DIFF
--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -167,7 +167,8 @@ export const makeCapTP = (
         slot = `p+${promiseID}`;
         // Set up promise listener to inform other side when this promise
         // is fulfilled/broken
-        val.then(
+        E.when(
+          val,
           res =>
             send({
               type: 'CTP_RESOLVE',


### PR DESCRIPTION
See https://github.com/Agoric/agoric-sdk/pull/6684

`val.then(` can be vulnerable to reentrancy by a "bad" `then` method, either because `val` is not a promise, or because it is a promise with an own `then` method overriding the `Promise.prototype.then` method.

`E.when` provides several advantages
   * it provides some protection against such reentrancy. (This protection is not perfect because of the `constructor` attack. With possible future changes to the language or platform, we may be able to address this, in which case we will upgrade `E.when` to provide this extra protection.)
   * It works even when `val` is properly described by the type `ERef<T>` rather than just `Promise<T>`. Thus, it is more equivalent to `Promise.resolve(val).then(`, but less verbose.
   * If we introduce non-thenable promise-likes, `E.when` will be generalized to work with those.

Alternatively, we're considering just generalizing the `E` function call behavior so that `E(val)` returns a safe non-promise thenable, in which case we'd replace all our `E.when(val, ...)` with `E(val).then(...)`. I agree this looks much prettier and we should switch to it. But switching to `E.when` in the meantime at least gives us a clearly marked starting point. (cc @mhofman that invented this prettier form)