### PR TITLE
doc: add issue link for bogus proxy trap observation

### DIFF
--- a/packages/ses/src/strict-scope-terminator.js
+++ b/packages/ses/src/strict-scope-terminator.js
@@ -58,6 +58,7 @@ const scopeProxyHandlerProperties = {
   },
 
   // Chip has seen this happen single stepping under the Chrome/v8 debugger.
+  // See also https://github.com/endojs/endo/issues/1510
   // TODO record how to reliably reproduce, and to test if this fix helps.
   // TODO report as bug to v8 or Chrome, and record issue link here.
   getOwnPropertyDescriptor(_target, prop) {

--- a/packages/ses/src/strict-scope-terminator.js
+++ b/packages/ses/src/strict-scope-terminator.js
@@ -57,10 +57,8 @@ const scopeProxyHandlerProperties = {
     return null;
   },
 
-  // Chip has seen this happen single stepping under the Chrome/v8 debugger.
-  // See also https://github.com/endojs/endo/issues/1510
-  // TODO record how to reliably reproduce, and to test if this fix helps.
-  // TODO report as bug to v8 or Chrome, and record issue link here.
+  // See https://github.com/endojs/endo/issues/1510
+  // TODO: report as bug to v8 or Chrome, and record issue link here.
   getOwnPropertyDescriptor(_target, prop) {
     // Coerce with `String` in case prop is a symbol.
     const quotedProp = q(String(prop));


### PR DESCRIPTION
Investigating https://github.com/endojs/endo/issues/1510 , I see that the code already had a proxy trap to deal with this case, and the trace I observed was correctly generated by a `console.warn` in that code. The issue adds a more specific observation of this anomaly. With this PR, that issue can be closed but remain linked as an explanation.

Closed #1510 