### PR TITLE
docs(pattern): Clean up the README and type documentation

### DIFF
--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -8,15 +8,15 @@ Defines new `Passable` data types and their encoding into the `Tagged` objects d
 
 The main export from the package is an `M` namespace object, for making a variety of Matchers (hence "M").
 
-`M` can also make _Guards_ that use Patterns to characterize dynamic behavior such as method argument/response signatures and promise awaiting. The `@endo/exo` package uses InterfaceGuards (each of which maps a collection of method names to their corresponding method guards) as the first level of defense for Exo objects against malformed input. For example:
+`M` can also make _Guards_ that use Patterns to characterize dynamic behavior such as method argument/response signatures and promise awaiting. The `@endo/exo` package uses InterfaceGuards (each of which maps a collection of method names to their respective method guards) as the first level of defense for Exo objects against malformed input. For example:
 ```js
 const asyncSerializerI = M.interface('AsyncSerializer', {
-  toString: M.callWhen(M.await(M.any())).returns(M.string()),
+  getStringOf: M.callWhen(M.await(M.any())).returns(M.string()),
 });
 const asyncSerializer = makeExo('AsyncSerializer', asyncSerializerI, {
   // M.callWhen() delays invocation of this method implementation
   // while externally-provided input is unsettled.
-  toString(val) { return String(val); },
+  getStringOf(val) { return String(val); },
 });
 ```
 

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -11,6 +11,12 @@ The main export from the package is an `M` namespace object, for making a variet
 `M` can also make _Guards_ that use Patterns to characterize dynamic behavior such as method argument/response signatures and promise awaiting. The `@endo/exo` package uses InterfaceGuards (each of which maps a collection of method names to their respective method guards) as the first level of defense for Exo objects against malformed input. For example:
 ```js
 const asyncSerializerI = M.interface('AsyncSerializer', {
+  // This interface has a single method, which accepts a single argument.
+  // The argument is consumed asynchronously as indicated and enforced by M.await()
+  // (making the method itself async), and the result of that implied `await`
+  // is allowed to fulfill to any value per M.any().
+  // The method result is a string as indicated by M.string(),
+  // which async behavior inherently wraps in a promise.
   getStringOf: M.callWhen(M.await(M.any())).returns(M.string()),
 });
 const asyncSerializer = makeExo('AsyncSerializer', asyncSerializerI, {
@@ -18,6 +24,10 @@ const asyncSerializer = makeExo('AsyncSerializer', asyncSerializerI, {
   // while externally-provided input is unsettled.
   getStringOf(val) { return String(val); },
 });
+
+const stringP = asyncSerializer.getStringOf(Promise.resolve(42n));
+isPromise(stringP); // => true
+await stringP; // => "42"
 ```
 
 See [types.js](./src/types.js) for the definitions of these new types and (at typedefs `PatternMatchers` and `GuardMakers`) the methods of the exported `M` namespace object.

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -1,7 +1,7 @@
 # `@endo/patterns`
 
 Defines new `Passable` data types and their encoding into the `Tagged` objects defined by the `@endo/pass-style` package. The `@endo/pass-style` package defines the lower level of abstraction on which we need broad agreement for interoperability. The higher level data types defined by this package include
-   - `CopyMap`, `CopySet`, `CopyBag` -- new container types, in addition to the `CopyArrag` and `CopyRecord` already defined by `@endo/pass-style`.
+   - `CopyMap`, `CopySet`, `CopyBag` -- new container types, in addition to the `CopyArray` and `CopyRecord` already defined by `@endo/pass-style`.
    - a variety of Matchers, for expression patterns that can match over Passables
    - `Key` -- those Passables that can be keys in CopyMaps, CopySets, CopyBags, as well as MapStores and SetStores.
    - `Pattern` -- includes both literal pass-by-copy structures as well as Matchers. A Pattern *matches* some subset of Passable objects.

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -6,6 +6,18 @@ Defines new `Passable` data types and their encoding into the `Tagged` objects d
    - `Key` -- Passables that can be keys in CopyMaps, CopySets, CopyBags, as well as MapStores and SetStores.
    - `Pattern` -- values that *match* some subset of Passables. Includes Matchers along with literal pass-by-copy structures that match theirselves.
 
-The main export from the package is an `M` namespace object, for making a variety of Matchers (hence "M") but also guards, such as the InterfaceGuards used by the `@endo/exo` package to serve as the first level of defense for Exo objects --- those exposed to external messages. The InterfaceGuards use patterns for enforcing type-like restrictions on the arguments and results of these potentially malicious messages.
+The main export from the package is an `M` namespace object, for making a variety of Matchers (hence "M").
 
