### PR TITLE
WIP feat(ses): suppress implicit coercion of objects to numbers

### DIFF
--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -55,6 +55,12 @@ import { makeCompartmentConstructor } from './compartment-shim.js';
 
 /** @typedef {import('../index.js').LockdownOptions} LockdownOptions */
 
+// eslint-disable-next-line no-restricted-globals
+const VALUE_OF_DISABLED_SYM = Symbol('valueOf disabled');
+
+// eslint-disable-next-line no-extend-native, no-restricted-globals
+Object.prototype.valueOf = () => VALUE_OF_DISABLED_SYM;
+
 const { Fail, details: d, quote: q } = assert;
 
 /** @type {Error=} */

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -445,6 +445,9 @@ export const whitelist = {
     toString: fn,
     valueOf: fn,
 
+    // To allow the suppression of implicit numeric conversion
+    '@@toPrimitive': fn,
+
     // Annex B: Additional Properties of the Object.prototype Object
 
     // See note in header about the difference between [[Proto]] and --proto--

--- a/packages/ses/test/test-obj-to-number-suppression.js
+++ b/packages/ses/test/test-obj-to-number-suppression.js
@@ -1,0 +1,15 @@
+import '../index.js';
+import test from 'ava';
+
+lockdown();
+
+test('plus append still works', t => {
+  t.is({} + {}, '[object Object][object Object]');
+});
+
+test('relational compare throws', t => {
+  // eslint-disable-next-line no-self-compare
+  t.throws(() => ({} < {}), {
+    message: 'Suppressing conversion of "[[object Object]]" to number',
+  });
+});


### PR DESCRIPTION
This is currently for diagnostic purposes only. DO NOT MERGE.

Probably, this should never merge. But it can still be used for diagnostic purposes when needed. 

@warner , is this useful to you right now?

For this to become a merge candidate, the suppression should be moved to a separate repair file, it should be off by default, and it should only be enabled by yet another new `lockdown` option. Such an option should still be understood as "for diagnostic purposes only". The deviation from standard JS is too great to consider. 

Also, it makes v8 incredibly slower. I expect it will make most engines incredibly slower. But I haven't actually measured anything.