### PR TITLE
fix(where): Fix XDG conventions

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -10,6 +10,7 @@ import path from 'path';
 import url from 'url';
 import crypto from 'crypto';
 import { spawn } from 'child_process';
+import os from 'os';
 
 import { Command } from 'commander';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -42,10 +43,18 @@ const packageDescriptorPath = url.fileURLToPath(
   new URL('../package.json', import.meta.url),
 );
 
-const statePath = whereEndoState(process.platform, process.env);
-const sockPath = whereEndoSock(process.platform, process.env);
-const cachePath = whereEndoCache(process.platform, process.env);
-const logPath = path.join(cachePath, 'endo.log');
+const { username, homedir } = os.userInfo();
+const temp = os.tmpdir();
+const info = {
+  user: username,
+  home: homedir,
+  temp,
+};
+
+const statePath = whereEndoState(process.platform, process.env, info);
+const sockPath = whereEndoSock(process.platform, process.env, info);
+const cachePath = whereEndoCache(process.platform, process.env, info);
+const logPath = path.join(statePath, 'endo.log');
 
 export const main = async rawArgs => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -5,6 +5,7 @@ import url from 'url';
 import popen from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -14,10 +15,18 @@ import { makeEndoClient } from './src/client.js';
 // Reexports:
 export { makeEndoClient } from './src/client.js';
 
