### PR TITLE
feat: Comment links error code errors to explanation

### DIFF
--- a/packages/ses/index.js
+++ b/packages/ses/index.js
@@ -26,6 +26,7 @@ function getThis() {
 }
 
 if (getThis()) {
+  // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_NO_SLOPPY.md
   throw new TypeError(`SES failed to initialize, sloppy mode (SES_NO_SLOPPY)`);
 }
 

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -97,6 +97,7 @@ export const defineProperty = (object, prop, descriptor) => {
   // Instead, to workaround the Safari bug
   const result = originalDefineProperty(object, prop, descriptor);
   if (result !== object) {
+    // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_DEFINE_PROPERTY_FAILED_SILENTLY.md
     throw TypeError(
       `Please report that the original defineProperty silently failed to set ${stringifyJson(
         String(prop),
@@ -279,6 +280,7 @@ export const FERAL_EVAL = eval;
 export const FERAL_FUNCTION = Function;
 
 export const noEvalEvaluate = () => {
+  // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_NO_EVAL.md
   throw new TypeError(
     'Cannot eval with evalTaming set to "noEval" (SES_NO_EVAL)',
   );

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -115,6 +115,7 @@ const assertDirectEvalAvailable = () => {
     allowed = true;
   }
   if (!allowed) {
+    // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_DIRECT_EVAL.md
     throw new TypeError(
       `SES cannot initialize unless 'eval' is the original intrinsic 'eval', suitable for direct-eval (dynamically scoped eval) (SES_DIRECT_EVAL)`,
     );
@@ -206,6 +207,7 @@ export const repairIntrinsics = (options = {}) => {
       d`Already locked down at ${priorLockdown} (SES_ALREADY_LOCKED_DOWN)`,
       TypeError,
     );
+  // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_ALREADY_LOCKED_DOWN.md
   priorLockdown = new TypeError('Prior lockdown (SES_ALREADY_LOCKED_DOWN)');
   // Tease V8 to generate the stack string and release the closures the stack
   // trace retained:
@@ -247,6 +249,7 @@ export const repairIntrinsics = (options = {}) => {
   };
 
   if (seemsToBeLockedDown()) {
+    // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_MULTIPLE_INSTANCES.md
     throw new TypeError(
       `Already locked down but not by this SES instance (SES_MULTIPLE_INSTANCES)`,
     );

--- a/packages/ses/src/tame-domains.js
+++ b/packages/ses/src/tame-domains.js
@@ -26,6 +26,7 @@ export function tameDomains(domainTaming = 'safe') {
     if (domainDescriptor !== undefined && domainDescriptor.get !== undefined) {
       // The domain descriptor on Node.js initially has value: null, which
       // becomes a get, set pair after domains initialize.
+      // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_NO_DOMAINS.md
       throw new TypeError(
         `SES failed to lockdown, Node.js domains have been initialized (SES_NO_DOMAINS)`,
       );

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -69,6 +69,7 @@ export const rejectHtmlComments = src => {
     return src;
   }
   const name = getSourceURL(src);
+  // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_HTML_COMMENT_REJECTED.md
   throw new SyntaxError(
     `Possible HTML comment rejected at ${name}:${lineNumber}. (SES_HTML_COMMENT_REJECTED)`,
   );
@@ -144,6 +145,7 @@ export const rejectImportExpressions = src => {
     return src;
   }
   const name = getSourceURL(src);
+  // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_IMPORT_REJECTED.md
   throw new SyntaxError(
     `Possible import expression rejected at ${name}:${lineNumber}. (SES_IMPORT_REJECTED)`,
   );
@@ -215,6 +217,7 @@ export const rejectSomeDirectEvalExpressions = src => {
     return src;
   }
   const name = getSourceURL(src);
+  // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_EVAL_REJECTED.md
   throw new SyntaxError(
     `Possible direct eval expression rejected at ${name}:${lineNumber}. (SES_EVAL_REJECTED)`,
   );


### PR DESCRIPTION
Mitigates https://github.com/endojs/endo/issues/1429

When seeing an error with an error code, it can be hard to find the page explaining that error code. As #1429 documents, Google searching on the error code is not helpful. However, @turadg noticed that he often uses the stack trace locations to look at the code that raised this error. This PR adds comments to the source code locations that raise errors we have already given error codes to, where these comments contain the URL of the error code explanation page we want the developer to discover.