### PR TITLE
Add `length` (number) prop to whitelist AsyncGenerator and AsyncFunctionPrototype

### DIFF
--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -1221,6 +1221,10 @@ export const whitelist = {
     '[[Proto]]': '%FunctionPrototype%',
     constructor: '%InertAsyncGeneratorFunction%',
     prototype: '%AsyncGeneratorPrototype%',
+    // length prop added here for React Native jsc-android
+    // https://github.com/endojs/endo/issues/660
+    // https://github.com/react-native-community/jsc-android-buildscripts/issues/181
+    length: 'number',
     '@@toStringTag': 'string',
   },
 
@@ -1303,6 +1307,10 @@ export const whitelist = {
     // Properties of the AsyncFunction Prototype Object
     '[[Proto]]': '%FunctionPrototype%',
     constructor: '%InertAsyncFunction%',
+    // length prop added here for React Native jsc-android
+    // https://github.com/endojs/endo/issues/660
+    // https://github.com/react-native-community/jsc-android-buildscripts/issues/181
+    length: 'number',
     '@@toStringTag': 'string',
   },
 


### PR DESCRIPTION
Fix: https://github.com/endojs/endo/issues/660
Fix: https://github.com/LavaMoat/docs/issues/16

cc @naugtur

_nb: will stick to 1 commit in future_

---

Before

<img width="1728" alt="Screenshot 2023-03-15 at 14 42 08" src="https://user-images.githubusercontent.com/1881059/225345340-1c2e8785-ca22-4a01-8ea9-fe71db33a386.png">

After

<img width="1728" alt="Screenshot 2023-03-15 at 14 43 12" src="https://user-images.githubusercontent.com/1881059/225345386-d6033f0b-b427-4648-bd92-b274149faf95.png">

---

looks like checks `CI / test-async-hooks` failing on GHA setup-node matrix after adding docs (code comments) :suspect:
so hopefully we only need to re-trigger the checks (i don't have permish from my fork)

```console
Run actions/setup-node@v1
  with:
    node-version: 16.1
    always-auth: false
Premature close
Waiting 14 seconds before trying again
Premature close
Waiting 1[2](https://github.com/endojs/endo/actions/runs/4425617947/jobs/7760903288#step:3:2) seconds before trying again
Error: Premature close
```

edit: rebase + force-push worked ✅ 