### PR TITLE
feat(pass-style,marshal): ByteArray, a new binary Passable type

### DIFF
--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -15,7 +15,6 @@ export {
 } from './src/encodePassable.js';
 
 export {
-  trivialComparator,
   compareNumerics,
   assertRankSorted,
   compareRank,

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -10,7 +10,7 @@ import {
 } from '@endo/pass-style';
 
 /**
- * @import {CopyRecord, PassStyle, Passable, RemotableObject as Remotable} from '@endo/pass-style'
+ * @import {CopyRecord, PassStyle, Passable, RemotableObject as Remotable, ByteArray} from '@endo/pass-style'
  */
 
 import { b, q, Fail } from '@endo/errors';
@@ -462,6 +462,17 @@ const decodeLegacyArray = (encoded, decodePassable, skip = 0) => {
   return harden(elements);
 };
 
+/**
+ * @param {ByteArray} byteArray
+ * @param {(byteArray: ByteArray) => string} _encodePassable
+ * @returns {string}
+ */
+const encodeByteArray = (byteArray, _encodePassable) => {
+  // TODO implement
+  Fail`encodePassable(copyData) not yet implemented: ${byteArray}`;
+  return ''; // Just for the type
+};
+
 const encodeRecord = (record, encodeArray, encodePassable) => {
   const names = recordNames(record);
   const values = recordValues(record, names);
@@ -625,6 +636,9 @@ const makeInnerEncode = (encodeStringSuffix, encodeArray, options) => {
       }
       case 'copyArray': {
         return encodeArray(passable, innerEncode);
+      }
+      case 'byteArray': {
+        return encodeByteArray(passable, innerEncode);
       }
       case 'copyRecord': {
         return encodeRecord(passable, encodeArray, innerEncode);
@@ -870,6 +884,7 @@ export const passStylePrefixes = {
   tagged: ':',
   promise: '?',
   copyArray: '[^',
+  byteArray: 'a',
   boolean: 'b',
   number: 'f',
   bigint: 'np',

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -194,6 +194,10 @@ export const makeEncodeToCapData = (encodeOptions = {}) => {
       case 'copyArray': {
         return passable.map(encodeToCapDataRecur);
       }
+      case 'byteArray': {
+        // TODO implement
+        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+      }
       case 'tagged': {
         return {
           [QCLASS]: 'tagged',

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -229,6 +229,10 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
       case 'copyArray': {
         return passable.map(encodeToSmallcapsRecur);
       }
+      case 'byteArray': {
+        // TODO implement
+        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+      }
       case 'tagged': {
         return {
           '#tag': encodeToSmallcapsRecur(getTag(passable)),

--- a/packages/marshal/test/encodePassable.test.js
+++ b/packages/marshal/test/encodePassable.test.js
@@ -15,7 +15,7 @@ import {
 import { compareRank, makeFullOrderComparatorKit } from '../src/rankOrder.js';
 import { unsortedSample } from './_marshal-test-data.js';
 
-const { arbPassable } = makeArbitraries(fc);
+const { arbPassable } = makeArbitraries(fc, ['byteArray']);
 
 const statelessEncodePassableLegacy = makeEncodePassable();
 

--- a/packages/marshal/test/marshal-stringify.test.js
+++ b/packages/marshal/test/marshal-stringify.test.js
@@ -38,11 +38,13 @@ test('marshal stringify errors', t => {
     t.throws(() => stringify({}), {
       message: /Cannot pass non-frozen objects like .*. Use harden()/,
     });
-    // @ts-expect-error intentional error
+    // at-ts-ignore rather than at-expect-error because of disagreement
+    // @ts-ignore intentional error
     t.throws(() => stringify(harden(new Uint8Array(1))), {
       message: 'Cannot pass mutable typed arrays like "[Uint8Array]".',
     });
-    // @ts-expect-error intentional error
+    // at-ts-ignore rather than at-expect-error because of disagreement
+    // @ts-ignore intentional error
     t.throws(() => stringify(harden(new Int16Array(1))), {
       message: 'Cannot pass mutable typed arrays like "[Int16Array]".',
     });

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -1,0 +1,49 @@
+import { X } from '@endo/errors';
+
+/**
+ * @import {PassStyleHelper} from './internal-types.js';
+ */
+
+const { getPrototypeOf, getOwnPropertyDescriptor } = Object;
+const { ownKeys, apply } = Reflect;
+
+// @ts-expect-error TODO How do I add it to the ArrayBuffer type?
+const AnImmutableArrayBuffer = new ArrayBuffer(0).transferToImmutable();
+
+/**
+ * As proposed, this will be the same as `ArrayBuffer.prototype`. As shimmed,
+ * this will be a hidden intrinsic that inherits from `ArrayBuffer.prototype`.
+ * Either way, get this in a way that we can trust it after lockdown, and
+ * require that all immutable ArrayBuffers directly inherit from it.
+ */
+const ImmutableArrayBufferPrototype = getPrototypeOf(AnImmutableArrayBuffer);
+
+const immutableGetter = /** @type {(this: ArrayBuffer) => boolean} */ (
+  // @ts-expect-error We know the desciptor is there.
+  getOwnPropertyDescriptor(ImmutableArrayBufferPrototype, 'immutable').get
+);
+
+/**
+ * @type {PassStyleHelper}
+ */
+export const ByteArrayHelper = harden({
+  styleName: 'byteArray',
+
+  canBeValid: (candidate, check = undefined) =>
+    (candidate instanceof ArrayBuffer &&
+      // @ts-expect-error TODO How do I add it to the ArrayBuffer type?
+      candidate.immutable) ||
+    (!!check && check(false, X`Immutable ArrayBuffer expected: ${candidate}`)),
+
+  assertRestValid: (candidate, _passStyleOfRecur) => {
+    getPrototypeOf(candidate) === ImmutableArrayBufferPrototype ||
+      assert.fail(X`Malformed ByteArray ${candidate}`, TypeError);
+    apply(immutableGetter, candidate, []) ||
+      assert.fail(X`Must be an immutable ArrayBuffer: ${candidate}`);
+    ownKeys(candidate).length === 0 ||
+      assert.fail(
+        X`ByteArrays must not have own properties: ${candidate}`,
+        TypeError,
+      );
+  },
+});

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -6,7 +6,7 @@ import { passStyleOf } from './passStyleOf.js';
 import { makeTagged } from './makeTagged.js';
 
 /**
- * @import {Passable, Primitive, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'
+ * @import {Passable, ByteArray, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'
  */
 
 const { ownKeys } = Reflect;
@@ -104,6 +104,11 @@ export const deeplyFulfilled = async val => {
       const valPs = arr.map(p => deeplyFulfilled(p));
       // @ts-expect-error not assignable to type 'DeeplyAwaited<T>'
       return E.when(Promise.all(valPs), vals => harden(vals));
+    }
+    case 'byteArray': {
+      const bytes = /** @type {ByteArray} */ (val);
+      // @ts-expect-error not assignable to type 'DeeplyAwaited<T>'
+      return bytes;
     }
     case 'tagged': {
       const tgd = /** @type {CopyTagged} */ (val);

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -12,6 +12,7 @@ import {
 } from './passStyle-helpers.js';
 
 import { CopyArrayHelper } from './copyArray.js';
+import { ByteArrayHelper } from './byteArray.js';
 import { CopyRecordHelper } from './copyRecord.js';
 import { TaggedHelper } from './tagged.js';
 import {
@@ -31,23 +32,20 @@ import { assertPassableString } from './string.js';
 /** @import {CopyArray, CopyRecord, CopyTagged, Passable} from './types.js' */
 /** @import {PassStyle} from './types.js' */
 /** @import {PassStyleOf} from './types.js' */
-/** @import {PrimitiveStyle} from './types.js' */
-
-/** @typedef {Exclude<PassStyle, PrimitiveStyle | "promise">} HelperPassStyle */
 
 const { ownKeys } = Reflect;
 const { isFrozen, getOwnPropertyDescriptors, values } = Object;
 
 /**
+ * @template {Record<PassStyle, PassStyleHelper>} HelpersRecord
  * @param {PassStyleHelper[]} passStyleHelpers
- * @returns {Record<HelperPassStyle, PassStyleHelper> }
+ * @returns {HelpersRecord}
  */
-
 const makeHelperTable = passStyleHelpers => {
-  /** @type {Record<HelperPassStyle, any> & {__proto__: null}} */
   const HelperTable = {
     __proto__: null,
     copyArray: undefined,
+    byteArray: undefined,
     copyRecord: undefined,
     tagged: undefined,
     error: undefined,
@@ -65,7 +63,9 @@ const makeHelperTable = passStyleHelpers => {
       Fail`missing helper for ${q(styleName)}`;
   }
 
-  return harden(HelperTable);
+  return /** @type {HelpersRecord} */ (
+    /** @type {unknown} */ (harden(HelperTable))
+  );
 };
 
 /**
@@ -236,6 +236,7 @@ export const passStyleOf =
   (globalThis && globalThis[PassStyleOfEndowmentSymbol]) ||
   makePassStyleOf([
     CopyArrayHelper,
+    ByteArrayHelper,
     CopyRecordHelper,
     TaggedHelper,
     ErrorHelper,

--- a/packages/pass-style/src/typeGuards.js
+++ b/packages/pass-style/src/typeGuards.js
@@ -1,7 +1,9 @@
 import { Fail, q } from '@endo/errors';
 import { passStyleOf } from './passStyleOf.js';
 
-/** @import {CopyArray, CopyRecord, Passable, RemotableObject} from './types.js' */
+/**
+ * @import {CopyArray, CopyRecord, Passable, RemotableObject, ByteArray} from './types.js'
+ */
 
 /**
  * Check whether the argument is a pass-by-copy array, AKA a "copyArray"
@@ -12,6 +14,16 @@ import { passStyleOf } from './passStyleOf.js';
  */
 const isCopyArray = arr => passStyleOf(arr) === 'copyArray';
 harden(isCopyArray);
+
+/**
+ * Check whether the argument is a pass-by-copy binary data, AKA a "byteArray"
+ * in @endo/marshal terms
+ *
+ * @param {Passable} arr
+ * @returns {arr is ByteArray}
+ */
+const isByteArray = arr => passStyleOf(arr) === 'byteArray';
+harden(isByteArray);
 
 /**
  * Check whether the argument is a pass-by-copy record, AKA a
@@ -47,6 +59,21 @@ const assertCopyArray = (arr, optNameOfArray = 'Alleged array') => {
 harden(assertCopyArray);
 
 /**
+ * @param {Passable} arr
+ * @param {string=} optNameOfArray
+ * @returns {asserts arr is ByteArray}
+ */
+const assertByteArray = (arr, optNameOfArray = 'Alleged byteArray') => {
+  const passStyle = passStyleOf(arr);
+  passStyle === 'byteArray' ||
+    Fail`${q(
+      optNameOfArray,
+    )} ${arr} must be a pass-by-copy binary data, not ${q(passStyle)}`;
+};
+harden(assertByteArray);
+
+/**
+ * @callback AssertRecord
  * @param {any} record
  * @param {string=} optNameOfRecord
  * @returns {asserts record is CopyRecord<any>}
@@ -80,8 +107,10 @@ harden(assertRemotable);
 export {
   assertRecord,
   assertCopyArray,
+  assertByteArray,
   assertRemotable,
   isRemotable,
   isRecord,
   isCopyArray,
+  isByteArray,
 };

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -3,15 +3,18 @@ import { PASS_STYLE } from './passStyle-helpers.js';
 
 /**
  * Matches any [primitive value](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
+ * TODO This now represents passable primitives, some of which are represented
+ * in JS as JS objects, not JS primitives.
  */
 export type Primitive =
-  | null
   | undefined
-  | string
-  | number
+  | null
   | boolean
-  | symbol
-  | bigint;
+  | number
+  | bigint
+  | string
+  | ByteArray
+  | symbol; // TODO we'll need to stop using the JS symbol type here.
 
 export type PrimitiveStyle =
   | 'undefined'
@@ -20,6 +23,7 @@ export type PrimitiveStyle =
   | 'number'
   | 'bigint'
   | 'string'
+  | 'byteArray'
   | 'symbol';
 
 export type ContainerStyle = 'copyRecord' | 'copyArray' | 'tagged';
@@ -116,16 +120,16 @@ export type PassStyleOf = {
 /**
  * A Passable is PureData when its entire data structure is free of PassableCaps
  * (remotables and promises) and error objects.
- * PureData is an arbitrary composition of primitive values into CopyArray
- * and/or
- * CopyRecord and/or CopyTagged containers (or a single primitive value with no
- * container), and is fully pass-by-copy.
+ * PureData is an arbitrary composition of primitive values into CopyArray,
+ * CopyRecord, and/or CopyTagged containers
+ * (or a single primitive value with no container), and is fully pass-by-copy.
  *
- * This restriction assures absence of side effects and interleaving risks *given*
- * that none of the containers can be a Proxy instance.
+ * This restriction assures absence of side effects and interleaving risks
+ * *given* that none of the containers can be a Proxy instance.
  * TODO SECURITY BUG we plan to enforce this, giving PureData the same security
  * properties as the proposed
  * [Records and Tuples](https://github.com/tc39/proposal-record-tuple).
+ * (TODO update to point at the non-trapping shim)
  *
  * Given this (currently counter-factual) assumption, a PureData value cannot
  * be used as a communications channel,
@@ -155,6 +159,11 @@ export type PassableCap = Promise<any> | RemotableObject;
  * A Passable sequence of Passable values.
  */
 export type CopyArray<T extends Passable = any> = Array<T>;
+
+/**
+ * A hardened immutable ArrayBuffer.
+ */
+export type ByteArray = ArrayBuffer;
 
 /**
  * A Passable dictionary in which each key is a string and each value is Passable.

--- a/packages/patterns/src/keys/compareKeys.js
+++ b/packages/patterns/src/keys/compareKeys.js
@@ -102,6 +102,7 @@ export const compareKeys = (left, right) => {
     case 'boolean':
     case 'bigint':
     case 'string':
+    case 'byteArray':
     case 'symbol': {
       // for these, keys compare the same as rank
       return compareRank(left, right);

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -90,8 +90,8 @@ export {};
  *
  * Patterns are Passable arbitrarily-nested pass-by-copy containers
  * (CopyArray, CopyRecord, CopySet, CopyBag, CopyMap) in which every
- * non-container leaf is either a Key or a {@link Matcher}, or such leaves in isolation
- * with no container.
+ * non-container leaf is either a Key or a {@link Matcher}, or such leaves in
+ * isolation with no container.
  *
  * A Pattern acts as a declarative total predicate over Passables, where each
  * Passable is either matched or not matched by it. Every {@link Key} is also a Pattern
@@ -205,6 +205,7 @@ export {};
  * @property {number} numPropertiesLimit
  * @property {number} propertyNameLengthLimit
  * @property {number} arrayLengthLimit
+ * @property {number} byteLengthLimit
  * @property {number} numSetElementsLimit
  * @property {number} numUniqueBagElementsLimit
  * @property {number} numMapEntriesLimit
@@ -296,6 +297,9 @@ export {};
  *
  * @property {(limits?: Limits) => Matcher} array
  * Matches any CopyArray, subject to limits.
+ *
+ * @property {(limits?: Limits) => Matcher} bytes
+ * Matches any ByteArray, subject to limits.
  *
  * @property {(limits?: Limits) => Matcher} set
  * Matches any CopySet, subject to limits.


### PR DESCRIPTION
Closes: #1331 
Refs: https://github.com/ocapn/ocapn/issues/5#issuecomment-1492778252 #2414 

## Description

Recognize Immutable ArrayBuffers, when also frozen, as the new pass-style `byteArray`. Add a branch for each of the dispatches on pass-style that must now understand byte-arrays as well. As of this PR, many of those additional branches are stubbed out with "not yet implemented" errors as placeholders.

### Security Considerations

The underlying shim implementation, if we're still using that, uses a normal mutable ArrayBuffer internally, but safely encapsulates it so nothing outside the shim can mutate it.

### Scaling Considerations

The underlying shim implementation helps us handle bulk binary data in a largely no-copy or minimal-copy manner.

### Documentation Considerations

Will add a new pass-style, so everywhere we enumerate all the pass-styles, we'll need to add byte-array.

### Testing Considerations

- [ ] TODO tests. For each stubbed out case, there instead should be a `test.failing` test.

### Compatibility Considerations

Old code that dispatched only on the pass-styles it knew about will not correctly handle passables that contain byte-arrays.

The shim cannot reasonably support TypedArrays of DataViews backed by Immutable ArrayBuffers.

### Upgrade Considerations

- [ ] TODO BREAKING.md
- [ ] TODO NEWS.md

