### PR TITLE
fix(stream-node): Handle write attempt after close

### DIFF
--- a/packages/stream-node/writer.js
+++ b/packages/stream-node/writer.js
@@ -7,6 +7,8 @@
 
 const { Fail } = assert;
 
+const sink = harden(() => {});
+
 /**
  * Adapts a Node.js writable stream to a JavaScript
  * async iterator of Uint8Array data chunks.
@@ -20,6 +22,7 @@ export const makeNodeWriter = writer => {
   !writer.writableObjectMode ||
     Fail`Cannot convert Node.js object mode Writer to AsyncIterator<undefined, Uint8Array>`;
 
+  let finalized = false;
   const finalIteration = new Promise((resolve, reject) => {
     const finalize = () => {
       // eslint-disable-next-line no-use-before-define
@@ -32,9 +35,12 @@ export const makeNodeWriter = writer => {
       reject(err);
     };
     const cleanup = () => {
+      finalized = true;
       writer.off('error', error);
       writer.off('finish', finalize);
       writer.off('close', finalize);
+      // Prevent Node 14 from triggering a global unhandled error if we race
+      writer.on('error', sink);
     };
     // Streams should emit either error or finish and then may emit close.
     // So, watching close is redundant but makes us feel safer.
@@ -49,10 +55,16 @@ export const makeNodeWriter = writer => {
   const nodeWriter = harden({
     /** @param {Uint8Array} value */
     async next(value) {
+      !finalized || Fail`Cannot write into closed Node stream`;
+
       return Promise.race([
         finalIteration,
-        new Promise(resolve => {
-          if (!writer.write(value)) {
+        new Promise((resolve, reject) => {
+          if (
+            !writer.write(value, err => {
+              if (err) reject(err);
+            })
+          ) {
             writer.once('drain', () => {
               resolve(nonFinalIterationResult);
             });


### PR DESCRIPTION
In https://github.com/Agoric/agoric-sdk/pull/6881, on Node 14, I experienced a hard failure when trying to write into the stream to the xsnap-worker child (a node stream implemented internally as a socket/pipe). The process exited with an error triggered by [`writeAfterFIN`](https://github.com/nodejs/node/blob/92caea621d0fea47ef5af0b3dda427ac2fe2df3f/lib/net.js#L458-L476).

Apparently an error on such a stream where no error handler is present results in a global unhandler error, on which the ses shim forcibly calls `process.exit`.

While installing a no-op error handler after cleanup solved that problem, I observed that really the write call should be error-ing itself as that is what would normally happen if the write callback was wired (which it wasn't, and now is). But really there is no reason to subject the node stream to a write attempt if we know it's closed, so this PR also guards and fails early on `next()` calls if the underlying stream is closed.

I could not reproduce my initial issue in the unit tests, so I did not update them to test for this behavior. I have verified that using this modification fixes the issues observed in the agoric-sdk PR.