### PR TITLE
compartment-mapper bundler: ensure archive execution machinery can be bundled

### DIFF
--- a/packages/compartment-mapper/test/fixtures-bundle-self/index.js
+++ b/packages/compartment-mapper/test/fixtures-bundle-self/index.js
@@ -1,0 +1,6 @@
+import { parseArchive } from '../../src/import-archive.js';
+
+export async function executeArchive(archive, fixture, globals) {
+  const application = await parseArchive(archive, fixture);
+  return application.import({ globals });
+}

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -42,6 +42,9 @@
       "import": "./index.js",
       "require": "./dist/ses.cjs"
     },
+    "./transforms": {
+      "import": "./src/transforms.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
relies on a potentially controversial feature: exposing evasive transforms from ses package

blocked by: https://github.com/endojs/endo/pull/1454