### PR TITLE
fix(exo): parse `$DEBUG` as comma-separated

### DIFF
--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -12,7 +12,7 @@ const env = (globalThis.process || {}).env || {};
 
 // Turn on to give each exo instance its own toStringTag value.
 const LABEL_INSTANCES = (env.DEBUG || '')
-  .split(':')
+  .split(',')
   .includes('label-instances');
 
 const makeSelf = (proto, instanceCount) => {


### PR DESCRIPTION
The [Agoric SDK](https://github.com/Agoric/agoric-sdk/blob/381b9d1197ffc18cfd2d5b63534e2aa71dafc9f1/docs/env.md#debug) describes `$DEBUG` as a comma-separated list of colon-separated namespaces.  The convention is derived from the Node.js `$NODE_DEBUG` environment variable, and is [part of JS development lore](https://dev.to/aderchox/what-is-the-debug-environment-variable-in-nodejs-and-how-to-use-it-3fal).

This PR adjusts `@endo/exo` to conform, so that `DEBUG=...,label-instances,...` is recognized by comma-splitting.
