### PR TITLE
feat(compartment-mapper): wildcard policy specified as "any"

### DIFF
--- a/packages/compartment-mapper/demo/policy/index.mjs
+++ b/packages/compartment-mapper/demo/policy/index.mjs
@@ -26,14 +26,8 @@ const ApiSubsetOfBuffer = harden({ from: Buffer.from });
 const options = {
   policy: {
     entry: {
-      globals: {
-        Buffer: true,
-        console: true,
-      },
-      packages: {
-        entropoetry: true,
-        dotenv: true,
-      },
+      globals: 'any',
+      packages: 'any',
       builtins: {
         fs: {
           attenuate: '@endo/compartment-mapper-demo-policy-attenuator1',


### PR DESCRIPTION
This change introduces an option to specify a more permissive policy so that building a more human-friendly policy format is not blocked but the impossibility of listing all possible values in the policy.

I choose the word `"any"` for the magic value because it already has a reputation because of what it means in Typescript and thus makes it more likely that a developer specifying it will get triggered to think twice.