### PR TITLE
chore: release

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,273 +3,167 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.28](https://github.com/endojs/endo/compare/@endo/base64@0.2.27...@endo/base64@0.2.28) (2022-11-14)
+### [0.2.29](https://github.com/endojs/endo/compare/@endo/base64@0.2.28...@endo/base64@0.2.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/base64
 
+### [0.2.28](https://github.com/endojs/endo/compare/@endo/base64@0.2.27...@endo/base64@0.2.28) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/base64
 
 ### [0.2.27](https://github.com/endojs/endo/compare/@endo/base64@0.2.26...@endo/base64@0.2.27) (2022-06-28)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.26](https://github.com/endojs/endo/compare/@endo/base64@0.2.25...@endo/base64@0.2.26) (2022-06-11)
-
 
 ### Features
 
-* **base64:** export `atob` and `btoa` ([68c840c](https://github.com/endojs/endo/commit/68c840ca43014a0ff7f32947c300f104c7625207))
-* **init:** shim `atob` and `btoa` ([8e933ea](https://github.com/endojs/endo/commit/8e933ea1e5aa144aef8e355529598fff094e8373))
-
+- **base64:** export `atob` and `btoa` ([68c840c](https://github.com/endojs/endo/commit/68c840ca43014a0ff7f32947c300f104c7625207))
+- **init:** shim `atob` and `btoa` ([8e933ea](https://github.com/endojs/endo/commit/8e933ea1e5aa144aef8e355529598fff094e8373))
 
 ### Bug Fixes
 
-* **base64:** test interoperability with original atob/btoa ([f2868f8](https://github.com/endojs/endo/commit/f2868f802f35ef546e7537df6f059699736b9ea0))
-
-
+- **base64:** test interoperability with original atob/btoa ([f2868f8](https://github.com/endojs/endo/commit/f2868f802f35ef546e7537df6f059699736b9ea0))
 
 ### [0.2.25](https://github.com/endojs/endo/compare/@endo/base64@0.2.24...@endo/base64@0.2.25) (2022-04-15)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.24](https://github.com/endojs/endo/compare/@endo/base64@0.2.23...@endo/base64@0.2.24) (2022-04-14)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/base64@0.2.22...@endo/base64@0.2.23) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.2.22](https://github.com/endojs/endo/compare/@endo/base64@0.2.21...@endo/base64@0.2.22) (2022-04-12)
 
-
 ### Bug Fixes
 
-* **base64:** ensure `decodeBase64` returns a `Uint8Array` ([24f88b5](https://github.com/endojs/endo/commit/24f88b520c3098b3200d03c073d66de4bc87916e))
-
-
+- **base64:** ensure `decodeBase64` returns a `Uint8Array` ([24f88b5](https://github.com/endojs/endo/commit/24f88b520c3098b3200d03c073d66de4bc87916e))
 
 ### [0.2.21](https://github.com/endojs/endo/compare/@endo/base64@0.2.20...@endo/base64@0.2.21) (2022-03-07)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/base64@0.2.19...@endo/base64@0.2.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/base64
-
-
-
-
 
 ### [0.2.19](https://github.com/endojs/endo/compare/@endo/base64@0.2.18...@endo/base64@0.2.19) (2022-02-20)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.18](https://github.com/endojs/endo/compare/@endo/base64@0.2.17...@endo/base64@0.2.18) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.2.17](https://github.com/endojs/endo/compare/@endo/base64@0.2.16...@endo/base64@0.2.17) (2022-01-31)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.16](https://github.com/endojs/endo/compare/@endo/base64@0.2.15...@endo/base64@0.2.16) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.2.15](https://github.com/endojs/endo/compare/@endo/base64@0.2.14...@endo/base64@0.2.15) (2022-01-25)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.14](https://github.com/endojs/endo/compare/@endo/base64@0.2.13...@endo/base64@0.2.14) (2022-01-23)
 
 **Note:** Version bump only for package @endo/base64
-
-
-
-
 
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/base64@0.2.12...@endo/base64@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.12](https://github.com/endojs/endo/compare/@endo/base64@0.2.11...@endo/base64@0.2.12) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
 
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/base64@0.2.10...@endo/base64@0.2.11) (2021-11-16)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.10](https://github.com/endojs/endo/compare/@endo/base64@0.2.9...@endo/base64@0.2.10) (2021-11-02)
 
 **Note:** Version bump only for package @endo/base64
-
-
-
-
 
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/base64@0.2.8...@endo/base64@0.2.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/base64@0.2.7...@endo/base64@0.2.8) (2021-09-18)
-
 
 ### Features
 
-* **base64:** Polyfill on XSnap ([#889](https://github.com/endojs/endo/issues/889)) ([f4f10e2](https://github.com/endojs/endo/commit/f4f10e2e30637fdb6b2925c65f6fcf7901aa907e))
-
-
+- **base64:** Polyfill on XSnap ([#889](https://github.com/endojs/endo/issues/889)) ([f4f10e2](https://github.com/endojs/endo/commit/f4f10e2e30637fdb6b2925c65f6fcf7901aa907e))
 
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/base64@0.2.6...@endo/base64@0.2.7) (2021-08-14)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/base64@0.2.5...@endo/base64@0.2.6) (2021-08-13)
 
 **Note:** Version bump only for package @endo/base64
-
-
-
-
 
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/base64@0.2.4...@endo/base64@0.2.5) (2021-07-22)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/base64@0.2.3...@endo/base64@0.2.4) (2021-06-20)
 
 **Note:** Version bump only for package @endo/base64
-
-
-
-
 
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/base64@0.2.2...@endo/base64@0.2.3) (2021-06-16)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/base64@0.2.1...@endo/base64@0.2.2) (2021-06-14)
 
 **Note:** Version bump only for package @endo/base64
 
-
-
-
-
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/base64@0.2.0...@endo/base64@0.2.1) (2021-06-06)
-
 
 ### Bug Fixes
 
-* Fix some stray packaging mistakes ([0eb9297](https://github.com/endojs/endo/commit/0eb9297b1fc9753c235c53d746aa7d7994781216))
-
-
+- Fix some stray packaging mistakes ([0eb9297](https://github.com/endojs/endo/commit/0eb9297b1fc9753c235c53d746aa7d7994781216))
 
 ## 0.2.0 (2021-06-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **base64:** No longer supports direct use from CommonJS
+- **base64:** No longer supports direct use from CommonJS
 
 ### Features
 
-* **base64:** Export package.json ([c5a0e53](https://github.com/endojs/endo/commit/c5a0e534cfb43c32ae3eb62c3bd85a8652f8b417))
-* **base64:** Update packaging, expose encode/decode entry modules, bridge RESM/NESM ([a93e947](https://github.com/endojs/endo/commit/a93e9472b24447f4e1fc790191f6953a9285ecfa))
-
+- **base64:** Export package.json ([c5a0e53](https://github.com/endojs/endo/commit/c5a0e534cfb43c32ae3eb62c3bd85a8652f8b417))
+- **base64:** Update packaging, expose encode/decode entry modules, bridge RESM/NESM ([a93e947](https://github.com/endojs/endo/commit/a93e9472b24447f4e1fc790191f6953a9285ecfa))
 
 ### Bug Fixes
 
-* Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
-* **base64:** Typo in default decoded file name ([6338133](https://github.com/endojs/endo/commit/6338133150c4e4dc7dfd465f726286f4d742c1f7))
-* update to eslint 7.23.0 ([#652](https://github.com/endojs/endo/issues/652)) ([e9199f4](https://github.com/endojs/endo/commit/e9199f41c511b5df10593d931febdd90693b011a))
-* **base64:** Fix minor docs typo in usage ([185234e](https://github.com/endojs/endo/commit/185234efd86673e647d9ef303a5626233ac659dd))
-* **base64:** Refine package.json ([fea29e5](https://github.com/endojs/endo/commit/fea29e5e3ffb574b32cf09bf0039f0816a203511))
-
-
+- Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
+- **base64:** Typo in default decoded file name ([6338133](https://github.com/endojs/endo/commit/6338133150c4e4dc7dfd465f726286f4d742c1f7))
+- update to eslint 7.23.0 ([#652](https://github.com/endojs/endo/issues/652)) ([e9199f4](https://github.com/endojs/endo/commit/e9199f41c511b5df10593d931febdd90693b011a))
+- **base64:** Fix minor docs typo in usage ([185234e](https://github.com/endojs/endo/commit/185234efd86673e647d9ef303a5626233ac659dd))
+- **base64:** Refine package.json ([fea29e5](https://github.com/endojs/endo/commit/fea29e5e3ffb574b32cf09bf0039f0816a203511))
 
 # 0.1.0 (2020-12-10)
 
-
 ### Features
 
-* **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
+- **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Transcodes base64",
   "keywords": [
     "base64",
@@ -39,7 +39,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,656 +3,388 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [2.4.2](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.1...@endo/bundle-source@2.4.2) (2022-11-14)
+### [2.4.3](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.2...@endo/bundle-source@2.4.3) (2022-12-23)
 
 **Note:** Version bump only for package @endo/bundle-source
 
+### [2.4.2](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.1...@endo/bundle-source@2.4.2) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/bundle-source
 
 ### [2.4.1](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.0...@endo/bundle-source@2.4.1) (2022-10-24)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ## [2.4.0](https://github.com/endojs/endo/compare/@endo/bundle-source@2.3.1...@endo/bundle-source@2.4.0) (2022-10-19)
-
 
 ### Features
 
-* **bundle-source:** make nestedEvaluate API compatible with getExport ([ec279a4](https://github.com/endojs/endo/commit/ec279a4dd7275f12c7a448d120e8fdf743061f89))
-
+- **bundle-source:** make nestedEvaluate API compatible with getExport ([ec279a4](https://github.com/endojs/endo/commit/ec279a4dd7275f12c7a448d120e8fdf743061f89))
 
 ### Bug Fixes
 
-* **bundle-source:** strip longest common prefix from bundle names ([51d30d8](https://github.com/endojs/endo/commit/51d30d8e5b8455e0e9d689596255fed56113f900))
-
-
+- **bundle-source:** strip longest common prefix from bundle names ([51d30d8](https://github.com/endojs/endo/commit/51d30d8e5b8455e0e9d689596255fed56113f900))
 
 ### [2.3.1](https://github.com/endojs/endo/compare/@endo/bundle-source@2.3.0...@endo/bundle-source@2.3.1) (2022-09-27)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ## [2.3.0](https://github.com/endojs/endo/compare/@endo/bundle-source@2.2.6...@endo/bundle-source@2.3.0) (2022-09-14)
-
 
 ### Features
 
-* **bundle-source:** Add JSON cache mode ([b73a7b8](https://github.com/endojs/endo/commit/b73a7b8f921818866bb2bf0b982fb93fefaa1860))
-
+- **bundle-source:** Add JSON cache mode ([b73a7b8](https://github.com/endojs/endo/commit/b73a7b8f921818866bb2bf0b982fb93fefaa1860))
 
 ### Bug Fixes
 
-* **bundle-source:** Remove redundant init devDependency ([1ef867c](https://github.com/endojs/endo/commit/1ef867cf277aeb6b6d40c196a0e362e08cce1b6c))
-
-
+- **bundle-source:** Remove redundant init devDependency ([1ef867c](https://github.com/endojs/endo/commit/1ef867cf277aeb6b6d40c196a0e362e08cce1b6c))
 
 ### [2.2.6](https://github.com/endojs/endo/compare/@endo/bundle-source@2.2.5...@endo/bundle-source@2.2.6) (2022-08-26)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ### [2.2.5](https://github.com/endojs/endo/compare/@endo/bundle-source@2.2.4...@endo/bundle-source@2.2.5) (2022-08-26)
 
 **Note:** Version bump only for package @endo/bundle-source
-
-
-
-
 
 ### [2.2.4](https://github.com/endojs/endo/compare/@endo/bundle-source@2.2.3...@endo/bundle-source@2.2.4) (2022-08-25)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ### [2.2.3](https://github.com/endojs/endo/compare/@endo/bundle-source@2.2.2...@endo/bundle-source@2.2.3) (2022-08-23)
 
 **Note:** Version bump only for package @endo/bundle-source
-
-
-
-
 
 ### [2.2.2](https://github.com/endojs/endo/compare/@endo/bundle-source@2.2.1...@endo/bundle-source@2.2.2) (2022-06-28)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ### [2.2.1](https://github.com/endojs/endo/compare/@endo/bundle-source@2.2.0...@endo/bundle-source@2.2.1) (2022-06-11)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ## [2.2.0](https://github.com/endojs/endo/compare/@endo/bundle-source@2.1.4...@endo/bundle-source@2.2.0) (2022-04-15)
-
 
 ### Features
 
-* **bundle-source:** CLI tool with caching ([#1160](https://github.com/endojs/endo/issues/1160)) ([05fdfb5](https://github.com/endojs/endo/commit/05fdfb50861e747df9e40d71382b31ce78c48e72))
-
+- **bundle-source:** CLI tool with caching ([#1160](https://github.com/endojs/endo/issues/1160)) ([05fdfb5](https://github.com/endojs/endo/commit/05fdfb50861e747df9e40d71382b31ce78c48e72))
 
 ### Bug Fixes
 
-* **bundle-source:** Limit public API to intentionally exported modules ([eabb877](https://github.com/endojs/endo/commit/eabb8771eb9309f19dbd7644ef795b85055abe81))
-
-
+- **bundle-source:** Limit public API to intentionally exported modules ([eabb877](https://github.com/endojs/endo/commit/eabb8771eb9309f19dbd7644ef795b85055abe81))
 
 ### [2.1.4](https://github.com/endojs/endo/compare/@endo/bundle-source@2.1.3...@endo/bundle-source@2.1.4) (2022-04-14)
 
-
 ### Bug Fixes
 
-* **bundle-source:** Use a github reference instead of a bundled tarball for rollup patch ([1bf0c18](https://github.com/endojs/endo/commit/1bf0c187e04bfe015850a91d51a33074aeebfde4))
-
-
+- **bundle-source:** Use a github reference instead of a bundled tarball for rollup patch ([1bf0c18](https://github.com/endojs/endo/commit/1bf0c187e04bfe015850a91d51a33074aeebfde4))
 
 ### [2.1.3](https://github.com/endojs/endo/compare/@endo/bundle-source@2.1.2...@endo/bundle-source@2.1.3) (2022-04-13)
 
-
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [2.1.2](https://github.com/endojs/endo/compare/@endo/bundle-source@2.1.1...@endo/bundle-source@2.1.2) (2022-04-12)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ### [2.1.1](https://github.com/endojs/endo/compare/@endo/bundle-source@2.1.0...@endo/bundle-source@2.1.1) (2022-03-07)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ## [2.1.0](https://github.com/endojs/endo/compare/@endo/bundle-source@2.0.7...@endo/bundle-source@2.1.0) (2022-03-02)
-
 
 ### Features
 
-* **bundle-source:** Add hash to Endo Zip Base64 bundle format ([b582931](https://github.com/endojs/endo/commit/b5829313daeaf1e910a9804e13acb3f1b413b4a6))
-* **bundle-source:** use newer babel with Agoric fixes ([e68f794](https://github.com/endojs/endo/commit/e68f794a182182d8e64bce2829dd90b4d9e4d947))
-
+- **bundle-source:** Add hash to Endo Zip Base64 bundle format ([b582931](https://github.com/endojs/endo/commit/b5829313daeaf1e910a9804e13acb3f1b413b4a6))
+- **bundle-source:** use newer babel with Agoric fixes ([e68f794](https://github.com/endojs/endo/commit/e68f794a182182d8e64bce2829dd90b4d9e4d947))
 
 ### Bug Fixes
 
-* **bundle-source:** c8 is a devDependency ([165ca62](https://github.com/endojs/endo/commit/165ca62738be5aff511a75347f68c5bcd923b908))
-* **bundle-source:** Remove change detector test ([c687592](https://github.com/endojs/endo/commit/c687592bd9c04a0dda550adaa3c06a351b62b0d2))
-* **bundle-source:** Upgrade babel-generator ([9feef03](https://github.com/endojs/endo/commit/9feef0372c6424870f86a7a14742eadb8aa57c53))
-
-
+- **bundle-source:** c8 is a devDependency ([165ca62](https://github.com/endojs/endo/commit/165ca62738be5aff511a75347f68c5bcd923b908))
+- **bundle-source:** Remove change detector test ([c687592](https://github.com/endojs/endo/commit/c687592bd9c04a0dda550adaa3c06a351b62b0d2))
+- **bundle-source:** Upgrade babel-generator ([9feef03](https://github.com/endojs/endo/commit/9feef0372c6424870f86a7a14742eadb8aa57c53))
 
 ### [2.0.7](https://github.com/endojs/endo/compare/@endo/bundle-source@2.0.6...@endo/bundle-source@2.0.7) (2022-02-20)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ### [2.0.6](https://github.com/endojs/endo/compare/@endo/bundle-source@2.0.5...@endo/bundle-source@2.0.6) (2022-02-18)
-
 
 ### Bug Fixes
 
-* adds some missing hardens ([#1077](https://github.com/endojs/endo/issues/1077)) ([1b6d8fd](https://github.com/endojs/endo/commit/1b6d8fdb2ca24f95b4c972ed26446044158c2572))
-* **bundle-source:** Add jsconfig for TypeScript ([952c415](https://github.com/endojs/endo/commit/952c4151b72d34ca274001d21f8234dd79be1b34))
-
-
+- adds some missing hardens ([#1077](https://github.com/endojs/endo/issues/1077)) ([1b6d8fd](https://github.com/endojs/endo/commit/1b6d8fdb2ca24f95b4c972ed26446044158c2572))
+- **bundle-source:** Add jsconfig for TypeScript ([952c415](https://github.com/endojs/endo/commit/952c4151b72d34ca274001d21f8234dd79be1b34))
 
 ### [2.0.5](https://github.com/endojs/endo/compare/@endo/bundle-source@2.0.4...@endo/bundle-source@2.0.5) (2022-01-31)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ### [2.0.4](https://github.com/endojs/endo/compare/@endo/bundle-source@2.0.3...@endo/bundle-source@2.0.4) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [2.0.3](https://github.com/endojs/endo/compare/@endo/bundle-source@2.0.2...@endo/bundle-source@2.0.3) (2022-01-25)
 
 **Note:** Version bump only for package @endo/bundle-source
 
-
-
-
-
 ### 2.0.2 (2022-01-23)
-
 
 ### Bug Fixes
 
-* **bundle-source:** Support Node.js 12 ([5f64d07](https://github.com/endojs/endo/commit/5f64d07dcfdcab6d1b599047b297c759b85466ea))
-* **bundle-source:** Windows support for tests ([59f3fc1](https://github.com/endojs/endo/commit/59f3fc11f9a0d959f172469caffb86c4749c2fbe))
-
-
+- **bundle-source:** Support Node.js 12 ([5f64d07](https://github.com/endojs/endo/commit/5f64d07dcfdcab6d1b599047b297c759b85466ea))
+- **bundle-source:** Windows support for tests ([59f3fc1](https://github.com/endojs/endo/commit/59f3fc11f9a0d959f172469caffb86c4749c2fbe))
 
 ### [2.0.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@2.0.0...@agoric/bundle-source@2.0.1) (2021-12-02)
 
-
 ### Bug Fixes
 
-* **deps:** remove explicit `@agoric/babel-standalone` ([4f22453](https://github.com/Agoric/agoric-sdk/commit/4f22453a6f2de1a2c27ae8ad0d11b13116890dab))
-
-
+- **deps:** remove explicit `@agoric/babel-standalone` ([4f22453](https://github.com/Agoric/agoric-sdk/commit/4f22453a6f2de1a2c27ae8ad0d11b13116890dab))
 
 ## [2.0.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.11...@agoric/bundle-source@2.0.0) (2021-10-13)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Switch default bundle type to endoZipBase64
+- Switch default bundle type to endoZipBase64
 
 ### Code Refactoring
 
-* Switch default bundle type to endoZipBase64 ([53cc1e5](https://github.com/Agoric/agoric-sdk/commit/53cc1e5a5af9861e96cff3b841e4269db8a302c0)), closes [#3859](https://github.com/Agoric/agoric-sdk/issues/3859)
-
-
+- Switch default bundle type to endoZipBase64 ([53cc1e5](https://github.com/Agoric/agoric-sdk/commit/53cc1e5a5af9861e96cff3b841e4269db8a302c0)), closes [#3859](https://github.com/Agoric/agoric-sdk/issues/3859)
 
 ### [1.4.11](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.10...@agoric/bundle-source@1.4.11) (2021-09-23)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ### [1.4.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.9...@agoric/bundle-source@1.4.10) (2021-09-15)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ### [1.4.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.8...@agoric/bundle-source@1.4.9) (2021-08-18)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ### [1.4.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.7...@agoric/bundle-source@1.4.8) (2021-08-17)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ### [1.4.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.4...@agoric/bundle-source@1.4.7) (2021-08-15)
 
 ### 0.26.10 (2021-07-28)
 
-
 ### Bug Fixes
 
-* **bundle-source:** Remove lingering package scaffold file ([e49edee](https://github.com/Agoric/agoric-sdk/commit/e49edee2d0e499e1710de2ac03ff59876e8252a9))
-
-
+- **bundle-source:** Remove lingering package scaffold file ([e49edee](https://github.com/Agoric/agoric-sdk/commit/e49edee2d0e499e1710de2ac03ff59876e8252a9))
 
 ### [1.4.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.4...@agoric/bundle-source@1.4.6) (2021-08-14)
 
 ### 0.26.10 (2021-07-28)
 
-
 ### Bug Fixes
 
-* **bundle-source:** Remove lingering package scaffold file ([e49edee](https://github.com/Agoric/agoric-sdk/commit/e49edee2d0e499e1710de2ac03ff59876e8252a9))
-
-
+- **bundle-source:** Remove lingering package scaffold file ([e49edee](https://github.com/Agoric/agoric-sdk/commit/e49edee2d0e499e1710de2ac03ff59876e8252a9))
 
 ### [1.4.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.4...@agoric/bundle-source@1.4.5) (2021-07-28)
 
-
 ### Bug Fixes
 
-* **bundle-source:** Remove lingering package scaffold file ([e49edee](https://github.com/Agoric/agoric-sdk/commit/e49edee2d0e499e1710de2ac03ff59876e8252a9))
-
-
+- **bundle-source:** Remove lingering package scaffold file ([e49edee](https://github.com/Agoric/agoric-sdk/commit/e49edee2d0e499e1710de2ac03ff59876e8252a9))
 
 ### [1.4.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.3...@agoric/bundle-source@1.4.4) (2021-07-01)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ### [1.4.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.2...@agoric/bundle-source@1.4.3) (2021-06-28)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ### [1.4.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.1...@agoric/bundle-source@1.4.2) (2021-06-25)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ### [1.4.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.4.0...@agoric/bundle-source@1.4.1) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.4.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.9...@agoric/bundle-source@1.4.0) (2021-06-23)
-
 
 ### Features
 
-* **bundle-source:** Add dev mode option ([866b98a](https://github.com/Agoric/agoric-sdk/commit/866b98a5c3667a66700d6023a7765ac6d7edcda7))
-* **bundle-source:** Endo support for following symlinks ([43dea96](https://github.com/Agoric/agoric-sdk/commit/43dea963a558f367a142fc103abc8fb11aac4482))
-
-
+- **bundle-source:** Add dev mode option ([866b98a](https://github.com/Agoric/agoric-sdk/commit/866b98a5c3667a66700d6023a7765ac6d7edcda7))
+- **bundle-source:** Endo support for following symlinks ([43dea96](https://github.com/Agoric/agoric-sdk/commit/43dea963a558f367a142fc103abc8fb11aac4482))
 
 ### [1.3.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.8...@agoric/bundle-source@1.3.9) (2021-06-16)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ### [1.3.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.7...@agoric/bundle-source@1.3.8) (2021-06-15)
-
 
 ### Bug Fixes
 
-* Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
-* Preinitialize Babel ([bb76808](https://github.com/Agoric/agoric-sdk/commit/bb768089c3588e54612d7c9a4528972b5688f4e6))
-* remove references to @agoric/babel-parser ([e4b1e2b](https://github.com/Agoric/agoric-sdk/commit/e4b1e2b4bb13436ef53f055136a4a1d5d933d99e))
-* solve nondeterminism in rollup2 output order ([c72b52d](https://github.com/Agoric/agoric-sdk/commit/c72b52d69d5ca4609ce648f24c9d30f66b200374))
-* upgrade acorn and babel parser ([048cc92](https://github.com/Agoric/agoric-sdk/commit/048cc925b3090f77e998fef1f3ac26846c4a8f26))
-
-
+- Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
+- Preinitialize Babel ([bb76808](https://github.com/Agoric/agoric-sdk/commit/bb768089c3588e54612d7c9a4528972b5688f4e6))
+- remove references to @agoric/babel-parser ([e4b1e2b](https://github.com/Agoric/agoric-sdk/commit/e4b1e2b4bb13436ef53f055136a4a1d5d933d99e))
+- solve nondeterminism in rollup2 output order ([c72b52d](https://github.com/Agoric/agoric-sdk/commit/c72b52d69d5ca4609ce648f24c9d30f66b200374))
+- upgrade acorn and babel parser ([048cc92](https://github.com/Agoric/agoric-sdk/commit/048cc925b3090f77e998fef1f3ac26846c4a8f26))
 
 ## [1.3.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.6...@agoric/bundle-source@1.3.7) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.3.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.5...@agoric/bundle-source@1.3.6) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ## [1.3.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.4...@agoric/bundle-source@1.3.5) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.3.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.3...@agoric/bundle-source@1.3.4) (2021-04-22)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ## [1.3.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.2...@agoric/bundle-source@1.3.3) (2021-04-18)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.3.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.1...@agoric/bundle-source@1.3.2) (2021-04-16)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ## [1.3.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.3.0...@agoric/bundle-source@1.3.1) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 # [1.3.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.2.4...@agoric/bundle-source@1.3.0) (2021-04-06)
-
 
 ### Features
 
-* **bundle-source:** Apply evasive transforms to Endo archives ([#2768](https://github.com/Agoric/agoric-sdk/issues/2768)) ([e15cee8](https://github.com/Agoric/agoric-sdk/commit/e15cee88cf1f74e2debd4426dbc22a99b88fb1d6))
-* **bundle-source:** Specific ModuleFormat type ([#2767](https://github.com/Agoric/agoric-sdk/issues/2767)) ([6fe2ff7](https://github.com/Agoric/agoric-sdk/commit/6fe2ff7d535ef5749f4e9bf7056b5e7dab897a61))
-
-
-
-
+- **bundle-source:** Apply evasive transforms to Endo archives ([#2768](https://github.com/Agoric/agoric-sdk/issues/2768)) ([e15cee8](https://github.com/Agoric/agoric-sdk/commit/e15cee88cf1f74e2debd4426dbc22a99b88fb1d6))
+- **bundle-source:** Specific ModuleFormat type ([#2767](https://github.com/Agoric/agoric-sdk/issues/2767)) ([6fe2ff7](https://github.com/Agoric/agoric-sdk/commit/6fe2ff7d535ef5749f4e9bf7056b5e7dab897a61))
 
 ## [1.2.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.2.3...@agoric/bundle-source@1.2.4) (2021-03-24)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.2.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.2.2...@agoric/bundle-source@1.2.3) (2021-03-16)
-
 
 ### Bug Fixes
 
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-* upgrade ses to 0.12.3 to avoid console noise ([#2552](https://github.com/Agoric/agoric-sdk/issues/2552)) ([f59f5f5](https://github.com/Agoric/agoric-sdk/commit/f59f5f58d1567bb11710166b1dbc80f25c39a04f))
-
-
-
-
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
+- upgrade ses to 0.12.3 to avoid console noise ([#2552](https://github.com/Agoric/agoric-sdk/issues/2552)) ([f59f5f5](https://github.com/Agoric/agoric-sdk/commit/f59f5f58d1567bb11710166b1dbc80f25c39a04f))
 
 ## [1.2.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.2.1...@agoric/bundle-source@1.2.2) (2021-02-22)
 
-
 ### Bug Fixes
 
-* **bundle-source:** Downgrade @rollup/plugin-commonjs for Windows ([2721da7](https://github.com/Agoric/agoric-sdk/commit/2721da770aad3077f1024b71c217883f31461641))
-
-
-
-
+- **bundle-source:** Downgrade @rollup/plugin-commonjs for Windows ([2721da7](https://github.com/Agoric/agoric-sdk/commit/2721da770aad3077f1024b71c217883f31461641))
 
 ## [1.2.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.2.0...@agoric/bundle-source@1.2.1) (2021-02-16)
 
-
 ### Bug Fixes
 
-* explicit setting in test-sanity ([#2388](https://github.com/Agoric/agoric-sdk/issues/2388)) ([6be4e02](https://github.com/Agoric/agoric-sdk/commit/6be4e0212d19a542ead6cd4bcef4cb6688a9d7d3))
-* take advantage of `/.../` being stripped from stack traces ([7acacc0](https://github.com/Agoric/agoric-sdk/commit/7acacc0d6ac06c37065ce984cc9147c945c572e5))
-
-
-
-
+- explicit setting in test-sanity ([#2388](https://github.com/Agoric/agoric-sdk/issues/2388)) ([6be4e02](https://github.com/Agoric/agoric-sdk/commit/6be4e0212d19a542ead6cd4bcef4cb6688a9d7d3))
+- take advantage of `/.../` being stripped from stack traces ([7acacc0](https://github.com/Agoric/agoric-sdk/commit/7acacc0d6ac06c37065ce984cc9147c945c572e5))
 
 # [1.2.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.10...@agoric/bundle-source@1.2.0) (2020-12-10)
 
-
 ### Features
 
-* **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
-
-
-
-
+- **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
 
 ## [1.1.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.10-dev.0...@agoric/bundle-source@1.1.10) (2020-11-07)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.1.10-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.9...@agoric/bundle-source@1.1.10-dev.0) (2020-10-19)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ## [1.1.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.9-dev.2...@agoric/bundle-source@1.1.9) (2020-10-11)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.1.9-dev.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.9-dev.1...@agoric/bundle-source@1.1.9-dev.2) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ## [1.1.9-dev.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.9-dev.0...@agoric/bundle-source@1.1.9-dev.1) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.1.9-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.8...@agoric/bundle-source@1.1.9-dev.0) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/bundle-source
-
-
-
-
 
 ## [1.1.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.7...@agoric/bundle-source@1.1.8) (2020-09-16)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.1.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.6...@agoric/bundle-source@1.1.7) (2020-08-31)
-
 
 ### Bug Fixes
 
-* **bundle-source:** fix comment misparse, make require optional ([e8f4127](https://github.com/Agoric/agoric-sdk/commit/e8f412767c5ad8a0e75aa29357a052fd2164e811)), closes [#1281](https://github.com/Agoric/agoric-sdk/issues/1281) [#362](https://github.com/Agoric/agoric-sdk/issues/362)
-* get line numbers to be proper again ([8c31701](https://github.com/Agoric/agoric-sdk/commit/8c31701a6b4353e549b7e8891114a41ee48457c8))
-* use Babel to strip comments and unmap line numbers ([24edbbc](https://github.com/Agoric/agoric-sdk/commit/24edbbc985500233ea876817228bbccc71b2bac3))
-* use only loc.start to ensure nodes begin on the correct line ([dc3bc65](https://github.com/Agoric/agoric-sdk/commit/dc3bc658cc2900a1f074c8d23fd3e5bae9773e18))
-
-
-
-
+- **bundle-source:** fix comment misparse, make require optional ([e8f4127](https://github.com/Agoric/agoric-sdk/commit/e8f412767c5ad8a0e75aa29357a052fd2164e811)), closes [#1281](https://github.com/Agoric/agoric-sdk/issues/1281) [#362](https://github.com/Agoric/agoric-sdk/issues/362)
+- get line numbers to be proper again ([8c31701](https://github.com/Agoric/agoric-sdk/commit/8c31701a6b4353e549b7e8891114a41ee48457c8))
+- use Babel to strip comments and unmap line numbers ([24edbbc](https://github.com/Agoric/agoric-sdk/commit/24edbbc985500233ea876817228bbccc71b2bac3))
+- use only loc.start to ensure nodes begin on the correct line ([dc3bc65](https://github.com/Agoric/agoric-sdk/commit/dc3bc658cc2900a1f074c8d23fd3e5bae9773e18))
 
 ## [1.1.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.5...@agoric/bundle-source@1.1.6) (2020-06-30)
 
-
 ### Bug Fixes
 
-* **bundle-source:** tests use install-ses ([f793424](https://github.com/Agoric/agoric-sdk/commit/f793424ea4314f5cf0fe61c6e49590b2d78e13c6))
-* handle circular module references in nestedEvaluate ([9790320](https://github.com/Agoric/agoric-sdk/commit/97903204fa1bd2fd4fec339d7e27e234148ca126))
-
-
-
-
+- **bundle-source:** tests use install-ses ([f793424](https://github.com/Agoric/agoric-sdk/commit/f793424ea4314f5cf0fe61c6e49590b2d78e13c6))
+- handle circular module references in nestedEvaluate ([9790320](https://github.com/Agoric/agoric-sdk/commit/97903204fa1bd2fd4fec339d7e27e234148ca126))
 
 ## [1.1.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.4...@agoric/bundle-source@1.1.5) (2020-05-17)
 
-
 ### Bug Fixes
 
-* make output from bundleSource correspond to source map lines ([c1ddd4a](https://github.com/Agoric/agoric-sdk/commit/c1ddd4a0a27de9561b3bd827213562d9741e61a8))
-* remove many build steps ([6c7d3bb](https://github.com/Agoric/agoric-sdk/commit/6c7d3bb0c70277c22f8eda40525d7240141a5434))
-
-
-
-
+- make output from bundleSource correspond to source map lines ([c1ddd4a](https://github.com/Agoric/agoric-sdk/commit/c1ddd4a0a27de9561b3bd827213562d9741e61a8))
+- remove many build steps ([6c7d3bb](https://github.com/Agoric/agoric-sdk/commit/6c7d3bb0c70277c22f8eda40525d7240141a5434))
 
 ## [1.1.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.3...@agoric/bundle-source@1.1.4) (2020-05-10)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.1.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.2...@agoric/bundle-source@1.1.3) (2020-05-04)
-
 
 ### Bug Fixes
 
-* default to nestedEvaluate format for better debugging ([4502f39](https://github.com/Agoric/agoric-sdk/commit/4502f39a46096b6f02a3a251989060b3bce4c3b2))
-* use the new (typed) harden package ([2eb1af0](https://github.com/Agoric/agoric-sdk/commit/2eb1af08fe3967629a3ce165752fd501a5c85a96))
-
-
-
-
+- default to nestedEvaluate format for better debugging ([4502f39](https://github.com/Agoric/agoric-sdk/commit/4502f39a46096b6f02a3a251989060b3bce4c3b2))
+- use the new (typed) harden package ([2eb1af0](https://github.com/Agoric/agoric-sdk/commit/2eb1af08fe3967629a3ce165752fd501a5c85a96))
 
 ## [1.1.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.2-alpha.0...@agoric/bundle-source@1.1.2) (2020-04-13)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.1.2-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.1...@agoric/bundle-source@1.1.2-alpha.0) (2020-04-12)
-
 
 ### Bug Fixes
 
-* rewrite HTML comments and import expressions for SES's sake ([1a970f6](https://github.com/Agoric/agoric-sdk/commit/1a970f65b67e047711e53949a286f1587b9a2e75))
-
-
-
-
+- rewrite HTML comments and import expressions for SES's sake ([1a970f6](https://github.com/Agoric/agoric-sdk/commit/1a970f65b67e047711e53949a286f1587b9a2e75))
 
 ## [1.1.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.1-alpha.0...@agoric/bundle-source@1.1.1) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 ## [1.1.1-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/bundle-source@1.1.0...@agoric/bundle-source@1.1.1-alpha.0) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/bundle-source
 
-
-
-
-
 # 1.1.0 (2020-03-26)
-
 
 ### Bug Fixes
 
-* make code clearer ([efc6b4a](https://github.com/Agoric/bundle-source/commit/efc6b4a369cc23813788f5626c61ec412e4e3f6a))
-* remove 'Nat' from the set that SwingSet provides to kernel/vat code ([b4798d9](https://github.com/Agoric/bundle-source/commit/b4798d9e323c4cc16beca8c7f2547bce59334ae4))
-* silence the builtin modules warning in agoric-cli deploy ([9043516](https://github.com/Agoric/bundle-source/commit/904351655f8acedd5720e5f0cc3ace83b5cf6192))
-* **agoric-cli:** changes to make `agoric --sdk` basically work again ([#459](https://github.com/Agoric/bundle-source/issues/459)) ([1dc046a](https://github.com/Agoric/bundle-source/commit/1dc046a02d5e616d33f48954e307692b43008442))
-* **bundle-source:** regain default 'getExport' ([f234d49](https://github.com/Agoric/bundle-source/commit/f234d49be14d50d13249d79f7302aa8e594e23d2))
-* **bundle-source:** remove `"type": "module"` from package.json ([326b00a](https://github.com/Agoric/bundle-source/commit/326b00af1f01383df0b3cdf3dbb9f1c6d2273002)), closes [#219](https://github.com/Agoric/bundle-source/issues/219)
-
+- make code clearer ([efc6b4a](https://github.com/Agoric/bundle-source/commit/efc6b4a369cc23813788f5626c61ec412e4e3f6a))
+- remove 'Nat' from the set that SwingSet provides to kernel/vat code ([b4798d9](https://github.com/Agoric/bundle-source/commit/b4798d9e323c4cc16beca8c7f2547bce59334ae4))
+- silence the builtin modules warning in agoric-cli deploy ([9043516](https://github.com/Agoric/bundle-source/commit/904351655f8acedd5720e5f0cc3ace83b5cf6192))
+- **agoric-cli:** changes to make `agoric --sdk` basically work again ([#459](https://github.com/Agoric/bundle-source/issues/459)) ([1dc046a](https://github.com/Agoric/bundle-source/commit/1dc046a02d5e616d33f48954e307692b43008442))
+- **bundle-source:** regain default 'getExport' ([f234d49](https://github.com/Agoric/bundle-source/commit/f234d49be14d50d13249d79f7302aa8e594e23d2))
+- **bundle-source:** remove `"type": "module"` from package.json ([326b00a](https://github.com/Agoric/bundle-source/commit/326b00af1f01383df0b3cdf3dbb9f1c6d2273002)), closes [#219](https://github.com/Agoric/bundle-source/issues/219)
 
 ### Features
 
-* **bundle-source:** make getExport evaluate separate modules ([bec9c66](https://github.com/Agoric/bundle-source/commit/bec9c661f9bf08ae676ba3ae3707c0e23599a58d))
+- **bundle-source:** make getExport evaluate separate modules ([bec9c66](https://github.com/Agoric/bundle-source/commit/bec9c661f9bf08ae676ba3ae3707c0e23599a58d))

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",
@@ -29,9 +29,9 @@
     "@agoric/babel-generator": "^7.17.4",
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
-    "@endo/base64": "^0.2.28",
-    "@endo/compartment-mapper": "^0.8.0",
-    "@endo/init": "^0.5.52",
+    "@endo/base64": "^0.2.29",
+    "@endo/compartment-mapper": "^0.8.1",
+    "@endo/init": "^0.5.53",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "acorn": "^8.2.4",
@@ -39,8 +39,8 @@
     "source-map": "^0.7.3"
   },
   "devDependencies": {
-    "@endo/lockdown": "^0.1.24",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/lockdown": "^0.1.25",
+    "@endo/ses-ava": "^0.2.37",
     "ava": "^5.1.0",
     "c8": "^7.7.3"
   },

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,714 +3,435 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [2.0.18](https://github.com/endojs/endo/compare/@endo/captp@2.0.17...@endo/captp@2.0.18) (2022-11-14)
-
+### [2.0.19](https://github.com/endojs/endo/compare/@endo/captp@2.0.18...@endo/captp@2.0.19) (2022-12-23)
 
 ### Bug Fixes
 
-* assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
-* fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
+- **captp:** Serialize serialization errors ([98a7720](https://github.com/endojs/endo/commit/98a77205235b456b2859eed4d3d7e5bbb5c03b7a))
+- change unsafe then to E.when ([#1407](https://github.com/endojs/endo/issues/1407)) ([5493e91](https://github.com/endojs/endo/commit/5493e91525be96128a7309a2f94434d50aac9792))
 
+### [2.0.18](https://github.com/endojs/endo/compare/@endo/captp@2.0.17...@endo/captp@2.0.18) (2022-11-14)
 
+### Bug Fixes
+
+- assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
+- fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
 
 ### [2.0.17](https://github.com/endojs/endo/compare/@endo/captp@2.0.16...@endo/captp@2.0.17) (2022-10-24)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.16](https://github.com/endojs/endo/compare/@endo/captp@2.0.15...@endo/captp@2.0.16) (2022-10-19)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.15](https://github.com/endojs/endo/compare/@endo/captp@2.0.14...@endo/captp@2.0.15) (2022-09-27)
-
 
 ### Bug Fixes
 
-* Provide smallcaps encoding in addition to capData ([#1282](https://github.com/endojs/endo/issues/1282)) ([233dbe2](https://github.com/endojs/endo/commit/233dbe2e159e454fd3bcdd0e08b15c4439b56ba7))
-
-
+- Provide smallcaps encoding in addition to capData ([#1282](https://github.com/endojs/endo/issues/1282)) ([233dbe2](https://github.com/endojs/endo/commit/233dbe2e159e454fd3bcdd0e08b15c4439b56ba7))
 
 ### [2.0.14](https://github.com/endojs/endo/compare/@endo/captp@2.0.13...@endo/captp@2.0.14) (2022-09-14)
 
-
 ### Bug Fixes
 
-* alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
-
-
+- alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
 
 ### [2.0.13](https://github.com/endojs/endo/compare/@endo/captp@2.0.12...@endo/captp@2.0.13) (2022-08-26)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.12](https://github.com/endojs/endo/compare/@endo/captp@2.0.11...@endo/captp@2.0.12) (2022-08-26)
 
 **Note:** Version bump only for package @endo/captp
-
-
-
-
 
 ### [2.0.11](https://github.com/endojs/endo/compare/@endo/captp@2.0.10...@endo/captp@2.0.11) (2022-08-25)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.10](https://github.com/endojs/endo/compare/@endo/captp@2.0.9...@endo/captp@2.0.10) (2022-08-23)
-
 
 ### Bug Fixes
 
-* more hardens ([#1241](https://github.com/endojs/endo/issues/1241)) ([b6ff811](https://github.com/endojs/endo/commit/b6ff8118a92fd72c5309b2bb285fac08d0531d92))
-
-
+- more hardens ([#1241](https://github.com/endojs/endo/issues/1241)) ([b6ff811](https://github.com/endojs/endo/commit/b6ff8118a92fd72c5309b2bb285fac08d0531d92))
 
 ### [2.0.9](https://github.com/endojs/endo/compare/@endo/captp@2.0.8...@endo/captp@2.0.9) (2022-06-28)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.8](https://github.com/endojs/endo/compare/@endo/captp@2.0.7...@endo/captp@2.0.8) (2022-06-11)
 
 **Note:** Version bump only for package @endo/captp
-
-
-
-
 
 ### [2.0.7](https://github.com/endojs/endo/compare/@endo/captp@2.0.6...@endo/captp@2.0.7) (2022-04-15)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.6](https://github.com/endojs/endo/compare/@endo/captp@2.0.5...@endo/captp@2.0.6) (2022-04-14)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.5](https://github.com/endojs/endo/compare/@endo/captp@2.0.4...@endo/captp@2.0.5) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [2.0.4](https://github.com/endojs/endo/compare/@endo/captp@2.0.3...@endo/captp@2.0.4) (2022-04-12)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.3](https://github.com/endojs/endo/compare/@endo/captp@2.0.2...@endo/captp@2.0.3) (2022-03-07)
 
 **Note:** Version bump only for package @endo/captp
-
-
-
-
 
 ### [2.0.2](https://github.com/endojs/endo/compare/@endo/captp@2.0.1...@endo/captp@2.0.2) (2022-03-02)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [2.0.1](https://github.com/endojs/endo/compare/@endo/captp@2.0.0...@endo/captp@2.0.1) (2022-02-20)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ## [2.0.0](https://github.com/endojs/endo/compare/@endo/captp@1.10.12...@endo/captp@2.0.0) (2022-02-18)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **marshal:** Remove ambient types
+- **marshal:** Remove ambient types
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* **marshal:** Remove ambient types ([2a9cf63](https://github.com/endojs/endo/commit/2a9cf6372042b1fb16e1c96af5f3f9526978570a))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- **marshal:** Remove ambient types ([2a9cf63](https://github.com/endojs/endo/commit/2a9cf6372042b1fb16e1c96af5f3f9526978570a))
 
 ### [1.10.12](https://github.com/endojs/endo/compare/@endo/captp@1.10.11...@endo/captp@1.10.12) (2022-01-31)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### [1.10.11](https://github.com/endojs/endo/compare/@endo/captp@1.10.10...@endo/captp@1.10.11) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [1.10.10](https://github.com/endojs/endo/compare/@endo/captp@1.10.9...@endo/captp@1.10.10) (2022-01-25)
 
 **Note:** Version bump only for package @endo/captp
 
-
-
-
-
 ### 1.10.9 (2022-01-23)
-
 
 ### Bug Fixes
 
-* **captp:** Windows test support ([67c8cc1](https://github.com/endojs/endo/commit/67c8cc1ced1c8be8dc8b795e56198b0dc5da1e7b))
-
-
+- **captp:** Windows test support ([67c8cc1](https://github.com/endojs/endo/commit/67c8cc1ced1c8be8dc8b795e56198b0dc5da1e7b))
 
 ### [1.10.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.7...@agoric/captp@1.10.8) (2021-12-22)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.10.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.6...@agoric/captp@1.10.7) (2021-12-02)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ### [1.10.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.5...@agoric/captp@1.10.6) (2021-10-13)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.10.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.4...@agoric/captp@1.10.5) (2021-09-23)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.10.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.3...@agoric/captp@1.10.4) (2021-09-15)
-
 
 ### Bug Fixes
 
-* more missing Fars. kill "this" ([#3746](https://github.com/Agoric/agoric-sdk/issues/3746)) ([7bd027a](https://github.com/Agoric/agoric-sdk/commit/7bd027a879f98a9a3f30429ee1b54e6057efec42))
-
-
+- more missing Fars. kill "this" ([#3746](https://github.com/Agoric/agoric-sdk/issues/3746)) ([7bd027a](https://github.com/Agoric/agoric-sdk/commit/7bd027a879f98a9a3f30429ee1b54e6057efec42))
 
 ### [1.10.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.2...@agoric/captp@1.10.3) (2021-08-18)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.10.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.1...@agoric/captp@1.10.2) (2021-08-17)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.10.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.10.0...@agoric/captp@1.10.1) (2021-08-16)
-
 
 ### Bug Fixes
 
-* remove more instances of `.cjs` files ([0f61d9b](https://github.com/Agoric/agoric-sdk/commit/0f61d9bff763aeb21c7b61010040ca5e7bd964eb))
-
-
+- remove more instances of `.cjs` files ([0f61d9b](https://github.com/Agoric/agoric-sdk/commit/0f61d9bff763aeb21c7b61010040ca5e7bd964eb))
 
 ## [1.10.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.20...@agoric/captp@1.10.0) (2021-08-15)
 
 ### 0.26.10 (2021-07-28)
 
-
 ### Features
 
-* **captp:** leverage makeSubscriptionKit to drive trapHost ([a350b9d](https://github.com/Agoric/agoric-sdk/commit/a350b9d4688bd156655e519dec9fe291b7353427))
-* **captp:** return Sync replies via arbitrary comm protocol ([c838e91](https://github.com/Agoric/agoric-sdk/commit/c838e918164fc136b0bcbd83029489c6893ea381))
-* **captp:** take suggestion in [#3289](https://github.com/Agoric/agoric-sdk/issues/3289) to prefix questionIDs ([a8e0e96](https://github.com/Agoric/agoric-sdk/commit/a8e0e965f7640dc1a1e75b15d4788916e9cd563e))
-* implement exportAsSyncable, and Sync powers ([714b214](https://github.com/Agoric/agoric-sdk/commit/714b214012e81faf2ac4955475a8504ef0c74a4a))
-* implement Sync for makeLoopback ([3d500a1](https://github.com/Agoric/agoric-sdk/commit/3d500a101d73995d434cbb48b9f5be206a076ed7))
-
+- **captp:** leverage makeSubscriptionKit to drive trapHost ([a350b9d](https://github.com/Agoric/agoric-sdk/commit/a350b9d4688bd156655e519dec9fe291b7353427))
+- **captp:** return Sync replies via arbitrary comm protocol ([c838e91](https://github.com/Agoric/agoric-sdk/commit/c838e918164fc136b0bcbd83029489c6893ea381))
+- **captp:** take suggestion in [#3289](https://github.com/Agoric/agoric-sdk/issues/3289) to prefix questionIDs ([a8e0e96](https://github.com/Agoric/agoric-sdk/commit/a8e0e965f7640dc1a1e75b15d4788916e9cd563e))
+- implement exportAsSyncable, and Sync powers ([714b214](https://github.com/Agoric/agoric-sdk/commit/714b214012e81faf2ac4955475a8504ef0c74a4a))
+- implement Sync for makeLoopback ([3d500a1](https://github.com/Agoric/agoric-sdk/commit/3d500a101d73995d434cbb48b9f5be206a076ed7))
 
 ### Bug Fixes
 
-* **captp:** clarify error handling ([21b72cd](https://github.com/Agoric/agoric-sdk/commit/21b72cd54ec95e9fcc86638086c7c0c09a3e71cf))
-* **captp:** don't rely on TextDecoder stream flag ([5a370a8](https://github.com/Agoric/agoric-sdk/commit/5a370a8404124409e5bbdf60c4ccf494fde8b103))
-* **captp:** ensure Sync(x) never returns a thenable ([d642c41](https://github.com/Agoric/agoric-sdk/commit/d642c414bd22036a72ab6db590d26393efd05568))
-* **captp:** ensure trapcap reply iteration is serial ([feda6c8](https://github.com/Agoric/agoric-sdk/commit/feda6c8510f56385c2becec40412223b4acf109d))
-* **captp:** more robust CTP_TRAP_ITERATE error handling ([003c3d1](https://github.com/Agoric/agoric-sdk/commit/003c3d16dc2301ae171d9cc60ab30509fa7ee9ea))
-* **captp:** properly export src/index.js ([592f0b7](https://github.com/Agoric/agoric-sdk/commit/592f0b78b6adcd2956c925b8294ed9452ff4c9bb))
-* **captp:** relax it.throw signature ([6fc842c](https://github.com/Agoric/agoric-sdk/commit/6fc842cc3160f134455a250c8a13418e07301848))
-* **solo:** clean up unnecessary deep captp import ([8b20562](https://github.com/Agoric/agoric-sdk/commit/8b20562b9cc3917818455ab7d85aa74c9efb3f56))
-* break up incoherent GetApply function into SyncImpl record ([1455298](https://github.com/Agoric/agoric-sdk/commit/14552986c6e47fde7eae720e449efce5aab23707))
-* don't create new promise IDs and stall the pipeline ([b90ae08](https://github.com/Agoric/agoric-sdk/commit/b90ae0835aec5484279eddcea4e9ccaa253d2db0))
-
-
+- **captp:** clarify error handling ([21b72cd](https://github.com/Agoric/agoric-sdk/commit/21b72cd54ec95e9fcc86638086c7c0c09a3e71cf))
+- **captp:** don't rely on TextDecoder stream flag ([5a370a8](https://github.com/Agoric/agoric-sdk/commit/5a370a8404124409e5bbdf60c4ccf494fde8b103))
+- **captp:** ensure Sync(x) never returns a thenable ([d642c41](https://github.com/Agoric/agoric-sdk/commit/d642c414bd22036a72ab6db590d26393efd05568))
+- **captp:** ensure trapcap reply iteration is serial ([feda6c8](https://github.com/Agoric/agoric-sdk/commit/feda6c8510f56385c2becec40412223b4acf109d))
+- **captp:** more robust CTP_TRAP_ITERATE error handling ([003c3d1](https://github.com/Agoric/agoric-sdk/commit/003c3d16dc2301ae171d9cc60ab30509fa7ee9ea))
+- **captp:** properly export src/index.js ([592f0b7](https://github.com/Agoric/agoric-sdk/commit/592f0b78b6adcd2956c925b8294ed9452ff4c9bb))
+- **captp:** relax it.throw signature ([6fc842c](https://github.com/Agoric/agoric-sdk/commit/6fc842cc3160f134455a250c8a13418e07301848))
+- **solo:** clean up unnecessary deep captp import ([8b20562](https://github.com/Agoric/agoric-sdk/commit/8b20562b9cc3917818455ab7d85aa74c9efb3f56))
+- break up incoherent GetApply function into SyncImpl record ([1455298](https://github.com/Agoric/agoric-sdk/commit/14552986c6e47fde7eae720e449efce5aab23707))
+- don't create new promise IDs and stall the pipeline ([b90ae08](https://github.com/Agoric/agoric-sdk/commit/b90ae0835aec5484279eddcea4e9ccaa253d2db0))
 
 ## [1.9.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.20...@agoric/captp@1.9.0) (2021-08-14)
 
 ### 0.26.10 (2021-07-28)
 
-
 ### Features
 
-* **captp:** leverage makeSubscriptionKit to drive trapHost ([a350b9d](https://github.com/Agoric/agoric-sdk/commit/a350b9d4688bd156655e519dec9fe291b7353427))
-* **captp:** return Sync replies via arbitrary comm protocol ([c838e91](https://github.com/Agoric/agoric-sdk/commit/c838e918164fc136b0bcbd83029489c6893ea381))
-* **captp:** take suggestion in [#3289](https://github.com/Agoric/agoric-sdk/issues/3289) to prefix questionIDs ([a8e0e96](https://github.com/Agoric/agoric-sdk/commit/a8e0e965f7640dc1a1e75b15d4788916e9cd563e))
-* implement exportAsSyncable, and Sync powers ([714b214](https://github.com/Agoric/agoric-sdk/commit/714b214012e81faf2ac4955475a8504ef0c74a4a))
-* implement Sync for makeLoopback ([3d500a1](https://github.com/Agoric/agoric-sdk/commit/3d500a101d73995d434cbb48b9f5be206a076ed7))
-
+- **captp:** leverage makeSubscriptionKit to drive trapHost ([a350b9d](https://github.com/Agoric/agoric-sdk/commit/a350b9d4688bd156655e519dec9fe291b7353427))
+- **captp:** return Sync replies via arbitrary comm protocol ([c838e91](https://github.com/Agoric/agoric-sdk/commit/c838e918164fc136b0bcbd83029489c6893ea381))
+- **captp:** take suggestion in [#3289](https://github.com/Agoric/agoric-sdk/issues/3289) to prefix questionIDs ([a8e0e96](https://github.com/Agoric/agoric-sdk/commit/a8e0e965f7640dc1a1e75b15d4788916e9cd563e))
+- implement exportAsSyncable, and Sync powers ([714b214](https://github.com/Agoric/agoric-sdk/commit/714b214012e81faf2ac4955475a8504ef0c74a4a))
+- implement Sync for makeLoopback ([3d500a1](https://github.com/Agoric/agoric-sdk/commit/3d500a101d73995d434cbb48b9f5be206a076ed7))
 
 ### Bug Fixes
 
-* **captp:** clarify error handling ([21b72cd](https://github.com/Agoric/agoric-sdk/commit/21b72cd54ec95e9fcc86638086c7c0c09a3e71cf))
-* **captp:** don't rely on TextDecoder stream flag ([5a370a8](https://github.com/Agoric/agoric-sdk/commit/5a370a8404124409e5bbdf60c4ccf494fde8b103))
-* **captp:** ensure Sync(x) never returns a thenable ([d642c41](https://github.com/Agoric/agoric-sdk/commit/d642c414bd22036a72ab6db590d26393efd05568))
-* **captp:** ensure trapcap reply iteration is serial ([feda6c8](https://github.com/Agoric/agoric-sdk/commit/feda6c8510f56385c2becec40412223b4acf109d))
-* **captp:** more robust CTP_TRAP_ITERATE error handling ([003c3d1](https://github.com/Agoric/agoric-sdk/commit/003c3d16dc2301ae171d9cc60ab30509fa7ee9ea))
-* **captp:** properly export src/index.js ([592f0b7](https://github.com/Agoric/agoric-sdk/commit/592f0b78b6adcd2956c925b8294ed9452ff4c9bb))
-* **captp:** relax it.throw signature ([6fc842c](https://github.com/Agoric/agoric-sdk/commit/6fc842cc3160f134455a250c8a13418e07301848))
-* **solo:** clean up unnecessary deep captp import ([8b20562](https://github.com/Agoric/agoric-sdk/commit/8b20562b9cc3917818455ab7d85aa74c9efb3f56))
-* break up incoherent GetApply function into SyncImpl record ([1455298](https://github.com/Agoric/agoric-sdk/commit/14552986c6e47fde7eae720e449efce5aab23707))
-* don't create new promise IDs and stall the pipeline ([b90ae08](https://github.com/Agoric/agoric-sdk/commit/b90ae0835aec5484279eddcea4e9ccaa253d2db0))
-
-
+- **captp:** clarify error handling ([21b72cd](https://github.com/Agoric/agoric-sdk/commit/21b72cd54ec95e9fcc86638086c7c0c09a3e71cf))
+- **captp:** don't rely on TextDecoder stream flag ([5a370a8](https://github.com/Agoric/agoric-sdk/commit/5a370a8404124409e5bbdf60c4ccf494fde8b103))
+- **captp:** ensure Sync(x) never returns a thenable ([d642c41](https://github.com/Agoric/agoric-sdk/commit/d642c414bd22036a72ab6db590d26393efd05568))
+- **captp:** ensure trapcap reply iteration is serial ([feda6c8](https://github.com/Agoric/agoric-sdk/commit/feda6c8510f56385c2becec40412223b4acf109d))
+- **captp:** more robust CTP_TRAP_ITERATE error handling ([003c3d1](https://github.com/Agoric/agoric-sdk/commit/003c3d16dc2301ae171d9cc60ab30509fa7ee9ea))
+- **captp:** properly export src/index.js ([592f0b7](https://github.com/Agoric/agoric-sdk/commit/592f0b78b6adcd2956c925b8294ed9452ff4c9bb))
+- **captp:** relax it.throw signature ([6fc842c](https://github.com/Agoric/agoric-sdk/commit/6fc842cc3160f134455a250c8a13418e07301848))
+- **solo:** clean up unnecessary deep captp import ([8b20562](https://github.com/Agoric/agoric-sdk/commit/8b20562b9cc3917818455ab7d85aa74c9efb3f56))
+- break up incoherent GetApply function into SyncImpl record ([1455298](https://github.com/Agoric/agoric-sdk/commit/14552986c6e47fde7eae720e449efce5aab23707))
+- don't create new promise IDs and stall the pipeline ([b90ae08](https://github.com/Agoric/agoric-sdk/commit/b90ae0835aec5484279eddcea4e9ccaa253d2db0))
 
 ## [1.8.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.20...@agoric/captp@1.8.0) (2021-07-28)
 
-
 ### Features
 
-* **captp:** leverage makeSubscriptionKit to drive trapHost ([a350b9d](https://github.com/Agoric/agoric-sdk/commit/a350b9d4688bd156655e519dec9fe291b7353427))
-* **captp:** return Sync replies via arbitrary comm protocol ([c838e91](https://github.com/Agoric/agoric-sdk/commit/c838e918164fc136b0bcbd83029489c6893ea381))
-* **captp:** take suggestion in [#3289](https://github.com/Agoric/agoric-sdk/issues/3289) to prefix questionIDs ([a8e0e96](https://github.com/Agoric/agoric-sdk/commit/a8e0e965f7640dc1a1e75b15d4788916e9cd563e))
-* implement exportAsSyncable, and Sync powers ([714b214](https://github.com/Agoric/agoric-sdk/commit/714b214012e81faf2ac4955475a8504ef0c74a4a))
-* implement Sync for makeLoopback ([3d500a1](https://github.com/Agoric/agoric-sdk/commit/3d500a101d73995d434cbb48b9f5be206a076ed7))
-
+- **captp:** leverage makeSubscriptionKit to drive trapHost ([a350b9d](https://github.com/Agoric/agoric-sdk/commit/a350b9d4688bd156655e519dec9fe291b7353427))
+- **captp:** return Sync replies via arbitrary comm protocol ([c838e91](https://github.com/Agoric/agoric-sdk/commit/c838e918164fc136b0bcbd83029489c6893ea381))
+- **captp:** take suggestion in [#3289](https://github.com/Agoric/agoric-sdk/issues/3289) to prefix questionIDs ([a8e0e96](https://github.com/Agoric/agoric-sdk/commit/a8e0e965f7640dc1a1e75b15d4788916e9cd563e))
+- implement exportAsSyncable, and Sync powers ([714b214](https://github.com/Agoric/agoric-sdk/commit/714b214012e81faf2ac4955475a8504ef0c74a4a))
+- implement Sync for makeLoopback ([3d500a1](https://github.com/Agoric/agoric-sdk/commit/3d500a101d73995d434cbb48b9f5be206a076ed7))
 
 ### Bug Fixes
 
-* **captp:** clarify error handling ([21b72cd](https://github.com/Agoric/agoric-sdk/commit/21b72cd54ec95e9fcc86638086c7c0c09a3e71cf))
-* **captp:** don't rely on TextDecoder stream flag ([5a370a8](https://github.com/Agoric/agoric-sdk/commit/5a370a8404124409e5bbdf60c4ccf494fde8b103))
-* **captp:** ensure Sync(x) never returns a thenable ([d642c41](https://github.com/Agoric/agoric-sdk/commit/d642c414bd22036a72ab6db590d26393efd05568))
-* **captp:** ensure trapcap reply iteration is serial ([feda6c8](https://github.com/Agoric/agoric-sdk/commit/feda6c8510f56385c2becec40412223b4acf109d))
-* **captp:** more robust CTP_TRAP_ITERATE error handling ([003c3d1](https://github.com/Agoric/agoric-sdk/commit/003c3d16dc2301ae171d9cc60ab30509fa7ee9ea))
-* **captp:** properly export src/index.js ([592f0b7](https://github.com/Agoric/agoric-sdk/commit/592f0b78b6adcd2956c925b8294ed9452ff4c9bb))
-* **captp:** relax it.throw signature ([6fc842c](https://github.com/Agoric/agoric-sdk/commit/6fc842cc3160f134455a250c8a13418e07301848))
-* **solo:** clean up unnecessary deep captp import ([8b20562](https://github.com/Agoric/agoric-sdk/commit/8b20562b9cc3917818455ab7d85aa74c9efb3f56))
-* break up incoherent GetApply function into SyncImpl record ([1455298](https://github.com/Agoric/agoric-sdk/commit/14552986c6e47fde7eae720e449efce5aab23707))
-* don't create new promise IDs and stall the pipeline ([b90ae08](https://github.com/Agoric/agoric-sdk/commit/b90ae0835aec5484279eddcea4e9ccaa253d2db0))
-
-
+- **captp:** clarify error handling ([21b72cd](https://github.com/Agoric/agoric-sdk/commit/21b72cd54ec95e9fcc86638086c7c0c09a3e71cf))
+- **captp:** don't rely on TextDecoder stream flag ([5a370a8](https://github.com/Agoric/agoric-sdk/commit/5a370a8404124409e5bbdf60c4ccf494fde8b103))
+- **captp:** ensure Sync(x) never returns a thenable ([d642c41](https://github.com/Agoric/agoric-sdk/commit/d642c414bd22036a72ab6db590d26393efd05568))
+- **captp:** ensure trapcap reply iteration is serial ([feda6c8](https://github.com/Agoric/agoric-sdk/commit/feda6c8510f56385c2becec40412223b4acf109d))
+- **captp:** more robust CTP_TRAP_ITERATE error handling ([003c3d1](https://github.com/Agoric/agoric-sdk/commit/003c3d16dc2301ae171d9cc60ab30509fa7ee9ea))
+- **captp:** properly export src/index.js ([592f0b7](https://github.com/Agoric/agoric-sdk/commit/592f0b78b6adcd2956c925b8294ed9452ff4c9bb))
+- **captp:** relax it.throw signature ([6fc842c](https://github.com/Agoric/agoric-sdk/commit/6fc842cc3160f134455a250c8a13418e07301848))
+- **solo:** clean up unnecessary deep captp import ([8b20562](https://github.com/Agoric/agoric-sdk/commit/8b20562b9cc3917818455ab7d85aa74c9efb3f56))
+- break up incoherent GetApply function into SyncImpl record ([1455298](https://github.com/Agoric/agoric-sdk/commit/14552986c6e47fde7eae720e449efce5aab23707))
+- don't create new promise IDs and stall the pipeline ([b90ae08](https://github.com/Agoric/agoric-sdk/commit/b90ae0835aec5484279eddcea4e9ccaa253d2db0))
 
 ### [1.7.20](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.19...@agoric/captp@1.7.20) (2021-07-01)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.7.19](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.18...@agoric/captp@1.7.19) (2021-06-28)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ### [1.7.18](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.17...@agoric/captp@1.7.18) (2021-06-25)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.7.17](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.16...@agoric/captp@1.7.17) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ### [1.7.16](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.15...@agoric/captp@1.7.16) (2021-06-23)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.7.15](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.14...@agoric/captp@1.7.15) (2021-06-16)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ### [1.7.14](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.13...@agoric/captp@1.7.14) (2021-06-15)
-
 
 ### Bug Fixes
 
-* Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
-
-
+- Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
 
 ## [1.7.13](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.12...@agoric/captp@1.7.13) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.7.12](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.11...@agoric/captp@1.7.12) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ## [1.7.11](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.10...@agoric/captp@1.7.11) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.7.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.9...@agoric/captp@1.7.10) (2021-04-22)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ## [1.7.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.8...@agoric/captp@1.7.9) (2021-04-18)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.7.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.7...@agoric/captp@1.7.8) (2021-04-16)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ## [1.7.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.6...@agoric/captp@1.7.7) (2021-04-14)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.7.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.5...@agoric/captp@1.7.6) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ## [1.7.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.4...@agoric/captp@1.7.5) (2021-04-06)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.7.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.3...@agoric/captp@1.7.4) (2021-03-24)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.7.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.2...@agoric/captp@1.7.3) (2021-03-16)
-
 
 ### Bug Fixes
 
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-
-
-
-
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
 
 ## [1.7.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.1...@agoric/captp@1.7.2) (2021-02-22)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.7.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.7.0...@agoric/captp@1.7.1) (2021-02-16)
-
 
 ### Bug Fixes
 
-* Correlate sent errors with received errors ([73b9cfd](https://github.com/Agoric/agoric-sdk/commit/73b9cfd33cf7842bdc105a79592028649cb1c92a))
-* wire through the CapTP bootstrap message ([7af41bc](https://github.com/Agoric/agoric-sdk/commit/7af41bc13a778c4872863e2060874910d6c1fefa))
-
-
-
-
+- Correlate sent errors with received errors ([73b9cfd](https://github.com/Agoric/agoric-sdk/commit/73b9cfd33cf7842bdc105a79592028649cb1c92a))
+- wire through the CapTP bootstrap message ([7af41bc](https://github.com/Agoric/agoric-sdk/commit/7af41bc13a778c4872863e2060874910d6c1fefa))
 
 # [1.7.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.6.0...@agoric/captp@1.7.0) (2020-12-10)
 
-
 ### Features
 
-* **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
-
-
-
-
+- **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
 
 # [1.6.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.5.2-dev.0...@agoric/captp@1.6.0) (2020-11-07)
 
-
 ### Bug Fixes
 
-* **captp:** don't crash hard on serialiasation failures ([8c98a9a](https://github.com/Agoric/agoric-sdk/commit/8c98a9a5f283dadd0007083255061773c94eda1d))
-
+- **captp:** don't crash hard on serialiasation failures ([8c98a9a](https://github.com/Agoric/agoric-sdk/commit/8c98a9a5f283dadd0007083255061773c94eda1d))
 
 ### Features
 
-* **assert:** Thread stack traces to console, add entangled assert ([#1884](https://github.com/Agoric/agoric-sdk/issues/1884)) ([5d4f35f](https://github.com/Agoric/agoric-sdk/commit/5d4f35f901f2ca40a2a4d66dab980a5fe8e575f4))
-
-
-
-
+- **assert:** Thread stack traces to console, add entangled assert ([#1884](https://github.com/Agoric/agoric-sdk/issues/1884)) ([5d4f35f](https://github.com/Agoric/agoric-sdk/commit/5d4f35f901f2ca40a2a4d66dab980a5fe8e575f4))
 
 ## [1.5.2-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.5.1...@agoric/captp@1.5.2-dev.0) (2020-10-19)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.5.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.5.1-dev.2...@agoric/captp@1.5.1) (2020-10-11)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ## [1.5.1-dev.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.5.1-dev.1...@agoric/captp@1.5.1-dev.2) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.5.1-dev.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.5.1-dev.0...@agoric/captp@1.5.1-dev.1) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ## [1.5.1-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.5.0...@agoric/captp@1.5.1-dev.0) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 # [1.5.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.4.0...@agoric/captp@1.5.0) (2020-09-16)
-
 
 ### Bug Fixes
 
-* add TODO unimplemented for liveSlots synthetic presences ([6089e71](https://github.com/Agoric/agoric-sdk/commit/6089e71aaa48867625c19d2f64c6e5b29880b7ad))
-* implement epochs and make tolerant of restarts ([1c786b8](https://github.com/Agoric/agoric-sdk/commit/1c786b861a445891d09df2f1a47d689d641a0c5f))
-* implement robust plugin persistence model ([2de552e](https://github.com/Agoric/agoric-sdk/commit/2de552ed4a4b25e5fcc641ff5e80afd5af1d167d))
-* let the other side know about a disconnect if we initiate it ([510f427](https://github.com/Agoric/agoric-sdk/commit/510f4275b43dc92bb719cde97a3078163da46211))
-* pass through the entire marshal stack to the vat ([f93c26b](https://github.com/Agoric/agoric-sdk/commit/f93c26b602766c9d8e3eb15740236cf81b38387f))
-* silence normal disconnects ([01d94af](https://github.com/Agoric/agoric-sdk/commit/01d94af7d9f4dd98b0859b3707bedb57d6a9af3f))
-
+- add TODO unimplemented for liveSlots synthetic presences ([6089e71](https://github.com/Agoric/agoric-sdk/commit/6089e71aaa48867625c19d2f64c6e5b29880b7ad))
+- implement epochs and make tolerant of restarts ([1c786b8](https://github.com/Agoric/agoric-sdk/commit/1c786b861a445891d09df2f1a47d689d641a0c5f))
+- implement robust plugin persistence model ([2de552e](https://github.com/Agoric/agoric-sdk/commit/2de552ed4a4b25e5fcc641ff5e80afd5af1d167d))
+- let the other side know about a disconnect if we initiate it ([510f427](https://github.com/Agoric/agoric-sdk/commit/510f4275b43dc92bb719cde97a3078163da46211))
+- pass through the entire marshal stack to the vat ([f93c26b](https://github.com/Agoric/agoric-sdk/commit/f93c26b602766c9d8e3eb15740236cf81b38387f))
+- silence normal disconnects ([01d94af](https://github.com/Agoric/agoric-sdk/commit/01d94af7d9f4dd98b0859b3707bedb57d6a9af3f))
 
 ### Features
 
-* bidirectional loopback with `makeNear` ([4e29d20](https://github.com/Agoric/agoric-sdk/commit/4e29d206f6e881f82715c8a569ce291dd7ae82a8))
-* implement makeLoopback and makeFar without a membrane ([b0bccba](https://github.com/Agoric/agoric-sdk/commit/b0bccbabecc2902c9d9f7319ffb0c509bccc2d01))
-
-
-
-
+- bidirectional loopback with `makeNear` ([4e29d20](https://github.com/Agoric/agoric-sdk/commit/4e29d206f6e881f82715c8a569ce291dd7ae82a8))
+- implement makeLoopback and makeFar without a membrane ([b0bccba](https://github.com/Agoric/agoric-sdk/commit/b0bccbabecc2902c9d9f7319ffb0c509bccc2d01))
 
 # [1.4.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.3.3...@agoric/captp@1.4.0) (2020-08-31)
 
-
 ### Bug Fixes
 
-* don't delete the questionID too soon ([1e51cef](https://github.com/Agoric/agoric-sdk/commit/1e51cef98cdf9e4267b92378c6bf6d0e3fdecf85))
-* properly abort all communication when CapTP is disconnected ([c2c0196](https://github.com/Agoric/agoric-sdk/commit/c2c0196001c2bc94d14645272b931e39ee38c197))
-* reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
-* rename producePromise to makePromiseKit ([#1329](https://github.com/Agoric/agoric-sdk/issues/1329)) ([1d2925a](https://github.com/Agoric/agoric-sdk/commit/1d2925ad640cce7b419751027b44737bd46a6d59))
-* send and receive Remotable tags ([#1628](https://github.com/Agoric/agoric-sdk/issues/1628)) ([1bae122](https://github.com/Agoric/agoric-sdk/commit/1bae1220c2c35f48f279cb3aeab6012bce8ddb5a))
-* shuffle around exports ([c95282e](https://github.com/Agoric/agoric-sdk/commit/c95282ec5b72260353441ec8dd2ad0eaba9cdfa8))
-* supply default disconnected abort exception ([274ed53](https://github.com/Agoric/agoric-sdk/commit/274ed53fb99c0fb135b8beae984e3f0b731dbb81))
-* **captp:** make more code paths fail on disconnect ([5c0c509](https://github.com/Agoric/agoric-sdk/commit/5c0c5097acd4dacf2b594d84606d0494d71f0216))
-
+- don't delete the questionID too soon ([1e51cef](https://github.com/Agoric/agoric-sdk/commit/1e51cef98cdf9e4267b92378c6bf6d0e3fdecf85))
+- properly abort all communication when CapTP is disconnected ([c2c0196](https://github.com/Agoric/agoric-sdk/commit/c2c0196001c2bc94d14645272b931e39ee38c197))
+- reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
+- rename producePromise to makePromiseKit ([#1329](https://github.com/Agoric/agoric-sdk/issues/1329)) ([1d2925a](https://github.com/Agoric/agoric-sdk/commit/1d2925ad640cce7b419751027b44737bd46a6d59))
+- send and receive Remotable tags ([#1628](https://github.com/Agoric/agoric-sdk/issues/1628)) ([1bae122](https://github.com/Agoric/agoric-sdk/commit/1bae1220c2c35f48f279cb3aeab6012bce8ddb5a))
+- shuffle around exports ([c95282e](https://github.com/Agoric/agoric-sdk/commit/c95282ec5b72260353441ec8dd2ad0eaba9cdfa8))
+- supply default disconnected abort exception ([274ed53](https://github.com/Agoric/agoric-sdk/commit/274ed53fb99c0fb135b8beae984e3f0b731dbb81))
+- **captp:** make more code paths fail on disconnect ([5c0c509](https://github.com/Agoric/agoric-sdk/commit/5c0c5097acd4dacf2b594d84606d0494d71f0216))
 
 ### Features
 
-* **captp:** allow onReject handler to avoid unhandled promise ([f76c804](https://github.com/Agoric/agoric-sdk/commit/f76c804bb47ad8be71a9c512800c8b864edd7e6a))
-
-
-
-
+- **captp:** allow onReject handler to avoid unhandled promise ([f76c804](https://github.com/Agoric/agoric-sdk/commit/f76c804bb47ad8be71a9c512800c8b864edd7e6a))
 
 ## [1.3.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.3.2...@agoric/captp@1.3.3) (2020-06-30)
 
-
 ### Bug Fixes
 
-* **captp:** stop creating dist bundles ([7067ae0](https://github.com/Agoric/agoric-sdk/commit/7067ae0e8afe122ee64f5652c45d0288b74516a5))
-
-
-
-
+- **captp:** stop creating dist bundles ([7067ae0](https://github.com/Agoric/agoric-sdk/commit/7067ae0e8afe122ee64f5652c45d0288b74516a5))
 
 ## [1.3.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.3.1...@agoric/captp@1.3.2) (2020-05-17)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.3.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.3.0...@agoric/captp@1.3.1) (2020-05-10)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 # [1.3.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.2.3...@agoric/captp@1.3.0) (2020-05-04)
-
 
 ### Bug Fixes
 
-* use the new (typed) harden package ([2eb1af0](https://github.com/Agoric/agoric-sdk/commit/2eb1af08fe3967629a3ce165752fd501a5c85a96))
-
+- use the new (typed) harden package ([2eb1af0](https://github.com/Agoric/agoric-sdk/commit/2eb1af08fe3967629a3ce165752fd501a5c85a96))
 
 ### Features
 
-* add Presence, getInterfaceOf, deepCopyData to marshal ([aac1899](https://github.com/Agoric/agoric-sdk/commit/aac1899b6cefc4241af04911a92ffc50fbac3429))
-
-
-
-
+- add Presence, getInterfaceOf, deepCopyData to marshal ([aac1899](https://github.com/Agoric/agoric-sdk/commit/aac1899b6cefc4241af04911a92ffc50fbac3429))
 
 ## [1.2.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.2.3-alpha.0...@agoric/captp@1.2.3) (2020-04-13)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.2.3-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.2.2...@agoric/captp@1.2.3-alpha.0) (2020-04-12)
 
 **Note:** Version bump only for package @agoric/captp
-
-
-
-
 
 ## [1.2.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.2.2-alpha.0...@agoric/captp@1.2.2) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## [1.2.2-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/captp@1.2.1...@agoric/captp@1.2.2-alpha.0) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/captp
 
-
-
-
-
 ## 1.2.1 (2020-03-26)
-
 
 ### Bug Fixes
 
-* **captp:** use new @agoric/eventual-send interface ([d1201a1](https://github.com/Agoric/CapTP/commit/d1201a1a1de324ae5e21736057f3bb03f97d2bc7))
-* **eventual-send:** Update the API throughout agoric-sdk ([97fc1e7](https://github.com/Agoric/CapTP/commit/97fc1e748d8e3955b29baf0e04bfa788d56dad9f))
+- **captp:** use new @agoric/eventual-send interface ([d1201a1](https://github.com/Agoric/CapTP/commit/d1201a1a1de324ae5e21736057f3bb03f97d2bc7))
+- **eventual-send:** Update the API throughout agoric-sdk ([97fc1e7](https://github.com/Agoric/CapTP/commit/97fc1e748d8e3955b29baf0e04bfa788d56dad9f))

--- a/packages/captp/NEWS.md
+++ b/packages/captp/NEWS.md
@@ -1,13 +1,18 @@
-User-visible changes in captp:
+User-visible changes in `@endo/captp`:
 
-## Release 1.2.0 (17-Dec-2019)
+# v2.0.19 (2022-12-23)
+
+- Remote objects now reflect methods present on their prototype chain.
+- Serialization errors now serialize.
+
+# v1.2.0 (17-Dec-2019)
 
 * use @agoric/eventual-send HandledPromise interface (#6)
 
 Moved from https://github.com/Agoric/captp into the `packages/captp/`
 directory in the monorepo at https://github.com/Agoric/agoric-sdk .
 
-## Release 1.8.0
+# v1.8.0
 
 * introduce TrapCaps for synchronous "kernel trap" interfaces (see the
   README.md).

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [
@@ -42,16 +42,16 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.52",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/init": "^0.5.53",
+    "@endo/ses-ava": "^0.2.37",
     "ava": "^5.1.0",
     "c8": "^7.7.3"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.16.8",
-    "@endo/marshal": "^0.8.1",
-    "@endo/nat": "^4.1.23",
-    "@endo/promise-kit": "^0.2.52"
+    "@endo/eventual-send": "^0.16.9",
+    "@endo/marshal": "^0.8.2",
+    "@endo/nat": "^4.1.24",
+    "@endo/promise-kit": "^0.2.53"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,147 +3,90 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.14](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.13...@endo/check-bundle@0.2.14) (2022-11-14)
+### [0.2.15](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.14...@endo/check-bundle@0.2.15) (2022-12-23)
 
+**Note:** Version bump only for package @endo/check-bundle
+
+### [0.2.14](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.13...@endo/check-bundle@0.2.14) (2022-11-14)
 
 ### Bug Fixes
 
-* assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
-
-
+- assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
 
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.12...@endo/check-bundle@0.2.13) (2022-10-24)
 
 **Note:** Version bump only for package @endo/check-bundle
 
-
-
-
-
 ### [0.2.12](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.11...@endo/check-bundle@0.2.12) (2022-10-19)
 
 **Note:** Version bump only for package @endo/check-bundle
-
-
-
-
 
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.10...@endo/check-bundle@0.2.11) (2022-09-27)
 
 **Note:** Version bump only for package @endo/check-bundle
 
-
-
-
-
 ### [0.2.10](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.9...@endo/check-bundle@0.2.10) (2022-09-14)
 
 **Note:** Version bump only for package @endo/check-bundle
-
-
-
-
 
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.8...@endo/check-bundle@0.2.9) (2022-08-26)
 
 **Note:** Version bump only for package @endo/check-bundle
 
-
-
-
-
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.7...@endo/check-bundle@0.2.8) (2022-08-26)
 
 **Note:** Version bump only for package @endo/check-bundle
-
-
-
-
 
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.6...@endo/check-bundle@0.2.7) (2022-08-25)
 
 **Note:** Version bump only for package @endo/check-bundle
 
-
-
-
-
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.5...@endo/check-bundle@0.2.6) (2022-08-23)
 
 **Note:** Version bump only for package @endo/check-bundle
 
-
-
-
-
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.4...@endo/check-bundle@0.2.5) (2022-06-28)
-
 
 ### Bug Fixes
 
-* tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
-
-
+- tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
 
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.3...@endo/check-bundle@0.2.4) (2022-06-11)
 
 **Note:** Version bump only for package @endo/check-bundle
 
-
-
-
-
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.2...@endo/check-bundle@0.2.3) (2022-04-15)
 
 **Note:** Version bump only for package @endo/check-bundle
-
-
-
-
 
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.1...@endo/check-bundle@0.2.2) (2022-04-14)
 
 **Note:** Version bump only for package @endo/check-bundle
 
-
-
-
-
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.0...@endo/check-bundle@0.2.1) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ## [0.2.0](https://github.com/endojs/endo/compare/@endo/check-bundle@0.1.2...@endo/check-bundle@0.2.0) (2022-04-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **check-bundle:** Verify immutability of checked bundle
-* **check-bundle:** Fix batteries-included API
+- **check-bundle:** Verify immutability of checked bundle
+- **check-bundle:** Fix batteries-included API
 
 ### Bug Fixes
 
-* **check-bundle:** Fix batteries-included API ([6a84660](https://github.com/endojs/endo/commit/6a84660001509561604cafb1cd58396ae965bf59))
-* **check-bundle:** Verify immutability of checked bundle ([3033b06](https://github.com/endojs/endo/commit/3033b06bdb906c413e8a6f735462bfa17abdf790))
-
-
+- **check-bundle:** Fix batteries-included API ([6a84660](https://github.com/endojs/endo/commit/6a84660001509561604cafb1cd58396ae965bf59))
+- **check-bundle:** Verify immutability of checked bundle ([3033b06](https://github.com/endojs/endo/commit/3033b06bdb906c413e8a6f735462bfa17abdf790))
 
 ### [0.1.2](https://github.com/endojs/endo/compare/@endo/check-bundle@0.1.1...@endo/check-bundle@0.1.2) (2022-03-07)
 
 **Note:** Version bump only for package @endo/check-bundle
 
-
-
-
-
 ### 0.1.1 (2022-03-02)
-
 
 ### Features
 
-* **check-bundle:** Implement bundle integrity checks ([c85a729](https://github.com/endojs/endo/commit/c85a729792c6e5b4604f9bf9fa67391e03d36a5c))
+- **check-bundle:** Implement bundle integrity checks ([c85a729](https://github.com/endojs/endo/commit/c85a729792c6e5b4604f9bf9fa67391e03d36a5c))

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",
@@ -37,14 +37,14 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.28",
-    "@endo/compartment-mapper": "^0.8.0"
+    "@endo/base64": "^0.2.29",
+    "@endo/compartment-mapper": "^0.8.1"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.4.2",
-    "@endo/eslint-config": "^0.5.1",
-    "@endo/init": "^0.5.52",
-    "@endo/zip": "^0.2.28",
+    "@endo/bundle-source": "^2.4.3",
+    "@endo/eslint-config": "^0.5.2",
+    "@endo/init": "^0.5.53",
+    "@endo/zip": "^0.2.29",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,256 +3,150 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.28](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.27...@endo/cjs-module-analyzer@0.2.28) (2022-11-14)
+### [0.2.29](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.28...@endo/cjs-module-analyzer@0.2.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
+### [0.2.28](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.27...@endo/cjs-module-analyzer@0.2.28) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/cjs-module-analyzer
 
 ### [0.2.27](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.26...@endo/cjs-module-analyzer@0.2.27) (2022-06-28)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.26](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.25...@endo/cjs-module-analyzer@0.2.26) (2022-06-11)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
-
-
-
-
 
 ### [0.2.25](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.24...@endo/cjs-module-analyzer@0.2.25) (2022-04-15)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.24](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.23...@endo/cjs-module-analyzer@0.2.24) (2022-04-14)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.22...@endo/cjs-module-analyzer@0.2.23) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.2.22](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.21...@endo/cjs-module-analyzer@0.2.22) (2022-04-12)
 
-
 ### Features
 
-* **compartment-mapper:** defer import errors based on parser support declaration ([cf074aa](https://github.com/endojs/endo/commit/cf074aab007a3af16ad7ac25b6dc1bd119d6d1b7))
-
+- **compartment-mapper:** defer import errors based on parser support declaration ([cf074aa](https://github.com/endojs/endo/commit/cf074aab007a3af16ad7ac25b6dc1bd119d6d1b7))
 
 ### Bug Fixes
 
-* **cjs-module-analyzer:** accept any require, not just top level ([7dfc183](https://github.com/endojs/endo/commit/7dfc183b859528de3abb7eade250913ade95455e))
-
-
+- **cjs-module-analyzer:** accept any require, not just top level ([7dfc183](https://github.com/endojs/endo/commit/7dfc183b859528de3abb7eade250913ade95455e))
 
 ### [0.2.21](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.20...@endo/cjs-module-analyzer@0.2.21) (2022-03-07)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.19...@endo/cjs-module-analyzer@0.2.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
-
-
-
-
 
 ### [0.2.19](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.18...@endo/cjs-module-analyzer@0.2.19) (2022-02-20)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.18](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.17...@endo/cjs-module-analyzer@0.2.18) (2022-02-18)
-
 
 ### Bug Fixes
 
-* **cjs-module-analyzer:** Broaden TypeScript checker inputs ([cd5f084](https://github.com/endojs/endo/commit/cd5f0840b1873bd7934eab11e73971b89351d464))
-* Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- **cjs-module-analyzer:** Broaden TypeScript checker inputs ([cd5f084](https://github.com/endojs/endo/commit/cd5f0840b1873bd7934eab11e73971b89351d464))
+- Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.2.17](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.16...@endo/cjs-module-analyzer@0.2.17) (2022-01-31)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.16](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.15...@endo/cjs-module-analyzer@0.2.16) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.2.15](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.14...@endo/cjs-module-analyzer@0.2.15) (2022-01-25)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.14](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.13...@endo/cjs-module-analyzer@0.2.14) (2022-01-23)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
-
-
-
-
 
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.12...@endo/cjs-module-analyzer@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.12](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.11...@endo/cjs-module-analyzer@0.2.12) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
 
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.10...@endo/cjs-module-analyzer@0.2.11) (2021-11-16)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.10](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.9...@endo/cjs-module-analyzer@0.2.10) (2021-11-02)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
-
-
-
-
 
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.8...@endo/cjs-module-analyzer@0.2.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.7...@endo/cjs-module-analyzer@0.2.8) (2021-09-18)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
-
-
-
-
 
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.6...@endo/cjs-module-analyzer@0.2.7) (2021-08-14)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.5...@endo/cjs-module-analyzer@0.2.6) (2021-08-13)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
-
-
-
-
 
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.4...@endo/cjs-module-analyzer@0.2.5) (2021-07-22)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.3...@endo/cjs-module-analyzer@0.2.4) (2021-06-20)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
-
-
-
-
 
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.2...@endo/cjs-module-analyzer@0.2.3) (2021-06-16)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.1...@endo/cjs-module-analyzer@0.2.2) (2021-06-14)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
-
-
-
-
 
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.0...@endo/cjs-module-analyzer@0.2.1) (2021-06-06)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer
 
-
-
-
-
 ## 0.2.0 (2021-06-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **cjs-module-analyzer:** No longer supports direct use from CommonJS
+- **cjs-module-analyzer:** No longer supports direct use from CommonJS
 
 ### Features
 
-* **cjs-module-analyzer:** Update packaging for RESM/NESM bridge ([e3c1e17](https://github.com/endojs/endo/commit/e3c1e17349da7350edf55837fbea53a057c747f3))
-
+- **cjs-module-analyzer:** Update packaging for RESM/NESM bridge ([e3c1e17](https://github.com/endojs/endo/commit/e3c1e17349da7350edf55837fbea53a057c747f3))
 
 ### Bug Fixes
 
-* Realign TS, JS, and package names ([#686](https://github.com/endojs/endo/issues/686)) ([439e0ff](https://github.com/endojs/endo/commit/439e0fff1fd214eec91486ded8b3d36a5eb4b801))
-* Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
+- Realign TS, JS, and package names ([#686](https://github.com/endojs/endo/issues/686)) ([439e0ff](https://github.com/endojs/endo/commit/439e0fff1fd214eec91486ded8b3d36a5eb4b801))
+- Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",
@@ -29,7 +29,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,197 +3,116 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.24](https://github.com/endojs/endo/compare/@endo/cli@0.1.23...@endo/cli@0.1.24) (2022-12-23)
+
+### Features
+
+- **cli:** Add log and ping subcommands ([aa80678](https://github.com/endojs/endo/commit/aa80678ea171bd9b0f0e8e4c1f63547fe7fac0bc))
+
 ### [0.1.23](https://github.com/endojs/endo/compare/@endo/cli@0.1.22...@endo/cli@0.1.23) (2022-11-14)
 
 **Note:** Version bump only for package @endo/cli
-
-
-
-
 
 ### [0.1.22](https://github.com/endojs/endo/compare/@endo/cli@0.1.21...@endo/cli@0.1.22) (2022-10-24)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.21](https://github.com/endojs/endo/compare/@endo/cli@0.1.20...@endo/cli@0.1.21) (2022-10-19)
 
 **Note:** Version bump only for package @endo/cli
-
-
-
-
 
 ### [0.1.20](https://github.com/endojs/endo/compare/@endo/cli@0.1.19...@endo/cli@0.1.20) (2022-09-27)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.19](https://github.com/endojs/endo/compare/@endo/cli@0.1.18...@endo/cli@0.1.19) (2022-09-14)
 
 **Note:** Version bump only for package @endo/cli
-
-
-
-
 
 ### [0.1.18](https://github.com/endojs/endo/compare/@endo/cli@0.1.17...@endo/cli@0.1.18) (2022-08-26)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.17](https://github.com/endojs/endo/compare/@endo/cli@0.1.16...@endo/cli@0.1.17) (2022-08-26)
 
 **Note:** Version bump only for package @endo/cli
-
-
-
-
 
 ### [0.1.16](https://github.com/endojs/endo/compare/@endo/cli@0.1.15...@endo/cli@0.1.16) (2022-08-25)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.15](https://github.com/endojs/endo/compare/@endo/cli@0.1.14...@endo/cli@0.1.15) (2022-08-23)
 
 **Note:** Version bump only for package @endo/cli
-
-
-
-
 
 ### [0.1.14](https://github.com/endojs/endo/compare/@endo/cli@0.1.13...@endo/cli@0.1.14) (2022-06-28)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.13](https://github.com/endojs/endo/compare/@endo/cli@0.1.12...@endo/cli@0.1.13) (2022-06-11)
 
 **Note:** Version bump only for package @endo/cli
-
-
-
-
 
 ### [0.1.12](https://github.com/endojs/endo/compare/@endo/cli@0.1.11...@endo/cli@0.1.12) (2022-04-15)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.11](https://github.com/endojs/endo/compare/@endo/cli@0.1.10...@endo/cli@0.1.11) (2022-04-14)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/cli@0.1.9...@endo/cli@0.1.10) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.1.9](https://github.com/endojs/endo/compare/@endo/cli@0.1.8...@endo/cli@0.1.9) (2022-04-12)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.8](https://github.com/endojs/endo/compare/@endo/cli@0.1.7...@endo/cli@0.1.8) (2022-03-07)
 
 **Note:** Version bump only for package @endo/cli
-
-
-
-
 
 ### [0.1.7](https://github.com/endojs/endo/compare/@endo/cli@0.1.6...@endo/cli@0.1.7) (2022-03-02)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.6](https://github.com/endojs/endo/compare/@endo/cli@0.1.5...@endo/cli@0.1.6) (2022-02-20)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.5](https://github.com/endojs/endo/compare/@endo/cli@0.1.4...@endo/cli@0.1.5) (2022-02-18)
-
 
 ### Features
 
-* **cli:** Add endo reset command ([470b33c](https://github.com/endojs/endo/commit/470b33c1413600191f3b0022ea106f12c2aa6dd2))
-
+- **cli:** Add endo reset command ([470b33c](https://github.com/endojs/endo/commit/470b33c1413600191f3b0022ea106f12c2aa6dd2))
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-* **cli:** Add missing dependencies ([72281f4](https://github.com/endojs/endo/commit/72281f4100c782c79856c8a792b85d8ef9604076))
-* **daemon:** Move init from lib to app ([7aaf1a0](https://github.com/endojs/endo/commit/7aaf1a07d2950b16f7202ecc1d281386ba812d67))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
+- **cli:** Add missing dependencies ([72281f4](https://github.com/endojs/endo/commit/72281f4100c782c79856c8a792b85d8ef9604076))
+- **daemon:** Move init from lib to app ([7aaf1a0](https://github.com/endojs/endo/commit/7aaf1a07d2950b16f7202ecc1d281386ba812d67))
 
 ### [0.1.4](https://github.com/endojs/endo/compare/@endo/cli@0.1.3...@endo/cli@0.1.4) (2022-01-31)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### [0.1.3](https://github.com/endojs/endo/compare/@endo/cli@0.1.2...@endo/cli@0.1.3) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.1.2](https://github.com/endojs/endo/compare/@endo/cli@0.1.1...@endo/cli@0.1.2) (2022-01-25)
 
 **Note:** Version bump only for package @endo/cli
 
-
-
-
-
 ### 0.1.1 (2022-01-23)
-
 
 ### Features
 
-* **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))
+- **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Endo command line interface",
   "keywords": [],
   "author": "Endo contributors",
@@ -24,18 +24,18 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/compartment-mapper": "^0.8.0",
-    "@endo/daemon": "^0.1.23",
-    "@endo/eventual-send": "^0.16.8",
-    "@endo/far": "^0.2.14",
-    "@endo/lockdown": "^0.1.24",
-    "@endo/promise-kit": "^0.2.52",
-    "@endo/where": "^0.2.10",
+    "@endo/compartment-mapper": "^0.8.1",
+    "@endo/daemon": "^0.1.24",
+    "@endo/eventual-send": "^0.16.9",
+    "@endo/far": "^0.2.15",
+    "@endo/lockdown": "^0.1.25",
+    "@endo/promise-kit": "^0.2.53",
+    "@endo/where": "^0.2.11",
     "commander": "^5.0.0",
-    "ses": "^0.18.0"
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,464 +3,363 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.8.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.15...@endo/compartment-mapper@0.8.0) (2022-11-14)
-
-
-### ⚠ BREAKING CHANGES
-
-* **compartment-mapper:** Remove support for globalLexicals
+### [0.8.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.8.0...@endo/compartment-mapper@0.8.1) (2022-12-23)
 
 ### Features
 
-* **compartment-mapper:** Bundles evaluate to entrypoint namespace ([85a69aa](https://github.com/endojs/endo/commit/85a69aaf8133fa84ec3548e8004777097cf7c326))
-* **compartment-mapper:** Remove support for globalLexicals ([7d9603d](https://github.com/endojs/endo/commit/7d9603d0c838e02c1b052cf6e8f725ebf195aaf2))
-* **compartment-mapper:** support peerDependencies and bundleDependencies ([3afd7c5](https://github.com/endojs/endo/commit/3afd7c5680813063a1ab7ff93af1a116e6af2f02))
-* **compartment-mapper:** support various types of optional deps ([72fa6e7](https://github.com/endojs/endo/commit/72fa6e7a3089be31be97caee2616090ac842bb3e))
-
+- **compartment-mapper:** add bundle support for commonjs ([aa5e164](https://github.com/endojs/endo/commit/aa5e164d955f72c9ade532886d81e2237c167814))
+- **compartment-mapper:** add tags to ArchiveOptions ([078b221](https://github.com/endojs/endo/commit/078b2211d0a654d4d7fc03a4fdfe1ac2bf78c9dc))
+- **compartment-mapper:** allow alternate searchSuffixes ([5f58cf6](https://github.com/endojs/endo/commit/5f58cf6e27cd954aad33ccf1144fecbc59b8dd34))
+- **compartment-mapper:** allow transforms to process unknown languages ([f577dc7](https://github.com/endojs/endo/commit/f577dc7e10e918dd613962593aa9d83e84cca6bc))
+- **compartment-mapper:** bundle should support tags ([26e9ff9](https://github.com/endojs/endo/commit/26e9ff9bc7548efc7cad0c49cf3a6373bf400889))
+- **compartment-mapper:** bundle should throw on encountering deferredError ([ad8df6a](https://github.com/endojs/endo/commit/ad8df6a05c0216a04ff15b7460a5cc10a59030f9))
+- **compartment-mapper:** for commonjs alias package root to default module ([2fd471d](https://github.com/endojs/endo/commit/2fd471d2dcb2b4ea366e5d0e37d0a2292184e0cc))
+- **compartment-mapper:** fully support node resolution candidates ([cdb0d8f](https://github.com/endojs/endo/commit/cdb0d8fadbc2085ed68907177f378971585930bb))
+- **compartment-mapper:** handle browser field in construction of compartmentMap ([ffe0719](https://github.com/endojs/endo/commit/ffe0719fece19315f39eaf97fd7c3dc068996989))
+- **compartment-mapper:** handle internalAliases including internal package aliases ([979f9c1](https://github.com/endojs/endo/commit/979f9c17b53b0fafa080b1b5ac5abdee0506446b))
+- **compartment-mapper:** importHook redirects + updates compartment map when candidate is present in moduleDescriptors ([c10b443](https://github.com/endojs/endo/commit/c10b443eb2fe11d7f458ee32f2a363cfc16377e0))
+- **compartment-mapper:** replace graph node exports with internal and external aliases ([1d52a8b](https://github.com/endojs/endo/commit/1d52a8bcaad35ddec9db824170c0a319927fd302))
+- **compartment-mapper:** support commonDependencies for injecting dependencies ([dff6908](https://github.com/endojs/endo/commit/dff6908e79146beee93c361dc46a2b178982c6f7))
 
 ### Bug Fixes
 
-* assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
+- **compartment-mapper:** add named reexports logic to bundle.js ([236a4e8](https://github.com/endojs/endo/commit/236a4e89b6931867a6ea532720560a2f448007ac))
+- **compartment-mapper:** allow specifier to include period and omit extension ([3768a3e](https://github.com/endojs/endo/commit/3768a3eaa9ec49589ceb1142dfc9b6dfe74cff68))
+- **compartment-mapper:** error unmatched locations with package self name ([b251988](https://github.com/endojs/endo/commit/b25198885cb5ec3558280af8018c7eae9d8fc207))
+- **compartment-mapper:** fix reflexive packageLocation in node-modules/translateGraph ([7f6638d](https://github.com/endojs/endo/commit/7f6638d43773c2aa847e5e1f08e2e6338001dca8))
+- **compartment-mapper:** handle package default module via externalAliases ([128eb40](https://github.com/endojs/endo/commit/128eb406afd09e9c6c806a97796a0cebd74d5fd0))
+- **compartment-mapper:** Harden bundles ([20c1d46](https://github.com/endojs/endo/commit/20c1d46c5c98e9c135417adfddecb0e168a52620))
+- **compartment-mapper:** importArchive - add explicit error for missing module ([369ca03](https://github.com/endojs/endo/commit/369ca034ab225b4939245a7fcc9608edf3435375))
+- **compartment-mapper:** inferred exports are relative ([fdacf1b](https://github.com/endojs/endo/commit/fdacf1b92e9b0e05119e1186edfd8018d44f68fb))
+- **compartment-mapper:** node-modules - name packageLocations differently ([d396fed](https://github.com/endojs/endo/commit/d396fedee14eabe17bf51865f6ac806b959aeb7c))
+- **compartment-mapper:** remove unused log in test ([82bf889](https://github.com/endojs/endo/commit/82bf889275879e57a4d445cae3982a1a0d199217))
+- **compartment-mapper:** rename some variables for improved readability ([0861b0c](https://github.com/endojs/endo/commit/0861b0cfd6fa521bfdb25d896180521fe68a9c98))
+- **compartment-mapper:** rename some variables for improved readability ([3abdfa9](https://github.com/endojs/endo/commit/3abdfa9cdaaa35afe4b8dc5081861f93dc4a2ce7))
+- **compartment-mapper:** rename transforms to moduleTransforms in link ([bbdae51](https://github.com/endojs/endo/commit/bbdae513cc71fcb2c56cc17207f2f27042cf79bd))
+- **compartment-mapper:** Thread dev option thru bundler ([c71561e](https://github.com/endojs/endo/commit/c71561e30bd95193a8be728295eec47e26a04251))
 
+## [0.8.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.15...@endo/compartment-mapper@0.8.0) (2022-11-14)
 
+### ⚠ BREAKING CHANGES
+
+- **compartment-mapper:** Remove support for globalLexicals
+
+### Features
+
+- **compartment-mapper:** Bundles evaluate to entrypoint namespace ([85a69aa](https://github.com/endojs/endo/commit/85a69aaf8133fa84ec3548e8004777097cf7c326))
+- **compartment-mapper:** Remove support for globalLexicals ([7d9603d](https://github.com/endojs/endo/commit/7d9603d0c838e02c1b052cf6e8f725ebf195aaf2))
+- **compartment-mapper:** support peerDependencies and bundleDependencies ([3afd7c5](https://github.com/endojs/endo/commit/3afd7c5680813063a1ab7ff93af1a116e6af2f02))
+- **compartment-mapper:** support various types of optional deps ([72fa6e7](https://github.com/endojs/endo/commit/72fa6e7a3089be31be97caee2616090ac842bb3e))
+
+### Bug Fixes
+
+- assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
 
 ### [0.7.15](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.14...@endo/compartment-mapper@0.7.15) (2022-10-24)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.7.14](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.13...@endo/compartment-mapper@0.7.14) (2022-10-19)
 
 **Note:** Version bump only for package @endo/compartment-mapper
-
-
-
-
 
 ### [0.7.13](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.12...@endo/compartment-mapper@0.7.13) (2022-09-27)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.7.12](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.11...@endo/compartment-mapper@0.7.12) (2022-09-14)
 
 **Note:** Version bump only for package @endo/compartment-mapper
-
-
-
-
 
 ### [0.7.11](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.10...@endo/compartment-mapper@0.7.11) (2022-08-26)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.7.10](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.9...@endo/compartment-mapper@0.7.10) (2022-08-26)
 
 **Note:** Version bump only for package @endo/compartment-mapper
-
-
-
-
 
 ### [0.7.9](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.8...@endo/compartment-mapper@0.7.9) (2022-08-25)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.7.8](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.7...@endo/compartment-mapper@0.7.8) (2022-08-23)
-
 
 ### Bug Fixes
 
-* **compartment-mapper:** avoid mislabeling cjs files as esm based on type field ([5a6a501](https://github.com/endojs/endo/commit/5a6a501f14f53170d047f847fee7d08674e72f23))
-
-
+- **compartment-mapper:** avoid mislabeling cjs files as esm based on type field ([5a6a501](https://github.com/endojs/endo/commit/5a6a501f14f53170d047f847fee7d08674e72f23))
 
 ### [0.7.7](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.6...@endo/compartment-mapper@0.7.7) (2022-06-28)
 
-
 ### Features
 
-* **compartment-mapper:** dancing skeleton require.resolve implementation ([ba1de8e](https://github.com/endojs/endo/commit/ba1de8e6f6225a9e16bd19fb2a4ec77badf457f5))
-* **compartment-mapper:** implement passing values in import.meta.url ([d6294f6](https://github.com/endojs/endo/commit/d6294f6832f978eaa7af94fee4496d76bd35a927))
-* **compartment-mapper:** implement require.resolve as an external configuration item ([45054de](https://github.com/endojs/endo/commit/45054dec37971da253773dbb91debddd0f56d0d6))
-* **compartment-mapper:** move require.resolve implementation to readPowers ([e841f74](https://github.com/endojs/endo/commit/e841f74ad508061c2661963ae2876669be966f32))
-* add the foundations for support of import.meta ([36f6449](https://github.com/endojs/endo/commit/36f644998c21f6333268707555b97938ff0fff08))
-* call importMetaHook on instantiation if import.meta uttered by module ([23e8c40](https://github.com/endojs/endo/commit/23e8c405e0be823c728f8af1a6db9607e21f2f74))
-
+- **compartment-mapper:** dancing skeleton require.resolve implementation ([ba1de8e](https://github.com/endojs/endo/commit/ba1de8e6f6225a9e16bd19fb2a4ec77badf457f5))
+- **compartment-mapper:** implement passing values in import.meta.url ([d6294f6](https://github.com/endojs/endo/commit/d6294f6832f978eaa7af94fee4496d76bd35a927))
+- **compartment-mapper:** implement require.resolve as an external configuration item ([45054de](https://github.com/endojs/endo/commit/45054dec37971da253773dbb91debddd0f56d0d6))
+- **compartment-mapper:** move require.resolve implementation to readPowers ([e841f74](https://github.com/endojs/endo/commit/e841f74ad508061c2661963ae2876669be966f32))
+- add the foundations for support of import.meta ([36f6449](https://github.com/endojs/endo/commit/36f644998c21f6333268707555b97938ff0fff08))
+- call importMetaHook on instantiation if import.meta uttered by module ([23e8c40](https://github.com/endojs/endo/commit/23e8c405e0be823c728f8af1a6db9607e21f2f74))
 
 ### Bug Fixes
 
-* **compartment-mapper:** adapt require.resolve assertion to Windows also ([58e1064](https://github.com/endojs/endo/commit/58e10642f4f099d7b8132f20ff59a85ed6a9443c))
-* **compartment-mapper:** importMeta always an empty object in bundler ([e9f809a](https://github.com/endojs/endo/commit/e9f809a0e3242421d9c32388f2bc885eb8d9510e))
-* rename meta to importMeta, fix detection to detect import.meta not import.meta.something ([c61a862](https://github.com/endojs/endo/commit/c61a862c9f4354f0e6d86d8c8efaa826840a6efd))
-
-
+- **compartment-mapper:** adapt require.resolve assertion to Windows also ([58e1064](https://github.com/endojs/endo/commit/58e10642f4f099d7b8132f20ff59a85ed6a9443c))
+- **compartment-mapper:** importMeta always an empty object in bundler ([e9f809a](https://github.com/endojs/endo/commit/e9f809a0e3242421d9c32388f2bc885eb8d9510e))
+- rename meta to importMeta, fix detection to detect import.meta not import.meta.something ([c61a862](https://github.com/endojs/endo/commit/c61a862c9f4354f0e6d86d8c8efaa826840a6efd))
 
 ### [0.7.6](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.5...@endo/compartment-mapper@0.7.6) (2022-06-11)
 
-
 ### Features
 
-* **compartment-mapper:** Archives retain compartments only for retained modules ([ee2e6e1](https://github.com/endojs/endo/commit/ee2e6e1d415d6cd5795030a978650f71fcc80cbb))
-* **compartment-mapper:** Support text and bytes asset module types ([acc828c](https://github.com/endojs/endo/commit/acc828cf74308b7cdcf000f7492a53e3135bdfd3))
-* **compartment-mapper:** Thread diagnostic name more thorougly ([d546823](https://github.com/endojs/endo/commit/d54682363790dcd9123b135d8784ffc75508fec0))
-* **compartment-mapper:** Use package.json files in nested folders of a package when determining module type ([4b1c6f4](https://github.com/endojs/endo/commit/4b1c6f4575f2b3ad24a0b4bb3a68a59a4d0dc6d9))
-
+- **compartment-mapper:** Archives retain compartments only for retained modules ([ee2e6e1](https://github.com/endojs/endo/commit/ee2e6e1d415d6cd5795030a978650f71fcc80cbb))
+- **compartment-mapper:** Support text and bytes asset module types ([acc828c](https://github.com/endojs/endo/commit/acc828cf74308b7cdcf000f7492a53e3135bdfd3))
+- **compartment-mapper:** Thread diagnostic name more thorougly ([d546823](https://github.com/endojs/endo/commit/d54682363790dcd9123b135d8784ffc75508fec0))
+- **compartment-mapper:** Use package.json files in nested folders of a package when determining module type ([4b1c6f4](https://github.com/endojs/endo/commit/4b1c6f4575f2b3ad24a0b4bb3a68a59a4d0dc6d9))
 
 ### Bug Fixes
 
-* **compartment-mapper:** Package exports may be absolute ([5a8a893](https://github.com/endojs/endo/commit/5a8a893b9f9d4375661fae597c158a0bbf258785))
-* **compartment-mapper:** provide correct values for __dirname __filename for cjs compatibility ([#1155](https://github.com/endojs/endo/issues/1155)) ([43fdf69](https://github.com/endojs/endo/commit/43fdf69f0de91fbb4e48c66199067a2fbc6738aa))
-* **compartment-mapper:** relativize all exports from package.json - undo the change allowing reexports of dependencies by just stating them in package.json "exports" field ([ceb1790](https://github.com/endojs/endo/commit/ceb17903e1926fb38ee72cdd26a332efde9d12b8))
-* **compartment-mapper:** Stabilize hashes in face of layout changes ([75a5db4](https://github.com/endojs/endo/commit/75a5db489f495d286bbd8c5932e4db2b57c136b5)), closes [#919](https://github.com/endojs/endo/issues/919)
-
-
+- **compartment-mapper:** Package exports may be absolute ([5a8a893](https://github.com/endojs/endo/commit/5a8a893b9f9d4375661fae597c158a0bbf258785))
+- **compartment-mapper:** provide correct values for **dirname **filename for cjs compatibility ([#1155](https://github.com/endojs/endo/issues/1155)) ([43fdf69](https://github.com/endojs/endo/commit/43fdf69f0de91fbb4e48c66199067a2fbc6738aa))
+- **compartment-mapper:** relativize all exports from package.json - undo the change allowing reexports of dependencies by just stating them in package.json "exports" field ([ceb1790](https://github.com/endojs/endo/commit/ceb17903e1926fb38ee72cdd26a332efde9d12b8))
+- **compartment-mapper:** Stabilize hashes in face of layout changes ([75a5db4](https://github.com/endojs/endo/commit/75a5db489f495d286bbd8c5932e4db2b57c136b5)), closes [#919](https://github.com/endojs/endo/issues/919)
 
 ### [0.7.5](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.4...@endo/compartment-mapper@0.7.5) (2022-04-15)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.7.4](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.3...@endo/compartment-mapper@0.7.4) (2022-04-14)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.7.3](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.2...@endo/compartment-mapper@0.7.3) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.7.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.1...@endo/compartment-mapper@0.7.2) (2022-04-12)
 
-
 ### Features
 
-* **compartment-mapper:** defer import errors based on parser support declaration ([cf074aa](https://github.com/endojs/endo/commit/cf074aab007a3af16ad7ac25b6dc1bd119d6d1b7))
-* **compartment-mapper:** proper default export implementation for cjs with import and require compatibility ([30cbaa8](https://github.com/endojs/endo/commit/30cbaa8cb79b906742a9f5c1854b22fe506b0575))
-* **compartment-mapper:** support for defineProperty on exports with getters ([4764487](https://github.com/endojs/endo/commit/4764487f149a9af225128cec75d557e35d20bf60))
-
+- **compartment-mapper:** defer import errors based on parser support declaration ([cf074aa](https://github.com/endojs/endo/commit/cf074aab007a3af16ad7ac25b6dc1bd119d6d1b7))
+- **compartment-mapper:** proper default export implementation for cjs with import and require compatibility ([30cbaa8](https://github.com/endojs/endo/commit/30cbaa8cb79b906742a9f5c1854b22fe506b0575))
+- **compartment-mapper:** support for defineProperty on exports with getters ([4764487](https://github.com/endojs/endo/commit/4764487f149a9af225128cec75d557e35d20bf60))
 
 ### Bug Fixes
 
-* **compartment-mapper:** add support for alternatives in exports defnitions ([#1134](https://github.com/endojs/endo/issues/1134)) ([6663f25](https://github.com/endojs/endo/commit/6663f255de7a514aac0f0081eaa99de880298f73))
-* **compartment-mapper:** Avoid some property override pitfalls ([b4efabe](https://github.com/endojs/endo/commit/b4efabee1d13b13af782ae4442daac4691c721b4))
-* **compartment-mapper:** Fix "module" property in package.json ([68395a2](https://github.com/endojs/endo/commit/68395a2b071856dd0dfdf0a1c7c3d57082d7803e))
-* **compartment-mapper:** handle passing and reading exports reference ([#1142](https://github.com/endojs/endo/issues/1142)) ([3b7584a](https://github.com/endojs/endo/commit/3b7584a9bf6b3ba5b4e3f839c230cd07f022d33e))
-* **compartment-mapper:** propagate parse-cjs changes to parse-pre-cjs, remove async from execute in parse-pre-cjs ([8ac94b8](https://github.com/endojs/endo/commit/8ac94b85a11539155929569a86882a05fc146ad3))
-* **compartment-mapper:** Remove stale note ([85a4eb8](https://github.com/endojs/endo/commit/85a4eb81f65dbe4ba746014fad41ab86d1f70167))
-* **compartment-mapper:** there's more benefit to keeping __esModule flag than not  ([#1145](https://github.com/endojs/endo/issues/1145)) ([c769447](https://github.com/endojs/endo/commit/c76944794ebbe9e0ec0c8896e5ae9cce2fb17cb3))
-* **endo:** Ensure conditions include default, import, and endo ([1361abd](https://github.com/endojs/endo/commit/1361abd8c732596d192ecef6a039eda98b4ee563))
-* **ses:** avoid cache corruption when execute() throws ([1d9c17b](https://github.com/endojs/endo/commit/1d9c17b4c4a5ed1450cddd996bd948dd59c80bf6))
-
-
+- **compartment-mapper:** add support for alternatives in exports defnitions ([#1134](https://github.com/endojs/endo/issues/1134)) ([6663f25](https://github.com/endojs/endo/commit/6663f255de7a514aac0f0081eaa99de880298f73))
+- **compartment-mapper:** Avoid some property override pitfalls ([b4efabe](https://github.com/endojs/endo/commit/b4efabee1d13b13af782ae4442daac4691c721b4))
+- **compartment-mapper:** Fix "module" property in package.json ([68395a2](https://github.com/endojs/endo/commit/68395a2b071856dd0dfdf0a1c7c3d57082d7803e))
+- **compartment-mapper:** handle passing and reading exports reference ([#1142](https://github.com/endojs/endo/issues/1142)) ([3b7584a](https://github.com/endojs/endo/commit/3b7584a9bf6b3ba5b4e3f839c230cd07f022d33e))
+- **compartment-mapper:** propagate parse-cjs changes to parse-pre-cjs, remove async from execute in parse-pre-cjs ([8ac94b8](https://github.com/endojs/endo/commit/8ac94b85a11539155929569a86882a05fc146ad3))
+- **compartment-mapper:** Remove stale note ([85a4eb8](https://github.com/endojs/endo/commit/85a4eb81f65dbe4ba746014fad41ab86d1f70167))
+- **compartment-mapper:** there's more benefit to keeping \_\_esModule flag than not ([#1145](https://github.com/endojs/endo/issues/1145)) ([c769447](https://github.com/endojs/endo/commit/c76944794ebbe9e0ec0c8896e5ae9cce2fb17cb3))
+- **endo:** Ensure conditions include default, import, and endo ([1361abd](https://github.com/endojs/endo/commit/1361abd8c732596d192ecef6a039eda98b4ee563))
+- **ses:** avoid cache corruption when execute() throws ([1d9c17b](https://github.com/endojs/endo/commit/1d9c17b4c4a5ed1450cddd996bd948dd59c80bf6))
 
 ### [0.7.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.7.0...@endo/compartment-mapper@0.7.1) (2022-03-07)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ## [0.7.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.7...@endo/compartment-mapper@0.7.0) (2022-03-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **compartment-mapper:** * Previously, `loadArchive` and `parseArchive`, when given a `computeSha512`, would accept just about any archive. Hash integrity checks for any used module occurred only after a request to import them. With this new version, all archives must use every file they contain and must pass hash integrity checks during the load or parse phase.  Consequently, if an archive requires any built-in modules ("exits"), these must be mentioned with the `modules` option to `loadArchive` or `parseArchive`, as an object whose keys are the names of the expected modules.
+- **compartment-mapper:** \* Previously, `loadArchive` and `parseArchive`, when given a `computeSha512`, would accept just about any archive. Hash integrity checks for any used module occurred only after a request to import them. With this new version, all archives must use every file they contain and must pass hash integrity checks during the load or parse phase. Consequently, if an archive requires any built-in modules ("exits"), these must be mentioned with the `modules` option to `loadArchive` or `parseArchive`, as an object whose keys are the names of the expected modules.
 
 ### Features
 
-* **compartment-mapper:** Add makeAndHashArchive ([ffbe0d5](https://github.com/endojs/endo/commit/ffbe0d5b7ddb4c4e8de08ecc0735f2140b62e3a4))
-* **compartment-mapper:** Pre-load for archive integrity checks ([3c28ddc](https://github.com/endojs/endo/commit/3c28ddc336d2acac4dde5cdf32a27c33c713bc00)), closes [#3859](https://github.com/endojs/endo/issues/3859)
-
-
+- **compartment-mapper:** Add makeAndHashArchive ([ffbe0d5](https://github.com/endojs/endo/commit/ffbe0d5b7ddb4c4e8de08ecc0735f2140b62e3a4))
+- **compartment-mapper:** Pre-load for archive integrity checks ([3c28ddc](https://github.com/endojs/endo/commit/3c28ddc336d2acac4dde5cdf32a27c33c713bc00)), closes [#3859](https://github.com/endojs/endo/issues/3859)
 
 ### [0.6.7](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.6...@endo/compartment-mapper@0.6.7) (2022-02-20)
 
-
 ### Features
 
-* **compartment-mapper:** parseArchive return hash ([1306c7d](https://github.com/endojs/endo/commit/1306c7d95b2a90b18217829dac368e1089793366))
-* **compartment-mapper:** Validate compartment maps ([4204058](https://github.com/endojs/endo/commit/4204058428a6fcb04b68fd0151fd5955c94ae80a))
-
-
+- **compartment-mapper:** parseArchive return hash ([1306c7d](https://github.com/endojs/endo/commit/1306c7d95b2a90b18217829dac368e1089793366))
+- **compartment-mapper:** Validate compartment maps ([4204058](https://github.com/endojs/endo/commit/4204058428a6fcb04b68fd0151fd5955c94ae80a))
 
 ### [0.6.6](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.5...@endo/compartment-mapper@0.6.6) (2022-02-18)
 
-
 ### Bug Fixes
 
-* Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-* **compartment-mapper:** change how parse-cjs.js treats exports to align with behavior of cjs in Node.js; make execute synchronous ([d1eb363](https://github.com/endojs/endo/commit/d1eb36326d487c61d111dc1edea446b1a5e0cfce))
-
-
+- Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
+- **compartment-mapper:** change how parse-cjs.js treats exports to align with behavior of cjs in Node.js; make execute synchronous ([d1eb363](https://github.com/endojs/endo/commit/d1eb36326d487c61d111dc1edea446b1a5e0cfce))
 
 ### [0.6.5](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.4...@endo/compartment-mapper@0.6.5) (2022-01-31)
 
-
 ### Bug Fixes
 
-* **compartment-mapper:** Needless genericity considered harmful ([#1026](https://github.com/endojs/endo/issues/1026)) ([77e3d91](https://github.com/endojs/endo/commit/77e3d91364782dbd293c5dbc64f6ef29942369f0))
-
-
+- **compartment-mapper:** Needless genericity considered harmful ([#1026](https://github.com/endojs/endo/issues/1026)) ([77e3d91](https://github.com/endojs/endo/commit/77e3d91364782dbd293c5dbc64f6ef29942369f0))
 
 ### [0.6.4](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.3...@endo/compartment-mapper@0.6.4) (2022-01-27)
 
-
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.6.3](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.2...@endo/compartment-mapper@0.6.3) (2022-01-25)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.6.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.1...@endo/compartment-mapper@0.6.2) (2022-01-23)
 
 **Note:** Version bump only for package @endo/compartment-mapper
-
-
-
-
 
 ### [0.6.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.6.0...@endo/compartment-mapper@0.6.1) (2021-12-14)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ## [0.6.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.6...@endo/compartment-mapper@0.6.0) (2021-12-08)
-
 
 ### Features
 
-* **compartment-mapper:** Thread url into power makers for Windows support ([fedcc8c](https://github.com/endojs/endo/commit/fedcc8c2b1204a76af3ff8211ea7033411c657f8))
-
+- **compartment-mapper:** Thread url into power makers for Windows support ([fedcc8c](https://github.com/endojs/endo/commit/fedcc8c2b1204a76af3ff8211ea7033411c657f8))
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-* **compartment-mapper:** prettier bundle code, with some reduction ([dc9ccaa](https://github.com/endojs/endo/commit/dc9ccaae184d6346d11d90df46a2ed46c3ad3480))
-* **static-module-record:** cleaner Babel codegen ([6e22569](https://github.com/endojs/endo/commit/6e22569b0c3f56e9f78d59943235b97ba0429921))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
+- **compartment-mapper:** prettier bundle code, with some reduction ([dc9ccaa](https://github.com/endojs/endo/commit/dc9ccaae184d6346d11d90df46a2ed46c3ad3480))
+- **static-module-record:** cleaner Babel codegen ([6e22569](https://github.com/endojs/endo/commit/6e22569b0c3f56e9f78d59943235b97ba0429921))
 
 ### [0.5.6](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.5...@endo/compartment-mapper@0.5.6) (2021-11-16)
 
-
 ### Features
 
-* **compartment-mapper:** Add hooks for sourceURL ([#932](https://github.com/endojs/endo/issues/932)) ([a7b42ae](https://github.com/endojs/endo/commit/a7b42ae2388b232f7daa099495ba11f385010fd1))
-* **compartment-mapper:** Archive source URL suffixes ([#930](https://github.com/endojs/endo/issues/930)) ([0dfb83e](https://github.com/endojs/endo/commit/0dfb83ebc9221d15475aabe430645f5ac5d17e71))
-
-
+- **compartment-mapper:** Add hooks for sourceURL ([#932](https://github.com/endojs/endo/issues/932)) ([a7b42ae](https://github.com/endojs/endo/commit/a7b42ae2388b232f7daa099495ba11f385010fd1))
+- **compartment-mapper:** Archive source URL suffixes ([#930](https://github.com/endojs/endo/issues/930)) ([0dfb83e](https://github.com/endojs/endo/commit/0dfb83ebc9221d15475aabe430645f5ac5d17e71))
 
 ### [0.5.5](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.4...@endo/compartment-mapper@0.5.5) (2021-11-02)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.5.4](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.3...@endo/compartment-mapper@0.5.4) (2021-10-15)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.5.3](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.2...@endo/compartment-mapper@0.5.3) (2021-09-18)
-
 
 ### Bug Fixes
 
-* **compartment-mapper:** Reduce pre-cjs dependence on URL ([#894](https://github.com/endojs/endo/issues/894)) ([b9f6dc0](https://github.com/endojs/endo/commit/b9f6dc07f249cb47866f623728faf0b74d509fd2))
-
-
+- **compartment-mapper:** Reduce pre-cjs dependence on URL ([#894](https://github.com/endojs/endo/issues/894)) ([b9f6dc0](https://github.com/endojs/endo/commit/b9f6dc07f249cb47866f623728faf0b74d509fd2))
 
 ### [0.5.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.1...@endo/compartment-mapper@0.5.2) (2021-08-14)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ### [0.5.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.5.0...@endo/compartment-mapper@0.5.1) (2021-08-13)
-
 
 ### Features
 
-* **compartment-mapper:** Support reflexive imports ([#861](https://github.com/endojs/endo/issues/861)) ([09e5485](https://github.com/endojs/endo/commit/09e548558d14d6a7bff17c3b2df686122218d345))
-
-
+- **compartment-mapper:** Support reflexive imports ([#861](https://github.com/endojs/endo/issues/861)) ([09e5485](https://github.com/endojs/endo/commit/09e548558d14d6a7bff17c3b2df686122218d345))
 
 ## [0.5.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.4.1...@endo/compartment-mapper@0.5.0) (2021-07-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Update preamble for SES StaticModuleRecord
+- Update preamble for SES StaticModuleRecord
 
 ### Features
 
-* **compartment-mapper:** Consistent hashing ([fba461f](https://github.com/endojs/endo/commit/fba461f2786e1f9569c1bfb839e03d45cee7d2a6))
-
+- **compartment-mapper:** Consistent hashing ([fba461f](https://github.com/endojs/endo/commit/fba461f2786e1f9569c1bfb839e03d45cee7d2a6))
 
 ### Bug Fixes
 
-* Update preamble for SES StaticModuleRecord ([790ed01](https://github.com/endojs/endo/commit/790ed01f0aa73ff2d232e69c9323ee0bb448c2b0))
-* **compartment-map:** Restore test fixture maker and support for exit modules from archives ([0ccc277](https://github.com/endojs/endo/commit/0ccc277e2083d89aaf97f70a0900fe6692a4ee45))
-* **compartment-mapper:** Adjust bundle calling convention for preamble ([5a43a8e](https://github.com/endojs/endo/commit/5a43a8ea8759a223f2dedf88a1ea7b1e276b81e3))
-
-
+- Update preamble for SES StaticModuleRecord ([790ed01](https://github.com/endojs/endo/commit/790ed01f0aa73ff2d232e69c9323ee0bb448c2b0))
+- **compartment-map:** Restore test fixture maker and support for exit modules from archives ([0ccc277](https://github.com/endojs/endo/commit/0ccc277e2083d89aaf97f70a0900fe6692a4ee45))
+- **compartment-mapper:** Adjust bundle calling convention for preamble ([5a43a8e](https://github.com/endojs/endo/commit/5a43a8ea8759a223f2dedf88a1ea7b1e276b81e3))
 
 ### [0.4.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.4.0...@endo/compartment-mapper@0.4.1) (2021-06-20)
 
-
 ### Bug Fixes
 
-* **compartment-mapper:** Export types properly ([54be905](https://github.com/endojs/endo/commit/54be905895e9ebdae69b7542f6c4d7ff3660c2ea))
-* **compartment-mapper:** Propagate explicit types ([289c906](https://github.com/endojs/endo/commit/289c906173a450d608f816ab83e702435ad80057))
-
-
+- **compartment-mapper:** Export types properly ([54be905](https://github.com/endojs/endo/commit/54be905895e9ebdae69b7542f6c4d7ff3660c2ea))
+- **compartment-mapper:** Propagate explicit types ([289c906](https://github.com/endojs/endo/commit/289c906173a450d608f816ab83e702435ad80057))
 
 ## [0.4.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.3.2...@endo/compartment-mapper@0.4.0) (2021-06-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **compartment-mapper:** Required exits on archives
+- **compartment-mapper:** Required exits on archives
 
 ### Features
 
-* **compartment-mapper:** Developer dependencies ([44f86cd](https://github.com/endojs/endo/commit/44f86cd6788b8f6bdc5492619866995ede73488b))
-* **compartment-mapper:** Required exits on archives ([f5e6378](https://github.com/endojs/endo/commit/f5e6378f4c4dc2c017d3c94544a3e22d762ade27))
-
+- **compartment-mapper:** Developer dependencies ([44f86cd](https://github.com/endojs/endo/commit/44f86cd6788b8f6bdc5492619866995ede73488b))
+- **compartment-mapper:** Required exits on archives ([f5e6378](https://github.com/endojs/endo/commit/f5e6378f4c4dc2c017d3c94544a3e22d762ade27))
 
 ### Bug Fixes
 
-* **compartment-mapper:** Missing node-powers from published files ([277fd47](https://github.com/endojs/endo/commit/277fd47e359ee90d31a521fadbac90a4853649f4))
-
-
+- **compartment-mapper:** Missing node-powers from published files ([277fd47](https://github.com/endojs/endo/commit/277fd47e359ee90d31a521fadbac90a4853649f4))
 
 ### [0.3.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.3.1...@endo/compartment-mapper@0.3.2) (2021-06-14)
 
-
 ### Features
 
-* **compartment-mapper:** Add actionable hint to linker error ([4dbe87b](https://github.com/endojs/endo/commit/4dbe87b40007d5ce9a084b4cf94ac254d9bd9e7a))
-* **compartment-mapper:** Add Node.js power adapter ([fd16355](https://github.com/endojs/endo/commit/fd1635517ce8260d3dc2766c2c39a599f58f9a0c))
-* **compartment-mapper:** Follow symbolic links ([ae553a4](https://github.com/endojs/endo/commit/ae553a469800f548975b0e1ba5bb2c63455a87f4))
-
-
+- **compartment-mapper:** Add actionable hint to linker error ([4dbe87b](https://github.com/endojs/endo/commit/4dbe87b40007d5ce9a084b4cf94ac254d9bd9e7a))
+- **compartment-mapper:** Add Node.js power adapter ([fd16355](https://github.com/endojs/endo/commit/fd1635517ce8260d3dc2766c2c39a599f58f9a0c))
+- **compartment-mapper:** Follow symbolic links ([ae553a4](https://github.com/endojs/endo/commit/ae553a469800f548975b0e1ba5bb2c63455a87f4))
 
 ### [0.3.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.3.0...@endo/compartment-mapper@0.3.1) (2021-06-06)
 
 **Note:** Version bump only for package @endo/compartment-mapper
 
-
-
-
-
 ## 0.3.0 (2021-06-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **compartment-mapper:** No longer supports direct use from CommonJS
-* **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD
-* **compartment-mapper:** Lean on RESM/NESM interoperability
-* **compartment-mapper:** Rearrange entry point modules
-* **compartment-mapper:** Cleanly separate StaticModuleRecord dependency (#698)
-* **compartment-mapper:** Refresh zip fixture
-* **compartment-mapper:** Temporarily disable CommonJS
-* **compartment-mapper:** Rename endowments to globals
-* **compartment-mapper:** Import options bags and thread transforms
+- **compartment-mapper:** No longer supports direct use from CommonJS
+- **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD
+- **compartment-mapper:** Lean on RESM/NESM interoperability
+- **compartment-mapper:** Rearrange entry point modules
+- **compartment-mapper:** Cleanly separate StaticModuleRecord dependency (#698)
+- **compartment-mapper:** Refresh zip fixture
+- **compartment-mapper:** Temporarily disable CommonJS
+- **compartment-mapper:** Rename endowments to globals
+- **compartment-mapper:** Import options bags and thread transforms
 
 ### Features
 
-* **compartment-mapper:** Add module transforms ([#625](https://github.com/endojs/endo/issues/625)) ([0a0fc02](https://github.com/endojs/endo/commit/0a0fc02c400ebf68dfdf942354c548db6a6058f7))
-* **compartment-mapper:** Blanket in TypeScript definitions ([f850ed8](https://github.com/endojs/endo/commit/f850ed87fcdf943a1e347ffbe218144bee4151e8))
-* **compartment-mapper:** Improve archive parser errors ([c5887d8](https://github.com/endojs/endo/commit/c5887d8c13406b9da64c5537e87b3cf29ca8893e))
-* **compartment-mapper:** Introduce rudimentary bundler ([2bcddb1](https://github.com/endojs/endo/commit/2bcddb10845183074dbf5c709d9a70dadbce6dcb))
-* **compartment-mapper:** Pivot to CommonJS lexical analyzer ([e68a991](https://github.com/endojs/endo/commit/e68a991a54843a447cdd2c31a390e87192a36d04))
-* **compartment-mapper:** Precompiled ESM ([eb2fcc4](https://github.com/endojs/endo/commit/eb2fcc40fb5a51a433488ac111bd62bbed3655b0)), closes [#673](https://github.com/endojs/endo/issues/673)
-* **compartment-mapper:** Reenable CommonJS ([e76d95e](https://github.com/endojs/endo/commit/e76d95efd7aaa367c64d4e63e0983bb47f754832))
-* **compartment-mapper:** Thread compartment constructor ([f3248f2](https://github.com/endojs/endo/commit/f3248f27dc61f568f7f1a5ea61e35e04fa6887ea))
-* **compartment-mapper:** Thread global lexicals ([f92379a](https://github.com/endojs/endo/commit/f92379a4bb45ff4ef5b64eea998d5d5323a3434e))
-* **compartment-mapper:** Update packaging for RESM/NESM bridge and reorg under [@endo](https://github.com/endo) ([5b7c24e](https://github.com/endojs/endo/commit/5b7c24e1a473b5aa9e1397f6ca338bea8ed82984))
-* **endo:** Freeze all global objects ([#631](https://github.com/endojs/endo/issues/631)) ([83b5db4](https://github.com/endojs/endo/commit/83b5db4a2b64fcf1cb8927698e0d5942439eec27))
-* **ses:** Allow import and eval methods ([#669](https://github.com/endojs/endo/issues/669)) ([505a7d7](https://github.com/endojs/endo/commit/505a7d7149c36825a00c9fe3795d0f1588035dde))
-
+- **compartment-mapper:** Add module transforms ([#625](https://github.com/endojs/endo/issues/625)) ([0a0fc02](https://github.com/endojs/endo/commit/0a0fc02c400ebf68dfdf942354c548db6a6058f7))
+- **compartment-mapper:** Blanket in TypeScript definitions ([f850ed8](https://github.com/endojs/endo/commit/f850ed87fcdf943a1e347ffbe218144bee4151e8))
+- **compartment-mapper:** Improve archive parser errors ([c5887d8](https://github.com/endojs/endo/commit/c5887d8c13406b9da64c5537e87b3cf29ca8893e))
+- **compartment-mapper:** Introduce rudimentary bundler ([2bcddb1](https://github.com/endojs/endo/commit/2bcddb10845183074dbf5c709d9a70dadbce6dcb))
+- **compartment-mapper:** Pivot to CommonJS lexical analyzer ([e68a991](https://github.com/endojs/endo/commit/e68a991a54843a447cdd2c31a390e87192a36d04))
+- **compartment-mapper:** Precompiled ESM ([eb2fcc4](https://github.com/endojs/endo/commit/eb2fcc40fb5a51a433488ac111bd62bbed3655b0)), closes [#673](https://github.com/endojs/endo/issues/673)
+- **compartment-mapper:** Reenable CommonJS ([e76d95e](https://github.com/endojs/endo/commit/e76d95efd7aaa367c64d4e63e0983bb47f754832))
+- **compartment-mapper:** Thread compartment constructor ([f3248f2](https://github.com/endojs/endo/commit/f3248f27dc61f568f7f1a5ea61e35e04fa6887ea))
+- **compartment-mapper:** Thread global lexicals ([f92379a](https://github.com/endojs/endo/commit/f92379a4bb45ff4ef5b64eea998d5d5323a3434e))
+- **compartment-mapper:** Update packaging for RESM/NESM bridge and reorg under [@endo](https://github.com/endo) ([5b7c24e](https://github.com/endojs/endo/commit/5b7c24e1a473b5aa9e1397f6ca338bea8ed82984))
+- **endo:** Freeze all global objects ([#631](https://github.com/endojs/endo/issues/631)) ([83b5db4](https://github.com/endojs/endo/commit/83b5db4a2b64fcf1cb8927698e0d5942439eec27))
+- **ses:** Allow import and eval methods ([#669](https://github.com/endojs/endo/issues/669)) ([505a7d7](https://github.com/endojs/endo/commit/505a7d7149c36825a00c9fe3795d0f1588035dde))
 
 ### Bug Fixes
 
-* Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
-* **compartment-mapper:** Deterministic archives ([577cdd8](https://github.com/endojs/endo/commit/577cdd81daa56ccffe4dbed4470f76077eeb3d71))
-* **compartment-mapper:** Different tack to evade SES import censor ([#513](https://github.com/endojs/endo/issues/513)) ([5df2c0e](https://github.com/endojs/endo/commit/5df2c0e2c185ee71d1ebfd3b2e01e84ebfcf6c56))
-* **compartment-mapper:** Dodge named reexport as bug in tests ([ad8c661](https://github.com/endojs/endo/commit/ad8c6618887ecf1d96522b1370094bde1c87f5f0))
-* **compartment-mapper:** Elide source URL from archived MJS ([ecc65b5](https://github.com/endojs/endo/commit/ecc65b51243f942771a11e253e1192004c2301f7))
-* **compartment-mapper:** Generate strict bundle ([c1e3a90](https://github.com/endojs/endo/commit/c1e3a908f4a220edc179104b88f2ea8ad375bdfb))
-* **compartment-mapper:** Remove extraneous internal exports ([d8eb6ac](https://github.com/endojs/endo/commit/d8eb6ac09936d03772e1ccd3ed9f7dd23e460d6a))
-* **compartment-mapper:** Restore named reexport as bug in tests ([2de06f3](https://github.com/endojs/endo/commit/2de06f38946c25c72152980bd055a9e9759bfb43))
-* **compartment-mapper:** Switch from Syrup to JSON ([0d80376](https://github.com/endojs/endo/commit/0d80376fcf4dfc804a406d9d3e6e65dc900cbf08))
-* **compartment-mapper:** Withdraw UMD Rollup ([#469](https://github.com/endojs/endo/issues/469)) ([9118807](https://github.com/endojs/endo/commit/911880719822f35362844ce32e56f93a26cd5c02))
-* **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD ([dcff87e](https://github.com/endojs/endo/commit/dcff87e6f1164d664dd31dfefb323fbbac0a8dd1))
-* Realign TS, JS, and package names ([#686](https://github.com/endojs/endo/issues/686)) ([439e0ff](https://github.com/endojs/endo/commit/439e0fff1fd214eec91486ded8b3d36a5eb4b801))
-* **compartment-mapper:** Work around dynamic import censoring ([#512](https://github.com/endojs/endo/issues/512)) ([b82398b](https://github.com/endojs/endo/commit/b82398b55eb714b8fe59c06aaec74ddf9b78dda7))
-* Fully thread __shimTransforms__ through Compartment Mapper and SES ([#509](https://github.com/endojs/endo/issues/509)) ([0f199ef](https://github.com/endojs/endo/commit/0f199ef088353ec09b29e37aefcfa26a89a6c582))
-* **compartment-mapper:** Temporarily disable CommonJS ([8d7fb04](https://github.com/endojs/endo/commit/8d7fb04f18acf49e22850576dded8bf7b7045548))
-
+- Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
+- **compartment-mapper:** Deterministic archives ([577cdd8](https://github.com/endojs/endo/commit/577cdd81daa56ccffe4dbed4470f76077eeb3d71))
+- **compartment-mapper:** Different tack to evade SES import censor ([#513](https://github.com/endojs/endo/issues/513)) ([5df2c0e](https://github.com/endojs/endo/commit/5df2c0e2c185ee71d1ebfd3b2e01e84ebfcf6c56))
+- **compartment-mapper:** Dodge named reexport as bug in tests ([ad8c661](https://github.com/endojs/endo/commit/ad8c6618887ecf1d96522b1370094bde1c87f5f0))
+- **compartment-mapper:** Elide source URL from archived MJS ([ecc65b5](https://github.com/endojs/endo/commit/ecc65b51243f942771a11e253e1192004c2301f7))
+- **compartment-mapper:** Generate strict bundle ([c1e3a90](https://github.com/endojs/endo/commit/c1e3a908f4a220edc179104b88f2ea8ad375bdfb))
+- **compartment-mapper:** Remove extraneous internal exports ([d8eb6ac](https://github.com/endojs/endo/commit/d8eb6ac09936d03772e1ccd3ed9f7dd23e460d6a))
+- **compartment-mapper:** Restore named reexport as bug in tests ([2de06f3](https://github.com/endojs/endo/commit/2de06f38946c25c72152980bd055a9e9759bfb43))
+- **compartment-mapper:** Switch from Syrup to JSON ([0d80376](https://github.com/endojs/endo/commit/0d80376fcf4dfc804a406d9d3e6e65dc900cbf08))
+- **compartment-mapper:** Withdraw UMD Rollup ([#469](https://github.com/endojs/endo/issues/469)) ([9118807](https://github.com/endojs/endo/commit/911880719822f35362844ce32e56f93a26cd5c02))
+- **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD ([dcff87e](https://github.com/endojs/endo/commit/dcff87e6f1164d664dd31dfefb323fbbac0a8dd1))
+- Realign TS, JS, and package names ([#686](https://github.com/endojs/endo/issues/686)) ([439e0ff](https://github.com/endojs/endo/commit/439e0fff1fd214eec91486ded8b3d36a5eb4b801))
+- **compartment-mapper:** Work around dynamic import censoring ([#512](https://github.com/endojs/endo/issues/512)) ([b82398b](https://github.com/endojs/endo/commit/b82398b55eb714b8fe59c06aaec74ddf9b78dda7))
+- Fully thread **shimTransforms** through Compartment Mapper and SES ([#509](https://github.com/endojs/endo/issues/509)) ([0f199ef](https://github.com/endojs/endo/commit/0f199ef088353ec09b29e37aefcfa26a89a6c582))
+- **compartment-mapper:** Temporarily disable CommonJS ([8d7fb04](https://github.com/endojs/endo/commit/8d7fb04f18acf49e22850576dded8bf7b7045548))
 
 ### Tests
 
-* **compartment-mapper:** Refresh zip fixture ([691ca31](https://github.com/endojs/endo/commit/691ca3126d7fbc2122c1575c3d564643df569b4c))
-
+- **compartment-mapper:** Refresh zip fixture ([691ca31](https://github.com/endojs/endo/commit/691ca3126d7fbc2122c1575c3d564643df569b4c))
 
 ### Code Refactoring
 
-* **compartment-mapper:** Cleanly separate StaticModuleRecord dependency ([#698](https://github.com/endojs/endo/issues/698)) ([0b28902](https://github.com/endojs/endo/commit/0b289021eee1256c05ceb4d83318165cb6288844))
-* **compartment-mapper:** Import options bags and thread transforms ([3aa9ed9](https://github.com/endojs/endo/commit/3aa9ed9dcf259ffba853c9fd53564e874113ab4a))
-* **compartment-mapper:** Lean on RESM/NESM interoperability ([eb1753e](https://github.com/endojs/endo/commit/eb1753e1d28df423be6de9c70bceb6e8a1e171a1))
-* **compartment-mapper:** Rearrange entry point modules ([f87dc14](https://github.com/endojs/endo/commit/f87dc14e030ed9e8d47be92ff2faa5b5bec46914))
-* **compartment-mapper:** Rename endowments to globals ([a7e8a2e](https://github.com/endojs/endo/commit/a7e8a2ea734651100a4d3dfd703932b354f5d386))
+- **compartment-mapper:** Cleanly separate StaticModuleRecord dependency ([#698](https://github.com/endojs/endo/issues/698)) ([0b28902](https://github.com/endojs/endo/commit/0b289021eee1256c05ceb4d83318165cb6288844))
+- **compartment-mapper:** Import options bags and thread transforms ([3aa9ed9](https://github.com/endojs/endo/commit/3aa9ed9dcf259ffba853c9fd53564e874113ab4a))
+- **compartment-mapper:** Lean on RESM/NESM interoperability ([eb1753e](https://github.com/endojs/endo/commit/eb1753e1d28df423be6de9c70bceb6e8a1e171a1))
+- **compartment-mapper:** Rearrange entry point modules ([f87dc14](https://github.com/endojs/endo/commit/f87dc14e030ed9e8d47be92ff2faa5b5bec46914))
+- **compartment-mapper:** Rename endowments to globals ([a7e8a2e](https://github.com/endojs/endo/commit/a7e8a2ea734651100a4d3dfd703932b354f5d386))

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,7 +1,11 @@
 User-visible changes to the compartment mapper:
 
-# next
+# 0.8.1 (2022-12-23)
 
+- Increases ecosystem compatibility for reflective imports, the `browser` field
+  specified ad hoc by Browserify, and a fix for differentiating module language
+  from its extension.
+- Adds CommonJS support to the unsafe bootstrapping bundle format.
 - Introduces usage of `__reexportsMap__` from static module record
   to handle named reexports in the bundler.
 

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -41,13 +41,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/cjs-module-analyzer": "^0.2.28",
-    "@endo/static-module-record": "^0.7.15",
-    "@endo/zip": "^0.2.28",
-    "ses": "^0.18.0"
+    "@endo/cjs-module-analyzer": "^0.2.29",
+    "@endo/static-module-record": "^0.7.16",
+    "@endo/zip": "^0.2.29",
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,200 +3,121 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.24](https://github.com/endojs/endo/compare/@endo/daemon@0.1.23...@endo/daemon@0.1.24) (2022-12-23)
+
+### Features
+
+- **daemon:** Respond to ping ([83b1d42](https://github.com/endojs/endo/commit/83b1d420ba28a8f70b3fa6bee59aea18db874e62))
+
 ### [0.1.23](https://github.com/endojs/endo/compare/@endo/daemon@0.1.22...@endo/daemon@0.1.23) (2022-11-14)
 
 **Note:** Version bump only for package @endo/daemon
-
-
-
-
 
 ### [0.1.22](https://github.com/endojs/endo/compare/@endo/daemon@0.1.21...@endo/daemon@0.1.22) (2022-10-24)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.21](https://github.com/endojs/endo/compare/@endo/daemon@0.1.20...@endo/daemon@0.1.21) (2022-10-19)
 
 **Note:** Version bump only for package @endo/daemon
-
-
-
-
 
 ### [0.1.20](https://github.com/endojs/endo/compare/@endo/daemon@0.1.19...@endo/daemon@0.1.20) (2022-09-27)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.19](https://github.com/endojs/endo/compare/@endo/daemon@0.1.18...@endo/daemon@0.1.19) (2022-09-14)
-
 
 ### Features
 
-* **netstring:** Chunked mode for writer ([355a391](https://github.com/endojs/endo/commit/355a391eefc35a2efcc069eba459c0d8a09a61f8))
-
-
+- **netstring:** Chunked mode for writer ([355a391](https://github.com/endojs/endo/commit/355a391eefc35a2efcc069eba459c0d8a09a61f8))
 
 ### [0.1.18](https://github.com/endojs/endo/compare/@endo/daemon@0.1.17...@endo/daemon@0.1.18) (2022-08-26)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.17](https://github.com/endojs/endo/compare/@endo/daemon@0.1.16...@endo/daemon@0.1.17) (2022-08-26)
 
 **Note:** Version bump only for package @endo/daemon
-
-
-
-
 
 ### [0.1.16](https://github.com/endojs/endo/compare/@endo/daemon@0.1.15...@endo/daemon@0.1.16) (2022-08-25)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.15](https://github.com/endojs/endo/compare/@endo/daemon@0.1.14...@endo/daemon@0.1.15) (2022-08-23)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.14](https://github.com/endojs/endo/compare/@endo/daemon@0.1.13...@endo/daemon@0.1.14) (2022-06-28)
-
 
 ### Bug Fixes
 
-* **daemon:** avoid leaking in promise race ([219e49d](https://github.com/endojs/endo/commit/219e49dcdb61bddad9bb6ff8662aed38b6d89b8e))
-
-
+- **daemon:** avoid leaking in promise race ([219e49d](https://github.com/endojs/endo/commit/219e49dcdb61bddad9bb6ff8662aed38b6d89b8e))
 
 ### [0.1.13](https://github.com/endojs/endo/compare/@endo/daemon@0.1.12...@endo/daemon@0.1.13) (2022-06-11)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.12](https://github.com/endojs/endo/compare/@endo/daemon@0.1.11...@endo/daemon@0.1.12) (2022-04-15)
 
 **Note:** Version bump only for package @endo/daemon
-
-
-
-
 
 ### [0.1.11](https://github.com/endojs/endo/compare/@endo/daemon@0.1.10...@endo/daemon@0.1.11) (2022-04-14)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/daemon@0.1.9...@endo/daemon@0.1.10) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.1.9](https://github.com/endojs/endo/compare/@endo/daemon@0.1.8...@endo/daemon@0.1.9) (2022-04-12)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.8](https://github.com/endojs/endo/compare/@endo/daemon@0.1.7...@endo/daemon@0.1.8) (2022-03-07)
 
 **Note:** Version bump only for package @endo/daemon
-
-
-
-
 
 ### [0.1.7](https://github.com/endojs/endo/compare/@endo/daemon@0.1.6...@endo/daemon@0.1.7) (2022-03-02)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.6](https://github.com/endojs/endo/compare/@endo/daemon@0.1.5...@endo/daemon@0.1.6) (2022-02-20)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.5](https://github.com/endojs/endo/compare/@endo/daemon@0.1.4...@endo/daemon@0.1.5) (2022-02-18)
-
 
 ### Features
 
-* **daemon:** Add reset feature ([f615e15](https://github.com/endojs/endo/commit/f615e1511a06fb040d376c99b9fdebc11552b94e))
-* **daemon:** Clarify endo worker/daemon log actor ([47f65b7](https://github.com/endojs/endo/commit/47f65b7cdce5e647f25951c119c6f06a9f9ecd73))
-* **daemon:** Preliminary worker ([88e3bc0](https://github.com/endojs/endo/commit/88e3bc048637e089ca7078221cb5b7d1d42c4b64))
-
+- **daemon:** Add reset feature ([f615e15](https://github.com/endojs/endo/commit/f615e1511a06fb040d376c99b9fdebc11552b94e))
+- **daemon:** Clarify endo worker/daemon log actor ([47f65b7](https://github.com/endojs/endo/commit/47f65b7cdce5e647f25951c119c6f06a9f9ecd73))
+- **daemon:** Preliminary worker ([88e3bc0](https://github.com/endojs/endo/commit/88e3bc048637e089ca7078221cb5b7d1d42c4b64))
 
 ### Bug Fixes
 
-* Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-* **daemon:** Move init from lib to app ([7aaf1a0](https://github.com/endojs/endo/commit/7aaf1a07d2950b16f7202ecc1d281386ba812d67))
-
-
+- Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
+- **daemon:** Move init from lib to app ([7aaf1a0](https://github.com/endojs/endo/commit/7aaf1a07d2950b16f7202ecc1d281386ba812d67))
 
 ### [0.1.4](https://github.com/endojs/endo/compare/@endo/daemon@0.1.3...@endo/daemon@0.1.4) (2022-01-31)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### [0.1.3](https://github.com/endojs/endo/compare/@endo/daemon@0.1.2...@endo/daemon@0.1.3) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.1.2](https://github.com/endojs/endo/compare/@endo/daemon@0.1.1...@endo/daemon@0.1.2) (2022-01-25)
 
 **Note:** Version bump only for package @endo/daemon
 
-
-
-
-
 ### 0.1.1 (2022-01-23)
-
 
 ### Features
 
-* **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))
+- **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Endo daemon",
   "keywords": [
     "endo",
@@ -34,19 +34,19 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/captp": "^2.0.18",
-    "@endo/eventual-send": "^0.16.8",
-    "@endo/far": "^0.2.14",
-    "@endo/lockdown": "^0.1.24",
-    "@endo/netstring": "^0.3.22",
-    "@endo/promise-kit": "^0.2.52",
-    "@endo/stream": "^0.3.21",
-    "@endo/stream-node": "^0.2.22",
-    "@endo/where": "^0.2.10",
-    "ses": "^0.18.0"
+    "@endo/captp": "^2.0.19",
+    "@endo/eventual-send": "^0.16.9",
+    "@endo/far": "^0.2.15",
+    "@endo/lockdown": "^0.1.25",
+    "@endo/netstring": "^0.3.23",
+    "@endo/promise-kit": "^0.2.53",
+    "@endo/stream": "^0.3.22",
+    "@endo/stream-node": "^0.2.23",
+    "@endo/where": "^0.2.11",
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,332 +3,190 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.2](https://github.com/endojs/endo/compare/@endo/eslint-config@0.5.1...@endo/eslint-config@0.5.2) (2022-12-23)
+
+**Note:** Version bump only for package @endo/eslint-config
+
 ### [0.5.1](https://github.com/endojs/endo/compare/@endo/eslint-config@0.5.0...@endo/eslint-config@0.5.1) (2022-06-28)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ## [0.5.0](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.10...@endo/eslint-config@0.5.0) (2022-06-11)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **eslint:** move env config to recommended
+- **eslint:** move env config to recommended
 
 ### Code Refactoring
 
-* **eslint:** move env config to recommended ([276afad](https://github.com/endojs/endo/commit/276afad1c8f94cf5b99967e81c3229b8451897b0))
-
-
+- **eslint:** move env config to recommended ([276afad](https://github.com/endojs/endo/commit/276afad1c8f94cf5b99967e81c3229b8451897b0))
 
 ### [0.4.10](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.9...@endo/eslint-config@0.4.10) (2022-04-15)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.4.9](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.8...@endo/eslint-config@0.4.9) (2022-04-14)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.4.8](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.7...@endo/eslint-config@0.4.8) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.4.7](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.6...@endo/eslint-config@0.4.7) (2022-04-12)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.4.6](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.5...@endo/eslint-config@0.4.6) (2022-03-07)
 
 **Note:** Version bump only for package @endo/eslint-config
-
-
-
-
 
 ### [0.4.5](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.4...@endo/eslint-config@0.4.5) (2022-03-02)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.4.4](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.3...@endo/eslint-config@0.4.4) (2022-02-20)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.4.3](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.2...@endo/eslint-config@0.4.3) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.4.2](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.1...@endo/eslint-config@0.4.2) (2022-01-31)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.4.1](https://github.com/endojs/endo/compare/@endo/eslint-config@0.4.0...@endo/eslint-config@0.4.1) (2022-01-27)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ## [0.4.0](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.21...@endo/eslint-config@0.4.0) (2022-01-25)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **eslint-config:** Check all files, especially TypeScript
+- **eslint-config:** Check all files, especially TypeScript
 
 ### Styles
 
-* **eslint-config:** Check all files, especially TypeScript ([2424343](https://github.com/endojs/endo/commit/242434364b464bd666a8117d116b20ad70396838))
-
-
+- **eslint-config:** Check all files, especially TypeScript ([2424343](https://github.com/endojs/endo/commit/242434364b464bd666a8117d116b20ad70396838))
 
 ### [0.3.21](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.20...@endo/eslint-config@0.3.21) (2022-01-23)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.3.20](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.19...@endo/eslint-config@0.3.20) (2021-12-14)
 
 **Note:** Version bump only for package @endo/eslint-config
-
-
-
-
 
 ### [0.3.19](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.18...@endo/eslint-config@0.3.19) (2021-12-08)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.3.18](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.17...@endo/eslint-config@0.3.18) (2021-11-16)
 
 **Note:** Version bump only for package @endo/eslint-config
-
-
-
-
 
 ### [0.3.17](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.16...@endo/eslint-config@0.3.17) (2021-11-02)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.3.16](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.15...@endo/eslint-config@0.3.16) (2021-10-15)
 
 **Note:** Version bump only for package @endo/eslint-config
-
-
-
-
 
 ### [0.3.15](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.14...@endo/eslint-config@0.3.15) (2021-09-18)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.3.14](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.13...@endo/eslint-config@0.3.14) (2021-08-14)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.3.13](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.12...@endo/eslint-config@0.3.13) (2021-08-13)
-
 
 ### Features
 
-* **eslint-config:** Demos entrain devDependencies ([#859](https://github.com/endojs/endo/issues/859)) ([2d5aa25](https://github.com/endojs/endo/commit/2d5aa25934302c35d0295f60e69e0d05f0b82e13))
-* delegate linting to the `[@jessie](https://github.com/jessie).js/eslint-plugin` ([43718d1](https://github.com/endojs/endo/commit/43718d150a86f2cfc3e9115a0b1935378ffe7c15))
-
-
+- **eslint-config:** Demos entrain devDependencies ([#859](https://github.com/endojs/endo/issues/859)) ([2d5aa25](https://github.com/endojs/endo/commit/2d5aa25934302c35d0295f60e69e0d05f0b82e13))
+- delegate linting to the `[@jessie](https://github.com/jessie).js/eslint-plugin` ([43718d1](https://github.com/endojs/endo/commit/43718d150a86f2cfc3e9115a0b1935378ffe7c15))
 
 ### [0.3.12](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.11...@endo/eslint-config@0.3.12) (2021-07-22)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.3.11](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.10...@endo/eslint-config@0.3.11) (2021-06-20)
 
 **Note:** Version bump only for package @endo/eslint-config
-
-
-
-
 
 ### [0.3.10](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.9...@endo/eslint-config@0.3.10) (2021-06-16)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### [0.3.9](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.8...@endo/eslint-config@0.3.9) (2021-06-14)
 
 **Note:** Version bump only for package @endo/eslint-config
-
-
-
-
 
 ### [0.3.8](https://github.com/endojs/endo/compare/@endo/eslint-config@0.3.7...@endo/eslint-config@0.3.8) (2021-06-06)
 
 **Note:** Version bump only for package @endo/eslint-config
 
-
-
-
-
 ### 0.3.7 (2021-06-02)
-
 
 ### Bug Fixes
 
-* **eslint-config:** Rename under [@endo](https://github.com/endo) ([ab37eda](https://github.com/endojs/endo/commit/ab37eda48be2e0ff6bba6f4dc2d6a796674b57d1))
-* update to eslint 7.23.0 ([#652](https://github.com/endojs/endo/issues/652)) ([e9199f4](https://github.com/endojs/endo/commit/e9199f41c511b5df10593d931febdd90693b011a))
-
-
+- **eslint-config:** Rename under [@endo](https://github.com/endo) ([ab37eda](https://github.com/endojs/endo/commit/ab37eda48be2e0ff6bba6f4dc2d6a796674b57d1))
+- update to eslint 7.23.0 ([#652](https://github.com/endojs/endo/issues/652)) ([e9199f4](https://github.com/endojs/endo/commit/e9199f41c511b5df10593d931febdd90693b011a))
 
 ## [0.3.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.3.5...@agoric/eslint-config@0.3.6) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/eslint-config
 
-
-
-
-
 ## [0.3.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.3.4...@agoric/eslint-config@0.3.5) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/eslint-config
-
-
-
-
 
 ## [0.3.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.3.3...@agoric/eslint-config@0.3.4) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/eslint-config
 
-
-
-
-
 ## [0.3.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.3.2...@agoric/eslint-config@0.3.3) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/eslint-config
 
-
-
-
-
 ## [0.3.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.3.1...@agoric/eslint-config@0.3.2) (2021-04-06)
-
 
 ### Bug Fixes
 
-* update eslint version ([#2804](https://github.com/Agoric/agoric-sdk/issues/2804)) ([3fc6c5e](https://github.com/Agoric/agoric-sdk/commit/3fc6c5e593f7cdcf5f908365c29cc469e309229d))
-
-
-
-
+- update eslint version ([#2804](https://github.com/Agoric/agoric-sdk/issues/2804)) ([3fc6c5e](https://github.com/Agoric/agoric-sdk/commit/3fc6c5e593f7cdcf5f908365c29cc469e309229d))
 
 ## [0.3.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.3.0...@agoric/eslint-config@0.3.1) (2021-03-24)
 
 **Note:** Version bump only for package @agoric/eslint-config
 
-
-
-
-
 # [0.3.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.2.1...@agoric/eslint-config@0.3.0) (2021-03-16)
-
 
 ### Bug Fixes
 
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
 
 ### Features
 
-* eslint 'use jessie'; detection and first cut at rules ([9ea9909](https://github.com/Agoric/agoric-sdk/commit/9ea99097336ade6bb5645b06a1714e38c7185864))
-
-
-
-
+- eslint 'use jessie'; detection and first cut at rules ([9ea9909](https://github.com/Agoric/agoric-sdk/commit/9ea99097336ade6bb5645b06a1714e38c7185864))
 
 ## [0.2.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.2.0...@agoric/eslint-config@0.2.1) (2021-02-22)
 
 **Note:** Version bump only for package @agoric/eslint-config
 
-
-
-
-
 # [0.2.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-config@0.1.1...@agoric/eslint-config@0.2.0) (2021-02-16)
-
 
 ### Features
 
-* make @agoric/eslint-plugin deal with assert.fail as throw ([f23adee](https://github.com/Agoric/agoric-sdk/commit/f23adee512aec50788d9c9efed1cea9d774dfe8f))
-* modified eslint config to forbid the use of for...in loops ([#2423](https://github.com/Agoric/agoric-sdk/issues/2423)) ([1eb65d4](https://github.com/Agoric/agoric-sdk/commit/1eb65d4af52a40e229ec1eefaff0200d3ab6aba0))
-
-
-
-
+- make @agoric/eslint-plugin deal with assert.fail as throw ([f23adee](https://github.com/Agoric/agoric-sdk/commit/f23adee512aec50788d9c9efed1cea9d774dfe8f))
+- modified eslint config to forbid the use of for...in loops ([#2423](https://github.com/Agoric/agoric-sdk/issues/2423)) ([1eb65d4](https://github.com/Agoric/agoric-sdk/commit/1eb65d4af52a40e229ec1eefaff0200d3ab6aba0))
 
 ## 0.1.1 (2020-12-10)
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-config",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "lint rules used in Endo development",
   "keywords": [
     "endo",
@@ -24,7 +24,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/eslint-plugin": "^0.4.1",
+    "@endo/eslint-plugin": "^0.4.2",
     "@jessie.js/eslint-plugin": "^0.2.0"
   },
   "files": [

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,320 +3,180 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.4.2](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.4.1...@endo/eslint-plugin@0.4.2) (2022-12-23)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
 ### [0.4.1](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.4.0...@endo/eslint-plugin@0.4.1) (2022-06-28)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ## [0.4.0](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.28...@endo/eslint-plugin@0.4.0) (2022-06-11)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **eslint:** move env config to recommended
+- **eslint:** move env config to recommended
 
 ### Code Refactoring
 
-* **eslint:** move env config to recommended ([276afad](https://github.com/endojs/endo/commit/276afad1c8f94cf5b99967e81c3229b8451897b0))
-
-
+- **eslint:** move env config to recommended ([276afad](https://github.com/endojs/endo/commit/276afad1c8f94cf5b99967e81c3229b8451897b0))
 
 ### [0.3.28](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.27...@endo/eslint-plugin@0.3.28) (2022-04-15)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.27](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.26...@endo/eslint-plugin@0.3.27) (2022-04-14)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.26](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.25...@endo/eslint-plugin@0.3.26) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.3.25](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.24...@endo/eslint-plugin@0.3.25) (2022-04-12)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.24](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.23...@endo/eslint-plugin@0.3.24) (2022-03-07)
 
 **Note:** Version bump only for package @endo/eslint-plugin
-
-
-
-
 
 ### [0.3.23](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.22...@endo/eslint-plugin@0.3.23) (2022-03-02)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.22](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.21...@endo/eslint-plugin@0.3.22) (2022-02-20)
 
 **Note:** Version bump only for package @endo/eslint-plugin
-
-
-
-
 
 ### [0.3.21](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.20...@endo/eslint-plugin@0.3.21) (2022-02-18)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.20](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.19...@endo/eslint-plugin@0.3.20) (2022-01-31)
 
 **Note:** Version bump only for package @endo/eslint-plugin
-
-
-
-
 
 ### [0.3.19](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.18...@endo/eslint-plugin@0.3.19) (2022-01-27)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.18](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.17...@endo/eslint-plugin@0.3.18) (2022-01-25)
 
 **Note:** Version bump only for package @endo/eslint-plugin
-
-
-
-
 
 ### [0.3.17](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.16...@endo/eslint-plugin@0.3.17) (2022-01-23)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.16](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.15...@endo/eslint-plugin@0.3.16) (2021-12-14)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.15](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.14...@endo/eslint-plugin@0.3.15) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Rewrite erroneous changelog repository references ([ab52b93](https://github.com/endojs/endo/commit/ab52b93db31d74be8c2407b719a54e0896ed6b70))
-
-
+- Rewrite erroneous changelog repository references ([ab52b93](https://github.com/endojs/endo/commit/ab52b93db31d74be8c2407b719a54e0896ed6b70))
 
 ### [0.3.14](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.13...@endo/eslint-plugin@0.3.14) (2021-11-16)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.13](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.12...@endo/eslint-plugin@0.3.13) (2021-11-02)
 
 **Note:** Version bump only for package @endo/eslint-plugin
-
-
-
-
 
 ### [0.3.12](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.11...@endo/eslint-plugin@0.3.12) (2021-10-15)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.11](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.10...@endo/eslint-plugin@0.3.11) (2021-09-18)
-
 
 ### Features
 
-* **eslint-plugin:** Add no-polymorphic-call rule ([03e8c5f](https://github.com/endojs/endo/commit/03e8c5f566a52d9d6e7fb9d876a67347ecf37324))
-
-
+- **eslint-plugin:** Add no-polymorphic-call rule ([03e8c5f](https://github.com/endojs/endo/commit/03e8c5f566a52d9d6e7fb9d876a67347ecf37324))
 
 ### [0.3.10](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.9...@endo/eslint-plugin@0.3.10) (2021-08-14)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.9](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.8...@endo/eslint-plugin@0.3.9) (2021-08-13)
-
 
 ### Features
 
-* delegate linting to the `[@jessie](https://github.com/jessie).js/eslint-plugin` ([43718d1](https://github.com/endojs/endo/commit/43718d150a86f2cfc3e9115a0b1935378ffe7c15))
-
-
+- delegate linting to the `[@jessie](https://github.com/jessie).js/eslint-plugin` ([43718d1](https://github.com/endojs/endo/commit/43718d150a86f2cfc3e9115a0b1935378ffe7c15))
 
 ### [0.3.8](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.7...@endo/eslint-plugin@0.3.8) (2021-07-22)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.7](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.6...@endo/eslint-plugin@0.3.7) (2021-06-20)
 
 **Note:** Version bump only for package @endo/eslint-plugin
-
-
-
-
 
 ### [0.3.6](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.5...@endo/eslint-plugin@0.3.6) (2021-06-16)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### [0.3.5](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.4...@endo/eslint-plugin@0.3.5) (2021-06-14)
 
 **Note:** Version bump only for package @endo/eslint-plugin
-
-
-
-
 
 ### [0.3.4](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.3.3...@endo/eslint-plugin@0.3.4) (2021-06-06)
 
 **Note:** Version bump only for package @endo/eslint-plugin
 
-
-
-
-
 ### 0.3.3 (2021-06-02)
 
 **Note:** Version bump only for package @endo/eslint-plugin
-
-
-
-
 
 ## [0.3.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-plugin@0.3.1...@agoric/eslint-plugin@0.3.2) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/eslint-plugin
 
-
-
-
-
 ## [0.3.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-plugin@0.3.0...@agoric/eslint-plugin@0.3.1) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/eslint-plugin
 
-
-
-
-
 # [0.3.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-plugin@0.2.3...@agoric/eslint-plugin@0.3.0) (2021-05-05)
-
 
 ### Features
 
-* upgrade use-jessie eslint, and honour '// [@jessie-check](https://github.com/jessie-check)' ([fd1c24a](https://github.com/Agoric/agoric-sdk/commit/fd1c24a84584f6b5f7b7d5e8b21d756464db05b6))
-
-
-
-
+- upgrade use-jessie eslint, and honour '// [@jessie-check](https://github.com/jessie-check)' ([fd1c24a](https://github.com/Agoric/agoric-sdk/commit/fd1c24a84584f6b5f7b7d5e8b21d756464db05b6))
 
 ## [0.2.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-plugin@0.2.2...@agoric/eslint-plugin@0.2.3) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/eslint-plugin
 
-
-
-
-
 ## [0.2.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-plugin@0.2.1...@agoric/eslint-plugin@0.2.2) (2021-04-06)
-
 
 ### Bug Fixes
 
-* update eslint version ([#2804](https://github.com/Agoric/agoric-sdk/issues/2804)) ([3fc6c5e](https://github.com/Agoric/agoric-sdk/commit/3fc6c5e593f7cdcf5f908365c29cc469e309229d))
-
-
-
-
+- update eslint version ([#2804](https://github.com/Agoric/agoric-sdk/issues/2804)) ([3fc6c5e](https://github.com/Agoric/agoric-sdk/commit/3fc6c5e593f7cdcf5f908365c29cc469e309229d))
 
 ## [0.2.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-plugin@0.2.0...@agoric/eslint-plugin@0.2.1) (2021-03-24)
 
 **Note:** Version bump only for package @agoric/eslint-plugin
 
-
-
-
-
 # [0.2.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-plugin@0.1.1...@agoric/eslint-plugin@0.2.0) (2021-03-16)
-
 
 ### Bug Fixes
 
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
 
 ### Features
 
-* eslint 'use jessie'; detection and first cut at rules ([9ea9909](https://github.com/Agoric/agoric-sdk/commit/9ea99097336ade6bb5645b06a1714e38c7185864))
-
-
-
-
+- eslint 'use jessie'; detection and first cut at rules ([9ea9909](https://github.com/Agoric/agoric-sdk/commit/9ea99097336ade6bb5645b06a1714e38c7185864))
 
 ## [0.1.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eslint-plugin@0.1.0...@agoric/eslint-plugin@0.1.1) (2021-02-22)
 
 **Note:** Version bump only for package @agoric/eslint-plugin
 
-
-
-
-
 # 0.1.0 (2021-02-16)
-
 
 ### Features
 
-* make @agoric/eslint-plugin deal with assert.fail as throw ([f23adee](https://github.com/Agoric/agoric-sdk/commit/f23adee512aec50788d9c9efed1cea9d774dfe8f))
+- make @agoric/eslint-plugin deal with assert.fail as throw ([f23adee](https://github.com/Agoric/agoric-sdk/commit/f23adee512aec50788d9c9efed1cea9d774dfe8f))

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,300 +3,201 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.16.8](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.7...@endo/eventual-send@0.16.8) (2022-11-14)
-
+### [0.16.9](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.8...@endo/eventual-send@0.16.9) (2022-12-23)
 
 ### Bug Fixes
 
-* assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
-* fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
+- **eventual-send:** E.resolve safer against constructor attack ([#1390](https://github.com/endojs/endo/issues/1390)) ([e71d723](https://github.com/endojs/endo/commit/e71d723e2da30f197963da8133017ee8b5e3941e))
+- include inherited methods in missing method error ([#1382](https://github.com/endojs/endo/issues/1382)) ([f0cd522](https://github.com/endojs/endo/commit/f0cd52295521de2aaa486c6a2d1c0dfb0bea578d))
 
+### [0.16.8](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.7...@endo/eventual-send@0.16.8) (2022-11-14)
 
+### Bug Fixes
+
+- assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
+- fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
 
 ### [0.16.7](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.6...@endo/eventual-send@0.16.7) (2022-10-24)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.16.6](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.5...@endo/eventual-send@0.16.6) (2022-10-19)
 
 **Note:** Version bump only for package @endo/eventual-send
-
-
-
-
 
 ### [0.16.5](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.4...@endo/eventual-send@0.16.5) (2022-09-27)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.16.4](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.3...@endo/eventual-send@0.16.4) (2022-09-14)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.16.3](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.2...@endo/eventual-send@0.16.3) (2022-08-26)
-
 
 ### Bug Fixes
 
-* **eventual-send:** Remove lingering ?. operator ([51b38c2](https://github.com/endojs/endo/commit/51b38c2ba4d3e3c1a69ad4ccf1a343dadd3eed93))
-
-
+- **eventual-send:** Remove lingering ?. operator ([51b38c2](https://github.com/endojs/endo/commit/51b38c2ba4d3e3c1a69ad4ccf1a343dadd3eed93))
 
 ### [0.16.2](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.1...@endo/eventual-send@0.16.2) (2022-08-26)
 
-
 ### Bug Fixes
 
-* **eventual-send:** Remove ?. and ?? operators for RESM ([15dc777](https://github.com/endojs/endo/commit/15dc777c64dce5e50386d3fa80e209e9991c516b))
-
-
+- **eventual-send:** Remove ?. and ?? operators for RESM ([15dc777](https://github.com/endojs/endo/commit/15dc777c64dce5e50386d3fa80e209e9991c516b))
 
 ### [0.16.1](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.0...@endo/eventual-send@0.16.1) (2022-08-25)
 
-
 ### Features
 
-* **eventual-send:** Feature-flag track-turns ([e07019e](https://github.com/endojs/endo/commit/e07019e3c312391da26fbe6cce6a875484302288))
-
+- **eventual-send:** Feature-flag track-turns ([e07019e](https://github.com/endojs/endo/commit/e07019e3c312391da26fbe6cce6a875484302288))
 
 ### Bug Fixes
 
-* **eventual-send:** hoist closures to discourage argument retention ([7786d4c](https://github.com/endojs/endo/commit/7786d4c201cfc5e5fbd27cd456d45597c25284a2)), closes [#1245](https://github.com/endojs/endo/issues/1245)
-
-
+- **eventual-send:** hoist closures to discourage argument retention ([7786d4c](https://github.com/endojs/endo/commit/7786d4c201cfc5e5fbd27cd456d45597c25284a2)), closes [#1245](https://github.com/endojs/endo/issues/1245)
 
 ## [0.16.0](https://github.com/endojs/endo/compare/@endo/eventual-send@0.15.5...@endo/eventual-send@0.16.0) (2022-08-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **eventual-send:** Disallow using E proxy methods as functions (#1255)
+- **eventual-send:** Disallow using E proxy methods as functions (#1255)
 
 ### Bug Fixes
 
-* **eventual-send:** Disallow using E proxy methods as functions ([#1255](https://github.com/endojs/endo/issues/1255)) ([43b7962](https://github.com/endojs/endo/commit/43b796232634b54c9e7de1c0a2349d22c29fc384))
-* typedef default onfulfilled handler for E.when ([c5582ca](https://github.com/endojs/endo/commit/c5582ca7473e0a5d94ef4753ff54e0626cdb1d0a))
-
-
+- **eventual-send:** Disallow using E proxy methods as functions ([#1255](https://github.com/endojs/endo/issues/1255)) ([43b7962](https://github.com/endojs/endo/commit/43b796232634b54c9e7de1c0a2349d22c29fc384))
+- typedef default onfulfilled handler for E.when ([c5582ca](https://github.com/endojs/endo/commit/c5582ca7473e0a5d94ef4753ff54e0626cdb1d0a))
 
 ### [0.15.5](https://github.com/endojs/endo/compare/@endo/eventual-send@0.15.4...@endo/eventual-send@0.15.5) (2022-06-28)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.15.4](https://github.com/endojs/endo/compare/@endo/eventual-send@0.15.3...@endo/eventual-send@0.15.4) (2022-06-11)
-
 
 ### Bug Fixes
 
-* **eventual-send:** no implicit rejection silencing; just harden ([ca07d81](https://github.com/endojs/endo/commit/ca07d8150fd1e12b9e90505a7c06ada6b25d0743))
-* **eventual-send:** use `!Object.is(a, b)` instead of `a !== b` for NaNs ([2b7e418](https://github.com/endojs/endo/commit/2b7e4189182dcac17832bbdcfb6ac56e32fee456))
-
-
+- **eventual-send:** no implicit rejection silencing; just harden ([ca07d81](https://github.com/endojs/endo/commit/ca07d8150fd1e12b9e90505a7c06ada6b25d0743))
+- **eventual-send:** use `!Object.is(a, b)` instead of `a !== b` for NaNs ([2b7e418](https://github.com/endojs/endo/commit/2b7e4189182dcac17832bbdcfb6ac56e32fee456))
 
 ### [0.15.3](https://github.com/endojs/endo/compare/@endo/eventual-send@0.15.2...@endo/eventual-send@0.15.3) (2022-04-15)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.15.2](https://github.com/endojs/endo/compare/@endo/eventual-send@0.15.1...@endo/eventual-send@0.15.2) (2022-04-14)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.15.1](https://github.com/endojs/endo/compare/@endo/eventual-send@0.15.0...@endo/eventual-send@0.15.1) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ## [0.15.0](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.8...@endo/eventual-send@0.15.0) (2022-04-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **far:** rename `Remote` to `FarRef`
+- **far:** rename `Remote` to `FarRef`
 
 ### Features
 
-* **far:** rename `Remote` to `FarRef` ([7bde2bf](https://github.com/endojs/endo/commit/7bde2bf28e88935606564cebd1b8d284cd70e4ef))
-
+- **far:** rename `Remote` to `FarRef` ([7bde2bf](https://github.com/endojs/endo/commit/7bde2bf28e88935606564cebd1b8d284cd70e4ef))
 
 ### Bug Fixes
 
-* **eventual-send:** evolve types based on marshal requirements ([ff388fa](https://github.com/endojs/endo/commit/ff388fa2f81446c1ae02618b78771dc17ce5c74b))
-* **eventual-send:** unwrap promises more fully ([6ba799f](https://github.com/endojs/endo/commit/6ba799f77e8d55530ecd7617c3ccad22324bade2))
-
-
+- **eventual-send:** evolve types based on marshal requirements ([ff388fa](https://github.com/endojs/endo/commit/ff388fa2f81446c1ae02618b78771dc17ce5c74b))
+- **eventual-send:** unwrap promises more fully ([6ba799f](https://github.com/endojs/endo/commit/6ba799f77e8d55530ecd7617c3ccad22324bade2))
 
 ### [0.14.8](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.7...@endo/eventual-send@0.14.8) (2022-03-07)
 
-
 ### Features
 
-* **eventual-send:** provide typing for `Remote<Primary, Local>` ([4d28509](https://github.com/endojs/endo/commit/4d285095a6ea1a78f1a3a4696bc822f5e4dfd43f))
-
+- **eventual-send:** provide typing for `Remote<Primary, Local>` ([4d28509](https://github.com/endojs/endo/commit/4d285095a6ea1a78f1a3a4696bc822f5e4dfd43f))
 
 ### Bug Fixes
 
-* **eventual-send:** properly declare `E` to be type `EProxy` ([3bdfdf7](https://github.com/endojs/endo/commit/3bdfdf77440f9ddea9bac1e783aaf015e9bcfa62))
-
-
+- **eventual-send:** properly declare `E` to be type `EProxy` ([3bdfdf7](https://github.com/endojs/endo/commit/3bdfdf77440f9ddea9bac1e783aaf015e9bcfa62))
 
 ### [0.14.7](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.6...@endo/eventual-send@0.14.7) (2022-03-02)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.14.6](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.5...@endo/eventual-send@0.14.6) (2022-02-20)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.14.5](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.4...@endo/eventual-send@0.14.5) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* **marshal:** Fix typing for TS 4.5 compatibility ([8513cfb](https://github.com/endojs/endo/commit/8513cfbaaa2308bee9f666585694e622e84fd24e))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- **marshal:** Fix typing for TS 4.5 compatibility ([8513cfb](https://github.com/endojs/endo/commit/8513cfbaaa2308bee9f666585694e622e84fd24e))
 
 ### [0.14.4](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.3...@endo/eventual-send@0.14.4) (2022-01-31)
 
 **Note:** Version bump only for package @endo/eventual-send
 
-
-
-
-
 ### [0.14.3](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.2...@endo/eventual-send@0.14.3) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.14.2](https://github.com/endojs/endo/compare/@endo/eventual-send@0.14.1...@endo/eventual-send@0.14.2) (2022-01-25)
 
-
 ### Features
 
-* **eventual-send:** harden things where possible under SES ([2394c71](https://github.com/endojs/endo/commit/2394c71673360ce8ec8a3c30f5fa47753fb9bec5))
-
+- **eventual-send:** harden things where possible under SES ([2394c71](https://github.com/endojs/endo/commit/2394c71673360ce8ec8a3c30f5fa47753fb9bec5))
 
 ### Bug Fixes
 
-* remove more extraneous spaced-comment comments ([#1009](https://github.com/endojs/endo/issues/1009)) ([980a798](https://github.com/endojs/endo/commit/980a79898a4643a359d905c308eecf70d8ab2758))
-
-
+- remove more extraneous spaced-comment comments ([#1009](https://github.com/endojs/endo/issues/1009)) ([980a798](https://github.com/endojs/endo/commit/980a79898a4643a359d905c308eecf70d8ab2758))
 
 ### 0.14.1 (2022-01-23)
 
-
 ### Bug Fixes
 
-* **eventual-send:** Accommodate TypeScript pickiness difference ([1c86bb0](https://github.com/endojs/endo/commit/1c86bb096c6fc8f4e5dd0220c2309534e8593b52))
-* **eventual-send:** Remove unused files ([309965c](https://github.com/endojs/endo/commit/309965c79c23079cdcf578b91b265c82d7657b09))
-
-
+- **eventual-send:** Accommodate TypeScript pickiness difference ([1c86bb0](https://github.com/endojs/endo/commit/1c86bb096c6fc8f4e5dd0220c2309534e8593b52))
+- **eventual-send:** Remove unused files ([309965c](https://github.com/endojs/endo/commit/309965c79c23079cdcf578b91b265c82d7657b09))
 
 ## [0.14.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.30...@agoric/eventual-send@0.14.0) (2021-12-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **eventual-send:** implement *SendOnly and handler defaults
+- **eventual-send:** implement \*SendOnly and handler defaults
 
 ### Features
 
-* **eventual-send:** implement *SendOnly and handler defaults ([8d2fb33](https://github.com/Agoric/agoric-sdk/commit/8d2fb334df18c88663094510fb2fea809ed8a2ac))
-
+- **eventual-send:** implement \*SendOnly and handler defaults ([8d2fb33](https://github.com/Agoric/agoric-sdk/commit/8d2fb334df18c88663094510fb2fea809ed8a2ac))
 
 ### Bug Fixes
 
-* **deps:** remove explicit `@agoric/babel-standalone` ([4f22453](https://github.com/Agoric/agoric-sdk/commit/4f22453a6f2de1a2c27ae8ad0d11b13116890dab))
-* **eslint-config:** loosen no-extraneous-dependencies patterns ([71be149](https://github.com/Agoric/agoric-sdk/commit/71be149522823ec41900bcf96a0b39f75b38bfd9))
-* **eventual-send:** do basic sanity of static method invocation ([596d77e](https://github.com/Agoric/agoric-sdk/commit/596d77ed4ed99a46133a78a437c76393665a4073))
-* **eventual-send:** make local handlers more robust ([30d4db5](https://github.com/Agoric/agoric-sdk/commit/30d4db5ab10c6f4201332db866f612b84ac084e5))
-* **eventual-send:** provide `returnedP` when it is available ([a779066](https://github.com/Agoric/agoric-sdk/commit/a7790660db426e1967f444c034c3dedd59ed33eb))
-* **eventual-send:** remove WeakMap workaround for pre-xsnap XS ([dcad6ac](https://github.com/Agoric/agoric-sdk/commit/dcad6ac6ac946414f6411ec1ad73017e04875d6d))
-
-
+- **deps:** remove explicit `@agoric/babel-standalone` ([4f22453](https://github.com/Agoric/agoric-sdk/commit/4f22453a6f2de1a2c27ae8ad0d11b13116890dab))
+- **eslint-config:** loosen no-extraneous-dependencies patterns ([71be149](https://github.com/Agoric/agoric-sdk/commit/71be149522823ec41900bcf96a0b39f75b38bfd9))
+- **eventual-send:** do basic sanity of static method invocation ([596d77e](https://github.com/Agoric/agoric-sdk/commit/596d77ed4ed99a46133a78a437c76393665a4073))
+- **eventual-send:** make local handlers more robust ([30d4db5](https://github.com/Agoric/agoric-sdk/commit/30d4db5ab10c6f4201332db866f612b84ac084e5))
+- **eventual-send:** provide `returnedP` when it is available ([a779066](https://github.com/Agoric/agoric-sdk/commit/a7790660db426e1967f444c034c3dedd59ed33eb))
+- **eventual-send:** remove WeakMap workaround for pre-xsnap XS ([dcad6ac](https://github.com/Agoric/agoric-sdk/commit/dcad6ac6ac946414f6411ec1ad73017e04875d6d))
 
 ### [0.13.30](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.29...@agoric/eventual-send@0.13.30) (2021-10-13)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.29](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.28...@agoric/eventual-send@0.13.29) (2021-09-23)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ### [0.13.28](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.27...@agoric/eventual-send@0.13.28) (2021-09-15)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.27](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.26...@agoric/eventual-send@0.13.27) (2021-08-18)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.26](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.25...@agoric/eventual-send@0.13.26) (2021-08-17)
-
 
 ### Bug Fixes
 
-* Remove dregs of node -r esm ([#3710](https://github.com/Agoric/agoric-sdk/issues/3710)) ([e30c934](https://github.com/Agoric/agoric-sdk/commit/e30c934a9de19e930677c7b65ad98abe0be16d56))
-
-
+- Remove dregs of node -r esm ([#3710](https://github.com/Agoric/agoric-sdk/issues/3710)) ([e30c934](https://github.com/Agoric/agoric-sdk/commit/e30c934a9de19e930677c7b65ad98abe0be16d56))
 
 ### [0.13.25](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.22...@agoric/eventual-send@0.13.25) (2021-08-15)
 
@@ -304,452 +205,267 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.24](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.22...@agoric/eventual-send@0.13.24) (2021-08-14)
 
 ### 0.26.10 (2021-07-28)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.23](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.22...@agoric/eventual-send@0.13.23) (2021-07-28)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ### [0.13.22](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.21...@agoric/eventual-send@0.13.22) (2021-07-01)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.21](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.20...@agoric/eventual-send@0.13.21) (2021-06-28)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ### [0.13.20](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.19...@agoric/eventual-send@0.13.20) (2021-06-25)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.19](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.18...@agoric/eventual-send@0.13.19) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ### [0.13.18](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.17...@agoric/eventual-send@0.13.18) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.17](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.16...@agoric/eventual-send@0.13.17) (2021-06-23)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ### [0.13.16](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.15...@agoric/eventual-send@0.13.16) (2021-06-16)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ### [0.13.15](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.14...@agoric/eventual-send@0.13.15) (2021-06-15)
-
 
 ### Bug Fixes
 
-* Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
-* upgrade acorn and babel parser ([048cc92](https://github.com/Agoric/agoric-sdk/commit/048cc925b3090f77e998fef1f3ac26846c4a8f26))
-
-
+- Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
+- upgrade acorn and babel parser ([048cc92](https://github.com/Agoric/agoric-sdk/commit/048cc925b3090f77e998fef1f3ac26846c4a8f26))
 
 ## [0.13.14](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.13...@agoric/eventual-send@0.13.14) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.13.13](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.12...@agoric/eventual-send@0.13.13) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ## [0.13.12](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.11...@agoric/eventual-send@0.13.12) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.13.11](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.10...@agoric/eventual-send@0.13.11) (2021-04-22)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ## [0.13.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.9...@agoric/eventual-send@0.13.10) (2021-04-18)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.13.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.8...@agoric/eventual-send@0.13.9) (2021-04-16)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ## [0.13.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.7...@agoric/eventual-send@0.13.8) (2021-04-14)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.13.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.6...@agoric/eventual-send@0.13.7) (2021-04-13)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ## [0.13.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.5...@agoric/eventual-send@0.13.6) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.13.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.4...@agoric/eventual-send@0.13.5) (2021-04-06)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ## [0.13.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.3...@agoric/eventual-send@0.13.4) (2021-03-24)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.13.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.2...@agoric/eventual-send@0.13.3) (2021-03-16)
-
 
 ### Bug Fixes
 
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-
-
-
-
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
 
 ## [0.13.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.1...@agoric/eventual-send@0.13.2) (2021-02-22)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.13.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.13.0...@agoric/eventual-send@0.13.1) (2021-02-16)
-
 
 ### Bug Fixes
 
-* add placeholder for top-of-turn error logging ([#2163](https://github.com/Agoric/agoric-sdk/issues/2163)) ([f0c257c](https://github.com/Agoric/agoric-sdk/commit/f0c257ceb420f1d6fb4513ff9ef8c7c773b6e333))
-* Correlate sent errors with received errors ([73b9cfd](https://github.com/Agoric/agoric-sdk/commit/73b9cfd33cf7842bdc105a79592028649cb1c92a))
-* review comments ([7db7e5c](https://github.com/Agoric/agoric-sdk/commit/7db7e5c4c569dfedff8d748dd58893218b0a2458))
-* use assert rather than FooError constructors ([f860c5b](https://github.com/Agoric/agoric-sdk/commit/f860c5bf5add165a08cb5bd543502857c3f57998))
-* **eventual-send:** test static method rejections ([f6bd055](https://github.com/Agoric/agoric-sdk/commit/f6bd055ccc897dc49ae92f452dcd5abf45bfae14))
-
-
-
-
+- add placeholder for top-of-turn error logging ([#2163](https://github.com/Agoric/agoric-sdk/issues/2163)) ([f0c257c](https://github.com/Agoric/agoric-sdk/commit/f0c257ceb420f1d6fb4513ff9ef8c7c773b6e333))
+- Correlate sent errors with received errors ([73b9cfd](https://github.com/Agoric/agoric-sdk/commit/73b9cfd33cf7842bdc105a79592028649cb1c92a))
+- review comments ([7db7e5c](https://github.com/Agoric/agoric-sdk/commit/7db7e5c4c569dfedff8d748dd58893218b0a2458))
+- use assert rather than FooError constructors ([f860c5b](https://github.com/Agoric/agoric-sdk/commit/f860c5bf5add165a08cb5bd543502857c3f57998))
+- **eventual-send:** test static method rejections ([f6bd055](https://github.com/Agoric/agoric-sdk/commit/f6bd055ccc897dc49ae92f452dcd5abf45bfae14))
 
 # [0.13.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.12.0...@agoric/eventual-send@0.13.0) (2020-12-10)
 
-
 ### Features
 
-* **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
-
-
-
-
+- **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
 
 # [0.12.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.12.0-dev.0...@agoric/eventual-send@0.12.0) (2020-11-07)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 # [0.12.0-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.11.1...@agoric/eventual-send@0.12.0-dev.0) (2020-10-19)
-
 
 ### Features
 
-* **E:** . ([eddf51e](https://github.com/Agoric/agoric-sdk/commit/eddf51eb3c3c59e4cf9031ee0c21231c6585b7c2))
-* **E:** . ([4ce1239](https://github.com/Agoric/agoric-sdk/commit/4ce12393a36c6d68046442e0cf6b517c9c97f03c))
-* **E:** . ([672c593](https://github.com/Agoric/agoric-sdk/commit/672c59351cf04a174f2cfd553f026929613cffaf))
-* **E:** . ([c0d8013](https://github.com/Agoric/agoric-sdk/commit/c0d80138bb66c047466b040c7c44ebe4626dd939))
-* **E:** . adding tests for the sendOnly variant. ([19182b3](https://github.com/Agoric/agoric-sdk/commit/19182b35088928e1feb5ef559efb66edec587a9a))
-* **E:** . another test added. ([162c0d7](https://github.com/Agoric/agoric-sdk/commit/162c0d7f26f113d8ed6608c229add9592265ff66))
-* **E:** . continuing ([6c51052](https://github.com/Agoric/agoric-sdk/commit/6c51052c7497e932d0b72d97b3fe0747b53b14cc))
-* **E:** . continuing onward ([2b1eb5b](https://github.com/Agoric/agoric-sdk/commit/2b1eb5b9715cb3bf8c7bf1e4617dc6b3fab2ecd3))
-* **E:** . fixing E.js ([4d57814](https://github.com/Agoric/agoric-sdk/commit/4d57814035576fccdd1f41fd13d50e3ebf719123))
-* **E:** . fixing test-e.js ([a48bb95](https://github.com/Agoric/agoric-sdk/commit/a48bb956f6e6d63c483c03a43aa561cf72eb3424))
-* **E:** . test skipped for now until I am destumped ([fd9df0f](https://github.com/Agoric/agoric-sdk/commit/fd9df0f3d78863e271107a687765c56d77edd62d))
-* **E:** . throwsAsync not asyncThrows ([aa62713](https://github.com/Agoric/agoric-sdk/commit/aa62713d8947c46868c4b511bd29f330d3a7a13b))
-* **E:** . voiding voids ([3908652](https://github.com/Agoric/agoric-sdk/commit/390865279be9cf30f64bb27500d50f5107ef1c89))
-* **E:** . was missing a closing paren. ([b87d485](https://github.com/Agoric/agoric-sdk/commit/b87d485e241f2bca9b147a8006c0e80a96c5036e))
-* **E:** starting to add missing E.sendOnly() ([e04ee59](https://github.com/Agoric/agoric-sdk/commit/e04ee592b761dc433adc3a7ccb08df0ac3895616))
-
-
-
-
+- **E:** . ([eddf51e](https://github.com/Agoric/agoric-sdk/commit/eddf51eb3c3c59e4cf9031ee0c21231c6585b7c2))
+- **E:** . ([4ce1239](https://github.com/Agoric/agoric-sdk/commit/4ce12393a36c6d68046442e0cf6b517c9c97f03c))
+- **E:** . ([672c593](https://github.com/Agoric/agoric-sdk/commit/672c59351cf04a174f2cfd553f026929613cffaf))
+- **E:** . ([c0d8013](https://github.com/Agoric/agoric-sdk/commit/c0d80138bb66c047466b040c7c44ebe4626dd939))
+- **E:** . adding tests for the sendOnly variant. ([19182b3](https://github.com/Agoric/agoric-sdk/commit/19182b35088928e1feb5ef559efb66edec587a9a))
+- **E:** . another test added. ([162c0d7](https://github.com/Agoric/agoric-sdk/commit/162c0d7f26f113d8ed6608c229add9592265ff66))
+- **E:** . continuing ([6c51052](https://github.com/Agoric/agoric-sdk/commit/6c51052c7497e932d0b72d97b3fe0747b53b14cc))
+- **E:** . continuing onward ([2b1eb5b](https://github.com/Agoric/agoric-sdk/commit/2b1eb5b9715cb3bf8c7bf1e4617dc6b3fab2ecd3))
+- **E:** . fixing E.js ([4d57814](https://github.com/Agoric/agoric-sdk/commit/4d57814035576fccdd1f41fd13d50e3ebf719123))
+- **E:** . fixing test-e.js ([a48bb95](https://github.com/Agoric/agoric-sdk/commit/a48bb956f6e6d63c483c03a43aa561cf72eb3424))
+- **E:** . test skipped for now until I am destumped ([fd9df0f](https://github.com/Agoric/agoric-sdk/commit/fd9df0f3d78863e271107a687765c56d77edd62d))
+- **E:** . throwsAsync not asyncThrows ([aa62713](https://github.com/Agoric/agoric-sdk/commit/aa62713d8947c46868c4b511bd29f330d3a7a13b))
+- **E:** . voiding voids ([3908652](https://github.com/Agoric/agoric-sdk/commit/390865279be9cf30f64bb27500d50f5107ef1c89))
+- **E:** . was missing a closing paren. ([b87d485](https://github.com/Agoric/agoric-sdk/commit/b87d485e241f2bca9b147a8006c0e80a96c5036e))
+- **E:** starting to add missing E.sendOnly() ([e04ee59](https://github.com/Agoric/agoric-sdk/commit/e04ee592b761dc433adc3a7ccb08df0ac3895616))
 
 ## [0.11.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.11.1-dev.2...@agoric/eventual-send@0.11.1) (2020-10-11)
 
-
 ### Bug Fixes
 
-* improved error message when eventual send target is undefined ([#1847](https://github.com/Agoric/agoric-sdk/issues/1847)) ([f33d30e](https://github.com/Agoric/agoric-sdk/commit/f33d30e46eeb209f039e81a92350c06611cc45a1))
-* **eventual-send:** silence unhandled rejection for remote calls ([fb7c247](https://github.com/Agoric/agoric-sdk/commit/fb7c247688eacf09e975ca87ab7ef246cd240136))
-
-
-
-
+- improved error message when eventual send target is undefined ([#1847](https://github.com/Agoric/agoric-sdk/issues/1847)) ([f33d30e](https://github.com/Agoric/agoric-sdk/commit/f33d30e46eeb209f039e81a92350c06611cc45a1))
+- **eventual-send:** silence unhandled rejection for remote calls ([fb7c247](https://github.com/Agoric/agoric-sdk/commit/fb7c247688eacf09e975ca87ab7ef246cd240136))
 
 ## [0.11.1-dev.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.11.1-dev.1...@agoric/eventual-send@0.11.1-dev.2) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.11.1-dev.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.11.1-dev.0...@agoric/eventual-send@0.11.1-dev.1) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/eventual-send
-
-
-
-
 
 ## [0.11.1-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.11.0...@agoric/eventual-send@0.11.1-dev.0) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 # [0.11.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.10.0...@agoric/eventual-send@0.11.0) (2020-09-16)
-
 
 ### Bug Fixes
 
-* allow local Presences to receive deliveries as well ([93c8933](https://github.com/Agoric/agoric-sdk/commit/93c8933b5c2bdafec26b325e0d3fc6e88978d199)), closes [#1719](https://github.com/Agoric/agoric-sdk/issues/1719)
-* implement epochs and make tolerant of restarts ([1c786b8](https://github.com/Agoric/agoric-sdk/commit/1c786b861a445891d09df2f1a47d689d641a0c5f))
-* minor updates from PR review ([aa37b4f](https://github.com/Agoric/agoric-sdk/commit/aa37b4f4439faa846ced5653c7963798f44e872e))
-* restoring most state, just need to isolate the plugin captp ([f92ee73](https://github.com/Agoric/agoric-sdk/commit/f92ee731afa69435b10b94cf4a483f25bed7a668))
-
+- allow local Presences to receive deliveries as well ([93c8933](https://github.com/Agoric/agoric-sdk/commit/93c8933b5c2bdafec26b325e0d3fc6e88978d199)), closes [#1719](https://github.com/Agoric/agoric-sdk/issues/1719)
+- implement epochs and make tolerant of restarts ([1c786b8](https://github.com/Agoric/agoric-sdk/commit/1c786b861a445891d09df2f1a47d689d641a0c5f))
+- minor updates from PR review ([aa37b4f](https://github.com/Agoric/agoric-sdk/commit/aa37b4f4439faa846ced5653c7963798f44e872e))
+- restoring most state, just need to isolate the plugin captp ([f92ee73](https://github.com/Agoric/agoric-sdk/commit/f92ee731afa69435b10b94cf4a483f25bed7a668))
 
 ### Features
 
-* implement CapTP forwarding over a plugin device ([b4a1be8](https://github.com/Agoric/agoric-sdk/commit/b4a1be8f600d60191570a3bbf42bc4c82af47b06))
-* implement makeLoopback and makeFar without a membrane ([b0bccba](https://github.com/Agoric/agoric-sdk/commit/b0bccbabecc2902c9d9f7319ffb0c509bccc2d01))
-
-
-
-
+- implement CapTP forwarding over a plugin device ([b4a1be8](https://github.com/Agoric/agoric-sdk/commit/b4a1be8f600d60191570a3bbf42bc4c82af47b06))
+- implement makeLoopback and makeFar without a membrane ([b0bccba](https://github.com/Agoric/agoric-sdk/commit/b0bccbabecc2902c9d9f7319ffb0c509bccc2d01))
 
 # [0.10.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.9.3...@agoric/eventual-send@0.10.0) (2020-08-31)
 
-
 ### Bug Fixes
 
-* `ERef<T>` is `T | PromiseLike<T>` ([#1383](https://github.com/Agoric/agoric-sdk/issues/1383)) ([8ef4d66](https://github.com/Agoric/agoric-sdk/commit/8ef4d662dc80daf80420c0c531c2abe41517b6cd))
-* clean up E.when and E.resolve ([#1561](https://github.com/Agoric/agoric-sdk/issues/1561)) ([634046c](https://github.com/Agoric/agoric-sdk/commit/634046c0fc541fc1db258105a75c7313b5668aa0))
-* don't early-bind the Promise constructor; metering changes it ([a703e6f](https://github.com/Agoric/agoric-sdk/commit/a703e6f1091b595d7f4fd368ec2c2407e5e89695))
-* excise @agoric/harden from the codebase ([eee6fe1](https://github.com/Agoric/agoric-sdk/commit/eee6fe1153730dec52841c9eb4c056a8c5438b0f))
-* need type decl for HandledPromise.reject ([#1406](https://github.com/Agoric/agoric-sdk/issues/1406)) ([aec2c99](https://github.com/Agoric/agoric-sdk/commit/aec2c9940b4ba580ec98f0a1f94b3cadde7fa2eb))
-* reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
-* remove obsolete "unwrap" ([#1360](https://github.com/Agoric/agoric-sdk/issues/1360)) ([5796e0e](https://github.com/Agoric/agoric-sdk/commit/5796e0e6f8bfd00619f725bdac4ff5743610a52f))
-* remove unnecessary types ([e242143](https://github.com/Agoric/agoric-sdk/commit/e24214342062f908ebee91a775c0427abc21e263))
-* try to use HandledPromise for pipelineability ([848a90f](https://github.com/Agoric/agoric-sdk/commit/848a90f8d7427e2c31dc5764555da2fde42eac8d))
-* update JS typings ([20941e6](https://github.com/Agoric/agoric-sdk/commit/20941e675302ee5905e4825638e661065ad5d3f9))
-* upgrade to SES v0.10.1, and make HandledPromise shim work ([5d0adea](https://github.com/Agoric/agoric-sdk/commit/5d0adea1b3b7369ae8131df55f99b61e0c428542))
-* use full harden when creating E ([adc8e73](https://github.com/Agoric/agoric-sdk/commit/adc8e73625975378e4856917146c8fd152d7c897))
-
+- `ERef<T>` is `T | PromiseLike<T>` ([#1383](https://github.com/Agoric/agoric-sdk/issues/1383)) ([8ef4d66](https://github.com/Agoric/agoric-sdk/commit/8ef4d662dc80daf80420c0c531c2abe41517b6cd))
+- clean up E.when and E.resolve ([#1561](https://github.com/Agoric/agoric-sdk/issues/1561)) ([634046c](https://github.com/Agoric/agoric-sdk/commit/634046c0fc541fc1db258105a75c7313b5668aa0))
+- don't early-bind the Promise constructor; metering changes it ([a703e6f](https://github.com/Agoric/agoric-sdk/commit/a703e6f1091b595d7f4fd368ec2c2407e5e89695))
+- excise @agoric/harden from the codebase ([eee6fe1](https://github.com/Agoric/agoric-sdk/commit/eee6fe1153730dec52841c9eb4c056a8c5438b0f))
+- need type decl for HandledPromise.reject ([#1406](https://github.com/Agoric/agoric-sdk/issues/1406)) ([aec2c99](https://github.com/Agoric/agoric-sdk/commit/aec2c9940b4ba580ec98f0a1f94b3cadde7fa2eb))
+- reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
+- remove obsolete "unwrap" ([#1360](https://github.com/Agoric/agoric-sdk/issues/1360)) ([5796e0e](https://github.com/Agoric/agoric-sdk/commit/5796e0e6f8bfd00619f725bdac4ff5743610a52f))
+- remove unnecessary types ([e242143](https://github.com/Agoric/agoric-sdk/commit/e24214342062f908ebee91a775c0427abc21e263))
+- try to use HandledPromise for pipelineability ([848a90f](https://github.com/Agoric/agoric-sdk/commit/848a90f8d7427e2c31dc5764555da2fde42eac8d))
+- update JS typings ([20941e6](https://github.com/Agoric/agoric-sdk/commit/20941e675302ee5905e4825638e661065ad5d3f9))
+- upgrade to SES v0.10.1, and make HandledPromise shim work ([5d0adea](https://github.com/Agoric/agoric-sdk/commit/5d0adea1b3b7369ae8131df55f99b61e0c428542))
+- use full harden when creating E ([adc8e73](https://github.com/Agoric/agoric-sdk/commit/adc8e73625975378e4856917146c8fd152d7c897))
 
 ### Features
 
-* introduce the shim/no-shim exports to distinguish callers ([d2a6bff](https://github.com/Agoric/agoric-sdk/commit/d2a6bffd74042e02cf0fbca88d2caf334a8de261))
-
-
-
-
+- introduce the shim/no-shim exports to distinguish callers ([d2a6bff](https://github.com/Agoric/agoric-sdk/commit/d2a6bffd74042e02cf0fbca88d2caf334a8de261))
 
 ## [0.9.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.9.2...@agoric/eventual-send@0.9.3) (2020-06-30)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 ## [0.9.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.9.1...@agoric/eventual-send@0.9.2) (2020-05-17)
-
 
 ### Bug Fixes
 
-* don't stall extra turns while resolving to local objects ([04740d6](https://github.com/Agoric/agoric-sdk/commit/04740d6e1c2279f8ae1ab17ecc83bd6f772034a7))
-* fix double invoke bug ([#1117](https://github.com/Agoric/agoric-sdk/issues/1117)) ([b8d462e](https://github.com/Agoric/agoric-sdk/commit/b8d462e56aa3f1080eb7617dd715a3ecbd2c9ae3))
-* remove many build steps ([6c7d3bb](https://github.com/Agoric/agoric-sdk/commit/6c7d3bb0c70277c22f8eda40525d7240141a5434))
-
-
-
-
+- don't stall extra turns while resolving to local objects ([04740d6](https://github.com/Agoric/agoric-sdk/commit/04740d6e1c2279f8ae1ab17ecc83bd6f772034a7))
+- fix double invoke bug ([#1117](https://github.com/Agoric/agoric-sdk/issues/1117)) ([b8d462e](https://github.com/Agoric/agoric-sdk/commit/b8d462e56aa3f1080eb7617dd715a3ecbd2c9ae3))
+- remove many build steps ([6c7d3bb](https://github.com/Agoric/agoric-sdk/commit/6c7d3bb0c70277c22f8eda40525d7240141a5434))
 
 ## [0.9.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.9.0...@agoric/eventual-send@0.9.1) (2020-05-10)
 
-
 ### Bug Fixes
 
-* be lazy in choosing which handler to use ([904b610](https://github.com/Agoric/agoric-sdk/commit/904b610685a50ba32dc0712e62f4c902f61e437a))
-* be sure to propagate handler failures ([2b931fc](https://github.com/Agoric/agoric-sdk/commit/2b931fcb60afcb24fd7c331eadd12dbfc4592e85))
-
-
-
-
+- be lazy in choosing which handler to use ([904b610](https://github.com/Agoric/agoric-sdk/commit/904b610685a50ba32dc0712e62f4c902f61e437a))
+- be sure to propagate handler failures ([2b931fc](https://github.com/Agoric/agoric-sdk/commit/2b931fcb60afcb24fd7c331eadd12dbfc4592e85))
 
 # [0.9.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.8.0...@agoric/eventual-send@0.9.0) (2020-05-04)
 
-
 ### Bug Fixes
 
-* lots and lots of improvements ([8f1c312](https://github.com/Agoric/agoric-sdk/commit/8f1c3128bbb4c3baf7f15b9ca632fc902acd238f))
-* use the new (typed) harden package ([2eb1af0](https://github.com/Agoric/agoric-sdk/commit/2eb1af08fe3967629a3ce165752fd501a5c85a96))
-
+- lots and lots of improvements ([8f1c312](https://github.com/Agoric/agoric-sdk/commit/8f1c3128bbb4c3baf7f15b9ca632fc902acd238f))
+- use the new (typed) harden package ([2eb1af0](https://github.com/Agoric/agoric-sdk/commit/2eb1af08fe3967629a3ce165752fd501a5c85a96))
 
 ### Features
 
-* implement channel host handler ([4e68f44](https://github.com/Agoric/agoric-sdk/commit/4e68f441b46d70dee481387ab96e88f1e0b69bfa))
-
-
-
-
+- implement channel host handler ([4e68f44](https://github.com/Agoric/agoric-sdk/commit/4e68f441b46d70dee481387ab96e88f1e0b69bfa))
 
 # [0.8.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.8.0-alpha.0...@agoric/eventual-send@0.8.0) (2020-04-13)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 # [0.8.0-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.7.0...@agoric/eventual-send@0.8.0-alpha.0) (2020-04-12)
-
 
 ### Bug Fixes
 
-* shorten HandledPromises to propagate handlers ([2ed50d2](https://github.com/Agoric/agoric-sdk/commit/2ed50d24c1b80959748bcaf0d04f1c4cd25f4242))
-
+- shorten HandledPromises to propagate handlers ([2ed50d2](https://github.com/Agoric/agoric-sdk/commit/2ed50d24c1b80959748bcaf0d04f1c4cd25f4242))
 
 ### Features
 
-* add the returnedP as the last argument to the handler ([1f83d99](https://github.com/Agoric/agoric-sdk/commit/1f83d994f48b659f3c49c4b5eb2b50ea7bb7b7a3))
-
-
-
-
+- add the returnedP as the last argument to the handler ([1f83d99](https://github.com/Agoric/agoric-sdk/commit/1f83d994f48b659f3c49c4b5eb2b50ea7bb7b7a3))
 
 # [0.7.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.7.0-alpha.0...@agoric/eventual-send@0.7.0) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/eventual-send
 
-
-
-
-
 # [0.7.0-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/eventual-send@0.6.0...@agoric/eventual-send@0.7.0-alpha.0) (2020-04-02)
-
 
 ### Features
 
-* add E.when(x, onfulfilled, onrejected) as a convenience ([4415f67](https://github.com/Agoric/agoric-sdk/commit/4415f67651f7770fddea85272ee7a02b69b9e8aa))
-
-
-
-
+- add E.when(x, onfulfilled, onrejected) as a convenience ([4415f67](https://github.com/Agoric/agoric-sdk/commit/4415f67651f7770fddea85272ee7a02b69b9e8aa))
 
 # 0.6.0 (2020-03-26)
 
-
 ### Bug Fixes
 
-* **api:** remove many unnecessary methods ([cf10dc3](https://github.com/Agoric/eventual-send/commit/cf10dc3af79cbeb33a3bc4980e6b87ac28503cd4)), closes [#41](https://github.com/Agoric/eventual-send/issues/41)
-* **E:** address PR comments ([a529982](https://github.com/Agoric/eventual-send/commit/a529982203e4842290b84f48831052fe1e6d30f9))
-* **eventual-send:** Update the API throughout agoric-sdk ([97fc1e7](https://github.com/Agoric/eventual-send/commit/97fc1e748d8e3955b29baf0e04bfa788d56dad9f))
-* **HandledPromise:** implement specified API ([8da7249](https://github.com/Agoric/eventual-send/commit/8da7249764da87b7c47b89b5ccb5c1f2125ef0d1)), closes [#42](https://github.com/Agoric/eventual-send/issues/42)
-* **resolve:** protect against reentrancy attack ([#401](https://github.com/Agoric/eventual-send/issues/401)) ([d1f25ef](https://github.com/Agoric/eventual-send/commit/d1f25ef2511168bd9df8b6ca6a8edfef13f6dd2b)), closes [#9](https://github.com/Agoric/eventual-send/issues/9)
-* **SwingSet:** passing all tests ([341718b](https://github.com/Agoric/eventual-send/commit/341718be335e16b58aa5e648b51a731ea065c1d6))
-* **unwrap:** pass through non-Thenables before throwing ([67aba42](https://github.com/Agoric/eventual-send/commit/67aba42962b10af9250248f7f1b2abc579291de6)), closes [#518](https://github.com/Agoric/eventual-send/issues/518)
-* address PR comments ([b9ed6b5](https://github.com/Agoric/eventual-send/commit/b9ed6b5a510433af968ba233d4e943b939defa1b))
-
+- **api:** remove many unnecessary methods ([cf10dc3](https://github.com/Agoric/eventual-send/commit/cf10dc3af79cbeb33a3bc4980e6b87ac28503cd4)), closes [#41](https://github.com/Agoric/eventual-send/issues/41)
+- **E:** address PR comments ([a529982](https://github.com/Agoric/eventual-send/commit/a529982203e4842290b84f48831052fe1e6d30f9))
+- **eventual-send:** Update the API throughout agoric-sdk ([97fc1e7](https://github.com/Agoric/eventual-send/commit/97fc1e748d8e3955b29baf0e04bfa788d56dad9f))
+- **HandledPromise:** implement specified API ([8da7249](https://github.com/Agoric/eventual-send/commit/8da7249764da87b7c47b89b5ccb5c1f2125ef0d1)), closes [#42](https://github.com/Agoric/eventual-send/issues/42)
+- **resolve:** protect against reentrancy attack ([#401](https://github.com/Agoric/eventual-send/issues/401)) ([d1f25ef](https://github.com/Agoric/eventual-send/commit/d1f25ef2511168bd9df8b6ca6a8edfef13f6dd2b)), closes [#9](https://github.com/Agoric/eventual-send/issues/9)
+- **SwingSet:** passing all tests ([341718b](https://github.com/Agoric/eventual-send/commit/341718be335e16b58aa5e648b51a731ea065c1d6))
+- **unwrap:** pass through non-Thenables before throwing ([67aba42](https://github.com/Agoric/eventual-send/commit/67aba42962b10af9250248f7f1b2abc579291de6)), closes [#518](https://github.com/Agoric/eventual-send/issues/518)
+- address PR comments ([b9ed6b5](https://github.com/Agoric/eventual-send/commit/b9ed6b5a510433af968ba233d4e943b939defa1b))
 
 ### Features
 
-* **E:** export E.resolve to use HandledPromise.resolve ([93c508d](https://github.com/Agoric/eventual-send/commit/93c508de8439d8d6b4b6030af3f95c370c46f91f))
-* **HandledPromise:** add sync unwrap() to get presences ([5ec5b78](https://github.com/Agoric/eventual-send/commit/5ec5b78a038f11d26827358c70bb6c820ed04a2e)), closes [#412](https://github.com/Agoric/eventual-send/issues/412)
+- **E:** export E.resolve to use HandledPromise.resolve ([93c508d](https://github.com/Agoric/eventual-send/commit/93c508de8439d8d6b4b6030af3f95c370c46f91f))
+- **HandledPromise:** add sync unwrap() to get presences ([5ec5b78](https://github.com/Agoric/eventual-send/commit/5ec5b78a038f11d26827358c70bb6c820ed04a2e)), closes [#412](https://github.com/Agoric/eventual-send/issues/412)

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/lockdown": "^0.1.24",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/lockdown": "^0.1.25",
+    "@endo/ses-ava": "^0.2.37",
     "ava": "^5.1.0",
     "c8": "^7.7.3",
     "tsd": "^0.24.1"

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,203 +3,121 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.15](https://github.com/endojs/endo/compare/@endo/far@0.2.14...@endo/far@0.2.15) (2022-12-23)
+
+### Bug Fixes
+
+- include inherited methods in missing method error ([#1382](https://github.com/endojs/endo/issues/1382)) ([f0cd522](https://github.com/endojs/endo/commit/f0cd52295521de2aaa486c6a2d1c0dfb0bea578d))
+
 ### [0.2.14](https://github.com/endojs/endo/compare/@endo/far@0.2.13...@endo/far@0.2.14) (2022-11-14)
 
 **Note:** Version bump only for package @endo/far
-
-
-
-
 
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/far@0.2.12...@endo/far@0.2.13) (2022-10-24)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.2.12](https://github.com/endojs/endo/compare/@endo/far@0.2.11...@endo/far@0.2.12) (2022-10-19)
 
 **Note:** Version bump only for package @endo/far
-
-
-
-
 
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/far@0.2.10...@endo/far@0.2.11) (2022-09-27)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.2.10](https://github.com/endojs/endo/compare/@endo/far@0.2.9...@endo/far@0.2.10) (2022-09-14)
 
 **Note:** Version bump only for package @endo/far
-
-
-
-
 
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/far@0.2.8...@endo/far@0.2.9) (2022-08-26)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/far@0.2.7...@endo/far@0.2.8) (2022-08-26)
 
 **Note:** Version bump only for package @endo/far
-
-
-
-
 
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/far@0.2.6...@endo/far@0.2.7) (2022-08-25)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/far@0.2.5...@endo/far@0.2.6) (2022-08-23)
 
 **Note:** Version bump only for package @endo/far
-
-
-
-
 
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/far@0.2.4...@endo/far@0.2.5) (2022-06-28)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/far@0.2.3...@endo/far@0.2.4) (2022-06-11)
 
 **Note:** Version bump only for package @endo/far
-
-
-
-
 
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/far@0.2.2...@endo/far@0.2.3) (2022-04-15)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/far@0.2.1...@endo/far@0.2.2) (2022-04-14)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/far@0.2.0...@endo/far@0.2.1) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ## [0.2.0](https://github.com/endojs/endo/compare/@endo/far@0.1.9...@endo/far@0.2.0) (2022-04-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **far:** rename `Remote` to `FarRef`
+- **far:** rename `Remote` to `FarRef`
 
 ### Features
 
-* **far:** rename `Remote` to `FarRef` ([7bde2bf](https://github.com/endojs/endo/commit/7bde2bf28e88935606564cebd1b8d284cd70e4ef))
-
-
+- **far:** rename `Remote` to `FarRef` ([7bde2bf](https://github.com/endojs/endo/commit/7bde2bf28e88935606564cebd1b8d284cd70e4ef))
 
 ### [0.1.9](https://github.com/endojs/endo/compare/@endo/far@0.1.8...@endo/far@0.1.9) (2022-03-07)
 
-
 ### Features
 
-* **far:** export `Remote<Primary, Local>` ([f406cb6](https://github.com/endojs/endo/commit/f406cb6b8658d457fdfda20c71ff844a8eea8112))
-
-
+- **far:** export `Remote<Primary, Local>` ([f406cb6](https://github.com/endojs/endo/commit/f406cb6b8658d457fdfda20c71ff844a8eea8112))
 
 ### [0.1.8](https://github.com/endojs/endo/compare/@endo/far@0.1.7...@endo/far@0.1.8) (2022-03-02)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.1.7](https://github.com/endojs/endo/compare/@endo/far@0.1.6...@endo/far@0.1.7) (2022-02-20)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.1.6](https://github.com/endojs/endo/compare/@endo/far@0.1.5...@endo/far@0.1.6) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
 
 ### [0.1.5](https://github.com/endojs/endo/compare/@endo/far@0.1.4...@endo/far@0.1.5) (2022-01-31)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### [0.1.4](https://github.com/endojs/endo/compare/@endo/far@0.1.3...@endo/far@0.1.4) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.1.3](https://github.com/endojs/endo/compare/@endo/far@0.1.2...@endo/far@0.1.3) (2022-01-25)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### 0.1.2 (2022-01-23)
 
 **Note:** Version bump only for package @endo/far
 
-
-
-
-
 ### 0.1.1 (2021-12-02)
-
 
 ### Features
 
-* **far:** export `ERef<T>` ([180149e](https://github.com/Agoric/agoric-sdk/commit/180149ea1406e0c548fa4e2aeddabe5f16f6089b))
-* **far:** new package `@agoric/far` ([8be558c](https://github.com/Agoric/agoric-sdk/commit/8be558c5dc9a4acef43d0f28d5e207cbbd11a019))
+- **far:** export `ERef<T>` ([180149e](https://github.com/Agoric/agoric-sdk/commit/180149ea1406e0c548fa4e2aeddabe5f16f6089b))
+- **far:** new package `@agoric/far` ([8be558c](https://github.com/Agoric/agoric-sdk/commit/8be558c5dc9a4acef43d0f28d5e207cbbd11a019))

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",
@@ -26,12 +26,12 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.16.8",
-    "@endo/marshal": "^0.8.1"
+    "@endo/eventual-send": "^0.16.9",
+    "@endo/marshal": "^0.8.2"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.52",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/init": "^0.5.53",
+    "@endo/ses-ava": "^0.2.37",
     "ava": "^5.1.0",
     "c8": "^7.7.3"
   },

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,644 +3,358 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.3.0](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.55...@endo/import-bundle@0.3.0) (2022-11-14)
+### [0.3.1](https://github.com/endojs/endo/compare/@endo/import-bundle@0.3.0...@endo/import-bundle@0.3.1) (2022-12-23)
 
+**Note:** Version bump only for package @endo/import-bundle
+
+## [0.3.0](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.55...@endo/import-bundle@0.3.0) (2022-11-14)
 
 ### ⚠ BREAKING CHANGES
 
-* **import-bundle:** Remove support for globalLexicals and inescapableGlobalLexicals
+- **import-bundle:** Remove support for globalLexicals and inescapableGlobalLexicals
 
 ### Features
 
-* **import-bundle:** Remove support for globalLexicals and inescapableGlobalLexicals ([c937056](https://github.com/endojs/endo/commit/c937056f9784294fcda793fe25d86baa5d5ca052))
-
+- **import-bundle:** Remove support for globalLexicals and inescapableGlobalLexicals ([c937056](https://github.com/endojs/endo/commit/c937056f9784294fcda793fe25d86baa5d5ca052))
 
 ### Bug Fixes
 
-* fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
-
-
+- fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
 
 ### [0.2.55](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.54...@endo/import-bundle@0.2.55) (2022-10-24)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.54](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.53...@endo/import-bundle@0.2.54) (2022-10-19)
 
 **Note:** Version bump only for package @endo/import-bundle
-
-
-
-
 
 ### [0.2.53](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.52...@endo/import-bundle@0.2.53) (2022-09-27)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.52](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.51...@endo/import-bundle@0.2.52) (2022-09-14)
-
 
 ### Bug Fixes
 
-* alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
-
-
+- alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
 
 ### [0.2.51](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.50...@endo/import-bundle@0.2.51) (2022-08-26)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.50](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.49...@endo/import-bundle@0.2.50) (2022-08-26)
 
 **Note:** Version bump only for package @endo/import-bundle
-
-
-
-
 
 ### [0.2.49](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.48...@endo/import-bundle@0.2.49) (2022-08-25)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.48](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.47...@endo/import-bundle@0.2.48) (2022-08-23)
 
 **Note:** Version bump only for package @endo/import-bundle
-
-
-
-
 
 ### [0.2.47](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.46...@endo/import-bundle@0.2.47) (2022-06-28)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.46](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.45...@endo/import-bundle@0.2.46) (2022-06-11)
-
 
 ### Features
 
-* **init:** shim `atob` and `btoa` ([8e933ea](https://github.com/endojs/endo/commit/8e933ea1e5aa144aef8e355529598fff094e8373))
-
-
+- **init:** shim `atob` and `btoa` ([8e933ea](https://github.com/endojs/endo/commit/8e933ea1e5aa144aef8e355529598fff094e8373))
 
 ### [0.2.45](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.44...@endo/import-bundle@0.2.45) (2022-04-15)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.44](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.43...@endo/import-bundle@0.2.44) (2022-04-14)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.43](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.42...@endo/import-bundle@0.2.43) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.2.42](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.41...@endo/import-bundle@0.2.42) (2022-04-12)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.41](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.40...@endo/import-bundle@0.2.41) (2022-03-07)
 
 **Note:** Version bump only for package @endo/import-bundle
-
-
-
-
 
 ### [0.2.40](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.39...@endo/import-bundle@0.2.40) (2022-03-02)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.39](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.38...@endo/import-bundle@0.2.39) (2022-02-20)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.38](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.37...@endo/import-bundle@0.2.38) (2022-02-18)
-
 
 ### Bug Fixes
 
-* adds some missing hardens ([#1077](https://github.com/endojs/endo/issues/1077)) ([1b6d8fd](https://github.com/endojs/endo/commit/1b6d8fdb2ca24f95b4c972ed26446044158c2572))
-
-
+- adds some missing hardens ([#1077](https://github.com/endojs/endo/issues/1077)) ([1b6d8fd](https://github.com/endojs/endo/commit/1b6d8fdb2ca24f95b4c972ed26446044158c2572))
 
 ### [0.2.37](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.36...@endo/import-bundle@0.2.37) (2022-01-31)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### [0.2.36](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.35...@endo/import-bundle@0.2.36) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.2.35](https://github.com/endojs/endo/compare/@endo/import-bundle@0.2.34...@endo/import-bundle@0.2.35) (2022-01-25)
 
 **Note:** Version bump only for package @endo/import-bundle
 
-
-
-
-
 ### 0.2.34 (2022-01-23)
-
 
 ### Bug Fixes
 
-* **import-bundle:** Support windows ([eab39f1](https://github.com/endojs/endo/commit/eab39f1581d341384b2f9c2b5a32b02bd04499a6))
-
-
+- **import-bundle:** Support windows ([eab39f1](https://github.com/endojs/endo/commit/eab39f1581d341384b2f9c2b5a32b02bd04499a6))
 
 ### [0.2.33](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.32...@agoric/import-bundle@0.2.33) (2021-12-22)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.32](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.31...@agoric/import-bundle@0.2.32) (2021-12-02)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.31](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.30...@agoric/import-bundle@0.2.31) (2021-10-13)
-
 
 ### Features
 
-* Thread URL and Base64 endowments ([b52269d](https://github.com/Agoric/agoric-sdk/commit/b52269d58be665baf45bbb38ace57ca741e5ae4c))
-
-
+- Thread URL and Base64 endowments ([b52269d](https://github.com/Agoric/agoric-sdk/commit/b52269d58be665baf45bbb38ace57ca741e5ae4c))
 
 ### [0.2.30](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.29...@agoric/import-bundle@0.2.30) (2021-09-23)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.29](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.28...@agoric/import-bundle@0.2.29) (2021-09-15)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ### [0.2.28](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.27...@agoric/import-bundle@0.2.28) (2021-08-18)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.27](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.26...@agoric/import-bundle@0.2.27) (2021-08-17)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ### [0.2.26](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.25...@agoric/import-bundle@0.2.26) (2021-08-16)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.25](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.22...@agoric/import-bundle@0.2.25) (2021-08-15)
 
 ### 0.26.10 (2021-07-28)
 
-
 ### Bug Fixes
 
-* tolerate endo pre and post [#822](https://github.com/Agoric/agoric-sdk/issues/822) ([#3472](https://github.com/Agoric/agoric-sdk/issues/3472)) ([e872c0c](https://github.com/Agoric/agoric-sdk/commit/e872c0c77a146a746066de583021d8c9f1721b93))
-
-
+- tolerate endo pre and post [#822](https://github.com/Agoric/agoric-sdk/issues/822) ([#3472](https://github.com/Agoric/agoric-sdk/issues/3472)) ([e872c0c](https://github.com/Agoric/agoric-sdk/commit/e872c0c77a146a746066de583021d8c9f1721b93))
 
 ### [0.2.24](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.22...@agoric/import-bundle@0.2.24) (2021-08-14)
 
 ### 0.26.10 (2021-07-28)
 
-
 ### Bug Fixes
 
-* tolerate endo pre and post [#822](https://github.com/Agoric/agoric-sdk/issues/822) ([#3472](https://github.com/Agoric/agoric-sdk/issues/3472)) ([e872c0c](https://github.com/Agoric/agoric-sdk/commit/e872c0c77a146a746066de583021d8c9f1721b93))
-
-
+- tolerate endo pre and post [#822](https://github.com/Agoric/agoric-sdk/issues/822) ([#3472](https://github.com/Agoric/agoric-sdk/issues/3472)) ([e872c0c](https://github.com/Agoric/agoric-sdk/commit/e872c0c77a146a746066de583021d8c9f1721b93))
 
 ### [0.2.23](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.22...@agoric/import-bundle@0.2.23) (2021-07-28)
 
-
 ### Bug Fixes
 
-* tolerate endo pre and post [#822](https://github.com/Agoric/agoric-sdk/issues/822) ([#3472](https://github.com/Agoric/agoric-sdk/issues/3472)) ([e872c0c](https://github.com/Agoric/agoric-sdk/commit/e872c0c77a146a746066de583021d8c9f1721b93))
-
-
+- tolerate endo pre and post [#822](https://github.com/Agoric/agoric-sdk/issues/822) ([#3472](https://github.com/Agoric/agoric-sdk/issues/3472)) ([e872c0c](https://github.com/Agoric/agoric-sdk/commit/e872c0c77a146a746066de583021d8c9f1721b93))
 
 ### [0.2.22](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.21...@agoric/import-bundle@0.2.22) (2021-07-01)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.21](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.20...@agoric/import-bundle@0.2.21) (2021-06-28)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ### [0.2.20](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.19...@agoric/import-bundle@0.2.20) (2021-06-25)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.19](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.18...@agoric/import-bundle@0.2.19) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ### [0.2.18](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.17...@agoric/import-bundle@0.2.18) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.17](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.16...@agoric/import-bundle@0.2.17) (2021-06-23)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ### [0.2.16](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.15...@agoric/import-bundle@0.2.16) (2021-06-16)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ### [0.2.15](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.14...@agoric/import-bundle@0.2.15) (2021-06-15)
-
 
 ### Bug Fixes
 
-* **import-bundle:** Add missing ses-ava import ([bc89bf9](https://github.com/Agoric/agoric-sdk/commit/bc89bf9479b1a06be0eaeb175b7a2329c2bbe744))
-* ensure replacements of globals can't be bypassed ([3d2a230](https://github.com/Agoric/agoric-sdk/commit/3d2a230822eed17e87a62ebe9df2609d9dcaa372))
-* incorporate changes from review feedback ([dcca675](https://github.com/Agoric/agoric-sdk/commit/dcca6750df50f6db4daff4f794968450a43d1b0e))
-* Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
-* Preinitialize Babel ([bb76808](https://github.com/Agoric/agoric-sdk/commit/bb768089c3588e54612d7c9a4528972b5688f4e6))
-
-
+- **import-bundle:** Add missing ses-ava import ([bc89bf9](https://github.com/Agoric/agoric-sdk/commit/bc89bf9479b1a06be0eaeb175b7a2329c2bbe744))
+- ensure replacements of globals can't be bypassed ([3d2a230](https://github.com/Agoric/agoric-sdk/commit/3d2a230822eed17e87a62ebe9df2609d9dcaa372))
+- incorporate changes from review feedback ([dcca675](https://github.com/Agoric/agoric-sdk/commit/dcca6750df50f6db4daff4f794968450a43d1b0e))
+- Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
+- Preinitialize Babel ([bb76808](https://github.com/Agoric/agoric-sdk/commit/bb768089c3588e54612d7c9a4528972b5688f4e6))
 
 ## [0.2.14](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.13...@agoric/import-bundle@0.2.14) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.2.13](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.12...@agoric/import-bundle@0.2.13) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.2.12](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.11...@agoric/import-bundle@0.2.12) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.2.11](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.10...@agoric/import-bundle@0.2.11) (2021-04-22)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.2.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.9...@agoric/import-bundle@0.2.10) (2021-04-18)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.2.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.8...@agoric/import-bundle@0.2.9) (2021-04-16)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.2.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.7...@agoric/import-bundle@0.2.8) (2021-04-14)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.2.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.6...@agoric/import-bundle@0.2.7) (2021-04-13)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.2.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.5...@agoric/import-bundle@0.2.6) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.2.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.4...@agoric/import-bundle@0.2.5) (2021-04-06)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.2.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.3...@agoric/import-bundle@0.2.4) (2021-03-24)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.2.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.2...@agoric/import-bundle@0.2.3) (2021-03-16)
-
 
 ### Bug Fixes
 
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-
-
-
-
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
 
 ## [0.2.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.1...@agoric/import-bundle@0.2.2) (2021-02-22)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.2.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.2.0...@agoric/import-bundle@0.2.1) (2021-02-16)
-
 
 ### Bug Fixes
 
-* review comments ([7db7e5c](https://github.com/Agoric/agoric-sdk/commit/7db7e5c4c569dfedff8d748dd58893218b0a2458))
-* use assert rather than FooError constructors ([f860c5b](https://github.com/Agoric/agoric-sdk/commit/f860c5bf5add165a08cb5bd543502857c3f57998))
-
-
-
-
+- review comments ([7db7e5c](https://github.com/Agoric/agoric-sdk/commit/7db7e5c4c569dfedff8d748dd58893218b0a2458))
+- use assert rather than FooError constructors ([f860c5b](https://github.com/Agoric/agoric-sdk/commit/f860c5bf5add165a08cb5bd543502857c3f57998))
 
 # [0.2.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.1.0...@agoric/import-bundle@0.2.0) (2020-12-10)
 
-
 ### Features
 
-* **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
-
-
-
-
+- **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
 
 # [0.1.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.12-dev.0...@agoric/import-bundle@0.1.0) (2020-11-07)
 
-
 ### Features
 
-* **assert:** Thread stack traces to console, add entangled assert ([#1884](https://github.com/Agoric/agoric-sdk/issues/1884)) ([5d4f35f](https://github.com/Agoric/agoric-sdk/commit/5d4f35f901f2ca40a2a4d66dab980a5fe8e575f4))
-
-
-
-
+- **assert:** Thread stack traces to console, add entangled assert ([#1884](https://github.com/Agoric/agoric-sdk/issues/1884)) ([5d4f35f](https://github.com/Agoric/agoric-sdk/commit/5d4f35f901f2ca40a2a4d66dab980a5fe8e575f4))
 
 ## [0.0.12-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.11...@agoric/import-bundle@0.0.12-dev.0) (2020-10-19)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.0.11](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.11-dev.2...@agoric/import-bundle@0.0.11) (2020-10-11)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.0.11-dev.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.11-dev.1...@agoric/import-bundle@0.0.11-dev.2) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.0.11-dev.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.11-dev.0...@agoric/import-bundle@0.0.11-dev.1) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.0.11-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.10...@agoric/import-bundle@0.0.11-dev.0) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.0.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.9...@agoric/import-bundle@0.0.10) (2020-09-16)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.0.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.8...@agoric/import-bundle@0.0.9) (2020-08-31)
-
 
 ### Bug Fixes
 
-* reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
-* upgrade to SES 0.10.0 ([bf8ceff](https://github.com/Agoric/agoric-sdk/commit/bf8ceff03ebb790728c18a131b6305ca7f7f4a4f))
-* upgrade to SES v0.10.1, and make HandledPromise shim work ([5d0adea](https://github.com/Agoric/agoric-sdk/commit/5d0adea1b3b7369ae8131df55f99b61e0c428542))
-
-
-
-
+- reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
+- upgrade to SES 0.10.0 ([bf8ceff](https://github.com/Agoric/agoric-sdk/commit/bf8ceff03ebb790728c18a131b6305ca7f7f4a4f))
+- upgrade to SES v0.10.1, and make HandledPromise shim work ([5d0adea](https://github.com/Agoric/agoric-sdk/commit/5d0adea1b3b7369ae8131df55f99b61e0c428542))
 
 ## [0.0.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.7...@agoric/import-bundle@0.0.8) (2020-06-30)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.0.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.6...@agoric/import-bundle@0.0.7) (2020-05-17)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.0.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.5...@agoric/import-bundle@0.0.6) (2020-05-10)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.0.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.4...@agoric/import-bundle@0.0.5) (2020-05-04)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.0.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.4-alpha.0...@agoric/import-bundle@0.0.4) (2020-04-13)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.0.4-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.3...@agoric/import-bundle@0.0.4-alpha.0) (2020-04-12)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## [0.0.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.2...@agoric/import-bundle@0.0.3) (2020-04-03)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## [0.0.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/import-bundle@0.0.2-alpha.0...@agoric/import-bundle@0.0.2) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/import-bundle
 
-
-
-
-
 ## 0.0.2-alpha.0 (2020-04-02)
 
 **Note:** Version bump only for package @agoric/import-bundle
-
-
-
-
 
 ## 0.0.2-alpha.0 (2020-04-02)
 

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "load modules created by @endo/bundle-source",
   "type": "module",
   "main": "src/index.js",
@@ -21,13 +21,13 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.28",
-    "@endo/compartment-mapper": "^0.8.0"
+    "@endo/base64": "^0.2.29",
+    "@endo/compartment-mapper": "^0.8.1"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.4.2",
-    "@endo/init": "^0.5.52",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/bundle-source": "^2.4.3",
+    "@endo/init": "^0.5.53",
+    "@endo/ses-ava": "^0.2.37",
     "ava": "^5.1.0",
     "c8": "^7.7.3"
   },

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,259 +3,153 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.5.52](https://github.com/endojs/endo/compare/@endo/init@0.5.51...@endo/init@0.5.52) (2022-11-14)
+### [0.5.53](https://github.com/endojs/endo/compare/@endo/init@0.5.52...@endo/init@0.5.53) (2022-12-23)
 
 **Note:** Version bump only for package @endo/init
 
+### [0.5.52](https://github.com/endojs/endo/compare/@endo/init@0.5.51...@endo/init@0.5.52) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/init
 
 ### [0.5.51](https://github.com/endojs/endo/compare/@endo/init@0.5.50...@endo/init@0.5.51) (2022-10-24)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.50](https://github.com/endojs/endo/compare/@endo/init@0.5.49...@endo/init@0.5.50) (2022-10-19)
 
 **Note:** Version bump only for package @endo/init
-
-
-
-
 
 ### [0.5.49](https://github.com/endojs/endo/compare/@endo/init@0.5.48...@endo/init@0.5.49) (2022-09-27)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.48](https://github.com/endojs/endo/compare/@endo/init@0.5.47...@endo/init@0.5.48) (2022-09-14)
 
 **Note:** Version bump only for package @endo/init
-
-
-
-
 
 ### [0.5.47](https://github.com/endojs/endo/compare/@endo/init@0.5.46...@endo/init@0.5.47) (2022-08-26)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.46](https://github.com/endojs/endo/compare/@endo/init@0.5.45...@endo/init@0.5.46) (2022-08-26)
 
 **Note:** Version bump only for package @endo/init
-
-
-
-
 
 ### [0.5.45](https://github.com/endojs/endo/compare/@endo/init@0.5.44...@endo/init@0.5.45) (2022-08-25)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.44](https://github.com/endojs/endo/compare/@endo/init@0.5.43...@endo/init@0.5.44) (2022-08-23)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.43](https://github.com/endojs/endo/compare/@endo/init@0.5.42...@endo/init@0.5.43) (2022-06-28)
-
 
 ### Features
 
-* **init:** Use promise-kit's leak-free race as vetted shim ([89c1e8f](https://github.com/endojs/endo/commit/89c1e8f4c08671169e9605cb40e091a21c02a2cd))
-
+- **init:** Use promise-kit's leak-free race as vetted shim ([89c1e8f](https://github.com/endojs/endo/commit/89c1e8f4c08671169e9605cb40e091a21c02a2cd))
 
 ### Bug Fixes
 
-* tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
-
-
+- tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
 
 ### [0.5.42](https://github.com/endojs/endo/compare/@endo/init@0.5.41...@endo/init@0.5.42) (2022-06-11)
 
-
 ### Features
 
-* **init:** `@endo/init/legacy.js` ([246bc32](https://github.com/endojs/endo/commit/246bc3259ddd8bdbe95ce1a442093688ff7014a9))
-* **init:** have `pre*.js` export the same as `@endo/lockdown` ([f1227d7](https://github.com/endojs/endo/commit/f1227d73fd33ecc6677b739c5f97007315d29536))
-* **init:** shim `atob` and `btoa` ([8e933ea](https://github.com/endojs/endo/commit/8e933ea1e5aa144aef8e355529598fff094e8373))
-
+- **init:** `@endo/init/legacy.js` ([246bc32](https://github.com/endojs/endo/commit/246bc3259ddd8bdbe95ce1a442093688ff7014a9))
+- **init:** have `pre*.js` export the same as `@endo/lockdown` ([f1227d7](https://github.com/endojs/endo/commit/f1227d73fd33ecc6677b739c5f97007315d29536))
+- **init:** shim `atob` and `btoa` ([8e933ea](https://github.com/endojs/endo/commit/8e933ea1e5aa144aef8e355529598fff094e8373))
 
 ### Bug Fixes
 
-* **init:** workaround node promise destroyed bug ([#1166](https://github.com/endojs/endo/issues/1166)) ([d03659e](https://github.com/endojs/endo/commit/d03659e1557f00c019074c020a42adf0746d3c9d))
-* **pre-node:** use and export 'pre.js' as well ([29c2c72](https://github.com/endojs/endo/commit/29c2c72b9d47637979b6e6253ed6565758f052ac))
-
-
+- **init:** workaround node promise destroyed bug ([#1166](https://github.com/endojs/endo/issues/1166)) ([d03659e](https://github.com/endojs/endo/commit/d03659e1557f00c019074c020a42adf0746d3c9d))
+- **pre-node:** use and export 'pre.js' as well ([29c2c72](https://github.com/endojs/endo/commit/29c2c72b9d47637979b6e6253ed6565758f052ac))
 
 ### [0.5.41](https://github.com/endojs/endo/compare/@endo/init@0.5.40...@endo/init@0.5.41) (2022-04-15)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.40](https://github.com/endojs/endo/compare/@endo/init@0.5.39...@endo/init@0.5.40) (2022-04-14)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.39](https://github.com/endojs/endo/compare/@endo/init@0.5.38...@endo/init@0.5.39) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.5.38](https://github.com/endojs/endo/compare/@endo/init@0.5.37...@endo/init@0.5.38) (2022-04-12)
 
-
 ### Features
 
-* **init:** Handle symbols installed on Promise by Node's `async_hooks` ([#1115](https://github.com/endojs/endo/issues/1115)) ([06827b9](https://github.com/endojs/endo/commit/06827b982c0450bae53b5ff0c410745678168c88))
-
-
+- **init:** Handle symbols installed on Promise by Node's `async_hooks` ([#1115](https://github.com/endojs/endo/issues/1115)) ([06827b9](https://github.com/endojs/endo/commit/06827b982c0450bae53b5ff0c410745678168c88))
 
 ### [0.5.37](https://github.com/endojs/endo/compare/@endo/init@0.5.36...@endo/init@0.5.37) (2022-03-07)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.36](https://github.com/endojs/endo/compare/@endo/init@0.5.35...@endo/init@0.5.36) (2022-03-02)
 
 **Note:** Version bump only for package @endo/init
-
-
-
-
 
 ### [0.5.35](https://github.com/endojs/endo/compare/@endo/init@0.5.34...@endo/init@0.5.35) (2022-02-20)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.34](https://github.com/endojs/endo/compare/@endo/init@0.5.33...@endo/init@0.5.34) (2022-02-18)
 
 **Note:** Version bump only for package @endo/init
-
-
-
-
 
 ### [0.5.33](https://github.com/endojs/endo/compare/@endo/init@0.5.32...@endo/init@0.5.33) (2022-01-31)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### [0.5.32](https://github.com/endojs/endo/compare/@endo/init@0.5.31...@endo/init@0.5.32) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.5.31](https://github.com/endojs/endo/compare/@endo/init@0.5.30...@endo/init@0.5.31) (2022-01-25)
 
 **Note:** Version bump only for package @endo/init
 
-
-
-
-
 ### 0.5.30 (2022-01-23)
-
 
 ### Features
 
-* **init:** Add explicit exports block ([f9d52ab](https://github.com/endojs/endo/commit/f9d52ab3e97df9965014fe408e7f792738a0b67c))
-
-
+- **init:** Add explicit exports block ([f9d52ab](https://github.com/endojs/endo/commit/f9d52ab3e97df9965014fe408e7f792738a0b67c))
 
 ### [0.5.29](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.28...@agoric/install-ses@0.5.29) (2021-12-02)
 
-
 ### Features
 
-* **install-ses:** provide `@agoric/install-ses/pre.js` ([f3b133f](https://github.com/Agoric/agoric-sdk/commit/f3b133fa34edcb0538b20a19d1fe717da34cf415))
-* **install-ses:** provide some composable entrypoints ([8f85868](https://github.com/Agoric/agoric-sdk/commit/8f8586872febaa12857d0833bd19d71dc9aa8134))
-
-
+- **install-ses:** provide `@agoric/install-ses/pre.js` ([f3b133f](https://github.com/Agoric/agoric-sdk/commit/f3b133fa34edcb0538b20a19d1fe717da34cf415))
+- **install-ses:** provide some composable entrypoints ([8f85868](https://github.com/Agoric/agoric-sdk/commit/8f8586872febaa12857d0833bd19d71dc9aa8134))
 
 ### [0.5.28](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.27...@agoric/install-ses@0.5.28) (2021-10-13)
 
-
 ### Features
 
-* Thread URL and Base64 endowments ([b52269d](https://github.com/Agoric/agoric-sdk/commit/b52269d58be665baf45bbb38ace57ca741e5ae4c))
-
-
+- Thread URL and Base64 endowments ([b52269d](https://github.com/Agoric/agoric-sdk/commit/b52269d58be665baf45bbb38ace57ca741e5ae4c))
 
 ### [0.5.27](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.26...@agoric/install-ses@0.5.27) (2021-09-23)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ### [0.5.26](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.25...@agoric/install-ses@0.5.26) (2021-09-15)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ### [0.5.25](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.24...@agoric/install-ses@0.5.25) (2021-08-18)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ### [0.5.24](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.23...@agoric/install-ses@0.5.24) (2021-08-17)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ### [0.5.23](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.20...@agoric/install-ses@0.5.23) (2021-08-15)
 
@@ -263,290 +157,156 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ### [0.5.22](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.20...@agoric/install-ses@0.5.22) (2021-08-14)
 
 ### 0.26.10 (2021-07-28)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ### [0.5.21](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.20...@agoric/install-ses@0.5.21) (2021-07-28)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ### [0.5.20](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.19...@agoric/install-ses@0.5.20) (2021-07-01)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ### [0.5.19](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.18...@agoric/install-ses@0.5.19) (2021-06-28)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ### [0.5.18](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.17...@agoric/install-ses@0.5.18) (2021-06-25)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ### [0.5.17](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.16...@agoric/install-ses@0.5.17) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ### [0.5.16](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.15...@agoric/install-ses@0.5.16) (2021-06-23)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ### [0.5.15](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.14...@agoric/install-ses@0.5.15) (2021-06-16)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ### [0.5.14](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.13...@agoric/install-ses@0.5.14) (2021-06-15)
-
 
 ### Bug Fixes
 
-* Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
-
-
+- Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
 
 ## [0.5.13](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.12...@agoric/install-ses@0.5.13) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.5.12](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.11...@agoric/install-ses@0.5.12) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ## [0.5.11](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.10...@agoric/install-ses@0.5.11) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.5.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.9...@agoric/install-ses@0.5.10) (2021-04-22)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ## [0.5.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.8...@agoric/install-ses@0.5.9) (2021-04-18)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.5.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.7...@agoric/install-ses@0.5.8) (2021-04-16)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ## [0.5.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.6...@agoric/install-ses@0.5.7) (2021-04-14)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.5.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.5...@agoric/install-ses@0.5.6) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.5.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.4...@agoric/install-ses@0.5.5) (2021-04-06)
-
 
 ### Bug Fixes
 
-* update to depend on ses 0.12.5 ([#2718](https://github.com/Agoric/agoric-sdk/issues/2718)) ([08dbe0d](https://github.com/Agoric/agoric-sdk/commit/08dbe0db5ce06944dc92c710865e441a60b31b5b))
-* update to ses 0.12.7, ses-ava 0.1.1 ([#2820](https://github.com/Agoric/agoric-sdk/issues/2820)) ([6d81775](https://github.com/Agoric/agoric-sdk/commit/6d81775715bc80e6033d75cb65edbfb1452b1608))
-* use ses-ava in SwingSet where possible ([#2709](https://github.com/Agoric/agoric-sdk/issues/2709)) ([85b674e](https://github.com/Agoric/agoric-sdk/commit/85b674e7942443219fa9828841cc7bd8ef909b47))
-
-
-
-
+- update to depend on ses 0.12.5 ([#2718](https://github.com/Agoric/agoric-sdk/issues/2718)) ([08dbe0d](https://github.com/Agoric/agoric-sdk/commit/08dbe0db5ce06944dc92c710865e441a60b31b5b))
+- update to ses 0.12.7, ses-ava 0.1.1 ([#2820](https://github.com/Agoric/agoric-sdk/issues/2820)) ([6d81775](https://github.com/Agoric/agoric-sdk/commit/6d81775715bc80e6033d75cb65edbfb1452b1608))
+- use ses-ava in SwingSet where possible ([#2709](https://github.com/Agoric/agoric-sdk/issues/2709)) ([85b674e](https://github.com/Agoric/agoric-sdk/commit/85b674e7942443219fa9828841cc7bd8ef909b47))
 
 ## [0.5.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.3...@agoric/install-ses@0.5.4) (2021-03-24)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.5.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.2...@agoric/install-ses@0.5.3) (2021-03-16)
-
 
 ### Bug Fixes
 
-* let errorTaming default to safe ([#2304](https://github.com/Agoric/agoric-sdk/issues/2304)) ([57c1f4c](https://github.com/Agoric/agoric-sdk/commit/57c1f4cc3841ba9c6be89c01b022ca70eeedc776))
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-* upgrade ses to 0.12.3 to avoid console noise ([#2552](https://github.com/Agoric/agoric-sdk/issues/2552)) ([f59f5f5](https://github.com/Agoric/agoric-sdk/commit/f59f5f58d1567bb11710166b1dbc80f25c39a04f))
-
-
-
-
+- let errorTaming default to safe ([#2304](https://github.com/Agoric/agoric-sdk/issues/2304)) ([57c1f4c](https://github.com/Agoric/agoric-sdk/commit/57c1f4cc3841ba9c6be89c01b022ca70eeedc776))
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
+- upgrade ses to 0.12.3 to avoid console noise ([#2552](https://github.com/Agoric/agoric-sdk/issues/2552)) ([f59f5f5](https://github.com/Agoric/agoric-sdk/commit/f59f5f58d1567bb11710166b1dbc80f25c39a04f))
 
 ## [0.5.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.1...@agoric/install-ses@0.5.2) (2021-02-22)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.5.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.5.0...@agoric/install-ses@0.5.1) (2021-02-16)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 # [0.5.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.4.0...@agoric/install-ses@0.5.0) (2020-12-10)
-
 
 ### Features
 
-* **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
-
-
-
-
+- **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
 
 # [0.4.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.3.3-dev.0...@agoric/install-ses@0.4.0) (2020-11-07)
 
-
 ### Features
 
-* **assert:** Thread stack traces to console, add entangled assert ([#1884](https://github.com/Agoric/agoric-sdk/issues/1884)) ([5d4f35f](https://github.com/Agoric/agoric-sdk/commit/5d4f35f901f2ca40a2a4d66dab980a5fe8e575f4))
-
-
-
-
+- **assert:** Thread stack traces to console, add entangled assert ([#1884](https://github.com/Agoric/agoric-sdk/issues/1884)) ([5d4f35f](https://github.com/Agoric/agoric-sdk/commit/5d4f35f901f2ca40a2a4d66dab980a5fe8e575f4))
 
 ## [0.3.3-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.3.2...@agoric/install-ses@0.3.3-dev.0) (2020-10-19)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.3.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.3.2-dev.2...@agoric/install-ses@0.3.2) (2020-10-11)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ## [0.3.2-dev.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.3.2-dev.1...@agoric/install-ses@0.3.2-dev.2) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.3.2-dev.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.3.2-dev.0...@agoric/install-ses@0.3.2-dev.1) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/install-ses
-
-
-
-
 
 ## [0.3.2-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.3.1...@agoric/install-ses@0.3.2-dev.0) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 ## [0.3.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.3.0...@agoric/install-ses@0.3.1) (2020-09-16)
 
 **Note:** Version bump only for package @agoric/install-ses
 
-
-
-
-
 # [0.3.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/install-ses@0.2.0...@agoric/install-ses@0.3.0) (2020-08-31)
-
 
 ### Bug Fixes
 
-* reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
-* upgrade to SES 0.10.0 ([bf8ceff](https://github.com/Agoric/agoric-sdk/commit/bf8ceff03ebb790728c18a131b6305ca7f7f4a4f))
-* upgrade to SES v0.10.1, and make HandledPromise shim work ([5d0adea](https://github.com/Agoric/agoric-sdk/commit/5d0adea1b3b7369ae8131df55f99b61e0c428542))
-
+- reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
+- upgrade to SES 0.10.0 ([bf8ceff](https://github.com/Agoric/agoric-sdk/commit/bf8ceff03ebb790728c18a131b6305ca7f7f4a4f))
+- upgrade to SES v0.10.1, and make HandledPromise shim work ([5d0adea](https://github.com/Agoric/agoric-sdk/commit/5d0adea1b3b7369ae8131df55f99b61e0c428542))
 
 ### Features
 
-* add HandledPromise shim before lockdown() ([5574462](https://github.com/Agoric/agoric-sdk/commit/55744622a7ff5909b6cc296cdf6ab0f2a6ee2e0c))
-
-
-
-
+- add HandledPromise shim before lockdown() ([5574462](https://github.com/Agoric/agoric-sdk/commit/55744622a7ff5909b6cc296cdf6ab0f2a6ee2e0c))
 
 # 0.2.0 (2020-06-30)
 
-
 ### Features
 
-* **install-ses:** new package ([7fa8f2c](https://github.com/Agoric/agoric-sdk/commit/7fa8f2c95914578e703efb56b52b1c5686f6c06b))
+- **install-ses:** new package ([7fa8f2c](https://github.com/Agoric/agoric-sdk/commit/7fa8f2c95914578e703efb56b52b1c5686f6c06b))

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "0.5.52",
+  "version": "0.5.53",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",
@@ -28,15 +28,15 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.0",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/compartment-mapper": "^0.8.1",
+    "@endo/ses-ava": "^0.2.37",
     "ava": "^5.1.0"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.28",
-    "@endo/eventual-send": "^0.16.8",
-    "@endo/lockdown": "^0.1.24",
-    "@endo/promise-kit": "^0.2.52"
+    "@endo/base64": "^0.2.29",
+    "@endo/eventual-send": "^0.16.9",
+    "@endo/lockdown": "^0.1.25",
+    "@endo/promise-kit": "^0.2.53"
   },
   "files": [
     "LICENSE*",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,201 +3,114 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.1.24](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.23...@endo/lockdown@0.1.24) (2022-11-14)
+### [0.1.25](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.24...@endo/lockdown@0.1.25) (2022-12-23)
 
 **Note:** Version bump only for package @endo/lockdown
 
+### [0.1.24](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.23...@endo/lockdown@0.1.24) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/lockdown
 
 ### [0.1.23](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.22...@endo/lockdown@0.1.23) (2022-10-24)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.22](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.21...@endo/lockdown@0.1.22) (2022-10-19)
 
 **Note:** Version bump only for package @endo/lockdown
-
-
-
-
 
 ### [0.1.21](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.20...@endo/lockdown@0.1.21) (2022-09-27)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.20](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.19...@endo/lockdown@0.1.20) (2022-09-14)
 
 **Note:** Version bump only for package @endo/lockdown
-
-
-
-
 
 ### [0.1.19](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.18...@endo/lockdown@0.1.19) (2022-08-26)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.18](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.17...@endo/lockdown@0.1.18) (2022-08-26)
 
 **Note:** Version bump only for package @endo/lockdown
-
-
-
-
 
 ### [0.1.17](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.16...@endo/lockdown@0.1.17) (2022-08-25)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.16](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.15...@endo/lockdown@0.1.16) (2022-08-23)
 
 **Note:** Version bump only for package @endo/lockdown
-
-
-
-
 
 ### [0.1.15](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.14...@endo/lockdown@0.1.15) (2022-06-28)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.14](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.13...@endo/lockdown@0.1.14) (2022-06-11)
 
 **Note:** Version bump only for package @endo/lockdown
-
-
-
-
 
 ### [0.1.13](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.12...@endo/lockdown@0.1.13) (2022-04-15)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.12](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.11...@endo/lockdown@0.1.12) (2022-04-14)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.11](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.10...@endo/lockdown@0.1.11) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.9...@endo/lockdown@0.1.10) (2022-04-12)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.9](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.8...@endo/lockdown@0.1.9) (2022-03-07)
 
 **Note:** Version bump only for package @endo/lockdown
-
-
-
-
 
 ### [0.1.8](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.7...@endo/lockdown@0.1.8) (2022-03-02)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.7](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.6...@endo/lockdown@0.1.7) (2022-02-20)
 
 **Note:** Version bump only for package @endo/lockdown
-
-
-
-
 
 ### [0.1.6](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.5...@endo/lockdown@0.1.6) (2022-02-18)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.5](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.4...@endo/lockdown@0.1.5) (2022-01-31)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### [0.1.4](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.3...@endo/lockdown@0.1.4) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.1.3](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.2...@endo/lockdown@0.1.3) (2022-01-25)
 
 **Note:** Version bump only for package @endo/lockdown
 
-
-
-
-
 ### 0.1.2 (2022-01-23)
-
 
 ### Bug Fixes
 
-* **lockdown:** Log to stderr ([960a9ef](https://github.com/endojs/endo/commit/960a9ef79e8e36dd564d01016441119156f2ad08))
-
-
+- **lockdown:** Log to stderr ([960a9ef](https://github.com/endojs/endo/commit/960a9ef79e8e36dd564d01016441119156f2ad08))
 
 ### 0.1.1 (2021-12-02)
 
-
 ### Features
 
-* **install-ses:** provide some composable entrypoints ([8f85868](https://github.com/Agoric/agoric-sdk/commit/8f8586872febaa12857d0833bd19d71dc9aa8134))
-
+- **install-ses:** provide some composable entrypoints ([8f85868](https://github.com/Agoric/agoric-sdk/commit/8f8586872febaa12857d0833bd19d71dc9aa8134))
 
 ### Bug Fixes
 
-* **lockdown:** use default `stackFiltering: 'concise'` for debug ([8fa0611](https://github.com/Agoric/agoric-sdk/commit/8fa0611b474d2770fbbae6d0831c47d97fe68c0b))
+- **lockdown:** use default `stackFiltering: 'concise'` for debug ([8fa0611](https://github.com/Agoric/agoric-sdk/commit/8fa0611b474d2770fbbae6d0831c47d97fe68c0b))

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
@@ -16,7 +16,7 @@
     "ava": "^5.1.0"
   },
   "dependencies": {
-    "ses": "^0.18.0"
+    "ses": "^0.18.1"
   },
   "files": [
     "LICENSE*",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,198 +3,118 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.3.22](https://github.com/endojs/endo/compare/@endo/lp32@0.3.21...@endo/lp32@0.3.22) (2022-11-14)
+### [0.3.23](https://github.com/endojs/endo/compare/@endo/lp32@0.3.22...@endo/lp32@0.3.23) (2022-12-23)
 
+**Note:** Version bump only for package @endo/lp32
+
+### [0.3.22](https://github.com/endojs/endo/compare/@endo/lp32@0.3.21...@endo/lp32@0.3.22) (2022-11-14)
 
 ### Bug Fixes
 
-* assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
-
-
+- assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
 
 ### [0.3.21](https://github.com/endojs/endo/compare/@endo/lp32@0.3.20...@endo/lp32@0.3.21) (2022-10-24)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.20](https://github.com/endojs/endo/compare/@endo/lp32@0.3.19...@endo/lp32@0.3.20) (2022-10-19)
 
 **Note:** Version bump only for package @endo/lp32
-
-
-
-
 
 ### [0.3.19](https://github.com/endojs/endo/compare/@endo/lp32@0.3.18...@endo/lp32@0.3.19) (2022-09-27)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.18](https://github.com/endojs/endo/compare/@endo/lp32@0.3.17...@endo/lp32@0.3.18) (2022-09-14)
 
 **Note:** Version bump only for package @endo/lp32
-
-
-
-
 
 ### [0.3.17](https://github.com/endojs/endo/compare/@endo/lp32@0.3.16...@endo/lp32@0.3.17) (2022-08-26)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.16](https://github.com/endojs/endo/compare/@endo/lp32@0.3.15...@endo/lp32@0.3.16) (2022-08-26)
 
 **Note:** Version bump only for package @endo/lp32
-
-
-
-
 
 ### [0.3.15](https://github.com/endojs/endo/compare/@endo/lp32@0.3.14...@endo/lp32@0.3.15) (2022-08-25)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.14](https://github.com/endojs/endo/compare/@endo/lp32@0.3.13...@endo/lp32@0.3.14) (2022-08-23)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.13](https://github.com/endojs/endo/compare/@endo/lp32@0.3.12...@endo/lp32@0.3.13) (2022-06-28)
-
 
 ### Bug Fixes
 
-* tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
-
-
+- tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
 
 ### [0.3.12](https://github.com/endojs/endo/compare/@endo/lp32@0.3.11...@endo/lp32@0.3.12) (2022-06-11)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.11](https://github.com/endojs/endo/compare/@endo/lp32@0.3.10...@endo/lp32@0.3.11) (2022-04-15)
 
 **Note:** Version bump only for package @endo/lp32
-
-
-
-
 
 ### [0.3.10](https://github.com/endojs/endo/compare/@endo/lp32@0.3.9...@endo/lp32@0.3.10) (2022-04-14)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.9](https://github.com/endojs/endo/compare/@endo/lp32@0.3.8...@endo/lp32@0.3.9) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.3.8](https://github.com/endojs/endo/compare/@endo/lp32@0.3.7...@endo/lp32@0.3.8) (2022-04-12)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.7](https://github.com/endojs/endo/compare/@endo/lp32@0.3.6...@endo/lp32@0.3.7) (2022-03-07)
 
 **Note:** Version bump only for package @endo/lp32
-
-
-
-
 
 ### [0.3.6](https://github.com/endojs/endo/compare/@endo/lp32@0.3.5...@endo/lp32@0.3.6) (2022-03-02)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.5](https://github.com/endojs/endo/compare/@endo/lp32@0.3.4...@endo/lp32@0.3.5) (2022-02-20)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.4](https://github.com/endojs/endo/compare/@endo/lp32@0.3.3...@endo/lp32@0.3.4) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-* **lp32:** Switch return type from `undefined` to `void` ([16414e2](https://github.com/endojs/endo/commit/16414e2310675525ff3c72ccb4eb43b0d1e226a6))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
+- **lp32:** Switch return type from `undefined` to `void` ([16414e2](https://github.com/endojs/endo/commit/16414e2310675525ff3c72ccb4eb43b0d1e226a6))
 
 ### [0.3.3](https://github.com/endojs/endo/compare/@endo/lp32@0.3.2...@endo/lp32@0.3.3) (2022-01-31)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ### [0.3.2](https://github.com/endojs/endo/compare/@endo/lp32@0.3.1...@endo/lp32@0.3.2) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.3.1](https://github.com/endojs/endo/compare/@endo/lp32@0.3.0...@endo/lp32@0.3.1) (2022-01-25)
 
 **Note:** Version bump only for package @endo/lp32
 
-
-
-
-
 ## 0.3.0 (2022-01-23)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **stream:** Use eventual send
+- **stream:** Use eventual send
 
 ### Features
 
-* **lp32:** Implement Chrome host message protocol ([ce80bc5](https://github.com/endojs/endo/commit/ce80bc53a038e96a5a0bf7c0221da05fe6e4243f))
-* **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
+- **lp32:** Implement Chrome host message protocol ([ce80bc5](https://github.com/endojs/endo/commit/ce80bc53a038e96a5a0bf7c0221da05fe6e4243f))
+- **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",
@@ -44,13 +44,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.52",
-    "@endo/stream": "^0.3.21",
-    "ses": "^0.18.0"
+    "@endo/init": "^0.5.53",
+    "@endo/stream": "^0.3.22",
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/eslint-config": "^0.5.2",
+    "@endo/ses-ava": "^0.2.37",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,321 +3,221 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.8.1](https://github.com/endojs/endo/compare/@endo/marshal@0.8.0...@endo/marshal@0.8.1) (2022-11-14)
-
+### [0.8.2](https://github.com/endojs/endo/compare/@endo/marshal@0.8.1...@endo/marshal@0.8.2) (2022-12-23)
 
 ### Bug Fixes
 
-* assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
-* fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
-* Start migrating encodePassable and rankOrder from agoric-sdk to endo ([#1260](https://github.com/endojs/endo/issues/1260)) ([a025103](https://github.com/endojs/endo/commit/a025103e8ee14f20dd3455fed0a8dbc6b11b076d))
+- **marshal:** Work around TypeScript issue ([56d3d81](https://github.com/endojs/endo/commit/56d3d8103238996c307b35a26bf6a3eaf3c40bcc))
 
+### [0.8.1](https://github.com/endojs/endo/compare/@endo/marshal@0.8.0...@endo/marshal@0.8.1) (2022-11-14)
 
+### Bug Fixes
+
+- assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
+- fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
+- Start migrating encodePassable and rankOrder from agoric-sdk to endo ([#1260](https://github.com/endojs/endo/issues/1260)) ([a025103](https://github.com/endojs/endo/commit/a025103e8ee14f20dd3455fed0a8dbc6b11b076d))
 
 ## [0.8.0](https://github.com/endojs/endo/compare/@endo/marshal@0.7.6...@endo/marshal@0.8.0) (2022-10-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **marshal:** Reject null as a substitute for Object.prototype
+- **marshal:** Reject null as a substitute for Object.prototype
 
 ### Bug Fixes
 
-* restore capdata leniency ([#1338](https://github.com/endojs/endo/issues/1338)) ([99a4d6c](https://github.com/endojs/endo/commit/99a4d6c83b9be4670e819ce496d7bff539b7587b))
-* **marshal:** Check if input is an error before checking if it is remotable ([#1323](https://github.com/endojs/endo/issues/1323)) ([f3e0982](https://github.com/endojs/endo/commit/f3e09824e49cf3fb3c75358879853443bbde2c34)), closes [#1318](https://github.com/endojs/endo/issues/1318)
-* **marshal:** Reject null as a substitute for Object.prototype ([1df4193](https://github.com/endojs/endo/commit/1df419350c2d18a9551a918b08dec5c43712043f)), closes [#1324](https://github.com/endojs/endo/issues/1324)
-
+- restore capdata leniency ([#1338](https://github.com/endojs/endo/issues/1338)) ([99a4d6c](https://github.com/endojs/endo/commit/99a4d6c83b9be4670e819ce496d7bff539b7587b))
+- **marshal:** Check if input is an error before checking if it is remotable ([#1323](https://github.com/endojs/endo/issues/1323)) ([f3e0982](https://github.com/endojs/endo/commit/f3e09824e49cf3fb3c75358879853443bbde2c34)), closes [#1318](https://github.com/endojs/endo/issues/1318)
+- **marshal:** Reject null as a substitute for Object.prototype ([1df4193](https://github.com/endojs/endo/commit/1df419350c2d18a9551a918b08dec5c43712043f)), closes [#1324](https://github.com/endojs/endo/issues/1324)
 
 ### Performance Improvements
 
-* **marshal:** Memoize checkRemotable ([5e9bd3f](https://github.com/endojs/endo/commit/5e9bd3f2fb166e80cf2fa4cca81756a3aeef1bc2))
-
-
+- **marshal:** Memoize checkRemotable ([5e9bd3f](https://github.com/endojs/endo/commit/5e9bd3f2fb166e80cf2fa4cca81756a3aeef1bc2))
 
 ### [0.7.6](https://github.com/endojs/endo/compare/@endo/marshal@0.7.5...@endo/marshal@0.7.6) (2022-10-19)
 
-
 ### Bug Fixes
 
-* **marshal:** Return a special error message from passStyleOf(typedArray) ([dbd498e](https://github.com/endojs/endo/commit/dbd498e30a5c3b0d2713d863bc7479ceef39cd79)), closes [#1326](https://github.com/endojs/endo/issues/1326)
-* parse positive bigints correctly despite XS parsing them wrong ([#1325](https://github.com/endojs/endo/issues/1325)) ([ab31d51](https://github.com/endojs/endo/commit/ab31d51fc2df0355b45da8bbeff892c45d81c98a)), closes [#1309](https://github.com/endojs/endo/issues/1309)
-* **marshal:** Add CapData encode/decode consistency assertions ([0b75021](https://github.com/endojs/endo/commit/0b75021acea174ce386c156f21de72a2150ad2dc))
-* **marshal:** Consistently quote "[@qclass](https://github.com/qclass)" in error messages ([4ab6743](https://github.com/endojs/endo/commit/4ab67436e9eb3c5ad9dc39d9e050529272e8dad6))
-* fix tiny typo ([#1321](https://github.com/endojs/endo/issues/1321)) ([7f3c371](https://github.com/endojs/endo/commit/7f3c371073d49b1b911d582cb8c63cbc9160d213))
-* **marshal:** Detect unexpected nonenumerable properties on tagged records and remotables ([da0f11f](https://github.com/endojs/endo/commit/da0f11f73ae1f2b9f7ec8c39e56b2c244e81b45d)), closes [#1316](https://github.com/endojs/endo/issues/1316)
-* unserialize makes copyRecords without problematic assign semantics ([#1304](https://github.com/endojs/endo/issues/1304)) ([5f0caf9](https://github.com/endojs/endo/commit/5f0caf95c40c55d8815818e66f63960788676cb0))
-
+- **marshal:** Return a special error message from passStyleOf(typedArray) ([dbd498e](https://github.com/endojs/endo/commit/dbd498e30a5c3b0d2713d863bc7479ceef39cd79)), closes [#1326](https://github.com/endojs/endo/issues/1326)
+- parse positive bigints correctly despite XS parsing them wrong ([#1325](https://github.com/endojs/endo/issues/1325)) ([ab31d51](https://github.com/endojs/endo/commit/ab31d51fc2df0355b45da8bbeff892c45d81c98a)), closes [#1309](https://github.com/endojs/endo/issues/1309)
+- **marshal:** Add CapData encode/decode consistency assertions ([0b75021](https://github.com/endojs/endo/commit/0b75021acea174ce386c156f21de72a2150ad2dc))
+- **marshal:** Consistently quote "[@qclass](https://github.com/qclass)" in error messages ([4ab6743](https://github.com/endojs/endo/commit/4ab67436e9eb3c5ad9dc39d9e050529272e8dad6))
+- fix tiny typo ([#1321](https://github.com/endojs/endo/issues/1321)) ([7f3c371](https://github.com/endojs/endo/commit/7f3c371073d49b1b911d582cb8c63cbc9160d213))
+- **marshal:** Detect unexpected nonenumerable properties on tagged records and remotables ([da0f11f](https://github.com/endojs/endo/commit/da0f11f73ae1f2b9f7ec8c39e56b2c244e81b45d)), closes [#1316](https://github.com/endojs/endo/issues/1316)
+- unserialize makes copyRecords without problematic assign semantics ([#1304](https://github.com/endojs/endo/issues/1304)) ([5f0caf9](https://github.com/endojs/endo/commit/5f0caf95c40c55d8815818e66f63960788676cb0))
 
 ### Performance Improvements
 
-* **marshal:** Extend new assert style to `check` calls ([11d9f97](https://github.com/endojs/endo/commit/11d9f976944b4faaea06037252cfd54e3dd91c37))
-* **marshal:** Skip unnecessary assert.details calls ([053ca12](https://github.com/endojs/endo/commit/053ca12110c706439a5f3611592a0b49cb829ac6))
-
-
+- **marshal:** Extend new assert style to `check` calls ([11d9f97](https://github.com/endojs/endo/commit/11d9f976944b4faaea06037252cfd54e3dd91c37))
+- **marshal:** Skip unnecessary assert.details calls ([053ca12](https://github.com/endojs/endo/commit/053ca12110c706439a5f3611592a0b49cb829ac6))
 
 ### [0.7.5](https://github.com/endojs/endo/compare/@endo/marshal@0.7.4...@endo/marshal@0.7.5) (2022-09-27)
 
-
 ### Bug Fixes
 
-* import endo/init, not lockdown ([#1299](https://github.com/endojs/endo/issues/1299)) ([f6eb272](https://github.com/endojs/endo/commit/f6eb2723b4f3e48e6c51d98194798a3dcdfb94a0))
-* Provide smallcaps encoding in addition to capData ([#1282](https://github.com/endojs/endo/issues/1282)) ([233dbe2](https://github.com/endojs/endo/commit/233dbe2e159e454fd3bcdd0e08b15c4439b56ba7))
-
-
+- import endo/init, not lockdown ([#1299](https://github.com/endojs/endo/issues/1299)) ([f6eb272](https://github.com/endojs/endo/commit/f6eb2723b4f3e48e6c51d98194798a3dcdfb94a0))
+- Provide smallcaps encoding in addition to capData ([#1282](https://github.com/endojs/endo/issues/1282)) ([233dbe2](https://github.com/endojs/endo/commit/233dbe2e159e454fd3bcdd0e08b15c4439b56ba7))
 
 ### [0.7.4](https://github.com/endojs/endo/compare/@endo/marshal@0.7.3...@endo/marshal@0.7.4) (2022-09-14)
 
-
 ### Bug Fixes
 
-* alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
-* bad check defaults ([#1274](https://github.com/endojs/endo/issues/1274)) ([7229fcf](https://github.com/endojs/endo/commit/7229fcfee146f12be3c2455c303015aee163709d))
-* tolerate more from async_hooks ([#1275](https://github.com/endojs/endo/issues/1275)) ([1a0b123](https://github.com/endojs/endo/commit/1a0b1230c9ca7a80d14ff1808986ef6d4a861553))
-
-
+- alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
+- bad check defaults ([#1274](https://github.com/endojs/endo/issues/1274)) ([7229fcf](https://github.com/endojs/endo/commit/7229fcfee146f12be3c2455c303015aee163709d))
+- tolerate more from async_hooks ([#1275](https://github.com/endojs/endo/issues/1275)) ([1a0b123](https://github.com/endojs/endo/commit/1a0b1230c9ca7a80d14ff1808986ef6d4a861553))
 
 ### [0.7.3](https://github.com/endojs/endo/compare/@endo/marshal@0.7.2...@endo/marshal@0.7.3) (2022-08-26)
 
 **Note:** Version bump only for package @endo/marshal
 
-
-
-
-
 ### [0.7.2](https://github.com/endojs/endo/compare/@endo/marshal@0.7.1...@endo/marshal@0.7.2) (2022-08-26)
-
 
 ### Bug Fixes
 
-* split marshal from its encoder ([#1259](https://github.com/endojs/endo/issues/1259)) ([1e3b7fc](https://github.com/endojs/endo/commit/1e3b7fcfffcb435c2c6b82c7c24e2c75382f3a18))
-
-
+- split marshal from its encoder ([#1259](https://github.com/endojs/endo/issues/1259)) ([1e3b7fc](https://github.com/endojs/endo/commit/1e3b7fcfffcb435c2c6b82c7c24e2c75382f3a18))
 
 ### [0.7.1](https://github.com/endojs/endo/compare/@endo/marshal@0.7.0...@endo/marshal@0.7.1) (2022-08-25)
 
-
 ### Bug Fixes
 
-* **marshal:** handle async_hooks symbols on promises ([94cbce7](https://github.com/endojs/endo/commit/94cbce7a6780b58a1f160faf0a374ac938c15047))
-
-
+- **marshal:** handle async_hooks symbols on promises ([94cbce7](https://github.com/endojs/endo/commit/94cbce7a6780b58a1f160faf0a374ac938c15047))
 
 ## [0.7.0](https://github.com/endojs/endo/compare/@endo/marshal@0.6.9...@endo/marshal@0.7.0) (2022-08-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **marshal:** assertPure wrong but unused (#1242)
+- **marshal:** assertPure wrong but unused (#1242)
 
 ### Bug Fixes
 
-* passStyleOf full input validation ([#1250](https://github.com/endojs/endo/issues/1250)) ([fb84bff](https://github.com/endojs/endo/commit/fb84bff75bbca277aaa90d88d29a811c2c6194ae))
-* prepare for far classes ([#1251](https://github.com/endojs/endo/issues/1251)) ([c22476f](https://github.com/endojs/endo/commit/c22476f4209513a07b73503cc07fda15d2799676))
-* remove dead environment-options module ([#1243](https://github.com/endojs/endo/issues/1243)) ([c43c939](https://github.com/endojs/endo/commit/c43c9396976ad6b0af5d99caed033b1abf448165))
-* **marshal:** assertPure wrong but unused ([#1242](https://github.com/endojs/endo/issues/1242)) ([1895f5b](https://github.com/endojs/endo/commit/1895f5b0172cadacb4fc54b9f64c7e0c8314d041))
-
-
+- passStyleOf full input validation ([#1250](https://github.com/endojs/endo/issues/1250)) ([fb84bff](https://github.com/endojs/endo/commit/fb84bff75bbca277aaa90d88d29a811c2c6194ae))
+- prepare for far classes ([#1251](https://github.com/endojs/endo/issues/1251)) ([c22476f](https://github.com/endojs/endo/commit/c22476f4209513a07b73503cc07fda15d2799676))
+- remove dead environment-options module ([#1243](https://github.com/endojs/endo/issues/1243)) ([c43c939](https://github.com/endojs/endo/commit/c43c9396976ad6b0af5d99caed033b1abf448165))
+- **marshal:** assertPure wrong but unused ([#1242](https://github.com/endojs/endo/issues/1242)) ([1895f5b](https://github.com/endojs/endo/commit/1895f5b0172cadacb4fc54b9f64c7e0c8314d041))
 
 ### [0.6.9](https://github.com/endojs/endo/compare/@endo/marshal@0.6.8...@endo/marshal@0.6.9) (2022-06-28)
 
 **Note:** Version bump only for package @endo/marshal
 
-
-
-
-
 ### [0.6.8](https://github.com/endojs/endo/compare/@endo/marshal@0.6.7...@endo/marshal@0.6.8) (2022-06-11)
-
 
 ### Bug Fixes
 
-* decodeToJustin accepts slot backrefs ([#1186](https://github.com/endojs/endo/issues/1186)) ([e4f71b4](https://github.com/endojs/endo/commit/e4f71b46a440bfb0e15bd24f709c58e94887b942))
-* retire deprecated sending only ([#1187](https://github.com/endojs/endo/issues/1187)) ([af656b2](https://github.com/endojs/endo/commit/af656b20491969b8c3106f51276865690f702794))
-
-
+- decodeToJustin accepts slot backrefs ([#1186](https://github.com/endojs/endo/issues/1186)) ([e4f71b4](https://github.com/endojs/endo/commit/e4f71b46a440bfb0e15bd24f709c58e94887b942))
+- retire deprecated sending only ([#1187](https://github.com/endojs/endo/issues/1187)) ([af656b2](https://github.com/endojs/endo/commit/af656b20491969b8c3106f51276865690f702794))
 
 ### [0.6.7](https://github.com/endojs/endo/compare/@endo/marshal@0.6.6...@endo/marshal@0.6.7) (2022-04-15)
 
 **Note:** Version bump only for package @endo/marshal
 
-
-
-
-
 ### [0.6.6](https://github.com/endojs/endo/compare/@endo/marshal@0.6.5...@endo/marshal@0.6.6) (2022-04-14)
 
 **Note:** Version bump only for package @endo/marshal
 
-
-
-
-
 ### [0.6.5](https://github.com/endojs/endo/compare/@endo/marshal@0.6.4...@endo/marshal@0.6.5) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.6.4](https://github.com/endojs/endo/compare/@endo/marshal@0.6.3...@endo/marshal@0.6.4) (2022-04-12)
 
-
 ### Features
 
-* **marshal:** stamp Remotable return with `RemotableBrand<L,R>` ([8b9b8fd](https://github.com/endojs/endo/commit/8b9b8fd9b1f40c22b1b9ddef46569db81dd7bff6))
-
-
+- **marshal:** stamp Remotable return with `RemotableBrand<L,R>` ([8b9b8fd](https://github.com/endojs/endo/commit/8b9b8fd9b1f40c22b1b9ddef46569db81dd7bff6))
 
 ### [0.6.3](https://github.com/endojs/endo/compare/@endo/marshal@0.6.2...@endo/marshal@0.6.3) (2022-03-07)
 
-
 ### Features
 
-* **marshal:** have `Remotable` create `Remote<T>`-compatible objs ([1ba89ba](https://github.com/endojs/endo/commit/1ba89ba922275f08d3b7b8c82fae0dca31752321))
-
-
+- **marshal:** have `Remotable` create `Remote<T>`-compatible objs ([1ba89ba](https://github.com/endojs/endo/commit/1ba89ba922275f08d3b7b8c82fae0dca31752321))
 
 ### [0.6.2](https://github.com/endojs/endo/compare/@endo/marshal@0.6.1...@endo/marshal@0.6.2) (2022-03-02)
 
 **Note:** Version bump only for package @endo/marshal
 
-
-
-
-
 ### [0.6.1](https://github.com/endojs/endo/compare/@endo/marshal@0.6.0...@endo/marshal@0.6.1) (2022-02-20)
 
 **Note:** Version bump only for package @endo/marshal
 
-
-
-
-
 ## [0.6.0](https://github.com/endojs/endo/compare/@endo/marshal@0.5.4...@endo/marshal@0.6.0) (2022-02-18)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **marshal:** Remove ambient types
+- **marshal:** Remove ambient types
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* remove pureCopy, ALLOW_IMPLICIT_REMOTABLES ([#1061](https://github.com/endojs/endo/issues/1061)) ([f08cad9](https://github.com/endojs/endo/commit/f08cad99aa715aa36f78dfd67b9f581cdd22bb3c))
-* **marshal:** Fix typing for TS 4.5 compatibility ([8513cfb](https://github.com/endojs/endo/commit/8513cfbaaa2308bee9f666585694e622e84fd24e))
-* **marshal:** Remove ambient types ([2a9cf63](https://github.com/endojs/endo/commit/2a9cf6372042b1fb16e1c96af5f3f9526978570a))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- remove pureCopy, ALLOW_IMPLICIT_REMOTABLES ([#1061](https://github.com/endojs/endo/issues/1061)) ([f08cad9](https://github.com/endojs/endo/commit/f08cad99aa715aa36f78dfd67b9f581cdd22bb3c))
+- **marshal:** Fix typing for TS 4.5 compatibility ([8513cfb](https://github.com/endojs/endo/commit/8513cfbaaa2308bee9f666585694e622e84fd24e))
+- **marshal:** Remove ambient types ([2a9cf63](https://github.com/endojs/endo/commit/2a9cf6372042b1fb16e1c96af5f3f9526978570a))
 
 ### [0.5.4](https://github.com/endojs/endo/compare/@endo/marshal@0.5.3...@endo/marshal@0.5.4) (2022-01-31)
 
 **Note:** Version bump only for package @endo/marshal
 
-
-
-
-
 ### [0.5.3](https://github.com/endojs/endo/compare/@endo/marshal@0.5.2...@endo/marshal@0.5.3) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.5.2](https://github.com/endojs/endo/compare/@endo/marshal@0.5.1...@endo/marshal@0.5.2) (2022-01-25)
 
-
 ### Bug Fixes
 
-* **marshal:** error serialization uses name from prototype ([#1010](https://github.com/endojs/endo/issues/1010)) ([aff3ff7](https://github.com/endojs/endo/commit/aff3ff71144df359e12949b0c2d8a1a5f491810a))
-* assert that unserialize makes only passables ([#996](https://github.com/endojs/endo/issues/996)) ([b34817b](https://github.com/endojs/endo/commit/b34817b9910fd0c9092dc9c1d11a14709ff11542))
-* only shallow freeze needed ([#994](https://github.com/endojs/endo/issues/994)) ([edeaf8a](https://github.com/endojs/endo/commit/edeaf8a111ad4dc625484555d317c38f38ae7641))
-* remove more extraneous spaced-comment comments ([#1009](https://github.com/endojs/endo/issues/1009)) ([980a798](https://github.com/endojs/endo/commit/980a79898a4643a359d905c308eecf70d8ab2758))
-
-
+- **marshal:** error serialization uses name from prototype ([#1010](https://github.com/endojs/endo/issues/1010)) ([aff3ff7](https://github.com/endojs/endo/commit/aff3ff71144df359e12949b0c2d8a1a5f491810a))
+- assert that unserialize makes only passables ([#996](https://github.com/endojs/endo/issues/996)) ([b34817b](https://github.com/endojs/endo/commit/b34817b9910fd0c9092dc9c1d11a14709ff11542))
+- only shallow freeze needed ([#994](https://github.com/endojs/endo/issues/994)) ([edeaf8a](https://github.com/endojs/endo/commit/edeaf8a111ad4dc625484555d317c38f38ae7641))
+- remove more extraneous spaced-comment comments ([#1009](https://github.com/endojs/endo/issues/1009)) ([980a798](https://github.com/endojs/endo/commit/980a79898a4643a359d905c308eecf70d8ab2758))
 
 ### 0.5.1 (2022-01-23)
 
 **Note:** Version bump only for package @endo/marshal
 
-
-
-
-
 ## [0.5.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.28...@agoric/marshal@0.5.0) (2021-12-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **ERTP:** NatValues now only accept bigints, lower-case amountMath is removed, and AmountMath methods always follow the order of: brand, value
+- **ERTP:** NatValues now only accept bigints, lower-case amountMath is removed, and AmountMath methods always follow the order of: brand, value
 
-* chore: fix up INPUT_VALIDATON.md
+- chore: fix up INPUT_VALIDATON.md
 
-* chore: address PR comments
+- chore: address PR comments
 
 ### Bug Fixes
 
-* default to disallowing implicit remotables ([#3736](https://github.com/Agoric/agoric-sdk/issues/3736)) ([d14a665](https://github.com/Agoric/agoric-sdk/commit/d14a66548f3981334f9738bbca3b906901c2e657))
-
+- default to disallowing implicit remotables ([#3736](https://github.com/Agoric/agoric-sdk/issues/3736)) ([d14a665](https://github.com/Agoric/agoric-sdk/commit/d14a66548f3981334f9738bbca3b906901c2e657))
 
 ### Miscellaneous Chores
 
-* **ERTP:** additional input validation and clean up ([#3892](https://github.com/Agoric/agoric-sdk/issues/3892)) ([067ea32](https://github.com/Agoric/agoric-sdk/commit/067ea32b069596202d7f8e7c5e09d5ea7821f6b2))
-
-
+- **ERTP:** additional input validation and clean up ([#3892](https://github.com/Agoric/agoric-sdk/issues/3892)) ([067ea32](https://github.com/Agoric/agoric-sdk/commit/067ea32b069596202d7f8e7c5e09d5ea7821f6b2))
 
 ### [0.4.28](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.27...@agoric/marshal@0.4.28) (2021-10-13)
 
-
 ### Bug Fixes
 
-* document copyRecord guarantees ([#3955](https://github.com/Agoric/agoric-sdk/issues/3955)) ([f4a0ba1](https://github.com/Agoric/agoric-sdk/commit/f4a0ba113dba913c33c37043e700825f3512cf73))
-
-
+- document copyRecord guarantees ([#3955](https://github.com/Agoric/agoric-sdk/issues/3955)) ([f4a0ba1](https://github.com/Agoric/agoric-sdk/commit/f4a0ba113dba913c33c37043e700825f3512cf73))
 
 ### [0.4.27](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.26...@agoric/marshal@0.4.27) (2021-09-23)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.26](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.25...@agoric/marshal@0.4.26) (2021-09-15)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ### [0.4.25](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.24...@agoric/marshal@0.4.25) (2021-08-18)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.24](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.23...@agoric/marshal@0.4.24) (2021-08-17)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.23](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.22...@agoric/marshal@0.4.23) (2021-08-16)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ### [0.4.22](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.19...@agoric/marshal@0.4.22) (2021-08-15)
 
@@ -325,409 +225,231 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.21](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.19...@agoric/marshal@0.4.21) (2021-08-14)
 
 ### 0.26.10 (2021-07-28)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.20](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.19...@agoric/marshal@0.4.20) (2021-07-28)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ### [0.4.19](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.18...@agoric/marshal@0.4.19) (2021-07-01)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.18](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.17...@agoric/marshal@0.4.18) (2021-06-28)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ### [0.4.17](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.16...@agoric/marshal@0.4.17) (2021-06-25)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.16](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.15...@agoric/marshal@0.4.16) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ### [0.4.15](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.14...@agoric/marshal@0.4.15) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.14](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.13...@agoric/marshal@0.4.14) (2021-06-23)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ### [0.4.13](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.12...@agoric/marshal@0.4.13) (2021-06-16)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ### [0.4.12](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.11...@agoric/marshal@0.4.12) (2021-06-15)
-
 
 ### Bug Fixes
 
-* Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
-
-
+- Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
 
 ## [0.4.11](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.10...@agoric/marshal@0.4.11) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.4.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.9...@agoric/marshal@0.4.10) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.4.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.8...@agoric/marshal@0.4.9) (2021-05-05)
-
 
 ### Bug Fixes
 
-* **marshal:** [#2435](https://github.com/Agoric/agoric-sdk/issues/2435) make getInterfaceOf truthful ([ff19f93](https://github.com/Agoric/agoric-sdk/commit/ff19f9333ed30a99bcbe1a9bfc167dea8d73c057))
-* add noIbids option ([#2886](https://github.com/Agoric/agoric-sdk/issues/2886)) ([39388bc](https://github.com/Agoric/agoric-sdk/commit/39388bc6b96c6b05b807d8c44614b9acb670467d))
-* remove deprecated ibid support ([#2898](https://github.com/Agoric/agoric-sdk/issues/2898)) ([f865a2a](https://github.com/Agoric/agoric-sdk/commit/f865a2a8fb5d6cb1d16d9fc21ad4868ea6d5a294)), closes [#2896](https://github.com/Agoric/agoric-sdk/issues/2896) [#2896](https://github.com/Agoric/agoric-sdk/issues/2896) [#2896](https://github.com/Agoric/agoric-sdk/issues/2896)
-* settle REMOTE_STYLE name ([#2900](https://github.com/Agoric/agoric-sdk/issues/2900)) ([3dc6638](https://github.com/Agoric/agoric-sdk/commit/3dc66385b85cb3e8a1056b8d6e64cd3e448c041f))
-* split marshal module ([#2803](https://github.com/Agoric/agoric-sdk/issues/2803)) ([2e19e78](https://github.com/Agoric/agoric-sdk/commit/2e19e7878bc06dd71e166e13c9cce462b3d5ff7a))
-
-
-
-
+- **marshal:** [#2435](https://github.com/Agoric/agoric-sdk/issues/2435) make getInterfaceOf truthful ([ff19f93](https://github.com/Agoric/agoric-sdk/commit/ff19f9333ed30a99bcbe1a9bfc167dea8d73c057))
+- add noIbids option ([#2886](https://github.com/Agoric/agoric-sdk/issues/2886)) ([39388bc](https://github.com/Agoric/agoric-sdk/commit/39388bc6b96c6b05b807d8c44614b9acb670467d))
+- remove deprecated ibid support ([#2898](https://github.com/Agoric/agoric-sdk/issues/2898)) ([f865a2a](https://github.com/Agoric/agoric-sdk/commit/f865a2a8fb5d6cb1d16d9fc21ad4868ea6d5a294)), closes [#2896](https://github.com/Agoric/agoric-sdk/issues/2896) [#2896](https://github.com/Agoric/agoric-sdk/issues/2896) [#2896](https://github.com/Agoric/agoric-sdk/issues/2896)
+- settle REMOTE_STYLE name ([#2900](https://github.com/Agoric/agoric-sdk/issues/2900)) ([3dc6638](https://github.com/Agoric/agoric-sdk/commit/3dc66385b85cb3e8a1056b8d6e64cd3e448c041f))
+- split marshal module ([#2803](https://github.com/Agoric/agoric-sdk/issues/2803)) ([2e19e78](https://github.com/Agoric/agoric-sdk/commit/2e19e7878bc06dd71e166e13c9cce462b3d5ff7a))
 
 ## [0.4.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.7...@agoric/marshal@0.4.8) (2021-04-22)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.4.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.6...@agoric/marshal@0.4.7) (2021-04-18)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ## [0.4.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.5...@agoric/marshal@0.4.6) (2021-04-16)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.4.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.4...@agoric/marshal@0.4.5) (2021-04-14)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ## [0.4.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.3...@agoric/marshal@0.4.4) (2021-04-13)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.4.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.2...@agoric/marshal@0.4.3) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ## [0.4.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.1...@agoric/marshal@0.4.2) (2021-04-06)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.4.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.4.0...@agoric/marshal@0.4.1) (2021-03-24)
-
 
 ### Bug Fixes
 
-* **marshal:** remove Data ([81dd9a4](https://github.com/Agoric/agoric-sdk/commit/81dd9a492bd70f63e71647a29356eb890063641d)), closes [#2018](https://github.com/Agoric/agoric-sdk/issues/2018)
-
-
-
-
+- **marshal:** remove Data ([81dd9a4](https://github.com/Agoric/agoric-sdk/commit/81dd9a492bd70f63e71647a29356eb890063641d)), closes [#2018](https://github.com/Agoric/agoric-sdk/issues/2018)
 
 # [0.4.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.3.2...@agoric/marshal@0.4.0) (2021-03-16)
 
-
 ### Bug Fixes
 
-* fix ibids. test ibids and slots ([#2625](https://github.com/Agoric/agoric-sdk/issues/2625)) ([891d9fd](https://github.com/Agoric/agoric-sdk/commit/891d9fd236ca86b63947384064b675c52e960abd))
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-* **marshal:** add Data marker, tolerate its presence ([d7b190f](https://github.com/Agoric/agoric-sdk/commit/d7b190f340ba336bd0d76a2ca8ed4829f227be61))
-* **marshal:** add placeholder warnings ([8499b8e](https://github.com/Agoric/agoric-sdk/commit/8499b8e4584f3ae155913f95614980a483c487e2))
-* **marshal:** serialize empty objects as data, not pass-by-reference ([aeee1ad](https://github.com/Agoric/agoric-sdk/commit/aeee1adf561d44ed3bc738989be605b683b3b656)), closes [#2018](https://github.com/Agoric/agoric-sdk/issues/2018)
-* separate ibid tables ([#2596](https://github.com/Agoric/agoric-sdk/issues/2596)) ([e0704eb](https://github.com/Agoric/agoric-sdk/commit/e0704eb640a54ceec11b39fc924488108cb10cee))
-
+- fix ibids. test ibids and slots ([#2625](https://github.com/Agoric/agoric-sdk/issues/2625)) ([891d9fd](https://github.com/Agoric/agoric-sdk/commit/891d9fd236ca86b63947384064b675c52e960abd))
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
+- **marshal:** add Data marker, tolerate its presence ([d7b190f](https://github.com/Agoric/agoric-sdk/commit/d7b190f340ba336bd0d76a2ca8ed4829f227be61))
+- **marshal:** add placeholder warnings ([8499b8e](https://github.com/Agoric/agoric-sdk/commit/8499b8e4584f3ae155913f95614980a483c487e2))
+- **marshal:** serialize empty objects as data, not pass-by-reference ([aeee1ad](https://github.com/Agoric/agoric-sdk/commit/aeee1adf561d44ed3bc738989be605b683b3b656)), closes [#2018](https://github.com/Agoric/agoric-sdk/issues/2018)
+- separate ibid tables ([#2596](https://github.com/Agoric/agoric-sdk/issues/2596)) ([e0704eb](https://github.com/Agoric/agoric-sdk/commit/e0704eb640a54ceec11b39fc924488108cb10cee))
 
 ### Features
 
-* **marshal:** add Data() to all unserialized empty records ([946fd6f](https://github.com/Agoric/agoric-sdk/commit/946fd6f1b811c55ee39668100755db24f1b52329))
-* **marshal:** allow marshalSaveError function to be specified ([c93bb04](https://github.com/Agoric/agoric-sdk/commit/c93bb046aecf476dc9ccc537671a14f446b89ed4))
-* **marshal:** Data({}) is pass-by-copy ([03d7b5e](https://github.com/Agoric/agoric-sdk/commit/03d7b5eed8ecd3f24725d6ea63919f4398d8a2f8))
-
-
-
-
+- **marshal:** add Data() to all unserialized empty records ([946fd6f](https://github.com/Agoric/agoric-sdk/commit/946fd6f1b811c55ee39668100755db24f1b52329))
+- **marshal:** allow marshalSaveError function to be specified ([c93bb04](https://github.com/Agoric/agoric-sdk/commit/c93bb046aecf476dc9ccc537671a14f446b89ed4))
+- **marshal:** Data({}) is pass-by-copy ([03d7b5e](https://github.com/Agoric/agoric-sdk/commit/03d7b5eed8ecd3f24725d6ea63919f4398d8a2f8))
 
 ## [0.3.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.3.1...@agoric/marshal@0.3.2) (2021-02-22)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.3.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.3.0...@agoric/marshal@0.3.1) (2021-02-16)
-
 
 ### Bug Fixes
 
-* **marshal:** reject getters in pass-by-ref, even if it returns a function ([#2438](https://github.com/Agoric/agoric-sdk/issues/2438)) ([b9368b6](https://github.com/Agoric/agoric-sdk/commit/b9368b6ee16a5562a622551539eff2b8708f0fdd)), closes [#2436](https://github.com/Agoric/agoric-sdk/issues/2436)
-* Correlate sent errors with received errors ([73b9cfd](https://github.com/Agoric/agoric-sdk/commit/73b9cfd33cf7842bdc105a79592028649cb1c92a))
-* Far and Remotable do unverified local marking rather than WeakMap ([#2361](https://github.com/Agoric/agoric-sdk/issues/2361)) ([ab59ab7](https://github.com/Agoric/agoric-sdk/commit/ab59ab779341b9740827b7c4cca4680e7b7212b2))
-* review comments ([7db7e5c](https://github.com/Agoric/agoric-sdk/commit/7db7e5c4c569dfedff8d748dd58893218b0a2458))
-* use assert rather than FooError constructors ([f860c5b](https://github.com/Agoric/agoric-sdk/commit/f860c5bf5add165a08cb5bd543502857c3f57998))
-
-
-
-
+- **marshal:** reject getters in pass-by-ref, even if it returns a function ([#2438](https://github.com/Agoric/agoric-sdk/issues/2438)) ([b9368b6](https://github.com/Agoric/agoric-sdk/commit/b9368b6ee16a5562a622551539eff2b8708f0fdd)), closes [#2436](https://github.com/Agoric/agoric-sdk/issues/2436)
+- Correlate sent errors with received errors ([73b9cfd](https://github.com/Agoric/agoric-sdk/commit/73b9cfd33cf7842bdc105a79592028649cb1c92a))
+- Far and Remotable do unverified local marking rather than WeakMap ([#2361](https://github.com/Agoric/agoric-sdk/issues/2361)) ([ab59ab7](https://github.com/Agoric/agoric-sdk/commit/ab59ab779341b9740827b7c4cca4680e7b7212b2))
+- review comments ([7db7e5c](https://github.com/Agoric/agoric-sdk/commit/7db7e5c4c569dfedff8d748dd58893218b0a2458))
+- use assert rather than FooError constructors ([f860c5b](https://github.com/Agoric/agoric-sdk/commit/f860c5bf5add165a08cb5bd543502857c3f57998))
 
 # [0.3.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.7...@agoric/marshal@0.3.0) (2020-12-10)
 
-
 ### Bug Fixes
 
-* minor tweaks for dapp-oracle ([b8169c1](https://github.com/Agoric/agoric-sdk/commit/b8169c1f39bc0c0d7c07099df2ac23ee7df05733))
-
+- minor tweaks for dapp-oracle ([b8169c1](https://github.com/Agoric/agoric-sdk/commit/b8169c1f39bc0c0d7c07099df2ac23ee7df05733))
 
 ### Features
 
-* **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
-
-
-
-
+- **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
 
 ## [0.2.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.7-dev.0...@agoric/marshal@0.2.7) (2020-11-07)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.2.7-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.6...@agoric/marshal@0.2.7-dev.0) (2020-10-19)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ## [0.2.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.6-dev.2...@agoric/marshal@0.2.6) (2020-10-11)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.2.6-dev.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.6-dev.1...@agoric/marshal@0.2.6-dev.2) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ## [0.2.6-dev.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.6-dev.0...@agoric/marshal@0.2.6-dev.1) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.2.6-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.5...@agoric/marshal@0.2.6-dev.0) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ## [0.2.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.4...@agoric/marshal@0.2.5) (2020-09-16)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.2.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.3...@agoric/marshal@0.2.4) (2020-08-31)
-
 
 ### Bug Fixes
 
-* add "TODO unimplemented"s ([#1580](https://github.com/Agoric/agoric-sdk/issues/1580)) ([7795f93](https://github.com/Agoric/agoric-sdk/commit/7795f9302843a2c94d4a2f42cb22affe1e91d41d))
-* clean up E.when and E.resolve ([#1561](https://github.com/Agoric/agoric-sdk/issues/1561)) ([634046c](https://github.com/Agoric/agoric-sdk/commit/634046c0fc541fc1db258105a75c7313b5668aa0))
-* excise @agoric/harden from the codebase ([eee6fe1](https://github.com/Agoric/agoric-sdk/commit/eee6fe1153730dec52841c9eb4c056a8c5438b0f))
-* minor: rearrange asserts in Remotable ([#1642](https://github.com/Agoric/agoric-sdk/issues/1642)) ([c43a08f](https://github.com/Agoric/agoric-sdk/commit/c43a08fb1733596172a7dc5ca89353d837033e23))
-* reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
-* rename producePromise to makePromiseKit ([#1329](https://github.com/Agoric/agoric-sdk/issues/1329)) ([1d2925a](https://github.com/Agoric/agoric-sdk/commit/1d2925ad640cce7b419751027b44737bd46a6d59))
-* send and receive Remotable tags ([#1628](https://github.com/Agoric/agoric-sdk/issues/1628)) ([1bae122](https://github.com/Agoric/agoric-sdk/commit/1bae1220c2c35f48f279cb3aeab6012bce8ddb5a))
-* stricter marshal requirements ([#1499](https://github.com/Agoric/agoric-sdk/issues/1499)) ([9d8ba97](https://github.com/Agoric/agoric-sdk/commit/9d8ba9763defb290de71668d08faa8619200d117))
-* use REMOTE_STYLE rather than 'presence' to prepare ([#1577](https://github.com/Agoric/agoric-sdk/issues/1577)) ([6b97ae8](https://github.com/Agoric/agoric-sdk/commit/6b97ae8670303631313a65d12393d7ad226b941d))
-* **marshal:** make toString and Symbol.toStringTag non-enumerable ([fc616ef](https://github.com/Agoric/agoric-sdk/commit/fc616eff1c3f61cd96e24644eeb76d8f8469a05c))
-
-
-
-
+- add "TODO unimplemented"s ([#1580](https://github.com/Agoric/agoric-sdk/issues/1580)) ([7795f93](https://github.com/Agoric/agoric-sdk/commit/7795f9302843a2c94d4a2f42cb22affe1e91d41d))
+- clean up E.when and E.resolve ([#1561](https://github.com/Agoric/agoric-sdk/issues/1561)) ([634046c](https://github.com/Agoric/agoric-sdk/commit/634046c0fc541fc1db258105a75c7313b5668aa0))
+- excise @agoric/harden from the codebase ([eee6fe1](https://github.com/Agoric/agoric-sdk/commit/eee6fe1153730dec52841c9eb4c056a8c5438b0f))
+- minor: rearrange asserts in Remotable ([#1642](https://github.com/Agoric/agoric-sdk/issues/1642)) ([c43a08f](https://github.com/Agoric/agoric-sdk/commit/c43a08fb1733596172a7dc5ca89353d837033e23))
+- reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
+- rename producePromise to makePromiseKit ([#1329](https://github.com/Agoric/agoric-sdk/issues/1329)) ([1d2925a](https://github.com/Agoric/agoric-sdk/commit/1d2925ad640cce7b419751027b44737bd46a6d59))
+- send and receive Remotable tags ([#1628](https://github.com/Agoric/agoric-sdk/issues/1628)) ([1bae122](https://github.com/Agoric/agoric-sdk/commit/1bae1220c2c35f48f279cb3aeab6012bce8ddb5a))
+- stricter marshal requirements ([#1499](https://github.com/Agoric/agoric-sdk/issues/1499)) ([9d8ba97](https://github.com/Agoric/agoric-sdk/commit/9d8ba9763defb290de71668d08faa8619200d117))
+- use REMOTE_STYLE rather than 'presence' to prepare ([#1577](https://github.com/Agoric/agoric-sdk/issues/1577)) ([6b97ae8](https://github.com/Agoric/agoric-sdk/commit/6b97ae8670303631313a65d12393d7ad226b941d))
+- **marshal:** make toString and Symbol.toStringTag non-enumerable ([fc616ef](https://github.com/Agoric/agoric-sdk/commit/fc616eff1c3f61cd96e24644eeb76d8f8469a05c))
 
 ## [0.2.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.2...@agoric/marshal@0.2.3) (2020-06-30)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.2.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.1...@agoric/marshal@0.2.2) (2020-05-17)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ## [0.2.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.2.0...@agoric/marshal@0.2.1) (2020-05-10)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 # [0.2.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.1.5...@agoric/marshal@0.2.0) (2020-05-04)
-
 
 ### Bug Fixes
 
-* address PR comments ([358952a](https://github.com/Agoric/agoric-sdk/commit/358952ab0f85ec9969a206a716fa91aa8b56c1e2))
-* propagate Go errors all the way to the caller ([ea5ba38](https://github.com/Agoric/agoric-sdk/commit/ea5ba381e4e510bb9c9053bfb681e778f782a801))
-* use getErrorConstructor to deep-copy an Error ([8ae1994](https://github.com/Agoric/agoric-sdk/commit/8ae1994f8ad9ee6dda34643b6323ed8422751115))
-
+- address PR comments ([358952a](https://github.com/Agoric/agoric-sdk/commit/358952ab0f85ec9969a206a716fa91aa8b56c1e2))
+- propagate Go errors all the way to the caller ([ea5ba38](https://github.com/Agoric/agoric-sdk/commit/ea5ba381e4e510bb9c9053bfb681e778f782a801))
+- use getErrorConstructor to deep-copy an Error ([8ae1994](https://github.com/Agoric/agoric-sdk/commit/8ae1994f8ad9ee6dda34643b6323ed8422751115))
 
 ### Features
 
-* add Presence, getInterfaceOf, deepCopyData to marshal ([aac1899](https://github.com/Agoric/agoric-sdk/commit/aac1899b6cefc4241af04911a92ffc50fbac3429))
-
-
-
-
+- add Presence, getInterfaceOf, deepCopyData to marshal ([aac1899](https://github.com/Agoric/agoric-sdk/commit/aac1899b6cefc4241af04911a92ffc50fbac3429))
 
 ## [0.1.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.1.5-alpha.0...@agoric/marshal@0.1.5) (2020-04-13)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.1.5-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.1.4...@agoric/marshal@0.1.5-alpha.0) (2020-04-12)
 
 **Note:** Version bump only for package @agoric/marshal
-
-
-
-
 
 ## [0.1.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.1.4-alpha.0...@agoric/marshal@0.1.4) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## [0.1.4-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/marshal@0.1.3...@agoric/marshal@0.1.4-alpha.0) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/marshal
 
-
-
-
-
 ## 0.1.3 (2020-03-26)
-
 
 ### Bug Fixes
 
-* first draft use collection equality ([6acbde7](https://github.com/Agoric/marshal/commit/6acbde71ec82101ec8da9eaafc729bab1fdd6df9))
-* symbols no longer passable ([7290a90](https://github.com/Agoric/marshal/commit/7290a90444f70d2a9a2f5c1e2782d18bea00039d))
-* **eventual-send:** Update the API throughout agoric-sdk ([97fc1e7](https://github.com/Agoric/marshal/commit/97fc1e748d8e3955b29baf0e04bfa788d56dad9f))
-* **SwingSet:** passing all tests ([341718b](https://github.com/Agoric/marshal/commit/341718be335e16b58aa5e648b51a731ea065c1d6))
+- first draft use collection equality ([6acbde7](https://github.com/Agoric/marshal/commit/6acbde71ec82101ec8da9eaafc729bab1fdd6df9))
+- symbols no longer passable ([7290a90](https://github.com/Agoric/marshal/commit/7290a90444f70d2a9a2f5c1e2782d18bea00039d))
+- **eventual-send:** Update the API throughout agoric-sdk ([97fc1e7](https://github.com/Agoric/marshal/commit/97fc1e748d8e3955b29baf0e04bfa788d56dad9f))
+- **SwingSet:** passing all tests ([341718b](https://github.com/Agoric/marshal/commit/341718be335e16b58aa5e648b51a731ea065c1d6))

--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in `@endo/marshal`:
 
+# v0.8.1 (2022-12-23)
+
+- Remote objects now reflect methods present on their prototype chain.
+- Serialization errors now serialize.
+
 # v0.8.0 (2022-10-24)
 
 - Requires plain objects to inherit from Object.prototype, ensuring pass-invariance

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "marshal",
   "type": "module",
   "main": "index.js",
@@ -36,14 +36,14 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.16.8",
-    "@endo/nat": "^4.1.23",
-    "@endo/promise-kit": "^0.2.52"
+    "@endo/eventual-send": "^0.16.9",
+    "@endo/nat": "^4.1.24",
+    "@endo/promise-kit": "^0.2.53"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.52",
-    "@endo/lockdown": "^0.1.24",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/init": "^0.5.53",
+    "@endo/lockdown": "^0.1.25",
+    "@endo/ses-ava": "^0.2.37",
     "@fast-check/ava": "^1.0.1",
     "ava": "^5.1.0",
     "c8": "^7.7.3"

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,189 +3,108 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [4.1.23](https://github.com/endojs/endo/compare/@endo/nat@4.1.22...@endo/nat@4.1.23) (2022-11-14)
+### [4.1.24](https://github.com/endojs/endo/compare/@endo/nat@4.1.23...@endo/nat@4.1.24) (2022-12-23)
 
 **Note:** Version bump only for package @endo/nat
 
+### [4.1.23](https://github.com/endojs/endo/compare/@endo/nat@4.1.22...@endo/nat@4.1.23) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/nat
 
 ### [4.1.22](https://github.com/endojs/endo/compare/@endo/nat@4.1.21...@endo/nat@4.1.22) (2022-10-24)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.21](https://github.com/endojs/endo/compare/@endo/nat@4.1.20...@endo/nat@4.1.21) (2022-10-19)
 
 **Note:** Version bump only for package @endo/nat
-
-
-
-
 
 ### [4.1.20](https://github.com/endojs/endo/compare/@endo/nat@4.1.19...@endo/nat@4.1.20) (2022-09-27)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.19](https://github.com/endojs/endo/compare/@endo/nat@4.1.18...@endo/nat@4.1.19) (2022-09-14)
 
 **Note:** Version bump only for package @endo/nat
-
-
-
-
 
 ### [4.1.18](https://github.com/endojs/endo/compare/@endo/nat@4.1.17...@endo/nat@4.1.18) (2022-08-26)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.17](https://github.com/endojs/endo/compare/@endo/nat@4.1.16...@endo/nat@4.1.17) (2022-08-26)
 
 **Note:** Version bump only for package @endo/nat
-
-
-
-
 
 ### [4.1.16](https://github.com/endojs/endo/compare/@endo/nat@4.1.15...@endo/nat@4.1.16) (2022-08-25)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.15](https://github.com/endojs/endo/compare/@endo/nat@4.1.14...@endo/nat@4.1.15) (2022-08-23)
 
 **Note:** Version bump only for package @endo/nat
-
-
-
-
 
 ### [4.1.14](https://github.com/endojs/endo/compare/@endo/nat@4.1.13...@endo/nat@4.1.14) (2022-06-28)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.13](https://github.com/endojs/endo/compare/@endo/nat@4.1.12...@endo/nat@4.1.13) (2022-06-11)
 
 **Note:** Version bump only for package @endo/nat
-
-
-
-
 
 ### [4.1.12](https://github.com/endojs/endo/compare/@endo/nat@4.1.11...@endo/nat@4.1.12) (2022-04-15)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.11](https://github.com/endojs/endo/compare/@endo/nat@4.1.10...@endo/nat@4.1.11) (2022-04-14)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.10](https://github.com/endojs/endo/compare/@endo/nat@4.1.9...@endo/nat@4.1.10) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [4.1.9](https://github.com/endojs/endo/compare/@endo/nat@4.1.8...@endo/nat@4.1.9) (2022-04-12)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.8](https://github.com/endojs/endo/compare/@endo/nat@4.1.7...@endo/nat@4.1.8) (2022-03-07)
 
 **Note:** Version bump only for package @endo/nat
-
-
-
-
 
 ### [4.1.7](https://github.com/endojs/endo/compare/@endo/nat@4.1.6...@endo/nat@4.1.7) (2022-03-02)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.6](https://github.com/endojs/endo/compare/@endo/nat@4.1.5...@endo/nat@4.1.6) (2022-02-20)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.5](https://github.com/endojs/endo/compare/@endo/nat@4.1.4...@endo/nat@4.1.5) (2022-02-18)
-
 
 ### Bug Fixes
 
-* **nat:** declare `allegedNum` as `unknown`, then check type ([ba3e60c](https://github.com/endojs/endo/commit/ba3e60c1ab2aa24e5955310792a9e40b6a0bea30))
-
-
+- **nat:** declare `allegedNum` as `unknown`, then check type ([ba3e60c](https://github.com/endojs/endo/commit/ba3e60c1ab2aa24e5955310792a9e40b6a0bea30))
 
 ### [4.1.4](https://github.com/endojs/endo/compare/@endo/nat@4.1.3...@endo/nat@4.1.4) (2022-01-31)
 
 **Note:** Version bump only for package @endo/nat
 
-
-
-
-
 ### [4.1.3](https://github.com/endojs/endo/compare/@endo/nat@4.1.2...@endo/nat@4.1.3) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [4.1.2](https://github.com/endojs/endo/compare/@endo/nat@4.1.1...@endo/nat@4.1.2) (2022-01-25)
 
-
 ### Bug Fixes
 
-* **nat:** Publish access public ([b986f1b](https://github.com/endojs/endo/commit/b986f1b0afbec1261fb2c047257751b9d418df7c))
-
-
+- **nat:** Publish access public ([b986f1b](https://github.com/endojs/endo/commit/b986f1b0afbec1261fb2c047257751b9d418df7c))
 
 ### 4.1.1 (2022-01-23)
 
-
 ### Bug Fixes
 
-* **nat:** Thread Windows read powers ([920d478](https://github.com/endojs/endo/commit/920d478532b0c830962de92a19f02f9be6a8a546))
+- **nat:** Thread Windows read powers ([920d478](https://github.com/endojs/endo/commit/920d478532b0c830962de92a19f02f9be6a8a546))

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "4.1.23",
+  "version": "4.1.24",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.0",
+    "@endo/compartment-mapper": "^0.8.1",
     "ava": "^5.1.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^3.4.1",
     "prettier": "^2.8.0",
-    "ses": "^0.18.0"
+    "ses": "^0.18.1"
   },
   "directories": {
     "test": "test"

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,341 +3,207 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.3.22](https://github.com/endojs/endo/compare/@endo/netstring@0.3.21...@endo/netstring@0.3.22) (2022-11-14)
+### [0.3.23](https://github.com/endojs/endo/compare/@endo/netstring@0.3.22...@endo/netstring@0.3.23) (2022-12-23)
 
 **Note:** Version bump only for package @endo/netstring
 
+### [0.3.22](https://github.com/endojs/endo/compare/@endo/netstring@0.3.21...@endo/netstring@0.3.22) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/netstring
 
 ### [0.3.21](https://github.com/endojs/endo/compare/@endo/netstring@0.3.20...@endo/netstring@0.3.21) (2022-10-24)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.20](https://github.com/endojs/endo/compare/@endo/netstring@0.3.19...@endo/netstring@0.3.20) (2022-10-19)
 
 **Note:** Version bump only for package @endo/netstring
-
-
-
-
 
 ### [0.3.19](https://github.com/endojs/endo/compare/@endo/netstring@0.3.18...@endo/netstring@0.3.19) (2022-09-27)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.18](https://github.com/endojs/endo/compare/@endo/netstring@0.3.17...@endo/netstring@0.3.18) (2022-09-14)
-
 
 ### Features
 
-* **netstring:** add reader maxMessageLength option ([31b17cc](https://github.com/endojs/endo/commit/31b17cce6a05fa2edad488343d35617d5f3a634d))
-* **netstring:** Chunked mode for writer ([355a391](https://github.com/endojs/endo/commit/355a391eefc35a2efcc069eba459c0d8a09a61f8))
-* **netstring:** writer support array of message chunks ([f873370](https://github.com/endojs/endo/commit/f873370ffe04f430e37165a32498df54bac827c0))
-
+- **netstring:** add reader maxMessageLength option ([31b17cc](https://github.com/endojs/endo/commit/31b17cce6a05fa2edad488343d35617d5f3a634d))
+- **netstring:** Chunked mode for writer ([355a391](https://github.com/endojs/endo/commit/355a391eefc35a2efcc069eba459c0d8a09a61f8))
+- **netstring:** writer support array of message chunks ([f873370](https://github.com/endojs/endo/commit/f873370ffe04f430e37165a32498df54bac827c0))
 
 ### Bug Fixes
 
-* **netstring:** add more reader tests ([dd86254](https://github.com/endojs/endo/commit/dd8625455a3c098948d774dcd89ab6abc6d948d5))
-* **netstring:** reader avoid copy when chunked separator ([d49255b](https://github.com/endojs/endo/commit/d49255b1d5f2cfecac795833fc1c5d7fa45dc605))
-* **netstring:** Reader rewrite ([9cccf38](https://github.com/endojs/endo/commit/9cccf38aaf54f811a993baf2d8dce30b85af22e7))
-
-
+- **netstring:** add more reader tests ([dd86254](https://github.com/endojs/endo/commit/dd8625455a3c098948d774dcd89ab6abc6d948d5))
+- **netstring:** reader avoid copy when chunked separator ([d49255b](https://github.com/endojs/endo/commit/d49255b1d5f2cfecac795833fc1c5d7fa45dc605))
+- **netstring:** Reader rewrite ([9cccf38](https://github.com/endojs/endo/commit/9cccf38aaf54f811a993baf2d8dce30b85af22e7))
 
 ### [0.3.17](https://github.com/endojs/endo/compare/@endo/netstring@0.3.16...@endo/netstring@0.3.17) (2022-08-26)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.16](https://github.com/endojs/endo/compare/@endo/netstring@0.3.15...@endo/netstring@0.3.16) (2022-08-26)
 
 **Note:** Version bump only for package @endo/netstring
-
-
-
-
 
 ### [0.3.15](https://github.com/endojs/endo/compare/@endo/netstring@0.3.14...@endo/netstring@0.3.15) (2022-08-25)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.14](https://github.com/endojs/endo/compare/@endo/netstring@0.3.13...@endo/netstring@0.3.14) (2022-08-23)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.13](https://github.com/endojs/endo/compare/@endo/netstring@0.3.12...@endo/netstring@0.3.13) (2022-06-28)
-
 
 ### Bug Fixes
 
-* tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
-
-
+- tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
 
 ### [0.3.12](https://github.com/endojs/endo/compare/@endo/netstring@0.3.11...@endo/netstring@0.3.12) (2022-06-11)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.11](https://github.com/endojs/endo/compare/@endo/netstring@0.3.10...@endo/netstring@0.3.11) (2022-04-15)
 
 **Note:** Version bump only for package @endo/netstring
-
-
-
-
 
 ### [0.3.10](https://github.com/endojs/endo/compare/@endo/netstring@0.3.9...@endo/netstring@0.3.10) (2022-04-14)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.9](https://github.com/endojs/endo/compare/@endo/netstring@0.3.8...@endo/netstring@0.3.9) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.3.8](https://github.com/endojs/endo/compare/@endo/netstring@0.3.7...@endo/netstring@0.3.8) (2022-04-12)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.7](https://github.com/endojs/endo/compare/@endo/netstring@0.3.6...@endo/netstring@0.3.7) (2022-03-07)
 
 **Note:** Version bump only for package @endo/netstring
-
-
-
-
 
 ### [0.3.6](https://github.com/endojs/endo/compare/@endo/netstring@0.3.5...@endo/netstring@0.3.6) (2022-03-02)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.5](https://github.com/endojs/endo/compare/@endo/netstring@0.3.4...@endo/netstring@0.3.5) (2022-02-20)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.4](https://github.com/endojs/endo/compare/@endo/netstring@0.3.3...@endo/netstring@0.3.4) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.3.3](https://github.com/endojs/endo/compare/@endo/netstring@0.3.2...@endo/netstring@0.3.3) (2022-01-31)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.3.2](https://github.com/endojs/endo/compare/@endo/netstring@0.3.1...@endo/netstring@0.3.2) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.3.1](https://github.com/endojs/endo/compare/@endo/netstring@0.3.0...@endo/netstring@0.3.1) (2022-01-25)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ## [0.3.0](https://github.com/endojs/endo/compare/@endo/netstring@0.2.13...@endo/netstring@0.3.0) (2022-01-23)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **stream:** Use eventual send
-* **netstring:** Eject stream library
+- **stream:** Use eventual send
+- **netstring:** Eject stream library
 
 ### Features
 
-* **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
-
+- **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
 
 ### Code Refactoring
 
-* **netstring:** Eject stream library ([31b00c3](https://github.com/endojs/endo/commit/31b00c391fe28c7997c2dfa58dc7d297099edc8a))
-
-
+- **netstring:** Eject stream library ([31b00c3](https://github.com/endojs/endo/commit/31b00c391fe28c7997c2dfa58dc7d297099edc8a))
 
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/netstring@0.2.12...@endo/netstring@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.2.12](https://github.com/endojs/endo/compare/@endo/netstring@0.2.11...@endo/netstring@0.2.12) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
 
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/netstring@0.2.10...@endo/netstring@0.2.11) (2021-11-16)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.2.10](https://github.com/endojs/endo/compare/@endo/netstring@0.2.9...@endo/netstring@0.2.10) (2021-11-02)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/netstring@0.2.8...@endo/netstring@0.2.9) (2021-10-15)
-
 
 ### Bug Fixes
 
-* **netstring:** Support concurrent writes ([20d22df](https://github.com/endojs/endo/commit/20d22df7e62ce130cdf989b977ce2682ce862e2c))
-
-
+- **netstring:** Support concurrent writes ([20d22df](https://github.com/endojs/endo/commit/20d22df7e62ce130cdf989b977ce2682ce862e2c))
 
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/netstring@0.2.7...@endo/netstring@0.2.8) (2021-09-18)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/netstring@0.2.6...@endo/netstring@0.2.7) (2021-08-14)
-
 
 ### Bug Fixes
 
-* **netstring:** Fix TypeScript definition typo ([#865](https://github.com/endojs/endo/issues/865)) ([cf0cb44](https://github.com/endojs/endo/commit/cf0cb44225f83635bade21b916f3914b222b1710))
-
-
+- **netstring:** Fix TypeScript definition typo ([#865](https://github.com/endojs/endo/issues/865)) ([cf0cb44](https://github.com/endojs/endo/commit/cf0cb44225f83635bade21b916f3914b222b1710))
 
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/netstring@0.2.5...@endo/netstring@0.2.6) (2021-08-13)
 
-
 ### Bug Fixes
 
-* **netstring:** Explicitly export types ([#856](https://github.com/endojs/endo/issues/856)) ([cd87163](https://github.com/endojs/endo/commit/cd87163fdbc7014d8b0d07d372cabfec36227a81))
-
-
+- **netstring:** Explicitly export types ([#856](https://github.com/endojs/endo/issues/856)) ([cd87163](https://github.com/endojs/endo/commit/cd87163fdbc7014d8b0d07d372cabfec36227a81))
 
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/netstring@0.2.4...@endo/netstring@0.2.5) (2021-07-22)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/netstring@0.2.3...@endo/netstring@0.2.4) (2021-06-20)
 
 **Note:** Version bump only for package @endo/netstring
-
-
-
-
 
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/netstring@0.2.2...@endo/netstring@0.2.3) (2021-06-16)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/netstring@0.2.1...@endo/netstring@0.2.2) (2021-06-14)
 
 **Note:** Version bump only for package @endo/netstring
-
-
-
-
 
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/netstring@0.2.0...@endo/netstring@0.2.1) (2021-06-06)
 
 **Note:** Version bump only for package @endo/netstring
 
-
-
-
-
 ## 0.2.0 (2021-06-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **netstring:** No longer supports direct use from CommonJS
+- **netstring:** No longer supports direct use from CommonJS
 
 ### Features
 
-* **netstring:** Add minimum viable netstring IO ([08cca1f](https://github.com/endojs/endo/commit/08cca1f078b0035b860546d452dfd2eefe9387de))
-* **netstring:** Update packaging for NESM/RESM bridge ([badc2d5](https://github.com/endojs/endo/commit/badc2d5769f99db6358e44d4f06ca4075e5ae223))
-
+- **netstring:** Add minimum viable netstring IO ([08cca1f](https://github.com/endojs/endo/commit/08cca1f078b0035b860546d452dfd2eefe9387de))
+- **netstring:** Update packaging for NESM/RESM bridge ([badc2d5](https://github.com/endojs/endo/commit/badc2d5769f99db6358e44d4f06ca4075e5ae223))
 
 ### Bug Fixes
 
-* Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
-* **netstring:** Visibility of Stream type ([2375620](https://github.com/endojs/endo/commit/237562008ea25127290a1b86bba2382ed153e663))
+- Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
+- **netstring:** Visibility of Stream type ([2375620](https://github.com/endojs/endo/commit/237562008ea25127290a1b86bba2382ed153e663))

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,12 +32,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.52",
-    "@endo/stream": "^0.3.21",
-    "ses": "^0.18.0"
+    "@endo/init": "^0.5.53",
+    "@endo/stream": "^0.3.22",
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,587 +3,328 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.52](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.51...@endo/promise-kit@0.2.52) (2022-11-14)
+### [0.2.53](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.52...@endo/promise-kit@0.2.53) (2022-12-23)
 
 **Note:** Version bump only for package @endo/promise-kit
 
+### [0.2.52](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.51...@endo/promise-kit@0.2.52) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/promise-kit
 
 ### [0.2.51](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.50...@endo/promise-kit@0.2.51) (2022-10-24)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.50](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.49...@endo/promise-kit@0.2.50) (2022-10-19)
 
 **Note:** Version bump only for package @endo/promise-kit
-
-
-
-
 
 ### [0.2.49](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.48...@endo/promise-kit@0.2.49) (2022-09-27)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.48](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.47...@endo/promise-kit@0.2.48) (2022-09-14)
 
 **Note:** Version bump only for package @endo/promise-kit
-
-
-
-
 
 ### [0.2.47](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.46...@endo/promise-kit@0.2.47) (2022-08-26)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.46](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.45...@endo/promise-kit@0.2.46) (2022-08-26)
 
 **Note:** Version bump only for package @endo/promise-kit
-
-
-
-
 
 ### [0.2.45](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.44...@endo/promise-kit@0.2.45) (2022-08-25)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.44](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.43...@endo/promise-kit@0.2.44) (2022-08-23)
-
 
 ### Bug Fixes
 
-* more hardens ([#1241](https://github.com/endojs/endo/issues/1241)) ([b6ff811](https://github.com/endojs/endo/commit/b6ff8118a92fd72c5309b2bb285fac08d0531d92))
-
-
+- more hardens ([#1241](https://github.com/endojs/endo/issues/1241)) ([b6ff811](https://github.com/endojs/endo/commit/b6ff8118a92fd72c5309b2bb285fac08d0531d92))
 
 ### [0.2.43](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.42...@endo/promise-kit@0.2.43) (2022-06-28)
 
-
 ### Features
 
-* **promise-kit:** Add non-leaky promise race helper ([505815c](https://github.com/endojs/endo/commit/505815cdb02512d2de6ba0ac73c1130626eebf77))
-* **promise-kit:** detach promise from resolvers after use ([d6e9fba](https://github.com/endojs/endo/commit/d6e9fbae05d9d42bdf7fb79c83893141b0348010))
-* **promise-kit:** Make leak-free race a fully compliant drop-in replacement ([14fbba4](https://github.com/endojs/endo/commit/14fbba496a564add617d4c151726fbfc271e1f4c))
-
-
+- **promise-kit:** Add non-leaky promise race helper ([505815c](https://github.com/endojs/endo/commit/505815cdb02512d2de6ba0ac73c1130626eebf77))
+- **promise-kit:** detach promise from resolvers after use ([d6e9fba](https://github.com/endojs/endo/commit/d6e9fbae05d9d42bdf7fb79c83893141b0348010))
+- **promise-kit:** Make leak-free race a fully compliant drop-in replacement ([14fbba4](https://github.com/endojs/endo/commit/14fbba496a564add617d4c151726fbfc271e1f4c))
 
 ### [0.2.42](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.41...@endo/promise-kit@0.2.42) (2022-06-11)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.41](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.40...@endo/promise-kit@0.2.41) (2022-04-15)
 
 **Note:** Version bump only for package @endo/promise-kit
-
-
-
-
 
 ### [0.2.40](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.39...@endo/promise-kit@0.2.40) (2022-04-14)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.39](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.38...@endo/promise-kit@0.2.39) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.2.38](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.37...@endo/promise-kit@0.2.38) (2022-04-12)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.37](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.36...@endo/promise-kit@0.2.37) (2022-03-07)
 
 **Note:** Version bump only for package @endo/promise-kit
-
-
-
-
 
 ### [0.2.36](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.35...@endo/promise-kit@0.2.36) (2022-03-02)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.35](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.34...@endo/promise-kit@0.2.35) (2022-02-20)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.34](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.33...@endo/promise-kit@0.2.34) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
-* Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
+- Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.2.33](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.32...@endo/promise-kit@0.2.33) (2022-01-31)
 
 **Note:** Version bump only for package @endo/promise-kit
 
-
-
-
-
 ### [0.2.32](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.31...@endo/promise-kit@0.2.32) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.2.31](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.30...@endo/promise-kit@0.2.31) (2022-01-25)
 
-
 ### Bug Fixes
 
-* **promise-kit:** Publish code ([9cd3655](https://github.com/endojs/endo/commit/9cd365532be42059f03b91ccdb03e34149ffd334))
-* remove more extraneous spaced-comment comments ([#1009](https://github.com/endojs/endo/issues/1009)) ([980a798](https://github.com/endojs/endo/commit/980a79898a4643a359d905c308eecf70d8ab2758))
-
-
+- **promise-kit:** Publish code ([9cd3655](https://github.com/endojs/endo/commit/9cd365532be42059f03b91ccdb03e34149ffd334))
+- remove more extraneous spaced-comment comments ([#1009](https://github.com/endojs/endo/issues/1009)) ([980a798](https://github.com/endojs/endo/commit/980a79898a4643a359d905c308eecf70d8ab2758))
 
 ### 0.2.30 (2022-01-23)
 
-
 ### Bug Fixes
 
-* **promise-kit:** SES AVA is a dev dependency ([1579160](https://github.com/endojs/endo/commit/1579160b222cd48308780d008743296ef764f163))
-
-
+- **promise-kit:** SES AVA is a dev dependency ([1579160](https://github.com/endojs/endo/commit/1579160b222cd48308780d008743296ef764f163))
 
 ### [0.2.29](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.28...@agoric/promise-kit@0.2.29) (2021-12-02)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ### [0.2.28](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.27...@agoric/promise-kit@0.2.28) (2021-10-13)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ### [0.2.27](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.26...@agoric/promise-kit@0.2.27) (2021-09-23)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ### [0.2.26](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.25...@agoric/promise-kit@0.2.26) (2021-09-15)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ### [0.2.25](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.24...@agoric/promise-kit@0.2.25) (2021-08-18)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ### [0.2.24](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.23...@agoric/promise-kit@0.2.24) (2021-08-17)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ### [0.2.23](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.20...@agoric/promise-kit@0.2.23) (2021-08-15)
 
 ### 0.26.10 (2021-07-28)
 
-
 ### Bug Fixes
 
-* **promise-kit:** make strict typing compliant ([#3397](https://github.com/Agoric/agoric-sdk/issues/3397)) ([69e2692](https://github.com/Agoric/agoric-sdk/commit/69e2692188a386b49dbe1a662ac8cde286e7fe7e))
-
-
+- **promise-kit:** make strict typing compliant ([#3397](https://github.com/Agoric/agoric-sdk/issues/3397)) ([69e2692](https://github.com/Agoric/agoric-sdk/commit/69e2692188a386b49dbe1a662ac8cde286e7fe7e))
 
 ### [0.2.22](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.20...@agoric/promise-kit@0.2.22) (2021-08-14)
 
 ### 0.26.10 (2021-07-28)
 
-
 ### Bug Fixes
 
-* **promise-kit:** make strict typing compliant ([#3397](https://github.com/Agoric/agoric-sdk/issues/3397)) ([69e2692](https://github.com/Agoric/agoric-sdk/commit/69e2692188a386b49dbe1a662ac8cde286e7fe7e))
-
-
+- **promise-kit:** make strict typing compliant ([#3397](https://github.com/Agoric/agoric-sdk/issues/3397)) ([69e2692](https://github.com/Agoric/agoric-sdk/commit/69e2692188a386b49dbe1a662ac8cde286e7fe7e))
 
 ### [0.2.21](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.20...@agoric/promise-kit@0.2.21) (2021-07-28)
 
-
 ### Bug Fixes
 
-* **promise-kit:** make strict typing compliant ([#3397](https://github.com/Agoric/agoric-sdk/issues/3397)) ([69e2692](https://github.com/Agoric/agoric-sdk/commit/69e2692188a386b49dbe1a662ac8cde286e7fe7e))
-
-
+- **promise-kit:** make strict typing compliant ([#3397](https://github.com/Agoric/agoric-sdk/issues/3397)) ([69e2692](https://github.com/Agoric/agoric-sdk/commit/69e2692188a386b49dbe1a662ac8cde286e7fe7e))
 
 ### [0.2.20](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.19...@agoric/promise-kit@0.2.20) (2021-07-01)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ### [0.2.19](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.18...@agoric/promise-kit@0.2.19) (2021-06-28)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ### [0.2.18](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.17...@agoric/promise-kit@0.2.18) (2021-06-25)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ### [0.2.17](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.16...@agoric/promise-kit@0.2.17) (2021-06-24)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ### [0.2.16](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.15...@agoric/promise-kit@0.2.16) (2021-06-23)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ### [0.2.15](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.14...@agoric/promise-kit@0.2.15) (2021-06-16)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ### [0.2.14](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.13...@agoric/promise-kit@0.2.14) (2021-06-15)
-
 
 ### Bug Fixes
 
-* Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
-
-
+- Pin ESM to forked version ([54dbb55](https://github.com/Agoric/agoric-sdk/commit/54dbb55d64d7ff7adb395bc4bd9d1461dd2d3c17))
 
 ## [0.2.13](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.12...@agoric/promise-kit@0.2.13) (2021-05-10)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.2.12](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.11...@agoric/promise-kit@0.2.12) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ## [0.2.11](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.10...@agoric/promise-kit@0.2.11) (2021-05-05)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.2.10](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.9...@agoric/promise-kit@0.2.10) (2021-04-22)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ## [0.2.9](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.8...@agoric/promise-kit@0.2.9) (2021-04-18)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.2.8](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.7...@agoric/promise-kit@0.2.8) (2021-04-16)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ## [0.2.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.6...@agoric/promise-kit@0.2.7) (2021-04-14)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.2.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.5...@agoric/promise-kit@0.2.6) (2021-04-07)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ## [0.2.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.4...@agoric/promise-kit@0.2.5) (2021-04-06)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.2.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.3...@agoric/promise-kit@0.2.4) (2021-03-24)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.2.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.2...@agoric/promise-kit@0.2.3) (2021-03-16)
-
 
 ### Bug Fixes
 
-* make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
-
-
-
-
+- make separate 'test:xs' target, remove XS from 'test' target ([b9c1a69](https://github.com/Agoric/agoric-sdk/commit/b9c1a6987093fc8e09e8aba7acd2a1618413bac8)), closes [#2647](https://github.com/Agoric/agoric-sdk/issues/2647)
 
 ## [0.2.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.1...@agoric/promise-kit@0.2.2) (2021-02-22)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.2.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.2.0...@agoric/promise-kit@0.2.1) (2021-02-16)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 # [0.2.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.1.7...@agoric/promise-kit@0.2.0) (2020-12-10)
-
 
 ### Features
 
-* **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
-
-
-
-
+- **import-bundle:** Preliminary support Endo zip hex bundle format ([#1983](https://github.com/Agoric/agoric-sdk/issues/1983)) ([983681b](https://github.com/Agoric/agoric-sdk/commit/983681bfc4bf512b6bd90806ed9220cd4fefc13c))
 
 ## [0.1.7](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.1.7-dev.0...@agoric/promise-kit@0.1.7) (2020-11-07)
 
-
 ### Bug Fixes
 
-* correct types for PromiseRecord.resolve ([84270a4](https://github.com/Agoric/agoric-sdk/commit/84270a4a10b17e285299126f9c7e7d2fb4a05aa1))
-
-
-
-
+- correct types for PromiseRecord.resolve ([84270a4](https://github.com/Agoric/agoric-sdk/commit/84270a4a10b17e285299126f9c7e7d2fb4a05aa1))
 
 ## [0.1.7-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.1.6...@agoric/promise-kit@0.1.7-dev.0) (2020-10-19)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.1.6](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.1.6-dev.2...@agoric/promise-kit@0.1.6) (2020-10-11)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ## [0.1.6-dev.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.1.6-dev.1...@agoric/promise-kit@0.1.6-dev.2) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.1.6-dev.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.1.6-dev.0...@agoric/promise-kit@0.1.6-dev.1) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/promise-kit
-
-
-
-
 
 ## [0.1.6-dev.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.1.5...@agoric/promise-kit@0.1.6-dev.0) (2020-09-18)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## [0.1.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/promise-kit@0.1.4...@agoric/promise-kit@0.1.5) (2020-09-16)
 
 **Note:** Version bump only for package @agoric/promise-kit
 
-
-
-
-
 ## 0.1.4 (2020-08-31)
-
 
 ### Bug Fixes
 
-* `ERef<T>` is `T | PromiseLike<T>` ([#1383](https://github.com/Agoric/agoric-sdk/issues/1383)) ([8ef4d66](https://github.com/Agoric/agoric-sdk/commit/8ef4d662dc80daf80420c0c531c2abe41517b6cd))
-* don't treat HandledPromises specially ([9015744](https://github.com/Agoric/agoric-sdk/commit/9015744f9eb57467feed5619c135f99455d19f80))
-* reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
-* remove obsolete "unwrap" ([#1360](https://github.com/Agoric/agoric-sdk/issues/1360)) ([5796e0e](https://github.com/Agoric/agoric-sdk/commit/5796e0e6f8bfd00619f725bdac4ff5743610a52f))
-* rename producePromise to makePromiseKit ([#1329](https://github.com/Agoric/agoric-sdk/issues/1329)) ([1d2925a](https://github.com/Agoric/agoric-sdk/commit/1d2925ad640cce7b419751027b44737bd46a6d59))
-* try to use HandledPromise for pipelineability ([848a90f](https://github.com/Agoric/agoric-sdk/commit/848a90f8d7427e2c31dc5764555da2fde42eac8d))
-
-
-
-
+- `ERef<T>` is `T | PromiseLike<T>` ([#1383](https://github.com/Agoric/agoric-sdk/issues/1383)) ([8ef4d66](https://github.com/Agoric/agoric-sdk/commit/8ef4d662dc80daf80420c0c531c2abe41517b6cd))
+- don't treat HandledPromises specially ([9015744](https://github.com/Agoric/agoric-sdk/commit/9015744f9eb57467feed5619c135f99455d19f80))
+- reduce inconsistency among our linting rules ([#1492](https://github.com/Agoric/agoric-sdk/issues/1492)) ([b6b675e](https://github.com/Agoric/agoric-sdk/commit/b6b675e2de110e2af19cad784a66220cab21dacf))
+- remove obsolete "unwrap" ([#1360](https://github.com/Agoric/agoric-sdk/issues/1360)) ([5796e0e](https://github.com/Agoric/agoric-sdk/commit/5796e0e6f8bfd00619f725bdac4ff5743610a52f))
+- rename producePromise to makePromiseKit ([#1329](https://github.com/Agoric/agoric-sdk/issues/1329)) ([1d2925a](https://github.com/Agoric/agoric-sdk/commit/1d2925ad640cce7b419751027b44737bd46a6d59))
+- try to use HandledPromise for pipelineability ([848a90f](https://github.com/Agoric/agoric-sdk/commit/848a90f8d7427e2c31dc5764555da2fde42eac8d))
 
 ## [0.1.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/produce-promise@0.1.2...@agoric/produce-promise@0.1.3) (2020-06-30)
 
 **Note:** Version bump only for package @agoric/produce-promise
 
-
-
-
-
 ## [0.1.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/produce-promise@0.1.1...@agoric/produce-promise@0.1.2) (2020-05-17)
 
 **Note:** Version bump only for package @agoric/produce-promise
-
-
-
-
 
 ## [0.1.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/produce-promise@0.1.0...@agoric/produce-promise@0.1.1) (2020-05-10)
 
 **Note:** Version bump only for package @agoric/produce-promise
 
-
-
-
-
 # [0.1.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/produce-promise@0.0.5...@agoric/produce-promise@0.1.0) (2020-05-04)
-
 
 ### Bug Fixes
 
-* use the new (typed) harden package ([2eb1af0](https://github.com/Agoric/agoric-sdk/commit/2eb1af08fe3967629a3ce165752fd501a5c85a96))
-
+- use the new (typed) harden package ([2eb1af0](https://github.com/Agoric/agoric-sdk/commit/2eb1af08fe3967629a3ce165752fd501a5c85a96))
 
 ### Features
 
-* implement channel host handler ([4e68f44](https://github.com/Agoric/agoric-sdk/commit/4e68f441b46d70dee481387ab96e88f1e0b69bfa))
-
-
-
-
+- implement channel host handler ([4e68f44](https://github.com/Agoric/agoric-sdk/commit/4e68f441b46d70dee481387ab96e88f1e0b69bfa))
 
 ## [0.0.5](https://github.com/Agoric/agoric-sdk/compare/@agoric/produce-promise@0.0.5-alpha.0...@agoric/produce-promise@0.0.5) (2020-04-13)
 
 **Note:** Version bump only for package @agoric/produce-promise
 
-
-
-
-
 ## 0.0.5-alpha.0 (2020-04-12)
 
 **Note:** Version bump only for package @agoric/produce-promise
-
-
-
-
 
 ## [0.0.4](https://github.com/Agoric/agoric-sdk/compare/@agoric/make-promise@0.0.3-alpha.0...@agoric/produce-promise@0.0.3) (2020-04-06)
 
@@ -595,21 +336,12 @@ Renamed from { p, res, reject } to { promise, resolve, reject }
 
 **Note:** Version bump only for package @agoric/make-promise
 
-
-
-
-
 ## [0.0.3-alpha.0](https://github.com/Agoric/agoric-sdk/compare/@agoric/make-promise@0.0.2...@agoric/make-promise@0.0.3-alpha.0) (2020-04-02)
 
 **Note:** Version bump only for package @agoric/make-promise
 
-
-
-
-
 ## 0.0.2 (2020-03-26)
-
 
 ### Bug Fixes
 
-* **makePromise:** support HandledPromise.unwrap(p) ([fb98636](https://github.com/Agoric/agoric-sdk/commit/fb98636864583e222f67087cbbe487bcfd74a772))
+- **makePromise:** support HandledPromise.unwrap(p) ([fb98636](https://github.com/Agoric/agoric-sdk/commit/fb98636864583e222f67087cbbe487bcfd74a772))

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "description": "Helper for making promises",
   "keywords": [
     "promise"
@@ -37,11 +37,11 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "ses": "^0.18.0"
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/eslint-config": "^0.5.2",
+    "@endo/ses-ava": "^0.2.37",
     "@types/node": ">=14.0",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,324 +3,189 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.36](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.35...@endo/ses-ava@0.2.36) (2022-11-14)
+### [0.2.37](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.36...@endo/ses-ava@0.2.37) (2022-12-23)
 
 **Note:** Version bump only for package @endo/ses-ava
 
+### [0.2.36](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.35...@endo/ses-ava@0.2.36) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/ses-ava
 
 ### [0.2.35](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.34...@endo/ses-ava@0.2.35) (2022-10-24)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.34](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.33...@endo/ses-ava@0.2.34) (2022-10-19)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.33](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.32...@endo/ses-ava@0.2.33) (2022-09-27)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.32](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.31...@endo/ses-ava@0.2.32) (2022-09-14)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.31](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.30...@endo/ses-ava@0.2.31) (2022-08-26)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.30](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.29...@endo/ses-ava@0.2.30) (2022-08-26)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.29](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.28...@endo/ses-ava@0.2.29) (2022-08-25)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.28](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.27...@endo/ses-ava@0.2.28) (2022-08-23)
-
 
 ### Bug Fixes
 
-* correct mistaken "thunk" comment ([#1234](https://github.com/endojs/endo/issues/1234)) ([f8b49d4](https://github.com/endojs/endo/commit/f8b49d4f4330200aa1619d865b8501f2df4f38d2))
-
-
+- correct mistaken "thunk" comment ([#1234](https://github.com/endojs/endo/issues/1234)) ([f8b49d4](https://github.com/endojs/endo/commit/f8b49d4f4330200aa1619d865b8501f2df4f38d2))
 
 ### [0.2.27](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.26...@endo/ses-ava@0.2.27) (2022-06-28)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.26](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.25...@endo/ses-ava@0.2.26) (2022-06-11)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.25](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.24...@endo/ses-ava@0.2.25) (2022-04-15)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.24](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.23...@endo/ses-ava@0.2.24) (2022-04-14)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.22...@endo/ses-ava@0.2.23) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.2.22](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.21...@endo/ses-ava@0.2.22) (2022-04-12)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.21](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.20...@endo/ses-ava@0.2.21) (2022-03-07)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.19...@endo/ses-ava@0.2.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.19](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.18...@endo/ses-ava@0.2.19) (2022-02-20)
-
 
 ### Bug Fixes
 
-* **ses-ava:** Export exported types ([#1088](https://github.com/endojs/endo/issues/1088)) ([14d28e0](https://github.com/endojs/endo/commit/14d28e0bacb81b57913d1bd5022d4e7210af2d05))
-
-
+- **ses-ava:** Export exported types ([#1088](https://github.com/endojs/endo/issues/1088)) ([14d28e0](https://github.com/endojs/endo/commit/14d28e0bacb81b57913d1bd5022d4e7210af2d05))
 
 ### [0.2.18](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.17...@endo/ses-ava@0.2.18) (2022-02-18)
 
-
 ### Bug Fixes
 
-* Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.2.17](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.16...@endo/ses-ava@0.2.17) (2022-01-31)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.16](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.15...@endo/ses-ava@0.2.16) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.2.15](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.14...@endo/ses-ava@0.2.15) (2022-01-25)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.14](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.13...@endo/ses-ava@0.2.14) (2022-01-23)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.12...@endo/ses-ava@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.12](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.11...@endo/ses-ava@0.2.12) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
 
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.10...@endo/ses-ava@0.2.11) (2021-11-16)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.10](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.9...@endo/ses-ava@0.2.10) (2021-11-02)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.8...@endo/ses-ava@0.2.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.7...@endo/ses-ava@0.2.8) (2021-09-18)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.6...@endo/ses-ava@0.2.7) (2021-08-14)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.5...@endo/ses-ava@0.2.6) (2021-08-13)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.4...@endo/ses-ava@0.2.5) (2021-07-22)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.3...@endo/ses-ava@0.2.4) (2021-06-20)
 
 **Note:** Version bump only for package @endo/ses-ava
-
-
-
-
 
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.2...@endo/ses-ava@0.2.3) (2021-06-16)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.1...@endo/ses-ava@0.2.2) (2021-06-14)
-
 
 ### Bug Fixes
 
-* **ses-ava:** Doc nit ([2cf239a](https://github.com/endojs/endo/commit/2cf239af199bc532acd4996bdecf4ef23382fc41))
-
-
+- **ses-ava:** Doc nit ([2cf239a](https://github.com/endojs/endo/commit/2cf239af199bc532acd4996bdecf4ef23382fc41))
 
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.0...@endo/ses-ava@0.2.1) (2021-06-06)
 
 **Note:** Version bump only for package @endo/ses-ava
 
-
-
-
-
 ## 0.2.0 (2021-06-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **ses-ava:** No longer supports direct use from CommonJS
-* **ses-ava:** Favor NESM and RESM compatibility over CJS and UMD
+- **ses-ava:** No longer supports direct use from CommonJS
+- **ses-ava:** Favor NESM and RESM compatibility over CJS and UMD
 
 ### Features
 
-* **ses-ava:** Export package.json ([a4fd0be](https://github.com/endojs/endo/commit/a4fd0bedf357d42e866794393a90fff22b23b2a4))
-* **ses-ava:** Update packaging for RESM/NESM bridge ([886d128](https://github.com/endojs/endo/commit/886d128e90600b24291c8c9b9d9c7dd6c584efa3))
-* **ses-ava:** Wrap ava test function to log failures to actual console ([#555](https://github.com/endojs/endo/issues/555)) ([576fa9b](https://github.com/endojs/endo/commit/576fa9b15ddd9ef36282e5e20daac2acc4f4a114))
-
+- **ses-ava:** Export package.json ([a4fd0be](https://github.com/endojs/endo/commit/a4fd0bedf357d42e866794393a90fff22b23b2a4))
+- **ses-ava:** Update packaging for RESM/NESM bridge ([886d128](https://github.com/endojs/endo/commit/886d128e90600b24291c8c9b9d9c7dd6c584efa3))
+- **ses-ava:** Wrap ava test function to log failures to actual console ([#555](https://github.com/endojs/endo/issues/555)) ([576fa9b](https://github.com/endojs/endo/commit/576fa9b15ddd9ef36282e5e20daac2acc4f4a114))
 
 ### Bug Fixes
 
-* Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
-* **ses-ava:** Favor NESM and RESM compatibility over CJS and UMD ([ea34d4f](https://github.com/endojs/endo/commit/ea34d4f4763c88ceda6958c6d47c8dc21f04bf32))
-* **ses-ava:** Fix usage docs ([07d35b2](https://github.com/endojs/endo/commit/07d35b20751a884a2a41e4da010d1edee7688af9))
-* support Ava "macros" in ses-ava ([#641](https://github.com/endojs/endo/issues/641)) ([01fabaf](https://github.com/endojs/endo/commit/01fabafee359205b92276db87453d45575f6c7db))
-* Unsafe errorTaming and consoleTaming needs other adjustments ([#637](https://github.com/endojs/endo/issues/637)) ([70cc86e](https://github.com/endojs/endo/commit/70cc86eb400655e922413b99c38818d7b2e79da0))
+- Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
+- **ses-ava:** Favor NESM and RESM compatibility over CJS and UMD ([ea34d4f](https://github.com/endojs/endo/commit/ea34d4f4763c88ceda6958c6d47c8dc21f04bf32))
+- **ses-ava:** Fix usage docs ([07d35b2](https://github.com/endojs/endo/commit/07d35b20751a884a2a41e4da010d1edee7688af9))
+- support Ava "macros" in ses-ava ([#641](https://github.com/endojs/endo/issues/641)) ([01fabaf](https://github.com/endojs/endo/commit/01fabafee359205b92276db87453d45575f6c7db))
+- Unsafe errorTaming and consoleTaming needs other adjustments ([#637](https://github.com/endojs/endo/issues/637)) ([70cc86e](https://github.com/endojs/endo/commit/70cc86eb400655e922413b99c38818d7b2e79da0))

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -33,10 +33,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.18.0"
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,331 +3,194 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.27](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.26...ses-integration-test@3.0.27) (2022-12-23)
+
+### Bug Fixes
+
+- **ses-integration-test:** Temporarily disable flaky unpkg integration ([6c652eb](https://github.com/Agoric/SES-shim/commit/6c652eb69fba5428315977735e99d2ff9bec9fed))
+
 ### [3.0.26](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.25...ses-integration-test@3.0.26) (2022-11-14)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.25](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.24...ses-integration-test@3.0.25) (2022-10-24)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.24](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.23...ses-integration-test@3.0.24) (2022-10-19)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.23](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.22...ses-integration-test@3.0.23) (2022-09-27)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.22](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.21...ses-integration-test@3.0.22) (2022-09-14)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.21](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.20...ses-integration-test@3.0.21) (2022-08-26)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.20](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.19...ses-integration-test@3.0.20) (2022-08-26)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.19](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.18...ses-integration-test@3.0.19) (2022-08-25)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.18](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.17...ses-integration-test@3.0.18) (2022-08-23)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.17](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.16...ses-integration-test@3.0.17) (2022-06-28)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.16](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.15...ses-integration-test@3.0.16) (2022-06-11)
-
 
 ### Bug Fixes
 
-* **integration-test:** report an unhandled rejection (not file://) ([03a6e76](https://github.com/Agoric/SES-shim/commit/03a6e76b22651d341f0acf18b4f3c8ed39d58923))
-
-
+- **integration-test:** report an unhandled rejection (not file://) ([03a6e76](https://github.com/Agoric/SES-shim/commit/03a6e76b22651d341f0acf18b4f3c8ed39d58923))
 
 ### [3.0.15](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.14...ses-integration-test@3.0.15) (2022-04-15)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.14](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.13...ses-integration-test@3.0.14) (2022-04-14)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.13](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.12...ses-integration-test@3.0.13) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/Agoric/SES-shim/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/Agoric/SES-shim/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [3.0.12](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.11...ses-integration-test@3.0.12) (2022-04-12)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.11](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.10...ses-integration-test@3.0.11) (2022-03-07)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.10](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.9...ses-integration-test@3.0.10) (2022-03-02)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.9](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.8...ses-integration-test@3.0.9) (2022-02-20)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.8](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.7...ses-integration-test@3.0.8) (2022-02-18)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.7](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.6...ses-integration-test@3.0.7) (2022-01-31)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.6](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.5...ses-integration-test@3.0.6) (2022-01-27)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.5](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.4...ses-integration-test@3.0.5) (2022-01-25)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [3.0.4](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.3...ses-integration-test@3.0.4) (2022-01-23)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.3](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.2...ses-integration-test@3.0.3) (2021-12-14)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [3.0.2](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.1...ses-integration-test@3.0.2) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/Agoric/SES-shim/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/Agoric/SES-shim/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
 
 ### [3.0.1](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.0...ses-integration-test@3.0.1) (2021-11-16)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ## [3.0.0](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.9...ses-integration-test@3.0.0) (2021-11-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **ses:** Withdraw support for muli-lockdown (#921)
+- **ses:** Withdraw support for muli-lockdown (#921)
 
 ### Features
 
-* **ses:** Read lockdown options from environment ([#871](https://github.com/Agoric/SES-shim/issues/871)) ([789d639](https://github.com/Agoric/SES-shim/commit/789d639c25c6882153a8090f4bd74d350bb29721))
-
+- **ses:** Read lockdown options from environment ([#871](https://github.com/Agoric/SES-shim/issues/871)) ([789d639](https://github.com/Agoric/SES-shim/commit/789d639c25c6882153a8090f4bd74d350bb29721))
 
 ### Bug Fixes
 
-* **ses:** Withdraw support for muli-lockdown ([#921](https://github.com/Agoric/SES-shim/issues/921)) ([99752b0](https://github.com/Agoric/SES-shim/commit/99752b046c2a3e2d866559bb9d58f625eb94b1a8)), closes [#814](https://github.com/Agoric/SES-shim/issues/814)
-
-
+- **ses:** Withdraw support for muli-lockdown ([#921](https://github.com/Agoric/SES-shim/issues/921)) ([99752b0](https://github.com/Agoric/SES-shim/commit/99752b046c2a3e2d866559bb9d58f625eb94b1a8)), closes [#814](https://github.com/Agoric/SES-shim/issues/814)
 
 ### [2.0.9](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.8...ses-integration-test@2.0.9) (2021-10-15)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [2.0.8](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.7...ses-integration-test@2.0.8) (2021-09-18)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [2.0.7](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.6...ses-integration-test@2.0.7) (2021-08-14)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [2.0.6](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.5...ses-integration-test@2.0.6) (2021-08-13)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [2.0.5](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.4...ses-integration-test@2.0.5) (2021-07-22)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [2.0.4](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.3...ses-integration-test@2.0.4) (2021-06-20)
 
 **Note:** Version bump only for package ses-integration-test
-
-
-
-
 
 ### [2.0.3](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.2...ses-integration-test@2.0.3) (2021-06-16)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [2.0.2](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.1...ses-integration-test@2.0.2) (2021-06-14)
 
 **Note:** Version bump only for package ses-integration-test
 
-
-
-
-
 ### [2.0.1](https://github.com/Agoric/SES-shim/compare/ses-integration-test@2.0.0...ses-integration-test@2.0.1) (2021-06-06)
-
 
 ### Bug Fixes
 
-* Fix some stray packaging mistakes ([0eb9297](https://github.com/Agoric/SES-shim/commit/0eb9297b1fc9753c235c53d746aa7d7994781216))
-
-
+- Fix some stray packaging mistakes ([0eb9297](https://github.com/Agoric/SES-shim/commit/0eb9297b1fc9753c235c53d746aa7d7994781216))
 
 ## 2.0.0 (2021-06-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **ses-integration-test:** No longer supports direct use from CommonJS
-* **ses:** Remove evaluate endowments option (#368)
-* **ses:** Surface SES on globalThis (#307)
+- **ses-integration-test:** No longer supports direct use from CommonJS
+- **ses:** Remove evaluate endowments option (#368)
+- **ses:** Surface SES on globalThis (#307)
 
 ### Features
 
-* **ses:** Add ModuleStaticRecord ([#279](https://github.com/Agoric/SES-shim/issues/279)) ([98c3a8f](https://github.com/Agoric/SES-shim/commit/98c3a8f0696ca1fedb865fd885f0affde388fd01))
-* **ses:** Surface SES on globalThis ([#307](https://github.com/Agoric/SES-shim/issues/307)) ([3ddfb95](https://github.com/Agoric/SES-shim/commit/3ddfb953098af5c0e127a5e4dbafbed2bea43a07))
-
+- **ses:** Add ModuleStaticRecord ([#279](https://github.com/Agoric/SES-shim/issues/279)) ([98c3a8f](https://github.com/Agoric/SES-shim/commit/98c3a8f0696ca1fedb865fd885f0affde388fd01))
+- **ses:** Surface SES on globalThis ([#307](https://github.com/Agoric/SES-shim/issues/307)) ([3ddfb95](https://github.com/Agoric/SES-shim/commit/3ddfb953098af5c0e127a5e4dbafbed2bea43a07))
 
 ### Bug Fixes
 
-* **ses:** Address charset error in integration ([17406d6](https://github.com/Agoric/SES-shim/commit/17406d6b045eefc082a17a559efdaf29293b8093))
-* **ses:** Remove evaluate endowments option ([#368](https://github.com/Agoric/SES-shim/issues/368)) ([e7b7b6e](https://github.com/Agoric/SES-shim/commit/e7b7b6eb8d2565886f9bbf7021223bcf96dc9173))
-* **ses:** Use CommonJS Rollup plugin ([#354](https://github.com/Agoric/SES-shim/issues/354)) ([f626365](https://github.com/Agoric/SES-shim/commit/f6263657fe7364df85cfe14e31ba1ac4dd7f03af))
-* Consolidate lint rules ([#262](https://github.com/Agoric/SES-shim/issues/262)) ([e5ce12a](https://github.com/Agoric/SES-shim/commit/e5ce12ac4343565f2adb0e6eca5d71c6c05903bf))
-
+- **ses:** Address charset error in integration ([17406d6](https://github.com/Agoric/SES-shim/commit/17406d6b045eefc082a17a559efdaf29293b8093))
+- **ses:** Remove evaluate endowments option ([#368](https://github.com/Agoric/SES-shim/issues/368)) ([e7b7b6e](https://github.com/Agoric/SES-shim/commit/e7b7b6eb8d2565886f9bbf7021223bcf96dc9173))
+- **ses:** Use CommonJS Rollup plugin ([#354](https://github.com/Agoric/SES-shim/issues/354)) ([f626365](https://github.com/Agoric/SES-shim/commit/f6263657fe7364df85cfe14e31ba1ac4dd7f03af))
+- Consolidate lint rules ([#262](https://github.com/Agoric/SES-shim/issues/262)) ([e5ce12a](https://github.com/Agoric/SES-shim/commit/e5ce12ac4343565f2adb0e6eca5d71c6c05903bf))
 
 ### Miscellaneous Chores
 
-* **ses-integration-test:** Update packaging ([9c59262](https://github.com/Agoric/SES-shim/commit/9c5926245435ac77a820324ca6c157e0b559e3fa))
+- **ses-integration-test:** Update packaging ([9c59262](https://github.com/Agoric/SES-shim/commit/9c5926245435ac77a820324ca6c157e0b559e3fa))

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,10 +30,10 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.18.0"
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,594 +3,470 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.18.0](https://github.com/endojs/endo/compare/ses@0.17.0...ses@0.18.0) (2022-11-14)
-
-
-### ⚠ BREAKING CHANGES
-
-* **ses:** Remove support for globalLexicals
+### [0.18.1](https://github.com/endojs/endo/compare/ses@0.18.0...ses@0.18.1) (2022-12-23)
 
 ### Features
 
-* **ses:** Remove support for globalLexicals ([3b90d5d](https://github.com/endojs/endo/commit/3b90d5d96984ff211efe5e47de1ce57cde7be980)), closes [#904](https://github.com/endojs/endo/issues/904)
-
+- **ses:** support RedirectStaticModuleInterface with implicit record ([356ed3b](https://github.com/endojs/endo/commit/356ed3b3b40b5b890d0970012f62d08ee7eea1f7))
 
 ### Bug Fixes
 
-* assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
-* fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
+- **ses:** Do not crash under no-unsafe-eval Content Security Policy ([#1333](https://github.com/endojs/endo/issues/1333)) ([e512174](https://github.com/endojs/endo/commit/e5121747d2ba01ad15304763c6390b721bb0df2a))
+- **ses:** handle named reexports without confusing bindings for matching imported names ([84a62cc](https://github.com/endojs/endo/commit/84a62cc0fca3ca9a98853619a8f6c30145b181d4))
+- **ses:** Link to primer on Hardened JavaScript ([121457d](https://github.com/endojs/endo/commit/121457dd2d82fdf92312a2efd47494007677654c))
+- **ses:** Remove superfluous tick in module loader ([342626a](https://github.com/endojs/endo/commit/342626ad6944d98aaecbe9274fcd60422247bb65)), closes [#1394](https://github.com/endojs/endo/issues/1394)
 
+## [0.18.0](https://github.com/endojs/endo/compare/ses@0.17.0...ses@0.18.0) (2022-11-14)
 
+### ⚠ BREAKING CHANGES
+
+- **ses:** Remove support for globalLexicals
+
+### Features
+
+- **ses:** Remove support for globalLexicals ([3b90d5d](https://github.com/endojs/endo/commit/3b90d5d96984ff211efe5e47de1ce57cde7be980)), closes [#904](https://github.com/endojs/endo/issues/904)
+
+### Bug Fixes
+
+- assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
+- fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
 
 ## [0.17.0](https://github.com/endojs/endo/compare/ses@0.16.0...ses@0.17.0) (2022-10-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **ses:** Prevent surprising global unscopables behavior
-* **ses:** Divide scope proxy into four layers
+- **ses:** Prevent surprising global unscopables behavior
+- **ses:** Divide scope proxy into four layers
 
 ### Features
 
-* **ses:** Revocable evalScope ([0187d1e](https://github.com/endojs/endo/commit/0187d1e3532cfc2f052619c46a8a6331a8c15ae8))
-
+- **ses:** Revocable evalScope ([0187d1e](https://github.com/endojs/endo/commit/0187d1e3532cfc2f052619c46a8a6331a8c15ae8))
 
 ### Bug Fixes
 
-* **ses:** Prevent surprising global unscopables behavior ([dcb8f5d](https://github.com/endojs/endo/commit/dcb8f5da2a453ac72b7f2cc3208f591a9c298402))
-* **ses:** Protect necessary eval admission before it has been admitted ([3d022b1](https://github.com/endojs/endo/commit/3d022b1e1b34ff9b86cf6af236c499bfbe291298))
-* **ses:** Typo in compartmentEvaluate ([d66db7a](https://github.com/endojs/endo/commit/d66db7a67fab6bdd36d18a931c6a9163e842c3fe))
-* **ses:** Typo in scope-constants ([a4ee1ea](https://github.com/endojs/endo/commit/a4ee1ea5e54d894ad3a3ce0c5e42507f026199e6))
-
+- **ses:** Prevent surprising global unscopables behavior ([dcb8f5d](https://github.com/endojs/endo/commit/dcb8f5da2a453ac72b7f2cc3208f591a9c298402))
+- **ses:** Protect necessary eval admission before it has been admitted ([3d022b1](https://github.com/endojs/endo/commit/3d022b1e1b34ff9b86cf6af236c499bfbe291298))
+- **ses:** Typo in compartmentEvaluate ([d66db7a](https://github.com/endojs/endo/commit/d66db7a67fab6bdd36d18a931c6a9163e842c3fe))
+- **ses:** Typo in scope-constants ([a4ee1ea](https://github.com/endojs/endo/commit/a4ee1ea5e54d894ad3a3ce0c5e42507f026199e6))
 
 ### Code Refactoring
 
-* **ses:** Divide scope proxy into four layers ([37c4b4a](https://github.com/endojs/endo/commit/37c4b4a22996e33dd4b2a48c67ce649ba88e5528))
-
-
+- **ses:** Divide scope proxy into four layers ([37c4b4a](https://github.com/endojs/endo/commit/37c4b4a22996e33dd4b2a48c67ce649ba88e5528))
 
 ## [0.16.0](https://github.com/endojs/endo/compare/ses@0.15.23...ses@0.16.0) (2022-10-19)
 
-
 ### Features
 
-* Add links to resources and community portals ([b0fef82](https://github.com/endojs/endo/commit/b0fef82192d476c43e9e10d5ad696cdad5bcb0b5))
-
+- Add links to resources and community portals ([b0fef82](https://github.com/endojs/endo/commit/b0fef82192d476c43e9e10d5ad696cdad5bcb0b5))
 
 ### Bug Fixes
 
-* **ses:** Fail safe when getOwnPropertyDescriptor reports absence of a known property ([5fa3b50](https://github.com/endojs/endo/commit/5fa3b506dc3d8826d0d213a9514e554986823a1d))
-* **ses:** Harden all non-integer typed array properties, even if canonical ([88cab0b](https://github.com/endojs/endo/commit/88cab0be4cf816dc578f2ff441fd9bcda0aa5cf5))
-* **ses:** Lock down all typed array expando properties ([dc82f5d](https://github.com/endojs/endo/commit/dc82f5d2908b3507965562c7c1b3bf12d852af8f))
-* minor improvements to some override comments ([#1327](https://github.com/endojs/endo/issues/1327)) ([678285a](https://github.com/endojs/endo/commit/678285a3345adec894f265ba56c2fa6636f846b8))
-* **marshal:** Return a special error message from passStyleOf(typedArray) ([dbd498e](https://github.com/endojs/endo/commit/dbd498e30a5c3b0d2713d863bc7479ceef39cd79)), closes [#1326](https://github.com/endojs/endo/issues/1326)
-* delete broken objectFromEntries ([#1306](https://github.com/endojs/endo/issues/1306)) ([d83be67](https://github.com/endojs/endo/commit/d83be675d23a928f287d6d9118f7258f0abd855a))
-* **ses:** expand the scope this-value test ([3d50c1a](https://github.com/endojs/endo/commit/3d50c1ac073250406a8b38735610ca6d86fdd680))
-* **ses:** Fix incompatible spelling ([c32fdf1](https://github.com/endojs/endo/commit/c32fdf10bdc1a21096ba190c384fa9f08f85f1f3))
-* **ses:** scope tests - expand Symbol.unscopables fidelity test ([bb542f7](https://github.com/endojs/endo/commit/bb542f78a1520a8e54e981d224dee28b171518d6))
-* **ses:** scope tests - expand Symbolunscopables fidelity test ([c603c5a](https://github.com/endojs/endo/commit/c603c5aa4a1ba271cf17d754df789a52aa7debfb))
-* **ses:** scope tests - move teardown into ava teardown call ([e59f682](https://github.com/endojs/endo/commit/e59f6829e3061adcd8fbf78cde84cf3f9abc5bf8))
-* **ses:** scope tests - rename variables to match purpose ([18d64c3](https://github.com/endojs/endo/commit/18d64c31315e47c798443f78a3bcfb77f4698366))
-* **ses:** this-value scope test includes optimizable props ([9c3fea3](https://github.com/endojs/endo/commit/9c3fea3dfd2d72f0fc13455bc1e54de455ead83e))
-* **ses:** this-value scope test includes unscopables fidelity test ([0be95ac](https://github.com/endojs/endo/commit/0be95acdb9a5251d1c37061bb5ae59180e298f65))
-
-
+- **ses:** Fail safe when getOwnPropertyDescriptor reports absence of a known property ([5fa3b50](https://github.com/endojs/endo/commit/5fa3b506dc3d8826d0d213a9514e554986823a1d))
+- **ses:** Harden all non-integer typed array properties, even if canonical ([88cab0b](https://github.com/endojs/endo/commit/88cab0be4cf816dc578f2ff441fd9bcda0aa5cf5))
+- **ses:** Lock down all typed array expando properties ([dc82f5d](https://github.com/endojs/endo/commit/dc82f5d2908b3507965562c7c1b3bf12d852af8f))
+- minor improvements to some override comments ([#1327](https://github.com/endojs/endo/issues/1327)) ([678285a](https://github.com/endojs/endo/commit/678285a3345adec894f265ba56c2fa6636f846b8))
+- **marshal:** Return a special error message from passStyleOf(typedArray) ([dbd498e](https://github.com/endojs/endo/commit/dbd498e30a5c3b0d2713d863bc7479ceef39cd79)), closes [#1326](https://github.com/endojs/endo/issues/1326)
+- delete broken objectFromEntries ([#1306](https://github.com/endojs/endo/issues/1306)) ([d83be67](https://github.com/endojs/endo/commit/d83be675d23a928f287d6d9118f7258f0abd855a))
+- **ses:** expand the scope this-value test ([3d50c1a](https://github.com/endojs/endo/commit/3d50c1ac073250406a8b38735610ca6d86fdd680))
+- **ses:** Fix incompatible spelling ([c32fdf1](https://github.com/endojs/endo/commit/c32fdf10bdc1a21096ba190c384fa9f08f85f1f3))
+- **ses:** scope tests - expand Symbol.unscopables fidelity test ([bb542f7](https://github.com/endojs/endo/commit/bb542f78a1520a8e54e981d224dee28b171518d6))
+- **ses:** scope tests - expand Symbolunscopables fidelity test ([c603c5a](https://github.com/endojs/endo/commit/c603c5aa4a1ba271cf17d754df789a52aa7debfb))
+- **ses:** scope tests - move teardown into ava teardown call ([e59f682](https://github.com/endojs/endo/commit/e59f6829e3061adcd8fbf78cde84cf3f9abc5bf8))
+- **ses:** scope tests - rename variables to match purpose ([18d64c3](https://github.com/endojs/endo/commit/18d64c31315e47c798443f78a3bcfb77f4698366))
+- **ses:** this-value scope test includes optimizable props ([9c3fea3](https://github.com/endojs/endo/commit/9c3fea3dfd2d72f0fc13455bc1e54de455ead83e))
+- **ses:** this-value scope test includes unscopables fidelity test ([0be95ac](https://github.com/endojs/endo/commit/0be95acdb9a5251d1c37061bb5ae59180e298f65))
 
 ### [0.15.23](https://github.com/endojs/endo/compare/ses@0.15.22...ses@0.15.23) (2022-09-27)
 
-
 ### Features
 
-* **ses:** improve performance of uncurryThis ([b1ad60a](https://github.com/endojs/endo/commit/b1ad60ae89545499d6cbcaa3812118ac4229d83c))
-
+- **ses:** improve performance of uncurryThis ([b1ad60a](https://github.com/endojs/endo/commit/b1ad60ae89545499d6cbcaa3812118ac4229d83c))
 
 ### Bug Fixes
 
-* add a do-nothing SharedError.prepareStackTrace ([#1290](https://github.com/endojs/endo/issues/1290)) ([705aef2](https://github.com/endojs/endo/commit/705aef24f34bb9794f0aa807d567b3efbf0c23af))
-* **ses:** report unhandled promise rejection when collected ([dae7235](https://github.com/endojs/endo/commit/dae7235011da907823c27ca5dfb9ed72519a4062))
-* **ses:** uncurryThis type fixes ([feb062c](https://github.com/endojs/endo/commit/feb062c56ee05b12657596defce68107894bafd4))
-
-
+- add a do-nothing SharedError.prepareStackTrace ([#1290](https://github.com/endojs/endo/issues/1290)) ([705aef2](https://github.com/endojs/endo/commit/705aef24f34bb9794f0aa807d567b3efbf0c23af))
+- **ses:** report unhandled promise rejection when collected ([dae7235](https://github.com/endojs/endo/commit/dae7235011da907823c27ca5dfb9ed72519a4062))
+- **ses:** uncurryThis type fixes ([feb062c](https://github.com/endojs/endo/commit/feb062c56ee05b12657596defce68107894bafd4))
 
 ### [0.15.22](https://github.com/endojs/endo/compare/ses@0.15.21...ses@0.15.22) (2022-09-14)
 
-
 ### Bug Fixes
 
-* alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
-
-
+- alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
 
 ### [0.15.21](https://github.com/endojs/endo/compare/ses@0.15.20...ses@0.15.21) (2022-08-26)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.20](https://github.com/endojs/endo/compare/ses@0.15.19...ses@0.15.20) (2022-08-26)
 
 **Note:** Version bump only for package ses
-
-
-
-
 
 ### [0.15.19](https://github.com/endojs/endo/compare/ses@0.15.18...ses@0.15.19) (2022-08-25)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.18](https://github.com/endojs/endo/compare/ses@0.15.17...ses@0.15.18) (2022-08-23)
-
 
 ### Bug Fixes
 
-* more hardens ([#1241](https://github.com/endojs/endo/issues/1241)) ([b6ff811](https://github.com/endojs/endo/commit/b6ff8118a92fd72c5309b2bb285fac08d0531d92))
-* remove __allowUnsafeMonkeyPatching__ ([fe9c784](https://github.com/endojs/endo/commit/fe9c78414eab5d1bce73cdb16e1455c1c4307e98))
-* remove dead environment-options module ([#1243](https://github.com/endojs/endo/issues/1243)) ([c43c939](https://github.com/endojs/endo/commit/c43c9396976ad6b0af5d99caed033b1abf448165))
-* **ses:** avoid leaks through CallSite structures ([69f69fa](https://github.com/endojs/endo/commit/69f69fac84154401a5bea72a533ba07f1ff2c191))
-
-
+- more hardens ([#1241](https://github.com/endojs/endo/issues/1241)) ([b6ff811](https://github.com/endojs/endo/commit/b6ff8118a92fd72c5309b2bb285fac08d0531d92))
+- remove **allowUnsafeMonkeyPatching** ([fe9c784](https://github.com/endojs/endo/commit/fe9c78414eab5d1bce73cdb16e1455c1c4307e98))
+- remove dead environment-options module ([#1243](https://github.com/endojs/endo/issues/1243)) ([c43c939](https://github.com/endojs/endo/commit/c43c9396976ad6b0af5d99caed033b1abf448165))
+- **ses:** avoid leaks through CallSite structures ([69f69fa](https://github.com/endojs/endo/commit/69f69fac84154401a5bea72a533ba07f1ff2c191))
 
 ### [0.15.17](https://github.com/endojs/endo/compare/ses@0.15.16...ses@0.15.17) (2022-06-28)
 
-
 ### Features
 
-* **compartment-mapper:** implement passing values in import.meta.url ([d6294f6](https://github.com/endojs/endo/commit/d6294f6832f978eaa7af94fee4496d76bd35a927))
-* add the foundations for support of import.meta ([36f6449](https://github.com/endojs/endo/commit/36f644998c21f6333268707555b97938ff0fff08))
-* call importMetaHook on instantiation if import.meta uttered by module ([23e8c40](https://github.com/endojs/endo/commit/23e8c405e0be823c728f8af1a6db9607e21f2f74))
-
+- **compartment-mapper:** implement passing values in import.meta.url ([d6294f6](https://github.com/endojs/endo/commit/d6294f6832f978eaa7af94fee4496d76bd35a927))
+- add the foundations for support of import.meta ([36f6449](https://github.com/endojs/endo/commit/36f644998c21f6333268707555b97938ff0fff08))
+- call importMetaHook on instantiation if import.meta uttered by module ([23e8c40](https://github.com/endojs/endo/commit/23e8c405e0be823c728f8af1a6db9607e21f2f74))
 
 ### Bug Fixes
 
-* rename meta to importMeta, fix detection to detect import.meta not import.meta.something ([c61a862](https://github.com/endojs/endo/commit/c61a862c9f4354f0e6d86d8c8efaa826840a6efd))
-* tolerate empty func.prototype ([#1221](https://github.com/endojs/endo/issues/1221)) ([4da7742](https://github.com/endojs/endo/commit/4da7742e8017d07094ed9b9336a85b6a4d3ee7b6))
-
-
+- rename meta to importMeta, fix detection to detect import.meta not import.meta.something ([c61a862](https://github.com/endojs/endo/commit/c61a862c9f4354f0e6d86d8c8efaa826840a6efd))
+- tolerate empty func.prototype ([#1221](https://github.com/endojs/endo/issues/1221)) ([4da7742](https://github.com/endojs/endo/commit/4da7742e8017d07094ed9b9336a85b6a4d3ee7b6))
 
 ### [0.15.16](https://github.com/endojs/endo/compare/ses@0.15.15...ses@0.15.16) (2022-06-11)
 
-
 ### Features
 
-* **console-taming:** `unhandledRejectionTrapping` after finalized ([7dccecf](https://github.com/endojs/endo/commit/7dccecfc1766b5287eeb0ebe958d1e1715cb63a4))
-* **ses:** add to commons ([9dc2de8](https://github.com/endojs/endo/commit/9dc2de812755a3c2ba6f73764f8ee7f43dd6f717))
-
+- **console-taming:** `unhandledRejectionTrapping` after finalized ([7dccecf](https://github.com/endojs/endo/commit/7dccecfc1766b5287eeb0ebe958d1e1715cb63a4))
+- **ses:** add to commons ([9dc2de8](https://github.com/endojs/endo/commit/9dc2de812755a3c2ba6f73764f8ee7f43dd6f717))
 
 ### Bug Fixes
 
-* **console:** close over severity for error note callbacks ([59910b2](https://github.com/endojs/endo/commit/59910b2a0ac146162c5191a3b315421b92ac5d77))
-* **console:** direct error output to the current severity ([f5d460d](https://github.com/endojs/endo/commit/f5d460d1cc1828100ce0ad237cb0f6bfd0a8e45c))
-* **ses:** Fix compartment with name from object with toString ([405c00b](https://github.com/endojs/endo/commit/405c00b3cc8f663ef73ef4275ba1776913dc26e7))
-* **static-module-record:** Make types consistent with implementation ([#1184](https://github.com/endojs/endo/issues/1184)) ([5b7e3a6](https://github.com/endojs/endo/commit/5b7e3a6d006a686520c4ffeedea5428a720f7e7d))
-* all errors have stacks, even if empty ([#1171](https://github.com/endojs/endo/issues/1171)) ([25b7d86](https://github.com/endojs/endo/commit/25b7d86240a5fc2772343664e5a42d1400d363d9))
-* make `*Trapping` orthogonal to `consoleTaming` ([8c5e12e](https://github.com/endojs/endo/commit/8c5e12e96f8c71d0c52e2d17786558e88585e04b))
-* repair deviations from local convention ([#1183](https://github.com/endojs/endo/issues/1183)) ([13614f5](https://github.com/endojs/endo/commit/13614f56872ac976e3440f8bcce706200ffe9822))
-
-
+- **console:** close over severity for error note callbacks ([59910b2](https://github.com/endojs/endo/commit/59910b2a0ac146162c5191a3b315421b92ac5d77))
+- **console:** direct error output to the current severity ([f5d460d](https://github.com/endojs/endo/commit/f5d460d1cc1828100ce0ad237cb0f6bfd0a8e45c))
+- **ses:** Fix compartment with name from object with toString ([405c00b](https://github.com/endojs/endo/commit/405c00b3cc8f663ef73ef4275ba1776913dc26e7))
+- **static-module-record:** Make types consistent with implementation ([#1184](https://github.com/endojs/endo/issues/1184)) ([5b7e3a6](https://github.com/endojs/endo/commit/5b7e3a6d006a686520c4ffeedea5428a720f7e7d))
+- all errors have stacks, even if empty ([#1171](https://github.com/endojs/endo/issues/1171)) ([25b7d86](https://github.com/endojs/endo/commit/25b7d86240a5fc2772343664e5a42d1400d363d9))
+- make `*Trapping` orthogonal to `consoleTaming` ([8c5e12e](https://github.com/endojs/endo/commit/8c5e12e96f8c71d0c52e2d17786558e88585e04b))
+- repair deviations from local convention ([#1183](https://github.com/endojs/endo/issues/1183)) ([13614f5](https://github.com/endojs/endo/commit/13614f56872ac976e3440f8bcce706200ffe9822))
 
 ### [0.15.15](https://github.com/endojs/endo/compare/ses@0.15.14...ses@0.15.15) (2022-04-15)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.14](https://github.com/endojs/endo/compare/ses@0.15.13...ses@0.15.14) (2022-04-14)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.13](https://github.com/endojs/endo/compare/ses@0.15.12...ses@0.15.13) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-* **ses:** Prevent hypothetical stack bumping to get unsafe eval ([3c64cde](https://github.com/endojs/endo/commit/3c64cdea5b410a053520dc29de04c43350a38e1a)), closes [#956](https://github.com/endojs/endo/issues/956)
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
+- **ses:** Prevent hypothetical stack bumping to get unsafe eval ([3c64cde](https://github.com/endojs/endo/commit/3c64cdea5b410a053520dc29de04c43350a38e1a)), closes [#956](https://github.com/endojs/endo/issues/956)
 
 ### [0.15.12](https://github.com/endojs/endo/compare/ses@0.15.11...ses@0.15.12) (2022-04-12)
 
-
 ### Features
 
-* add Array#at close [#1139](https://github.com/endojs/endo/issues/1139) ([#1146](https://github.com/endojs/endo/issues/1146)) ([43494c8](https://github.com/endojs/endo/commit/43494c8d0c50cba205050fcf472fda4aed03d6ca))
-* **compartment-mapper:** proper default export implementation for cjs with import and require compatibility ([30cbaa8](https://github.com/endojs/endo/commit/30cbaa8cb79b906742a9f5c1854b22fe506b0575))
-* **init:** Handle symbols installed on Promise by Node's `async_hooks` ([#1115](https://github.com/endojs/endo/issues/1115)) ([06827b9](https://github.com/endojs/endo/commit/06827b982c0450bae53b5ff0c410745678168c88))
-
+- add Array#at close [#1139](https://github.com/endojs/endo/issues/1139) ([#1146](https://github.com/endojs/endo/issues/1146)) ([43494c8](https://github.com/endojs/endo/commit/43494c8d0c50cba205050fcf472fda4aed03d6ca))
+- **compartment-mapper:** proper default export implementation for cjs with import and require compatibility ([30cbaa8](https://github.com/endojs/endo/commit/30cbaa8cb79b906742a9f5c1854b22fe506b0575))
+- **init:** Handle symbols installed on Promise by Node's `async_hooks` ([#1115](https://github.com/endojs/endo/issues/1115)) ([06827b9](https://github.com/endojs/endo/commit/06827b982c0450bae53b5ff0c410745678168c88))
 
 ### Bug Fixes
 
-* **ses:** avoid cache corruption when execute() throws ([1d9c17b](https://github.com/endojs/endo/commit/1d9c17b4c4a5ed1450cddd996bd948dd59c80bf6))
-* some tests sensitive to errorTaming ([#1135](https://github.com/endojs/endo/issues/1135)) ([0c22364](https://github.com/endojs/endo/commit/0c22364104fb8b2528cd5437accda09a045a6ff0))
-* **endo:** Ensure conditions include default, import, and endo ([1361abd](https://github.com/endojs/endo/commit/1361abd8c732596d192ecef6a039eda98b4ee563))
-* **ses:** Do not bundle modules for use as modules ([7d27020](https://github.com/endojs/endo/commit/7d2702037295211d8d3f08431a4d4de0a4e3ffd7))
-* **ses:** Do not get confused by well-known look-alikes ([5139dad](https://github.com/endojs/endo/commit/5139dad7719d7a32360e2daf8a37b9ab3f2cd94a))
-* **ses:** Ignore Array unscopable findLast{,Index} ([#1129](https://github.com/endojs/endo/issues/1129)) ([bbf7e7d](https://github.com/endojs/endo/commit/bbf7e7dd0ba19349120d4913016c62b9f8dc4995))
-* **ses:** make import * and default from cjs wire up correctly ([33cbd27](https://github.com/endojs/endo/commit/33cbd2776f9d47e6e8438650565155e4185d9373))
-
-
+- **ses:** avoid cache corruption when execute() throws ([1d9c17b](https://github.com/endojs/endo/commit/1d9c17b4c4a5ed1450cddd996bd948dd59c80bf6))
+- some tests sensitive to errorTaming ([#1135](https://github.com/endojs/endo/issues/1135)) ([0c22364](https://github.com/endojs/endo/commit/0c22364104fb8b2528cd5437accda09a045a6ff0))
+- **endo:** Ensure conditions include default, import, and endo ([1361abd](https://github.com/endojs/endo/commit/1361abd8c732596d192ecef6a039eda98b4ee563))
+- **ses:** Do not bundle modules for use as modules ([7d27020](https://github.com/endojs/endo/commit/7d2702037295211d8d3f08431a4d4de0a4e3ffd7))
+- **ses:** Do not get confused by well-known look-alikes ([5139dad](https://github.com/endojs/endo/commit/5139dad7719d7a32360e2daf8a37b9ab3f2cd94a))
+- **ses:** Ignore Array unscopable findLast{,Index} ([#1129](https://github.com/endojs/endo/issues/1129)) ([bbf7e7d](https://github.com/endojs/endo/commit/bbf7e7dd0ba19349120d4913016c62b9f8dc4995))
+- **ses:** make import \* and default from cjs wire up correctly ([33cbd27](https://github.com/endojs/endo/commit/33cbd2776f9d47e6e8438650565155e4185d9373))
 
 ### [0.15.11](https://github.com/endojs/endo/compare/ses@0.15.10...ses@0.15.11) (2022-03-07)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.10](https://github.com/endojs/endo/compare/ses@0.15.9...ses@0.15.10) (2022-03-02)
-
 
 ### Features
 
-* add evalTaming option ([#961](https://github.com/endojs/endo/issues/961)) ([735ff94](https://github.com/endojs/endo/commit/735ff94bf3513613e64aaca03116f289d07aa366))
-
-
+- add evalTaming option ([#961](https://github.com/endojs/endo/issues/961)) ([735ff94](https://github.com/endojs/endo/commit/735ff94bf3513613e64aaca03116f289d07aa366))
 
 ### [0.15.9](https://github.com/endojs/endo/compare/ses@0.15.8...ses@0.15.9) (2022-02-20)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.8](https://github.com/endojs/endo/compare/ses@0.15.7...ses@0.15.8) (2022-02-18)
-
 
 ### Features
 
-* **ses:** Harden typed arrays ([#1032](https://github.com/endojs/endo/issues/1032)) ([0dfa7de](https://github.com/endojs/endo/commit/0dfa7de417e9e801e3188596bfe9d10a69d541a6))
-
+- **ses:** Harden typed arrays ([#1032](https://github.com/endojs/endo/issues/1032)) ([0dfa7de](https://github.com/endojs/endo/commit/0dfa7de417e9e801e3188596bfe9d10a69d541a6))
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* **ses:** update index.d.ts with second argument to compartment.evaluate ([716621c](https://github.com/endojs/endo/commit/716621c3259965f699ec12ac1fa5d874884348b5))
-* remove pureCopy, ALLOW_IMPLICIT_REMOTABLES ([#1061](https://github.com/endojs/endo/issues/1061)) ([f08cad9](https://github.com/endojs/endo/commit/f08cad99aa715aa36f78dfd67b9f581cdd22bb3c))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-* **ses:** Relax hardened typed array test to be insensitive to bugfix between Node.js 14 and 16 ([#1048](https://github.com/endojs/endo/issues/1048)) ([e12508d](https://github.com/endojs/endo/commit/e12508db74e0c5b921db92daf3de684b739f7bc3)), closes [#1045](https://github.com/endojs/endo/issues/1045)
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- **ses:** update index.d.ts with second argument to compartment.evaluate ([716621c](https://github.com/endojs/endo/commit/716621c3259965f699ec12ac1fa5d874884348b5))
+- remove pureCopy, ALLOW_IMPLICIT_REMOTABLES ([#1061](https://github.com/endojs/endo/issues/1061)) ([f08cad9](https://github.com/endojs/endo/commit/f08cad99aa715aa36f78dfd67b9f581cdd22bb3c))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
+- **ses:** Relax hardened typed array test to be insensitive to bugfix between Node.js 14 and 16 ([#1048](https://github.com/endojs/endo/issues/1048)) ([e12508d](https://github.com/endojs/endo/commit/e12508db74e0c5b921db92daf3de684b739f7bc3)), closes [#1045](https://github.com/endojs/endo/issues/1045)
 
 ### [0.15.7](https://github.com/endojs/endo/compare/ses@0.15.6...ses@0.15.7) (2022-01-31)
 
-
 ### Bug Fixes
 
-* **ses:** Globals have vars, not consts ([#1027](https://github.com/endojs/endo/issues/1027)) ([157669f](https://github.com/endojs/endo/commit/157669f0b669332f703747e36dd867bf6a823e59))
-
-
+- **ses:** Globals have vars, not consts ([#1027](https://github.com/endojs/endo/issues/1027)) ([157669f](https://github.com/endojs/endo/commit/157669f0b669332f703747e36dd867bf6a823e59))
 
 ### [0.15.6](https://github.com/endojs/endo/compare/ses@0.15.5...ses@0.15.6) (2022-01-27)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.5](https://github.com/endojs/endo/compare/ses@0.15.4...ses@0.15.5) (2022-01-25)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.4](https://github.com/endojs/endo/compare/ses@0.15.3...ses@0.15.4) (2022-01-23)
-
 
 ### Features
 
-* **ses:** Check early for dynamic evalability ([d0f6f09](https://github.com/endojs/endo/commit/d0f6f099d41edee3f484da5d5094848f72f93084)), closes [#343](https://github.com/endojs/endo/issues/343)
-
+- **ses:** Check early for dynamic evalability ([d0f6f09](https://github.com/endojs/endo/commit/d0f6f099d41edee3f484da5d5094848f72f93084)), closes [#343](https://github.com/endojs/endo/issues/343)
 
 ### Bug Fixes
 
-* **ses:** Direct eval check should not preclude no-eval under CSP ([#1004](https://github.com/endojs/endo/issues/1004)) ([fc8f9ee](https://github.com/endojs/endo/commit/fc8f9eee5ec703ebc611bc015b94fc8ecb721324))
-* **ses:** Fix mistaken this binding example ([#990](https://github.com/endojs/endo/issues/990)) ([71db876](https://github.com/endojs/endo/commit/71db876ee3d7557f0f19dd995a4e027cc7945c2b))
-* minor wording ([#989](https://github.com/endojs/endo/issues/989)) ([f8d6ff6](https://github.com/endojs/endo/commit/f8d6ff6c63b0c46bcaf93378b61d7286d971fd5f))
-* **ses:** Add assert.error options bag to type definition ([#978](https://github.com/endojs/endo/issues/978)) ([ca42997](https://github.com/endojs/endo/commit/ca4299714d5769ea15418612f679abb400ff7e25)), closes [#977](https://github.com/endojs/endo/issues/977)
-* **ses:** Number.prototype.toLocaleString radix confusion ([#975](https://github.com/endojs/endo/issues/975)) ([6a17595](https://github.com/endojs/endo/commit/6a175953e5c78d2575c2e9e4e72e6b893bcdb631)), closes [#852](https://github.com/endojs/endo/issues/852)
-* **ses:** Remove superfluous error cause on prototypes ([#955](https://github.com/endojs/endo/issues/955)) ([6e50c45](https://github.com/endojs/endo/commit/6e50c4526f457b31e00a783406d175b0088907eb))
-
-
+- **ses:** Direct eval check should not preclude no-eval under CSP ([#1004](https://github.com/endojs/endo/issues/1004)) ([fc8f9ee](https://github.com/endojs/endo/commit/fc8f9eee5ec703ebc611bc015b94fc8ecb721324))
+- **ses:** Fix mistaken this binding example ([#990](https://github.com/endojs/endo/issues/990)) ([71db876](https://github.com/endojs/endo/commit/71db876ee3d7557f0f19dd995a4e027cc7945c2b))
+- minor wording ([#989](https://github.com/endojs/endo/issues/989)) ([f8d6ff6](https://github.com/endojs/endo/commit/f8d6ff6c63b0c46bcaf93378b61d7286d971fd5f))
+- **ses:** Add assert.error options bag to type definition ([#978](https://github.com/endojs/endo/issues/978)) ([ca42997](https://github.com/endojs/endo/commit/ca4299714d5769ea15418612f679abb400ff7e25)), closes [#977](https://github.com/endojs/endo/issues/977)
+- **ses:** Number.prototype.toLocaleString radix confusion ([#975](https://github.com/endojs/endo/issues/975)) ([6a17595](https://github.com/endojs/endo/commit/6a175953e5c78d2575c2e9e4e72e6b893bcdb631)), closes [#852](https://github.com/endojs/endo/issues/852)
+- **ses:** Remove superfluous error cause on prototypes ([#955](https://github.com/endojs/endo/issues/955)) ([6e50c45](https://github.com/endojs/endo/commit/6e50c4526f457b31e00a783406d175b0088907eb))
 
 ### [0.15.3](https://github.com/endojs/endo/compare/ses@0.15.2...ses@0.15.3) (2021-12-14)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.15.2](https://github.com/endojs/endo/compare/ses@0.15.1...ses@0.15.2) (2021-12-08)
-
 
 ### Bug Fixes
 
-* **ses:** Constrain URL types in bundle script ([bdd7996](https://github.com/endojs/endo/commit/bdd79964c56e1716113f2b852f39eb3af3022742))
-* **ses:** Send removal warnings to STDERR ([#949](https://github.com/endojs/endo/issues/949)) ([761774c](https://github.com/endojs/endo/commit/761774c25d318d675c3e665f6112ff946ac7b59c))
-* **ses:** Windows support for bundle build script ([f8c6885](https://github.com/endojs/endo/commit/f8c6885116c52436e2fb675c1544bc765a1dd0f1))
-* **ses:** Windows support for tests ([3bc504b](https://github.com/endojs/endo/commit/3bc504b5356d13e1411d127cefc7ad3bc99fbfa5))
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-* update whitelist with stage 3 and 4 proposals ([#946](https://github.com/endojs/endo/issues/946)) ([8112430](https://github.com/endojs/endo/commit/811243015cc2e3e588080ceef6146b7b5e42f2bb))
-
-
+- **ses:** Constrain URL types in bundle script ([bdd7996](https://github.com/endojs/endo/commit/bdd79964c56e1716113f2b852f39eb3af3022742))
+- **ses:** Send removal warnings to STDERR ([#949](https://github.com/endojs/endo/issues/949)) ([761774c](https://github.com/endojs/endo/commit/761774c25d318d675c3e665f6112ff946ac7b59c))
+- **ses:** Windows support for bundle build script ([f8c6885](https://github.com/endojs/endo/commit/f8c6885116c52436e2fb675c1544bc765a1dd0f1))
+- **ses:** Windows support for tests ([3bc504b](https://github.com/endojs/endo/commit/3bc504b5356d13e1411d127cefc7ad3bc99fbfa5))
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
+- update whitelist with stage 3 and 4 proposals ([#946](https://github.com/endojs/endo/issues/946)) ([8112430](https://github.com/endojs/endo/commit/811243015cc2e3e588080ceef6146b7b5e42f2bb))
 
 ### [0.15.1](https://github.com/endojs/endo/compare/ses@0.15.0...ses@0.15.1) (2021-11-16)
 
-
 ### Bug Fixes
 
-* **ses:** Add errorTrapping none to type definition ([#935](https://github.com/endojs/endo/issues/935)) ([313d47c](https://github.com/endojs/endo/commit/313d47c5a5c02afcd57e933ca876fec22a059972))
-* **ses:** Include error in trapped error log ([#936](https://github.com/endojs/endo/issues/936)) ([22c4644](https://github.com/endojs/endo/commit/22c4644b6ad31c9eb7fdb4d760d91f8667e7a2c7))
-
-
+- **ses:** Add errorTrapping none to type definition ([#935](https://github.com/endojs/endo/issues/935)) ([313d47c](https://github.com/endojs/endo/commit/313d47c5a5c02afcd57e933ca876fec22a059972))
+- **ses:** Include error in trapped error log ([#936](https://github.com/endojs/endo/issues/936)) ([22c4644](https://github.com/endojs/endo/commit/22c4644b6ad31c9eb7fdb4d760d91f8667e7a2c7))
 
 ## [0.15.0](https://github.com/endojs/endo/compare/ses@0.14.4...ses@0.15.0) (2021-11-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **ses:** Withdraw support for muli-lockdown (#921)
-* **ses:** Domain taming safe by default (#917)
+- **ses:** Withdraw support for muli-lockdown (#921)
+- **ses:** Domain taming safe by default (#917)
 
 ### Features
 
-* **ses:** Read lockdown options from environment ([#871](https://github.com/endojs/endo/issues/871)) ([789d639](https://github.com/endojs/endo/commit/789d639c25c6882153a8090f4bd74d350bb29721))
-
+- **ses:** Read lockdown options from environment ([#871](https://github.com/endojs/endo/issues/871)) ([789d639](https://github.com/endojs/endo/commit/789d639c25c6882153a8090f4bd74d350bb29721))
 
 ### Bug Fixes
 
-* **ses:** Domain taming safe by default ([#917](https://github.com/endojs/endo/issues/917)) ([7039276](https://github.com/endojs/endo/commit/7039276ef91a2de2b048c91085a7557c8830f677))
-* **ses:** Withdraw support for muli-lockdown ([#921](https://github.com/endojs/endo/issues/921)) ([99752b0](https://github.com/endojs/endo/commit/99752b046c2a3e2d866559bb9d58f625eb94b1a8)), closes [#814](https://github.com/endojs/endo/issues/814)
-
-
+- **ses:** Domain taming safe by default ([#917](https://github.com/endojs/endo/issues/917)) ([7039276](https://github.com/endojs/endo/commit/7039276ef91a2de2b048c91085a7557c8830f677))
+- **ses:** Withdraw support for muli-lockdown ([#921](https://github.com/endojs/endo/issues/921)) ([99752b0](https://github.com/endojs/endo/commit/99752b046c2a3e2d866559bb9d58f625eb94b1a8)), closes [#814](https://github.com/endojs/endo/issues/814)
 
 ### [0.14.4](https://github.com/endojs/endo/compare/ses@0.14.3...ses@0.14.4) (2021-10-15)
 
-
 ### Features
 
-* **ses:** lazily create evaluate ([f1cf92a](https://github.com/endojs/endo/commit/f1cf92a3b8e23aab3894f8431d8b65b4f75daa77))
-
+- **ses:** lazily create evaluate ([f1cf92a](https://github.com/endojs/endo/commit/f1cf92a3b8e23aab3894f8431d8b65b4f75daa77))
 
 ### Bug Fixes
 
-* **ses:** Add test and warning about the `has` hazard ([9066c97](https://github.com/endojs/endo/commit/9066c97b41b35a4e37fd12256a0802fb656af755))
-* **ses:** more detailed `has` hazard test ([f010a9e](https://github.com/endojs/endo/commit/f010a9ebe09dadc72a8f22bd54caed8aa3787243))
-* **ses:** Refactor Compartment to use shared evaluator ([dc0bad6](https://github.com/endojs/endo/commit/dc0bad6c1f963ff379e45f320852218228203050))
-
-
+- **ses:** Add test and warning about the `has` hazard ([9066c97](https://github.com/endojs/endo/commit/9066c97b41b35a4e37fd12256a0802fb656af755))
+- **ses:** more detailed `has` hazard test ([f010a9e](https://github.com/endojs/endo/commit/f010a9ebe09dadc72a8f22bd54caed8aa3787243))
+- **ses:** Refactor Compartment to use shared evaluator ([dc0bad6](https://github.com/endojs/endo/commit/dc0bad6c1f963ff379e45f320852218228203050))
 
 ### [0.14.3](https://github.com/endojs/endo/compare/ses@0.14.2...ses@0.14.3) (2021-09-18)
 
-
 ### Features
 
-* **eslint-plugin:** Add no-polymorphic-call rule ([03e8c5f](https://github.com/endojs/endo/commit/03e8c5f566a52d9d6e7fb9d876a67347ecf37324))
-* **ses:** Lockdown option domainTaming ([ee3e4c3](https://github.com/endojs/endo/commit/ee3e4c309ece70249d6c95b806ca8d02549f1837))
-
+- **eslint-plugin:** Add no-polymorphic-call rule ([03e8c5f](https://github.com/endojs/endo/commit/03e8c5f566a52d9d6e7fb9d876a67347ecf37324))
+- **ses:** Lockdown option domainTaming ([ee3e4c3](https://github.com/endojs/endo/commit/ee3e4c309ece70249d6c95b806ca8d02549f1837))
 
 ### Bug Fixes
 
-* **ses:** Fix reflexive imports ([d259db7](https://github.com/endojs/endo/commit/d259db75022941c4ea1881b4ca4005acc1a37a1c))
-* **ses:** Search engine optimization ([#886](https://github.com/endojs/endo/issues/886)) ([ef03184](https://github.com/endojs/endo/commit/ef031843b445a4a9df7b717fba7a315371eadae0))
-* add "name" to moderate override of all errors ([#867](https://github.com/endojs/endo/issues/867)) ([d608325](https://github.com/endojs/endo/commit/d608325c3edade0c64f9ca9a84379f8d3e3addf0))
-* update NEWS with news of [#867](https://github.com/endojs/endo/issues/867) ([#869](https://github.com/endojs/endo/issues/869)) ([c3139d2](https://github.com/endojs/endo/commit/c3139d2ff7433afce3653639fc71a65dbe3c6313))
-
-
+- **ses:** Fix reflexive imports ([d259db7](https://github.com/endojs/endo/commit/d259db75022941c4ea1881b4ca4005acc1a37a1c))
+- **ses:** Search engine optimization ([#886](https://github.com/endojs/endo/issues/886)) ([ef03184](https://github.com/endojs/endo/commit/ef031843b445a4a9df7b717fba7a315371eadae0))
+- add "name" to moderate override of all errors ([#867](https://github.com/endojs/endo/issues/867)) ([d608325](https://github.com/endojs/endo/commit/d608325c3edade0c64f9ca9a84379f8d3e3addf0))
+- update NEWS with news of [#867](https://github.com/endojs/endo/issues/867) ([#869](https://github.com/endojs/endo/issues/869)) ([c3139d2](https://github.com/endojs/endo/commit/c3139d2ff7433afce3653639fc71a65dbe3c6313))
 
 ### [0.14.2](https://github.com/endojs/endo/compare/ses@0.14.1...ses@0.14.2) (2021-08-14)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.14.1](https://github.com/endojs/endo/compare/ses@0.14.0...ses@0.14.1) (2021-08-13)
-
 
 ### Features
 
-* **ses:** Add permits for at methods ([#857](https://github.com/endojs/endo/issues/857)) ([8b9e138](https://github.com/endojs/endo/commit/8b9e13830113fef9c3b5a36ba88436dba5677b4c)), closes [#854](https://github.com/endojs/endo/issues/854)
-
-
+- **ses:** Add permits for at methods ([#857](https://github.com/endojs/endo/issues/857)) ([8b9e138](https://github.com/endojs/endo/commit/8b9e13830113fef9c3b5a36ba88436dba5677b4c)), closes [#854](https://github.com/endojs/endo/issues/854)
 
 ## [0.14.0](https://github.com/endojs/endo/compare/ses@0.13.4...ses@0.14.0) (2021-07-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Update preamble for SES StaticModuleRecord
-* **ses:** Adjust preamble for module instances to expect entries instead of a Map
+- Update preamble for SES StaticModuleRecord
+- **ses:** Adjust preamble for module instances to expect entries instead of a Map
 
 ### Features
 
-* **ses:** Add errorTrapping lockdown option ([2a88adb](https://github.com/endojs/endo/commit/2a88adb2ac65ae401a20c2019fe61bac2d7b4fd2))
-* **ses:** Reveal harden only after lockdown ([424af0f](https://github.com/endojs/endo/commit/424af0f0cabd28d691b3cf7183bf1a0d34f0af70)), closes [#787](https://github.com/endojs/endo/issues/787)
-
+- **ses:** Add errorTrapping lockdown option ([2a88adb](https://github.com/endojs/endo/commit/2a88adb2ac65ae401a20c2019fe61bac2d7b4fd2))
+- **ses:** Reveal harden only after lockdown ([424af0f](https://github.com/endojs/endo/commit/424af0f0cabd28d691b3cf7183bf1a0d34f0af70)), closes [#787](https://github.com/endojs/endo/issues/787)
 
 ### Bug Fixes
 
-* **ses:** Adjust preamble for module instances to expect entries instead of a Map ([574c518](https://github.com/endojs/endo/commit/574c518de757c34a57096ef3c5be5681249e5294))
-* **ses:** Defend integrity of intrinsics ([14e451c](https://github.com/endojs/endo/commit/14e451ce32f95de68f10d15fe99a260dc638150d))
-* **ses:** Fix assert type assertions ([53d284d](https://github.com/endojs/endo/commit/53d284d04eebed57ccaf19b43a1ff9a71393cc6b))
-* **ses:** Fix packaging for `@web/dev-server` ([8c35e33](https://github.com/endojs/endo/commit/8c35e333818bd9e7f6630ae2be93e5ca98d85e17))
-* **ses:** Fix version number errors in news ([9aff6c3](https://github.com/endojs/endo/commit/9aff6c3ca0c7cd9971879b720ca7e5ac6afff805))
-* **ses:** Improve error messages for invalid module records ([5c07c85](https://github.com/endojs/endo/commit/5c07c850f8b3299aaa2042c4fbe0cf7116304284))
-* **ses:** Scope proxy defense against property descriptor prototype pollution ([cbfbf85](https://github.com/endojs/endo/commit/cbfbf850139712e4ddeb97128e980353b309b4b9))
-* **ses:** Use eslint-disable notation consistently ([#837](https://github.com/endojs/endo/issues/837)) ([6ddb50c](https://github.com/endojs/endo/commit/6ddb50c179e4b9e0645ab23bade6c3e5d3aa485e))
-* typo vs type checker ([#798](https://github.com/endojs/endo/issues/798)) ([fcb433f](https://github.com/endojs/endo/commit/fcb433fa67584ae36b4685232259e35e7fa3b8ec))
-* Update preamble for SES StaticModuleRecord ([790ed01](https://github.com/endojs/endo/commit/790ed01f0aa73ff2d232e69c9323ee0bb448c2b0))
-* **ses:** Trap and report errors ([a79df15](https://github.com/endojs/endo/commit/a79df15f6dcebc8df2ddf389af605313cb1b17b0)), closes [#769](https://github.com/endojs/endo/issues/769)
-
-
+- **ses:** Adjust preamble for module instances to expect entries instead of a Map ([574c518](https://github.com/endojs/endo/commit/574c518de757c34a57096ef3c5be5681249e5294))
+- **ses:** Defend integrity of intrinsics ([14e451c](https://github.com/endojs/endo/commit/14e451ce32f95de68f10d15fe99a260dc638150d))
+- **ses:** Fix assert type assertions ([53d284d](https://github.com/endojs/endo/commit/53d284d04eebed57ccaf19b43a1ff9a71393cc6b))
+- **ses:** Fix packaging for `@web/dev-server` ([8c35e33](https://github.com/endojs/endo/commit/8c35e333818bd9e7f6630ae2be93e5ca98d85e17))
+- **ses:** Fix version number errors in news ([9aff6c3](https://github.com/endojs/endo/commit/9aff6c3ca0c7cd9971879b720ca7e5ac6afff805))
+- **ses:** Improve error messages for invalid module records ([5c07c85](https://github.com/endojs/endo/commit/5c07c850f8b3299aaa2042c4fbe0cf7116304284))
+- **ses:** Scope proxy defense against property descriptor prototype pollution ([cbfbf85](https://github.com/endojs/endo/commit/cbfbf850139712e4ddeb97128e980353b309b4b9))
+- **ses:** Use eslint-disable notation consistently ([#837](https://github.com/endojs/endo/issues/837)) ([6ddb50c](https://github.com/endojs/endo/commit/6ddb50c179e4b9e0645ab23bade6c3e5d3aa485e))
+- typo vs type checker ([#798](https://github.com/endojs/endo/issues/798)) ([fcb433f](https://github.com/endojs/endo/commit/fcb433fa67584ae36b4685232259e35e7fa3b8ec))
+- Update preamble for SES StaticModuleRecord ([790ed01](https://github.com/endojs/endo/commit/790ed01f0aa73ff2d232e69c9323ee0bb448c2b0))
+- **ses:** Trap and report errors ([a79df15](https://github.com/endojs/endo/commit/a79df15f6dcebc8df2ddf389af605313cb1b17b0)), closes [#769](https://github.com/endojs/endo/issues/769)
 
 ### [0.13.4](https://github.com/endojs/endo/compare/ses@0.13.3...ses@0.13.4) (2021-06-20)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.13.3](https://github.com/endojs/endo/compare/ses@0.13.2...ses@0.13.3) (2021-06-16)
-
 
 ### Features
 
-* **ses:** Improve link errors ([71a509c](https://github.com/endojs/endo/commit/71a509cd67305b5af60d66f0b2b600ed0df8b632))
-
-
+- **ses:** Improve link errors ([71a509c](https://github.com/endojs/endo/commit/71a509cd67305b5af60d66f0b2b600ed0df8b632))
 
 ### [0.13.2](https://github.com/endojs/endo/compare/ses@0.13.1...ses@0.13.2) (2021-06-14)
 
 **Note:** Version bump only for package ses
 
-
-
-
-
 ### [0.13.1](https://github.com/endojs/endo/compare/ses@0.13.0...ses@0.13.1) (2021-06-06)
-
 
 ### Bug Fixes
 
-* **ses:** Export hardener types properly ([0d2e8f0](https://github.com/endojs/endo/commit/0d2e8f0570d7de06b54b4faee56f487bbf7aeb8b))
-
-
+- **ses:** Export hardener types properly ([0d2e8f0](https://github.com/endojs/endo/commit/0d2e8f0570d7de06b54b4faee56f487bbf7aeb8b))
 
 ## 0.13.0 (2021-06-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **ses:** No longer supports direct use from CommonJS
-* **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD
-* **ses:** Remove evaluate endowments option (#368)
-* **ses:** Simplify transforms (#325)
-* **ses, transform-module:** Fix StaticModuleRecord name (#323)
-* **ses:** Surface SES on globalThis (#307)
+- **ses:** No longer supports direct use from CommonJS
+- **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD
+- **ses:** Remove evaluate endowments option (#368)
+- **ses:** Simplify transforms (#325)
+- **ses, transform-module:** Fix StaticModuleRecord name (#323)
+- **ses:** Surface SES on globalThis (#307)
 
 ### Features
 
-* **ses:** Add __shimTransforms__ Compartment option ([#485](https://github.com/endojs/endo/issues/485)) ([5196521](https://github.com/endojs/endo/commit/5196521a17ac4b28f9aaaef2aa312eebe9edcbb7))
-* **ses:** Add Compartment load function ([#349](https://github.com/endojs/endo/issues/349)) ([8352fa1](https://github.com/endojs/endo/commit/8352fa1b038ec9f6d21a1ae4b6559f687c27fd81))
-* **ses:** add Compartment shim utility method __isKnownScopeProxy__ ([#623](https://github.com/endojs/endo/issues/623)) ([22dbe36](https://github.com/endojs/endo/commit/22dbe368d42b983a9f8b8db3d88003b5400c3e23))
-* **ses:** Add minimal Compartment to SES-lite ([#443](https://github.com/endojs/endo/issues/443)) ([3d1dfd2](https://github.com/endojs/endo/commit/3d1dfd285a758b9be5c1de766c82a12e82329224))
-* **ses:** Add moduleMapHook ([#419](https://github.com/endojs/endo/issues/419)) ([f053ba4](https://github.com/endojs/endo/commit/f053ba4a0ebcb9194a8ffb880359862e3748289c))
-* **ses:** Add ModuleStaticRecord ([#279](https://github.com/endojs/endo/issues/279)) ([98c3a8f](https://github.com/endojs/endo/commit/98c3a8f0696ca1fedb865fd885f0affde388fd01))
-* **ses:** Add news for override mistake fix ([#417](https://github.com/endojs/endo/issues/417)) ([01bf4d7](https://github.com/endojs/endo/commit/01bf4d7ef13b32e71f2d36baef573423b21e012d))
-* **ses:** Add support for third-party modules ([#393](https://github.com/endojs/endo/issues/393)) ([0abe442](https://github.com/endojs/endo/commit/0abe442311bb4555bb06be3796f9ea77e6616b38))
-* **ses:** Add TypeScript definitions for Compartment aux types ([07715ce](https://github.com/endojs/endo/commit/07715cea0c053cf623e9e44e03c0c331c709eb64))
-* **ses:** Allow import and eval methods ([#669](https://github.com/endojs/endo/issues/669)) ([505a7d7](https://github.com/endojs/endo/commit/505a7d7149c36825a00c9fe3795d0f1588035dde))
-* **ses:** Carry compartment names in error messages ([#441](https://github.com/endojs/endo/issues/441)) ([765172a](https://github.com/endojs/endo/commit/765172aa68c338947b14ec6292be18519ac14aee))
-* **ses:** Censorship error messages may now contain the source name ([#515](https://github.com/endojs/endo/issues/515)) ([2bcd726](https://github.com/endojs/endo/commit/2bcd726ee96d53da2467eb15304531d04eb683ed))
-* **ses:** Create a thin lockdown layer ([#406](https://github.com/endojs/endo/issues/406)) ([ff693ae](https://github.com/endojs/endo/commit/ff693ae5e012afdd8dbbec105d0da299d36fdbf9))
-* **ses:** Create ses/lockdown alias ([17d416f](https://github.com/endojs/endo/commit/17d416f1652873c75cbd6c8fd34db37e90300ea6))
-* **ses:** Detect invalid sloppy mode execution ([86c4751](https://github.com/endojs/endo/commit/86c4751abb7f8ce3d44b086e50ab2a5f229e12dc)), closes [#740](https://github.com/endojs/endo/issues/740)
-* **ses:** Expand TypeScript coverage for Compartment and lockdown ([#584](https://github.com/endojs/endo/issues/584)) ([e31c86b](https://github.com/endojs/endo/commit/e31c86b407be4804bdaa719da544965ec7cb4480))
-* **ses:** Export SES Transforms ([#608](https://github.com/endojs/endo/issues/608)) ([5ec8858](https://github.com/endojs/endo/commit/5ec8858648254e7cd2a1bf9c054a1d5d2749c31b))
-* **ses:** Prepare to publish with TypeScript definitions ([#384](https://github.com/endojs/endo/issues/384)) ([af48adb](https://github.com/endojs/endo/commit/af48adb5b9e7cf9b5a70f3c429a1219fa99718b6))
-* **ses:** Replace Rollup with Endo bundler ([c826f77](https://github.com/endojs/endo/commit/c826f779660f4e17713b1750c732cc381b7bb89f))
-* **ses:** Retract evaluate name option, use sourceURL ([#521](https://github.com/endojs/endo/issues/521)) ([d1fa7ec](https://github.com/endojs/endo/commit/d1fa7ecd023ca51e4fe75b15780587aabe08c3f9))
-* **ses:** Support global lexicals ([#356](https://github.com/endojs/endo/issues/356)) ([aefefbf](https://github.com/endojs/endo/commit/aefefbfcbe53f5b4520542bfb4da14dd68f13ec6))
-* **ses:** Surface SES on globalThis ([#307](https://github.com/endojs/endo/issues/307)) ([3ddfb95](https://github.com/endojs/endo/commit/3ddfb953098af5c0e127a5e4dbafbed2bea43a07))
-* **ses:** Update packaging for RESM/NESM bridge ([6abbcdc](https://github.com/endojs/endo/commit/6abbcdc847ead40aeedb2004b8317eac06047fc0))
-* create `overrideDebug: [...props]` option ([#728](https://github.com/endojs/endo/issues/728)) ([2573c1a](https://github.com/endojs/endo/commit/2573c1a0e2ebcdad030ae29e75ef4e1bce7e5594))
-* **ses:** Revert "Export SES Transforms ([#608](https://github.com/endojs/endo/issues/608))" ([#618](https://github.com/endojs/endo/issues/618)) ([df5739d](https://github.com/endojs/endo/commit/df5739db9237b5cd037c88001da548a63ecf9071))
-* **ses:** Support explicit exports of third-party modules ([dfa4775](https://github.com/endojs/endo/commit/dfa47754e1c0c12e3717c57eebff020887699678))
-* non-security mode for create-react-scripts compat. (KLUDGE) ([#642](https://github.com/endojs/endo/issues/642)) ([6bd9f03](https://github.com/endojs/endo/commit/6bd9f03ec0c138d79391ee26894e8630cf1a104f))
-* **ses:** Support importHook alias returns ([#432](https://github.com/endojs/endo/issues/432)) ([1c8e706](https://github.com/endojs/endo/commit/1c8e7066c195d212c06a31cd91efb47c2b6a3e76))
-
+- **ses:** Add **shimTransforms** Compartment option ([#485](https://github.com/endojs/endo/issues/485)) ([5196521](https://github.com/endojs/endo/commit/5196521a17ac4b28f9aaaef2aa312eebe9edcbb7))
+- **ses:** Add Compartment load function ([#349](https://github.com/endojs/endo/issues/349)) ([8352fa1](https://github.com/endojs/endo/commit/8352fa1b038ec9f6d21a1ae4b6559f687c27fd81))
+- **ses:** add Compartment shim utility method **isKnownScopeProxy** ([#623](https://github.com/endojs/endo/issues/623)) ([22dbe36](https://github.com/endojs/endo/commit/22dbe368d42b983a9f8b8db3d88003b5400c3e23))
+- **ses:** Add minimal Compartment to SES-lite ([#443](https://github.com/endojs/endo/issues/443)) ([3d1dfd2](https://github.com/endojs/endo/commit/3d1dfd285a758b9be5c1de766c82a12e82329224))
+- **ses:** Add moduleMapHook ([#419](https://github.com/endojs/endo/issues/419)) ([f053ba4](https://github.com/endojs/endo/commit/f053ba4a0ebcb9194a8ffb880359862e3748289c))
+- **ses:** Add ModuleStaticRecord ([#279](https://github.com/endojs/endo/issues/279)) ([98c3a8f](https://github.com/endojs/endo/commit/98c3a8f0696ca1fedb865fd885f0affde388fd01))
+- **ses:** Add news for override mistake fix ([#417](https://github.com/endojs/endo/issues/417)) ([01bf4d7](https://github.com/endojs/endo/commit/01bf4d7ef13b32e71f2d36baef573423b21e012d))
+- **ses:** Add support for third-party modules ([#393](https://github.com/endojs/endo/issues/393)) ([0abe442](https://github.com/endojs/endo/commit/0abe442311bb4555bb06be3796f9ea77e6616b38))
+- **ses:** Add TypeScript definitions for Compartment aux types ([07715ce](https://github.com/endojs/endo/commit/07715cea0c053cf623e9e44e03c0c331c709eb64))
+- **ses:** Allow import and eval methods ([#669](https://github.com/endojs/endo/issues/669)) ([505a7d7](https://github.com/endojs/endo/commit/505a7d7149c36825a00c9fe3795d0f1588035dde))
+- **ses:** Carry compartment names in error messages ([#441](https://github.com/endojs/endo/issues/441)) ([765172a](https://github.com/endojs/endo/commit/765172aa68c338947b14ec6292be18519ac14aee))
+- **ses:** Censorship error messages may now contain the source name ([#515](https://github.com/endojs/endo/issues/515)) ([2bcd726](https://github.com/endojs/endo/commit/2bcd726ee96d53da2467eb15304531d04eb683ed))
+- **ses:** Create a thin lockdown layer ([#406](https://github.com/endojs/endo/issues/406)) ([ff693ae](https://github.com/endojs/endo/commit/ff693ae5e012afdd8dbbec105d0da299d36fdbf9))
+- **ses:** Create ses/lockdown alias ([17d416f](https://github.com/endojs/endo/commit/17d416f1652873c75cbd6c8fd34db37e90300ea6))
+- **ses:** Detect invalid sloppy mode execution ([86c4751](https://github.com/endojs/endo/commit/86c4751abb7f8ce3d44b086e50ab2a5f229e12dc)), closes [#740](https://github.com/endojs/endo/issues/740)
+- **ses:** Expand TypeScript coverage for Compartment and lockdown ([#584](https://github.com/endojs/endo/issues/584)) ([e31c86b](https://github.com/endojs/endo/commit/e31c86b407be4804bdaa719da544965ec7cb4480))
+- **ses:** Export SES Transforms ([#608](https://github.com/endojs/endo/issues/608)) ([5ec8858](https://github.com/endojs/endo/commit/5ec8858648254e7cd2a1bf9c054a1d5d2749c31b))
+- **ses:** Prepare to publish with TypeScript definitions ([#384](https://github.com/endojs/endo/issues/384)) ([af48adb](https://github.com/endojs/endo/commit/af48adb5b9e7cf9b5a70f3c429a1219fa99718b6))
+- **ses:** Replace Rollup with Endo bundler ([c826f77](https://github.com/endojs/endo/commit/c826f779660f4e17713b1750c732cc381b7bb89f))
+- **ses:** Retract evaluate name option, use sourceURL ([#521](https://github.com/endojs/endo/issues/521)) ([d1fa7ec](https://github.com/endojs/endo/commit/d1fa7ecd023ca51e4fe75b15780587aabe08c3f9))
+- **ses:** Support global lexicals ([#356](https://github.com/endojs/endo/issues/356)) ([aefefbf](https://github.com/endojs/endo/commit/aefefbfcbe53f5b4520542bfb4da14dd68f13ec6))
+- **ses:** Surface SES on globalThis ([#307](https://github.com/endojs/endo/issues/307)) ([3ddfb95](https://github.com/endojs/endo/commit/3ddfb953098af5c0e127a5e4dbafbed2bea43a07))
+- **ses:** Update packaging for RESM/NESM bridge ([6abbcdc](https://github.com/endojs/endo/commit/6abbcdc847ead40aeedb2004b8317eac06047fc0))
+- create `overrideDebug: [...props]` option ([#728](https://github.com/endojs/endo/issues/728)) ([2573c1a](https://github.com/endojs/endo/commit/2573c1a0e2ebcdad030ae29e75ef4e1bce7e5594))
+- **ses:** Revert "Export SES Transforms ([#608](https://github.com/endojs/endo/issues/608))" ([#618](https://github.com/endojs/endo/issues/618)) ([df5739d](https://github.com/endojs/endo/commit/df5739db9237b5cd037c88001da548a63ecf9071))
+- **ses:** Support explicit exports of third-party modules ([dfa4775](https://github.com/endojs/endo/commit/dfa47754e1c0c12e3717c57eebff020887699678))
+- non-security mode for create-react-scripts compat. (KLUDGE) ([#642](https://github.com/endojs/endo/issues/642)) ([6bd9f03](https://github.com/endojs/endo/commit/6bd9f03ec0c138d79391ee26894e8630cf1a104f))
+- **ses:** Support importHook alias returns ([#432](https://github.com/endojs/endo/issues/432)) ([1c8e706](https://github.com/endojs/endo/commit/1c8e7066c195d212c06a31cd91efb47c2b6a3e76))
 
 ### Bug Fixes
 
-* Add pre-publish build step ([#263](https://github.com/endojs/endo/issues/263)) ([e22f094](https://github.com/endojs/endo/commit/e22f0945c901296f3f5ca1cbe357172d21f050f9))
-* Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
-* **ses:** Address charset error in integration ([17406d6](https://github.com/endojs/endo/commit/17406d6b045eefc082a17a559efdaf29293b8093))
-* **ses:** Address Parcel need for ESM export ([fb3297e](https://github.com/endojs/endo/commit/fb3297e23236313764a0faeabe87629577370f08))
-* **ses:** Fix intentional typo ([da3b8aa](https://github.com/endojs/endo/commit/da3b8aa85caebc70e424dd9deae0287acb25d89e))
-* **ses:** Handle null moduleMap ([b863922](https://github.com/endojs/endo/commit/b863922f50a993201aec72bc34f91a44cc286654))
-* **ses:** Make dist directory before bundles ([51afb2f](https://github.com/endojs/endo/commit/51afb2fdcf1a9e1f21135988da16a4b618752ca4))
-* **ses:** Remove superfluous dev dependency on @agoric/babel-standalone ([3a278b5](https://github.com/endojs/endo/commit/3a278b51c1938774cd83510ef1b37e1f44bbd34d))
-* **ses:** Validate third-party static module record exports ([9ec51b3](https://github.com/endojs/endo/commit/9ec51b3941b6dbdb3c7e2820753d775fc010d4ec))
-* **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD ([dcff87e](https://github.com/endojs/endo/commit/dcff87e6f1164d664dd31dfefb323fbbac0a8dd1))
-* adapt whitelist to XS. clean it up too ([#549](https://github.com/endojs/endo/issues/549)) ([bd0952a](https://github.com/endojs/endo/commit/bd0952ac6569985b7a3508b257916e262b837606))
-* add "confirm" a terminating variant of "assert" ([8929475](https://github.com/endojs/endo/commit/89294755245b0c558c8cf6423f66a1a48ec7f905))
-* add missing testcase ([#575](https://github.com/endojs/endo/issues/575)) ([f5e1c25](https://github.com/endojs/endo/commit/f5e1c25667e0410488ed7be7684e2cb4cae9d1a6))
-* Add missing ts-checks. Fix type errors ([#565](https://github.com/endojs/endo/issues/565)) ([52e6830](https://github.com/endojs/endo/commit/52e683091ece4c0fa4c77016c517d257d42ec7e8))
-* assert.typeof(xxx, 'object') should assert record or null ([#603](https://github.com/endojs/endo/issues/603)) ([c84ba97](https://github.com/endojs/endo/commit/c84ba971d5fa54fe970cbf33b044b60eaceca78f))
-* blocklist properties we expect to remove ([#614](https://github.com/endojs/endo/issues/614)) ([992f35f](https://github.com/endojs/endo/commit/992f35fdf4679faa8fb7d1c7e265c6b654156399))
-* comment ([#561](https://github.com/endojs/endo/issues/561)) ([5e55d16](https://github.com/endojs/endo/commit/5e55d168e2cb341c22d89954a957582e813fee69))
-* comment who needs push enabled ([#596](https://github.com/endojs/endo/issues/596)) ([1218bcd](https://github.com/endojs/endo/commit/1218bcd1b22b72f285a2236b08639c5016416afc))
-* comments only ([#598](https://github.com/endojs/endo/issues/598)) ([1230901](https://github.com/endojs/endo/commit/1230901717c7eae50aaa0a61a058fd99c1c61928))
-* consolidate honorary native function printing ([#392](https://github.com/endojs/endo/issues/392)) ([038bb13](https://github.com/endojs/endo/commit/038bb13f8bfb56b247875c965393c804a492c463))
-* Consolidate lint rules ([#262](https://github.com/endojs/endo/issues/262)) ([e5ce12a](https://github.com/endojs/endo/commit/e5ce12ac4343565f2adb0e6eca5d71c6c05903bf))
-* coordinate assert typing with agoric-sdk ([#510](https://github.com/endojs/endo/issues/510)) ([195f988](https://github.com/endojs/endo/commit/195f9887119e1a81ca35dd6f445b73241a5e7338))
-* correct fix for override mistake ([#409](https://github.com/endojs/endo/issues/409)) ([b576211](https://github.com/endojs/endo/commit/b5762114ecd227a1c259321ab97fda3837813199))
-* de-url-ify error codes ([#548](https://github.com/endojs/endo/issues/548)) ([b7e2e2c](https://github.com/endojs/endo/commit/b7e2e2cf51fb3ac687168310af7169a8451999f1))
-* eslint rule to suppress bogus dependency warning ([#483](https://github.com/endojs/endo/issues/483)) ([7e3d9ea](https://github.com/endojs/endo/commit/7e3d9ea816e1626566bc2062b83cf513020f0b8d))
-* evaluate options to evade rejections ([#546](https://github.com/endojs/endo/issues/546)) ([dec75ad](https://github.com/endojs/endo/commit/dec75adedf9b19a7fb1c53e17cbaf6e9b31e7d2b))
-* flatten tameFunctionToString ([#482](https://github.com/endojs/endo/issues/482)) ([3d7570f](https://github.com/endojs/endo/commit/3d7570f4aa5871ed75a99d0985d5881ab9ae3af5))
-* friendlier nested console output for browsers ([#557](https://github.com/endojs/endo/issues/557)) ([2c5c622](https://github.com/endojs/endo/commit/2c5c62285516ca8642e39791666bcc5e98adb0a4))
-* Fully thread __shimTransforms__ through Compartment Mapper and SES ([#509](https://github.com/endojs/endo/issues/509)) ([0f199ef](https://github.com/endojs/endo/commit/0f199ef088353ec09b29e37aefcfa26a89a6c582))
-* kill obsolete repair-legacy-accessors ([#552](https://github.com/endojs/endo/issues/552)) ([be202b9](https://github.com/endojs/endo/commit/be202b9861eb770bbae8d16948cede0a1b4f829b))
-* Lint universal package metadata ([#266](https://github.com/endojs/endo/issues/266)) ([24ff867](https://github.com/endojs/endo/commit/24ff867adcbde89bef6b1ec702a0a8b91ad29f70))
-* Massive intrinsic reform. Start vs other compartments. ([#372](https://github.com/endojs/endo/issues/372)) ([5cf2a20](https://github.com/endojs/endo/commit/5cf2a20389601d159b5c0683bb87bffd6bbc7b87))
-* Move NativeErrors list to whitelist.js ([#444](https://github.com/endojs/endo/issues/444)) ([f2b8fcd](https://github.com/endojs/endo/commit/f2b8fcdf5a5f1dcaae1af93d64ebb9785f9b314b))
-* no more detached properties ([#473](https://github.com/endojs/endo/issues/473)) ([efa990c](https://github.com/endojs/endo/commit/efa990cc12ac30aaa69f13df1ee9e1a7f3b12189))
-* partial intrinsic reform ([#358](https://github.com/endojs/endo/issues/358)) ([9b13f73](https://github.com/endojs/endo/commit/9b13f73d282c44c11e93968332f282b5eb4372ff))
-* remove "apply" from enablements whitelist ([#475](https://github.com/endojs/endo/issues/475)) ([b52f8d2](https://github.com/endojs/endo/commit/b52f8d22d380e048e5590ce74028f9a0070cf281))
-* remove "debugger;" statement ([#558](https://github.com/endojs/endo/issues/558)) ([c5988e6](https://github.com/endojs/endo/commit/c5988e6a4cc576634981ba2bc152fe49a0b531f6))
-* remove deprecated noTame options ([#328](https://github.com/endojs/endo/issues/328)) ([5d7b781](https://github.com/endojs/endo/commit/5d7b781d9b0783f7b1243898a36e30014e4662be))
-* remove extra stackframe ([#391](https://github.com/endojs/endo/issues/391)) ([9ba5ecf](https://github.com/endojs/endo/commit/9ba5ecf019694e92ac78d98416e8c88b0e4a2cf4))
-* rename to originalValue ([#476](https://github.com/endojs/endo/issues/476)) ([54e0b0c](https://github.com/endojs/endo/commit/54e0b0c910fd19bec14f9e3ff9e556f17f952fd4))
-* Repair released damage caused when I merged [#552](https://github.com/endojs/endo/issues/552) ([#638](https://github.com/endojs/endo/issues/638)) ([145595c](https://github.com/endojs/endo/commit/145595c5767a6f868c13b9717a03db641e60825b))
-* restore locale methods safely ([#382](https://github.com/endojs/endo/issues/382)) ([0a091a4](https://github.com/endojs/endo/commit/0a091a4fc87ecc9ee6aff227f7245c91d9a88852))
-* suggested fix in [#570](https://github.com/endojs/endo/issues/570) ([#571](https://github.com/endojs/endo/issues/571)) ([3877d72](https://github.com/endojs/endo/commit/3877d72757db120cb3978ddf32a6673868dd06f0))
-* tame Error constructor ([#359](https://github.com/endojs/endo/issues/359)) ([bfe610f](https://github.com/endojs/endo/commit/bfe610fe5fe7afd31659fc8e40ee6e77d622e264))
-* tolerate symbols as property names ([#547](https://github.com/endojs/endo/issues/547)) ([f16bbc3](https://github.com/endojs/endo/commit/f16bbc389303eda73cd6dd1705cd667a3fc6d288))
-* tolerate whitelist absence better ([#408](https://github.com/endojs/endo/issues/408)) ([9ed1ad8](https://github.com/endojs/endo/commit/9ed1ad87ba5380d39c47967fb7e9b52c4a2333e1))
-* towards reconciling with agoric-sdk ([#451](https://github.com/endojs/endo/issues/451)) ([5f71e91](https://github.com/endojs/endo/commit/5f71e91c42e7b6aa2a532372d9bccef53209db46))
-* typo ([#471](https://github.com/endojs/endo/issues/471)) ([d5742c2](https://github.com/endojs/endo/commit/d5742c234c2acf22c10b71f72fdb454fe0c6da8e))
-* typo ([#527](https://github.com/endojs/endo/issues/527)) ([c7a3895](https://github.com/endojs/endo/commit/c7a3895100176e9b6c6e887e45181fd3a1fc2dea))
-* Unsafe errorTaming and consoleTaming needs other adjustments ([#637](https://github.com/endojs/endo/issues/637)) ([70cc86e](https://github.com/endojs/endo/commit/70cc86eb400655e922413b99c38818d7b2e79da0))
-* update to eslint 7.23.0 ([#652](https://github.com/endojs/endo/issues/652)) ([e9199f4](https://github.com/endojs/endo/commit/e9199f41c511b5df10593d931febdd90693b011a))
-* use string instead of symbol for getter property ([e514a6e](https://github.com/endojs/endo/commit/e514a6ed88ccb0739ae1c03a35c1d9d57effe911))
-* workaround remaining validation bug ([#667](https://github.com/endojs/endo/issues/667)) ([cbc3247](https://github.com/endojs/endo/commit/cbc3247bc254e1418a4398d3c1b079e4c69c2750))
-* **326:** accept old and new taming options during transition ([#327](https://github.com/endojs/endo/issues/327)) ([67eb6e8](https://github.com/endojs/endo/commit/67eb6e8704386e022fbb1ff8f01beb40424d6dff))
-* **ses:** Add HandledPromise to the whitelist ([#416](https://github.com/endojs/endo/issues/416)) ([a7330a8](https://github.com/endojs/endo/commit/a7330a8ce1112163982dce35d14ac8ab1ba3749f))
-* **ses:** Aliasing true to t did not improve readability ([#360](https://github.com/endojs/endo/issues/360)) ([90a40c6](https://github.com/endojs/endo/commit/90a40c650214372d070d4c28e2d6e771d0874514))
-* **ses:** comments ([#254](https://github.com/endojs/endo/issues/254)) ([435f1af](https://github.com/endojs/endo/commit/435f1af0b08d8dccf196b385093d629a31316b1c))
-* **ses:** Fix lockdown layer pollution from module layer ([#472](https://github.com/endojs/endo/issues/472)) ([9a7a097](https://github.com/endojs/endo/commit/9a7a0975036d8d938263ba265f747876d7d91599))
-* **ses:** Fix missing change to compartment load method ([42759a8](https://github.com/endojs/endo/commit/42759a8dff3b76c8f06d25904be0a58e72eeed05))
-* **ses:** Generally import "ses/lockdown" ([#410](https://github.com/endojs/endo/issues/410)) ([6ef4a3f](https://github.com/endojs/endo/commit/6ef4a3ffe4ebd0145ca6af0edc8c04c2342e8cac))
-* **ses:** Reform conditional tamings, especially Error ([#250](https://github.com/endojs/endo/issues/250)) ([dfa22b3](https://github.com/endojs/endo/commit/dfa22b3857f08f87f49c6ca4f51aa33fba0b1535))
-* **ses:** regexp taming ([b010f8a](https://github.com/endojs/endo/commit/b010f8a1212aa949be8aa4970eb4ebc25aa83517)), closes [#237](https://github.com/endojs/endo/issues/237)
-* **ses:** remove code that failed to add species ([3cfc8da](https://github.com/endojs/endo/commit/3cfc8da4646aa8306b09189dc0e202db0d633a65)), closes [#239](https://github.com/endojs/endo/issues/239)
-* **ses:** Remove evaluate endowments option ([#368](https://github.com/endojs/endo/issues/368)) ([e7b7b6e](https://github.com/endojs/endo/commit/e7b7b6eb8d2565886f9bbf7021223bcf96dc9173))
-* **ses:** Simplify transforms ([#325](https://github.com/endojs/endo/issues/325)) ([86a373e](https://github.com/endojs/endo/commit/86a373e008e97b2a30c25ee53df86ab120a7804b))
-* **ses:** Spelling errors ([#362](https://github.com/endojs/endo/issues/362)) ([8f606f4](https://github.com/endojs/endo/commit/8f606f424f8b103f9ddb593d210e2e58f37430c4))
-* **ses:** transform is an object with a rewrite method ([#255](https://github.com/endojs/endo/issues/255)) ([979fbc6](https://github.com/endojs/endo/commit/979fbc6fc9529d2b7516c9e99dcd6c1a7f4c1db3)), closes [#248](https://github.com/endojs/endo/issues/248) [#248](https://github.com/endojs/endo/issues/248)
-* **ses:** Unravel compartment/lockdown import cycle ([#405](https://github.com/endojs/endo/issues/405)) ([b931629](https://github.com/endojs/endo/commit/b9316296ac04bd840fb434ee86a819f8717f561d))
-* **ses:** Use CommonJS Rollup plugin ([#354](https://github.com/endojs/endo/issues/354)) ([f626365](https://github.com/endojs/endo/commit/f6263657fe7364df85cfe14e31ba1ac4dd7f03af))
-* **ses, transform-module:** Fix StaticModuleRecord name ([#323](https://github.com/endojs/endo/issues/323)) ([10eb49a](https://github.com/endojs/endo/commit/10eb49ad499984dc44d99e84b5d59a34f1abb73b))
+- Add pre-publish build step ([#263](https://github.com/endojs/endo/issues/263)) ([e22f094](https://github.com/endojs/endo/commit/e22f0945c901296f3f5ca1cbe357172d21f050f9))
+- Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
+- **ses:** Address charset error in integration ([17406d6](https://github.com/endojs/endo/commit/17406d6b045eefc082a17a559efdaf29293b8093))
+- **ses:** Address Parcel need for ESM export ([fb3297e](https://github.com/endojs/endo/commit/fb3297e23236313764a0faeabe87629577370f08))
+- **ses:** Fix intentional typo ([da3b8aa](https://github.com/endojs/endo/commit/da3b8aa85caebc70e424dd9deae0287acb25d89e))
+- **ses:** Handle null moduleMap ([b863922](https://github.com/endojs/endo/commit/b863922f50a993201aec72bc34f91a44cc286654))
+- **ses:** Make dist directory before bundles ([51afb2f](https://github.com/endojs/endo/commit/51afb2fdcf1a9e1f21135988da16a4b618752ca4))
+- **ses:** Remove superfluous dev dependency on @agoric/babel-standalone ([3a278b5](https://github.com/endojs/endo/commit/3a278b51c1938774cd83510ef1b37e1f44bbd34d))
+- **ses:** Validate third-party static module record exports ([9ec51b3](https://github.com/endojs/endo/commit/9ec51b3941b6dbdb3c7e2820753d775fc010d4ec))
+- **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD ([dcff87e](https://github.com/endojs/endo/commit/dcff87e6f1164d664dd31dfefb323fbbac0a8dd1))
+- adapt whitelist to XS. clean it up too ([#549](https://github.com/endojs/endo/issues/549)) ([bd0952a](https://github.com/endojs/endo/commit/bd0952ac6569985b7a3508b257916e262b837606))
+- add "confirm" a terminating variant of "assert" ([8929475](https://github.com/endojs/endo/commit/89294755245b0c558c8cf6423f66a1a48ec7f905))
+- add missing testcase ([#575](https://github.com/endojs/endo/issues/575)) ([f5e1c25](https://github.com/endojs/endo/commit/f5e1c25667e0410488ed7be7684e2cb4cae9d1a6))
+- Add missing ts-checks. Fix type errors ([#565](https://github.com/endojs/endo/issues/565)) ([52e6830](https://github.com/endojs/endo/commit/52e683091ece4c0fa4c77016c517d257d42ec7e8))
+- assert.typeof(xxx, 'object') should assert record or null ([#603](https://github.com/endojs/endo/issues/603)) ([c84ba97](https://github.com/endojs/endo/commit/c84ba971d5fa54fe970cbf33b044b60eaceca78f))
+- blocklist properties we expect to remove ([#614](https://github.com/endojs/endo/issues/614)) ([992f35f](https://github.com/endojs/endo/commit/992f35fdf4679faa8fb7d1c7e265c6b654156399))
+- comment ([#561](https://github.com/endojs/endo/issues/561)) ([5e55d16](https://github.com/endojs/endo/commit/5e55d168e2cb341c22d89954a957582e813fee69))
+- comment who needs push enabled ([#596](https://github.com/endojs/endo/issues/596)) ([1218bcd](https://github.com/endojs/endo/commit/1218bcd1b22b72f285a2236b08639c5016416afc))
+- comments only ([#598](https://github.com/endojs/endo/issues/598)) ([1230901](https://github.com/endojs/endo/commit/1230901717c7eae50aaa0a61a058fd99c1c61928))
+- consolidate honorary native function printing ([#392](https://github.com/endojs/endo/issues/392)) ([038bb13](https://github.com/endojs/endo/commit/038bb13f8bfb56b247875c965393c804a492c463))
+- Consolidate lint rules ([#262](https://github.com/endojs/endo/issues/262)) ([e5ce12a](https://github.com/endojs/endo/commit/e5ce12ac4343565f2adb0e6eca5d71c6c05903bf))
+- coordinate assert typing with agoric-sdk ([#510](https://github.com/endojs/endo/issues/510)) ([195f988](https://github.com/endojs/endo/commit/195f9887119e1a81ca35dd6f445b73241a5e7338))
+- correct fix for override mistake ([#409](https://github.com/endojs/endo/issues/409)) ([b576211](https://github.com/endojs/endo/commit/b5762114ecd227a1c259321ab97fda3837813199))
+- de-url-ify error codes ([#548](https://github.com/endojs/endo/issues/548)) ([b7e2e2c](https://github.com/endojs/endo/commit/b7e2e2cf51fb3ac687168310af7169a8451999f1))
+- eslint rule to suppress bogus dependency warning ([#483](https://github.com/endojs/endo/issues/483)) ([7e3d9ea](https://github.com/endojs/endo/commit/7e3d9ea816e1626566bc2062b83cf513020f0b8d))
+- evaluate options to evade rejections ([#546](https://github.com/endojs/endo/issues/546)) ([dec75ad](https://github.com/endojs/endo/commit/dec75adedf9b19a7fb1c53e17cbaf6e9b31e7d2b))
+- flatten tameFunctionToString ([#482](https://github.com/endojs/endo/issues/482)) ([3d7570f](https://github.com/endojs/endo/commit/3d7570f4aa5871ed75a99d0985d5881ab9ae3af5))
+- friendlier nested console output for browsers ([#557](https://github.com/endojs/endo/issues/557)) ([2c5c622](https://github.com/endojs/endo/commit/2c5c62285516ca8642e39791666bcc5e98adb0a4))
+- Fully thread **shimTransforms** through Compartment Mapper and SES ([#509](https://github.com/endojs/endo/issues/509)) ([0f199ef](https://github.com/endojs/endo/commit/0f199ef088353ec09b29e37aefcfa26a89a6c582))
+- kill obsolete repair-legacy-accessors ([#552](https://github.com/endojs/endo/issues/552)) ([be202b9](https://github.com/endojs/endo/commit/be202b9861eb770bbae8d16948cede0a1b4f829b))
+- Lint universal package metadata ([#266](https://github.com/endojs/endo/issues/266)) ([24ff867](https://github.com/endojs/endo/commit/24ff867adcbde89bef6b1ec702a0a8b91ad29f70))
+- Massive intrinsic reform. Start vs other compartments. ([#372](https://github.com/endojs/endo/issues/372)) ([5cf2a20](https://github.com/endojs/endo/commit/5cf2a20389601d159b5c0683bb87bffd6bbc7b87))
+- Move NativeErrors list to whitelist.js ([#444](https://github.com/endojs/endo/issues/444)) ([f2b8fcd](https://github.com/endojs/endo/commit/f2b8fcdf5a5f1dcaae1af93d64ebb9785f9b314b))
+- no more detached properties ([#473](https://github.com/endojs/endo/issues/473)) ([efa990c](https://github.com/endojs/endo/commit/efa990cc12ac30aaa69f13df1ee9e1a7f3b12189))
+- partial intrinsic reform ([#358](https://github.com/endojs/endo/issues/358)) ([9b13f73](https://github.com/endojs/endo/commit/9b13f73d282c44c11e93968332f282b5eb4372ff))
+- remove "apply" from enablements whitelist ([#475](https://github.com/endojs/endo/issues/475)) ([b52f8d2](https://github.com/endojs/endo/commit/b52f8d22d380e048e5590ce74028f9a0070cf281))
+- remove "debugger;" statement ([#558](https://github.com/endojs/endo/issues/558)) ([c5988e6](https://github.com/endojs/endo/commit/c5988e6a4cc576634981ba2bc152fe49a0b531f6))
+- remove deprecated noTame options ([#328](https://github.com/endojs/endo/issues/328)) ([5d7b781](https://github.com/endojs/endo/commit/5d7b781d9b0783f7b1243898a36e30014e4662be))
+- remove extra stackframe ([#391](https://github.com/endojs/endo/issues/391)) ([9ba5ecf](https://github.com/endojs/endo/commit/9ba5ecf019694e92ac78d98416e8c88b0e4a2cf4))
+- rename to originalValue ([#476](https://github.com/endojs/endo/issues/476)) ([54e0b0c](https://github.com/endojs/endo/commit/54e0b0c910fd19bec14f9e3ff9e556f17f952fd4))
+- Repair released damage caused when I merged [#552](https://github.com/endojs/endo/issues/552) ([#638](https://github.com/endojs/endo/issues/638)) ([145595c](https://github.com/endojs/endo/commit/145595c5767a6f868c13b9717a03db641e60825b))
+- restore locale methods safely ([#382](https://github.com/endojs/endo/issues/382)) ([0a091a4](https://github.com/endojs/endo/commit/0a091a4fc87ecc9ee6aff227f7245c91d9a88852))
+- suggested fix in [#570](https://github.com/endojs/endo/issues/570) ([#571](https://github.com/endojs/endo/issues/571)) ([3877d72](https://github.com/endojs/endo/commit/3877d72757db120cb3978ddf32a6673868dd06f0))
+- tame Error constructor ([#359](https://github.com/endojs/endo/issues/359)) ([bfe610f](https://github.com/endojs/endo/commit/bfe610fe5fe7afd31659fc8e40ee6e77d622e264))
+- tolerate symbols as property names ([#547](https://github.com/endojs/endo/issues/547)) ([f16bbc3](https://github.com/endojs/endo/commit/f16bbc389303eda73cd6dd1705cd667a3fc6d288))
+- tolerate whitelist absence better ([#408](https://github.com/endojs/endo/issues/408)) ([9ed1ad8](https://github.com/endojs/endo/commit/9ed1ad87ba5380d39c47967fb7e9b52c4a2333e1))
+- towards reconciling with agoric-sdk ([#451](https://github.com/endojs/endo/issues/451)) ([5f71e91](https://github.com/endojs/endo/commit/5f71e91c42e7b6aa2a532372d9bccef53209db46))
+- typo ([#471](https://github.com/endojs/endo/issues/471)) ([d5742c2](https://github.com/endojs/endo/commit/d5742c234c2acf22c10b71f72fdb454fe0c6da8e))
+- typo ([#527](https://github.com/endojs/endo/issues/527)) ([c7a3895](https://github.com/endojs/endo/commit/c7a3895100176e9b6c6e887e45181fd3a1fc2dea))
+- Unsafe errorTaming and consoleTaming needs other adjustments ([#637](https://github.com/endojs/endo/issues/637)) ([70cc86e](https://github.com/endojs/endo/commit/70cc86eb400655e922413b99c38818d7b2e79da0))
+- update to eslint 7.23.0 ([#652](https://github.com/endojs/endo/issues/652)) ([e9199f4](https://github.com/endojs/endo/commit/e9199f41c511b5df10593d931febdd90693b011a))
+- use string instead of symbol for getter property ([e514a6e](https://github.com/endojs/endo/commit/e514a6ed88ccb0739ae1c03a35c1d9d57effe911))
+- workaround remaining validation bug ([#667](https://github.com/endojs/endo/issues/667)) ([cbc3247](https://github.com/endojs/endo/commit/cbc3247bc254e1418a4398d3c1b079e4c69c2750))
+- **326:** accept old and new taming options during transition ([#327](https://github.com/endojs/endo/issues/327)) ([67eb6e8](https://github.com/endojs/endo/commit/67eb6e8704386e022fbb1ff8f01beb40424d6dff))
+- **ses:** Add HandledPromise to the whitelist ([#416](https://github.com/endojs/endo/issues/416)) ([a7330a8](https://github.com/endojs/endo/commit/a7330a8ce1112163982dce35d14ac8ab1ba3749f))
+- **ses:** Aliasing true to t did not improve readability ([#360](https://github.com/endojs/endo/issues/360)) ([90a40c6](https://github.com/endojs/endo/commit/90a40c650214372d070d4c28e2d6e771d0874514))
+- **ses:** comments ([#254](https://github.com/endojs/endo/issues/254)) ([435f1af](https://github.com/endojs/endo/commit/435f1af0b08d8dccf196b385093d629a31316b1c))
+- **ses:** Fix lockdown layer pollution from module layer ([#472](https://github.com/endojs/endo/issues/472)) ([9a7a097](https://github.com/endojs/endo/commit/9a7a0975036d8d938263ba265f747876d7d91599))
+- **ses:** Fix missing change to compartment load method ([42759a8](https://github.com/endojs/endo/commit/42759a8dff3b76c8f06d25904be0a58e72eeed05))
+- **ses:** Generally import "ses/lockdown" ([#410](https://github.com/endojs/endo/issues/410)) ([6ef4a3f](https://github.com/endojs/endo/commit/6ef4a3ffe4ebd0145ca6af0edc8c04c2342e8cac))
+- **ses:** Reform conditional tamings, especially Error ([#250](https://github.com/endojs/endo/issues/250)) ([dfa22b3](https://github.com/endojs/endo/commit/dfa22b3857f08f87f49c6ca4f51aa33fba0b1535))
+- **ses:** regexp taming ([b010f8a](https://github.com/endojs/endo/commit/b010f8a1212aa949be8aa4970eb4ebc25aa83517)), closes [#237](https://github.com/endojs/endo/issues/237)
+- **ses:** remove code that failed to add species ([3cfc8da](https://github.com/endojs/endo/commit/3cfc8da4646aa8306b09189dc0e202db0d633a65)), closes [#239](https://github.com/endojs/endo/issues/239)
+- **ses:** Remove evaluate endowments option ([#368](https://github.com/endojs/endo/issues/368)) ([e7b7b6e](https://github.com/endojs/endo/commit/e7b7b6eb8d2565886f9bbf7021223bcf96dc9173))
+- **ses:** Simplify transforms ([#325](https://github.com/endojs/endo/issues/325)) ([86a373e](https://github.com/endojs/endo/commit/86a373e008e97b2a30c25ee53df86ab120a7804b))
+- **ses:** Spelling errors ([#362](https://github.com/endojs/endo/issues/362)) ([8f606f4](https://github.com/endojs/endo/commit/8f606f424f8b103f9ddb593d210e2e58f37430c4))
+- **ses:** transform is an object with a rewrite method ([#255](https://github.com/endojs/endo/issues/255)) ([979fbc6](https://github.com/endojs/endo/commit/979fbc6fc9529d2b7516c9e99dcd6c1a7f4c1db3)), closes [#248](https://github.com/endojs/endo/issues/248) [#248](https://github.com/endojs/endo/issues/248)
+- **ses:** Unravel compartment/lockdown import cycle ([#405](https://github.com/endojs/endo/issues/405)) ([b931629](https://github.com/endojs/endo/commit/b9316296ac04bd840fb434ee86a819f8717f561d))
+- **ses:** Use CommonJS Rollup plugin ([#354](https://github.com/endojs/endo/issues/354)) ([f626365](https://github.com/endojs/endo/commit/f6263657fe7364df85cfe14e31ba1ac4dd7f03af))
+- **ses, transform-module:** Fix StaticModuleRecord name ([#323](https://github.com/endojs/endo/issues/323)) ([10eb49a](https://github.com/endojs/endo/commit/10eb49ad499984dc44d99e84b5d59a34f1abb73b))

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,10 +1,16 @@
 User-visible changes in SES:
 
-# next
+# v0.18.1 (2022-12-23)
 
+- Fixes a bug for SES initialization in a no-unsafe-eval
+  Content-Security-Policy.
 - Fixes a bug where reexport of multiple named exports of the same name was
   causing them to be overridden by the last value. Now named exports are 
   handled in the same manner as `export *`.
+- Allows Compatment `importHook` implementations to return aliases: module
+  descriptors that refer to a module by its specifier in the same or a
+  specified compartment, without providing a static module record (module
+  source).
 
 # v0.18.0 (2022-11-14)
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",
@@ -59,10 +59,10 @@
     "test:platform-compatibility": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.0",
-    "@endo/eslint-config": "^0.5.1",
-    "@endo/static-module-record": "^0.7.15",
-    "@endo/test262-runner": "^0.1.28",
+    "@endo/compartment-mapper": "^0.8.1",
+    "@endo/eslint-config": "^0.5.2",
+    "@endo/static-module-record": "^0.7.16",
+    "@endo/test262-runner": "^0.1.29",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,365 +3,242 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.7.15](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.14...@endo/static-module-record@0.7.15) (2022-11-14)
+### [0.7.16](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.15...@endo/static-module-record@0.7.16) (2022-12-23)
 
+### Features
+
+- **static-module-record:** expose named reexports separately so they can be wired up correctly in upper layers ([4bd09b0](https://github.com/endojs/endo/commit/4bd09b09e2b6ca04b923f261ff87ecb3c876c603))
 
 ### Bug Fixes
 
-* **static-module-record:** Do not mark live binding for non-exported name ([6846226](https://github.com/endojs/endo/commit/6846226552784200146a951b758b334dc442f598))
-* **static-module-record:** error with module url on transform fail ([ee051b0](https://github.com/endojs/endo/commit/ee051b0b5da4c53b4cdebb282aeaf8c6b8c832a0))
-* fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
+- **compartment-mapper:** add named reexports logic to bundle.js ([236a4e8](https://github.com/endojs/endo/commit/236a4e89b6931867a6ea532720560a2f448007ac))
 
+### [0.7.15](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.14...@endo/static-module-record@0.7.15) (2022-11-14)
 
+### Bug Fixes
+
+- **static-module-record:** Do not mark live binding for non-exported name ([6846226](https://github.com/endojs/endo/commit/6846226552784200146a951b758b334dc442f598))
+- **static-module-record:** error with module url on transform fail ([ee051b0](https://github.com/endojs/endo/commit/ee051b0b5da4c53b4cdebb282aeaf8c6b8c832a0))
+- fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
 
 ### [0.7.14](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.13...@endo/static-module-record@0.7.14) (2022-10-24)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.7.13](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.12...@endo/static-module-record@0.7.13) (2022-10-19)
 
 **Note:** Version bump only for package @endo/static-module-record
-
-
-
-
 
 ### [0.7.12](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.11...@endo/static-module-record@0.7.12) (2022-09-27)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.7.11](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.10...@endo/static-module-record@0.7.11) (2022-09-14)
 
 **Note:** Version bump only for package @endo/static-module-record
-
-
-
-
 
 ### [0.7.10](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.9...@endo/static-module-record@0.7.10) (2022-08-26)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.7.9](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.8...@endo/static-module-record@0.7.9) (2022-08-26)
 
 **Note:** Version bump only for package @endo/static-module-record
-
-
-
-
 
 ### [0.7.8](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.7...@endo/static-module-record@0.7.8) (2022-08-25)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.7.7](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.6...@endo/static-module-record@0.7.7) (2022-08-23)
-
 
 ### Bug Fixes
 
-* more hardens ([#1241](https://github.com/endojs/endo/issues/1241)) ([b6ff811](https://github.com/endojs/endo/commit/b6ff8118a92fd72c5309b2bb285fac08d0531d92))
-
-
+- more hardens ([#1241](https://github.com/endojs/endo/issues/1241)) ([b6ff811](https://github.com/endojs/endo/commit/b6ff8118a92fd72c5309b2bb285fac08d0531d92))
 
 ### [0.7.6](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.5...@endo/static-module-record@0.7.6) (2022-06-28)
 
-
 ### Features
 
-* add the foundations for support of import.meta ([36f6449](https://github.com/endojs/endo/commit/36f644998c21f6333268707555b97938ff0fff08))
-* call importMetaHook on instantiation if import.meta uttered by module ([23e8c40](https://github.com/endojs/endo/commit/23e8c405e0be823c728f8af1a6db9607e21f2f74))
-
+- add the foundations for support of import.meta ([36f6449](https://github.com/endojs/endo/commit/36f644998c21f6333268707555b97938ff0fff08))
+- call importMetaHook on instantiation if import.meta uttered by module ([23e8c40](https://github.com/endojs/endo/commit/23e8c405e0be823c728f8af1a6db9607e21f2f74))
 
 ### Bug Fixes
 
-* **compartment-mapper:** importMeta always an empty object in bundler ([e9f809a](https://github.com/endojs/endo/commit/e9f809a0e3242421d9c32388f2bc885eb8d9510e))
-* **static-module-record:** babelPlugin visitor to not skip declarations in exports + benchmark setup ([#1188](https://github.com/endojs/endo/issues/1188)) ([d3a137c](https://github.com/endojs/endo/commit/d3a137c02fa88486ec009413bb004d0baf2c9d5c))
-* rename meta to importMeta, fix detection to detect import.meta not import.meta.something ([c61a862](https://github.com/endojs/endo/commit/c61a862c9f4354f0e6d86d8c8efaa826840a6efd))
-
-
+- **compartment-mapper:** importMeta always an empty object in bundler ([e9f809a](https://github.com/endojs/endo/commit/e9f809a0e3242421d9c32388f2bc885eb8d9510e))
+- **static-module-record:** babelPlugin visitor to not skip declarations in exports + benchmark setup ([#1188](https://github.com/endojs/endo/issues/1188)) ([d3a137c](https://github.com/endojs/endo/commit/d3a137c02fa88486ec009413bb004d0baf2c9d5c))
+- rename meta to importMeta, fix detection to detect import.meta not import.meta.something ([c61a862](https://github.com/endojs/endo/commit/c61a862c9f4354f0e6d86d8c8efaa826840a6efd))
 
 ### [0.7.5](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.4...@endo/static-module-record@0.7.5) (2022-06-11)
 
-
 ### Bug Fixes
 
-* **static-module-record:** Make types consistent with implementation ([#1184](https://github.com/endojs/endo/issues/1184)) ([5b7e3a6](https://github.com/endojs/endo/commit/5b7e3a6d006a686520c4ffeedea5428a720f7e7d))
-
-
+- **static-module-record:** Make types consistent with implementation ([#1184](https://github.com/endojs/endo/issues/1184)) ([5b7e3a6](https://github.com/endojs/endo/commit/5b7e3a6d006a686520c4ffeedea5428a720f7e7d))
 
 ### [0.7.4](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.3...@endo/static-module-record@0.7.4) (2022-04-15)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.7.3](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.2...@endo/static-module-record@0.7.3) (2022-04-14)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.7.2](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.1...@endo/static-module-record@0.7.2) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.7.1](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.0...@endo/static-module-record@0.7.1) (2022-04-12)
 
-
 ### Bug Fixes
 
-* **static-module-record:** use `Object.create(null)` to prevent crashes ([6af1201](https://github.com/endojs/endo/commit/6af1201969319cf17a22b289e920c67a7fce47bd))
-
-
+- **static-module-record:** use `Object.create(null)` to prevent crashes ([6af1201](https://github.com/endojs/endo/commit/6af1201969319cf17a22b289e920c67a7fce47bd))
 
 ## [0.7.0](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.15...@endo/static-module-record@0.7.0) (2022-03-07)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **static-module-record:** remove dependencies on `@babel/standalone`
+- **static-module-record:** remove dependencies on `@babel/standalone`
 
 ### Bug Fixes
 
-* **static-module-record:** remove dependencies on `@babel/standalone` ([1a1d1a4](https://github.com/endojs/endo/commit/1a1d1a4f5a7094f32d3e1edfc620e64065771efa))
-
-
+- **static-module-record:** remove dependencies on `@babel/standalone` ([1a1d1a4](https://github.com/endojs/endo/commit/1a1d1a4f5a7094f32d3e1edfc620e64065771efa))
 
 ### [0.6.15](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.14...@endo/static-module-record@0.6.15) (2022-03-02)
 
-
 ### Features
 
-* **bundle-source:** use newer babel with Agoric fixes ([e68f794](https://github.com/endojs/endo/commit/e68f794a182182d8e64bce2829dd90b4d9e4d947))
-
-
+- **bundle-source:** use newer babel with Agoric fixes ([e68f794](https://github.com/endojs/endo/commit/e68f794a182182d8e64bce2829dd90b4d9e4d947))
 
 ### [0.6.14](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.13...@endo/static-module-record@0.6.14) (2022-02-20)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.6.13](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.12...@endo/static-module-record@0.6.13) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### Reverts
 
-* Revert "Revert "fix(static-module-record): minimise source changes with `recast`"" ([ce53158](https://github.com/endojs/endo/commit/ce5315849ffcb71794f3264871b371eb5ae6d00c))
-
-
+- Revert "Revert "fix(static-module-record): minimise source changes with `recast`"" ([ce53158](https://github.com/endojs/endo/commit/ce5315849ffcb71794f3264871b371eb5ae6d00c))
 
 ### [0.6.12](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.11...@endo/static-module-record@0.6.12) (2022-01-31)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.6.11](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.10...@endo/static-module-record@0.6.11) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.6.10](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.9...@endo/static-module-record@0.6.10) (2022-01-25)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.6.9](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.8...@endo/static-module-record@0.6.9) (2022-01-23)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.6.8](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.7...@endo/static-module-record@0.6.8) (2021-12-14)
-
 
 ### Bug Fixes
 
-* **static-module-record:** Account for unlocated nodes in displayAsExport ([d8770d1](https://github.com/endojs/endo/commit/d8770d1dceacd6298ed0b228b9552fc6cf8ba07b))
-
+- **static-module-record:** Account for unlocated nodes in displayAsExport ([d8770d1](https://github.com/endojs/endo/commit/d8770d1dceacd6298ed0b228b9552fc6cf8ba07b))
 
 ### Reverts
 
-* Revert "build(deps): add a patched version of `recast`" ([1d800ef](https://github.com/endojs/endo/commit/1d800ef6bba28b575bb38f44c9e8f85de7246997))
-* Revert "fix(static-module-record): minimise source changes with `recast`" ([9c76633](https://github.com/endojs/endo/commit/9c7663388576ab93d9f4a3b7fb55d3e20c4e9b45))
-
-
+- Revert "build(deps): add a patched version of `recast`" ([1d800ef](https://github.com/endojs/endo/commit/1d800ef6bba28b575bb38f44c9e8f85de7246997))
+- Revert "fix(static-module-record): minimise source changes with `recast`" ([9c76633](https://github.com/endojs/endo/commit/9c7663388576ab93d9f4a3b7fb55d3e20c4e9b45))
 
 ### [0.6.7](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.6...@endo/static-module-record@0.6.7) (2021-12-08)
 
-
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-* **static-module-record:** cleaner Babel codegen ([6e22569](https://github.com/endojs/endo/commit/6e22569b0c3f56e9f78d59943235b97ba0429921))
-* **static-module-record:** minimise source changes with `recast` ([ce464ff](https://github.com/endojs/endo/commit/ce464ffddc9fbee27ab167b5cb06e0c788ae31e7))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
+- **static-module-record:** cleaner Babel codegen ([6e22569](https://github.com/endojs/endo/commit/6e22569b0c3f56e9f78d59943235b97ba0429921))
+- **static-module-record:** minimise source changes with `recast` ([ce464ff](https://github.com/endojs/endo/commit/ce464ffddc9fbee27ab167b5cb06e0c788ae31e7))
 
 ### [0.6.6](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.5...@endo/static-module-record@0.6.6) (2021-11-16)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.6.5](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.4...@endo/static-module-record@0.6.5) (2021-11-02)
 
 **Note:** Version bump only for package @endo/static-module-record
-
-
-
-
 
 ### [0.6.4](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.3...@endo/static-module-record@0.6.4) (2021-10-15)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.6.3](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.2...@endo/static-module-record@0.6.3) (2021-09-18)
-
 
 ### Bug Fixes
 
-* **static-module-record:** Opt out of compact codegen ([d113270](https://github.com/endojs/endo/commit/d1132708fb4204b99c4646b3788d6e0b3e81dc9d))
-
-
+- **static-module-record:** Opt out of compact codegen ([d113270](https://github.com/endojs/endo/commit/d1132708fb4204b99c4646b3788d6e0b3e81dc9d))
 
 ### [0.6.2](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.1...@endo/static-module-record@0.6.2) (2021-08-14)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.6.1](https://github.com/endojs/endo/compare/@endo/static-module-record@0.6.0...@endo/static-module-record@0.6.1) (2021-08-13)
-
 
 ### Bug Fixes
 
-* **static-module-record:** Do not duplicate comments ([#863](https://github.com/endojs/endo/issues/863)) ([85136e3](https://github.com/endojs/endo/commit/85136e314ecbe238a82e86c47be1757ef2887dd2))
-
-
+- **static-module-record:** Do not duplicate comments ([#863](https://github.com/endojs/endo/issues/863)) ([85136e3](https://github.com/endojs/endo/commit/85136e314ecbe238a82e86c47be1757ef2887dd2))
 
 ## [0.6.0](https://github.com/endojs/endo/compare/@endo/static-module-record@0.5.4...@endo/static-module-record@0.6.0) (2021-07-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Update preamble for SES StaticModuleRecord
-* **static-module-record:** Remove reliance on Map in scope of preamble
+- Update preamble for SES StaticModuleRecord
+- **static-module-record:** Remove reliance on Map in scope of preamble
 
 ### Bug Fixes
 
-* Update preamble for SES StaticModuleRecord ([790ed01](https://github.com/endojs/endo/commit/790ed01f0aa73ff2d232e69c9323ee0bb448c2b0))
-* **static-module-record:** Remove reliance on Map in scope of preamble ([4b4aa65](https://github.com/endojs/endo/commit/4b4aa65a039ea5297970c9d2ac3c0a3827a4f3f8))
-
-
+- Update preamble for SES StaticModuleRecord ([790ed01](https://github.com/endojs/endo/commit/790ed01f0aa73ff2d232e69c9323ee0bb448c2b0))
+- **static-module-record:** Remove reliance on Map in scope of preamble ([4b4aa65](https://github.com/endojs/endo/commit/4b4aa65a039ea5297970c9d2ac3c0a3827a4f3f8))
 
 ### [0.5.4](https://github.com/endojs/endo/compare/@endo/static-module-record@0.5.3...@endo/static-module-record@0.5.4) (2021-06-20)
 
-
 ### Bug Fixes
 
-* **static-module-record:** Propagate explicit types ([a625ca4](https://github.com/endojs/endo/commit/a625ca4cb3642bc4923becdef62224bde6738aca))
-
-
+- **static-module-record:** Propagate explicit types ([a625ca4](https://github.com/endojs/endo/commit/a625ca4cb3642bc4923becdef62224bde6738aca))
 
 ### [0.5.3](https://github.com/endojs/endo/compare/@endo/static-module-record@0.5.2...@endo/static-module-record@0.5.3) (2021-06-16)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ### [0.5.2](https://github.com/endojs/endo/compare/@endo/static-module-record@0.5.1...@endo/static-module-record@0.5.2) (2021-06-14)
 
 **Note:** Version bump only for package @endo/static-module-record
-
-
-
-
 
 ### [0.5.1](https://github.com/endojs/endo/compare/@endo/static-module-record@0.5.0...@endo/static-module-record@0.5.1) (2021-06-06)
 
 **Note:** Version bump only for package @endo/static-module-record
 
-
-
-
-
 ## 0.5.0 (2021-06-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **static-module-record:** No longer supports direct use from CommonJS
-* **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD
+- **static-module-record:** No longer supports direct use from CommonJS
+- **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD
 
 ### Features
 
-* **static-module-record:** Make source location argument optional ([c8ada3e](https://github.com/endojs/endo/commit/c8ada3e70c2f71386c32eb1151133ad3c9c841c9))
-* **static-module-record:** Update packaging for RESM/NESM bridge ([fe5059d](https://github.com/endojs/endo/commit/fe5059d3cc866b0f65f9395fbc0ad00cb610044b))
-
+- **static-module-record:** Make source location argument optional ([c8ada3e](https://github.com/endojs/endo/commit/c8ada3e70c2f71386c32eb1151133ad3c9c841c9))
+- **static-module-record:** Update packaging for RESM/NESM bridge ([fe5059d](https://github.com/endojs/endo/commit/fe5059d3cc866b0f65f9395fbc0ad00cb610044b))
 
 ### Bug Fixes
 
-* Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
-* **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD ([dcff87e](https://github.com/endojs/endo/commit/dcff87e6f1164d664dd31dfefb323fbbac0a8dd1))
-* **static-module-record:** Fix export name as ([2f13a08](https://github.com/endojs/endo/commit/2f13a084df5b24ae53ca574b91b97cca3f8c664c))
-* **static-module-record:** Fix RESM/NESM babel import compatibility ([59c6d6f](https://github.com/endojs/endo/commit/59c6d6f03f7b6abea7ea656a566b60056333017c))
-* **static-module-record:** Fix treatment of local vs exported names in test scaffold ([5422e4f](https://github.com/endojs/endo/commit/5422e4f35590136b28b516af0515e580f2290445))
-* **static-module-record:** make exported unassigned functions fixed ([96d26cc](https://github.com/endojs/endo/commit/96d26ccff62c238acd03c87d6e04e9e5304dc943))
-* **static-module-record:** preserve function hoisting when export defaulted ([11fe4b2](https://github.com/endojs/endo/commit/11fe4b25778fd79c8395d88a6f91f050ffcc786d))
+- Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
+- **static-module-record:** Emphasize RESM/NESM compatibility over CJS/UMD ([dcff87e](https://github.com/endojs/endo/commit/dcff87e6f1164d664dd31dfefb323fbbac0a8dd1))
+- **static-module-record:** Fix export name as ([2f13a08](https://github.com/endojs/endo/commit/2f13a084df5b24ae53ca574b91b97cca3f8c664c))
+- **static-module-record:** Fix RESM/NESM babel import compatibility ([59c6d6f](https://github.com/endojs/endo/commit/59c6d6f03f7b6abea7ea656a566b60056333017c))
+- **static-module-record:** Fix treatment of local vs exported names in test scaffold ([5422e4f](https://github.com/endojs/endo/commit/5422e4f35590136b28b516af0515e580f2290445))
+- **static-module-record:** make exported unassigned functions fixed ([96d26cc](https://github.com/endojs/endo/commit/96d26ccff62c238acd03c87d6e04e9e5304dc943))
+- **static-module-record:** preserve function hoisting when export defaulted ([11fe4b2](https://github.com/endojs/endo/commit/11fe4b25778fd79c8395d88a6f91f050ffcc786d))

--- a/packages/static-module-record/NEWS.md
+++ b/packages/static-module-record/NEWS.md
@@ -1,6 +1,7 @@
 User-visible changes in Static Module Record, née Transform Module:
 
-# next
+# 0.7.16 (2022-12-23)
+
 - Introduces `__reexportsMap__` to `StaticModuleRecord` instance to differentiate
   individual named reexports from local exports to enable correct handling of
   their names in SES.

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -39,12 +39,12 @@
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
     "@babel/types": "^7.17.0",
-    "ses": "^0.18.0"
+    "ses": "^0.18.1"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.1",
-    "@endo/eslint-config": "^0.5.1",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/eslint-config": "^0.5.2",
+    "@endo/ses-ava": "^0.2.37",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "benchmark": "^2.1.4",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,202 +3,124 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.22](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.21...@endo/stream-node@0.2.22) (2022-11-14)
+### [0.2.23](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.22...@endo/stream-node@0.2.23) (2022-12-23)
 
+**Note:** Version bump only for package @endo/stream-node
+
+### [0.2.22](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.21...@endo/stream-node@0.2.22) (2022-11-14)
 
 ### Bug Fixes
 
-* assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
-* fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
-
-
+- assert touchups ([#1350](https://github.com/endojs/endo/issues/1350)) ([3fcb5b1](https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4))
+- fail template ([#1334](https://github.com/endojs/endo/issues/1334)) ([725b987](https://github.com/endojs/endo/commit/725b987ffa812a070ff45fcd496cf8fd88df6963))
 
 ### [0.2.21](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.20...@endo/stream-node@0.2.21) (2022-10-24)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.19...@endo/stream-node@0.2.20) (2022-10-19)
 
 **Note:** Version bump only for package @endo/stream-node
-
-
-
-
 
 ### [0.2.19](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.18...@endo/stream-node@0.2.19) (2022-09-27)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.18](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.17...@endo/stream-node@0.2.18) (2022-09-14)
-
 
 ### Bug Fixes
 
-* alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
-* **stream-node:** next always returns IteratorResult ([8af9508](https://github.com/endojs/endo/commit/8af95089897465c4ffbc75045e31aec6fd60cd97))
-
-
+- alt syntax for positive but faster assertions ([#1280](https://github.com/endojs/endo/issues/1280)) ([dc24f2f](https://github.com/endojs/endo/commit/dc24f2f2c3cac7ce239a64c503493c41a2334315))
+- **stream-node:** next always returns IteratorResult ([8af9508](https://github.com/endojs/endo/commit/8af95089897465c4ffbc75045e31aec6fd60cd97))
 
 ### [0.2.17](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.16...@endo/stream-node@0.2.17) (2022-08-26)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.16](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.15...@endo/stream-node@0.2.16) (2022-08-26)
 
 **Note:** Version bump only for package @endo/stream-node
-
-
-
-
 
 ### [0.2.15](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.14...@endo/stream-node@0.2.15) (2022-08-25)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.14](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.13...@endo/stream-node@0.2.14) (2022-08-23)
-
 
 ### Bug Fixes
 
-* **stream-node:** avoid finalize leak ([ec4d8fc](https://github.com/endojs/endo/commit/ec4d8fc933e691fa6c80d43a0ac859f4db1113d7))
-
-
+- **stream-node:** avoid finalize leak ([ec4d8fc](https://github.com/endojs/endo/commit/ec4d8fc933e691fa6c80d43a0ac859f4db1113d7))
 
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.12...@endo/stream-node@0.2.13) (2022-06-28)
 
-
 ### Bug Fixes
 
-* tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
-
-
+- tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
 
 ### [0.2.12](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.11...@endo/stream-node@0.2.12) (2022-06-11)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.10...@endo/stream-node@0.2.11) (2022-04-15)
 
 **Note:** Version bump only for package @endo/stream-node
-
-
-
-
 
 ### [0.2.10](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.9...@endo/stream-node@0.2.10) (2022-04-14)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.8...@endo/stream-node@0.2.9) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.7...@endo/stream-node@0.2.8) (2022-04-12)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.6...@endo/stream-node@0.2.7) (2022-03-07)
 
 **Note:** Version bump only for package @endo/stream-node
-
-
-
-
 
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.5...@endo/stream-node@0.2.6) (2022-03-02)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.4...@endo/stream-node@0.2.5) (2022-02-20)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.3...@endo/stream-node@0.2.4) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.2...@endo/stream-node@0.2.3) (2022-01-31)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.1...@endo/stream-node@0.2.2) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.0...@endo/stream-node@0.2.1) (2022-01-25)
 
 **Note:** Version bump only for package @endo/stream-node
 
-
-
-
-
 ## 0.2.0 (2022-01-23)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **stream:** Use eventual send
+- **stream:** Use eventual send
 
 ### Features
 
-* **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
-* **stream-node:** Add Node.js stream adapters ([834c439](https://github.com/endojs/endo/commit/834c43915e5e80b1c96c2642e4cf01398fd9441d))
+- **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
+- **stream-node:** Add Node.js stream adapters ([834c439](https://github.com/endojs/endo/commit/834c43915e5e80b1c96c2642e4cf01398fd9441d))

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",
@@ -38,13 +38,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.52",
-    "@endo/stream": "^0.3.21",
-    "ses": "^0.18.0"
+    "@endo/init": "^0.5.53",
+    "@endo/stream": "^0.3.22",
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/eslint-config": "^0.5.2",
+    "@endo/ses-ava": "^0.2.37",
     "@typescript-eslint/parser": "^5.27.0",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,194 +3,110 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.1.33](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.32...@endo/stream-types-test@0.1.33) (2022-11-14)
+### [0.1.34](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.33...@endo/stream-types-test@0.1.34) (2022-12-23)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
+### [0.1.33](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.32...@endo/stream-types-test@0.1.33) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/stream-types-test
 
 ### [0.1.32](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.31...@endo/stream-types-test@0.1.32) (2022-10-24)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.31](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.30...@endo/stream-types-test@0.1.31) (2022-10-19)
 
 **Note:** Version bump only for package @endo/stream-types-test
-
-
-
-
 
 ### [0.1.30](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.29...@endo/stream-types-test@0.1.30) (2022-09-27)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.29](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.28...@endo/stream-types-test@0.1.29) (2022-09-14)
 
 **Note:** Version bump only for package @endo/stream-types-test
-
-
-
-
 
 ### [0.1.28](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.27...@endo/stream-types-test@0.1.28) (2022-08-26)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.27](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.26...@endo/stream-types-test@0.1.27) (2022-08-26)
 
 **Note:** Version bump only for package @endo/stream-types-test
-
-
-
-
 
 ### [0.1.26](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.25...@endo/stream-types-test@0.1.26) (2022-08-25)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.25](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.24...@endo/stream-types-test@0.1.25) (2022-08-23)
 
 **Note:** Version bump only for package @endo/stream-types-test
-
-
-
-
 
 ### [0.1.24](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.23...@endo/stream-types-test@0.1.24) (2022-06-28)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.23](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.22...@endo/stream-types-test@0.1.23) (2022-06-11)
 
 **Note:** Version bump only for package @endo/stream-types-test
-
-
-
-
 
 ### [0.1.22](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.21...@endo/stream-types-test@0.1.22) (2022-04-15)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.21](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.20...@endo/stream-types-test@0.1.21) (2022-04-14)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.20](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.19...@endo/stream-types-test@0.1.20) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.1.19](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.18...@endo/stream-types-test@0.1.19) (2022-04-12)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.18](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.17...@endo/stream-types-test@0.1.18) (2022-03-07)
 
 **Note:** Version bump only for package @endo/stream-types-test
-
-
-
-
 
 ### [0.1.17](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.16...@endo/stream-types-test@0.1.17) (2022-03-02)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.16](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.15...@endo/stream-types-test@0.1.16) (2022-02-20)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.15](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.14...@endo/stream-types-test@0.1.15) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.1.14](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.13...@endo/stream-types-test@0.1.14) (2022-01-31)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### [0.1.13](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.12...@endo/stream-types-test@0.1.13) (2022-01-27)
 
 **Note:** Version bump only for package @endo/stream-types-test
-
-
-
-
 
 ### [0.1.12](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.11...@endo/stream-types-test@0.1.12) (2022-01-25)
 
 **Note:** Version bump only for package @endo/stream-types-test
 
-
-
-
-
 ### 0.1.11 (2022-01-23)
-
 
 ### Features
 
-* **stream:** Add mapReader and mapWriter ([c05c2d4](https://github.com/endojs/endo/commit/c05c2d4d5077e303fe54b1b5a5e0a54a8c432795))
-* **stream:** Add pump and prime ([b555147](https://github.com/endojs/endo/commit/b555147ea727eee68f9f08b00912be306f8d8e2a))
-
+- **stream:** Add mapReader and mapWriter ([c05c2d4](https://github.com/endojs/endo/commit/c05c2d4d5077e303fe54b1b5a5e0a54a8c432795))
+- **stream:** Add pump and prime ([b555147](https://github.com/endojs/endo/commit/b555147ea727eee68f9f08b00912be306f8d8e2a))
 
 ### Bug Fixes
 
-* **stream:** Default types to undefined ([eba45b6](https://github.com/endojs/endo/commit/eba45b6db4538f84ba86a60f7be5bd940a007f7e))
+- **stream:** Default types to undefined ([eba45b6](https://github.com/endojs/endo/commit/eba45b6db4538f84ba86a60f7be5bd940a007f7e))

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],
@@ -25,11 +25,11 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "@endo/stream": "^0.3.21",
-    "ses": "^0.18.0"
+    "@endo/stream": "^0.3.22",
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,208 +3,127 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.3.21](https://github.com/endojs/endo/compare/@endo/stream@0.3.20...@endo/stream@0.3.21) (2022-11-14)
+### [0.3.22](https://github.com/endojs/endo/compare/@endo/stream@0.3.21...@endo/stream@0.3.22) (2022-12-23)
 
 **Note:** Version bump only for package @endo/stream
 
+### [0.3.21](https://github.com/endojs/endo/compare/@endo/stream@0.3.20...@endo/stream@0.3.21) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/stream
 
 ### [0.3.20](https://github.com/endojs/endo/compare/@endo/stream@0.3.19...@endo/stream@0.3.20) (2022-10-24)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.19](https://github.com/endojs/endo/compare/@endo/stream@0.3.18...@endo/stream@0.3.19) (2022-10-19)
 
 **Note:** Version bump only for package @endo/stream
-
-
-
-
 
 ### [0.3.18](https://github.com/endojs/endo/compare/@endo/stream@0.3.17...@endo/stream@0.3.18) (2022-09-27)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.17](https://github.com/endojs/endo/compare/@endo/stream@0.3.16...@endo/stream@0.3.17) (2022-09-14)
 
 **Note:** Version bump only for package @endo/stream
-
-
-
-
 
 ### [0.3.16](https://github.com/endojs/endo/compare/@endo/stream@0.3.15...@endo/stream@0.3.16) (2022-08-26)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.15](https://github.com/endojs/endo/compare/@endo/stream@0.3.14...@endo/stream@0.3.15) (2022-08-26)
 
 **Note:** Version bump only for package @endo/stream
-
-
-
-
 
 ### [0.3.14](https://github.com/endojs/endo/compare/@endo/stream@0.3.13...@endo/stream@0.3.14) (2022-08-25)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.13](https://github.com/endojs/endo/compare/@endo/stream@0.3.12...@endo/stream@0.3.13) (2022-08-23)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.12](https://github.com/endojs/endo/compare/@endo/stream@0.3.11...@endo/stream@0.3.12) (2022-06-28)
-
 
 ### Bug Fixes
 
-* tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
-
-
+- tests use debug settings ([#1213](https://github.com/endojs/endo/issues/1213)) ([c92e02a](https://github.com/endojs/endo/commit/c92e02aa70c2687abdf4c8fd8dd661e221c0e9fe))
 
 ### [0.3.11](https://github.com/endojs/endo/compare/@endo/stream@0.3.10...@endo/stream@0.3.11) (2022-06-11)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.10](https://github.com/endojs/endo/compare/@endo/stream@0.3.9...@endo/stream@0.3.10) (2022-04-15)
 
 **Note:** Version bump only for package @endo/stream
-
-
-
-
 
 ### [0.3.9](https://github.com/endojs/endo/compare/@endo/stream@0.3.8...@endo/stream@0.3.9) (2022-04-14)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.8](https://github.com/endojs/endo/compare/@endo/stream@0.3.7...@endo/stream@0.3.8) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.3.7](https://github.com/endojs/endo/compare/@endo/stream@0.3.6...@endo/stream@0.3.7) (2022-04-12)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.6](https://github.com/endojs/endo/compare/@endo/stream@0.3.5...@endo/stream@0.3.6) (2022-03-07)
 
 **Note:** Version bump only for package @endo/stream
-
-
-
-
 
 ### [0.3.5](https://github.com/endojs/endo/compare/@endo/stream@0.3.4...@endo/stream@0.3.5) (2022-03-02)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.4](https://github.com/endojs/endo/compare/@endo/stream@0.3.3...@endo/stream@0.3.4) (2022-02-20)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.3](https://github.com/endojs/endo/compare/@endo/stream@0.3.2...@endo/stream@0.3.3) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.3.2](https://github.com/endojs/endo/compare/@endo/stream@0.3.1...@endo/stream@0.3.2) (2022-01-31)
 
 **Note:** Version bump only for package @endo/stream
 
-
-
-
-
 ### [0.3.1](https://github.com/endojs/endo/compare/@endo/stream@0.3.0...@endo/stream@0.3.1) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ## [0.3.0](https://github.com/endojs/endo/compare/@endo/stream@0.2.0...@endo/stream@0.3.0) (2022-01-25)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **eslint-config:** Check all files, especially TypeScript
+- **eslint-config:** Check all files, especially TypeScript
 
 ### Styles
 
-* **eslint-config:** Check all files, especially TypeScript ([2424343](https://github.com/endojs/endo/commit/242434364b464bd666a8117d116b20ad70396838))
-
-
+- **eslint-config:** Check all files, especially TypeScript ([2424343](https://github.com/endojs/endo/commit/242434364b464bd666a8117d116b20ad70396838))
 
 ## 0.2.0 (2022-01-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **stream:** Use eventual send
+- **stream:** Use eventual send
 
 ### Features
 
-* **stream:** Add mapReader and mapWriter ([c05c2d4](https://github.com/endojs/endo/commit/c05c2d4d5077e303fe54b1b5a5e0a54a8c432795))
-* **stream:** Add pump and prime ([b555147](https://github.com/endojs/endo/commit/b555147ea727eee68f9f08b00912be306f8d8e2a))
-* **stream:** Add stream library ([cc684d8](https://github.com/endojs/endo/commit/cc684d89898ef0abe00511c897865f605b7ddeb3))
-* **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
-
+- **stream:** Add mapReader and mapWriter ([c05c2d4](https://github.com/endojs/endo/commit/c05c2d4d5077e303fe54b1b5a5e0a54a8c432795))
+- **stream:** Add pump and prime ([b555147](https://github.com/endojs/endo/commit/b555147ea727eee68f9f08b00912be306f8d8e2a))
+- **stream:** Add stream library ([cc684d8](https://github.com/endojs/endo/commit/cc684d89898ef0abe00511c897865f605b7ddeb3))
+- **stream:** Use eventual send ([1aafa86](https://github.com/endojs/endo/commit/1aafa86e7de1f0e05e3b2a065a8d06a4c7f2add1))
 
 ### Bug Fixes
 
-* **stream:** Default types to undefined ([eba45b6](https://github.com/endojs/endo/commit/eba45b6db4538f84ba86a60f7be5bd940a007f7e))
+- **stream:** Default types to undefined ([eba45b6](https://github.com/endojs/endo/commit/eba45b6db4538f84ba86a60f7be5bd940a007f7e))

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",
@@ -38,14 +38,14 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.16.8",
-    "@endo/promise-kit": "^0.2.52",
-    "ses": "^0.18.0"
+    "@endo/eventual-send": "^0.16.9",
+    "@endo/promise-kit": "^0.2.53",
+    "ses": "^0.18.1"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
-    "@endo/init": "^0.5.52",
-    "@endo/ses-ava": "^0.2.36",
+    "@endo/eslint-config": "^0.5.2",
+    "@endo/init": "^0.5.53",
+    "@endo/ses-ava": "^0.2.37",
     "@typescript-eslint/parser": "^5.27.0",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,251 +3,145 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.1.28](https://github.com/endojs/endo/compare/@endo/syrup@0.1.27...@endo/syrup@0.1.28) (2022-11-14)
+### [0.1.29](https://github.com/endojs/endo/compare/@endo/syrup@0.1.28...@endo/syrup@0.1.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/syrup
 
+### [0.1.28](https://github.com/endojs/endo/compare/@endo/syrup@0.1.27...@endo/syrup@0.1.28) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/syrup
 
 ### [0.1.27](https://github.com/endojs/endo/compare/@endo/syrup@0.1.26...@endo/syrup@0.1.27) (2022-06-28)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.26](https://github.com/endojs/endo/compare/@endo/syrup@0.1.25...@endo/syrup@0.1.26) (2022-06-11)
 
 **Note:** Version bump only for package @endo/syrup
-
-
-
-
 
 ### [0.1.25](https://github.com/endojs/endo/compare/@endo/syrup@0.1.24...@endo/syrup@0.1.25) (2022-04-15)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.24](https://github.com/endojs/endo/compare/@endo/syrup@0.1.23...@endo/syrup@0.1.24) (2022-04-14)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.23](https://github.com/endojs/endo/compare/@endo/syrup@0.1.22...@endo/syrup@0.1.23) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.1.22](https://github.com/endojs/endo/compare/@endo/syrup@0.1.21...@endo/syrup@0.1.22) (2022-04-12)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.21](https://github.com/endojs/endo/compare/@endo/syrup@0.1.20...@endo/syrup@0.1.21) (2022-03-07)
 
 **Note:** Version bump only for package @endo/syrup
-
-
-
-
 
 ### [0.1.20](https://github.com/endojs/endo/compare/@endo/syrup@0.1.19...@endo/syrup@0.1.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.19](https://github.com/endojs/endo/compare/@endo/syrup@0.1.18...@endo/syrup@0.1.19) (2022-02-20)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.18](https://github.com/endojs/endo/compare/@endo/syrup@0.1.17...@endo/syrup@0.1.18) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.1.17](https://github.com/endojs/endo/compare/@endo/syrup@0.1.16...@endo/syrup@0.1.17) (2022-01-31)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.16](https://github.com/endojs/endo/compare/@endo/syrup@0.1.15...@endo/syrup@0.1.16) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.1.15](https://github.com/endojs/endo/compare/@endo/syrup@0.1.14...@endo/syrup@0.1.15) (2022-01-25)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.14](https://github.com/endojs/endo/compare/@endo/syrup@0.1.13...@endo/syrup@0.1.14) (2022-01-23)
 
 **Note:** Version bump only for package @endo/syrup
-
-
-
-
 
 ### [0.1.13](https://github.com/endojs/endo/compare/@endo/syrup@0.1.12...@endo/syrup@0.1.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.12](https://github.com/endojs/endo/compare/@endo/syrup@0.1.11...@endo/syrup@0.1.12) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
 
 ### [0.1.11](https://github.com/endojs/endo/compare/@endo/syrup@0.1.10...@endo/syrup@0.1.11) (2021-11-16)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/syrup@0.1.9...@endo/syrup@0.1.10) (2021-11-02)
 
 **Note:** Version bump only for package @endo/syrup
-
-
-
-
 
 ### [0.1.9](https://github.com/endojs/endo/compare/@endo/syrup@0.1.8...@endo/syrup@0.1.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.8](https://github.com/endojs/endo/compare/@endo/syrup@0.1.7...@endo/syrup@0.1.8) (2021-09-18)
 
 **Note:** Version bump only for package @endo/syrup
-
-
-
-
 
 ### [0.1.7](https://github.com/endojs/endo/compare/@endo/syrup@0.1.6...@endo/syrup@0.1.7) (2021-08-14)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.6](https://github.com/endojs/endo/compare/@endo/syrup@0.1.5...@endo/syrup@0.1.6) (2021-08-13)
 
 **Note:** Version bump only for package @endo/syrup
-
-
-
-
 
 ### [0.1.5](https://github.com/endojs/endo/compare/@endo/syrup@0.1.4...@endo/syrup@0.1.5) (2021-07-22)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.4](https://github.com/endojs/endo/compare/@endo/syrup@0.1.3...@endo/syrup@0.1.4) (2021-06-20)
 
 **Note:** Version bump only for package @endo/syrup
-
-
-
-
 
 ### [0.1.3](https://github.com/endojs/endo/compare/@endo/syrup@0.1.2...@endo/syrup@0.1.3) (2021-06-16)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ### [0.1.2](https://github.com/endojs/endo/compare/@endo/syrup@0.1.1...@endo/syrup@0.1.2) (2021-06-14)
 
 **Note:** Version bump only for package @endo/syrup
-
-
-
-
 
 ### [0.1.1](https://github.com/endojs/endo/compare/@endo/syrup@0.1.0...@endo/syrup@0.1.1) (2021-06-06)
 
 **Note:** Version bump only for package @endo/syrup
 
-
-
-
-
 ## 0.1.0 (2021-06-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **syrup:** No longer supports direct use from CommonJS
+- **syrup:** No longer supports direct use from CommonJS
 
 ### Features
 
-* **syrup:** Introduce minimum viable codec ([#684](https://github.com/endojs/endo/issues/684)) ([cb19ddc](https://github.com/endojs/endo/commit/cb19ddcaae9074742181250976fdf408dd18062b))
-* **syrup:** Update packaging for RESM/NESM bridge ([6fe01b9](https://github.com/endojs/endo/commit/6fe01b9173be6e03c597bf011bc96480101af1e9))
-
+- **syrup:** Introduce minimum viable codec ([#684](https://github.com/endojs/endo/issues/684)) ([cb19ddc](https://github.com/endojs/endo/commit/cb19ddcaae9074742181250976fdf408dd18062b))
+- **syrup:** Update packaging for RESM/NESM bridge ([6fe01b9](https://github.com/endojs/endo/commit/6fe01b9173be6e03c597bf011bc96480101af1e9))
 
 ### Bug Fixes
 
-* **syrup:** Attempt to tease lerna into granting 0.1.0 initial revision ([f83ea37](https://github.com/endojs/endo/commit/f83ea37f9cb7685dbb10d2df39ee8b110c485fba))
-* **syrup:** Mark package private ([3519db3](https://github.com/endojs/endo/commit/3519db3e9c761e3b4132cf11e6711292847ce5c4))
+- **syrup:** Attempt to tease lerna into granting 0.1.0 initial revision ([f83ea37](https://github.com/endojs/endo/commit/f83ea37f9cb7685dbb10d2df39ee8b110c485fba))
+- **syrup:** Mark package private ([3519db3](https://github.com/endojs/endo/commit/3519db3e9c761e3b4132cf11e6711292847ce5c4))

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,229 +3,126 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.1.28](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.27...@endo/test262-runner@0.1.28) (2022-06-28)
+### [0.1.29](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.28...@endo/test262-runner@0.1.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/test262-runner
 
+### [0.1.28](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.27...@endo/test262-runner@0.1.28) (2022-06-28)
 
-
-
+**Note:** Version bump only for package @endo/test262-runner
 
 ### [0.1.27](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.26...@endo/test262-runner@0.1.27) (2022-06-11)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.26](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.25...@endo/test262-runner@0.1.26) (2022-04-15)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.25](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.24...@endo/test262-runner@0.1.25) (2022-04-14)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.24](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.23...@endo/test262-runner@0.1.24) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.1.23](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.22...@endo/test262-runner@0.1.23) (2022-04-12)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.22](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.21...@endo/test262-runner@0.1.22) (2022-03-07)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.21](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.20...@endo/test262-runner@0.1.21) (2022-03-02)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.20](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.19...@endo/test262-runner@0.1.20) (2022-02-20)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.19](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.18...@endo/test262-runner@0.1.19) (2022-02-18)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.18](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.17...@endo/test262-runner@0.1.18) (2022-01-31)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.17](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.16...@endo/test262-runner@0.1.17) (2022-01-27)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.16](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.15...@endo/test262-runner@0.1.16) (2022-01-25)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.15](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.14...@endo/test262-runner@0.1.15) (2022-01-23)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.14](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.13...@endo/test262-runner@0.1.14) (2021-12-14)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.13](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.12...@endo/test262-runner@0.1.13) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-* Rewrite erroneous changelog repository references ([ab52b93](https://github.com/endojs/endo/commit/ab52b93db31d74be8c2407b719a54e0896ed6b70))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
+- Rewrite erroneous changelog repository references ([ab52b93](https://github.com/endojs/endo/commit/ab52b93db31d74be8c2407b719a54e0896ed6b70))
 
 ### [0.1.12](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.11...@endo/test262-runner@0.1.12) (2021-11-16)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.11](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.10...@endo/test262-runner@0.1.11) (2021-11-02)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.10](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.9...@endo/test262-runner@0.1.10) (2021-10-15)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.9](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.8...@endo/test262-runner@0.1.9) (2021-09-18)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.8](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.7...@endo/test262-runner@0.1.8) (2021-08-14)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.7](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.6...@endo/test262-runner@0.1.7) (2021-08-13)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.6](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.5...@endo/test262-runner@0.1.6) (2021-07-22)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.5](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.4...@endo/test262-runner@0.1.5) (2021-06-20)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.4](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.3...@endo/test262-runner@0.1.4) (2021-06-16)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### [0.1.3](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.2...@endo/test262-runner@0.1.3) (2021-06-14)
 
 **Note:** Version bump only for package @endo/test262-runner
-
-
-
-
 
 ### [0.1.2](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.1...@endo/test262-runner@0.1.2) (2021-06-06)
 
 **Note:** Version bump only for package @endo/test262-runner
 
-
-
-
-
 ### 0.1.1 (2021-06-02)
-
 
 ### Bug Fixes
 
-* Consolidate lint rules ([#262](https://github.com/endojs/endo/issues/262)) ([e5ce12a](https://github.com/endojs/endo/commit/e5ce12ac4343565f2adb0e6eca5d71c6c05903bf))
-* Lint universal package metadata ([#266](https://github.com/endojs/endo/issues/266)) ([24ff867](https://github.com/endojs/endo/commit/24ff867adcbde89bef6b1ec702a0a8b91ad29f70))
+- Consolidate lint rules ([#262](https://github.com/endojs/endo/issues/262)) ([e5ce12a](https://github.com/endojs/endo/commit/e5ce12ac4343565f2adb0e6eca5d71c6c05903bf))
+- Lint universal package metadata ([#266](https://github.com/endojs/endo/issues/266)) ([24ff867](https://github.com/endojs/endo/commit/24ff867adcbde89bef6b1ec702a0a8b91ad29f70))

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "description": "Test262 Runner",
   "author": "Agoric",
@@ -17,7 +17,7 @@
     "test262-parser": "^2.2.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "sinon": "8.0.4"
   },
   "ava": {

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,135 +3,84 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.10](https://github.com/endojs/endo/compare/@endo/where@0.2.9...@endo/where@0.2.10) (2022-11-14)
+### [0.2.11](https://github.com/endojs/endo/compare/@endo/where@0.2.10...@endo/where@0.2.11) (2022-12-23)
 
 **Note:** Version bump only for package @endo/where
 
+### [0.2.10](https://github.com/endojs/endo/compare/@endo/where@0.2.9...@endo/where@0.2.10) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/where
 
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/where@0.2.8...@endo/where@0.2.9) (2022-06-28)
 
 **Note:** Version bump only for package @endo/where
 
-
-
-
-
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/where@0.2.7...@endo/where@0.2.8) (2022-06-11)
 
 **Note:** Version bump only for package @endo/where
-
-
-
-
 
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/where@0.2.6...@endo/where@0.2.7) (2022-04-15)
 
 **Note:** Version bump only for package @endo/where
 
-
-
-
-
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/where@0.2.5...@endo/where@0.2.6) (2022-04-14)
 
 **Note:** Version bump only for package @endo/where
 
-
-
-
-
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/where@0.2.4...@endo/where@0.2.5) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/where@0.2.3...@endo/where@0.2.4) (2022-04-12)
 
 **Note:** Version bump only for package @endo/where
 
-
-
-
-
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/where@0.2.2...@endo/where@0.2.3) (2022-03-07)
 
 **Note:** Version bump only for package @endo/where
-
-
-
-
 
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/where@0.2.1...@endo/where@0.2.2) (2022-03-02)
 
 **Note:** Version bump only for package @endo/where
 
-
-
-
-
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/where@0.2.0...@endo/where@0.2.1) (2022-02-20)
 
 **Note:** Version bump only for package @endo/where
 
-
-
-
-
 ## [0.2.0](https://github.com/endojs/endo/compare/@endo/where@0.1.4...@endo/where@0.2.0) (2022-02-18)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **where:** Renames to state, cache, sock
+- **where:** Renames to state, cache, sock
 
 ### Bug Fixes
 
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### Code Refactoring
 
-* **where:** Renames to state, cache, sock ([a742765](https://github.com/endojs/endo/commit/a742765eb9ef6e7bfd178ce7ded7fa96300fe7f8))
-
-
+- **where:** Renames to state, cache, sock ([a742765](https://github.com/endojs/endo/commit/a742765eb9ef6e7bfd178ce7ded7fa96300fe7f8))
 
 ### [0.1.4](https://github.com/endojs/endo/compare/@endo/where@0.1.3...@endo/where@0.1.4) (2022-01-31)
 
 **Note:** Version bump only for package @endo/where
 
-
-
-
-
 ### [0.1.3](https://github.com/endojs/endo/compare/@endo/where@0.1.2...@endo/where@0.1.3) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.1.2](https://github.com/endojs/endo/compare/@endo/where@0.1.1...@endo/where@0.1.2) (2022-01-25)
 
 **Note:** Version bump only for package @endo/where
 
-
-
-
-
 ### 0.1.1 (2022-01-23)
-
 
 ### Features
 
-* **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))
+- **endo:** Initial implementation of daemon, cli, where ([91f0ba3](https://github.com/endojs/endo/commit/91f0ba33201ae00624c84fe8cc99e7928ac44fdf))

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": null,
   "description": "Description forthcoming.",
   "keywords": [],
@@ -34,7 +34,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,251 +3,145 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.28](https://github.com/endojs/endo/compare/@endo/zip@0.2.27...@endo/zip@0.2.28) (2022-11-14)
+### [0.2.29](https://github.com/endojs/endo/compare/@endo/zip@0.2.28...@endo/zip@0.2.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/zip
 
+### [0.2.28](https://github.com/endojs/endo/compare/@endo/zip@0.2.27...@endo/zip@0.2.28) (2022-11-14)
 
-
-
+**Note:** Version bump only for package @endo/zip
 
 ### [0.2.27](https://github.com/endojs/endo/compare/@endo/zip@0.2.26...@endo/zip@0.2.27) (2022-06-28)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.26](https://github.com/endojs/endo/compare/@endo/zip@0.2.25...@endo/zip@0.2.26) (2022-06-11)
 
 **Note:** Version bump only for package @endo/zip
-
-
-
-
 
 ### [0.2.25](https://github.com/endojs/endo/compare/@endo/zip@0.2.24...@endo/zip@0.2.25) (2022-04-15)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.24](https://github.com/endojs/endo/compare/@endo/zip@0.2.23...@endo/zip@0.2.24) (2022-04-14)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/zip@0.2.22...@endo/zip@0.2.23) (2022-04-13)
-
 
 ### Bug Fixes
 
-* Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
-
-
+- Revert dud release ([c8a7101](https://github.com/endojs/endo/commit/c8a71017d8d7af10a97909c9da9c5c7e59aed939))
 
 ### [0.2.22](https://github.com/endojs/endo/compare/@endo/zip@0.2.21...@endo/zip@0.2.22) (2022-04-12)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.21](https://github.com/endojs/endo/compare/@endo/zip@0.2.20...@endo/zip@0.2.21) (2022-03-07)
 
 **Note:** Version bump only for package @endo/zip
-
-
-
-
 
 ### [0.2.20](https://github.com/endojs/endo/compare/@endo/zip@0.2.19...@endo/zip@0.2.20) (2022-03-02)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.19](https://github.com/endojs/endo/compare/@endo/zip@0.2.18...@endo/zip@0.2.19) (2022-02-20)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.18](https://github.com/endojs/endo/compare/@endo/zip@0.2.17...@endo/zip@0.2.18) (2022-02-18)
-
 
 ### Bug Fixes
 
-* Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
-* Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
-* Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
-* Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
-* Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
-
-
+- Address TypeScript recommendations ([2d1e1e0](https://github.com/endojs/endo/commit/2d1e1e0bdd385a514315be908c33b8f8eb157295))
+- Make jsconfigs less brittle ([861ca32](https://github.com/endojs/endo/commit/861ca32a72f0a48410fd93b1cbaaad9139590659))
+- Type definitions canot overshadow ([4d193fd](https://github.com/endojs/endo/commit/4d193fd3387dadd6f55fd51ad872f10878ef46f9))
+- Make sure lint:type runs correctly in CI ([a520419](https://github.com/endojs/endo/commit/a52041931e72cb7b7e3e21dde39c099cc9f262b0))
+- Unify TS version to ~4.2 ([5fb173c](https://github.com/endojs/endo/commit/5fb173c05c9427dca5adfe66298c004780e8b86c))
 
 ### [0.2.17](https://github.com/endojs/endo/compare/@endo/zip@0.2.16...@endo/zip@0.2.17) (2022-01-31)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.16](https://github.com/endojs/endo/compare/@endo/zip@0.2.15...@endo/zip@0.2.16) (2022-01-27)
-
 
 ### Bug Fixes
 
-* Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
-
-
+- Publish all materials consistently ([#1021](https://github.com/endojs/endo/issues/1021)) ([a2c74d9](https://github.com/endojs/endo/commit/a2c74d9de68a325761d62e1b2187a117ef884571))
 
 ### [0.2.15](https://github.com/endojs/endo/compare/@endo/zip@0.2.14...@endo/zip@0.2.15) (2022-01-25)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.14](https://github.com/endojs/endo/compare/@endo/zip@0.2.13...@endo/zip@0.2.14) (2022-01-23)
 
 **Note:** Version bump only for package @endo/zip
-
-
-
-
 
 ### [0.2.13](https://github.com/endojs/endo/compare/@endo/zip@0.2.12...@endo/zip@0.2.13) (2021-12-14)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.12](https://github.com/endojs/endo/compare/@endo/zip@0.2.11...@endo/zip@0.2.12) (2021-12-08)
-
 
 ### Bug Fixes
 
-* Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
-
-
+- Avoid eslint globs for Windows ([4b4f3cc](https://github.com/endojs/endo/commit/4b4f3ccaf3f5e8d53faefb4264db343dd603bf80))
 
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/zip@0.2.10...@endo/zip@0.2.11) (2021-11-16)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.10](https://github.com/endojs/endo/compare/@endo/zip@0.2.9...@endo/zip@0.2.10) (2021-11-02)
 
 **Note:** Version bump only for package @endo/zip
-
-
-
-
 
 ### [0.2.9](https://github.com/endojs/endo/compare/@endo/zip@0.2.8...@endo/zip@0.2.9) (2021-10-15)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.8](https://github.com/endojs/endo/compare/@endo/zip@0.2.7...@endo/zip@0.2.8) (2021-09-18)
 
 **Note:** Version bump only for package @endo/zip
-
-
-
-
 
 ### [0.2.7](https://github.com/endojs/endo/compare/@endo/zip@0.2.6...@endo/zip@0.2.7) (2021-08-14)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.6](https://github.com/endojs/endo/compare/@endo/zip@0.2.5...@endo/zip@0.2.6) (2021-08-13)
 
 **Note:** Version bump only for package @endo/zip
-
-
-
-
 
 ### [0.2.5](https://github.com/endojs/endo/compare/@endo/zip@0.2.4...@endo/zip@0.2.5) (2021-07-22)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.4](https://github.com/endojs/endo/compare/@endo/zip@0.2.3...@endo/zip@0.2.4) (2021-06-20)
 
 **Note:** Version bump only for package @endo/zip
-
-
-
-
 
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/zip@0.2.2...@endo/zip@0.2.3) (2021-06-16)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/zip@0.2.1...@endo/zip@0.2.2) (2021-06-14)
 
 **Note:** Version bump only for package @endo/zip
-
-
-
-
 
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/zip@0.2.0...@endo/zip@0.2.1) (2021-06-06)
 
 **Note:** Version bump only for package @endo/zip
 
-
-
-
-
 ## 0.2.0 (2021-06-02)
-
 
 ### ⚠ BREAKING CHANGES
 
-* **zip:** No longer supports direct use from CommonJS
+- **zip:** No longer supports direct use from CommonJS
 
 ### Features
 
-* **zip:** Update packaging for NESM/RESM bridge ([b3ad00b](https://github.com/endojs/endo/commit/b3ad00b5a07357f778a7978b257603c6aaddaca2))
-
+- **zip:** Update packaging for NESM/RESM bridge ([b3ad00b](https://github.com/endojs/endo/commit/b3ad00b5a07357f778a7978b257603c6aaddaca2))
 
 ### Bug Fixes
 
-* Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
-* **zip:** Tolerate XS null terminated string limitation ([e997530](https://github.com/endojs/endo/commit/e99753088332508e056b6f5065141fb44185ad2a))
+- Regularize format of NEWS.md ([0ec29b3](https://github.com/endojs/endo/commit/0ec29b34a18b17cc6b90e5a46575e634714e978e))
+- **zip:** Tolerate XS null terminated string limitation ([e997530](https://github.com/endojs/endo/commit/e99753088332508e056b6f5065141fb44185ad2a))

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",
@@ -35,7 +35,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.1",
+    "@endo/eslint-config": "^0.5.2",
     "ava": "^5.1.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",


### PR DESCRIPTION
- Bugfix from external contributor @Jack-Works that unbreaks MetaMask's
  Browserify-style bundles in a no-unsafe-eval Content Security Policy.
- @kumavis and @naugtur Improved Node.js and Browserify ecosystem
  compatibility to cover more of the behaviors of the `browser` field in
  `package.json`, which required work on SES Compartments to enable import hooks
  to effect module aliases, reflective imports (module imports self by own package name),
  a fix for differentiating module languages based on their extension.
  They also added CommonJS support to Endo's Compartment Mapper bootstrapping bundle
  format.
- @erights Eventual send now reflects prototype inheritance.
- @gibson042 Paid off some refactoring debt in marshalling.
- @kriskowal Endo Daemon now has debugging commands, `log`, `log -f`, and `ping`.
- @kriskowal Fix marshalling bug, such that serialization errors get
  communicated up the promise resolution chain.
- @turadg Upgraded Ava from version 3 to 5.
- @turadg Updated Prettier to 2.8 and addressed style changes.
- @turadg Made progress on homogenizing our approach to publishing TypeScript types.
- External contributor @smotaal upgrades Lerna to version 5.
- @erights Performance refactor for assertions, using Fail tag
- @kriskowal The SES bundle now uses a more hardened generated internal linkage runtime.