### PR TITLE
fix(exo): fix exo-tools TSC problem

### DIFF
--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -231,8 +231,7 @@ export const defendPrototype = (
       methodGuards && methodGuards[prop],
     );
   }
-  // @ts-expect-error could be instantiated with different subtype
-  return Far(tag, prototype);
+  return Far(tag, /** @type {T} */ (prototype));
 };
 harden(defendPrototype);
 


### PR DESCRIPTION
Running tsc in some other packages causes this unrelated line in packages/exo to start complaining. Removing the ts-expect-error caused it to fail tsc when run in packages/exo. Thanks to @michaelfig for a fix that appeased both cases.

Copied from https://github.com/Agoric/agoric-sdk/pull/7177