### PR TITLE
fix: sync with exo API change

### DIFF
--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -47,7 +47,7 @@ export const defineExoClass = (
   const contextMap = new WeakMap();
   const prototype = defendPrototype(
     tag,
-    contextMap,
+    self => contextMap.get(self),
     methods,
     true,
     interfaceGuard,
@@ -94,9 +94,13 @@ export const defineExoClassKit = (
   options = undefined,
 ) => {
   const contextMapKit = objectMap(methodsKit, () => new WeakMap());
+  const getContextKit = objectMap(
+    methodsKit,
+    (_v, name) => facet => contextMapKit[name].get(facet),
+  );
   const prototypeKit = defendPrototypeKit(
     tag,
-    contextMapKit,
+    getContextKit,
     methodsKit,
     true,
     interfaceGuardKit,


### PR DESCRIPTION
Sync with https://github.com/Agoric/agoric-sdk/pull/7304 

To cope with the https://github.com/Agoric/agoric-sdk/pull/7138 API change, so that the next published endo can be compat with the agoric-sdk upgraded to depend on it.