### PR TITLE
fix(ses): limit logged args per error

### DIFF
--- a/packages/ses/test/error/test-lru-cache-map.js
+++ b/packages/ses/test/error/test-lru-cache-map.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+
+import { makeLRUCacheMap } from '../../src/error/note-log-args.js';
+
+test('lru cache map basic', t => {
+  const lruMap = makeLRUCacheMap(2);
+  const key1 = {};
+  const key2 = {};
+  const key3 = {};
+  t.is(lruMap.has(key1), false);
+
+  lruMap.set(key1, 'x');
+  lruMap.set(key2, 'y');
+  t.is(lruMap.has(key2), true);
+  t.is(lruMap.has(key1), true);
+  t.is(lruMap.has(key3), false);
+
+  lruMap.set(key3, 'z');
+  t.is(lruMap.has(key1), true);
+  t.is(lruMap.has(key2), false);
+  t.is(lruMap.has(key3), true);
+});

--- a/packages/ses/test/error/test-note-log-args.js
+++ b/packages/ses/test/error/test-note-log-args.js
@@ -1,0 +1,24 @@
+import test from 'ava';
+
+import { makeNoteLogArgsArrayKit } from '../../src/error/note-log-args.js';
+
+test('note log args array kit basic', t => {
+  const { addLogArgs, takeLogArgsArray } = makeNoteLogArgsArrayKit(3, 2);
+  const e1 = Error('e1');
+  const e2 = Error('e2');
+  const e3 = Error('e3');
+  const e4 = Error('e4');
+
+  addLogArgs(e1, ['a']);
+  addLogArgs(e3, ['b']);
+  addLogArgs(e2, ['c']);
+  addLogArgs(e4, ['d']); // drops e1
+  addLogArgs(e1, ['e']); // new e1 entry, drops e3
+  addLogArgs(e2, ['f']);
+  addLogArgs(e2, ['g']); // drops e2,c
+  addLogArgs(e2, ['h']); // drops e2,f
+  t.deepEqual(takeLogArgsArray(e1), [['e']]);
+  t.deepEqual(takeLogArgsArray(e2), [['g'], ['h']]);
+  t.deepEqual(takeLogArgsArray(e3), undefined);
+  t.deepEqual(takeLogArgsArray(e4), [['d']]);
+});


### PR DESCRIPTION
While @michaelfig and I were trying to track down a different bug, we noticed that the LRU budget on error notes, while correctly limiting the number of logged errors according to budget, failed to limit the number of logged args per error.

The latter is just kept as an ordered array. For the errors, there's a chronology of use after the initial entry was created, so an LRU was needed. For the logged args per error, they are only entered, and then not used until all of them are taken at once. Thus, dropping the front of the array if over budget is an adequate LRU.

This PR adds and enforces this separate budget of logged args per error.