### PR TITLE
chore: release

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.30](https://github.com/endojs/endo/compare/@endo/base64@0.2.29...@endo/base64@0.2.30) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.2.29](https://github.com/endojs/endo/compare/@endo/base64@0.2.28...@endo/base64@0.2.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "Transcodes base64",
   "keywords": [
     "base64",
@@ -39,7 +39,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.4.4](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.3...@endo/bundle-source@2.4.4) (2023-03-07)
+
+### Bug Fixes
+
+- **bundle-source:** exit with error code on cli failure ([#1479](https://github.com/endojs/endo/issues/1479)) ([1f97e54](https://github.com/endojs/endo/commit/1f97e54e9aafdf349caec2a9732b2a4befa333f0))
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- Improve typing information ([765d262](https://github.com/endojs/endo/commit/765d2625ee278608494f7e998bcd3a3ee8b845a4))
+
 ### [2.4.3](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.2...@endo/bundle-source@2.4.3) (2022-12-23)
 
 **Note:** Version bump only for package @endo/bundle-source

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",
@@ -29,9 +29,9 @@
     "@agoric/babel-generator": "^7.17.4",
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
-    "@endo/base64": "^0.2.29",
-    "@endo/compartment-mapper": "^0.8.1",
-    "@endo/init": "^0.5.53",
+    "@endo/base64": "^0.2.30",
+    "@endo/compartment-mapper": "^0.8.2",
+    "@endo/init": "^0.5.54",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "acorn": "^8.2.4",
@@ -39,8 +39,8 @@
     "source-map": "^0.7.3"
   },
   "devDependencies": {
-    "@endo/lockdown": "^0.1.25",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/lockdown": "^0.1.26",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/endojs/endo/compare/@endo/captp@2.0.19...@endo/captp@3.0.0) (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- **captp:** implement garbage collection
+
+### Features
+
+- **captp:** add `exportHook` to fire when local references are sent remotely ([8967c15](https://github.com/endojs/endo/commit/8967c157d5612357e2a561c798c3303c2ee44ec7))
+- **captp:** add loopback options and `isOnlyNear`/`isOnlyFar` ([8244c26](https://github.com/endojs/endo/commit/8244c26ba5c843169012637d0c1f293e9456cbb8))
+- **captp:** implement `isOnlyLocal` ([1a3988c](https://github.com/endojs/endo/commit/1a3988c387728b0d236957d5352ae961a43042d3))
+- **captp:** implement garbage collection ([901dd23](https://github.com/endojs/endo/commit/901dd23b5064dda754d1a675e6e6acb456a32ac0))
+- **pass-style:** Extract passStyleOf and friends from marshal into the new pass-style package ([#1439](https://github.com/endojs/endo/issues/1439)) ([ccd003c](https://github.com/endojs/endo/commit/ccd003c96f3d969d919104118d8a34b3c1126aef))
+
+### Bug Fixes
+
+- **captp:** avoid `.then` reentrancy attacks ([86eea88](https://github.com/endojs/endo/commit/86eea88b3a11bc744e7b3215419ca1af7838e73b))
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- Improve typing information ([7b3fc39](https://github.com/endojs/endo/commit/7b3fc397862ac2c8617454d587f1069be1e15517))
+
 ### [2.0.19](https://github.com/endojs/endo/compare/@endo/captp@2.0.18...@endo/captp@2.0.19) (2022-12-23)
 
 ### Bug Fixes

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "2.0.19",
+  "version": "3.0.0",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [
@@ -42,16 +42,16 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.53",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/init": "^0.5.54",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.16.9",
-    "@endo/marshal": "^0.8.2",
-    "@endo/nat": "^4.1.24",
-    "@endo/promise-kit": "^0.2.53"
+    "@endo/eventual-send": "^0.17.0",
+    "@endo/marshal": "^0.8.3",
+    "@endo/nat": "^4.1.25",
+    "@endo/promise-kit": "^0.2.54"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.16](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.15...@endo/check-bundle@0.2.16) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.2.15](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.14...@endo/check-bundle@0.2.15) (2022-12-23)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",
@@ -37,14 +37,14 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.29",
-    "@endo/compartment-mapper": "^0.8.1"
+    "@endo/base64": "^0.2.30",
+    "@endo/compartment-mapper": "^0.8.2"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.4.3",
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/init": "^0.5.53",
-    "@endo/zip": "^0.2.29",
+    "@endo/bundle-source": "^2.4.4",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/init": "^0.5.54",
+    "@endo/zip": "^0.2.30",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.30](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.29...@endo/cjs-module-analyzer@0.2.30) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.2.29](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.28...@endo/cjs-module-analyzer@0.2.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",
@@ -29,7 +29,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0](https://github.com/endojs/endo/compare/@endo/cli@0.1.24...@endo/cli@0.2.0) (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- **where:** Thread OS info
+
+### Bug Fixes
+
+- **cli:** Fix hash, map, and hash-archive commands ([2a0a312](https://github.com/endojs/endo/commit/2a0a31206fe5144bac7e3754a4b88fbb883eb8d7))
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- **where:** Thread OS info ([b7c2441](https://github.com/endojs/endo/commit/b7c24412250b45984964156894efb72ef72ac3f6))
+
 ### [0.1.24](https://github.com/endojs/endo/compare/@endo/cli@0.1.23...@endo/cli@0.1.24) (2022-12-23)
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "0.1.24",
+  "version": "0.2.0",
   "description": "Endo command line interface",
   "keywords": [],
   "author": "Endo contributors",
@@ -24,18 +24,18 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/compartment-mapper": "^0.8.1",
-    "@endo/daemon": "^0.1.24",
-    "@endo/eventual-send": "^0.16.9",
-    "@endo/far": "^0.2.15",
-    "@endo/lockdown": "^0.1.25",
-    "@endo/promise-kit": "^0.2.53",
-    "@endo/where": "^0.2.11",
+    "@endo/compartment-mapper": "^0.8.2",
+    "@endo/daemon": "^0.2.0",
+    "@endo/eventual-send": "^0.17.0",
+    "@endo/far": "^0.2.16",
+    "@endo/lockdown": "^0.1.26",
+    "@endo/promise-kit": "^0.2.54",
+    "@endo/where": "^0.3.0",
     "commander": "^5.0.0",
-    "ses": "^0.18.1"
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.8.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.8.1...@endo/compartment-mapper@0.8.2) (2023-03-07)
+
+### Features
+
+- **compartment-mapper:** add policy enforcement to compartment-mapper ([9315993](https://github.com/endojs/endo/commit/9315993d20f38c8b077a814cba67fd399e47ca1e))
+- **compartment-mapper:** add the ability to specify a default attenuator for the policy ([95bdcc3](https://github.com/endojs/endo/commit/95bdcc3455deab091ebe423f2fc6cba4019b8df3))
+- **compartment-mapper:** allow omitting globalThis freeze with policy ([bbec3ca](https://github.com/endojs/endo/commit/bbec3ca195cdc38f412e8194f9143bf6d8bb8759))
+- **compartment-mapper:** attenuate builtins with attenuators from packages ([dc8426f](https://github.com/endojs/endo/commit/dc8426f40f4471ffd65db98451c9cde97b2064b9))
+- **compartment-mapper:** error propagation from globalThis attenuators ([43799be](https://github.com/endojs/endo/commit/43799be7f3c895600a381c6e568cde3137fd5afd))
+- **compartment-mapper:** expect independent names for globals and module attenuator ([5c7e048](https://github.com/endojs/endo/commit/5c7e0481a0c98dd991f9936031b7cc7a660847c3))
+- **compartment-mapper:** globals attenuation enabling LavaMoat feature parity ([20acd6f](https://github.com/endojs/endo/commit/20acd6f428226b2a079a543e04cc7777e6b25e4f))
+- **compartment-mapper:** validate policy in compartment map ([55a3991](https://github.com/endojs/endo/commit/55a39913253e1939dd3d494858e91d564097f9e1))
+- **compartment-mapper:** wildcard policy specified as "any" ([89e7104](https://github.com/endojs/endo/commit/89e71043c104e701d361bde14f9a5669492228e1))
+
+### Bug Fixes
+
+- **compartment-mapper:** fix naming conventions, move entry compartment policy, clean up demo and readme ([35a7d8b](https://github.com/endojs/endo/commit/35a7d8bc26616a3511c72eb32e26f6cf41cb6c34))
+- **compartment-mapper:** use reliable information to identify packages for policy application ([2fb7900](https://github.com/endojs/endo/commit/2fb7900f39f35232568c16328c5a07f13525695b))
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- Improve typing information ([7b3fc39](https://github.com/endojs/endo/commit/7b3fc397862ac2c8617454d587f1069be1e15517))
+
 ### [0.8.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.8.0...@endo/compartment-mapper@0.8.1) (2022-12-23)
 
 ### Features

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -41,13 +41,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/cjs-module-analyzer": "^0.2.29",
-    "@endo/static-module-record": "^0.7.16",
-    "@endo/zip": "^0.2.29",
-    "ses": "^0.18.1"
+    "@endo/cjs-module-analyzer": "^0.2.30",
+    "@endo/static-module-record": "^0.7.17",
+    "@endo/zip": "^0.2.30",
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0](https://github.com/endojs/endo/compare/@endo/daemon@0.1.24...@endo/daemon@0.2.0) (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- **where:** Thread OS info
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- Improve typing information ([765d262](https://github.com/endojs/endo/commit/765d2625ee278608494f7e998bcd3a3ee8b845a4))
+- **where:** Thread OS info ([b7c2441](https://github.com/endojs/endo/commit/b7c24412250b45984964156894efb72ef72ac3f6))
+
 ### [0.1.24](https://github.com/endojs/endo/compare/@endo/daemon@0.1.23...@endo/daemon@0.1.24) (2022-12-23)
 
 ### Features

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "0.1.24",
+  "version": "0.2.0",
   "description": "Endo daemon",
   "keywords": [
     "endo",
@@ -34,19 +34,19 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/captp": "^2.0.19",
-    "@endo/eventual-send": "^0.16.9",
-    "@endo/far": "^0.2.15",
-    "@endo/lockdown": "^0.1.25",
-    "@endo/netstring": "^0.3.23",
-    "@endo/promise-kit": "^0.2.53",
-    "@endo/stream": "^0.3.22",
-    "@endo/stream-node": "^0.2.23",
-    "@endo/where": "^0.2.11",
-    "ses": "^0.18.1"
+    "@endo/captp": "^3.0.0",
+    "@endo/eventual-send": "^0.17.0",
+    "@endo/far": "^0.2.16",
+    "@endo/lockdown": "^0.1.26",
+    "@endo/netstring": "^0.3.24",
+    "@endo/promise-kit": "^0.2.54",
+    "@endo/stream": "^0.3.23",
+    "@endo/stream-node": "^0.2.24",
+    "@endo/where": "^0.3.0",
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.3](https://github.com/endojs/endo/compare/@endo/eslint-config@0.5.2...@endo/eslint-config@0.5.3) (2023-03-07)
+
+### Features
+
+- Default linting to be type-aware in "src" directories ([307fdbc](https://github.com/endojs/endo/commit/307fdbca4ad0c8e96831fafbe5c15b3b985a287e))
+- **eslint-config:** Acknowledge explicit ENDO_LINT_TYPES via log output ([246826f](https://github.com/endojs/endo/commit/246826fd5296d3ddff96375f7dc0f454f9cafcc1))
+- **eslint-config:** Support type-aware linting by environment variable ([68eaea4](https://github.com/endojs/endo/commit/68eaea447bf86ea4a714b9a6e1c661fd22d8e0ec))
+- **eslint-config:** Use relational comparison operand type checking when possible ([be5b279](https://github.com/endojs/endo/commit/be5b279eea48009645e230260eeebe0e987cba86))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.5.2](https://github.com/endojs/endo/compare/@endo/eslint-config@0.5.1...@endo/eslint-config@0.5.2) (2022-12-23)
 
 **Note:** Version bump only for package @endo/eslint-config

--- a/packages/eslint-config/NEWS.md
+++ b/packages/eslint-config/NEWS.md
@@ -1,4 +1,5 @@
-# Next release
+# v0.5.3 (2023-03-07)
+
 * Support type-aware linting by environment variable
   * `ENDO_LINT_TYPES=NONE`: Linting is type-ignorant.
   * `ENDO_LINT_TYPES=SRC`: Linting of "src" directories is type-aware (default,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-config",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "lint rules used in Endo development",
   "keywords": [
     "endo",
@@ -24,7 +24,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/eslint-plugin": "^0.4.2",
+    "@endo/eslint-plugin": "^0.4.3",
     "@jessie.js/eslint-plugin": "^0.3.0"
   },
   "files": [

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.4.3](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.4.2...@endo/eslint-plugin@0.4.3) (2023-03-07)
+
+### Features
+
+- **eslint-config:** Use relational comparison operand type checking when possible ([be5b279](https://github.com/endojs/endo/commit/be5b279eea48009645e230260eeebe0e987cba86))
+- **eslint-plugin:** Add a custom rule for rejecting mixed-type relational comparison ([90bb19d](https://github.com/endojs/endo/commit/90bb19d8ce55faa681e1c73175f9e607f4aa33d0))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.4.2](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.4.1...@endo/eslint-plugin@0.4.2) (2022-12-23)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.17.0](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.9...@endo/eventual-send@0.17.0) (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- **captp:** implement garbage collection
+
+### Features
+
+- **captp:** implement garbage collection ([901dd23](https://github.com/endojs/endo/commit/901dd23b5064dda754d1a675e6e6acb456a32ac0))
+- **eventual-send:** Harden HandledPromise modulo intrinsic exit points ([#1468](https://github.com/endojs/endo/issues/1468)) ([4fc4923](https://github.com/endojs/endo/commit/4fc4923744ed04a66692763e017937bdde4f5c96))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.16.9](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.8...@endo/eventual-send@0.16.9) (2022-12-23)
 
 ### Bug Fixes

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "0.16.9",
+  "version": "0.17.0",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/lockdown": "^0.1.25",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/lockdown": "^0.1.26",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "c8": "^7.7.3",
     "tsd": "^0.24.1"

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.2.0 (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- rename 'fit' to 'mustMatch' (#1464)
+
+### Features
+
+- **exo:** start migrating exo from @agoric/store ([#1459](https://github.com/endojs/endo/issues/1459)) ([a882b7c](https://github.com/endojs/endo/commit/a882b7ca88863d7f85310074c38f3cc0032e1e0e))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- missed documentation suggestion ([#1463](https://github.com/endojs/endo/issues/1463)) ([3f266bf](https://github.com/endojs/endo/commit/3f266bffdf122c73dedada6f311de770210b426a))
+
+### Miscellaneous Chores
+
+- rename 'fit' to 'mustMatch' ([#1464](https://github.com/endojs/endo/issues/1464)) ([a4f88f8](https://github.com/endojs/endo/commit/a4f88f8ef1e7d62b993900244e260d90113f9759))
+
+## 0.2.0 (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- rename 'fit' to 'mustMatch' (#1464)
+
+### Features
+
+- **exo:** start migrating exo from @agoric/store ([#1459](https://github.com/endojs/endo/issues/1459)) ([a882b7c](https://github.com/endojs/endo/commit/a882b7ca88863d7f85310074c38f3cc0032e1e0e))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- missed documentation suggestion ([#1463](https://github.com/endojs/endo/issues/1463)) ([3f266bf](https://github.com/endojs/endo/commit/3f266bffdf122c73dedada6f311de770210b426a))
+
+### Miscellaneous Chores
+
+- rename 'fit' to 'mustMatch' ([#1464](https://github.com/endojs/endo/issues/1464)) ([a4f88f8](https://github.com/endojs/endo/commit/a4f88f8ef1e7d62b993900244e260d90113f9759))

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",
@@ -30,13 +30,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/far": "^0.2.15",
-    "@endo/patterns": "^0.1.0"
+    "@endo/far": "^0.2.16",
+    "@endo/patterns": "^0.2.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/init": "^0.5.53",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/init": "^0.5.54",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.16](https://github.com/endojs/endo/compare/@endo/far@0.2.15...@endo/far@0.2.16) (2023-03-07)
+
+### Features
+
+- **pass-style:** Extract passStyleOf and friends from marshal into the new pass-style package ([#1439](https://github.com/endojs/endo/issues/1439)) ([ccd003c](https://github.com/endojs/endo/commit/ccd003c96f3d969d919104118d8a34b3c1126aef))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.2.15](https://github.com/endojs/endo/compare/@endo/far@0.2.14...@endo/far@0.2.15) (2022-12-23)
 
 ### Bug Fixes

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",
@@ -26,12 +26,12 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.16.9",
-    "@endo/pass-style": "^0.1.0"
+    "@endo/eventual-send": "^0.17.0",
+    "@endo/pass-style": "^0.1.1"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.53",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/init": "^0.5.54",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.2](https://github.com/endojs/endo/compare/@endo/import-bundle@0.3.1...@endo/import-bundle@0.3.2) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.3.1](https://github.com/endojs/endo/compare/@endo/import-bundle@0.3.0...@endo/import-bundle@0.3.1) (2022-12-23)
 
 **Note:** Version bump only for package @endo/import-bundle

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "load modules created by @endo/bundle-source",
   "type": "module",
   "main": "src/index.js",
@@ -21,13 +21,13 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.29",
-    "@endo/compartment-mapper": "^0.8.1"
+    "@endo/base64": "^0.2.30",
+    "@endo/compartment-mapper": "^0.8.2"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.4.3",
-    "@endo/init": "^0.5.53",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/bundle-source": "^2.4.4",
+    "@endo/init": "^0.5.54",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.54](https://github.com/endojs/endo/compare/@endo/init@0.5.53...@endo/init@0.5.54) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.5.53](https://github.com/endojs/endo/compare/@endo/init@0.5.52...@endo/init@0.5.53) (2022-12-23)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "0.5.53",
+  "version": "0.5.54",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",
@@ -28,15 +28,15 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.1",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/compartment-mapper": "^0.8.2",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.1.1"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.29",
-    "@endo/eventual-send": "^0.16.9",
-    "@endo/lockdown": "^0.1.25",
-    "@endo/promise-kit": "^0.2.53"
+    "@endo/base64": "^0.2.30",
+    "@endo/eventual-send": "^0.17.0",
+    "@endo/lockdown": "^0.1.26",
+    "@endo/promise-kit": "^0.2.54"
   },
   "files": [
     "LICENSE*",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.26](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.25...@endo/lockdown@0.1.26) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.1.25](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.24...@endo/lockdown@0.1.25) (2022-12-23)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
@@ -16,7 +16,7 @@
     "ava": "^5.1.1"
   },
   "dependencies": {
-    "ses": "^0.18.1"
+    "ses": "^0.18.2"
   },
   "files": [
     "LICENSE*",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.24](https://github.com/endojs/endo/compare/@endo/lp32@0.3.23...@endo/lp32@0.3.24) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.3.23](https://github.com/endojs/endo/compare/@endo/lp32@0.3.22...@endo/lp32@0.3.23) (2022-12-23)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",
@@ -44,13 +44,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.53",
-    "@endo/stream": "^0.3.22",
-    "ses": "^0.18.1"
+    "@endo/init": "^0.5.54",
+    "@endo/stream": "^0.3.23",
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.8.3](https://github.com/endojs/endo/compare/@endo/marshal@0.8.2...@endo/marshal@0.8.3) (2023-03-07)
+
+### Features
+
+- **marshal:** display slot values if supplied ([6edaf4a](https://github.com/endojs/endo/commit/6edaf4ac5a81640f0dddef30027a7d24e88ff09c))
+- **marshal:** new methods {to,from}CapData ([2c97bb9](https://github.com/endojs/endo/commit/2c97bb9484a594a7143c767d33c290dcfb8d1321))
+- **pass-style:** Extract passStyleOf and friends from marshal into the new pass-style package ([#1439](https://github.com/endojs/endo/issues/1439)) ([ccd003c](https://github.com/endojs/endo/commit/ccd003c96f3d969d919104118d8a34b3c1126aef))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- make deeplyFulfilled an async function ([#1455](https://github.com/endojs/endo/issues/1455)) ([fdc3374](https://github.com/endojs/endo/commit/fdc33741414cb6b11bfa322cff8e027fe9c858b0))
+- marshal export what others import ([#1447](https://github.com/endojs/endo/issues/1447)) ([e2a016f](https://github.com/endojs/endo/commit/e2a016f0b94d262256d30f67d48d3a194cb1b35d))
+- move arb-passable to pass-style ([#1448](https://github.com/endojs/endo/issues/1448)) ([09235a9](https://github.com/endojs/endo/commit/09235a9a339229636fb37b4483ccddbe3b60d5ee))
+- tools arb passable ([#1291](https://github.com/endojs/endo/issues/1291)) ([368d7cb](https://github.com/endojs/endo/commit/368d7cbd754efb5248248106773a625d5ec68504))
+
 ### [0.8.2](https://github.com/endojs/endo/compare/@endo/marshal@0.8.1...@endo/marshal@0.8.2) (2022-12-23)
 
 ### Bug Fixes

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",
@@ -36,15 +36,15 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.16.9",
-    "@endo/nat": "^4.1.24",
-    "@endo/pass-style": "^0.1.0",
-    "@endo/promise-kit": "^0.2.53"
+    "@endo/eventual-send": "^0.17.0",
+    "@endo/nat": "^4.1.25",
+    "@endo/pass-style": "^0.1.1",
+    "@endo/promise-kit": "^0.2.54"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.53",
-    "@endo/lockdown": "^0.1.25",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/init": "^0.5.54",
+    "@endo/lockdown": "^0.1.26",
+    "@endo/ses-ava": "^0.2.38",
     "@fast-check/ava": "^1.1.3",
     "ava": "^5.2.0",
     "c8": "^7.7.3"

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.25](https://github.com/endojs/endo/compare/@endo/nat@4.1.24...@endo/nat@4.1.25) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [4.1.24](https://github.com/endojs/endo/compare/@endo/nat@4.1.23...@endo/nat@4.1.24) (2022-12-23)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "4.1.24",
+  "version": "4.1.25",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.1",
+    "@endo/compartment-mapper": "^0.8.2",
     "ava": "^5.2.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^3.4.1",
     "prettier": "^2.8.0",
-    "ses": "^0.18.1"
+    "ses": "^0.18.2"
   },
   "directories": {
     "test": "test"

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.24](https://github.com/endojs/endo/compare/@endo/netstring@0.3.23...@endo/netstring@0.3.24) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.3.23](https://github.com/endojs/endo/compare/@endo/netstring@0.3.22...@endo/netstring@0.3.23) (2022-12-23)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,12 +32,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.53",
-    "@endo/stream": "^0.3.22",
-    "ses": "^0.18.1"
+    "@endo/init": "^0.5.54",
+    "@endo/stream": "^0.3.23",
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### 0.1.1 (2023-03-07)
+
+### Features
+
+- **pass-style:** Extract passStyleOf and friends from marshal into the new pass-style package ([#1439](https://github.com/endojs/endo/issues/1439)) ([ccd003c](https://github.com/endojs/endo/commit/ccd003c96f3d969d919104118d8a34b3c1126aef))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- move arb-passable to pass-style ([#1448](https://github.com/endojs/endo/issues/1448)) ([09235a9](https://github.com/endojs/endo/commit/09235a9a339229636fb37b4483ccddbe3b60d5ee))
+
+### 0.1.1 (2023-03-07)
+
+### Features
+
+- **pass-style:** Extract passStyleOf and friends from marshal into the new pass-style package ([#1439](https://github.com/endojs/endo/issues/1439)) ([ccd003c](https://github.com/endojs/endo/commit/ccd003c96f3d969d919104118d8a34b3c1126aef))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- move arb-passable to pass-style ([#1448](https://github.com/endojs/endo/issues/1448)) ([09235a9](https://github.com/endojs/endo/commit/09235a9a339229636fb37b4483ccddbe3b60d5ee))

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "pass-style: defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",
@@ -30,13 +30,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/promise-kit": "^0.2.53",
+    "@endo/promise-kit": "^0.2.54",
     "@fast-check/ava": "^1.1.3"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/init": "^0.5.53",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/init": "^0.5.54",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.2.0 (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- rename 'fit' to 'mustMatch' (#1464)
+
+### Features
+
+- **exo:** start migrating exo from @agoric/store ([#1459](https://github.com/endojs/endo/issues/1459)) ([a882b7c](https://github.com/endojs/endo/commit/a882b7ca88863d7f85310074c38f3cc0032e1e0e))
+- **patterns:** Start migrating patterns from @agoric/store to new @endo/patterns ([#1451](https://github.com/endojs/endo/issues/1451)) ([69b61e3](https://github.com/endojs/endo/commit/69b61e3f9a0af9a9714413708ddb9bcf68772846))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
+### Miscellaneous Chores
+
+- rename 'fit' to 'mustMatch' ([#1464](https://github.com/endojs/endo/issues/1464)) ([a4f88f8](https://github.com/endojs/endo/commit/a4f88f8ef1e7d62b993900244e260d90113f9759))
+
+## 0.2.0 (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- rename 'fit' to 'mustMatch' (#1464)
+
+### Features
+
+- **exo:** start migrating exo from @agoric/store ([#1459](https://github.com/endojs/endo/issues/1459)) ([a882b7c](https://github.com/endojs/endo/commit/a882b7ca88863d7f85310074c38f3cc0032e1e0e))
+- **patterns:** Start migrating patterns from @agoric/store to new @endo/patterns ([#1451](https://github.com/endojs/endo/issues/1451)) ([69b61e3](https://github.com/endojs/endo/commit/69b61e3f9a0af9a9714413708ddb9bcf68772846))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
+### Miscellaneous Chores
+
+- rename 'fit' to 'mustMatch' ([#1464](https://github.com/endojs/endo/issues/1464)) ([a4f88f8](https://github.com/endojs/endo/commit/a4f88f8ef1e7d62b993900244e260d90113f9759))

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Description forthcoming.",
   "keywords": [],
   "author": "Endo contributors",
@@ -29,14 +29,14 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.16.8",
-    "@endo/marshal": "^0.8.2",
-    "@endo/promise-kit": "^0.2.52"
+    "@endo/eventual-send": "^0.17.0",
+    "@endo/marshal": "^0.8.3",
+    "@endo/promise-kit": "^0.2.54"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/init": "^0.5.53",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/init": "^0.5.54",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.54](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.53...@endo/promise-kit@0.2.54) (2023-03-07)
+
+### Features
+
+- **ses-ava:** Support the full ava API ([#1465](https://github.com/endojs/endo/issues/1465)) ([0e4f980](https://github.com/endojs/endo/commit/0e4f980fd71966d1eb7e0a607ebeae47fa93072d)), closes [#1235](https://github.com/endojs/endo/issues/1235)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.2.53](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.52...@endo/promise-kit@0.2.53) (2022-12-23)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "description": "Helper for making promises",
   "keywords": [
     "promise"
@@ -37,11 +37,11 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "ses": "^0.18.1"
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/ses-ava": "^0.2.38",
     "@types/node": ">=14.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.38](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.37...@endo/ses-ava@0.2.38) (2023-03-07)
+
+### Features
+
+- **ses-ava:** Include test title in special console error logging ([#1477](https://github.com/endojs/endo/issues/1477)) ([7648bc7](https://github.com/endojs/endo/commit/7648bc77cd18e85c668b9201d0e6e957609e33b5))
+- **ses-ava:** Support the full ava API ([#1465](https://github.com/endojs/endo/issues/1465)) ([0e4f980](https://github.com/endojs/endo/commit/0e4f980fd71966d1eb7e0a607ebeae47fa93072d)), closes [#1235](https://github.com/endojs/endo/issues/1235)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.2.37](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.36...@endo/ses-ava@0.2.37) (2022-12-23)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/NEWS.md
+++ b/packages/ses-ava/NEWS.md
@@ -1,6 +1,7 @@
 User-visible changes in SES-Ava:
 
-# Next release
+# 0.2.38 (2023-03-07)
+
 * Support the full ava API ([#1235](https://github.com/endojs/endo/issues/1235))
 
 # 0.2.0 (2021-06-01)

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -33,10 +33,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.18.1"
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.28](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.27...ses-integration-test@3.0.28) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/Agoric/SES-shim/issues/1472)) ([389733d](https://github.com/Agoric/SES-shim/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [3.0.27](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.26...ses-integration-test@3.0.27) (2022-12-23)
 
 ### Bug Fixes

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "3.0.27",
+  "version": "3.0.28",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,10 +30,10 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.18.1"
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.18.2](https://github.com/endojs/endo/compare/ses@0.18.1...ses@0.18.2) (2023-03-07)
+
+### Features
+
+- Comment links error code errors to explanation ([#1431](https://github.com/endojs/endo/issues/1431)) ([91362f1](https://github.com/endojs/endo/commit/91362f1e585928f83496ffbabec7d583ec6b031e))
+- **ses:** export tools ([ba562df](https://github.com/endojs/endo/commit/ba562dfe32601deaee8242c06925d6957156f7e2))
+- **ses:** module execute uses syncModuleFunctor if present ([079098e](https://github.com/endojs/endo/commit/079098ed2944b4da990cf359857b09b0437f714a))
+
+### Bug Fixes
+
+- extend severeEnablements with immer workaround ([#1433](https://github.com/endojs/endo/issues/1433)) ([f072995](https://github.com/endojs/endo/commit/f07299530de8424e133f0359d8902cff5e4fef5b))
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- Improve typing information ([765d262](https://github.com/endojs/endo/commit/765d2625ee278608494f7e998bcd3a3ee8b845a4))
+- **ses:** Fix guide.md Compartment link ([#1457](https://github.com/endojs/endo/issues/1457)) ([c9b0276](https://github.com/endojs/endo/commit/c9b02769594a7fb7d6cbdb7a9536ba79c23de520))
+- **ses:** Fix SES_NO_SLOPPY.md typo ([#1458](https://github.com/endojs/endo/issues/1458)) ([4cf1845](https://github.com/endojs/endo/commit/4cf184566210ef59e0ef84dcabf8a70aa8b5d841))
+
 ### [0.18.1](https://github.com/endojs/endo/compare/ses@0.18.0...ses@0.18.1) (2022-12-23)
 
 ### Features

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in SES:
 
-# next
+# v0.18.2 (2023-03-07)
 
 - Introduces the `__syncModuleFunctor__` property of static module record
   to replace evauluation of `__syncModuleProgram__` for environments without eval.

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",
@@ -60,10 +60,10 @@
     "test:platform-compatibility": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.1",
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/static-module-record": "^0.7.16",
-    "@endo/test262-runner": "^0.1.29",
+    "@endo/compartment-mapper": "^0.8.2",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/static-module-record": "^0.7.17",
+    "@endo/test262-runner": "^0.1.30",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.7.17](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.16...@endo/static-module-record@0.7.17) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- **static-module-record:** ESM compatibility ([#1466](https://github.com/endojs/endo/issues/1466)) ([1d142e5](https://github.com/endojs/endo/commit/1d142e58bc3a7388cf851fc74892707f73e4cfd1))
+
 ### [0.7.16](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.15...@endo/static-module-record@0.7.16) (2022-12-23)
 
 ### Features

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -39,11 +39,11 @@
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
     "@babel/types": "^7.17.0",
-    "ses": "^0.18.1"
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/ses-ava": "^0.2.38",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "benchmark": "^2.1.4",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.24](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.23...@endo/stream-node@0.2.24) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- **stream-node:** Handle write attempt after close ([#1481](https://github.com/endojs/endo/issues/1481)) ([00204a9](https://github.com/endojs/endo/commit/00204a9b462db0df6db4d438d0743e55bc075bd1))
+
 ### [0.2.23](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.22...@endo/stream-node@0.2.23) (2022-12-23)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",
@@ -38,13 +38,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.53",
-    "@endo/stream": "^0.3.22",
-    "ses": "^0.18.1"
+    "@endo/init": "^0.5.54",
+    "@endo/stream": "^0.3.23",
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/ses-ava": "^0.2.38",
     "@typescript-eslint/parser": "^5.53.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.35](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.34...@endo/stream-types-test@0.1.35) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.1.34](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.33...@endo/stream-types-test@0.1.34) (2022-12-23)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],
@@ -25,11 +25,11 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "@endo/stream": "^0.3.22",
-    "ses": "^0.18.1"
+    "@endo/stream": "^0.3.23",
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.23](https://github.com/endojs/endo/compare/@endo/stream@0.3.22...@endo/stream@0.3.23) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.3.22](https://github.com/endojs/endo/compare/@endo/stream@0.3.21...@endo/stream@0.3.22) (2022-12-23)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",
@@ -38,14 +38,14 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.16.9",
-    "@endo/promise-kit": "^0.2.53",
-    "ses": "^0.18.1"
+    "@endo/eventual-send": "^0.17.0",
+    "@endo/promise-kit": "^0.2.54",
+    "ses": "^0.18.2"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
-    "@endo/init": "^0.5.53",
-    "@endo/ses-ava": "^0.2.37",
+    "@endo/eslint-config": "^0.5.3",
+    "@endo/init": "^0.5.54",
+    "@endo/ses-ava": "^0.2.38",
     "@typescript-eslint/parser": "^5.53.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.30](https://github.com/endojs/endo/compare/@endo/syrup@0.1.29...@endo/syrup@0.1.30) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.1.29](https://github.com/endojs/endo/compare/@endo/syrup@0.1.28...@endo/syrup@0.1.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/syrup

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",
@@ -36,7 +36,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.30](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.29...@endo/test262-runner@0.1.30) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.1.29](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.28...@endo/test262-runner@0.1.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "private": true,
   "description": "Test262 Runner",
   "author": "Agoric",
@@ -17,7 +17,7 @@
     "test262-parser": "^2.2.0"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "sinon": "8.0.4"
   },
   "ava": {

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.0](https://github.com/endojs/endo/compare/@endo/where@0.2.11...@endo/where@0.3.0) (2023-03-07)
+
+### ⚠ BREAKING CHANGES
+
+- **where:** Thread OS info
+
+### Features
+
+- **where:** Distinguish protocol in socket or pipe name ([907b031](https://github.com/endojs/endo/commit/907b0313616694c4920b97e0af30a7ea2c90f8f4))
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+- **where:** Differentiate ephemeral state, clarify tests ([59e6a3c](https://github.com/endojs/endo/commit/59e6a3cbad40b1e9fe70c5bfbf43cddab4236716))
+- **where:** Fix XDG conventions ([f1dec29](https://github.com/endojs/endo/commit/f1dec29ebce27c962181a7f027396f416f782983))
+- **where:** Thread OS info ([b7c2441](https://github.com/endojs/endo/commit/b7c24412250b45984964156894efb72ef72ac3f6))
+
 ### [0.2.11](https://github.com/endojs/endo/compare/@endo/where@0.2.10...@endo/where@0.2.11) (2022-12-23)
 
 **Note:** Version bump only for package @endo/where

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "private": null,
   "description": "Description forthcoming.",
   "keywords": [],
@@ -34,7 +34,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.30](https://github.com/endojs/endo/compare/@endo/zip@0.2.29...@endo/zip@0.2.30) (2023-03-07)
+
+### Bug Fixes
+
+- Fix hackerone.com links in SECURITY.md ([#1472](https://github.com/endojs/endo/issues/1472)) ([389733d](https://github.com/endojs/endo/commit/389733dbc7a74992f909c38d27ea7e8e68623959))
+
 ### [0.2.29](https://github.com/endojs/endo/compare/@endo/zip@0.2.28...@endo/zip@0.2.29) (2022-12-23)
 
 **Note:** Version bump only for package @endo/zip

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",
@@ -35,7 +35,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@endo/eslint-config": "^0.5.2",
+    "@endo/eslint-config": "^0.5.3",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",


### PR DESCRIPTION
- @leotm fix HackerOne links from `SECURITY.md`
- @mhofman make `bundle-source` script properly exit with failure
- @kriskowal fix `@endo/cli` `hash`, `hash-map` and `hash-archive` commands
- @gibson042 many improvements to type information
- @naugtur `@endo/compartment-mapper` features in order to support LavaMoat policies
- @gibson042 introduce type-aware linting via ESLint Typescript support
- @gibson042 stricter relational operand compatibility checking
- @michaelfig simple `@endo/captp` garbage collection
- @gibson042 `@endo/eventual-send` moreæ thorough freezing of the `HandledPromise` shim
- @markm extract `@endo/pass-style` package from `@endo/marshal`
- @michaelfig display slot values if supplied to `decodeToJustin`
- @mhofman fix `@endo/stream-node` double-close error
- @kriskowal use XDG conventions in `@endo/where`