### PR TITLE
feat(ses): use the start compartment's `globalThis.harden` if available

### DIFF
--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -27,6 +27,7 @@ import {
   TypeError,
   WeakMap,
   WeakSet,
+  globalThis,
   apply,
   arrayForEach,
   defineProperty,
@@ -127,6 +128,12 @@ const freezeTypedArray = array => {
  * @returns {Harden}
  */
 export const makeHardener = () => {
+  // Use a native hardener if possible.
+  if (typeof globalThis.harden === 'function') {
+    const safeHarden = globalThis.harden;
+    return safeHarden;
+  }
+
   const hardened = new WeakSet();
 
   const { harden } = {

--- a/packages/ses/src/tame-harden.js
+++ b/packages/ses/src/tame-harden.js
@@ -16,6 +16,12 @@ export const tameHarden = (safeHarden, hardenTaming) => {
   Object.isSealed = () => true;
   Reflect.isExtensible = () => false;
 
+  if (safeHarden.isFake) {
+    // The "safe" hardener is already a fake hardener.
+    // Just use it.
+    return safeHarden;
+  }
+
   const fakeHarden = arg => arg;
   fakeHarden.isFake = true;
   return freeze(fakeHarden);

--- a/packages/ses/test/harden-mockery.js
+++ b/packages/ses/test/harden-mockery.js
@@ -1,0 +1,13 @@
+export const mockHardened = new WeakSet();
+export const mockHarden = x => {
+  if (Object(x) !== x) {
+    return x;
+  }
+  mockHardened.add(x);
+  return x;
+};
+mockHarden.isFake = true;
+Object.freeze(mockHarden);
+
+// eslint-disable-next-line no-undef
+globalThis.harden = mockHarden;

--- a/packages/ses/test/lockdown-harden-unsafe.js
+++ b/packages/ses/test/lockdown-harden-unsafe.js
@@ -1,0 +1,24 @@
+import '../index.js';
+
+import {
+  isFrozen,
+  isSealed,
+  isExtensible,
+  reflectIsExtensible,
+} from '../src/commons.js';
+
+export const assertFakeFrozen = (t, specimen) => {
+  // Built-in function replacements must report frozenness.
+  t.is(Object.isExtensible(specimen), false);
+  t.is(Object.isFrozen(specimen), true);
+  t.is(Object.isSealed(specimen), true);
+  t.is(Reflect.isExtensible(specimen), false);
+
+  // In-the-know functions must report the truth.
+  t.is(isExtensible(specimen), true);
+  t.is(isFrozen(specimen), false);
+  t.is(isSealed(specimen), false);
+  t.is(reflectIsExtensible(specimen), true);
+};
+
+lockdown({ __hardenTaming__: 'unsafe' });

--- a/packages/ses/test/test-native-harden.js
+++ b/packages/ses/test/test-native-harden.js
@@ -1,13 +1,18 @@
+import { mockHarden, mockHardened } from './harden-mockery.js';
 import { assertFakeFrozen } from './lockdown-harden-unsafe.js';
+
 // eslint-disable-next-line import/order
 import test from 'ava';
 
-test('fake harden', t => {
+test('mocked globalThis.harden', t => {
+  t.is(harden, mockHarden);
   t.is(harden.isFake, true);
 
   const obj = {};
+  t.false(mockHardened.has(obj));
   assertFakeFrozen(t, obj);
 
   harden(obj);
+  t.true(mockHardened.has(obj));
   assertFakeFrozen(t, obj);
 });


### PR DESCRIPTION
Allows the start compartment to provide `globalThis.harden` to override the `harden` used by the SES shim.
This enables some hosts (like Moddable's XS) to provide their own (likely more performant) `harden` implementations.
