### PR TITLE
refactor: Tighten pattern-related type constraints

### DIFF
--- a/packages/pass-style/src/types.js
+++ b/packages/pass-style/src/types.js
@@ -21,7 +21,8 @@ export {};
  * @typedef {*} Passable
  *
  * A Passable is acyclic data that can be marshalled. It must be hardened to remain
- * stable even if some components are proxies, and is classified by PassStyle:
+ * stable (even if some components are proxies; see PureData restriction below),
+ * and is classified by PassStyle:
  *   * Atomic primitive values have a PrimitiveStyle (PassStyle
  *     "undefined" | "null" | "boolean" | "number" | "bigint" | "string" | "symbol").
  *   * Containers aggregate other Passables into

--- a/packages/pass-style/src/types.js
+++ b/packages/pass-style/src/types.js
@@ -78,14 +78,14 @@ export {};
  */
 
 /**
- * @template T
+ * @template {Passable} T
  * @typedef {T[]} CopyArray
  *
  * A Passable sequence of Passable values.
  */
 
 /**
- * @template T
+ * @template {Passable} T
  * @typedef {Record<string, T>} CopyRecord
  *
  * A Passable dictionary in which each key is a string and each value is Passable.
@@ -94,7 +94,8 @@ export {};
 /**
  * @typedef {{
  *   [Symbol.toStringTag]: string,
- *   payload: Passable
+ *   payload: Passable,
+ *   [passStyle: symbol]: 'tagged' | string,
  * }} CopyTagged
  *
  * A Passable "tagged record" with semantics specific to the tag identified in
@@ -103,7 +104,8 @@ export {};
  * and no other properties except `[Symbol.toStringTag]` and `payload`,
  * but TypeScript complains about a declaration like `[PASS_STYLE]: 'tagged'`
  * because importing packages do not know what `PASS_STYLE` is
- * so we appease it with a looser but less accurate definition.
+ * so we appease it with a looser but less accurate definition
+ * using symbol index properties.
  */
 
 /**
@@ -139,6 +141,6 @@ export {};
  *
  * See the various uses for good examples.
  * @param {boolean} cond
- * @param {Details=} details
+ * @param {Details} [details]
  * @returns {boolean}
  */

--- a/packages/pass-style/src/types.js
+++ b/packages/pass-style/src/types.js
@@ -54,15 +54,18 @@ export {};
  * CopyRecord and/or CopyTagged containers (or a single primitive value with no
  * container), and is fully pass-by-copy.
  *
