### PR TITLE
Endo inbox followers

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -367,25 +367,32 @@ export const main = async rawArgs => {
     }
   });
 
-  program.command('inbox').action(async () => {
-    const { getBootstrap } = await provideEndoClient(
-      'cli',
-      sockPath,
-      cancelled,
-    );
-    try {
-      const bootstrap = getBootstrap();
-      const iterable = await E(bootstrap).inbox();
-      const iterator = await E(iterable)[Symbol.asyncIterator]();
-      for await (const { number, who, what } of makeRefIterator(iterator)) {
-        // TODO ensure the description is ASCII.
-        console.log(`${number}. ${who}: ${what}`);
+  program
+    .command('inbox')
+    .option('-n,--name <name>', 'The name of an alternate inbox')
+    .option('-f,--follow', 'Follow the inbox for messages as they arrive')
+    .action(async cmd => {
+      const { name: inboxName, follow } = cmd.opts();
+      const { getBootstrap } = await provideEndoClient(
+        'cli',
+        sockPath,
+        cancelled,
+      );
+      try {
+        const bootstrap = getBootstrap();
+        const inbox =
+          inboxName === undefined ? bootstrap : E(bootstrap).provide(inboxName);
+        const iterable = follow ? E(inbox).followInbox() : E(inbox).inbox();
+        const iterator = await E(iterable)[Symbol.asyncIterator]();
+        for await (const { number, who, what } of makeRefIterator(iterator)) {
+          // TODO ensure the description is ASCII.
+          console.log(`${number}. ${who}: ${what}`);
+        }
+      } catch (error) {
+        console.error(error);
+        cancel(error);
       }
-    } catch (error) {
-      console.error(error);
-      cancel(error);
-    }
-  });
+    });
 
   program
     .command('resolve <request-number> <resolution-name>')

--- a/packages/daemon/test/service.js
+++ b/packages/daemon/test/service.js
@@ -1,0 +1,12 @@
+import { E, Far } from '@endo/far';
+
+export const main0 = powers => {
+  return Far('Service', {
+    async ask() {
+      return E(powers).request(
+        'the meaning of life, the universe, everything',
+        'answer',
+      );
+    },
+  });
+};

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -258,3 +258,77 @@ test('closure state lost by restart', async t => {
     t.is(three, 3);
   }
 });
+
+test('persist import-unsafe0 services and their requests', async t => {
+  const { promise: cancelled } = makePromiseKit();
+  const locator = makeLocator('tmp', 'import-unsafe0');
+
+  await stop(locator).catch(() => {});
+  await reset(locator);
+  await start(locator);
+
+  const inboxFinished = (async () => {
+    const { promise: followerCancelled, reject: cancelFollower } =
+      makePromiseKit();
+    cancelled.catch(cancelFollower);
+    const { getBootstrap } = await makeEndoClient(
+      'client',
+      locator.sockPath,
+      followerCancelled,
+    );
+    const bootstrap = getBootstrap();
+    const worker = await E(bootstrap).makeWorker('userWorker');
+    await E(worker).evaluate(
+      `
+      Far('Answer', {
+        value: () => 42,
+      })
+    `,
+      [],
+      [],
+      'answer',
+    );
+    const iteratorRef = E(bootstrap).followInbox();
+    const { value: message } = await E(iteratorRef).next();
+    const { number } = E.get(message);
+    await E(bootstrap).resolve(await number, 'answer');
+  })();
+
+  const workflowFinished = (async () => {
+    const { getBootstrap } = await makeEndoClient(
+      'client',
+      locator.sockPath,
+      cancelled,
+    );
+    const bootstrap = getBootstrap();
+    const w1 = await E(bootstrap).makeWorker('w1');
+    const servicePath = path.join(dirname, 'test', 'service.js');
+    await E(w1).importUnsafe0(servicePath, 's1');
+
+    const w2 = await E(bootstrap).makeWorker('w2');
+    const answer = await E(w2).evaluate(
+      'E(service).ask()',
+      ['service'],
+      ['s1'],
+      'answer',
+    );
+    const number = await E(answer).value();
+    t.is(number, 42);
+  })();
+
+  await Promise.all([inboxFinished, workflowFinished]);
+
+  await restart(locator);
+
+  {
+    const { getBootstrap } = await makeEndoClient(
+      'client',
+      locator.sockPath,
+      cancelled,
+    );
+    const bootstrap = getBootstrap();
+    const answer = await E(bootstrap).provide('answer');
+    const number = await E(answer).value();
+    t.is(number, 42);
+  }
+});


### PR DESCRIPTION
This change introduces the CLI `endo inbox --follow` which will tail an async iterator of all incoming messages, and the corresponding `E(endo).followInbox()` API that returns a reference to an async iterator that will produce all current and future pending messages, via pubsub #1432.

This change makes it possible to properly test #1422.