### PR TITLE
fix(static-module-record): ESM compatibility

### DIFF
--- a/packages/static-module-record/src/transformSource.js
+++ b/packages/static-module-record/src/transformSource.js
@@ -1,7 +1,7 @@
 import * as babelParser from '@babel/parser';
 import babelGenerate from '@agoric/babel-generator';
 import babelTraverse from '@babel/traverse';
-import babelTypes from '@babel/types';
+import * as babelTypes from '@babel/types';
 
 const parseBabel = babelParser.default
   ? babelParser.default.parse

--- a/packages/static-module-record/test/fixtures/small.js
+++ b/packages/static-module-record/test/fixtures/small.js
@@ -3,7 +3,7 @@ console.error("This is a code sample for trying out babel transforms, it's not m
 import * as babelParser from '@babel/parser';
 import babelGenerate from '@agoric/babel-generator';
 import babelTraverse from '@babel/traverse';
-import babelTypes from '@babel/types';
+import * as babelTypes from '@babel/types';
 
 import makeModulePlugins from './babelPlugin.js';
 


### PR DESCRIPTION
There is no `default` export on `@babel/types`. Not sure how this worked in the first place for Node.js but it makes `esm` happy for the few places that still use RESM.

See https://github.com/babel/babel/pull/14674 and https://github.com/babel/babel/pull/13414