### PR TITLE
fix: speed up assert default details case

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -389,28 +389,34 @@ const makeAssert = (optRaise = undefined, unredacted = false) => {
     optDetails = undefined,
     ErrorConstructor = undefined,
   ) {
-    if (!flag) {
-      throw fail(optDetails, ErrorConstructor);
-    }
+    flag || fail(optDetails, ErrorConstructor);
   }
 
   /** @type {AssertEqual} */
   const equal = (
     actual,
     expected,
-    optDetails = details`Expected ${actual} is same as ${expected}`,
-    ErrorConstructor = RangeError,
+    optDetails = undefined,
+    ErrorConstructor = undefined,
   ) => {
-    baseAssert(is(actual, expected), optDetails, ErrorConstructor);
+    is(actual, expected) ||
+      fail(
+        optDetails || details`Expected ${actual} is same as ${expected}`,
+        ErrorConstructor || RangeError,
+      );
   };
   freeze(equal);
 
   /** @type {AssertTypeof} */
   const assertTypeof = (specimen, typename, optDetails) => {
-    baseAssert(
-      typeof typename === 'string',
-      details`${quote(typename)} must be a string`,
-    );
+    // This will safely fall through if typename is not a string,
+    // which is what we want.
+    // eslint-disable-next-line valid-typeof
+    if (typeof specimen === typename) {
+      return;
+    }
+    typeof typename === 'string' || Fail`${quote(typename)} must be a string`;
+
     if (optDetails === undefined) {
       // Like
       // ```js
@@ -420,12 +426,12 @@ const makeAssert = (optRaise = undefined, unredacted = false) => {
       // so it doesn't get quoted.
       optDetails = details(['', ` must be ${an(typename)}`], specimen);
     }
-    equal(typeof specimen, typename, optDetails, TypeError);
+    fail(optDetails, TypeError);
   };
   freeze(assertTypeof);
 
   /** @type {AssertString} */
-  const assertString = (specimen, optDetails) =>
+  const assertString = (specimen, optDetails = undefined) =>
     assertTypeof(specimen, 'string', optDetails);
 
   // Note that "assert === baseAssert"

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -362,9 +362,11 @@ export { loggedErrorHandler };
  */
 const makeAssert = (optRaise = undefined, unredacted = false) => {
   const details = unredacted ? unredactedDetails : redactedDetails;
+  const assertFailedDetails = details`Check failed`;
+
   /** @type {AssertFail} */
   const fail = (
-    optDetails = details`Assert failed`,
+    optDetails = assertFailedDetails,
     ErrorConstructor = globalThis.Error,
   ) => {
     const reason = makeError(optDetails, ErrorConstructor);
@@ -384,8 +386,8 @@ const makeAssert = (optRaise = undefined, unredacted = false) => {
   /** @type {BaseAssert} */
   function baseAssert(
     flag,
-    optDetails = details`Check failed`,
-    ErrorConstructor = globalThis.Error,
+    optDetails = undefined,
+    ErrorConstructor = undefined,
   ) {
     if (!flag) {
       throw fail(optDetails, ErrorConstructor);

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -73,7 +73,7 @@ test('assert', t => {
   throwsAndLogs(t, () => assert(false, 'foo'), /foo/, [
     ['log', 'Caught', Error],
   ]);
-  throwsAndLogs(t, () => assert.fail(), /Assert failed/, [
+  throwsAndLogs(t, () => assert.fail(), /Check failed/, [
     ['log', 'Caught', Error],
   ]);
   throwsAndLogs(t, () => assert.fail('foo'), /foo/, [['log', 'Caught', Error]]);


### PR DESCRIPTION
Pick the lowest hanging performance fruit.

In general we try to avoid the 

```js
assert(cond, X`...`);
```
style, and use instead
```js
cond || Fail`...`;
```

However, sometimes we are confident enough that the failure can never happen that we do not bother with the details (the 
```js
Something`...`
```
part). This happens often when we're just doing the assertion to inform the type checker of something we believe to be true. For these cases, we often write
```js
assert(cond);
```
Yes, the success case is slower than the `|| Fail` pattern by a function call. But the success case should not be more slower than that. It was, due to a completely unnecessary function call within the default argument for `assert`'s optional second parameter. 

Also fixed: The optional third parameter also happened to be doing work that was unneeded in the success case.