### PR TITLE
Default `TRACK_TURNS=disabled`

### DIFF
--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -508,7 +508,7 @@ export const makeHandledPromise = () => {
           return;
         }
         try {
-          resolve(trackedDoDispatch(handlerName, handler, o));
+          resolve(harden(trackedDoDispatch(handlerName, handler, o)));
         } catch (reason) {
           reject(harden(reason));
         }

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -34,7 +34,7 @@ if (!validOptionValues.includes(envOptionValue)) {
     `unrecognized TRACK_TURNS ${JSON.stringify(envOptionValue)}`,
   );
 }
-const ENABLED = (envOptionValue || 'enabled') !== 'disabled';
+const ENABLED = (envOptionValue || 'disabled') === 'enabled';
 
 // We hoist the following functions out of trackTurns() to discourage the
 // closures from holding onto 'args' or 'func' longer than necessary,

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -75,7 +75,7 @@ const wrapFunction =
       // Must capture this now, not when the catch triggers.
       const detailsNote = X`Rejection from: ${hiddenPriorError}:${hiddenCurrentTurn}.${hiddenCurrentEvent}`;
       Promise.resolve(result).catch(addRejectionNote(detailsNote));
-      return harden(result);
+      return result;
     } finally {
       hiddenPriorError = undefined;
     }


### PR DESCRIPTION
As discussed at Agoric.

Also, fix a layering mistake in which hardened results required `TRACK_TURNS=enabled`.
