### PR TITLE
feat(stream): Pubsub

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -49,6 +49,8 @@
     "ses": "^0.18.4"
   },
   "devDependencies": {
+    "@endo/init": "^0.5.56",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.3.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.14.0",

--- a/packages/daemon/src/pubsub.js
+++ b/packages/daemon/src/pubsub.js
@@ -1,0 +1,72 @@
+import { makePromiseKit } from '@endo/promise-kit';
+import { makeStream } from '@endo/stream';
+
+// TypeScript ReadOnly semantics are not sufficiently expressive to distinguish
+// a value one promises not to alter from a value one must not alter,
+// making it useless.
+const freeze = /** @type {<T>(v: T | Readonly<T>) => T} */ (Object.freeze);
+
+/**
+ * @template TValue TValue
+ * @param {TValue} value
+ * @returns {import('./types.js').AsyncQueue<TValue, unknown>}
+ */
+export const makeNullQueue = value =>
+  harden({
+    put: () => {},
+    get: async () => value,
+  });
+
+export const nullIteratorQueue = makeNullQueue(
+  harden({ value: undefined, done: false }),
+);
+
+/**
+ * @template TValue
+ */
+export const makeChangePubSub = () => {
+  // Request pubsub async queue internals
+  let { promise: tailPromise, resolve: tailResolve } = makePromiseKit();
+
+  const sink = {
+    /**
+     * @param {TValue} value
+     */
+    put: value => {
+      const { resolve, promise } = makePromiseKit();
+      tailResolve(freeze({ value, promise }));
+      tailResolve = resolve;
+      // Unlike a queue, advance the read head for future subscribers.
+      tailPromise = promise;
+    },
+  };
+
+  const makeSpring = () => {
+    // Capture the read head for the next published value.
+    let cursor = tailPromise;
+    return {
+      get: () => {
+        const promise = cursor.then(next => next.value);
+        cursor = cursor.then(next => next.promise);
+        return harden(promise);
+      },
+    };
+  };
+
+  return harden({ sink, makeSpring });
+};
+harden(makeChangePubSub);
+
+/**
+ * @template TValue
+ * @returns {import('./types.js').Topic<TValue>}
+ */
+export const makeChangeTopic = () => {
+  /** @type {ReturnType<makeChangePubSub<TValue>>} */
+  const { sink, makeSpring } = makeChangePubSub();
+  return harden({
+    publisher: makeStream(nullIteratorQueue, sink),
+    subscribe: () => makeStream(makeSpring(), nullIteratorQueue),
+  });
+};
+harden(makeChangeTopic);

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1,4 +1,4 @@
-import type { Reader, Writer } from '@endo/stream';
+import type { Reader, Writer, Stream } from '@endo/stream';
 
 export type Locator = {
   statePath: string;
@@ -114,3 +114,13 @@ export type Request = {
 };
 
 export type Message = Label & Request;
+
+export interface Topic<
+  TRead,
+  TWrite = undefined,
+  TReadReturn = undefined,
+  TWriteReturn = undefined,
+> {
+  publisher: Stream<TWrite, TRead, TWriteReturn, TReadReturn>;
+  subscribe(): Stream<TRead, TWrite, TReadReturn, TWriteReturn>;
+}

--- a/packages/daemon/test/test-pubsub.js
+++ b/packages/daemon/test/test-pubsub.js
@@ -1,0 +1,131 @@
+// @ts-check
+/* eslint-disable no-await-in-loop */
+
+import '@endo/init/debug.js';
+
+import rawTest from 'ava';
+import { wrapTest } from '@endo/ses-ava';
+import { makePromiseKit } from '@endo/promise-kit';
+import { makeChangeTopic } from '../src/pubsub.js';
+
+const test = wrapTest(rawTest);
+
+test('change topic supports parallel subscriptions', async (/** @type {import('ava').Assertions} */ t) => {
+  const { publisher, subscribe } = makeChangeTopic();
+
+  // Coordinated checkpoints.
+  const [p1, p2, p4, s1, s2, s3, s4] = (function* generatePromiseKits() {
+    for (;;) yield makePromiseKit();
+  })();
+
+  await Promise.all([
+    (async () => {
+      // This await ensures that the synchronous portion of the first, full
+      // subscription obtains a subscriber before it yields to the event loop
+      // the first time.
+      await null;
+      await publisher.next(1);
+      p1.resolve();
+
+      await s1.promise;
+      await publisher.next(2);
+      p2.resolve();
+
+      await Promise.all([s2.promise, s3.promise]);
+      await publisher.next(3);
+
+      await publisher.next(4);
+      p4.resolve();
+
+      await s4.promise;
+      await publisher.return('EOL');
+    })(),
+
+    // Full subscription.
+    (async () => {
+      let expected = 1;
+      const subscription = subscribe();
+      for await (const actual of subscription) {
+        t.is(actual, expected);
+        expected += 1;
+      }
+      t.is(expected, 5);
+    })(),
+
+    // Delayed subscriber.
+    (async () => {
+      await p1.promise;
+      const subscription = subscribe();
+      s1.resolve();
+
+      let expected = 2;
+      for await (const actual of subscription) {
+        t.is(actual, expected);
+        expected += 1;
+      }
+      t.is(expected, 5);
+    })(),
+
+    // Further delayed subscriber.
+    (async () => {
+      await p2.promise;
+      const subscription = subscribe();
+      s2.resolve();
+
+      let expected = 3;
+      for await (const actual of subscription) {
+        t.is(actual, expected);
+        expected += 1;
+      }
+      t.is(expected, 5);
+    })(),
+
+    // Same subscription timing as previous, but using the iterator protocol to
+    // see the final value.
+    (async () => {
+      await p2.promise;
+      const subscription = subscribe();
+      s3.resolve();
+
+      let expected = 3;
+      for (;;) {
+        const iteratorResult = await subscription.next();
+        if (iteratorResult.done) {
+          t.is(iteratorResult.value, 'EOL');
+          break;
+        }
+        t.is(iteratorResult.value, expected);
+        expected += 1;
+      }
+    })(),
+
+    // Observe the completion value by dint of yield*.
+    (async () => {
+      await p4.promise;
+      const subscription = subscribe();
+      s4.resolve();
+
+      const generator = (async function* consumer() {
+        return yield* subscription;
+      })();
+      const { value, done } = await generator.next();
+      t.is(done, true);
+      t.is(value, 'EOL');
+    })(),
+  ]);
+
+  t.pass();
+});
+
+test('change topic terminates with error', async (/** @type {import('ava').Assertions} */ t) => {
+  const { publisher, subscribe } = makeChangeTopic();
+
+  const subscription = subscribe();
+
+  await publisher.throw(new TypeError('sentinel'));
+
+  await t.throwsAsync(() => subscription.next(), {
+    instanceOf: TypeError,
+    message: 'sentinel',
+  });
+});


### PR DESCRIPTION
In the course of implementing Endo CLI inbox followers, I needed a minimum viable pubsub topic. Endo doesn’t have `@agoric/notifiers` yet, but it does have streams. Given that I expect notifiers to eventually make their way up to Endo, I’d accept a recommendation to instead inline this feature in the Endo Daemon in anticipation of replacing the implementation with a notifier. However, I believe this implementation stands on its own at least pedagogically.

This change introduces a succinct implementation of pubsub in terms of streams (async iterators). The `makeTopic` function is a pubsub analog for `makePipe`, but is broadcast instead of unicast, and consequently loses the ability to connect forward- and back-pressure signals. Where `makePipe` returns an entangled pair of streams, `makeTopic` produces a single `publisher` stream and a `subscribe` function for any number of subscriber streams.

The key insight that unlocks this change is that `makeQueue` is not a suitable foundation for pubsub, but is a suitable pattern to apply toward a new `makePubSub` variation on the theme. This function returns the producer side of a queue (which I’m calling a sink) and a function for generating consumers (springs). Like an async queue, a pub sub pair is backed by an async linked list, but the publisher side willfully advances the read head, such that new subscriptions only see future values and historical values are forgotten. Then, each subscriber captures a cursor so it doesn’t forget any of the links since its subscription was created.

In order to disentangle the pub and subs, `makeTopic` uses a `nullQueue`, so each pub and sub is paired with either the sink or spring side of the null queue. Consequently, I’ve found it useful to narrow the types accepted by `makeStream` to `Sink` and `Spring`, since pubs and subs only present these narrower types.