### PR TITLE
fix: marshal export what others import

### DIFF
--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -6,6 +6,27 @@ export { stringify, parse } from './src/marshal-stringify.js';
 
 export { decodeToJustin } from './src/marshal-justin.js';
 
+export {
+  makeEncodePassable,
+  makeDecodePassable,
+  isEncodedRemotable,
+  zeroPad,
+  recordNames,
+  recordValues,
+} from './src/encodePassable.js';
+
+export {
+  assertRankSorted,
+  compareRank,
+  isRankSorted,
+  sortByRank,
+  compareAntiRank,
+  makeFullOrderComparatorKit,
+  getPassStyleCover,
+  intersectRankCovers,
+  unionRankCovers,
+} from './src/rankOrder.js';
+
 // eslint-disable-next-line import/export
 export * from './src/types.js';
 


### PR DESCRIPTION
Now that @endo/marshal has what it should (due to https://github.com/endojs/endo/pull/1439 and https://github.com/endojs/endo/pull/1291 ), when this version of endo is released and agoric-sdk is upgraded to depend on it, we have a potential problem: deep imports by code in agoric-sdk into the midst of internal modules in endo. In particular, the compat requirements #1439 was written to meet was to continue to support code that imports what @endo/marshal explicitly exports. But #1439 was not written to support code that deeply imports from the internals of marshal.

The best answer to that is for agoric-sdk to stop deeply importing from marshal, which is what https://github.com/Agoric/agoric-sdk/pull/6792 will accomplish. But https://github.com/Agoric/agoric-sdk/pull/6792 cannot work until agoric-sdk has been upgraded to depend on a version of endo in which those imports are exported directly by marshal, which is what this PR does.