### PR TITLE
feat(daemon): Persist worker endowments

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -367,6 +367,64 @@ export const main = async rawArgs => {
     }
   });
 
+  program.command('inbox').action(async () => {
+    const { getBootstrap } = await provideEndoClient(
+      'cli',
+      sockPath,
+      cancelled,
+    );
+    try {
+      const bootstrap = getBootstrap();
+      const iterable = await E(bootstrap).inbox();
+      const iterator = await E(iterable)[Symbol.asyncIterator]();
+      for await (const { number, who, what } of makeRefIterator(iterator)) {
+        // TODO ensure the description is ASCII.
+        console.log(`${number}. ${who}: ${what}`);
+      }
+    } catch (error) {
+      console.error(error);
+      cancel(error);
+    }
+  });
+
+  program
+    .command('resolve <request-number> <resolution-name>')
+    .action(async (requestNumberText, resolutionName) => {
+      // TODO less bad number parsing.
+      const requestNumber = Number(requestNumberText);
+      const { getBootstrap } = await provideEndoClient(
+        'cli',
+        sockPath,
+        cancelled,
+      );
+      try {
+        const bootstrap = getBootstrap();
+        await E(bootstrap).resolve(requestNumber, resolutionName);
+      } catch (error) {
+        console.error(error);
+        cancel(error);
+      }
+    });
+
+  program
+    .command('reject <request-number> [message]')
+    .action(async (requestNumberText, message) => {
+      // TODO less bad number parsing.
+      const requestNumber = Number(requestNumberText);
+      const { getBootstrap } = await provideEndoClient(
+        'cli',
+        sockPath,
+        cancelled,
+      );
+      try {
+        const bootstrap = getBootstrap();
+        await E(bootstrap).reject(requestNumber, message);
+      } catch (error) {
+        console.error(error);
+        cancel(error);
+      }
+    });
+
   program
     .command('eval <worker> <source> [names...]')
     .option(

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -100,3 +100,17 @@ export type Ref =
   | ValueUuid
   | EvalRef
   | ImportUnsafe0Ref;
+
+export type Label = {
+  number: number;
+  who: string;
+  what: string;
+  when: string;
+};
+
+export type Request = {
+  type: 'request';
+  settled: Promise<void>;
+};
+
+export type Message = Label & Request;


### PR DESCRIPTION
This change introduces a `request` function to the worker power box. The `request` function takes a string description of the object the worker needs and an optional pet name for the response, such that future requests for the same pet name will get the same object, or a new capability will be constructed if the worker restarts. The user will only be interrogated for the first grant of a persisted endowment.

This allows the user to restart the Endo daemon with a minimum of ceremony, only loosing ephemeral state, and allows services to largely but not completely interact with their neighbors through ephemeral message passing.

Currently, the power box is only available to “unsafe import” services, but the same object will be provided to confined programs from bundles or archives.

To validate at home, the following script Works on My Machine™:

```
$ endo reset
$ endo spawn worker
$ cat service

import { E, Far } from '@endo/far';

export const main0 = powers => {
  return Far('Service', {
    answer() {
      return E(powers).request('the meaning of life, the universe, everything', 'answer');
    }
  });
};

$ endo import-unsafe0 worker service.js -n service
Object [Alleged: Service] {}
$ endo eval worker 'E(service).answer()' service -n answer
```

The last command hangs, waiting for the user to resolve or reject the request.

Meanwhile, in another terminal, the user can get a list of pending requests.

```
$ endo inbox
0. @worker: the meaning of life, the universe, everything
```

Then they can resolve the request with another pet-named value.

```
$ endo eval worker 42 -n fortyTwo
42
$ endo resolve 0 fortyTwo
```

At this time, the previous terminal resumes, printing `42`.  Restarting Endo exits the daemon, the worker, and consequently throws away all closure state.  But, the Daemon will replay all the necessary steps above to reconstruct the value for the pet name `answer`.

```
$ endo restart
$ endo show answer
42
```

This produces the following Endo state tree:

```
Endo
Endo/endo.log
Endo/worker-uuid
Endo/worker-uuid/9e1e7f21-2486-4f3a-840e-e91c0fc5718f
Endo/worker-uuid/9e1e7f21-2486-4f3a-840e-e91c0fc5718f/worker.log
Endo/worker-uuid/9e1e7f21-2486-4f3a-840e-e91c0fc5718f/pet-name
Endo/worker-uuid/9e1e7f21-2486-4f3a-840e-e91c0fc5718f/pet-name/answer.json
Endo/value-uuid
Endo/value-uuid/39df2498-6772-4a65-af0e-3d85f4bb34ac.json
Endo/value-uuid/782249f2-e44b-40f9-99a6-16e4236da6f2.json
Endo/value-uuid/abee4e2e-a90c-479d-9991-24f89fdc3cc3.json
Endo/captp0.sock
Endo/pet-name
Endo/pet-name/service.json
Endo/pet-name/worker.json
Endo/pet-name/answer.json
Endo/pet-name/fortyTwo.json
```