### PR TITLE
fix(cli): Fix hash, map, and hash-archive commands

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -135,32 +135,26 @@ export const main = async rawArgs => {
     process.stderr.write('ok\n');
   });
 
-  program
-    .command('map <application-path>')
-    .action(async (_cmd, [applicationPath]) => {
-      const applicationLocation = url.pathToFileURL(applicationPath);
-      const compartmentMapBytes = await mapLocation(
-        readPowers,
-        applicationLocation,
-      );
-      process.stdout.write(compartmentMapBytes);
-    });
+  program.command('map <application-path>').action(async applicationPath => {
+    const applicationLocation = url.pathToFileURL(applicationPath);
+    const compartmentMapBytes = await mapLocation(
+      readPowers,
+      applicationLocation,
+    );
+    process.stdout.write(compartmentMapBytes);
+  });
 
-  program
-    .command('hash <application-path>')
-    .action(async (_cmd, [applicationPath]) => {
-      const applicationLocation = url.pathToFileURL(applicationPath);
-      const sha512 = await hashLocation(readPowers, applicationLocation);
-      process.stdout.write(`${sha512}\n`);
-    });
+  program.command('hash <application-path>').action(async applicationPath => {
+    const applicationLocation = url.pathToFileURL(applicationPath);
+    const sha512 = await hashLocation(readPowers, applicationLocation);
+    process.stdout.write(`${sha512}\n`);
+  });
 
-  program
-    .command('hash-archive <archive-path>')
-    .action(async (_cmd, [archivePath]) => {
-      const archiveLocation = url.pathToFileURL(archivePath);
-      const { sha512 } = await loadArchive(readPowers, archiveLocation);
-      process.stdout.write(`${sha512}\n`);
-    });
+  program.command('hash-archive <archive-path>').action(async archivePath => {
+    const archiveLocation = url.pathToFileURL(archivePath);
+    const { sha512 } = await loadArchive(readPowers, archiveLocation);
+    process.stdout.write(`${sha512}\n`);
+  });
 
   program
     .command('archive <archive-path> <application-path>')


### PR DESCRIPTION
Either these never worked or something changed in an upgrade of Commander (the command line flag parser we use) between when these commands last worked and present day.
