### PR TITLE
feat(ses): allow module-instance to use a precompiledFunctor

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in SES:
 
+# next
+
+- Introduces the `__syncModuleFunctor__` property of static module record
+  to replace evauluation of `__syncModuleProgram__` for environments without eval.
+
 # v0.18.1 (2022-12-23)
 
 - Fixes a bug for SES initialization in a no-unsafe-eval

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -441,6 +441,11 @@ A compiled static module record has the following shape:
     - `onceVar` is a record that maps constants exported by this
       module to a function that may be called to initialize the
       corresponding value in another module.
+- `__syncModuleFunctor__` is an optional function that if present is used
+  instead of the evaluation of the `__syncModuleProgram__` string. It will be
+  called with the initialization record described above. It is intended to be
+  used in environments where eval is not available. Sandboxing of the functor is
+  the responsibility of the author of the StaticModuleRecord.
 - `__liveExportsMap__` is a record that maps import names or names in the lexical
   scope of the module to export names, for variables that may change after
   initialization. Any reexported name is assumed to possibly change.

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -136,6 +136,7 @@ export const makeModuleInstance = (
     __liveExportMap__: liveExportMap = {},
     __reexportMap__: reexportMap = {},
     __needsImportMeta__: needsImportMeta = false,
+    __syncModuleFunctor__,
   } = staticModuleRecord;
 
   const compartmentFields = weakmapGet(privateFields, compartment);
@@ -444,11 +445,16 @@ export const makeModuleInstance = (
     activate();
   }
 
-  let optFunctor = compartmentEvaluate(compartmentFields, functorSource, {
-    globalObject: compartment.globalThis,
-    transforms: __shimTransforms__,
-    __moduleShimLexicals__: moduleLexicals,
-  });
+  let optFunctor;
+  if (__syncModuleFunctor__ !== undefined) {
+    optFunctor = __syncModuleFunctor__;
+  } else {
+    optFunctor = compartmentEvaluate(compartmentFields, functorSource, {
+      globalObject: compartment.globalThis,
+      transforms: __shimTransforms__,
+      __moduleShimLexicals__: moduleLexicals,
+    });
+  }
   let didThrow = false;
   let thrownError;
   function execute() {


### PR DESCRIPTION
the "precompiled functor" is a function potentially present on the `staticModuleRecord`. If present, it is used as a replacement for string evaluation of the module code, useful in environments where eval is not available. Confinement of the functor is the responsibility of the creator of the precompiled functor and `staticModuleRecord`.

`ThirdPartyModuleInstances` can already do this by implementing a custom `execute` fn https://github.com/endojs/endo/blob/7de3ef8e9d5bcecc09545f5782eeb647a742ba51/packages/ses/src/module-instance.js#L99-L103

This is intended to be used by the `compartment-mapper`'s secureBundler "no eval" output format