### PR TITLE
fix: extend severeEnablements with immer workaround

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -206,4 +206,16 @@ export const severeEnablements = {
    * enablements just enable them all.
    */
   '%TypedArrayPrototype%': '*',
+
+  /**
+   * Needed to work with Immer before https://github.com/immerjs/immer/pull/914
+   * is accepted.
+   */
+  '%MapPrototype%': '*',
+
+  /**
+   * Needed to work with Immer before https://github.com/immerjs/immer/pull/914
+   * is accepted.
+   */
+  '%SetPrototype%': '*',
 };


### PR DESCRIPTION
The Immer library currently provokes the override mistake. https://github.com/immerjs/immer/pull/914 is a PR that would fix it, but this PR has currently been rejected, seemingly committing the Immer library to not fixing is problem. (Appeal at https://github.com/immerjs/immer/pull/914#issuecomment-1374677902 )

For compatibility with Immer before https://github.com/immerjs/immer/pull/914 is accepted,  this PR extends the severeEnablements to enable all the properties of `Map.prototype` and `Set.prototype` to be overridden by assignment.

@Jack-Works , for some reason I cannot add you as a reviewer to this PR. But please consider yourself one. I would appreciate your comments. Thanks.