### PR TITLE
Release 2023-04-14 16:21:01Z

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Everything else is wired up thanks to workspaces, so no need to run installs in 
 * Commit the results.
 
   ```sh
-  git commit -am 'chore: Update release notes'
+  git commit -am 'docs: Update release notes'
   ```
 
 * Push the branch.

--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.31](https://github.com/endojs/endo/compare/@endo/base64@0.2.30...@endo/base64@0.2.31) (2023-04-14)
+
+**Note:** Version bump only for package @endo/base64
+
 ### [0.2.30](https://github.com/endojs/endo/compare/@endo/base64@0.2.29...@endo/base64@0.2.30) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "Transcodes base64",
   "keywords": [
     "base64",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.5.0](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.4...@endo/bundle-source@2.5.0) (2023-04-14)
+
+### Features
+
+- **bundle-source:** separate entrypoint from `cache.js` library ([0973f34](https://github.com/endojs/endo/commit/0973f34648a1b06894f6ddac58ab4d43d4cfbc9e))
+
 ### [2.4.4](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.3...@endo/bundle-source@2.4.4) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/bundle-source/NEWS.md
+++ b/packages/bundle-source/NEWS.md
@@ -1,3 +1,8 @@
+# v2.5.0 (2023-04-14)
+
+- Separates the `bundle-source` entrypoint from the new
+  `@endo/bundle-source/cache.js` importable library.
+
 # v2.3.0 (2022-09-14)
 
 - Adds a `--cache-json` mode that:

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "2.4.4",
+  "version": "2.5.0",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",
@@ -30,10 +30,10 @@
     "@agoric/babel-generator": "^7.17.4",
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
-    "@endo/base64": "^0.2.30",
-    "@endo/compartment-mapper": "^0.8.2",
-    "@endo/init": "^0.5.54",
-    "@endo/promise-kit": "^0.2.54",
+    "@endo/base64": "^0.2.31",
+    "@endo/compartment-mapper": "^0.8.3",
+    "@endo/init": "^0.5.55",
+    "@endo/promise-kit": "^0.2.55",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "acorn": "^8.2.4",
@@ -42,8 +42,8 @@
     "source-map": "^0.7.3"
   },
   "devDependencies": {
-    "@endo/lockdown": "^0.1.26",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/lockdown": "^0.1.27",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.0](https://github.com/endojs/endo/compare/@endo/captp@3.0.0...@endo/captp@3.1.0) (2023-04-14)
+
+### Features
+
+- **captp:** add `CTP_DROP.decRefs` GC approach ([366764b](https://github.com/endojs/endo/commit/366764ba61e11bb66f5c3c6939431e1cee9f9e29))
+- **captp:** disable GC by default ([49c9222](https://github.com/endojs/endo/commit/49c9222154b3cfdbfcb90d05f31f95c098b99528))
+- **ses:** finite deep stacks, on by default ([#1513](https://github.com/endojs/endo/issues/1513)) ([aae0e57](https://github.com/endojs/endo/commit/aae0e57f7a6bdcc898396c65ec22616a33672d32))
+- **ses:** option to fake harden unsafely ([697bf58](https://github.com/endojs/endo/commit/697bf5855e4a6578db4cbca40bfeca253a6a2cfe))
+
+### Bug Fixes
+
+- sort type confusion between `pass-style` and `marshal` ([db09e13](https://github.com/endojs/endo/commit/db09e13463806b4524951cd694272243958a7182))
+
 ## [3.0.0](https://github.com/endojs/endo/compare/@endo/captp@2.0.19...@endo/captp@3.0.0) (2023-03-07)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/captp/NEWS.md
+++ b/packages/captp/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in `@endo/captp`:
 
+# v3.1.0 (2023-04-14)
+
+- Disable GC by default to work around known issues with dropping
+  still-referenced objects.
+
 # v2.0.19 (2022-12-23)
 
 - Remote objects now reflect methods present on their prototype chain.

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [
@@ -42,16 +42,16 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/init": "^0.5.55",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.17.0",
-    "@endo/marshal": "^0.8.3",
-    "@endo/nat": "^4.1.25",
-    "@endo/promise-kit": "^0.2.54"
+    "@endo/eventual-send": "^0.17.1",
+    "@endo/marshal": "^0.8.4",
+    "@endo/nat": "^4.1.26",
+    "@endo/promise-kit": "^0.2.55"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.17](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.16...@endo/check-bundle@0.2.17) (2023-04-14)
+
+### Features
+
+- **ses:** option to fake harden unsafely ([697bf58](https://github.com/endojs/endo/commit/697bf5855e4a6578db4cbca40bfeca253a6a2cfe))
+
 ### [0.2.16](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.15...@endo/check-bundle@0.2.16) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",
@@ -39,13 +39,13 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.30",
-    "@endo/compartment-mapper": "^0.8.2"
+    "@endo/base64": "^0.2.31",
+    "@endo/compartment-mapper": "^0.8.3"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.4.4",
-    "@endo/init": "^0.5.54",
-    "@endo/zip": "^0.2.30",
+    "@endo/bundle-source": "^2.5.0",
+    "@endo/init": "^0.5.55",
+    "@endo/zip": "^0.2.31",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.31](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.30...@endo/cjs-module-analyzer@0.2.31) (2023-04-14)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
 ### [0.2.30](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@0.2.29...@endo/cjs-module-analyzer@0.2.30) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/cli@0.2.0...@endo/cli@0.2.1) (2023-04-14)
+
+**Note:** Version bump only for package @endo/cli
+
 ## [0.2.0](https://github.com/endojs/endo/compare/@endo/cli@0.1.24...@endo/cli@0.2.0) (2023-03-07)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Endo command line interface",
   "keywords": [],
   "author": "Endo contributors",
@@ -26,15 +26,15 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/compartment-mapper": "^0.8.2",
-    "@endo/daemon": "^0.2.0",
-    "@endo/eventual-send": "^0.17.0",
-    "@endo/far": "^0.2.16",
-    "@endo/lockdown": "^0.1.26",
-    "@endo/promise-kit": "^0.2.54",
-    "@endo/where": "^0.3.0",
+    "@endo/compartment-mapper": "^0.8.3",
+    "@endo/daemon": "^0.2.1",
+    "@endo/eventual-send": "^0.17.1",
+    "@endo/far": "^0.2.17",
+    "@endo/lockdown": "^0.1.27",
+    "@endo/promise-kit": "^0.2.55",
+    "@endo/where": "^0.3.1",
     "commander": "^5.0.0",
-    "ses": "^0.18.2"
+    "ses": "^0.18.3"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.8.3](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.8.2...@endo/compartment-mapper@0.8.3) (2023-04-14)
+
+**Note:** Version bump only for package @endo/compartment-mapper
+
 ### [0.8.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.8.1...@endo/compartment-mapper@0.8.2) (2023-03-07)
 
 ### Features

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -43,10 +43,10 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/cjs-module-analyzer": "^0.2.30",
-    "@endo/static-module-record": "^0.7.17",
-    "@endo/zip": "^0.2.30",
-    "ses": "^0.18.2"
+    "@endo/cjs-module-analyzer": "^0.2.31",
+    "@endo/static-module-record": "^0.7.18",
+    "@endo/zip": "^0.2.31",
+    "ses": "^0.18.3"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/daemon@0.2.0...@endo/daemon@0.2.1) (2023-04-14)
+
+**Note:** Version bump only for package @endo/daemon
+
 ## [0.2.0](https://github.com/endojs/endo/compare/@endo/daemon@0.1.24...@endo/daemon@0.2.0) (2023-03-07)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Endo daemon",
   "keywords": [
     "endo",
@@ -36,16 +36,16 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/captp": "^3.0.0",
-    "@endo/eventual-send": "^0.17.0",
-    "@endo/far": "^0.2.16",
-    "@endo/lockdown": "^0.1.26",
-    "@endo/netstring": "^0.3.24",
-    "@endo/promise-kit": "^0.2.54",
-    "@endo/stream": "^0.3.23",
-    "@endo/stream-node": "^0.2.24",
-    "@endo/where": "^0.3.0",
-    "ses": "^0.18.2"
+    "@endo/captp": "^3.1.0",
+    "@endo/eventual-send": "^0.17.1",
+    "@endo/far": "^0.2.17",
+    "@endo/lockdown": "^0.1.27",
+    "@endo/netstring": "^0.3.25",
+    "@endo/promise-kit": "^0.2.55",
+    "@endo/stream": "^0.3.24",
+    "@endo/stream-node": "^0.2.25",
+    "@endo/where": "^0.3.1",
+    "ses": "^0.18.3"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.4.4](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.4.3...@endo/eslint-plugin@0.4.4) (2023-04-14)
+
+### Features
+
+- **eslint-plugin:** separate rules into subsets ([688e89c](https://github.com/endojs/endo/commit/688e89c80dccb2ec01183a5a4c3600f72078e67b))
+
 ### [0.4.3](https://github.com/endojs/endo/compare/@endo/eslint-plugin@0.4.2...@endo/eslint-plugin@0.4.3) (2023-03-07)
 
 ### Features

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.17.1](https://github.com/endojs/endo/compare/@endo/eventual-send@0.17.0...@endo/eventual-send@0.17.1) (2023-04-14)
+
+### Features
+
+- **ses:** finite deep stacks, on by default ([#1513](https://github.com/endojs/endo/issues/1513)) ([aae0e57](https://github.com/endojs/endo/commit/aae0e57f7a6bdcc898396c65ec22616a33672d32))
+
+### Bug Fixes
+
+- **eventual-send:** default to `TRACK_TURNS=disabled` ([a4b66cd](https://github.com/endojs/endo/commit/a4b66cd53c99f54c2fe3767b181b19abb3dfc8ef))
+- **eventual-send:** hardening should not depend on `TRACK_TURNS=enabled` ([db8e74a](https://github.com/endojs/endo/commit/db8e74a9e5e8fe59ce800329fa405909d647786e))
+
 ## [0.17.0](https://github.com/endojs/endo/compare/@endo/eventual-send@0.16.9...@endo/eventual-send@0.17.0) (2023-03-07)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/eventual-send/NEWS.md
+++ b/packages/eventual-send/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in eventual-send:
 
+# v0.17.1 (2023-04-14)
+
+- Defaults to `TRACK_TURNS=disabled`
+
 # v0.16.3 (2022-08-26)
 
 - Actually fixes eventual-send when used in combination with the `-r esm`

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/lockdown": "^0.1.26",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/lockdown": "^0.1.27",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "c8": "^7.7.3",
     "tsd": "^0.24.1"

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/exo@0.2.0...@endo/exo@0.2.1) (2023-04-14)
+
+### Features
+
+- **pass-style,exo:** label remotable instances ([56edc68](https://github.com/endojs/endo/commit/56edc68444ac3e0d94d43028bc7d53fe804bb332))
+
+### Bug Fixes
+
+- **exo:** fix exo-tools TSC problem ([#1512](https://github.com/endojs/endo/issues/1512)) ([e413d9c](https://github.com/endojs/endo/commit/e413d9cd97fbeefc1497b3b67daad278869ccdfc))
+- sync with exo API change ([df861c1](https://github.com/endojs/endo/commit/df861c1ffbfef3a2d54c23c5011d06f2e93f7a32))
+- sync with shadows in agoric-sdk ([19e2833](https://github.com/endojs/endo/commit/19e28339e359791fd2a9f78d2c3801598e3894ca))
+
 ## 0.2.0 (2023-03-07)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/exo/NEWS.md
+++ b/packages/exo/NEWS.md
@@ -1,0 +1,5 @@
+User-visible changes in `@endo/exo`:
+
+# v0.2.1 (2023-04-14)
+
+- Label remotable instances

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,12 +32,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/far": "^0.2.16",
-    "@endo/patterns": "^0.2.0"
+    "@endo/far": "^0.2.17",
+    "@endo/patterns": "^0.2.1"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/init": "^0.5.55",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.17](https://github.com/endojs/endo/compare/@endo/far@0.2.16...@endo/far@0.2.17) (2023-04-14)
+
+### Features
+
+- **pass-style,exo:** label remotable instances ([56edc68](https://github.com/endojs/endo/commit/56edc68444ac3e0d94d43028bc7d53fe804bb332))
+- **ses:** option to fake harden unsafely ([697bf58](https://github.com/endojs/endo/commit/697bf5855e4a6578db4cbca40bfeca253a6a2cfe))
+
 ### [0.2.16](https://github.com/endojs/endo/compare/@endo/far@0.2.15...@endo/far@0.2.16) (2023-03-07)
 
 ### Features

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",
@@ -28,12 +28,12 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.17.0",
-    "@endo/pass-style": "^0.1.1"
+    "@endo/eventual-send": "^0.17.1",
+    "@endo/pass-style": "^0.1.2"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/init": "^0.5.55",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.3](https://github.com/endojs/endo/compare/@endo/import-bundle@0.3.2...@endo/import-bundle@0.3.3) (2023-04-14)
+
+**Note:** Version bump only for package @endo/import-bundle
+
 ### [0.3.2](https://github.com/endojs/endo/compare/@endo/import-bundle@0.3.1...@endo/import-bundle@0.3.2) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "load modules created by @endo/bundle-source",
   "type": "module",
   "main": "src/index.js",
@@ -21,13 +21,13 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.30",
-    "@endo/compartment-mapper": "^0.8.2"
+    "@endo/base64": "^0.2.31",
+    "@endo/compartment-mapper": "^0.8.3"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.4.4",
-    "@endo/init": "^0.5.54",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/bundle-source": "^2.5.0",
+    "@endo/init": "^0.5.55",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.55](https://github.com/endojs/endo/compare/@endo/init@0.5.54...@endo/init@0.5.55) (2023-04-14)
+
+### Features
+
+- **init:** add `@endo/init/unsafe-fast.js` ([7db62c5](https://github.com/endojs/endo/commit/7db62c5d4366c911d72581a3ab7e15c348b2120c))
+- **ses:** option to fake harden unsafely ([697bf58](https://github.com/endojs/endo/commit/697bf5855e4a6578db4cbca40bfeca253a6a2cfe))
+
 ### [0.5.54](https://github.com/endojs/endo/compare/@endo/init@0.5.53...@endo/init@0.5.54) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/init/NEWS.md
+++ b/packages/init/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes to the Endo environment initializer:
 
+# 0.5.55 (2023-04-14)
+
+New `@endo/init/unsafe-fast.js` export to enable fake `harden`.
+
 # v0.5.43 (2022-06-28)
 
 Patch `Promise.race` to use a non-leaky implementation.

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "0.5.54",
+  "version": "0.5.55",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",
@@ -29,15 +29,15 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.2",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/compartment-mapper": "^0.8.3",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.1.1"
   },
   "dependencies": {
-    "@endo/base64": "^0.2.30",
-    "@endo/eventual-send": "^0.17.0",
-    "@endo/lockdown": "^0.1.26",
-    "@endo/promise-kit": "^0.2.54"
+    "@endo/base64": "^0.2.31",
+    "@endo/eventual-send": "^0.17.1",
+    "@endo/lockdown": "^0.1.27",
+    "@endo/promise-kit": "^0.2.55"
   },
   "files": [
     "LICENSE*",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.27](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.26...@endo/lockdown@0.1.27) (2023-04-14)
+
+**Note:** Version bump only for package @endo/lockdown
+
 ### [0.1.26](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.25...@endo/lockdown@0.1.26) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
@@ -16,7 +16,7 @@
     "ava": "^5.1.1"
   },
   "dependencies": {
-    "ses": "^0.18.2"
+    "ses": "^0.18.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.25](https://github.com/endojs/endo/compare/@endo/lp32@0.3.24...@endo/lp32@0.3.25) (2023-04-14)
+
+**Note:** Version bump only for package @endo/lp32
+
 ### [0.3.24](https://github.com/endojs/endo/compare/@endo/lp32@0.3.23...@endo/lp32@0.3.24) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",
@@ -46,12 +46,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/stream": "^0.3.23",
-    "ses": "^0.18.2"
+    "@endo/init": "^0.5.55",
+    "@endo/stream": "^0.3.24",
+    "ses": "^0.18.3"
   },
   "devDependencies": {
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.8.4](https://github.com/endojs/endo/compare/@endo/marshal@0.8.3...@endo/marshal@0.8.4) (2023-04-14)
+
+### Features
+
+- **pass-style,exo:** label remotable instances ([56edc68](https://github.com/endojs/endo/commit/56edc68444ac3e0d94d43028bc7d53fe804bb332))
+- **ses:** option to fake harden unsafely ([697bf58](https://github.com/endojs/endo/commit/697bf5855e4a6578db4cbca40bfeca253a6a2cfe))
+
+### Bug Fixes
+
+- sort type confusion between `pass-style` and `marshal` ([db09e13](https://github.com/endojs/endo/commit/db09e13463806b4524951cd694272243958a7182))
+
+### Reverts
+
+- Revert "fix: parse positive bigints correctly despite XS parsing them wrong (#1325)" ([657c4aa](https://github.com/endojs/endo/commit/657c4aada2b87ae1427fd2dbb3e51ae1cc558799)), closes [#1325](https://github.com/endojs/endo/issues/1325)
+
 ### [0.8.3](https://github.com/endojs/endo/compare/@endo/marshal@0.8.2...@endo/marshal@0.8.3) (2023-03-07)
 
 ### Features

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",
@@ -36,15 +36,15 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.17.0",
-    "@endo/nat": "^4.1.25",
-    "@endo/pass-style": "^0.1.1",
-    "@endo/promise-kit": "^0.2.54"
+    "@endo/eventual-send": "^0.17.1",
+    "@endo/nat": "^4.1.26",
+    "@endo/pass-style": "^0.1.2",
+    "@endo/promise-kit": "^0.2.55"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/lockdown": "^0.1.26",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/init": "^0.5.55",
+    "@endo/lockdown": "^0.1.27",
+    "@endo/ses-ava": "^0.2.39",
     "@fast-check/ava": "^1.1.3",
     "ava": "^5.2.0",
     "c8": "^7.7.3"

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.26](https://github.com/endojs/endo/compare/@endo/nat@4.1.25...@endo/nat@4.1.26) (2023-04-14)
+
+**Note:** Version bump only for package @endo/nat
+
 ### [4.1.25](https://github.com/endojs/endo/compare/@endo/nat@4.1.24...@endo/nat@4.1.25) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "4.1.25",
+  "version": "4.1.26",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",
@@ -24,14 +24,14 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.2",
+    "@endo/compartment-mapper": "^0.8.3",
     "ava": "^5.2.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "prettier": "^2.8.5",
-    "ses": "^0.18.2"
+    "ses": "^0.18.3"
   },
   "directories": {
     "test": "test"

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.25](https://github.com/endojs/endo/compare/@endo/netstring@0.3.24...@endo/netstring@0.3.25) (2023-04-14)
+
+**Note:** Version bump only for package @endo/netstring
+
 ### [0.3.24](https://github.com/endojs/endo/compare/@endo/netstring@0.3.23...@endo/netstring@0.3.24) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -34,9 +34,9 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/stream": "^0.3.23",
-    "ses": "^0.18.2"
+    "@endo/init": "^0.5.55",
+    "@endo/stream": "^0.3.24",
+    "ses": "^0.18.3"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.2](https://github.com/endojs/endo/compare/@endo/pass-style@0.1.1...@endo/pass-style@0.1.2) (2023-04-14)
+
+### Features
+
+- **pass-style,exo:** label remotable instances ([56edc68](https://github.com/endojs/endo/commit/56edc68444ac3e0d94d43028bc7d53fe804bb332))
+- **ses:** option to fake harden unsafely ([697bf58](https://github.com/endojs/endo/commit/697bf5855e4a6578db4cbca40bfeca253a6a2cfe))
+
+### Bug Fixes
+
+- sort type confusion between `pass-style` and `marshal` ([db09e13](https://github.com/endojs/endo/commit/db09e13463806b4524951cd694272243958a7182))
+
 ### 0.1.1 (2023-03-07)
 
 ### Features

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "pass-style: defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,12 +32,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/promise-kit": "^0.2.54",
+    "@endo/promise-kit": "^0.2.55",
     "@fast-check/ava": "^1.1.3"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/init": "^0.5.55",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/patterns@0.2.0...@endo/patterns@0.2.1) (2023-04-14)
+
+### Bug Fixes
+
+- copy collection param type defaults ([98634b0](https://github.com/endojs/endo/commit/98634b033901714eecf5d0f85a74e143a2a42f56))
+- sync with shadows in agoric-sdk ([19e2833](https://github.com/endojs/endo/commit/19e28339e359791fd2a9f78d2c3801598e3894ca))
+
 ## 0.2.0 (2023-03-07)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Description forthcoming.",
   "keywords": [],
   "author": "Endo contributors",
@@ -31,13 +31,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.17.0",
-    "@endo/marshal": "^0.8.3",
-    "@endo/promise-kit": "^0.2.54"
+    "@endo/eventual-send": "^0.17.1",
+    "@endo/marshal": "^0.8.4",
+    "@endo/promise-kit": "^0.2.55"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/init": "^0.5.55",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.55](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.54...@endo/promise-kit@0.2.55) (2023-04-14)
+
+**Note:** Version bump only for package @endo/promise-kit
+
 ### [0.2.54](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.53...@endo/promise-kit@0.2.54) (2023-03-07)
 
 ### Features

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "description": "Helper for making promises",
   "keywords": [
     "promise"
@@ -37,10 +37,10 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "ses": "^0.18.2"
+    "ses": "^0.18.3"
   },
   "devDependencies": {
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/ses-ava": "^0.2.39",
     "@types/node": ">=14.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.39](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.38...@endo/ses-ava@0.2.39) (2023-04-14)
+
+**Note:** Version bump only for package @endo/ses-ava
+
 ### [0.2.38](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.37...@endo/ses-ava@0.2.38) (2023-03-07)
 
 ### Features

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -35,7 +35,7 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.18.2"
+    "ses": "^0.18.3"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.29](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.28...ses-integration-test@3.0.29) (2023-04-14)
+
+**Note:** Version bump only for package ses-integration-test
+
 ### [3.0.28](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.27...ses-integration-test@3.0.28) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "3.0.28",
+  "version": "3.0.29",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,7 +30,7 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.18.2"
+    "ses": "^0.18.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^13.0.0",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.18.3](https://github.com/endojs/endo/compare/ses@0.18.2...ses@0.18.3) (2023-04-14)
+
+### Features
+
+- **eslint-plugin:** separate rules into subsets ([688e89c](https://github.com/endojs/endo/commit/688e89c80dccb2ec01183a5a4c3600f72078e67b))
+- **ses:** finite deep stacks, on by default ([#1513](https://github.com/endojs/endo/issues/1513)) ([aae0e57](https://github.com/endojs/endo/commit/aae0e57f7a6bdcc898396c65ec22616a33672d32))
+- **ses:** option to fake harden unsafely ([697bf58](https://github.com/endojs/endo/commit/697bf5855e4a6578db4cbca40bfeca253a6a2cfe))
+
+### Bug Fixes
+
+- limit logged args per error ([88f4662](https://github.com/endojs/endo/commit/88f46620314f34dc964f8c490179b38d39d26bc7))
+- **ses:** Add length (number) prop to whitelist %AsyncGenerator% and %AsyncFunctionPrototype% ([#1511](https://github.com/endojs/endo/issues/1511)) ([c08b15b](https://github.com/endojs/endo/commit/c08b15b09f295775c3f253ca7f03c105ac87bab7))
+- **ses:** avoid holding deep stacks strongly ([996af60](https://github.com/endojs/endo/commit/996af60df50120da971ba962e56fcc333ba70e3e))
+
 ### [0.18.2](https://github.com/endojs/endo/compare/ses@0.18.1...ses@0.18.2) (2023-03-07)
 
 ### Features

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,15 @@
 User-visible changes in SES:
 
+# v0.18.3 (2023-04-14)
+
+- New `__hardenTaming__: 'unsafe'` lockdown option to fake harden unsafely,
+  which can be used to improve performance for applications that are known to be
+  safe even with a no-op `harden`.
+- Finite deep stacks, using LRU budgets for depth of stacks an well as the
+  maximum number of weakly-held errors to annotate.
+- Add `%AsyncGenerator%.length` and `%AsyncFunctionPrototype%.length` `number`
+  properties to allowlist.
+
 # v0.18.2 (2023-03-07)
 
 - Introduces the `__syncModuleFunctor__` property of static module record

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",
@@ -60,9 +60,9 @@
     "test:platform-compatibility": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.2",
-    "@endo/static-module-record": "^0.7.17",
-    "@endo/test262-runner": "^0.1.30",
+    "@endo/compartment-mapper": "^0.8.3",
+    "@endo/static-module-record": "^0.7.18",
+    "@endo/test262-runner": "^0.1.31",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.7.18](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.17...@endo/static-module-record@0.7.18) (2023-04-14)
+
+**Note:** Version bump only for package @endo/static-module-record
+
 ### [0.7.17](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.16...@endo/static-module-record@0.7.17) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -41,10 +41,10 @@
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
     "@babel/types": "^7.17.0",
-    "ses": "^0.18.2"
+    "ses": "^0.18.3"
   },
   "devDependencies": {
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/ses-ava": "^0.2.39",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "benchmark": "^2.1.4",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.25](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.24...@endo/stream-node@0.2.25) (2023-04-14)
+
+**Note:** Version bump only for package @endo/stream-node
+
 ### [0.2.24](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.23...@endo/stream-node@0.2.24) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",
@@ -40,12 +40,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/stream": "^0.3.23",
-    "ses": "^0.18.2"
+    "@endo/init": "^0.5.55",
+    "@endo/stream": "^0.3.24",
+    "ses": "^0.18.3"
   },
   "devDependencies": {
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/ses-ava": "^0.2.39",
     "@typescript-eslint/parser": "^5.53.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.36](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.35...@endo/stream-types-test@0.1.36) (2023-04-14)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
 ### [0.1.35](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.34...@endo/stream-types-test@0.1.35) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],
@@ -25,8 +25,8 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "@endo/stream": "^0.3.23",
-    "ses": "^0.18.2"
+    "@endo/stream": "^0.3.24",
+    "ses": "^0.18.3"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.24](https://github.com/endojs/endo/compare/@endo/stream@0.3.23...@endo/stream@0.3.24) (2023-04-14)
+
+**Note:** Version bump only for package @endo/stream
+
 ### [0.3.23](https://github.com/endojs/endo/compare/@endo/stream@0.3.22...@endo/stream@0.3.23) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",
@@ -40,13 +40,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.17.0",
-    "@endo/promise-kit": "^0.2.54",
-    "ses": "^0.18.2"
+    "@endo/eventual-send": "^0.17.1",
+    "@endo/promise-kit": "^0.2.55",
+    "ses": "^0.18.3"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.54",
-    "@endo/ses-ava": "^0.2.38",
+    "@endo/init": "^0.5.55",
+    "@endo/ses-ava": "^0.2.39",
     "@typescript-eslint/parser": "^5.53.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.31](https://github.com/endojs/endo/compare/@endo/syrup@0.1.30...@endo/syrup@0.1.31) (2023-04-14)
+
+**Note:** Version bump only for package @endo/syrup
+
 ### [0.1.30](https://github.com/endojs/endo/compare/@endo/syrup@0.1.29...@endo/syrup@0.1.30) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.31](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.30...@endo/test262-runner@0.1.31) (2023-04-14)
+
+**Note:** Version bump only for package @endo/test262-runner
+
 ### [0.1.30](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.29...@endo/test262-runner@0.1.30) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": true,
   "description": "Test262 Runner",
   "author": "Agoric",

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.1](https://github.com/endojs/endo/compare/@endo/where@0.3.0...@endo/where@0.3.1) (2023-04-14)
+
+**Note:** Version bump only for package @endo/where
+
 ## [0.3.0](https://github.com/endojs/endo/compare/@endo/where@0.2.11...@endo/where@0.3.0) (2023-03-07)
 
 ### ⚠ BREAKING CHANGES

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": null,
   "description": "Description forthcoming.",
   "keywords": [],

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.31](https://github.com/endojs/endo/compare/@endo/zip@0.2.30...@endo/zip@0.2.31) (2023-04-14)
+
+**Note:** Version bump only for package @endo/zip
+
 ### [0.2.30](https://github.com/endojs/endo/compare/@endo/zip@0.2.29...@endo/zip@0.2.30) (2023-03-07)
 
 ### Bug Fixes

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",


### PR DESCRIPTION
Create a new release that's been tested as viable for the current Agoric SDK.

The included changes are valuable and should benefit all external users of the Endo packages.

* @gibson042 - `patterns` type refinements
* @leotm - add `%AsyncGenerator%.length` and `%AsyncFunctionPrototype%.length` to allowlist
* @turadg - dependency updates
* @turadg - linter improvements including separating `prettier` from `eslint`
* @michaelfig - refactor `eslint-plugin` and remove `eslint-config`
* @erights - `lockdown` unsafe-but-performant option `__hardenTaming__: 'unsafe'`
* @erights - sync `exo`, `patterns` with Agoric SDK
* @gibson042 - export `pass-style`'s `isPassableSymbol`
* @erights - limited size LRUs for deep stacks and annotated Errors
* @mhofman, @michaelfig - weaken LRU Cache Map to release otherwise unreferenced Errors
* @gibson042 - narrower Exo context types (from Agoric SDK)
* @michaelfig - consistently produce Typescript declarations on `yarn pack`
* @michaelfig - sort type confusion in `pass-style`,`marshal`
* @erights - update `@endo/pattern` key types (from Agoric SDK)
* @michaelfig - separate `bundle-source` script from `@endo/bundle-source/cache.js`
* @turadg - revert bigint parsing workaround (fixed in a new Moddable XS release)
* @michaelfig - by default, turn off `@endo/captp` GC since it has known issues
* @michaelfig - add `@endo/init/unsafe-fast.js`
* @erights - `pass-style`,`exo` label remotable instances
