### PR TITLE
revert bigint parsing workaround

### DIFF
--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -376,9 +376,7 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
               }
             }
           }
-          case '+': {
-            return BigInt(encoding.slice(1));
-          }
+          case '+':
           case '-': {
             return BigInt(encoding);
           }


### PR DESCRIPTION
closes: https://github.com/endojs/endo/issues/1548

This reverts commit ab31d51fc2df0355b45da8bbeff892c45d81c98a from https://github.com/endojs/endo/issues/1309