- * This restriction assures purity *given* that none of these pass-by-copy composites
- * can be a Proxy. TODO SECURITY BUG we plan to enforce this, giving these
- * pass-by-copy composites much of the same security properties as the
- * proposed Records and Tuples (TODO need link).
+ * This restriction assures absence of side effects and interleaving risks *given*
+ * that none of the containers can be a Proxy instance.
+ * TODO SECURITY BUG we plan to enforce this, giving PureData the same security
+ * properties as the proposed [Records and Tuples](https://github.com/tc39/proposal-record-tuple).
  *
  * Given this (currently counter-factual) assumption, a PureData value cannot
  * be used as a communications channel,
  * and can therefore be safely shared with subgraphs that should not be able
  * to communicate with each other.
+ * Without that assumption, such a guarantee requires a marshal-unmarshal round
+ * trip (as exists between vats) to produce data structures disconnected from
+ * any potential proxies.
  */
 
 /**

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -1005,7 +1005,7 @@ const makePatternKit = () => {
         payload,
         harden([]),
         check,
-        'match:bigint payload',
+        'match:symbol payload',
       ),
 
     getRankCover: (_matchPayload, _encodePassable) =>

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -144,7 +144,7 @@
 /**
  * @typedef {-1 | 0 | 1 | NaN} KeyComparison
  * The result of a `KeyCompare` function that defines a meaningful
- * and meaningfully precise partial order of `Key` values. See `KeyCompare`.
+ * and meaningfully precise partial order of Key values. See `KeyCompare`.
  */
 
 /**
@@ -162,7 +162,7 @@
  * equivalent to `right` in the partial ordering.
  *
  * Key order (a partial order) and rank order (a total preorder) are
- * co-designed so that we store passables in rank order and index into them
+ * co-designed so that we store Passables in rank order and index into them
  * with keys for key-based queries. To keep these distinct, when speaking
  * informally about rank, we talk about "earlier" and "later". When speaking
  * informally about keys, we talk about "smaller" and "bigger".
@@ -182,7 +182,7 @@
  * incomparable with Y in key order. For example, the record `{b: 3, a: 5}` is
  * earlier than the record `{b: 5, a: 3}` in rank order but they are
  * incomparable as keys. And two distinct remotables such as `Far('X', {})` and
- * `Far('Y', {})` are equivalent in rank order but incomparable as keys.
+ * `Far('Y', {})` are equivalent in rank order but incomparable as Keys.
  *
  * This lets us translate a range search over the
  * partial key order into a range search over rank order followed by filtering
@@ -232,21 +232,21 @@
  * @typedef {object} PatternMatchers
  *
  * @property {() => Matcher} any
- * Matches any passable.
+ * Matches any Passable.
  *
  * @property {(...subPatts: Pattern[]) => Matcher} and
- * Matches against the intersection of all sub-patterns.
+ * Matches against the intersection of all sub-Patterns.
  *
  * @property {(...subPatts: Pattern[]) => Matcher} or
- * Matches against the union of all sub-patterns
+ * Matches against the union of all sub-Patterns
  * (requiring a successful match against at least one).
  *
  * @property {(subPatt: Pattern) => Matcher} not
- * Matches against the negation of the sub-pattern.
+ * Matches against the negation of the sub-Pattern.
  *
  * @property {() => Matcher} scalar
  * Matches any Passable primitive value or Remotable.
- * All matched values are keys.
+ * All matched values are Keys.
  *
  * @property {() => Matcher} key
  * Matches any value that can be a key in a CopyMap
@@ -254,8 +254,8 @@
  * All matched values are also valid Patterns that match only themselves.
  *
  * @property {() => Matcher} pattern
- * Matches any Pattern that can be used to characterize passables.
- * A pattern cannot contain errors or promises,
+ * Matches any Pattern that can be used to characterize Passables.
+ * A Pattern cannot contain promises or errors,
  * as these are not stable enough to usefully match.
  *
  * @property {(kind: PassStyle | string) => Matcher} kind
@@ -311,17 +311,17 @@
  *
  * @property {() => Matcher} error
  * Matches any error object.
- * Error objects are passable, but are neither keys nor symbols.
+ * Error objects are Passable, but are neither Keys nor Patterns.
  * They do not have a useful identity.
  *
  * @property {() => Matcher} promise
  * Matches any promise object.
- * Promises are passable, but are neither keys nor symbols.
+ * Promises are Passable, but are neither Keys nor Patterns.
  * They do not have a useful identity.
  *
  * @property {() => Matcher} undefined
  * Matches the exact value `undefined`.
- * All keys including `undefined` are already valid patterns and
+ * All keys including `undefined` are already valid Patterns and
  * so can validly represent themselves.
  * But optional Pattern arguments `(patt = undefined) => ...`
  * treat explicit `undefined` as omission of the argument.

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -81,16 +81,22 @@
 // TODO parameterize CopyTagged to support these refinements
 
 /**
- * @template K
- * @typedef {CopyTagged} CopySet
+ * @template {Key} K
+ * @typedef {CopyTagged & {
+ *   [Symbol.toStringTag]: 'copySet',
+ *   payload: Array<K>,
+ * }} CopySet
  *
  * A Passable collection of Keys that are all mutually distinguishable
  * according to the key distributed equality semantics exposed by `keyEQ`.
  */
 
 /**
- * @template K
- * @typedef {CopyTagged} CopyBag
+ * @template {Key} K
+ * @typedef {CopyTagged & {
+ *   [Symbol.toStringTag]: 'copyBag',
+ *   payload: Array<[K, bigint]>,
+ * }} CopyBag
  *
  * A Passable collection of entries with Keys that are all mutually distinguishable
  * according to the key distributed equality semantics exposed by `keyEQ`,
@@ -98,16 +104,23 @@
  */
 
 /**
- * @template K,V
- * @typedef {CopyTagged} CopyMap
+ * @template {Key} K
+ * @template {Passable} V
+ * @typedef {CopyTagged & {
+ *   [Symbol.toStringTag]: 'copyMap',
+ *   payload: { keys: Array<K>, values: Array<V> },
+ * }} CopyMap
  *
  * A Passable collection of entries with Keys that are all mutually distinguishable
  * according to the key distributed equality semantics exposed by `keyEQ`,
  * each with a corresponding Passable value.
  */
 
+// TODO: enumerate Matcher tag values?
 /**
- * @typedef {CopyTagged} Matcher
+ * @typedef {CopyTagged & {
+ *   [Symbol.toStringTag]: `match:${string}`,
+ * }} Matcher
  *
  * A Pattern representing the predicate characterizing a category of Passables,
  * such as strings or 8-bit unsigned integer numbers or CopyArrays of Remotables.


### PR DESCRIPTION
* Update JSDoc descriptions for pattern-related types.
* Consistently capitalize types Key, Passable, and Pattern.
* Constrain template base types for CopyArray, CopyRecord, CopySet, CopyBag, CopyMap, and Matcher.
* Approximate `[PASS_STYLE]: 'tagged'` in the CopyTagged typedef.
* Update typo in an error message.

cc @Tyrosine22