### PR TITLE
exitModuleImportHook alongside synchronous exit module linking

### DIFF
--- a/packages/compartment-mapper/demo/policy/index.mjs
+++ b/packages/compartment-mapper/demo/policy/index.mjs
@@ -7,10 +7,6 @@ lockdown({
 });
 
 import fs from 'fs';
-import os from 'os';
-import assert from 'assert';
-import zlib from 'zlib';
-import path from 'path';
 
 import { importLocation, makeArchive, parseArchive } from '../../index.js';
 
@@ -98,13 +94,17 @@ const options = {
     console,
     process,
   },
+  exitModuleImportHook: async specifier => {
+    const module = await import(specifier);
+    return module;
+  },
   modules: {
-    path: await addToCompartment('path', path),
-    assert: await addToCompartment('assert', assert),
+    // path: await addToCompartment('path', path),
+    // assert: await addToCompartment('assert', assert),
     buffer: await addToCompartment('buffer', Object.create(null)), // imported but unused
-    zlib: await addToCompartment('zlib', zlib),
-    fs: await addToCompartment('fs', fs),
-    os: await addToCompartment('os', os),
+    // zlib: await addToCompartment('zlib', zlib),
+    // fs: await addToCompartment('fs', fs),
+    // os: await addToCompartment('os', os),
   },
 };
 
