### PR TITLE
feat(marshal): cheap capData stringify and parse

### DIFF
--- a/packages/marshal/src/stringify-capdata.js
+++ b/packages/marshal/src/stringify-capdata.js
@@ -1,0 +1,54 @@
+/** @template S @typedef {import('./types.js').CapData<S>} CapData */
+
+const { Fail, quote: q } = assert;
+
+/** @typedef {string} SimpleString */
+
+/**
+ * A SimpleString is one where JSON.strigify-ing the string just
+ * puts quotes around the contents, and it contains no close square
+ * brackets. Many slot encodings use slot strings that
+ * obey these rules, which is why they are useful.
+ *
+ * @param {unknown} str
+ * @returns {asserts str is SimpleString}
+ */
+export const assertSimpleString = str => {
+  assert(typeof str === 'string');
+  const stringified = JSON.stringify(str);
+  const expected = `"${str}"`;
+  stringified === expected ||
+    Fail`Expected to stringify to ${q(expected)}, not ${q(stringified)}}`
+  assert(str.indexOf(']') === -1);
+};
+harden(assertSimpleString);
+
+/**
+ * @param {CapData<SimpleString>} capData
+ * @returns {string}
+ */
+export const stringifyCapData = capData => {
+  const { body, slots: [...slots] } = capData;
+  assert(typeof body === 'string');
+  assert(body.startsWith('#'));
+  const scBody = body.slice(1);
+  JSON.parse(scBody); // Just asserts that it parses as JSON
+  slots.forEach(assertSimpleString);
+  return `{"slots":${JSON.stringify(slots)},"#body":${scBody}}`;
+}
+harden(stringifyCapData);
+
+const DSL = /^\{"slots":(\[[^\]]*\]),"#body":(.*)\}$/;
+
+export const parseCapData = str => {
+  assert(typeof str === 'string');
+  const matches = DSL.exec(str);
+  assert(matches && matches.length === 3);
+  const slots = JSON.parse(matches[1]);
+  slots.forEach(assertSimpleString);
+  const scBody = matches[2];
+  JSON.parse(scBody); // Just asserts that it parses as JSON
+  const body = `#${scBody}`;
+  return harden({ body, slots });
+};
+harden(parseCapData);

--- a/packages/marshal/src/stringify-capdata.js
+++ b/packages/marshal/src/stringify-capdata.js
@@ -18,7 +18,7 @@ export const assertSimpleString = str => {
   const stringified = JSON.stringify(str);
   const expected = `"${str}"`;
   stringified === expected ||
-    Fail`Expected to stringify to ${q(expected)}, not ${q(stringified)}}`
+    Fail`Expected to stringify to ${q(expected)}, not ${q(stringified)}}`;
   assert(str.indexOf(']') === -1);
 };
 harden(assertSimpleString);
@@ -28,14 +28,17 @@ harden(assertSimpleString);
  * @returns {string}
  */
 export const stringifyCapData = capData => {
-  const { body, slots: [...slots] } = capData;
+  const {
+    body,
+    slots: [...slots],
+  } = capData;
   assert(typeof body === 'string');
   assert(body.startsWith('#'));
   const scBody = body.slice(1);
   JSON.parse(scBody); // Just asserts that it parses as JSON
   slots.forEach(assertSimpleString);
   return `{"slots":${JSON.stringify(slots)},"#body":${scBody}}`;
-}
+};
 harden(stringifyCapData);
 
 const DSL = /^\{"slots":(\[[^\]]*\]),"#body":(.*)\}$/;

--- a/packages/marshal/test/test-stringify-capdata.js
+++ b/packages/marshal/test/test-stringify-capdata.js
@@ -1,6 +1,10 @@
 import { test } from './prepare-test-env-ava.js';
 
-import { assertSimpleString, parseCapData, stringifyCapData } from '../src/stringify-capdata.js';
+import {
+  assertSimpleString,
+  parseCapData,
+  stringifyCapData,
+} from '../src/stringify-capdata.js';
 
 test('test assertSimpleString', t => {
   t.notThrows(() => assertSimpleString('x'));

--- a/packages/marshal/test/test-stringify-capdata.js
+++ b/packages/marshal/test/test-stringify-capdata.js
@@ -1,0 +1,22 @@
+import { test } from './prepare-test-env-ava.js';
+
+import { assertSimpleString, parseCapData, stringifyCapData } from '../src/stringify-capdata.js';
+
+test('test assertSimpleString', t => {
+  t.notThrows(() => assertSimpleString('x'));
+  t.throws(() => assertSimpleString('x"'), {
+    message: 'Expected to stringify to "\\"x\\"\\"", not "\\"x\\\\\\"\\""}',
+  });
+  t.throws(() => assertSimpleString('[x]'), {
+    message: 'Check failed',
+  });
+});
+
+const roundTrips = (t, capData, str) => {
+  t.is(stringifyCapData(capData), str);
+  t.deepEqual(parseCapData(str), capData);
+};
+
+test('test capData roundTrips', t => {
+  roundTrips(t, { body: '#[]', slots: ['a'] }, '{"slots":["a"],"#body":[]}');
+});


### PR DESCRIPTION
Given that `capData` is a CapData whose `slots` are themselves simple strings (see def in PR), and whose `body` is a smallcaps string, then `stringifyCapData(capData)` cheaply stringifies the capData as a whole to a JSON-parsable string, while avoiding the double encoding of the body. This should make the body considerable shorter and more readable.

`parseCapData` cheaply does the reverse of course.

Example:
```js
  roundTrips(t, { body: '#[]', slots: ['a'] }, '{"slots":["a"],"#body":[]}');
```

@arirubinstein this uses a regexp. Are both directions safe against malicious input? @gibson042 , does this seem fastcheck-able?

Everyone, assume this is not urgent. But it is small and, if robust, would be pleasant.