### PR TITLE
test(captp): split gc tests into separate files

### DIFF
--- a/packages/captp/test/gc-and-finalize.js
+++ b/packages/captp/test/gc-and-finalize.js
@@ -88,5 +88,7 @@ export async function makeGcAndFinalize(gcPowerP) {
     await new Promise(setImmediate);
     // Node.js seems to need another for promises to get cleared out
     await new Promise(setImmediate);
+    // And Windows Node.js even needs a third
+    await new Promise(setImmediate);
   };
 }

--- a/packages/captp/test/test-gc.js
+++ b/packages/captp/test/test-gc.js
@@ -6,7 +6,6 @@ import { E, makeLoopback } from '../src/loopback.js';
 
 import { detectEngineGC } from './engine-gc.js';
 import { makeGcAndFinalize } from './gc-and-finalize.js';
-import { makeFinalizingMap } from '../src/finalize.js';
 
 const isolated = async (t, makeFar) => {
   const local = Far('local', {
@@ -16,37 +15,12 @@ const isolated = async (t, makeFar) => {
   t.is(await E(far).method(), 'local');
 };
 
-test.serial('test loopback gc', async t => {
+test('test loopback gc', async t => {
   const { makeFar, getFarStats, getNearStats } = makeLoopback('dean');
   const gcAndFinalize = await makeGcAndFinalize(detectEngineGC());
 
   await isolated(t, makeFar);
   await gcAndFinalize();
-  // It would be nice to specify these counts, but we just can't reprodue them
-  // on Windows.
-  t.assert(getFarStats().sendCount.CTP_DROP > 0);
-  t.assert(getNearStats().recvCount.CTP_DROP > 0);
-});
-
-const setAndDrop = async (t, map, droppedKey) => {
-  const obj = {};
-  map.set(droppedKey, obj);
-  t.is(map.get(droppedKey), obj);
-};
-
-test.serial('finalizing map', async t => {
-  const gcAndFinalize = await makeGcAndFinalize(detectEngineGC());
-
-  const droppedKey = 'dropped';
-  const map = makeFinalizingMap(key => t.is(key, droppedKey));
-
-  const preserved = {};
-  map.set('preserved', preserved);
-  setAndDrop(t, map, droppedKey);
-
-  t.is(map.getSize(), 2);
-  await gcAndFinalize();
-  await gcAndFinalize();
-  t.is(map.getSize(), 1);
-  t.is(map.get('preserved'), preserved);
+  t.is(getFarStats().sendCount.CTP_DROP, 3);
+  t.is(getNearStats().recvCount.CTP_DROP, 3);
 });


### PR DESCRIPTION
Track down divergent Node.js GC behaviour on Windows.