@@ -124,6 +124,7 @@ console.log('\n\n________________________________________________ Archive\n');
   const archive = await makeArchive(readPower, entrypointPath, {
     modules: options.modules,
     policy: options.policy,
+    exitModuleImportHook: options.exitModuleImportHook,
   });
   console.log('>----------makeArchive -> parseArchive');
   const application = await parseArchive(archive, '<unknown>', {
@@ -133,6 +134,7 @@ console.log('\n\n________________________________________________ Archive\n');
   const { namespace } = await application.import({
     globals: options.globals,
     modules: options.modules,
+    exitModuleImportHook: options.exitModuleImportHook,
   });
   console.log('>----------import -> end');
   console.log(2, namespace.poem);

--- a/packages/compartment-mapper/demo/policy/index.mjs
+++ b/packages/compartment-mapper/demo/policy/index.mjs
@@ -95,8 +95,15 @@ const options = {
     process,
   },
   exitModuleImportHook: async specifier => {
-    const module = await import(specifier);
-    return module;
+    const ns = await import(specifier);
+    return Object.freeze({
+      imports: [],
+      exports: Object.keys(ns),
+      execute: moduleExports => {
+        moduleExports.default = ns; // Why is typescript complaining about this?
+        Object.assign(moduleExports, ns);
+      },
+    });
   },
   modules: {
     // path: await addToCompartment('path', path),

--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -259,6 +259,7 @@ const digestLocation = async (powers, moduleLocation, options) => {
     searchSuffixes = undefined,
     commonDependencies = undefined,
     policy = undefined,
+    exitModuleImportHook = undefined,
   } = options || {};
   const { read, computeSha512 } = unpackReadPowers(powers);
   const {
@@ -299,6 +300,7 @@ const digestLocation = async (powers, moduleLocation, options) => {
     sources,
     compartments,
     exitModules,
+    exitModuleImportHook, // should it get the archiveOnly hint somehow?
     computeSha512,
     searchSuffixes,
   );

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -207,6 +207,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
     sources,
     compartments,
     undefined,
+    undefined, // TODO: support exitModuleImportHook
     undefined,
     searchSuffixes,
   );

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -14,6 +14,7 @@
 /** @typedef {import('./types.js').ComputeSourceLocationHook} ComputeSourceLocationHook */
 /** @typedef {import('./types.js').LoadArchiveOptions} LoadArchiveOptions */
 /** @typedef {import('./types.js').ExecuteOptions} ExecuteOptions */
+/** @typedef {import('./types.js').ExitModuleImportHook} ExitModuleImportHook */
 
 import { ZipReader } from '@endo/zip';
 import { link } from './link.js';
@@ -78,6 +79,7 @@ const postponeErrorToExecute = errorMessage => {
  * @param {string} archiveLocation
  * @param {HashFn} [computeSha512]
  * @param {ComputeSourceLocationHook} [computeSourceLocation]
+ * @param {ExitModuleImportHook} [exitModuleImportHook]
  * @returns {ArchiveImportHookMaker}
  */
 const makeArchiveImportHookMaker = (
@@ -86,6 +88,7 @@ const makeArchiveImportHookMaker = (
   archiveLocation,
   computeSha512 = undefined,
   computeSourceLocation = undefined,
+  exitModuleImportHook = undefined,
 ) => {
   // per-assembly:
   /** @type {ArchiveImportHookMaker} */
@@ -97,6 +100,23 @@ const makeArchiveImportHookMaker = (
       // per-module:
       const module = modules[moduleSpecifier];
       if (module === undefined) {
+        if (exitModuleImportHook) {
+          console.error('#################x');
+          const ns = await exitModuleImportHook(moduleSpecifier);
+          if (ns) {
+            return {
+              record: freeze({
+                imports: [],
+                exports: Object.keys(ns),
+                execute: moduleExports => {
+                  moduleExports.default = ns;
+                  Object.assign(moduleExports, ns);
+                },
+              }),
+              specifier: moduleSpecifier,
+            };
+          }
+        }
         throw new Error(
           `Cannot find module ${q(moduleSpecifier)} in package ${q(
             packageLocation,
@@ -190,6 +210,7 @@ const makeFeauxModuleExportsNamespace = Compartment => {
  * @param {string} [options.expectedSha512]
  * @param {HashFn} [options.computeSha512]
  * @param {Record<string, unknown>} [options.modules]
+ * @param {ExitModuleImportHook} [options.exitModuleImportHook]
  * @param {Compartment} [options.Compartment]
  * @param {ComputeSourceLocationHook} [options.computeSourceLocation]
  * @returns {Promise<Application>}
@@ -205,6 +226,7 @@ export const parseArchive = async (
     computeSourceLocation = undefined,
     Compartment = DefaultCompartment,
     modules = undefined,
+    exitModuleImportHook = undefined,
   } = options;
 
   const archive = new ZipReader(archiveBytes, { name: archiveLocation });
@@ -264,6 +286,7 @@ export const parseArchive = async (
       archiveLocation,
       computeSha512,
       computeSourceLocation,
+      exitModuleImportHook,
     );
     // A weakness of the current Compartment design is that the `modules` map
     // must be given a module namespace object that passes a brand check.
@@ -291,14 +314,21 @@ export const parseArchive = async (
 
   /** @type {ExecuteFn} */
   const execute = async options => {
-    const { globals, modules, transforms, __shimTransforms__, Compartment } =
-      options || {};
+    const {
+      globals,
+      modules,
+      transforms,
+      __shimTransforms__,
+      Compartment,
+      exitModuleImportHook,
+    } = options || {};
     const makeImportHook = makeArchiveImportHookMaker(
       get,
       compartments,
       archiveLocation,
       computeSha512,
       computeSourceLocation,
+      exitModuleImportHook,
     );
     const { compartment, pendingJobsPromise } = link(compartmentMap, {
       makeImportHook,

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -102,17 +102,10 @@ const makeArchiveImportHookMaker = (
       if (module === undefined) {
         if (exitModuleImportHook) {
           console.error('#################x');
-          const ns = await exitModuleImportHook(moduleSpecifier);
-          if (ns) {
+          const record = await exitModuleImportHook(moduleSpecifier);
+          if (record) {
             return {
-              record: freeze({
-                imports: [],
-                exports: Object.keys(ns),
-                execute: moduleExports => {
-                  moduleExports.default = ns;
-                  Object.assign(moduleExports, ns);
-                },
-              }),
+              record,
               specifier: moduleSpecifier,
             };
           }

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -70,14 +70,21 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
 
   /** @type {ExecuteFn} */
   const execute = async (options = {}) => {
-    const { globals, modules, transforms, __shimTransforms__, Compartment } =
-      options;
+    const {
+      globals,
+      modules,
+      transforms,
+      __shimTransforms__,
+      Compartment,
+      exitModuleImportHook,
+    } = options;
     const makeImportHook = makeImportHookMaker(
       readPowers,
       packageLocation,
       undefined,
       compartmentMap.compartments,
-      undefined,
+      modules,
+      exitModuleImportHook,
       undefined,
       searchSuffixes,
     );

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -228,7 +228,7 @@ export {};
 /**
  * @callback ExitModuleImportHook
  * @param {string} specifier
- * @returns {Promise<object>} module namespace
+ * @returns {Promise<FinalStaticModuleType>} module namespace
  */
 
 /**

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -226,6 +226,12 @@ export {};
  */
 
 /**
+ * @callback ExitModuleImportHook
+ * @param {string} specifier
+ * @returns {Promise<object>} module namespace
+ */
+
+/**
  * @typedef {object} LoadArchiveOptions
  * @property {string} [expectedSha512]
  * @property {Record<string, any>} [modules]
@@ -239,6 +245,7 @@ export {};
  * @property {Array<Transform>} [transforms]
  * @property {Array<Transform>} [__shimTransforms__]
  * @property {Record<string, object>} [modules]
+ * @property {ExitModuleImportHook} [exitModuleImportHook]
  * @property {Record<string, object>} [attenuations]
  * @property {Compartment} [Compartment]
  */
@@ -310,6 +317,7 @@ export {};
  * @typedef {object} ArchiveOptions
  * @property {ModuleTransforms} [moduleTransforms]
  * @property {Record<string, any>} [modules]
+ * @property {ExitModuleImportHook} [exitModuleImportHook]
  * @property {boolean} [dev]
  * @property {object} [policy]
  * @property {Set<string>} [tags]

--- a/packages/compartment-mapper/test/fixtures-policy/node_modules/app/importActualBuiltin.js
+++ b/packages/compartment-mapper/test/fixtures-policy/node_modules/app/importActualBuiltin.js
@@ -1,0 +1,3 @@
+import fs from 'fs';
+
+export const rootExists = fs.existsSync('/');

--- a/packages/compartment-mapper/test/scaffold.js
+++ b/packages/compartment-mapper/test/scaffold.js
@@ -78,6 +78,7 @@ export function scaffold(
     tags = undefined,
     searchSuffixes = undefined,
     commonDependencies = undefined,
+    additionalOptions = {},
   } = {},
 ) {
   // wrapping each time allows for convenient use of test.only
@@ -120,11 +121,13 @@ export function scaffold(
       tags,
       searchSuffixes,
       commonDependencies,
+      ...additionalOptions,
     });
     const { namespace } = await application.import({
       globals: { ...globals, ...addGlobals },
       modules,
       Compartment,
+      ...additionalOptions,
     });
     return namespace;
   });
@@ -142,6 +145,7 @@ export function scaffold(
       tags,
       searchSuffixes,
       commonDependencies,
+      ...additionalOptions,
     });
     return namespace;
   });
@@ -159,6 +163,7 @@ export function scaffold(
         tags,
         searchSuffixes,
         commonDependencies,
+        ...additionalOptions,
       });
       const application = await parseArchive(archive, '<unknown>', {
         modules: Object.fromEntries(
@@ -175,6 +180,7 @@ export function scaffold(
         globals: { ...globals, ...addGlobals },
         modules,
         Compartment,
+        ...additionalOptions,
       });
       return namespace;
     },
@@ -194,6 +200,7 @@ export function scaffold(
         tags,
         searchSuffixes,
         commonDependencies,
+        ...additionalOptions,
       });
       const prefixArchive = new Uint8Array(archive.length + 10);
       prefixArchive.set(archive, 10);
@@ -206,6 +213,7 @@ export function scaffold(
         globals: { ...globals, ...addGlobals },
         modules,
         Compartment,
+        ...additionalOptions,
       });
       return namespace;
     },
@@ -237,6 +245,7 @@ export function scaffold(
         tags,
         searchSuffixes,
         commonDependencies,
+        ...additionalOptions,
       });
       const application = await loadArchive(fakeRead, 'app.agar', {
         modules,
@@ -246,6 +255,7 @@ export function scaffold(
         globals: { ...globals, ...addGlobals },
         modules,
         Compartment,
+        ...additionalOptions,
       });
       return namespace;
     },
@@ -277,11 +287,13 @@ export function scaffold(
         tags,
         searchSuffixes,
         commonDependencies,
+        ...additionalOptions,
       });
       const { namespace } = await importArchive(fakeRead, 'app.agar', {
         globals: { ...globals, ...addGlobals },
         modules,
         Compartment,
+        ...additionalOptions,
       });
       return namespace;
     },
@@ -299,6 +311,7 @@ export function scaffold(
         tags,
         searchSuffixes,
         commonDependencies,
+        ...additionalOptions,
       });
 
       const archiveBytes = await makeArchive(readPowers, fixture, {
@@ -307,6 +320,7 @@ export function scaffold(
         tags,
         searchSuffixes,
         commonDependencies,
+        ...additionalOptions,
       });
 
       const { computeSha512 } = readPowers;
@@ -319,6 +333,7 @@ export function scaffold(
           tags,
           computeSha512,
           expectedSha512,
+          ...additionalOptions,
         },
       );
 
@@ -336,6 +351,7 @@ export function scaffold(
         tags,
         searchSuffixes,
         commonDependencies,
+        ...additionalOptions,
       });
 
       const archive = await makeArchive(readPowers, fixture, {
@@ -344,6 +360,7 @@ export function scaffold(
         tags,
         searchSuffixes,
         commonDependencies,
+        ...additionalOptions,
       });
 
       const reader = new ZipReader(archive);
@@ -360,6 +377,7 @@ export function scaffold(
           parseArchive(corruptArchive, 'app.agar', {
             computeSha512,
             expectedSha512,
+            ...additionalOptions,
           }),
         {
           message: /compartment map failed a SHA-512 integrity check/,

--- a/packages/compartment-mapper/test/test-exit-hook.js
+++ b/packages/compartment-mapper/test/test-exit-hook.js
@@ -1,0 +1,27 @@
+// import "./ses-lockdown.js";
+import 'ses';
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+
+const fixture = new URL(
+  'fixtures-policy/node_modules/app/importActualBuiltin.js',
+  import.meta.url,
+).toString();
+
+scaffold(
+  'exitModuleImportHook - import actual builtin',
+  test,
+  fixture,
+  (t, { namespace }) => {
+    t.is(namespace.rootExists, true);
+  },
+  1, // expected number of assertions
+  {
+    additionalOptions: {
+      exitModuleImportHook: async specifier => {
+        const module = await import(specifier);
+        return module;
+      },
+    },
+  },
+);

--- a/packages/compartment-mapper/test/test-exit-hook.js
+++ b/packages/compartment-mapper/test/test-exit-hook.js
@@ -19,8 +19,15 @@ scaffold(
   {
     additionalOptions: {
       exitModuleImportHook: async specifier => {
-        const module = await import(specifier);
-        return module;
+        const ns = await import(specifier);
+        return Object.freeze({
+          imports: [],
+          exports: Object.keys(ns),
+          execute: moduleExports => {
+            moduleExports.default = ns;
+            Object.assign(moduleExports, ns);
+          },
+        });
       },
     },
   },


### PR DESCRIPTION
### Abandoned in favor of https://github.com/endojs/endo/pull/1507

This is a PoC exitModuleImportHook.

It works, but not necessarily the way we want it to work. 


Notes:

- It seems to make sense for the exitModuleImportHook to return a `ThirdPartyStaticModuleInterface`
- I am exploring replacing exitModules with the exitModuleImportHook entirely, which removes a lot of complications from linking, changes module attenuation slightly (might be for the better, not sure yet) but it changes how modules from external assemblies or compartments could get included. I don't see a lot of use for that though. 
- I don't yet see a way to properly attenuate on top of exitModuleImportHook - I just discovered that attenuation would only run once per builtin and then it gets cached by the specifier, so attenuation would have to return a unique alias record at least. I'm not sure if that's enough.