### PR TITLE
feat(init): add `@endo/init/unsafe-fast.js`

### DIFF
--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -8,6 +8,7 @@
     ".": "./index.js",
     "./debug.js": "./debug.js",
     "./legacy.js": "./legacy.js",
+    "./unsafe-fast.js": "./unsafe-fast.js",
     "./pre.js": {
       "node": "./src/pre-node.js",
       "default": "./pre.js"

--- a/packages/init/test/test-init.js
+++ b/packages/init/test/test-init.js
@@ -5,3 +5,17 @@ test('globals are present', t => {
   t.is(typeof Compartment, 'function');
   t.is(typeof harden, 'function');
 });
+
+test('default init hardens', async t => {
+  const a = {};
+  t.false(Object.isFrozen(a));
+  a.prop = 'init';
+  t.is(a.prop, 'init');
+  harden(a);
+  t.true(Object.isFrozen(a));
+  t.throws(() => (a.prop = 123), { instanceOf: TypeError });
+  t.is(a.prop, 'init');
+  Object.freeze(a);
+  t.throws(() => (a.prop = 456), { instanceOf: TypeError });
+  t.is(a.prop, 'init');
+});

--- a/packages/init/test/test-unsafe-fast.js
+++ b/packages/init/test/test-unsafe-fast.js
@@ -1,0 +1,17 @@
+import '../unsafe-fast.js';
+
+import test from 'ava';
+
+test('unsafe-fast does not harden', async t => {
+  const a = {};
+  t.true(Object.isFrozen(a));
+  a.prop = 'init';
+  t.is(a.prop, 'init');
+  harden(a);
+  t.true(Object.isFrozen(a));
+  a.prop = 123;
+  t.is(a.prop, 123);
+  Object.freeze(a);
+  t.throws(() => (a.prop = 456), { instanceOf: TypeError });
+  t.is(a.prop, 123);
+});

--- a/packages/init/unsafe-fast.js
+++ b/packages/init/unsafe-fast.js
@@ -1,0 +1,8 @@
+// unsafe-fast.js - call lockdown with performant but unsafe options
+import { lockdown } from '@endo/lockdown';
+import './pre-remoting.js';
+
+const options = {
+  __hardenTaming__: 'unsafe',
+};
+lockdown(options);


### PR DESCRIPTION
As discussed with @erights in a private meeting:

Create `@endo/init/unsafe-fast.js` to use a performant, but less-than-safe SES lockdown, currently

`lockdown({ __hardenTaming__: 'unsafe' })`