-See [types.js](./src/types.js) for the definitions of these new types and the methods of the exported `M` namespace object.
+`M` can also make _Guards_ that use Patterns to characterize dynamic behavior such as method argument/response signatures and promise awaiting. The `@endo/exo` package uses InterfaceGuards (each of which maps a collection of method names to their corresponding method guards) as the first level of defense for Exo objects against malformed input. For example:
+```js
+const asyncSerializerI = M.interface('AsyncSerializer', {
+  toString: M.callWhen(M.await(M.any())).returns(M.string()),
+});
+const asyncSerializer = makeExo('AsyncSerializer', asyncSerializerI, {
+  // M.callWhen() delays invocation of this method implementation
+  // while externally-provided input is unsettled.
+  toString(val) { return String(val); },
+});
+```
+
+See [types.js](./src/types.js) for the definitions of these new types and (at typedef `PatternMatchers`) the methods of the exported `M` namespace object.

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -11,17 +11,17 @@ The main export from the package is an `M` namespace object, for making a variet
 `M` can also make _Guards_ that use Patterns to characterize dynamic behavior such as method argument/response signatures and promise awaiting. The `@endo/exo` package uses InterfaceGuards (each of which maps a collection of method names to their respective method guards) as the first level of defense for Exo objects against malformed input. For example:
 ```js
 const asyncSerializerI = M.interface('AsyncSerializer', {
-  // This interface has a single method, which accepts a single argument.
-  // The argument is consumed asynchronously as indicated and enforced by M.await()
-  // (making the method itself async), and the result of that implied `await`
-  // is allowed to fulfill to any value per M.any().
+  // This interface has a single method, which is async as indicated by M.callWhen().
+  // The method accepts a single argument, consumed with an implied `await` as indicated by M.await(),
+  // and the result of that implied `await` is allowed to fulfill to any value per M.any().
   // The method result is a string as indicated by M.string(),
-  // which async behavior inherently wraps in a promise.
+  // which is inherently wrapped in a promise by the async nature of the method.
   getStringOf: M.callWhen(M.await(M.any())).returns(M.string()),
 });
 const asyncSerializer = makeExo('AsyncSerializer', asyncSerializerI, {
   // M.callWhen() delays invocation of this method implementation
-  // while externally-provided input is unsettled.
+  // while provided argument is in a pending state
+  // (i.e., it is a promise that has not yet settled).
   getStringOf(val) { return String(val); },
 });
 

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -3,8 +3,8 @@
 Defines new `Passable` data types and their encoding into the `Tagged` objects defined by the `@endo/pass-style` package. The `@endo/pass-style` package defines the lower level of abstraction on which we need broad agreement for interoperability. The higher level data types defined by this package include
    - `CopyMap`, `CopySet`, `CopyBag` -- new container types, in addition to the `CopyArray` and `CopyRecord` already defined by `@endo/pass-style`.
    - a variety of Matchers, for expression patterns that can match over Passables
-   - `Key` -- those Passables that can be keys in CopyMaps, CopySets, CopyBags, as well as MapStores and SetStores.
-   - `Pattern` -- includes both literal pass-by-copy structures as well as Matchers. A Pattern *matches* some subset of Passable objects.
+   - `Key` -- Passables that can be keys in CopyMaps, CopySets, CopyBags, as well as MapStores and SetStores.
+   - `Pattern` -- values that *match* some subset of Passables. Includes Matchers along with literal pass-by-copy structures that match theirselves.
 
 The main export from the package is an `M` namespace object, for making a variety of Matchers (hence "M") but also guards, such as the InterfaceGuards used by the `@endo/exo` package to serve as the first level of defense for Exo objects --- those exposed to external messages. The InterfaceGuards use patterns for enforcing type-like restrictions on the arguments and results of these potentially malicious messages.
 

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -20,4 +20,4 @@ const asyncSerializer = makeExo('AsyncSerializer', asyncSerializerI, {
 });
 ```
 
-See [types.js](./src/types.js) for the definitions of these new types and (at typedef `PatternMatchers`) the methods of the exported `M` namespace object.
+See [types.js](./src/types.js) for the definitions of these new types and (at typedefs `PatternMatchers` and `GuardMakers`) the methods of the exported `M` namespace object.

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -54,20 +54,19 @@
  * Patterns are often used in a type-like manner, to represent the category
  * of passables that are intended* to match that pattern. To keep this
  * distinction clear, we often use the suffix "Shape" rather than "Pattern"
- * to avoid the levels confusion when the pattern itself represents
+ * to avoid confusion when the pattern itself represents
  * some category of pattern. For example, an "AmountShape" represents the
  * category of Amounts. And "AmountPatternShape" represents the
  * category of patterns over Amounts.
  *
- * * I say "intended" above because Patterns, in order to be declarative
+ * * We say "intended" above because Patterns, in order to be declarative
  * and passable, cannot have the generality of predicates written in a
  * Turing-universal programming language. Rather, to represent the category of
  * things intended to be a Foo, a FooShape should reliably
  * accept all Foos and reject only non-Foos. However, a FooShape may also accept
- * non-Foos that "look like" or have "the same shape as" genuine Foos. To write
- * as accurate predicate, for use, for example, for input validation, would
- * need to supplement the pattern check with code to check for the residual
- * cases.
+ * non-Foos that "look like" or "have the same shape as" genuine Foos.
+ * An accurate predicate for e.g. input validation would need to supplement the
+ * pattern check with code to detect the residual cases.
  * We hope the "Shape" metaphor helps remind us of this type-like imprecision
  * of patterns.
  */


### PR DESCRIPTION
* Fix typos
* Tweak phrasing
* Add a clarifying example