### PR TITLE
Weak LRU Cache Map

### DIFF
--- a/packages/captp/test/test-gc.js
+++ b/packages/captp/test/test-gc.js
@@ -21,7 +21,6 @@ test('test loopback gc', async t => {
 
   await isolated(t, makeFar);
   await gcAndFinalize();
-  // TODO(mfig,erights): explain why #1513 changed these counts from 3 to 2
-  t.is(getFarStats().sendCount.CTP_DROP, 2);
-  t.is(getNearStats().recvCount.CTP_DROP, 2);
+  t.is(getFarStats().sendCount.CTP_DROP, 3);
+  t.is(getNearStats().recvCount.CTP_DROP, 3);
 });

--- a/packages/ses/test/error/test-note-log-args.js
+++ b/packages/ses/test/error/test-note-log-args.js
@@ -1,6 +1,10 @@
+// @ts-check
 import test from 'ava';
 
-import { makeNoteLogArgsArrayKit } from '../../src/error/note-log-args.js';
+import {
+  makeNoteLogArgsArrayKit,
+  makeLRUCacheMap,
+} from '../../src/error/note-log-args.js';
 
 test('note log args array kit basic', t => {
   const { addLogArgs, takeLogArgsArray } = makeNoteLogArgsArrayKit(3, 2);
@@ -21,4 +25,41 @@ test('note log args array kit basic', t => {
   t.deepEqual(takeLogArgsArray(e2), [['g'], ['h']]);
   t.deepEqual(takeLogArgsArray(e3), undefined);
   t.deepEqual(takeLogArgsArray(e4), [['d']]);
+});
+
+test('weak LRUCacheMap', t => {
+  /** @type {WeakMap<{}, number>} */
+  const lru = makeLRUCacheMap(3);
+  const o1 = {};
+  const o2 = {};
+  const o3 = {};
+  const o4 = {};
+
+  // Overflow drops the oldest.
+  lru.set(o1, 1);
+  t.is(lru.get(o1), 1);
+  lru.set(o3, 2);
+  lru.set(o2, 3);
+  lru.set(o4, 4); // drops o1
+  t.falsy(lru.has(o1));
+  t.is(lru.get(o4), 4);
+  lru.set(o4, 5);
+  t.is(lru.get(o4), 5);
+  t.true(lru.has(o4));
+  lru.set(o1, 6); // drops o3
+  t.is(lru.get(o1), 6);
+  t.false(lru.has(o3));
+
+  // Explicit delete keeps all other elements.
+  lru.delete(o1); // explicit delete o1
+  t.is(lru.get(o1), undefined);
+  t.false(lru.has(o1));
+  t.true(lru.has(o2));
+  t.true(lru.has(o4));
+  t.false(lru.has(o3));
+  lru.set(o3, 7);
+  lru.set(o1, 8); // drops o2
+  t.false(lru.has(o2));
+  t.is(lru.get(o1), 8);
+  t.is(lru.get(o3), 7);
 });


### PR DESCRIPTION
Refs #1513 

I tracked down the object leak to [where cause stacks are being attached to a given eventual-send](https://github.com/endojs/endo/blob/aae0e57f7a6bdcc898396c65ec22616a33672d32/packages/eventual-send/src/track-turns.js#L116). This pointed to a strongly-held chain of errors and their details arguments.

This weakifying of the LRUCacheMap uses an outer WeakMap instead of the strong map, and then a *unique* WeakMap instance **per non-condemned entry in the cache**.  That is, given N entries in the cache, 1+N WeakMaps in total (!).  This is because WeakMaps don't support composite keys, and we are avoiding using WeakRefs in the Endo implementation.

The benefit is that we no longer have a leak.  Now the CapTP GC drop counts are the same as before #1513 (3 drop messages instead of 2 for `packages/captp/test/test-gc.js`).
