### PR TITLE
fix(pattern): copy collection param type defaults

### DIFF
--- a/packages/patterns/src/keys/checkKey.js
+++ b/packages/patterns/src/keys/checkKey.js
@@ -141,7 +141,7 @@ harden(assertKey);
 // Moved to here so they can check that the copySet contains only keys
 // without creating an import cycle.
 
-/** @type WeakSet<CopySet<Key>> */
+/** @type WeakSet<CopySet> */
 const copySetMemo = new WeakSet();
 
 /**
@@ -168,7 +168,7 @@ harden(checkCopySet);
 /**
  * @callback IsCopySet
  * @param {Passable} s
- * @returns {s is CopySet<Key>}
+ * @returns {s is CopySet}
  */
 
 /** @type {IsCopySet} */
@@ -178,7 +178,7 @@ harden(isCopySet);
 /**
  * @callback AssertCopySet
  * @param {Passable} s
- * @returns {asserts s is CopySet<Key>}
+ * @returns {asserts s is CopySet}
  */
 
 /** @type {AssertCopySet} */
@@ -225,7 +225,7 @@ harden(makeCopySet);
 // Moved to here so they can check that the copyBag contains only keys
 // without creating an import cycle.
 
-/** @type WeakSet<CopyBag<Key>> */
+/** @type WeakSet<CopyBag> */
 const copyBagMemo = new WeakSet();
 
 /**
@@ -252,7 +252,7 @@ harden(checkCopyBag);
 /**
  * @callback IsCopyBag
  * @param {Passable} b
- * @returns {b is CopyBag<Key>}
+ * @returns {b is CopyBag}
  */
 
 /** @type {IsCopyBag} */
@@ -262,7 +262,7 @@ harden(isCopyBag);
 /**
  * @callback AssertCopyBag
  * @param {Passable} b
- * @returns {asserts b is CopyBag<Key>}
+ * @returns {asserts b is CopyBag}
  */
 
 /** @type {AssertCopyBag} */

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -83,7 +83,7 @@
 // TODO parameterize CopyTagged to support these refinements
 
 /**
- * @template {Key} K
+ * @template {Key} [K=Key]
  * @typedef {CopyTagged & {
  *   [Symbol.toStringTag]: 'copySet',
  *   payload: Array<K>,
@@ -94,7 +94,7 @@
  */
 
 /**
- * @template {Key} K
+ * @template {Key} [K=Key]
  * @typedef {CopyTagged & {
  *   [Symbol.toStringTag]: 'copyBag',
  *   payload: Array<[K, bigint]>,
@@ -106,8 +106,8 @@
  */
 
 /**
- * @template {Key} K
- * @template {Passable} V
+ * @template {Key} [K=Key]
+ * @template {Passable} [V=Passable]
  * @typedef {CopyTagged & {
  *   [Symbol.toStringTag]: 'copyMap',
  *   payload: { keys: Array<K>, values: Array<V> },


### PR DESCRIPTION
Enables us to say, for example, `CopyBag` rather than `CopyBag<Key>`, which in turn lets agoric-sdk delete unnecessary names like `CopyBagValue`.

Coordinated with change to agoric-sdk at https://github.com/Agoric/agoric-sdk/pull/7363

Will help https://github.com/Agoric/agoric-sdk/pull/7352