### PR TITLE
docs: missed documentation suggestion

### DIFF
--- a/packages/exo/docs/exo-taxonomy.md
+++ b/packages/exo/docs/exo-taxonomy.md
@@ -39,8 +39,8 @@ The virtual and durable variants are contributed by higher layer packages that b
 "prepare" is like "provide" in that it defines something that should be in the baggage, using the one that is there if found, but otherwise making a new one and registering it, so that the successor vat-invocation will find it at the same place in the baggage. Unlike "provide", for each exo behavior already in the baggage, one must call "prepare" immediately --- during the first crank of the vat incarnation. What is passed in baggage is only the state of the durable objects. Only the `prepare*` calls associate that state with code, giving it behavior. All these objects must be prepared early, so they know how to react when they receive messages.
 
 - **_`prepareExo`_** <br>
-  Like `makeDurableExo` but for a durable exo in baggage.
+  Like `makeExo` but for a durable exo in baggage.
 - **_`prepareExoClass`_** <br>
-  Like `defineDurableExoClass` but for a durable exo in baggage.
+  Like `defineExoClass` but for a durable exo in baggage.
 - **_`prepareExoClassKit`_** <br>
-  Like `defineDurableExoClassKit` but for a durable exo in baggage.
+  Like `defineExoClassKit` but for a durable exo in baggage.


### PR DESCRIPTION
The change I made to the agoric-sdk copy of this package also has a doc fix in response to https://github.com/Agoric/agoric-sdk/pull/6838#discussion_r1085515755 that I foolishly omitted from https://github.com/endojs/endo/pull/1459 . This PR repairs that, bringing the copies back into alignment.