### PR TITLE
chore(pass-style): Export isPassableSymbol

### DIFF
--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -15,9 +15,10 @@ export {
 export { getInterfaceOf } from './src/remotable.js';
 
 export {
+  assertPassableSymbol,
+  isPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
-  assertPassableSymbol,
 } from './src/symbol.js';
 
 export { passStyleOf, assertPassable } from './src/passStyleOf.js';


### PR DESCRIPTION
Needed in [agoric-sdk callback.js](https://github.com/Agoric/agoric-sdk/blob/master/packages/internal/src/callback.js) as of https://github.com/Agoric/agoric-sdk/pull/7341