### PR TITLE
Update docs links into agoric.com to avoid 404s

### DIFF
--- a/packages/far/README.md
+++ b/packages/far/README.md
@@ -1,7 +1,7 @@
 # Endo Far Object helpers
 
 The `@endo/far` package provides a convenient way to use the Endo
-[distributed objects system](https://agoric.com/documentation/js-programming/far.html) without  relying on the underlying messaging
+[distributed objects system](https://docs.agoric.com/guides/js-programming/) without  relying on the underlying messaging
 implementation.
 
 It exists to reduce the boilerplate in Hardened JavaScript vats that are running

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -530,7 +530,7 @@ console uses these side tables to output more informative diagnostics.
 
 The `ses` shim concerns boundaries between programs in the same process and
 JavaScript realm.
-In terms of the [Taxonomy of Security Issues](https://agoric.com/blog/all/taxonomy-of-security-issues/),
+In terms of the [Taxonomy of Security Issues](https://papers.agoric.com/taxonomy-of-security-issues/),
 the `ses` shim creates a boundary that is finer than an operating system
 process or thread and facilitates boundaries as fine as individual objects.
 While `ses` can interpose at granularities where process isolation is not a
@@ -701,7 +701,7 @@ As a result of the search for flaws, deficiencies, and weaknesses in the code
 (which is currently a Stage 1 proposal with the ECMA TC39 committee), a series
 of small code changes and documentation improvements were made. There is a
 report available on the
-[Agoric blog](https://agoric.com/blog/technology/metamask-agoric-hardened-js-security-review/)
+[Agoric blog](https://agoric.com/blog/technology/purple-teaming-how-metamask-and-agoric-hunted-bugs-to-harden-javascript)
 that includes links to recordings of code walk-throughs and technical
 discussion, and issues are tagged
 [audit-SEStival](https://github.com/endojs/endo/issues?q=label%3Aaudit-sestival).
@@ -711,7 +711,7 @@ provide useful background for future audits, reviews, and for learning more
 about how the `ses` shim constructs a Hardened JavaScript environment.
 
 In addition to vulnerability assessments, active efforts to [formally verify
-the Agoric kernel](https://agoric.com/blog/technology/the-path-to-verified-blds-how-informal-systems-and-agoric-are-using-formal-methods-analysis-to-improve-software-integrity/)
+the Agoric kernel](https://agoric.com/blog/technology/the-path-to-verified-blds-how-informal-systems-and-agoric-are-using-formal)
 have found the object capability model that `ses` provides to be sound.
 
 Hardened JavaScript is also within the scope of the [Agoric bug bounty

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -79,7 +79,7 @@ risk.
 
 **Background**: In de facto plain JavaScript, the legacy `RegExp` static
 methods like `RegExp.lastMatch` are an unsafe global
-[overt communications channel](https://agoric.com/taxonomy-of-security-issues/).
+[overt communications channel](https://papers.agoric.com/taxonomy-of-security-issues/).
 They reveal on the `RegExp` constructor information derived from the last match
 made by any `RegExp` instance&mdash;a bizarre form of non-local causality.
 These static methods are currently part of de facto
@@ -224,7 +224,7 @@ In most JavaScript engines running normal JavaScript, if `err` is an
 Error instance, the expression `err.stack` will produce a string
 revealing the stack trace. This is an
 [overt information leak, a confidentiality
-violation](https://agoric.com/taxonomy-of-security-issues/).
+violation](https://papers.agoric.com/taxonomy-of-security-issues/).
 This `stack` property reveals information about the call stack that violates
 the encapsulation of the callers.
 
@@ -274,7 +274,7 @@ Currently is it not possible for the SES-shim to hide it on other
 engines, leaving this information leak available. Note that it is only an
 information leak. It reveals the magic information only as a powerless
 string. This leak threatens
-[confidentiality but not integrity](https://agoric.com/taxonomy-of-security-issues/).
+[confidentiality but not integrity](https://papers.agoric.com/taxonomy-of-security-issues/).
 
 Since the current JavaScript de facto reality is that the stack is only
 available by saying `err.stack`, a number of development tools assume they


### PR DESCRIPTION
## Summary
Update agoric.com doc links to remove 404s. Addresses #1475

## Details
Did a quick search on repo for `agoric.com/` and updated all doc links to things that don't 404

## Testing
Manually clicked all the links I added. No code changes to no real tests.