### PR TITLE
build: consistently produce `yarn pack` type declarations

### DIFF
--- a/packages/base64/jsconfig.build.json
+++ b/packages/base64/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -31,6 +31,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -8,12 +8,6 @@
 
 // This logic was mostly lifted from @agoric/swingset-vat liveSlots.js
 // Defects in it are mfig's fault.
-//
-// @ts-ignore We actually mean the function, not the type,
-// but TS somehow no longer knows that -- following the extraction
-// of @endo/pass-style from @endo/marshal.
-// We're using @ts-ignore here because TS is inconsistent about whether this
-// line is an error. It is not locally, but it is under CI.
 import { Remotable, Far, makeMarshal, QCLASS } from '@endo/marshal';
 import { E, HandledPromise } from '@endo/eventual-send';
 import { isPromise, makePromiseKit } from '@endo/promise-kit';
@@ -418,10 +412,6 @@ export const makeCapTP = (
         }
         // A new remote presence
         // Use Remotable rather than Far to make a remote from a presence
-        //
-        // @ts-ignore We actually mean the function, not the type,
-        // but TS somehow no longer knows that -- following the extraction
-        // of @endo/pass-style from @endo/marshal.
         val = Remotable(iface, undefined, settler.resolveWithPresence());
         if (importHook) {
           importHook(val, slot);

--- a/packages/check-bundle/jsconfig.build.json
+++ b/packages/check-bundle/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -29,6 +29,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",

--- a/packages/cjs-module-analyzer/jsconfig.build.json
+++ b/packages/cjs-module-analyzer/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -21,6 +21,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/cli/jsconfig.build.json
+++ b/packages/cli/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,8 @@
   "exports": {},
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",

--- a/packages/compartment-mapper/jsconfig.build.json
+++ b/packages/compartment-mapper/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -32,6 +32,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/daemon/jsconfig.build.json
+++ b/packages/daemon/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -26,6 +26,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/exo/jsconfig.build.json
+++ b/packages/exo/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -23,6 +23,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",

--- a/packages/far/jsconfig.build.json
+++ b/packages/far/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -9,6 +9,8 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/lp32/jsconfig.build.json
+++ b/packages/lp32/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -36,6 +36,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -32,7 +32,4 @@ export * from './src/types.js';
 
 // For compatibility, but importers of these should instead import these
 // directly from `@endo/pass-style` or (if applicable) `@endo/far`.
-// @ts-expect-error TS only complains about this line when checking other
-// packages that depend on this one, like marshal. The complaint is about
-// repeatedly exported types. Specifically "Remotable".
 export * from '@endo/pass-style';

--- a/packages/marshal/src/deeplyFulfilled.js
+++ b/packages/marshal/src/deeplyFulfilled.js
@@ -4,7 +4,7 @@ import { E } from '@endo/eventual-send';
 import { isPromise } from '@endo/promise-kit';
 import { getTag, isObject, makeTagged, passStyleOf } from '@endo/pass-style';
 
-/** @typedef {import('./types.js').Passable} Passable */
+/** @typedef {import('@endo/pass-style').Passable} Passable */
 /** @template T @typedef {import('@endo/eventual-send').ERef<T>} ERef */
 
 const { details: X, quote: q } = assert;

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -9,10 +9,10 @@ import {
   passableSymbolForName,
 } from '@endo/pass-style';
 
-/** @typedef {import('./types.js').PassStyle} PassStyle */
-/** @typedef {import('./types.js').Passable} Passable */
-/** @typedef {import('./types.js').Remotable} Remotable */
-/** @template T @typedef {import('./types.js').CopyRecord<T>} CopyRecord */
+/** @typedef {import('@endo/pass-style').PassStyle} PassStyle */
+/** @typedef {import('@endo/pass-style').Passable} Passable */
+/** @typedef {import('@endo/pass-style').RemotableObject} Remotable */
+/** @template T @typedef {import('@endo/pass-style').CopyRecord<T>} CopyRecord */
 /** @typedef {import('./types.js').RankCover} RankCover */
 
 const { quote: q, Fail } = assert;
@@ -491,11 +491,7 @@ harden(isEncodedRemotable);
  * prefix used by any cover so that ordinal mapping keys are always outside
  * the range of valid collection entry keys.
  */
-// @ts-expect-error TS does not understand thst `__proto__;` in this position
-// is special syntax. Instead, it complains that the `null` is not a string,
-// which would only make sense if this were defining a property.
-export const passStylePrefixes = harden({
-  __proto__: null,
+export const passStylePrefixes = {
   error: '!',
   copyRecord: '(',
   tagged: ':',
@@ -509,4 +505,6 @@ export const passStylePrefixes = harden({
   null: 'v',
   symbol: 'y',
   undefined: 'z',
-});
+};
+Object.setPrototypeOf(passStylePrefixes, null);
+harden(passStylePrefixes);

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -18,9 +18,9 @@ import {
   passableSymbolForName,
 } from '@endo/pass-style';
 
-/** @typedef {import('./types.js').Passable} Passable */
+/** @typedef {import('@endo/pass-style').Passable} Passable */
 /** @typedef {import('./types.js').Encoding} Encoding */
-/** @typedef {import('./types.js').Remotable} Remotable */
+/** @typedef {import('@endo/pass-style').Remotable} Remotable */
 /** @typedef {import('./types.js').EncodingUnion} EncodingUnion */
 
 const { ownKeys } = Reflect;

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -17,8 +17,8 @@ import {
   passableSymbolForName,
 } from '@endo/pass-style';
 
-/** @typedef {import('./types.js').Passable} Passable */
-/** @typedef {import('./types.js').Remotable} Remotable */
+/** @typedef {import('@endo/pass-style').Passable} Passable */
+/** @typedef {import('@endo/pass-style').Remotable} Remotable */
 // @typedef {import('./types.js').SmallcapsEncoding} SmallcapsEncoding */
 // @typedef {import('./types.js').SmallcapsEncodingUnion} SmallcapsEncodingUnion */
 /** @typedef {any} SmallcapsEncoding */

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -2,7 +2,7 @@
 
 import { makeMarshal } from './marshal.js';
 
-/** @typedef {import('./types.js').Passable} Passable */
+/** @typedef {import('@endo/pass-style').Passable} Passable */
 
 const { Fail } = assert;
 

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -23,10 +23,10 @@ import {
 /** @template Slot @typedef {import('./types.js').ConvertValToSlot<Slot>} ConvertValToSlot */
 /** @template Slot @typedef {import('./types.js').ToCapData<Slot>} ToCapData */
 /** @template Slot @typedef {import('./types.js').FromCapData<Slot>} FromCapData */
-/** @typedef {import('./types.js').Passable} Passable */
-/** @typedef {import('./types.js').InterfaceSpec} InterfaceSpec */
+/** @typedef {import('@endo/pass-style').Passable} Passable */
+/** @typedef {import('@endo/pass-style').InterfaceSpec} InterfaceSpec */
 /** @typedef {import('./types.js').Encoding} Encoding */
-/** @typedef {import('./types.js').Remotable} Remotable */
+/** @typedef {import('@endo/pass-style').RemotableObject} Remotable */
 
 const { isArray } = Array;
 const { details: X, Fail, quote: q } = assert;
@@ -330,13 +330,7 @@ export const makeMarshal = (
     };
 
     const reviveFromSmallcaps = makeDecodeFromSmallcaps({
-      // @ts-expect-error This error started after separating pass-style
-      // out of marshal into its own package. Aside from that, I do not
-      // understand this error at all.
       decodeRemotableFromSmallcaps,
-      // @ts-expect-error This error started after separating pass-style
-      // out of marshal into its own package. Aside from that, I do not
-      // understand this error at all.
       decodePromiseFromSmallcaps,
       decodeErrorFromSmallcaps,
     });

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -5,8 +5,8 @@ import {
   recordValues,
 } from './encodePassable.js';
 
-/** @typedef {import('./types.js').Passable} Passable */
-/** @typedef {import('./types.js').PassStyle} PassStyle */
+/** @typedef {import('@endo/pass-style').Passable} Passable */
+/** @typedef {import('@endo/pass-style').PassStyle} PassStyle */
 /** @typedef {import('./types.js').RankCover} RankCover */
 
 const { Fail, quote: q } = assert;

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -138,13 +138,3 @@ export {};
  * of a string-comparison range that covers all possible encodings for
  * a set of values.
  */
-
-// /////////////////////// Type reexports @endo/pass-style /////////////////////
-
-/** @typedef {import('@endo/pass-style').Checker} Checker */
-/** @typedef {import('@endo/pass-style').PassStyle} PassStyle */
-/** @typedef {import('@endo/pass-style').Passable} Passable */
-/** @typedef {import('@endo/pass-style').Remotable} Remotable */
-/** @template T @typedef {import('@endo/pass-style').CopyArray<T>} CopyArray */
-/** @template T @typedef {import('@endo/pass-style').CopyRecord<T>} CopyRecord */
-/** @typedef {import('@endo/pass-style').InterfaceSpec} InterfaceSpec */

--- a/packages/netstring/jsconfig.build.json
+++ b/packages/netstring/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -24,6 +24,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -34,3 +34,6 @@ export {
   isRecord,
   isCopyArray,
 } from './src/typeGuards.js';
+
+// eslint-disable-next-line import/export
+export * from './src/types.js';

--- a/packages/pass-style/jsconfig.build.json
+++ b/packages/pass-style/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -23,6 +23,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -15,7 +15,7 @@ import {
 /** @typedef {import('./types.js').InterfaceSpec} InterfaceSpec */
 /** @typedef {import('./types.js').MarshalGetInterfaceOf} MarshalGetInterfaceOf */
 /** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
-/** @typedef {import('./types.js').Remotable} Remotable */
+/** @typedef {import('./types.js').RemotableObject} Remotable */
 
 const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;

--- a/packages/pass-style/src/typeGuards.js
+++ b/packages/pass-style/src/typeGuards.js
@@ -3,7 +3,7 @@ import { passStyleOf } from './passStyleOf.js';
 /** @typedef {import('./types.js').Passable} Passable */
 /** @template T @typedef {import('./types.js').CopyArray<T>} CopyArray */
 /** @template T @typedef {import('./types.js').CopyRecord<T>} CopyRecord */
-/** @typedef {import('./types.js').Remotable} Remotable */
+/** @typedef {import('./types.js').RemotableObject} Remotable */
 
 const { Fail, quote: q } = assert;
 

--- a/packages/pass-style/src/types.js
+++ b/packages/pass-style/src/types.js
@@ -69,14 +69,14 @@ export {};
  */
 
 /**
- * @typedef {Passable} Remotable
+ * @typedef {Passable} RemotableObject
  *
  * An object marked as remotely accessible using the `Far` or `Remotable`
  * functions, or a local presence representing such a remote object.
  */
 
 /**
- * @typedef {Promise | Remotable} PassableCap
+ * @typedef {Promise | RemotableObject} PassableCap
  *
  * The authority-bearing leaves of a Passable's pass-by-copy superstructure.
  */

--- a/packages/patterns/jsconfig.build.json
+++ b/packages/patterns/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -22,6 +22,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",
     "lint:js": "eslint .",

--- a/packages/ses-ava/jsconfig.build.json
+++ b/packages/ses-ava/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -25,6 +25,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/static-module-record/jsconfig.build.json
+++ b/packages/static-module-record/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -27,6 +27,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint:types": "tsc -p jsconfig.json",

--- a/packages/stream-node/jsconfig.build.json
+++ b/packages/stream-node/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -30,6 +30,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/stream/jsconfig.build.json
+++ b/packages/stream/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -30,6 +30,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/syrup/jsconfig.build.json
+++ b/packages/syrup/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -28,6 +28,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/where/jsconfig.build.json
+++ b/packages/where/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -26,6 +26,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/packages/zip/jsconfig.build.json
+++ b/packages/zip/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -27,6 +27,8 @@
   },
   "scripts": {
     "build": "exit 0",
+    "prepack": "tsc --build jsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:js",
     "lint-fix": "eslint --fix .",

--- a/scripts/repackage.sh
+++ b/scripts/repackage.sh
@@ -79,6 +79,8 @@ NEWPKGJSONHASH=$(
     ),
     scripts: ((.scripts // {}) + {
       "build": "exit 0",
+      "prepack": "tsc --build jsconfig.build.json",
+      "postpack": "git clean -f '\''*.d.ts*'\''",
       "test": "ava",
       "lint": "yarn lint:types && yarn lint:js",
       "lint:types": "tsc -p jsconfig.json",

--- a/skel/jsconfig.build.json
+++ b/skel/jsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./jsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true
+  },
+  "exclude": ["test/"]
+}


### PR DESCRIPTION
- `prepack` now consistently builds Typscript types, and `postpack` removes them
- Sort out the difficulties between `@endo/marshal` and `@endo/pass-style`
