### PR TITLE
feat(pass-style,exo): label remotable instances

### DIFF
--- a/packages/exo/test/prepare-test-env-ava-label-instances.js
+++ b/packages/exo/test/prepare-test-env-ava-label-instances.js
@@ -1,0 +1,9 @@
+/* global globalThis */
+
+export * from './prepare-test-env-ava.js';
+
+// TODO Use environment-options.js currently in ses/src after factoring it out
+// to a new package.
+const env = (globalThis.process || {}).env || {};
+
+env.DEBUG = 'label-instances';

--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -1,4 +1,6 @@
+// eslint-disable-next-line import/order
 import { test } from './prepare-test-env-ava.js';
+
 // eslint-disable-next-line import/order
 import { M } from '@endo/patterns';
 import {
@@ -107,6 +109,7 @@ test('test makeExo', t => {
   t.throws(() => upCounter.incr(-3), {
     message: 'In "incr" method of (upCounter): arg 0?: -3 - Must be >= 0',
   });
+  // @ts-expect-error deliberately bad arg for testing
   t.throws(() => upCounter.incr('foo'), {
     message:
       'In "incr" method of (upCounter): arg 0?: string "foo" - Must be a number',

--- a/packages/exo/test/test-label-instances.js
+++ b/packages/exo/test/test-label-instances.js
@@ -1,0 +1,113 @@
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava-label-instances.js';
+
+// eslint-disable-next-line import/order
+import { passStyleOf } from '@endo/far';
+import { M } from '@endo/patterns';
+import {
+  defineExoClass,
+  defineExoClassKit,
+  makeExo,
+} from '../src/exo-makers.js';
+
+const { quote: q } = assert;
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call().returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call().returns(M.number()),
+});
+
+test('test defineExoClass', t => {
+  const makeUpCounter = defineExoClass(
+    'UpCounter',
+    UpCounterI,
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      incr() {
+        const { state } = this;
+        state.x += 1;
+        return state.x;
+      },
+    },
+  );
+  const up1 = makeUpCounter(3);
+  const up2 = makeUpCounter(7);
+  t.is(passStyleOf(up1), 'remotable');
+  t.is(`${up1}`, '[object Alleged: UpCounter#1]');
+  t.is(`${q(up1)}`, '"[Alleged: UpCounter#1]"');
+
+  t.is(passStyleOf(up2), 'remotable');
+  t.is(`${up2}`, '[object Alleged: UpCounter#2]');
+  t.is(`${q(up2)}`, '"[Alleged: UpCounter#2]"');
+});
+
+test('test defineExoClassKit', t => {
+  const makeCounterKit = defineExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr() {
+          const { state } = this;
+          state.x += 1;
+          return state.x;
+        },
+      },
+      down: {
+        decr() {
+          const { state } = this;
+          state.x -= 1;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: up1, down: down1 } = makeCounterKit(3);
+  const { up: up2, down: down2 } = makeCounterKit(7);
+
+  t.is(passStyleOf(up1), 'remotable');
+  t.is(`${up1}`, '[object Alleged: Counter up#1]');
+  t.is(`${q(up1)}`, '"[Alleged: Counter up#1]"');
+
+  t.is(passStyleOf(up2), 'remotable');
+  t.is(`${up2}`, '[object Alleged: Counter up#2]');
+  t.is(`${q(up2)}`, '"[Alleged: Counter up#2]"');
+
+  t.is(passStyleOf(down1), 'remotable');
+  t.is(`${down1}`, '[object Alleged: Counter down#1]');
+  t.is(`${q(down1)}`, '"[Alleged: Counter down#1]"');
+
+  t.is(passStyleOf(down2), 'remotable');
+  t.is(`${down2}`, '[object Alleged: Counter down#2]');
+  t.is(`${q(down2)}`, '"[Alleged: Counter down#2]"');
+});
+
+test('test makeExo', t => {
+  let x = 3;
+  const up1 = makeExo('upCounterA', UpCounterI, {
+    incr() {
+      x += 1;
+      return x;
+    },
+  });
+  const up2 = makeExo('upCounterB', UpCounterI, {
+    incr() {
+      x += 1;
+      return x;
+    },
+  });
+
+  t.is(passStyleOf(up1), 'remotable');
+  t.is(`${up1}`, '[object Alleged: upCounterA#1]');
+  t.is(`${q(up1)}`, '"[Alleged: upCounterA#1]"');
+
+  t.is(passStyleOf(up2), 'remotable');
+  t.is(`${up2}`, '[object Alleged: upCounterB#1]');
+  t.is(`${q(up2)}`, '"[Alleged: upCounterB#1]"');
+});

--- a/packages/far/test/test-marshal-far-obj.js
+++ b/packages/far/test/test-marshal-far-obj.js
@@ -108,7 +108,7 @@ const NON_METHOD = {
 };
 const IFACE_ALLEGED = {
   message:
-    /For now, iface "Bad remotable proto" must be "Remotable" or begin with "Alleged: "; unimplemented/,
+    /For now, iface "Bad remotable proto" must be "Remotable" or begin with "Alleged: " or "DebugName: "; unimplemented/,
 };
 const UNEXPECTED_PROPS = {
   message: /Unexpected properties on Remotable Proto .*/,

--- a/packages/marshal/test/test-marshal-far-obj.js
+++ b/packages/marshal/test/test-marshal-far-obj.js
@@ -128,7 +128,7 @@ const NON_METHOD = {
 };
 const IFACE_ALLEGED = {
   message:
-    /For now, iface "Bad remotable proto" must be "Remotable" or begin with "Alleged: "; unimplemented/,
+    /For now, iface "Bad remotable proto" must be "Remotable" or begin with "Alleged: " or "DebugName: "; unimplemented/,
 };
 const UNEXPECTED_PROPS = {
   message: /Unexpected properties on Remotable Proto .*/,

--- a/packages/marshal/test/test-marshal-smallcaps.js
+++ b/packages/marshal/test/test-marshal-smallcaps.js
@@ -301,11 +301,13 @@ test('smallcaps encoding examples', t => {
 
   // Remotables
   const foo = Far('foo', {});
-  const bar = Far('bar', {});
+  const bar = Far('bar', {
+    [Symbol.toStringTag]: 'DebugName: Bart',
+  });
   assertRoundTrip(foo, '#"$0.Alleged: foo"', [foo], 'Remotable object');
   assertRoundTrip(
     harden([foo, bar, foo, bar]),
-    '#["$0.Alleged: foo","$1.Alleged: bar","$0","$1"]',
+    '#["$0.Alleged: foo","$1.DebugName: Bart","$0","$1"]',
     [foo, bar],
     'Only show iface once',
   );

--- a/packages/pass-style/src/make-far.js
+++ b/packages/pass-style/src/make-far.js
@@ -63,9 +63,10 @@ const assertCanBeRemotable = candidate =>
  * @template {{}} T
  * @param {InterfaceSpec} [iface='Remotable'] The interface specification for
  * the remotable. For now, a string iface must be "Remotable" or begin with
- * "Alleged: ", to serve as the alleged name. More general ifaces are not yet
- * implemented. This is temporary. We include the
- * "Alleged" as a reminder that we do not yet have SwingSet or Comms Vat
+ * "Alleged: " or "DebugName: ", to serve as the alleged name. More
+ * general ifaces are not yet implemented. This is temporary. We include the
+ * "Alleged" or "DebugName" as a reminder that we do not yet have SwingSet
+ * or Comms Vat
  * support for ensuring this is according to the vat hosting the object.
  * Currently, Alice can tell Bob about Carol, where VatA (on Alice's behalf)
  * misrepresents Carol's `iface`. VatB and therefore Bob will then see


### PR DESCRIPTION
Replaces https://github.com/Agoric/agoric-sdk/pull/6218 on the endo side. Similar LABEL_INSTANCE logic will then be needed on the agoric-sdk side using `baseRef` and `facetNames` as https://github.com/Agoric/agoric-sdk/pull/6218 does.

Stay in sync with https://github.com/Agoric/agoric-sdk/pull/7409