### PR TITLE
refactor: faster assert style

### DIFF
--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -1,6 +1,6 @@
 import { trackTurns } from './track-turns.js';
 
-const { details: X, quote: q } = assert;
+const { details: X, quote: q, Fail } = assert;
 
 /** @type {ProxyHandler<any>} */
 const baseFreezableProxyHandler = {
@@ -90,11 +90,10 @@ function EsendOnlyProxyHandler(x, HandledPromise) {
           // is not constructable, it also avoids the `function` syntax.
           [p](...args) {
             // Throw since the function returns nothing
-            assert.equal(
-              this,
-              receiver,
-              X`Unexpected receiver for "${p}" method of E.sendOnly(${q(x)})`,
-            );
+            this === receiver ||
+              Fail`Unexpected receiver for "${q(p)}" method of E.sendOnly(${q(
+                x,
+              )})`;
             HandledPromise.applyMethodSendOnly(x, p, args);
             return undefined;
           },

--- a/packages/eventual-send/src/local.js
+++ b/packages/eventual-send/src/local.js
@@ -1,4 +1,4 @@
-const { details: X, quote: q } = assert;
+const { details: X, quote: q, Fail } = assert;
 
 const { getOwnPropertyDescriptors, getPrototypeOf, freeze } = Object;
 const { apply, ownKeys } = Reflect;
@@ -65,11 +65,11 @@ export const getMethodNames = val => {
 freeze(getMethodNames);
 
 export const localApplyFunction = (t, args) => {
-  assert.typeof(
-    t,
-    'function',
-    X`Cannot invoke target as a function; typeof target is ${q(ntypeof(t))}`,
-  );
+  typeof t === 'function' ||
+    assert.fail(
+      X`Cannot invoke target as a function; typeof target is ${q(ntypeof(t))}`,
+      TypeError,
+    );
   return apply(t, undefined, args);
 };
 
@@ -94,11 +94,8 @@ export const localApplyMethod = (t, method, args) => {
     );
   }
   const ftype = ntypeof(fn);
-  assert.typeof(
-    fn,
-    'function',
-    X`invoked method ${q(method)} is not a function; it is a ${q(ftype)}`,
-  );
+  typeof fn === 'function' ||
+    Fail`invoked method ${q(method)} is not a function; it is a ${q(ftype)}`;
   return apply(fn, t, args);
 };
 

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -329,11 +329,8 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
       return jsonEncoded.map(encodedVal => decodeFromCapData(encodedVal));
     } else if (hasQClass(jsonEncoded)) {
       const qclass = jsonEncoded[QCLASS];
-      assert.typeof(
-        qclass,
-        'string',
-        X`invalid ${q(QCLASS)} typeof ${q(typeof qclass)}`,
-      );
+      typeof qclass === 'string' ||
+        Fail`invalid ${q(QCLASS)} typeof ${q(typeof qclass)}`;
       switch (qclass) {
         // Encoding of primitives not handled by JSON
         case 'undefined': {
@@ -355,11 +352,8 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
           // @ts-ignore inadequate type inference
           // See https://github.com/endojs/endo/pull/1259#discussion_r954561901
           const { digits } = jsonEncoded;
-          assert.typeof(
-            digits,
-            'string',
-            X`invalid digits typeof ${q(typeof digits)}`,
-          );
+          typeof digits === 'string' ||
+            Fail`invalid digits typeof ${q(typeof digits)}`;
           return BigInt(digits);
         }
         case '@@asyncIterator': {

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -146,11 +146,8 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
     assert(rawTree !== null);
     if (QCLASS in rawTree) {
       const qclass = rawTree[QCLASS];
-      assert.typeof(
-        qclass,
-        'string',
-        X`invalid qclass typeof ${q(typeof qclass)}`,
-      );
+      typeof qclass === 'string' ||
+        Fail`invalid qclass typeof ${q(typeof qclass)}`;
       assert(!isArray(rawTree));
       switch (rawTree['@qclass']) {
         case 'undefined':
@@ -161,11 +158,8 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
         }
         case 'bigint': {
           const { digits } = rawTree;
-          assert.typeof(
-            digits,
-            'string',
-            X`invalid digits typeof ${q(typeof digits)}`,
-          );
+          typeof digits === 'string' ||
+            Fail`invalid digits typeof ${q(typeof digits)}`;
           return;
         }
         case '@@asyncIterator': {
@@ -198,11 +192,8 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
             Fail`Invalid Hilbert Hotel encoding ${rawTree}`;
           prepare(original);
           if ('rest' in rawTree) {
-            assert.typeof(
-              rest,
-              'object',
-              X`Rest ${rest} encoding must be an object`,
-            );
+            typeof rest === 'object' ||
+              Fail`Rest ${rest} encoding must be an object`;
             if (rest === null) {
               throw Fail`Rest ${rest} encoding must not be null`;
             }
@@ -211,11 +202,8 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
               Fail`Rest encoding ${rest} must not contain ${q(QCLASS)}`;
             const names = ownKeys(rest);
             for (const name of names) {
-              assert.typeof(
-                name,
-                'string',
-                X`Property name ${name} of ${rawTree} must be a string`,
-              );
+              typeof name === 'string' ||
+                Fail`Property name ${name} of ${rawTree} must be a string`;
               prepare(rest[name]);
             }
           }
@@ -223,18 +211,12 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
         }
         case 'error': {
           const { name, message } = rawTree;
-          assert.typeof(
-            name,
-            'string',
-            X`invalid error name typeof ${q(typeof name)}`,
-          );
+          typeof name === 'string' ||
+            Fail`invalid error name typeof ${q(typeof name)}`;
           getErrorConstructor(name) !== undefined ||
             Fail`Must be the name of an Error constructor ${name}`;
-          assert.typeof(
-            message,
-            'string',
-            X`invalid error message typeof ${q(typeof message)}`,
-          );
+          typeof message === 'string' ||
+            Fail`invalid error message typeof ${q(typeof message)}`;
           return;
         }
 
@@ -250,11 +232,9 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
     } else {
       const names = ownKeys(rawTree);
       for (const name of names) {
-        assert.typeof(
-          name,
-          'string',
-          X`Property name ${name} of ${rawTree} must be a string`,
-        );
+        if (typeof name !== 'string') {
+          throw Fail`Property name ${name} of ${rawTree} must be a string`;
+        }
         prepare(rawTree[name]);
       }
     }
@@ -389,11 +369,11 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
             assert(rest !== null);
             const names = ownKeys(rest);
             for (const name of names) {
-              assert.typeof(
-                name,
-                'string',
-                X`Property name ${name} of ${rest} must be a string`,
-              );
+              if (typeof name !== 'string') {
+                throw Fail`Property name ${q(
+                  name,
+                )} of ${rest} must be a string`;
+              }
               decodeProperty(name, rest[name]);
             }
           }

--- a/packages/pass-style/src/makeTagged.js
+++ b/packages/pass-style/src/makeTagged.js
@@ -4,14 +4,11 @@ import { PASS_STYLE } from './passStyle-helpers.js';
 import { assertPassable } from './passStyleOf.js';
 
 const { create, prototype: objectPrototype } = Object;
-const { details: X } = assert;
+const { Fail } = assert;
 
 export const makeTagged = (tag, payload) => {
-  assert.typeof(
-    tag,
-    'string',
-    X`The tag of a tagged record must be a string: ${tag}`,
-  );
+  typeof tag === 'string' ||
+    Fail`The tag of a tagged record must be a string: ${tag}`;
   assertPassable(harden(payload));
   return harden(
     create(objectPrototype, {

--- a/packages/ses/src/environment-options.js
+++ b/packages/ses/src/environment-options.js
@@ -5,7 +5,7 @@
 import { arrayPush, freeze } from './commons.js';
 import { assert } from './error/assert.js';
 
-const { details: X, Fail, quote: q } = assert;
+const { Fail, quote: q } = assert;
 
 /**
  * JavaScript module semantics resists attempts to parameterize a module's
@@ -70,19 +70,13 @@ export const makeEnvironmentCaptor = aGlobal => {
    */
   const getEnvironmentOption = (optionName, defaultSetting) => {
     // eslint-disable-next-line @endo/no-polymorphic-call
-    assert.typeof(
-      optionName,
-      'string',
-      X`Environment option name ${q(optionName)} must be a string.`,
-    );
+    typeof optionName === 'string' ||
+      Fail`Environment option name ${q(optionName)} must be a string.`;
     // eslint-disable-next-line @endo/no-polymorphic-call
-    assert.typeof(
-      defaultSetting,
-      'string',
-      X`Environment option default setting ${q(
+    typeof defaultSetting === 'string' ||
+      Fail`Environment option default setting ${q(
         defaultSetting,
-      )} must be a string.`,
-    );
+      )} must be a string.`;
 
     /** @type {string} */
     let setting = defaultSetting;
@@ -94,15 +88,12 @@ export const makeEnvironmentCaptor = aGlobal => {
           arrayPush(capturedEnvironmentOptionNames, optionName);
           const optionValue = globalEnv[optionName];
           // eslint-disable-next-line @endo/no-polymorphic-call
-          assert.typeof(
-            optionValue,
-            'string',
-            X`Environment option named ${q(
+          typeof optionValue === 'string' ||
+            Fail`Environment option named ${q(
               optionName,
             )}, if present, must have a corresponding string value, got ${q(
               optionValue,
-            )}`,
-          );
+            )}`;
           setting = optionValue;
         }
       }


### PR DESCRIPTION
Convert more code to new assert style.

Newly motivated by perf cost of old style, but these changes not measured.

See https://github.com/Agoric/agoric-sdk/pull/7100