### PR TITLE
Endo support for unsafe Node.js plugins

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -407,6 +407,34 @@ export const main = async rawArgs => {
       }
     });
 
+  program
+    .command('import-unsafe0 <worker> <path>')
+    .option(
+      '-n,--name <name>',
+      'Assigns a name to the result for future reference, persisted between restarts',
+    )
+    .action(async (worker, importPath, cmd) => {
+      const { name: resultPetName } = cmd.opts();
+      const { getBootstrap } = await provideEndoClient(
+        'cli',
+        sockPath,
+        cancelled,
+      );
+      try {
+        const bootstrap = getBootstrap();
+        const workerRef = E(bootstrap).provide(worker);
+
+        const result = await E(workerRef).importUnsafe0(
+          path.resolve(importPath),
+          resultPetName,
+        );
+        console.log(result);
+      } catch (error) {
+        console.error(error);
+        cancel(error);
+      }
+    });
+
   // Throw an error instead of exiting directly.
   program.exitOverride();
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -298,6 +298,18 @@ const makeEndoBootstrap = (
         // eslint-disable-next-line no-use-before-define
         return makeRef(ref, resultName);
       },
+
+      importUnsafe0: async (importPath, resultName) => {
+        const ref = {
+          /** @type {'importUnsafe0'} */
+          type: 'importUnsafe0',
+          workerUuid,
+          importPath,
+        };
+        // Behold, recursion:
+        // eslint-disable-next-line no-use-before-define
+        return makeRef(ref, resultName);
+      },
     });
 
     workerBootstraps.set(worker, workerBootstrap);
@@ -337,6 +349,17 @@ const makeEndoBootstrap = (
       Object.values(refs).map(ref => provideRef(ref)),
     );
     return E(workerBootstrap).evaluate(source, codeNames, endowmentValues);
+  };
+
+  /**
+   * @param {string} workerUuid
+   * @param {string} importPath
+   */
+  const provideImportUnsafe0 = async (workerUuid, importPath) => {
+    const workerFacet = await provideWorkerUuid(workerUuid);
+    const workerBootstrap = workerBootstraps.get(workerFacet);
+    assert(workerBootstrap);
+    return E(workerBootstrap).importUnsafe0(importPath);
   };
 
   /**
@@ -387,6 +410,8 @@ const makeEndoBootstrap = (
       return provideValueUuid(ref.valueUuid);
     } else if (ref.type === 'eval') {
       return provideEval(ref.workerUuid, ref.source, ref.refs);
+    } else if (ref.type === 'importUnsafe0') {
+      return provideImportUnsafe0(ref.workerUuid, ref.importPath);
     } else {
       throw new TypeError(`Invalid reference: ${JSON.stringify(ref)}`);
     }

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -56,6 +56,7 @@ export type DaemonicPowers = {
 
 export type MignonicPowers = {
   exitOnError: (error) => void;
+  pathToFileURL: (path: string) => string;
   connection: {
     reader: Reader<Uint8Array>;
     writer: Writer<Uint8Array>;
@@ -87,4 +88,15 @@ type EvalRef = {
   refs: Record<string, Ref>;
 };
 
-export type Ref = ReadableSha512Ref | WorkerUuidRef | ValueUuid | EvalRef;
+type ImportUnsafe0Ref = {
+  type: 'importUnsafe0';
+  workerUuid: string;
+  importPath: string;
+};
+
+export type Ref =
+  | ReadableSha512Ref
+  | WorkerUuidRef
+  | ValueUuid
+  | EvalRef
+  | ImportUnsafe0Ref;

--- a/packages/daemon/src/worker-node-powers.js
+++ b/packages/daemon/src/worker-node-powers.js
@@ -6,9 +6,10 @@ import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
 /**
  * @param {object} modules
  * @param {typeof import('fs')} modules.fs
+ * @param {typeof import('url')} modules.url
  * @returns {import('./types.js').MignonicPowers}
  */
-export const makePowers = ({ fs }) => {
+export const makePowers = ({ fs, url }) => {
   /** @param {Error} error */
   const exitOnError = error => {
     console.error(error);
@@ -25,8 +26,11 @@ export const makePowers = ({ fs }) => {
     writer,
   };
 
+  const { pathToFileURL } = url;
+
   return harden({
     exitOnError,
     connection,
+    pathToFileURL: path => pathToFileURL(path).toString(),
   });
 };

--- a/packages/daemon/src/worker-node.js
+++ b/packages/daemon/src/worker-node.js
@@ -7,6 +7,7 @@ import '@endo/promise-kit/shim.js';
 import '@endo/lockdown/commit.js';
 
 import fs from 'fs';
+import url from 'url';
 
 import { makePromiseKit } from '@endo/promise-kit';
 import { main } from './worker.js';
@@ -31,7 +32,7 @@ const locator = {
   cachePath,
 };
 
-const powers = makePowers({ fs });
+const powers = makePowers({ fs, url });
 
 const { promise: cancelled, reject: cancel } =
   /** @type {import('@endo/promise-kit').PromiseKit<never>} */ (


### PR DESCRIPTION
This change introduces a new type of sturdy reference builder/rebuilder to the Endo Daemon. Workers currently can only evaluate compartmentalized code in the presence of specified endowments. With this change, workers can now load arbitrary Node.js plugins using the `export const main0 = powers => exo` calling convention. If given a pet name, these services will be restored on demand after an Endo restart or system reboot.

This is a prelude to a future `import-bundle` command that will have the same calling convention but only operate on confined applications.