### PR TITLE
fix(captp): Serialize serialization errors

### DIFF
--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -379,11 +379,21 @@ export const makeCapTP = (
 
       /** @type {(isReject: boolean, value: any) => void} */
       let processResult = (isReject, value) => {
+        // Serialize the result.
+        let serial;
+        try {
+          serial = serialize(harden(value));
+        } catch (error) {
+          // Promote serialization errors to rejections.
+          isReject = true;
+          serial = serialize(harden(error));
+        }
+
         send({
           type: 'CTP_RETURN',
           epoch,
           answerID: questionID,
-          [isReject ? 'exception' : 'result']: serialize(harden(value)),
+          [isReject ? 'exception' : 'result']: serial,
         });
       };
       if (trap) {


### PR DESCRIPTION
Wherein we observe that resolving a remote promise with a non-remotable causes an exception and for the receiver to hang indefinitely. This neat trick promotes the serialization error and stuffs it in the return path so the originator can observe the error.