### PR TITLE
feat(ses): option to fake harden unsafely

### DIFF
--- a/packages/captp/test/test-export-hook.js
+++ b/packages/captp/test/test-export-hook.js
@@ -66,8 +66,11 @@ test('exportHook', async t => {
 
   // Trigger the hook to throw.
   harden(exports);
-  await t.throwsAsync(() => E(bs).echo(Promise.resolve('never exported')), {
-    message: /.*object is not extensible/,
-  });
+  // @ts-ignore `isFake` purposely omitted from type
+  if (!harden.isFake) {
+    await t.throwsAsync(() => E(bs).echo(Promise.resolve('never exported')), {
+      message: /.*object is not extensible/,
+    });
+  }
   t.deepEqual(exports, []);
 });

--- a/packages/check-bundle/test/test-check-bundle.js
+++ b/packages/check-bundle/test/test-check-bundle.js
@@ -100,9 +100,15 @@ test('bundle and check corrupt endo zip base64 package', async t => {
 
 test('bundle and hash unfrozen object', async t => {
   const bundle = {};
-  await t.throwsAsync(checkBundle(bundle, computeSha512, 'fixture/main.js'), {
-    message: `checkBundle cannot vouch for the ongoing integrity of an unfrozen object, got {}`,
-  });
+  await null;
+  // @ts-ignore `isFake` purposely omitted from type
+  if (harden.isFake) {
+    t.pass();
+  } else {
+    await t.throwsAsync(checkBundle(bundle, computeSha512, 'fixture/main.js'), {
+      message: `checkBundle cannot vouch for the ongoing integrity of an unfrozen object, got {}`,
+    });
+  }
 });
 
 test('bundle and hash bogus package', async t => {

--- a/packages/far/test/test-marshal-far-function.js
+++ b/packages/far/test/test-marshal-far-function.js
@@ -22,16 +22,19 @@ test('Acceptable far functions', t => {
 });
 
 test('Unacceptable far functions', t => {
-  t.throws(
-    () =>
-      Far(
-        'alreadyFrozen',
-        freeze(a => a + 1),
-      ),
-    {
-      message: /is already frozen/,
-    },
-  );
+  // @ts-ignore `isFake` purposely omitted from type
+  if (!harden.isFake) {
+    t.throws(
+      () =>
+        Far(
+          'alreadyFrozen',
+          freeze(a => a + 1),
+        ),
+      {
+        message: /is already frozen/,
+      },
+    );
+  }
   // eslint-disable-next-line prefer-arrow-callback -- under test
   t.throws(() => Far('keywordFunc', function keyword() {}), {
     message: /unexpected properties besides \.name and \.length/,

--- a/packages/init/test/test-async_hooks.js
+++ b/packages/init/test/test-async_hooks.js
@@ -50,7 +50,9 @@ test('async_hooks Promise patch', async t => {
 
     // Create a promise with symbols attached
     const p3 = Promise.resolve();
-    t.is(Reflect.ownKeys(p3).length > 0, hasAsyncSymbols);
+    if (!harden.isFake) {
+      t.is(Reflect.ownKeys(p3).length > 0, hasAsyncSymbols);
+    }
 
     return Promise.resolve().then(() => {
       resolve(8);
@@ -62,7 +64,9 @@ test('async_hooks Promise patch', async t => {
       // node versions will fail and generate a new one because of an own check
       p1.then(() => {});
 
-      t.is(Reflect.ownKeys(ret).length > 0, hasAsyncSymbols);
+      if (!harden.isFake) {
+        t.is(Reflect.ownKeys(ret).length > 0, hasAsyncSymbols);
+      }
 
       // testHooks.disable();
 

--- a/packages/marshal/test/test-marshal-capdata.js
+++ b/packages/marshal/test/test-marshal-capdata.js
@@ -187,9 +187,13 @@ test('serialize unserialize round trip pairs', t => {
 test('serialize static data', t => {
   const m = makeTestMarshal();
   const ser = val => m.serialize(val);
-  t.throws(() => ser([1, 2]), {
-    message: /Cannot pass non-frozen objects like/,
-  });
+
+  // @ts-ignore `isFake` purposely omitted from type
+  if (!harden.isFake) {
+    t.throws(() => ser([1, 2]), {
+      message: /Cannot pass non-frozen objects like/,
+    });
+  }
   // -0 serialized as 0
   t.deepEqual(ser(0), { body: '0', slots: [] });
   t.deepEqual(ser(-0), { body: '0', slots: [] });
@@ -242,14 +246,20 @@ test('serialize errors', t => {
   errExtra.foo = [];
   freeze(errExtra);
   t.assert(isFrozen(errExtra));
-  // @ts-ignore Check dynamic consequences of type violation
-  t.falsy(isFrozen(errExtra.foo));
+  // @ts-ignore `isFake` purposely omitted from type
+  if (!harden.isFake) {
+    // @ts-ignore Check dynamic consequences of type violation
+    t.falsy(isFrozen(errExtra.foo));
+  }
   t.deepEqual(ser(errExtra), {
     body: '{"@qclass":"error","errorId":"error:anon-marshal#10003","message":"has extra properties","name":"Error"}',
     slots: [],
   });
-  // @ts-ignore Check dynamic consequences of type violation
-  t.falsy(isFrozen(errExtra.foo));
+  // @ts-ignore `isFake` purposely omitted from type
+  if (!harden.isFake) {
+    // @ts-ignore Check dynamic consequences of type violation
+    t.falsy(isFrozen(errExtra.foo));
+  }
 
   // Bad prototype and bad "message" property
   const nonErrorProto1 = { __proto__: Error.prototype, name: 'included' };
@@ -322,12 +332,15 @@ test('records', t => {
 
   // empty objects
 
-  // rejected because it is not hardened
-  t.throws(
-    () => ser({}),
-    { message: /Cannot pass non-frozen objects/ },
-    'non-frozen data cannot be serialized',
-  );
+  // @ts-ignore `isFake` purposely omitted from type
+  if (!harden.isFake) {
+    // rejected because it is not hardened
+    t.throws(
+      () => ser({}),
+      { message: /Cannot pass non-frozen objects/ },
+      'non-frozen data cannot be serialized',
+    );
+  }
 
   // harden({})
   t.deepEqual(ser(build()), emptyData);

--- a/packages/marshal/test/test-marshal-far-function.js
+++ b/packages/marshal/test/test-marshal-far-function.js
@@ -21,16 +21,19 @@ test('Acceptable far functions', t => {
 });
 
 test('Unacceptable far functions', t => {
-  t.throws(
-    () =>
-      Far(
-        'alreadyFrozen',
-        freeze(a => a + 1),
-      ),
-    {
-      message: /is already frozen/,
-    },
-  );
+  // @ts-ignore `isFake` purposely omitted from type
+  if (!harden.isFake) {
+    t.throws(
+      () =>
+        Far(
+          'alreadyFrozen',
+          freeze(a => a + 1),
+        ),
+      {
+        message: /is already frozen/,
+      },
+    );
+  }
   // eslint-disable-next-line prefer-arrow-callback -- under test
   t.throws(() => Far('keywordFunc', function keyword() {}), {
     message: /unexpected properties besides \.name and \.length/,

--- a/packages/marshal/test/test-marshal-stringify.js
+++ b/packages/marshal/test/test-marshal-stringify.js
@@ -27,18 +27,21 @@ test('marshal parse', t => {
 });
 
 test('marshal stringify errors', t => {
-  t.throws(() => stringify([]), {
-    message: /Cannot pass non-frozen objects like .*. Use harden()/,
-  });
-  t.throws(() => stringify({}), {
-    message: /Cannot pass non-frozen objects like .*. Use harden()/,
-  });
-  t.throws(() => stringify(harden(new Uint8Array(1))), {
-    message: 'Cannot pass mutable typed arrays like "[Uint8Array]".',
-  });
-  t.throws(() => stringify(harden(new Int16Array(1))), {
-    message: 'Cannot pass mutable typed arrays like "[Int16Array]".',
-  });
+  // @ts-ignore `isFake` purposely omitted from type
+  if (!harden.isFake) {
+    t.throws(() => stringify([]), {
+      message: /Cannot pass non-frozen objects like .*. Use harden()/,
+    });
+    t.throws(() => stringify({}), {
+      message: /Cannot pass non-frozen objects like .*. Use harden()/,
+    });
+    t.throws(() => stringify(harden(new Uint8Array(1))), {
+      message: 'Cannot pass mutable typed arrays like "[Uint8Array]".',
+    });
+    t.throws(() => stringify(harden(new Int16Array(1))), {
+      message: 'Cannot pass mutable typed arrays like "[Int16Array]".',
+    });
+  }
 
   t.throws(() => stringify(harden(Promise.resolve(8))), {
     message: /Marshal's stringify rejects presences and promises .*/,

--- a/packages/pass-style/src/make-far.js
+++ b/packages/pass-style/src/make-far.js
@@ -94,8 +94,15 @@ export const Remotable = (
     Fail`Remotable ${remotable} is already marked as a ${q(
       remotable[PASS_STYLE],
     )}`;
-  // Ensure that the remotable isn't already frozen.
-  !isFrozen(remotable) || Fail`Remotable ${remotable} is already frozen`;
+  // `isFrozen` always returns true with a fake `harden`, but we want that case
+  // to succeed anyway. Faking `harden` is only correctness preserving
+  // if the code in question contains no bugs that the real `harden` would
+  // have caught.
+  // @ts-ignore `isFake` purposely not in the type
+  harden.isFake ||
+    // Ensure that the remotable isn't already frozen.
+    !isFrozen(remotable) ||
+    Fail`Remotable ${remotable} is already frozen`;
   const remotableProto = makeRemotableProto(remotable, iface);
 
   // Take a static copy of the enumerable own properties as data properties.

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -59,6 +59,8 @@ export const {
   getOwnPropertyNames,
   getPrototypeOf,
   is,
+  isFrozen,
+  isSealed,
   isExtensible,
   keys,
   prototype: objectPrototype,

--- a/packages/ses/src/tame-harden.js
+++ b/packages/ses/src/tame-harden.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-restricted-globals */
+import { TypeError, freeze } from './commons.js';
+
+export const tameHarden = (safeHarden, hardenTaming) => {
+  if (hardenTaming !== 'safe' && hardenTaming !== 'unsafe') {
+    throw new TypeError(`unrecognized fakeHardenOption ${hardenTaming}`);
+  }
+
+  if (hardenTaming === 'safe') {
+    return safeHarden;
+  }
+
+  // In on the joke
+  Object.isExtensible = () => false;
+  Object.isFrozen = () => true;
+  Object.isSealed = () => true;
+  Reflect.isExtensible = () => false;
+
+  const fakeHarden = arg => arg;
+  fakeHarden.isFake = true;
+  return freeze(fakeHarden);
+};
+freeze(tameHarden);

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -1376,7 +1376,7 @@ export const whitelist = {
   },
 
   lockdown: fn,
-  harden: fn,
+  harden: { ...fn, isFake: 'boolean' },
 
   '%InitialGetStackString%': fn,
 };

--- a/packages/ses/test/test-compartment.js
+++ b/packages/ses/test/test-compartment.js
@@ -10,7 +10,8 @@ test('create', t => {
 });
 
 test('SES compartment does not see primal realm names', t => {
-  const hidden = 1; // eslint-disable-line no-unused-vars
+  // eslint-disable-next-line no-unused-vars
+  const hidden = 1;
   const c = new Compartment();
   t.throws(() => c.evaluate('hidden+1'), { instanceOf: ReferenceError });
 });
@@ -46,8 +47,10 @@ test('SES compartment has harden', t => {
   const c = new Compartment({ a: 123 });
   const obj = c.evaluate('harden({a})');
   t.is(obj.a, 123, 'expected object');
-  t.throws(() => (obj.a = 'ignored'));
-  t.is(obj.a, 123, 'hardened object retains value');
+  if (!harden.isFake) {
+    t.throws(() => (obj.a = 'ignored'));
+    t.is(obj.a, 123, 'hardened object retains value');
+  }
 });
 
 // test('SESRealm.SES wraps exceptions', t => {

--- a/packages/ses/test/test-enable-default-overrides-default.js
+++ b/packages/ses/test/test-enable-default-overrides-default.js
@@ -1,7 +1,7 @@
 import '../index.js';
 import test from 'ava';
 
-lockdown();
+lockdown({ __hardenTaming__: 'safe' });
 
 // See https://github.com/endojs/endo/issues/616#issuecomment-800733101
 

--- a/packages/ses/test/test-enable-property-overrides-default-unsafeError.js
+++ b/packages/ses/test/test-enable-property-overrides-default-unsafeError.js
@@ -2,7 +2,7 @@ import '../index.js';
 import test from 'ava';
 import { overrideTester } from './override-tester.js';
 
-lockdown({ errorTaming: 'unsafe' });
+lockdown({ errorTaming: 'unsafe', __hardenTaming__: 'safe' });
 
 test('property overrides default with unsafe errorTaming', t => {
   overrideTester(t, 'Error', new Error(), [

--- a/packages/ses/test/test-enable-property-overrides-default.js
+++ b/packages/ses/test/test-enable-property-overrides-default.js
@@ -2,7 +2,7 @@ import '../index.js';
 import test from 'ava';
 import { overrideTester } from './override-tester.js';
 
-lockdown({ errorTaming: 'safe' });
+lockdown({ errorTaming: 'safe', __hardenTaming__: 'safe' });
 
 test('enablePropertyOverrides - on', t => {
   overrideTester(t, 'Object', {}, ['toString', 'valueOf']);

--- a/packages/ses/test/test-enable-property-overrides-min-unsafeError.js
+++ b/packages/ses/test/test-enable-property-overrides-min-unsafeError.js
@@ -2,7 +2,11 @@ import '../index.js';
 import test from 'ava';
 import { overrideTester } from './override-tester.js';
 
-lockdown({ errorTaming: 'unsafe', overrideTaming: 'min' });
+lockdown({
+  errorTaming: 'unsafe',
+  overrideTaming: 'min',
+  __hardenTaming__: 'safe',
+});
 
 test('property overrides min with unsafe errorTaming', t => {
   overrideTester(t, 'Error', new Error(), ['name', 'stack']);

--- a/packages/ses/test/test-enable-property-overrides-min.js
+++ b/packages/ses/test/test-enable-property-overrides-min.js
@@ -2,7 +2,11 @@ import '../index.js';
 import test from 'ava';
 import { overrideTester } from './override-tester.js';
 
-lockdown({ errorTaming: 'safe', overrideTaming: 'min' });
+lockdown({
+  errorTaming: 'safe',
+  overrideTaming: 'min',
+  __hardenTaming__: 'safe',
+});
 
 test('enablePropertyOverrides - on', t => {
   overrideTester(t, 'Object', {}, ['toString']);

--- a/packages/ses/test/test-enable-property-overrides-severe-debug.js
+++ b/packages/ses/test/test-enable-property-overrides-severe-debug.js
@@ -5,6 +5,7 @@ import { overrideTester } from './override-tester.js';
 lockdown({
   overrideTaming: 'severe',
   overrideDebug: ['constructor', 'push', 'unrecognized'],
+  __hardenTaming__: 'safe',
 });
 
 const { getPrototypeOf } = Object;

--- a/packages/ses/test/test-enable-property-overrides-severe.js
+++ b/packages/ses/test/test-enable-property-overrides-severe.js
@@ -2,7 +2,7 @@ import '../index.js';
 import test from 'ava';
 import { overrideTester } from './override-tester.js';
 
-lockdown({ overrideTaming: 'severe' });
+lockdown({ overrideTaming: 'severe', __hardenTaming__: 'safe' });
 
 const { getPrototypeOf } = Object;
 const { ownKeys } = Reflect;

--- a/packages/ses/test/test-global-object.js
+++ b/packages/ses/test/test-global-object.js
@@ -38,7 +38,7 @@ test('globalObject', t => {
 
   t.truthy(globalObject instanceof Object);
   t.is(Object.getPrototypeOf(globalObject), Object.prototype);
-  t.truthy(!Object.isFrozen(globalObject));
+  t.truthy(!Object.isFrozen(globalObject) || harden.isFake);
   t.not(globalObject, globalThis);
   t.is(globalObject.globalThis, globalObject);
 

--- a/packages/ses/test/test-harden.js
+++ b/packages/ses/test/test-harden.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import '../index.js';
 
-lockdown();
+lockdown({ __hardenTaming__: 'safe' });
 
 test('Compartment global is not frozen', t => {
   const c = new Compartment();

--- a/packages/ses/test/test-ses.js
+++ b/packages/ses/test/test-ses.js
@@ -102,8 +102,10 @@ test('SES compartment has harden', t => {
   const c = new Compartment({ a: 123 });
   const obj = c.evaluate('harden({a})');
   t.is(obj.a, 123, 'expected object');
-  t.throws(() => (obj.a = 'ignored'));
-  t.is(obj.a, 123, 'hardened object retains value');
+  if (!harden.isFake) {
+    t.throws(() => (obj.a = 'ignored'));
+    t.is(obj.a, 123, 'hardened object retains value');
+  }
 });
 
 // test('SESRealm.SES wraps exceptions', t => {

--- a/packages/ses/test/test-tame-harden.js
+++ b/packages/ses/test/test-tame-harden.js
@@ -1,0 +1,34 @@
+import '../index.js';
+import test from 'ava';
+import {
+  isFrozen,
+  isSealed,
+  isExtensible,
+  reflectIsExtensible,
+} from '../src/commons.js';
+
+lockdown({ __hardenTaming__: 'unsafe' });
+
+test('fake harden', t => {
+  t.is(harden.isFake, true);
+
+  const assertFakeFrozen = specimen => {
+    // Built-in function replacements must report frozenness.
+    t.is(Object.isExtensible(specimen), false);
+    t.is(Object.isFrozen(specimen), true);
+    t.is(Object.isSealed(specimen), true);
+    t.is(Reflect.isExtensible(specimen), false);
+
+    // In-the-know functions must report the truth.
+    t.is(isExtensible(specimen), true);
+    t.is(isFrozen(specimen), false);
+    t.is(isSealed(specimen), false);
+    t.is(reflectIsExtensible(specimen), true);
+  };
+
+  const obj = {};
+  assertFakeFrozen(obj);
+
+  harden(obj);
+  assertFakeFrozen(obj);
+});

--- a/packages/ses/test/test-tolerate-empty-prototype.js
+++ b/packages/ses/test/test-tolerate-empty-prototype.js
@@ -17,7 +17,7 @@ test('tolerate empty prototype', t => {
     Object.getOwnPropertyDescriptor(Array.prototype.push, 'prototype'),
     {
       value: undefined,
-      writable: false,
+      writable: !!harden.isFake,
       enumerable: false,
       configurable: false,
     },

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -33,6 +33,7 @@ export interface LockdownOptions {
   overrideTaming?: 'moderate' | 'min' | 'severe';
   overrideDebug?: Array<string>;
   domainTaming?: 'safe' | 'unsafe';
+  __hardenTaming__?: 'safe' | 'unsafe';
 }
 
 export type Lockdown = (options?: LockdownOptions) => void;


### PR DESCRIPTION
Adds an option to make `harden` a do-nothing identity function, specifically for speed of the SwingSet kernel, though it could be used for other highly vetted, style restricted, security-critical, and speed-critical code. This would be safe to turn on in the SwingSet kernel or other such specialized code once we're confident that they are free of the kinds of bugs that a working `harden` would have protected them from.

Adds a `__hardenTaming__` option to `lockdown`, with values `'safe'` (the default) in which `harden` still works, and `'unsafe'`, in which `harden` is a do-nothing identity function.

There are various tests for whether something is frozen, sealed, non-extensible, non-configurable, non-writable, that could all be broken by this fake `harden`. However, in all cases in our non-test, non-demo code that we are aware of so far, for each such branch, one side of the branch reports an error and only the other side is the happy path. If we're confident we have no bugs that `harden` would have caught, then we need only ensure we go down the happy paths for such tests.

`Object.isFrozen`, `Object.isSealed`, `Object.isExtensible`, `Reflect.isExtensible` are patched to claim that everything is frozen, since that is typically the happy path. But not always. For those rare occasions where not being frozen is the happy path, we have added a `harden.isFake = true` property. When this unsafe option is not turned on, there is no `isFake` property, so `harden.isFake` is falsy. This lets code test `harden.isFake` to ensure it still goes down the happy path. This PR fixes the one case of that we know of in the non-test, non-demo code of the endo repository. To my surprise, there do not seem to be any in the non-test, non-demo code of the agoric-sdk repository.

At this time, we do not patch any of the builtins for reflecting on property attributes, such as `Object.getOwnPropertyDescriptor`. We will soon see if we need to.
   * Found the first. See https://github.com/Agoric/agoric-sdk/pull/7263

---

Reviewers, please review by commit. The second commit, `fix: tolerate LOCKDOWN_HARDEN_TAMING=unsafe`, is not needed to pass under CI. But it is needed to pass locally if I first set `export LOCKDOWN_HARDEN_TAMING=unsafe`. The fact that it *only* modifies test files so that the first commit made all the needed changes to the non-test,non-demo files.