+const { username, homedir } = os.userInfo();
+const temp = os.tmpdir();
+const info = {
+  user: username,
+  home: homedir,
+  temp,
+};
+
 const defaultLocator = {
-  statePath: whereEndoState(process.platform, process.env),
-  sockPath: whereEndoSock(process.platform, process.env),
-  cachePath: whereEndoCache(process.platform, process.env),
+  statePath: whereEndoState(process.platform, process.env, info),
+  sockPath: whereEndoSock(process.platform, process.env, info),
+  cachePath: whereEndoCache(process.platform, process.env, info),
 };
 
 const endoDaemonPath = url.fileURLToPath(

--- a/packages/where/README.md
+++ b/packages/where/README.md
@@ -4,3 +4,12 @@ This package provides a utility for finding the user files and Unix domain
 socket or Windows named pipe for the Endo daemon.
 The Endo user directory stores the per-user runtime data for Endo,
 including logs and other application storage.
+
+Endo attempts to use or infer [Cross-desktop XDG conventions][XDG] paths in
+every meaningful way.
+Windows named pipes do not appear to fit this model.
+Otherwise falls back to the native conventions on Windows and Mac/Darwin.
+On Windows, Endo does not use separate state and cache directories and does not
+yet sync state between home directories.
+
+[XDG]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/packages/where/index.d.ts
+++ b/packages/where/index.d.ts
@@ -1,1 +1,6 @@
-export { whereEndoState, whereEndoSock, whereEndoCache } from './types.js';
+export {
+  whereEndoState,
+  whereEndoEphemeralState,
+  whereEndoSock,
+  whereEndoCache,
+} from './types.js';

--- a/packages/where/index.js
+++ b/packages/where/index.js
@@ -1,33 +1,41 @@
 // @ts-check
 
-/* Infers the rendezvous path for the endo.sock file and apps from the platform
- * and environment.
- */
-
 const { raw } = String;
 
 /**
+ * Returns a path for local Endo application user data on Windows.
+ *
  * @param {{[name: string]: string}} env
  */
 const whereEndoHomeWindows = env => {
   // Favoring local app data over roaming app data since I don't expect to be
   // able to listen on one host and connect on another.
+  // TODO support roaming data for shared content addressable state and
+  // find a suitable mechanism for merging state that may change independently
+  // on separate roaming hosts.
   if (env.LOCALAPPDATA !== undefined) {
     return `${env.LOCALAPPDATA}\\Endo`;
   }
   if (env.APPDATA !== undefined) {
-    return `${env.APPDATA}\\Endo`;
+    return `${env.APPDATA}\\Local\\Endo`;
   }
   if (env.USERPROFILE !== undefined) {
-    return `${env.USERPROFILE}\\AppData\\Endo`;
+    return `${env.USERPROFILE}\\AppData\\Local\\Endo`;
   }
   if (env.HOMEDRIVE !== undefined && env.HOMEPATH !== undefined) {
-    return `${env.HOMEDRIVE}${env.HOMEPATH}\\AppData\\Endo`;
+    return `${env.HOMEDRIVE}${env.HOMEPATH}\\AppData\\Local\\Endo`;
   }
   return 'Endo';
 };
 
 /**
+ * Returns the most suitable path for Endo state with this platform and
+ * environment.
+ * Endo uses the state directory for saved files including applications,
+ * durable capabilities, and the user's pet names for them.
+ * Endo also logs here, per XDG's preference to persist logs even when caches
+ * are purged.
+ *
  * @type {typeof import('./types.js').whereEndoState}
  */
 export const whereEndoState = (platform, env) => {
@@ -46,6 +54,37 @@ export const whereEndoState = (platform, env) => {
 };
 
 /**
+ * Returns the most suitable location for storing state that ideally does not
+ * persist between restarts or reboots, specifically PID files.
+ * This should be coincident with the directory containing UNIX domain sockets,
+ * but is not suitable for Windows named pipes.
+ *
+ * @type {typeof import('./types.js').whereEndoEphemeralState}
+ */
+export const whereEndoEphemeralState = (platform, env) => {
+  if (env.XDG_RUNTIME_DIR !== undefined) {
+    return `${env.XDG_RUNTIME_DIR}/endo`;
+  } else if (platform === 'win32') {
+    return whereEndoHomeWindows(env);
+  } else if (platform === 'darwin') {
+    if (env.HOME !== undefined) {
+      return `${env.HOME}/Library/Application Support/Endo`;
+    }
+  }
+  if (env.USER !== undefined) {
+    // The XDG specification says that in this case, we should fall through to
+    // system specific behavior, but we are not in a position to assume which
+    // system we're using, other than it is probably a variety of Linux,
+    // in which case /tmp and /run might be viable base paths.
+    return `/tmp/endo-${env.USER}`;
+  }
+  return '/tmp/endo';
+};
+
+/**
+ * Returns the most suitable path for the Endo UNIX domain socket or Windows
+ * named pipe.
+ *
  * @type {typeof import('./types.js').whereEndoSock}
  */
 export const whereEndoSock = (platform, env) => {
@@ -69,6 +108,8 @@ export const whereEndoSock = (platform, env) => {
 };
 
 /**
+ * Returns the most suitable path for Endo caches.
+ *
  * @type {typeof import('./types.js').whereEndoCache}
  */
 export const whereEndoCache = (platform, env) => {

--- a/packages/where/index.js
+++ b/packages/where/index.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-const { raw } = String;
-
 /**
  * Returns a path for local Endo application user data on Windows.
  *
@@ -87,24 +85,24 @@ export const whereEndoEphemeralState = (platform, env) => {
  *
  * @type {typeof import('./types.js').whereEndoSock}
  */
-export const whereEndoSock = (platform, env) => {
+export const whereEndoSock = (platform, env, protocol = 'captp0') => {
   if (platform === 'win32') {
     // Named pipes have a special place in Windows (and in our ashen hearts).
     if (env.USERNAME !== undefined) {
-      return `\\\\?\\pipe\\${env.USERNAME}-Endo\\endo.pipe`;
+      return `\\\\?\\pipe\\${env.USERNAME}-Endo\\${protocol}.pipe`;
     } else {
-      return raw`\\?\pipe\Endo\endo.pipe`;
+      return `\\\\?\\pipe\\Endo\\${protocol}.pipe`;
     }
   } else if (env.XDG_RUNTIME_DIR !== undefined) {
-    return `${env.XDG_RUNTIME_DIR}/endo/endo.sock`;
+    return `${env.XDG_RUNTIME_DIR}/endo/${protocol}.sock`;
   } else if (platform === 'darwin') {
     if (env.HOME !== undefined) {
-      return `${env.HOME}/Library/Application Support/Endo/endo.sock`;
+      return `${env.HOME}/Library/Application Support/Endo/${protocol}.sock`;
     }
   } else if (env.USER !== undefined) {
-    return `/tmp/endo-${env.USER}/endo.sock`;
+    return `/tmp/endo-${env.USER}/${protocol}.sock`;
   }
-  return 'endo/endo.sock';
+  return `endo/${protocol}.sock`;
 };
 
 /**

--- a/packages/where/index.js
+++ b/packages/where/index.js
@@ -9,7 +9,7 @@ const { raw } = String;
 /**
  * @param {{[name: string]: string}} env
  */
-const whereEndoStateWindows = env => {
+const whereEndoHomeWindows = env => {
   // Favoring local app data over roaming app data since I don't expect to be
   // able to listen on one host and connect on another.
   if (env.LOCALAPPDATA !== undefined) {
@@ -24,28 +24,25 @@ const whereEndoStateWindows = env => {
   if (env.HOMEDRIVE !== undefined && env.HOMEPATH !== undefined) {
     return `${env.HOMEDRIVE}${env.HOMEPATH}\\AppData\\Endo`;
   }
-  return '.';
+  return 'Endo';
 };
 
 /**
  * @type {typeof import('./types.js').whereEndoState}
  */
 export const whereEndoState = (platform, env) => {
-  if (platform === 'win32') {
-    return whereEndoStateWindows(env);
+  if (env.XDG_STATE_HOME !== undefined) {
+    return `${env.XDG_STATE_HOME}/endo`;
+  } else if (platform === 'win32') {
+    return whereEndoHomeWindows(env);
   } else if (platform === 'darwin') {
     if (env.HOME !== undefined) {
       return `${env.HOME}/Library/Application Support/Endo`;
     }
-  } else {
-    if (env.XDG_CONFIG_DIR !== undefined) {
-      return `${env.XDG_CONFIG_DIR}/endo`;
-    }
-    if (env.HOME !== undefined) {
-      return `${env.HOME}/.config/endo`;
-    }
+  } else if (env.HOME !== undefined) {
+    return `${env.HOME}/.local/state/endo`;
   }
-  return 'endo';
+  return 'endo/state';
 };
 
 /**
@@ -59,32 +56,32 @@ export const whereEndoSock = (platform, env) => {
     } else {
       return raw`\\?\pipe\Endo\endo.pipe`;
     }
+  } else if (env.XDG_RUNTIME_DIR !== undefined) {
+    return `${env.XDG_RUNTIME_DIR}/endo/endo.sock`;
   } else if (platform === 'darwin') {
     if (env.HOME !== undefined) {
       return `${env.HOME}/Library/Application Support/Endo/endo.sock`;
     }
-  } else if (env.XDG_RUNTIME_DIR !== undefined) {
-    return `${env.XDG_RUNTIME_DIR}/endo/endo.sock`;
   } else if (env.USER !== undefined) {
     return `/tmp/endo-${env.USER}/endo.sock`;
   }
-  return 'endo.sock';
+  return 'endo/endo.sock';
 };
 
 /**
  * @type {typeof import('./types.js').whereEndoCache}
  */
 export const whereEndoCache = (platform, env) => {
-  if (platform === 'win32') {
-    return `${whereEndoStateWindows(env)}`;
+  if (env.XDG_CACHE_HOME !== undefined) {
+    return `${env.XDG_CACHE_HOME}/endo`;
+  } else if (platform === 'win32') {
+    return `${whereEndoHomeWindows(env)}`;
   } else if (platform === 'darwin') {
     if (env.HOME !== undefined) {
       return `${env.HOME}/Library/Caches/Endo`;
     }
-  } else if (env.XDG_CACHE_HOME !== undefined) {
-    return `${env.XDG_CACHE_HOME}/endo`;
   } else if (env.HOME !== undefined) {
     return `${env.HOME}/.cache/endo`;
   }
-  return '';
+  return 'endo/cache';
 };

--- a/packages/where/index.js
+++ b/packages/where/index.js
@@ -3,27 +3,28 @@
 /**
  * Returns a path for local Endo application user data on Windows.
  *
- * @param {{[name: string]: string}} env
+ * @param {{[name: string]: string | undefined}} env
+ * @param {import('./types.js').Info} info
  */
-const whereEndoHomeWindows = env => {
+const whereHomeWindows = (env, info) => {
   // Favoring local app data over roaming app data since I don't expect to be
   // able to listen on one host and connect on another.
   // TODO support roaming data for shared content addressable state and
   // find a suitable mechanism for merging state that may change independently
   // on separate roaming hosts.
   if (env.LOCALAPPDATA !== undefined) {
-    return `${env.LOCALAPPDATA}\\Endo`;
+    return `${env.LOCALAPPDATA}`;
   }
   if (env.APPDATA !== undefined) {
-    return `${env.APPDATA}\\Local\\Endo`;
+    return `${env.APPDATA}\\Local`;
   }
   if (env.USERPROFILE !== undefined) {
-    return `${env.USERPROFILE}\\AppData\\Local\\Endo`;
+    return `${env.USERPROFILE}\\AppData\\Local`;
   }
   if (env.HOMEDRIVE !== undefined && env.HOMEPATH !== undefined) {
-    return `${env.HOMEDRIVE}${env.HOMEPATH}\\AppData\\Local\\Endo`;
+    return `${env.HOMEDRIVE}${env.HOMEPATH}\\AppData\\Local`;
   }
-  return 'Endo';
+  return `${info.home}\\AppData\\Local`;
 };
 
 /**
@@ -36,47 +37,36 @@ const whereEndoHomeWindows = env => {
  *
  * @type {typeof import('./types.js').whereEndoState}
  */
-export const whereEndoState = (platform, env) => {
+export const whereEndoState = (platform, env, info) => {
   if (env.XDG_STATE_HOME !== undefined) {
     return `${env.XDG_STATE_HOME}/endo`;
   } else if (platform === 'win32') {
-    return whereEndoHomeWindows(env);
-  } else if (platform === 'darwin') {
-    if (env.HOME !== undefined) {
-      return `${env.HOME}/Library/Application Support/Endo`;
-    }
-  } else if (env.HOME !== undefined) {
-    return `${env.HOME}/.local/state/endo`;
+    return `${whereHomeWindows(env, info)}\\Endo`;
   }
-  return 'endo/state';
+  const home = env.HOME !== undefined ? env.HOME : info.home;
+  if (platform === 'darwin') {
+    if (home !== undefined) {
+      return `${home}/Library/Application Support/Endo`;
+    }
+  }
+  return `${home}/.local/state/endo`;
 };
 
 /**
  * Returns the most suitable location for storing state that ideally does not
  * persist between restarts or reboots, specifically PID files.
- * This should be coincident with the directory containing UNIX domain sockets,
- * but is not suitable for Windows named pipes.
  *
  * @type {typeof import('./types.js').whereEndoEphemeralState}
  */
-export const whereEndoEphemeralState = (platform, env) => {
+export const whereEndoEphemeralState = (platform, env, info) => {
   if (env.XDG_RUNTIME_DIR !== undefined) {
     return `${env.XDG_RUNTIME_DIR}/endo`;
   } else if (platform === 'win32') {
-    return whereEndoHomeWindows(env);
-  } else if (platform === 'darwin') {
-    if (env.HOME !== undefined) {
-      return `${env.HOME}/Library/Application Support/Endo`;
-    }
+    return `${whereHomeWindows(env, info)}\\Temp\\Endo`;
   }
-  if (env.USER !== undefined) {
-    // The XDG specification says that in this case, we should fall through to
-    // system specific behavior, but we are not in a position to assume which
-    // system we're using, other than it is probably a variety of Linux,
-    // in which case /tmp and /run might be viable base paths.
-    return `/tmp/endo-${env.USER}`;
-  }
-  return '/tmp/endo';
+  const temp = env.TMPDIR !== undefined ? env.TMPDIR : info.temp;
+  const user = env.USER !== undefined ? env.USER : info.user;
+  return `${temp}/endo-${user}`;
 };
 
 /**
@@ -85,24 +75,25 @@ export const whereEndoEphemeralState = (platform, env) => {
  *
  * @type {typeof import('./types.js').whereEndoSock}
  */
-export const whereEndoSock = (platform, env, protocol = 'captp0') => {
-  if (platform === 'win32') {
+export const whereEndoSock = (platform, env, info, protocol = 'captp0') => {
+  // It must be possible to override the socket or named pipe location, but we
+  // cannot use XDG_RUNTIME_DIR for Windows named pipes, so for this case, we
+  // invent our own environment variable.
+  if (env.ENDO_SOCK !== undefined) {
+    return env.ENDO_SOCK;
+  } else if (platform === 'win32') {
     // Named pipes have a special place in Windows (and in our ashen hearts).
-    if (env.USERNAME !== undefined) {
-      return `\\\\?\\pipe\\${env.USERNAME}-Endo\\${protocol}.pipe`;
-    } else {
-      return `\\\\?\\pipe\\Endo\\${protocol}.pipe`;
-    }
+    const user = env.USERNAME !== undefined ? env.USERNAME : info.user;
+    return `\\\\?\\pipe\\${user}-Endo\\${protocol}.pipe`;
   } else if (env.XDG_RUNTIME_DIR !== undefined) {
     return `${env.XDG_RUNTIME_DIR}/endo/${protocol}.sock`;
   } else if (platform === 'darwin') {
-    if (env.HOME !== undefined) {
-      return `${env.HOME}/Library/Application Support/Endo/${protocol}.sock`;
-    }
-  } else if (env.USER !== undefined) {
-    return `/tmp/endo-${env.USER}/${protocol}.sock`;
+    const home = env.HOME !== undefined ? env.HOME : info.home;
+    return `${home}/Library/Application Support/Endo/${protocol}.sock`;
   }
-  return `endo/${protocol}.sock`;
+  const user = env.USER !== undefined ? env.USER : info.user;
+  const temp = env.TMPDIR !== undefined ? env.TMPDIR : info.temp;
+  return `${temp}/endo-${user}/${protocol}.sock`;
 };
 
 /**
@@ -110,17 +101,15 @@ export const whereEndoSock = (platform, env, protocol = 'captp0') => {
  *
  * @type {typeof import('./types.js').whereEndoCache}
  */
-export const whereEndoCache = (platform, env) => {
+export const whereEndoCache = (platform, env, info) => {
   if (env.XDG_CACHE_HOME !== undefined) {
     return `${env.XDG_CACHE_HOME}/endo`;
   } else if (platform === 'win32') {
-    return `${whereEndoHomeWindows(env)}`;
+    return `${whereHomeWindows(env, info)}\\Endo`;
   } else if (platform === 'darwin') {
-    if (env.HOME !== undefined) {
-      return `${env.HOME}/Library/Caches/Endo`;
-    }
-  } else if (env.HOME !== undefined) {
-    return `${env.HOME}/.cache/endo`;
+    const home = env.HOME !== undefined ? env.HOME : info.home;
+    return `${home}/Library/Caches/Endo`;
   }
-  return 'endo/cache';
+  const home = env.HOME !== undefined ? env.HOME : info.home;
+  return `${home}/.cache/endo`;
 };

--- a/packages/where/test/test-where-endo-cache.js
+++ b/packages/where/test/test-where-endo-cache.js
@@ -5,65 +5,94 @@ test('windows', t => {
   t.is(
     whereEndoCache('win32', {
       LOCALAPPDATA: 'C:\\Users\\Alice\\AppData\\Local',
+      APPDATA: 'IGNOREME',
+      USERPROFILE: 'IGNOREME',
+      HOMEDRIVE: 'IGNOREME',
+      HOMEPATH: 'IGNOREME',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'LOCALAPPDATA has highest precedence for locating the Endo cache on Windows.',
+  );
+  t.is(
+    whereEndoCache('win32', {
       APPDATA: 'C:\\Users\\Alice\\AppData',
+      USERPROFILE: 'IGNOREME',
+      HOMEDRIVE: 'IGNOREME',
+      HOMEPATH: 'IGNOREME',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Infer LOCALAPPDATA from APPDATA',
+  );
+  t.is(
+    whereEndoCache('win32', {
       USERPROFILE: 'C:\\Users\\Alice',
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
     'C:\\Users\\Alice\\AppData\\Local\\Endo',
-  );
-  t.is(
-    whereEndoCache('win32', {
-      APPDATA: 'C:\\Users\\Alice\\AppData',
-      USERPROFILE: 'C:\\Users\\Alice',
-      HOMEDRIVE: 'C:\\',
-      HOMEPATH: 'Users\\Alice',
-    }),
-    'C:\\Users\\Alice\\AppData\\Endo',
-  );
-  t.is(
-    whereEndoCache('win32', {
-      USERPROFILE: 'C:\\Users\\Alice',
-      HOMEDRIVE: 'C:\\',
-      HOMEPATH: 'Users\\Alice',
-    }),
-    'C:\\Users\\Alice\\AppData\\Endo',
+    'Infer LOCALAPPDATA from USERPROFILE',
   );
   t.is(
     whereEndoCache('win32', {
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
-    'C:\\Users\\Alice\\AppData\\Endo',
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Infer LOCALAPPDATA from HOMEDRIVE and HOMEPATH',
   );
-  t.is(whereEndoCache('win32', {}), 'Endo');
+  t.is(
+    whereEndoCache('win32', {}),
+    'Endo',
+    'Under duress, fall back to a relative path, just Endo',
+  );
 });
 
 test('darwin', t => {
   t.is(
     whereEndoCache('darwin', {
+      XDG_CACHE_HOME: '/Users/alice/.config',
+      HOME: 'IGNOREME',
+    }),
+    '/Users/alice/.config/endo',
+    'Prioritize XDG environment if provided, even on a Mac',
+  );
+  t.is(
+    whereEndoCache('darwin', {
       HOME: '/Users/alice',
     }),
     '/Users/alice/Library/Caches/Endo',
+    'In absence of XDG environment, use conventional Mac cache location',
   );
-  t.is(whereEndoCache('darwin', {}), 'endo/cache');
+  t.is(
+    whereEndoCache('darwin', {}),
+    'endo/cache',
+    'Under duress, fall back to a relative path, just endo/cache',
+  );
 });
 
 test('linux', t => {
   t.is(
     whereEndoCache('linux', {
       XDG_CACHE_HOME: '/var/cache/users/alice',
-      USER: 'alice',
-      HOME: '/Users/alice',
+      USER: 'IGNOREME',
+      HOME: 'IGNOREME',
     }),
     '/var/cache/users/alice/endo',
+    'Prioritize XDG environment location for caches',
   );
   t.is(
     whereEndoCache('linux', {
-      USER: 'alice',
+      USER: 'IGNOREME',
       HOME: '/Users/alice',
     }),
     '/Users/alice/.cache/endo',
+    'Infer the conventional XDG environment from the user HOME',
   );
-  t.is(whereEndoCache('linux', {}), 'endo/cache');
+  t.is(
+    whereEndoCache('linux', {
+      USER: 'IGNOREME',
+    }),
+    'endo/cache',
+    'Under duress, do not attempt to infer whether /users/ or /home/ is a correct USER prefix for HOME, fall through to a relative path',
+  );
 });

--- a/packages/where/test/test-where-endo-cache.js
+++ b/packages/where/test/test-where-endo-cache.js
@@ -36,7 +36,7 @@ test('windows', t => {
     }),
     'C:\\Users\\Alice\\AppData\\Endo',
   );
-  t.is(whereEndoCache('win32', {}), '.');
+  t.is(whereEndoCache('win32', {}), 'Endo');
 });
 
 test('darwin', t => {
@@ -46,7 +46,7 @@ test('darwin', t => {
     }),
     '/Users/alice/Library/Caches/Endo',
   );
-  t.is(whereEndoCache('darwin', {}), '');
+  t.is(whereEndoCache('darwin', {}), 'endo/cache');
 });
 
 test('linux', t => {
@@ -65,5 +65,5 @@ test('linux', t => {
     }),
     '/Users/alice/.cache/endo',
   );
-  t.is(whereEndoCache('linux', {}), '');
+  t.is(whereEndoCache('linux', {}), 'endo/cache');
 });

--- a/packages/where/test/test-where-endo-cache.js
+++ b/packages/where/test/test-where-endo-cache.js
@@ -41,9 +41,15 @@ test('windows', t => {
     'Infer LOCALAPPDATA from HOMEDRIVE and HOMEPATH',
   );
   t.is(
-    whereEndoCache('win32', {}),
-    'Endo',
-    'Under duress, fall back to a relative path, just Endo',
+    whereEndoCache(
+      'win32',
+      {},
+      {
+        home: 'C:\\Users\\Alice',
+      },
+    ),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Fall through to system-provided home',
   );
 });
 
@@ -64,9 +70,15 @@ test('darwin', t => {
     'In absence of XDG environment, use conventional Mac cache location',
   );
   t.is(
-    whereEndoCache('darwin', {}),
-    'endo/cache',
-    'Under duress, fall back to a relative path, just endo/cache',
+    whereEndoCache(
+      'darwin',
+      {},
+      {
+        home: '/Users/homer',
+      },
+    ),
+    '/Users/homer/Library/Caches/Endo',
+    'Fall back to system provided home',
   );
 });
 
@@ -89,10 +101,16 @@ test('linux', t => {
     'Infer the conventional XDG environment from the user HOME',
   );
   t.is(
-    whereEndoCache('linux', {
-      USER: 'IGNOREME',
-    }),
-    'endo/cache',
+    whereEndoCache(
+      'linux',
+      {
+        USER: 'IGNOREME',
+      },
+      {
+        home: '/home/homer',
+      },
+    ),
+    '/home/homer/.cache/endo',
     'Under duress, do not attempt to infer whether /users/ or /home/ is a correct USER prefix for HOME, fall through to a relative path',
   );
 });

--- a/packages/where/test/test-where-endo-ephemeral-state.js
+++ b/packages/where/test/test-where-endo-ephemeral-state.js
@@ -10,7 +10,7 @@ test('windows', t => {
       HOMEDRIVE: 'IGNOREME',
       HOMEPATH: 'IGNOREME',
     }),
-    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'C:\\Users\\Alice\\AppData\\Local\\Temp\\Endo',
     'Use LOCALAPPDATA for Endo state if available',
   );
   t.is(
@@ -20,7 +20,7 @@ test('windows', t => {
       HOMEDRIVE: 'IGNOREME',
       HOMEPATH: 'IGNOREME',
     }),
-    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'C:\\Users\\Alice\\AppData\\Local\\Temp\\Endo',
     'Infer LOCALAPPDATA from APPDATA if necessary and possible',
   );
   t.is(
@@ -29,7 +29,7 @@ test('windows', t => {
       HOMEDRIVE: 'IGNOREME',
       HOMEPATH: 'IGNOREME',
     }),
-    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'C:\\Users\\Alice\\AppData\\Local\\Temp\\Endo',
     'Infer LOCALAPPDATA from USERPROFILE if necessary and possible',
   );
   t.is(
@@ -37,12 +37,18 @@ test('windows', t => {
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
-    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'C:\\Users\\Alice\\AppData\\Local\\Temp\\Endo',
     'Infer LOCALAPPDATA from HOMEDRIVE and HOMEPATH if necessary and possible',
   );
   t.is(
-    whereEndoEphemeralState('win32', {}),
-    'Endo',
+    whereEndoEphemeralState(
+      'win32',
+      {},
+      {
+        home: 'C:\\Users\\Alice',
+      },
+    ),
+    'C:\\Users\\Alice\\AppData\\Local\\Temp\\Endo',
     'Under duress, just use a relative path',
   );
 });
@@ -59,16 +65,18 @@ test('darwin', t => {
     'Favor XDG state home over Darwin conventions if provided by the user',
   );
   t.is(
-    whereEndoEphemeralState('darwin', {
-      HOME: '/Users/alice',
-    }),
-    '/Users/alice/Library/Application Support/Endo',
-    'Use the Mac/Darwin conventional location for Application user data',
-  );
-  t.is(
-    whereEndoEphemeralState('darwin', {}),
-    '/tmp/endo',
-    'Under duress, fall back to an Endo tmp directory',
+    whereEndoEphemeralState(
+      'darwin',
+      {
+        HOME: 'IGNOREME',
+      },
+      {
+        user: 'alice',
+        temp: '/tmp/volumes/0',
+      },
+    ),
+    '/tmp/volumes/0/endo-alice',
+    'Use the system temporary location and user name',
   );
 });
 
@@ -84,16 +92,29 @@ test('linux', t => {
     'Use XDG state home if provided by the user',
   );
   t.is(
-    whereEndoEphemeralState('linux', {
-      USER: 'alice',
-      HOME: 'IGNOREME',
-    }),
-    '/tmp/endo-alice',
+    whereEndoEphemeralState(
+      'linux',
+      {
+        USER: 'alice',
+        HOME: 'IGNOREME',
+      },
+      {
+        temp: '/tmp/volume/0',
+      },
+    ),
+    '/tmp/volume/0/endo-alice',
     'In the absence of XDG information, infer a temporary location from the USER if available',
   );
   t.is(
-    whereEndoEphemeralState('linux', {}),
-    '/tmp/endo',
+    whereEndoEphemeralState(
+      'linux',
+      {},
+      {
+        user: 'homer',
+        temp: '/tmp/volume/0',
+      },
+    ),
+    '/tmp/volume/0/endo-homer',
     'For lack of any useful environment information, fall back to a shared temporary directory',
   );
 });

--- a/packages/where/test/test-where-endo-ephemeral-state.js
+++ b/packages/where/test/test-where-endo-ephemeral-state.js
@@ -1,0 +1,99 @@
+import test from 'ava';
+import { whereEndoEphemeralState } from '../index.js';
+
+test('windows', t => {
+  t.is(
+    whereEndoEphemeralState('win32', {
+      LOCALAPPDATA: 'C:\\Users\\Alice\\AppData\\Local',
+      APPDATA: 'IGNOREME',
+      USERPROFILE: 'IGNOREME',
+      HOMEDRIVE: 'IGNOREME',
+      HOMEPATH: 'IGNOREME',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Use LOCALAPPDATA for Endo state if available',
+  );
+  t.is(
+    whereEndoEphemeralState('win32', {
+      APPDATA: 'C:\\Users\\Alice\\AppData',
+      USERPROFILE: 'IGNOREME',
+      HOMEDRIVE: 'IGNOREME',
+      HOMEPATH: 'IGNOREME',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Infer LOCALAPPDATA from APPDATA if necessary and possible',
+  );
+  t.is(
+    whereEndoEphemeralState('win32', {
+      USERPROFILE: 'C:\\Users\\Alice',
+      HOMEDRIVE: 'IGNOREME',
+      HOMEPATH: 'IGNOREME',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Infer LOCALAPPDATA from USERPROFILE if necessary and possible',
+  );
+  t.is(
+    whereEndoEphemeralState('win32', {
+      HOMEDRIVE: 'C:\\',
+      HOMEPATH: 'Users\\Alice',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Infer LOCALAPPDATA from HOMEDRIVE and HOMEPATH if necessary and possible',
+  );
+  t.is(
+    whereEndoEphemeralState('win32', {}),
+    'Endo',
+    'Under duress, just use a relative path',
+  );
+});
+
+test('darwin', t => {
+  t.is(
+    whereEndoEphemeralState('darwin', {
+      XDG_RUNTIME_DIR: '/Users/alice/.run',
+      XDG_STATE_HOME: 'IGNOREME',
+      XDG_CONFIG_HOME: 'IGNOREME',
+      HOME: 'IGNOREME',
+    }),
+    '/Users/alice/.run/endo',
+    'Favor XDG state home over Darwin conventions if provided by the user',
+  );
+  t.is(
+    whereEndoEphemeralState('darwin', {
+      HOME: '/Users/alice',
+    }),
+    '/Users/alice/Library/Application Support/Endo',
+    'Use the Mac/Darwin conventional location for Application user data',
+  );
+  t.is(
+    whereEndoEphemeralState('darwin', {}),
+    '/tmp/endo',
+    'Under duress, fall back to an Endo tmp directory',
+  );
+});
+
+test('linux', t => {
+  t.is(
+    whereEndoEphemeralState('linux', {
+      XDG_RUNTIME_DIR: '/Users/alice/.run',
+      XDG_CONFIG_HOME: 'IGNOREME',
+      XDG_STATE_HOME: 'IGNOREME',
+      HOME: 'IGNOREME',
+    }),
+    '/Users/alice/.run/endo',
+    'Use XDG state home if provided by the user',
+  );
+  t.is(
+    whereEndoEphemeralState('linux', {
+      USER: 'alice',
+      HOME: 'IGNOREME',
+    }),
+    '/tmp/endo-alice',
+    'In the absence of XDG information, infer a temporary location from the USER if available',
+  );
+  t.is(
+    whereEndoEphemeralState('linux', {}),
+    '/tmp/endo',
+    'For lack of any useful environment information, fall back to a shared temporary directory',
+  );
+});

--- a/packages/where/test/test-where-endo-sock.js
+++ b/packages/where/test/test-where-endo-sock.js
@@ -11,8 +11,14 @@ test('windows', t => {
     'Use Windows named pipe namespace, scoped to the user when possible',
   );
   t.is(
-    whereEndoSock('win32', {}),
-    '\\\\?\\pipe\\Endo\\captp0.pipe',
+    whereEndoSock(
+      'win32',
+      {},
+      {
+        user: 'Bill',
+      },
+    ),
+    '\\\\?\\pipe\\Bill-Endo\\captp0.pipe',
     'Under duress, fall back to a location shared by all users',
   );
 });
@@ -34,9 +40,15 @@ test('darwin', t => {
     'Infer Darwin/Mac conventional socket location from HOME',
   );
   t.is(
-    whereEndoSock('darwin', {}),
-    'endo/captp0.sock',
-    'Under duress, fall through to a relative path',
+    whereEndoSock(
+      'darwin',
+      {},
+      {
+        home: '/Users/alice',
+      },
+    ),
+    '/Users/alice/Library/Application Support/Endo/captp0.sock',
+    'Fall through to system-provided home',
   );
 });
 
@@ -50,15 +62,16 @@ test('linux', t => {
     'XDG takes precedence over USER on Linux',
   );
   t.is(
-    whereEndoSock('linux', {
-      USER: 'alice',
-    }),
-    '/tmp/endo-alice/captp0.sock',
-    'Under duress, assume the host has a /tmp file system and scope the UNIX domain socket to the user by name',
-  );
-  t.is(
-    whereEndoSock('linux', {}),
-    'endo/captp0.sock',
-    'Under extreme duress, just use a relative path for the socket',
+    whereEndoSock(
+      'linux',
+      {
+        USER: 'alice',
+      },
+      {
+        temp: '/tmp/volume/0',
+      },
+    ),
+    '/tmp/volume/0/endo-alice/captp0.sock',
+    'Under duress, fall back to host provided temporary directory',
   );
 });

--- a/packages/where/test/test-where-endo-sock.js
+++ b/packages/where/test/test-where-endo-sock.js
@@ -4,6 +4,7 @@ import { whereEndoSock } from '../index.js';
 test('windows', t => {
   t.is(
     whereEndoSock('win32', {
+      XDG_RUNTIME_DIR: 'IGNORE_ME',
       USERNAME: 'alice',
     }),
     '\\\\?\\pipe\\alice-Endo\\endo.pipe',
@@ -14,11 +15,18 @@ test('windows', t => {
 test('darwin', t => {
   t.is(
     whereEndoSock('darwin', {
+      XDG_RUNTIME_DIR: '/var/run/user/alice',
+      USER: 'alice',
+    }),
+    '/var/run/user/alice/endo/endo.sock',
+  );
+  t.is(
+    whereEndoSock('darwin', {
       HOME: '/Users/alice',
     }),
     '/Users/alice/Library/Application Support/Endo/endo.sock',
   );
-  t.is(whereEndoSock('darwin', {}), 'endo.sock');
+  t.is(whereEndoSock('darwin', {}), 'endo/endo.sock');
 });
 
 test('linux', t => {
@@ -35,5 +43,5 @@ test('linux', t => {
     }),
     '/tmp/endo-alice/endo.sock',
   );
-  t.is(whereEndoSock('linux', {}), 'endo.sock');
+  t.is(whereEndoSock('linux', {}), 'endo/endo.sock');
 });

--- a/packages/where/test/test-where-endo-sock.js
+++ b/packages/where/test/test-where-endo-sock.js
@@ -7,12 +7,12 @@ test('windows', t => {
       XDG_RUNTIME_DIR: 'IGNOREME', // Not necessarily suitable for named pipes
       USERNAME: 'alice',
     }),
-    '\\\\?\\pipe\\alice-Endo\\endo.pipe',
+    '\\\\?\\pipe\\alice-Endo\\captp0.pipe',
     'Use Windows named pipe namespace, scoped to the user when possible',
   );
   t.is(
     whereEndoSock('win32', {}),
-    '\\\\?\\pipe\\Endo\\endo.pipe',
+    '\\\\?\\pipe\\Endo\\captp0.pipe',
     'Under duress, fall back to a location shared by all users',
   );
 });
@@ -23,19 +23,19 @@ test('darwin', t => {
       XDG_RUNTIME_DIR: '/var/run/user/alice',
       USER: 'IGNOREME',
     }),
-    '/var/run/user/alice/endo/endo.sock',
+    '/var/run/user/alice/endo/captp0.sock',
     'Favor XDG over local conventions, even on a Mac',
   );
   t.is(
     whereEndoSock('darwin', {
       HOME: '/Users/alice',
     }),
-    '/Users/alice/Library/Application Support/Endo/endo.sock',
+    '/Users/alice/Library/Application Support/Endo/captp0.sock',
     'Infer Darwin/Mac conventional socket location from HOME',
   );
   t.is(
     whereEndoSock('darwin', {}),
-    'endo/endo.sock',
+    'endo/captp0.sock',
     'Under duress, fall through to a relative path',
   );
 });
@@ -46,19 +46,19 @@ test('linux', t => {
       XDG_RUNTIME_DIR: '/var/run/user/alice',
       USER: 'IGNOREME',
     }),
-    '/var/run/user/alice/endo/endo.sock',
+    '/var/run/user/alice/endo/captp0.sock',
     'XDG takes precedence over USER on Linux',
   );
   t.is(
     whereEndoSock('linux', {
       USER: 'alice',
     }),
-    '/tmp/endo-alice/endo.sock',
+    '/tmp/endo-alice/captp0.sock',
     'Under duress, assume the host has a /tmp file system and scope the UNIX domain socket to the user by name',
   );
   t.is(
     whereEndoSock('linux', {}),
-    'endo/endo.sock',
+    'endo/captp0.sock',
     'Under extreme duress, just use a relative path for the socket',
   );
 });

--- a/packages/where/test/test-where-endo-sock.js
+++ b/packages/where/test/test-where-endo-sock.js
@@ -4,44 +4,61 @@ import { whereEndoSock } from '../index.js';
 test('windows', t => {
   t.is(
     whereEndoSock('win32', {
-      XDG_RUNTIME_DIR: 'IGNORE_ME',
+      XDG_RUNTIME_DIR: 'IGNOREME', // Not necessarily suitable for named pipes
       USERNAME: 'alice',
     }),
     '\\\\?\\pipe\\alice-Endo\\endo.pipe',
+    'Use Windows named pipe namespace, scoped to the user when possible',
   );
-  t.is(whereEndoSock('win32', {}), '\\\\?\\pipe\\Endo\\endo.pipe');
+  t.is(
+    whereEndoSock('win32', {}),
+    '\\\\?\\pipe\\Endo\\endo.pipe',
+    'Under duress, fall back to a location shared by all users',
+  );
 });
 
 test('darwin', t => {
   t.is(
     whereEndoSock('darwin', {
       XDG_RUNTIME_DIR: '/var/run/user/alice',
-      USER: 'alice',
+      USER: 'IGNOREME',
     }),
     '/var/run/user/alice/endo/endo.sock',
+    'Favor XDG over local conventions, even on a Mac',
   );
   t.is(
     whereEndoSock('darwin', {
       HOME: '/Users/alice',
     }),
     '/Users/alice/Library/Application Support/Endo/endo.sock',
+    'Infer Darwin/Mac conventional socket location from HOME',
   );
-  t.is(whereEndoSock('darwin', {}), 'endo/endo.sock');
+  t.is(
+    whereEndoSock('darwin', {}),
+    'endo/endo.sock',
+    'Under duress, fall through to a relative path',
+  );
 });
 
 test('linux', t => {
   t.is(
     whereEndoSock('linux', {
       XDG_RUNTIME_DIR: '/var/run/user/alice',
-      USER: 'alice',
+      USER: 'IGNOREME',
     }),
     '/var/run/user/alice/endo/endo.sock',
+    'XDG takes precedence over USER on Linux',
   );
   t.is(
     whereEndoSock('linux', {
       USER: 'alice',
     }),
     '/tmp/endo-alice/endo.sock',
+    'Under duress, assume the host has a /tmp file system and scope the UNIX domain socket to the user by name',
   );
-  t.is(whereEndoSock('linux', {}), 'endo/endo.sock');
+  t.is(
+    whereEndoSock('linux', {}),
+    'endo/endo.sock',
+    'Under extreme duress, just use a relative path for the socket',
+  );
 });

--- a/packages/where/test/test-where-endo-state.js
+++ b/packages/where/test/test-where-endo-state.js
@@ -36,7 +36,7 @@ test('windows', t => {
     }),
     'C:\\Users\\Alice\\AppData\\Endo',
   );
-  t.is(whereEndoState('win32', {}), '.');
+  t.is(whereEndoState('win32', {}), 'Endo');
 });
 
 test('darwin', t => {
@@ -46,22 +46,23 @@ test('darwin', t => {
     }),
     '/Users/alice/Library/Application Support/Endo',
   );
-  t.is(whereEndoState('darwin', {}), 'endo');
+  t.is(whereEndoState('darwin', {}), 'endo/state');
 });
 
 test('linux', t => {
   t.is(
     whereEndoState('linux', {
-      XDG_CONFIG_DIR: '/Users/alice/.config2',
+      XDG_CONFIG_HOME: '/Users/alice/.config2',
+      XDG_STATE_HOME: '/Users/alice/.local/state',
       HOME: '/Users/alice',
     }),
-    '/Users/alice/.config2/endo',
+    '/Users/alice/.local/state/endo',
   );
   t.is(
     whereEndoState('linux', {
       HOME: '/Users/alice',
     }),
-    '/Users/alice/.config/endo',
+    '/Users/alice/.local/state/endo',
   );
-  t.is(whereEndoState('linux', {}), 'endo');
+  t.is(whereEndoState('linux', {}), 'endo/state');
 });

--- a/packages/where/test/test-where-endo-state.js
+++ b/packages/where/test/test-where-endo-state.js
@@ -41,9 +41,15 @@ test('windows', t => {
     'Infer LOCALAPPDATA from HOMEDRIVE and HOMEPATH if necessary and possible',
   );
   t.is(
-    whereEndoState('win32', {}),
-    'Endo',
-    'Under duress, just use a relative path',
+    whereEndoState(
+      'win32',
+      {},
+      {
+        home: 'C:\\Users\\Bill',
+      },
+    ),
+    'C:\\Users\\Bill\\AppData\\Local\\Endo',
+    'Fall back to system-provided home',
   );
 });
 
@@ -65,9 +71,15 @@ test('darwin', t => {
     'Use the Mac/Darwin conventional location for Application user data',
   );
   t.is(
-    whereEndoState('darwin', {}),
-    'endo/state',
-    'Under duress, fall back to a relative path for state',
+    whereEndoState(
+      'darwin',
+      {},
+      {
+        home: '/Users/Johnny',
+      },
+    ),
+    '/Users/Johnny/Library/Application Support/Endo',
+    'Fall back to system-provided home',
   );
 });
 
@@ -89,8 +101,14 @@ test('linux', t => {
     'Infer XDG state home from HOME on Linux',
   );
   t.is(
-    whereEndoState('linux', {}),
-    'endo/state',
+    whereEndoState(
+      'linux',
+      {},
+      {
+        home: '/home/homer',
+      },
+    ),
+    '/home/homer/.local/state/endo',
     'For lack of any useful environment information, fall back to a relative path',
   );
 });

--- a/packages/where/test/test-where-endo-state.js
+++ b/packages/where/test/test-where-endo-state.js
@@ -5,64 +5,92 @@ test('windows', t => {
   t.is(
     whereEndoState('win32', {
       LOCALAPPDATA: 'C:\\Users\\Alice\\AppData\\Local',
+      APPDATA: 'IGNOREME',
+      USERPROFILE: 'IGNOREME',
+      HOMEDRIVE: 'IGNOREME',
+      HOMEPATH: 'IGNOREME',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Use LOCALAPPDATA for Endo state if available',
+  );
+  t.is(
+    whereEndoState('win32', {
       APPDATA: 'C:\\Users\\Alice\\AppData',
+      USERPROFILE: 'IGNOREME',
+      HOMEDRIVE: 'IGNOREME',
+      HOMEPATH: 'IGNOREME',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Infer LOCALAPPDATA from APPDATA if necessary and possible',
+  );
+  t.is(
+    whereEndoState('win32', {
       USERPROFILE: 'C:\\Users\\Alice',
+      HOMEDRIVE: 'IGNOREME',
+      HOMEPATH: 'IGNOREME',
+    }),
+    'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Infer LOCALAPPDATA from USERPROFILE if necessary and possible',
+  );
+  t.is(
+    whereEndoState('win32', {
       HOMEDRIVE: 'C:\\',
       HOMEPATH: 'Users\\Alice',
     }),
     'C:\\Users\\Alice\\AppData\\Local\\Endo',
+    'Infer LOCALAPPDATA from HOMEDRIVE and HOMEPATH if necessary and possible',
   );
   t.is(
-    whereEndoState('win32', {
-      APPDATA: 'C:\\Users\\Alice\\AppData',
-      USERPROFILE: 'C:\\Users\\Alice',
-      HOMEDRIVE: 'C:\\',
-      HOMEPATH: 'Users\\Alice',
-    }),
-    'C:\\Users\\Alice\\AppData\\Endo',
+    whereEndoState('win32', {}),
+    'Endo',
+    'Under duress, just use a relative path',
   );
-  t.is(
-    whereEndoState('win32', {
-      USERPROFILE: 'C:\\Users\\Alice',
-      HOMEDRIVE: 'C:\\',
-      HOMEPATH: 'Users\\Alice',
-    }),
-    'C:\\Users\\Alice\\AppData\\Endo',
-  );
-  t.is(
-    whereEndoState('win32', {
-      HOMEDRIVE: 'C:\\',
-      HOMEPATH: 'Users\\Alice',
-    }),
-    'C:\\Users\\Alice\\AppData\\Endo',
-  );
-  t.is(whereEndoState('win32', {}), 'Endo');
 });
 
 test('darwin', t => {
   t.is(
     whereEndoState('darwin', {
+      XDG_STATE_HOME: '/Users/alice/.local/state',
+      XDG_CONFIG_HOME: 'IGNOREME',
+      HOME: 'IGNOREME',
+    }),
+    '/Users/alice/.local/state/endo',
+    'Favor XDG state home over Darwin conventions if provided by the user',
+  );
+  t.is(
+    whereEndoState('darwin', {
       HOME: '/Users/alice',
     }),
     '/Users/alice/Library/Application Support/Endo',
+    'Use the Mac/Darwin conventional location for Application user data',
   );
-  t.is(whereEndoState('darwin', {}), 'endo/state');
+  t.is(
+    whereEndoState('darwin', {}),
+    'endo/state',
+    'Under duress, fall back to a relative path for state',
+  );
 });
 
 test('linux', t => {
   t.is(
     whereEndoState('linux', {
-      XDG_CONFIG_HOME: '/Users/alice/.config2',
       XDG_STATE_HOME: '/Users/alice/.local/state',
-      HOME: '/Users/alice',
+      XDG_CONFIG_HOME: 'IGNOREME',
+      HOME: 'IGNOREME',
     }),
     '/Users/alice/.local/state/endo',
+    'Use XDG state home if provided by the user',
   );
   t.is(
     whereEndoState('linux', {
       HOME: '/Users/alice',
     }),
     '/Users/alice/.local/state/endo',
+    'Infer XDG state home from HOME on Linux',
   );
-  t.is(whereEndoState('linux', {}), 'endo/state');
+  t.is(
+    whereEndoState('linux', {}),
+    'endo/state',
+    'For lack of any useful environment information, fall back to a relative path',
+  );
 });

--- a/packages/where/types.d.ts
+++ b/packages/where/types.d.ts
@@ -1,12 +1,16 @@
 export function whereEndoState(
   platform: string,
-  env: { [name: string]: string },
+  env: { [name: string]: string | undefined },
+): string;
+export function whereEndoEphemeralState(
+  platform: string,
+  env: { [name: string]: string | undefined },
 ): string;
 export function whereEndoSock(
   platform: string,
-  env: { [name: string]: string },
+  env: { [name: string]: string | undefined },
 ): string;
 export function whereEndoCache(
   platform: string,
-  env: { [name: string]: string },
+  env: { [name: string]: string | undefined },
 ): string;

--- a/packages/where/types.d.ts
+++ b/packages/where/types.d.ts
@@ -1,16 +1,27 @@
+export type Info = {
+  home: string;
+  user: string;
+  temp: string;
+};
+
 export function whereEndoState(
   platform: string,
   env: { [name: string]: string | undefined },
+  info: Info,
 ): string;
 export function whereEndoEphemeralState(
   platform: string,
   env: { [name: string]: string | undefined },
+  info: Info,
 ): string;
 export function whereEndoSock(
   platform: string,
   env: { [name: string]: string | undefined },
+  info: Info,
+  protocol?: string,
 ): string;
 export function whereEndoCache(
   platform: string,
   env: { [name: string]: string | undefined },
+  info: Info,
 ): string;


### PR DESCRIPTION
1. There’s a typo for `XDG_CACHE_DIR` that should be `XDG_CACHE_HOME`
2. `XDG` prefixes should be respected everywhere, including Darwin and Windows, except (probably) for the named pipe on Windows.
3. State and Cache should be clearly delineated, except on Windows where there does not appear to be an (obvious) separation within its native conventions.

Based on feedback out of band, I intend to use whereEndoState to locate anything intended to persist between daemon restarts, including logs. I no longer have anything in mind for whereEndoCache. whereEndoSock is using the runtime directory for PID files and Unix Domain Sockets.