### PR TITLE
test: expect `SyntaxError` instance only instead of "Unexpected token…" message

### DIFF
--- a/packages/marshal/test/test-marshal-stringify.js
+++ b/packages/marshal/test/test-marshal-stringify.js
@@ -56,7 +56,7 @@ test('marshal parse errors', t => {
     message: /Marshal's parse must not encode any slot positions .*/,
   });
   t.throws(() => parse('X'), {
-    message: /Unexpected token X in JSON at position 0*/,
+    instanceOf: SyntaxError,
   });
   t.throws(() => parse('{"@qclass":8}'), {
     message: /invalid "@qclass" typeof "number"*/,

--- a/packages/ses/test/test-tame-function-unit.js
+++ b/packages/ses/test/test-tame-function-unit.js
@@ -25,7 +25,7 @@ test('AsyncFunction.constructor', t => {
     const proto = Object.getPrototypeOf((0, eval)('(async function() {})'));
     t.throws(() => proto.constructor(''), { instanceOf: TypeError });
   } catch (e) {
-    if (e instanceof SyntaxError && e.message.startsWith('Unexpected token')) {
+    if (e instanceof SyntaxError) {
       t.pass('not supported');
     } else {
       throw e;
@@ -41,7 +41,7 @@ test('GeneratorFunction.constructor', t => {
     const proto = Object.getPrototypeOf((0, eval)('(function* () {})'));
     t.throws(() => proto.constructor(''), { instanceOf: TypeError });
   } catch (e) {
-    if (e instanceof SyntaxError && e.message.startsWith('Unexpected token')) {
+    if (e instanceof SyntaxError) {
       t.pass('not supported');
     } else {
       throw e;
@@ -57,7 +57,7 @@ test('AsyncGeneratorFunction.constructor', t => {
     const proto = Object.getPrototypeOf((0, eval)('(async function* () {})'));
     t.throws(() => proto.constructor(''), { instanceOf: TypeError });
   } catch (e) {
-    if (e instanceof SyntaxError && e.message.startsWith('Unexpected token')) {
+    if (e instanceof SyntaxError) {
       t.pass('not supported');
     } else {
       throw e;


### PR DESCRIPTION
Addresses: #1414

The ECMAScript spec explicitly states the types of error to be expected in the cases of [`JSON.parse`](https://tc39.es/ecma262/#sec-json.parse) and [`eval`](https://tc39.es/ecma262/#sec-performeval) leaving the message itself at the discretion of implementers.

As such, this PR removes assertions for the `message` string from across this repository, some of which fail today in newer Node.js versions tracking with https://github.com/v8/v8/commit/718f743750135b3a3e643655a0406a90bf4bf010.

Co-Authored-By: @michaelfig