### PR TITLE
Run confined services in Endo

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "test": "exit 0"
   },
   "dependencies": {
+    "@endo/bundle-source": "^2.5.1",
     "@endo/compartment-mapper": "^0.8.4",
     "@endo/daemon": "^0.2.2",
     "@endo/eventual-send": "^0.17.2",

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -527,6 +527,34 @@ export const main = async rawArgs => {
       }
     });
 
+  program
+    .command('import-bundle0 <worker> <readableBundleName>')
+    .option(
+      '-n,--name <name>',
+      'Assigns a name to the result for future reference, persisted between restarts',
+    )
+    .action(async (worker, readableBundleName, cmd) => {
+      const { name: resultPetName } = cmd.opts();
+      const { getBootstrap } = await provideEndoClient(
+        'cli',
+        sockPath,
+        cancelled,
+      );
+      try {
+        const bootstrap = getBootstrap();
+        const workerRef = E(bootstrap).provide(worker);
+
+        const result = await E(workerRef).importBundle0(
+          readableBundleName,
+          resultPetName,
+        );
+        console.log(result);
+      } catch (error) {
+        console.error(error);
+        cancel(error);
+      }
+    });
+
   // Throw an error instead of exiting directly.
   program.exitOverride();
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -40,6 +40,7 @@
     "@endo/captp": "^3.1.1",
     "@endo/eventual-send": "^0.17.2",
     "@endo/far": "^0.2.18",
+    "@endo/import-bundle": "^0.3.4",
     "@endo/lockdown": "^0.1.28",
     "@endo/netstring": "^0.3.26",
     "@endo/promise-kit": "^0.2.56",

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -94,12 +94,21 @@ type ImportUnsafe0Ref = {
   importPath: string;
 };
 
+type ImportBundle0Ref = {
+  type: 'importBundle0';
+  workerUuid: string;
+  // Behold: recursion
+  // eslint-disable-next-line no-use-before-define
+  readableBundleRef: Ref;
+};
+
 export type Ref =
   | ReadableSha512Ref
   | WorkerUuidRef
   | ValueUuid
   | EvalRef
-  | ImportUnsafe0Ref;
+  | ImportUnsafe0Ref
+  | ImportBundle0Ref;
 
 export type Label = {
   number: number;

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -66,6 +66,19 @@ export const makeWorkerFacet = ({
       const namespace = await import(url);
       return namespace.main0(powerBox);
     },
+
+    importBundle0: async readable => {
+      const bundleText = await E(readable).text();
+      const bundle = JSON.parse(bundleText);
+
+      // We defer importing the import-bundle machinery to this in order to
+      // avoid an up-front cost for workers that never use importBundle.
+      const { importBundle } = await import('@endo/import-bundle');
+      const namespace = await importBundle(bundle, {
+        endowments,
+      });
+      return namespace.main0(powerBox);
+    },
   });
 };
 


### PR DESCRIPTION
This change adds commands `endo bundle <path> -n <bundleName>` and `endo import-bundle0 <workerName> <bundleName> -n <resultName>` that enable the user to create a bundle of an Endo program and then run that program in a confined compartment of a particular worker.