### PR TITLE
refactor: expand out some export star

### DIFF
--- a/packages/captp/src/index.js
+++ b/packages/captp/src/index.js
@@ -4,4 +4,10 @@ export * from '@endo/marshal';
 
 export * from './captp.js';
 export { makeLoopback } from './loopback.js';
-export * from './atomics.js';
+export {
+  MIN_DATA_BUFFER_LENGTH,
+  TRANSFER_OVERHEAD_LENGTH,
+  MIN_TRANSFER_BUFFER_LENGTH,
+  makeAtomicsTrapHost,
+  makeAtomicsTrapGuest,
+} from './atomics.js';

--- a/packages/promise-kit/index.js
+++ b/packages/promise-kit/index.js
@@ -5,7 +5,7 @@
 import { makeReleasingExecutorKit } from './src/promise-executor-kit.js';
 import { memoRace } from './src/memo-race.js';
 
-export * from './src/is-promise.js';
+export { isPromise } from './src/is-promise.js';
 // eslint-disable-next-line import/export
 export * from './src/types.js';
 


### PR DESCRIPTION
Expand out `export * ...` into their explicit exports. A bit harder to write, but helps reading and reasoning about modularity.

See https://github.com/Agoric/agoric-sdk/pull/6932