### PR TITLE
Release 2023-04-20 19:45:20Z

### DIFF
--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.5.1](https://github.com/endojs/endo/compare/@endo/bundle-source@2.5.0...@endo/bundle-source@2.5.1) (2023-04-20)
+
+**Note:** Version bump only for package @endo/bundle-source
+
 ## [2.5.0](https://github.com/endojs/endo/compare/@endo/bundle-source@2.4.4...@endo/bundle-source@2.5.0) (2023-04-14)
 
 ### Features

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",
@@ -31,9 +31,9 @@
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
     "@endo/base64": "^0.2.31",
-    "@endo/compartment-mapper": "^0.8.3",
-    "@endo/init": "^0.5.55",
-    "@endo/promise-kit": "^0.2.55",
+    "@endo/compartment-mapper": "^0.8.4",
+    "@endo/init": "^0.5.56",
+    "@endo/promise-kit": "^0.2.56",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "acorn": "^8.2.4",
@@ -42,8 +42,8 @@
     "source-map": "^0.7.3"
   },
   "devDependencies": {
-    "@endo/lockdown": "^0.1.27",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/lockdown": "^0.1.28",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.1.1](https://github.com/endojs/endo/compare/@endo/captp@3.1.0...@endo/captp@3.1.1) (2023-04-20)
+
+**Note:** Version bump only for package @endo/captp
+
 ## [3.1.0](https://github.com/endojs/endo/compare/@endo/captp@3.0.0...@endo/captp@3.1.0) (2023-04-14)
 
 ### Features

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [
@@ -42,16 +42,16 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/init": "^0.5.56",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.17.1",
-    "@endo/marshal": "^0.8.4",
-    "@endo/nat": "^4.1.26",
-    "@endo/promise-kit": "^0.2.55"
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/marshal": "^0.8.5",
+    "@endo/nat": "^4.1.27",
+    "@endo/promise-kit": "^0.2.56"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.18](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.17...@endo/check-bundle@0.2.18) (2023-04-20)
+
+**Note:** Version bump only for package @endo/check-bundle
+
 ### [0.2.17](https://github.com/endojs/endo/compare/@endo/check-bundle@0.2.16...@endo/check-bundle@0.2.17) (2023-04-14)
 
 ### Features

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",
@@ -40,11 +40,11 @@
   },
   "dependencies": {
     "@endo/base64": "^0.2.31",
-    "@endo/compartment-mapper": "^0.8.3"
+    "@endo/compartment-mapper": "^0.8.4"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.5.0",
-    "@endo/init": "^0.5.55",
+    "@endo/bundle-source": "^2.5.1",
+    "@endo/init": "^0.5.56",
     "@endo/zip": "^0.2.31",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/endojs/endo/compare/@endo/cli@0.2.1...@endo/cli@0.2.2) (2023-04-20)
+
+**Note:** Version bump only for package @endo/cli
+
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/cli@0.2.0...@endo/cli@0.2.1) (2023-04-14)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Endo command line interface",
   "keywords": [],
   "author": "Endo contributors",
@@ -26,15 +26,15 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "@endo/compartment-mapper": "^0.8.3",
-    "@endo/daemon": "^0.2.1",
-    "@endo/eventual-send": "^0.17.1",
-    "@endo/far": "^0.2.17",
-    "@endo/lockdown": "^0.1.27",
-    "@endo/promise-kit": "^0.2.55",
+    "@endo/compartment-mapper": "^0.8.4",
+    "@endo/daemon": "^0.2.2",
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/far": "^0.2.18",
+    "@endo/lockdown": "^0.1.28",
+    "@endo/promise-kit": "^0.2.56",
     "@endo/where": "^0.3.1",
     "commander": "^5.0.0",
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.8.4](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.8.3...@endo/compartment-mapper@0.8.4) (2023-04-20)
+
+**Note:** Version bump only for package @endo/compartment-mapper
+
 ### [0.8.3](https://github.com/endojs/endo/compare/@endo/compartment-mapper@0.8.2...@endo/compartment-mapper@0.8.3) (2023-04-14)
 
 **Note:** Version bump only for package @endo/compartment-mapper

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",
@@ -44,9 +44,9 @@
   },
   "dependencies": {
     "@endo/cjs-module-analyzer": "^0.2.31",
-    "@endo/static-module-record": "^0.7.18",
+    "@endo/static-module-record": "^0.7.19",
     "@endo/zip": "^0.2.31",
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/endojs/endo/compare/@endo/daemon@0.2.1...@endo/daemon@0.2.2) (2023-04-20)
+
+**Note:** Version bump only for package @endo/daemon
+
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/daemon@0.2.0...@endo/daemon@0.2.1) (2023-04-14)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Endo daemon",
   "keywords": [
     "endo",
@@ -36,16 +36,16 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/captp": "^3.1.0",
-    "@endo/eventual-send": "^0.17.1",
-    "@endo/far": "^0.2.17",
-    "@endo/lockdown": "^0.1.27",
-    "@endo/netstring": "^0.3.25",
-    "@endo/promise-kit": "^0.2.55",
-    "@endo/stream": "^0.3.24",
-    "@endo/stream-node": "^0.2.25",
+    "@endo/captp": "^3.1.1",
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/far": "^0.2.18",
+    "@endo/lockdown": "^0.1.28",
+    "@endo/netstring": "^0.3.26",
+    "@endo/promise-kit": "^0.2.56",
+    "@endo/stream": "^0.3.25",
+    "@endo/stream-node": "^0.2.26",
     "@endo/where": "^0.3.1",
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.17.2](https://github.com/endojs/endo/compare/@endo/eventual-send@0.17.1...@endo/eventual-send@0.17.2) (2023-04-20)
+
+**Note:** Version bump only for package @endo/eventual-send
+
 ### [0.17.1](https://github.com/endojs/endo/compare/@endo/eventual-send@0.17.0...@endo/eventual-send@0.17.1) (2023-04-14)
 
 ### Features

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/lockdown": "^0.1.27",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/lockdown": "^0.1.28",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "c8": "^7.7.3",
     "tsd": "^0.24.1"

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/endojs/endo/compare/@endo/exo@0.2.1...@endo/exo@0.2.2) (2023-04-20)
+
+### Bug Fixes
+
+- **exo:** correct types ([07345f0](https://github.com/endojs/endo/commit/07345f0d3c88a75a9b3438cdaaa3c438bea2ab2b))
+- **exo:** parse `$DEBUG` as comma-separated ([902f766](https://github.com/endojs/endo/commit/902f7662a5d4f344b3c5280d731fc2f14a616f21))
+
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/exo@0.2.0...@endo/exo@0.2.1) (2023-04-14)
 
 ### Features

--- a/packages/exo/NEWS.md
+++ b/packages/exo/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `@endo/exo`:
 
+# v0.2.2 (2023-04-20)
+
+- Parse `$DEBUG` as comma-separated
+
 # v0.2.1 (2023-04-14)
 
 - Label remotable instances

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,12 +32,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/far": "^0.2.17",
-    "@endo/patterns": "^0.2.1"
+    "@endo/far": "^0.2.18",
+    "@endo/patterns": "^0.2.2"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/init": "^0.5.56",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.18](https://github.com/endojs/endo/compare/@endo/far@0.2.17...@endo/far@0.2.18) (2023-04-20)
+
+**Note:** Version bump only for package @endo/far
+
 ### [0.2.17](https://github.com/endojs/endo/compare/@endo/far@0.2.16...@endo/far@0.2.17) (2023-04-14)
 
 ### Features

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",
@@ -28,12 +28,12 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.17.1",
-    "@endo/pass-style": "^0.1.2"
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/pass-style": "^0.1.3"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/init": "^0.5.56",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.4](https://github.com/endojs/endo/compare/@endo/import-bundle@0.3.3...@endo/import-bundle@0.3.4) (2023-04-20)
+
+**Note:** Version bump only for package @endo/import-bundle
+
 ### [0.3.3](https://github.com/endojs/endo/compare/@endo/import-bundle@0.3.2...@endo/import-bundle@0.3.3) (2023-04-14)
 
 **Note:** Version bump only for package @endo/import-bundle

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "load modules created by @endo/bundle-source",
   "type": "module",
   "main": "src/index.js",
@@ -22,12 +22,12 @@
   },
   "dependencies": {
     "@endo/base64": "^0.2.31",
-    "@endo/compartment-mapper": "^0.8.3"
+    "@endo/compartment-mapper": "^0.8.4"
   },
   "devDependencies": {
-    "@endo/bundle-source": "^2.5.0",
-    "@endo/init": "^0.5.55",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/bundle-source": "^2.5.1",
+    "@endo/init": "^0.5.56",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "c8": "^7.7.3"
   },

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.5.56](https://github.com/endojs/endo/compare/@endo/init@0.5.55...@endo/init@0.5.56) (2023-04-20)
+
+**Note:** Version bump only for package @endo/init
+
 ### [0.5.55](https://github.com/endojs/endo/compare/@endo/init@0.5.54...@endo/init@0.5.55) (2023-04-14)
 
 ### Features

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",
@@ -29,15 +29,15 @@
     "lint:types": "tsc -p jsconfig.json"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.3",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/compartment-mapper": "^0.8.4",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.1.1"
   },
   "dependencies": {
     "@endo/base64": "^0.2.31",
-    "@endo/eventual-send": "^0.17.1",
-    "@endo/lockdown": "^0.1.27",
-    "@endo/promise-kit": "^0.2.55"
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/lockdown": "^0.1.28",
+    "@endo/promise-kit": "^0.2.56"
   },
   "files": [
     "LICENSE*",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.28](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.27...@endo/lockdown@0.1.28) (2023-04-20)
+
+**Note:** Version bump only for package @endo/lockdown
+
 ### [0.1.27](https://github.com/endojs/endo/compare/@endo/lockdown@0.1.26...@endo/lockdown@0.1.27) (2023-04-14)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
@@ -16,7 +16,7 @@
     "ava": "^5.1.1"
   },
   "dependencies": {
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "files": [
     "LICENSE*",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.26](https://github.com/endojs/endo/compare/@endo/lp32@0.3.25...@endo/lp32@0.3.26) (2023-04-20)
+
+**Note:** Version bump only for package @endo/lp32
+
 ### [0.3.25](https://github.com/endojs/endo/compare/@endo/lp32@0.3.24...@endo/lp32@0.3.25) (2023-04-14)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",
@@ -46,12 +46,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/stream": "^0.3.24",
-    "ses": "^0.18.3"
+    "@endo/init": "^0.5.56",
+    "@endo/stream": "^0.3.25",
+    "ses": "^0.18.4"
   },
   "devDependencies": {
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.8.5](https://github.com/endojs/endo/compare/@endo/marshal@0.8.4...@endo/marshal@0.8.5) (2023-04-20)
+
+### Bug Fixes
+
+- **marshal:** correct types ([2d3ba15](https://github.com/endojs/endo/commit/2d3ba1565927ab66922d71d05efc344f9307a709))
+
 ### [0.8.4](https://github.com/endojs/endo/compare/@endo/marshal@0.8.3...@endo/marshal@0.8.4) (2023-04-14)
 
 ### Features

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",
@@ -36,15 +36,15 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/eventual-send": "^0.17.1",
-    "@endo/nat": "^4.1.26",
-    "@endo/pass-style": "^0.1.2",
-    "@endo/promise-kit": "^0.2.55"
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/nat": "^4.1.27",
+    "@endo/pass-style": "^0.1.3",
+    "@endo/promise-kit": "^0.2.56"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/lockdown": "^0.1.27",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/init": "^0.5.56",
+    "@endo/lockdown": "^0.1.28",
+    "@endo/ses-ava": "^0.2.40",
     "@fast-check/ava": "^1.1.3",
     "ava": "^5.2.0",
     "c8": "^7.7.3"

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.27](https://github.com/endojs/endo/compare/@endo/nat@4.1.26...@endo/nat@4.1.27) (2023-04-20)
+
+**Note:** Version bump only for package @endo/nat
+
 ### [4.1.26](https://github.com/endojs/endo/compare/@endo/nat@4.1.25...@endo/nat@4.1.26) (2023-04-14)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "4.1.26",
+  "version": "4.1.27",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",
@@ -24,14 +24,14 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.3",
+    "@endo/compartment-mapper": "^0.8.4",
     "ava": "^5.2.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "prettier": "^2.8.5",
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "directories": {
     "test": "test"

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.26](https://github.com/endojs/endo/compare/@endo/netstring@0.3.25...@endo/netstring@0.3.26) (2023-04-20)
+
+**Note:** Version bump only for package @endo/netstring
+
 ### [0.3.25](https://github.com/endojs/endo/compare/@endo/netstring@0.3.24...@endo/netstring@0.3.25) (2023-04-14)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",
@@ -34,9 +34,9 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/stream": "^0.3.24",
-    "ses": "^0.18.3"
+    "@endo/init": "^0.5.56",
+    "@endo/stream": "^0.3.25",
+    "ses": "^0.18.4"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.3](https://github.com/endojs/endo/compare/@endo/pass-style@0.1.2...@endo/pass-style@0.1.3) (2023-04-20)
+
+### Bug Fixes
+
+- **pass-style:** correct types ([4bf9cec](https://github.com/endojs/endo/commit/4bf9cecfb79db11274fdf6a0708ad3f3205cc245))
+
 ### [0.1.2](https://github.com/endojs/endo/compare/@endo/pass-style@0.1.1...@endo/pass-style@0.1.2) (2023-04-14)
 
 ### Features

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "pass-style: defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",
@@ -32,12 +32,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/promise-kit": "^0.2.55",
+    "@endo/promise-kit": "^0.2.56",
     "@fast-check/ava": "^1.1.3"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/init": "^0.5.56",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/endojs/endo/compare/@endo/patterns@0.2.1...@endo/patterns@0.2.2) (2023-04-20)
+
+### Bug Fixes
+
+- **patterns:** correct types ([b73622b](https://github.com/endojs/endo/commit/b73622bf16f0dabc7f1e0ceee013c8bec5543a2f))
+
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/patterns@0.2.0...@endo/patterns@0.2.1) (2023-04-14)
 
 ### Bug Fixes

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Description forthcoming.",
   "keywords": [],
   "author": "Endo contributors",
@@ -31,13 +31,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.17.1",
-    "@endo/marshal": "^0.8.4",
-    "@endo/promise-kit": "^0.2.55"
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/marshal": "^0.8.5",
+    "@endo/promise-kit": "^0.2.56"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/init": "^0.5.56",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^7.32.0",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.56](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.55...@endo/promise-kit@0.2.56) (2023-04-20)
+
+**Note:** Version bump only for package @endo/promise-kit
+
 ### [0.2.55](https://github.com/endojs/endo/compare/@endo/promise-kit@0.2.54...@endo/promise-kit@0.2.55) (2023-04-14)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "description": "Helper for making promises",
   "keywords": [
     "promise"
@@ -37,10 +37,10 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "devDependencies": {
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/ses-ava": "^0.2.40",
     "@types/node": ">=14.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.40](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.39...@endo/ses-ava@0.2.40) (2023-04-20)
+
+**Note:** Version bump only for package @endo/ses-ava
+
 ### [0.2.39](https://github.com/endojs/endo/compare/@endo/ses-ava@0.2.38...@endo/ses-ava@0.2.39) (2023-04-14)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",
@@ -35,7 +35,7 @@
     "test": "ava"
   },
   "dependencies": {
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/packages/ses-integration-test/CHANGELOG.md
+++ b/packages/ses-integration-test/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.30](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.29...ses-integration-test@3.0.30) (2023-04-20)
+
+**Note:** Version bump only for package ses-integration-test
+
 ### [3.0.29](https://github.com/Agoric/SES-shim/compare/ses-integration-test@3.0.28...ses-integration-test@3.0.29) (2023-04-14)
 
 **Note:** Version bump only for package ses-integration-test

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses-integration-test",
-  "version": "3.0.29",
+  "version": "3.0.30",
   "private": true,
   "description": "",
   "keywords": [],
@@ -30,7 +30,7 @@
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
   "dependencies": {
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^13.0.0",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.18.4](https://github.com/endojs/endo/compare/ses@0.18.3...ses@0.18.4) (2023-04-20)
+
+### Features
+
+- **ses:** use `globalThis.harden` as `safeHarden` if available ([5f3de3e](https://github.com/endojs/endo/commit/5f3de3e539ab93c86d152ce7dd82b9e6af56c57d))
+
+### Bug Fixes
+
+- **ses:** correct types ([c38235c](https://github.com/endojs/endo/commit/c38235c78bb038100e52da79ca69944ec516299a))
+
 ### [0.18.3](https://github.com/endojs/endo/compare/ses@0.18.2...ses@0.18.3) (2023-04-14)
 
 ### Features

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in SES:
 
+# v0.18.4 (2023-04-20)
+
+- Pass through the start compartment's `globalThis.harden` if defined.
+
 # v0.18.3 (2023-04-14)
 
 - New `__hardenTaming__: 'unsafe'` lockdown option to fake harden unsafely,

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",
@@ -60,8 +60,8 @@
     "test:platform-compatibility": "node test/package/test.cjs"
   },
   "devDependencies": {
-    "@endo/compartment-mapper": "^0.8.3",
-    "@endo/static-module-record": "^0.7.18",
+    "@endo/compartment-mapper": "^0.8.4",
+    "@endo/static-module-record": "^0.7.19",
     "@endo/test262-runner": "^0.1.31",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/static-module-record/CHANGELOG.md
+++ b/packages/static-module-record/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.7.19](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.18...@endo/static-module-record@0.7.19) (2023-04-20)
+
+**Note:** Version bump only for package @endo/static-module-record
+
 ### [0.7.18](https://github.com/endojs/endo/compare/@endo/static-module-record@0.7.17...@endo/static-module-record@0.7.18) (2023-04-14)
 
 **Note:** Version bump only for package @endo/static-module-record

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/static-module-record",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Shim for the SES StaticModuleRecord and module-to-program transformer",
   "keywords": [
     "ses",
@@ -41,10 +41,10 @@
     "@babel/parser": "^7.17.3",
     "@babel/traverse": "^7.17.3",
     "@babel/types": "^7.17.0",
-    "ses": "^0.18.3"
+    "ses": "^0.18.4"
   },
   "devDependencies": {
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/ses-ava": "^0.2.40",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "benchmark": "^2.1.4",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.26](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.25...@endo/stream-node@0.2.26) (2023-04-20)
+
+**Note:** Version bump only for package @endo/stream-node
+
 ### [0.2.25](https://github.com/endojs/endo/compare/@endo/stream-node@0.2.24...@endo/stream-node@0.2.25) (2023-04-14)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",
@@ -40,12 +40,12 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/stream": "^0.3.24",
-    "ses": "^0.18.3"
+    "@endo/init": "^0.5.56",
+    "@endo/stream": "^0.3.25",
+    "ses": "^0.18.4"
   },
   "devDependencies": {
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/ses-ava": "^0.2.40",
     "@typescript-eslint/parser": "^5.53.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.37](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.36...@endo/stream-types-test@0.1.37) (2023-04-20)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
 ### [0.1.36](https://github.com/endojs/endo/compare/@endo/stream-types-test@0.1.35...@endo/stream-types-test@0.1.36) (2023-04-14)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],
@@ -25,8 +25,8 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
-    "@endo/stream": "^0.3.24",
-    "ses": "^0.18.3"
+    "@endo/stream": "^0.3.25",
+    "ses": "^0.18.4"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.25](https://github.com/endojs/endo/compare/@endo/stream@0.3.24...@endo/stream@0.3.25) (2023-04-20)
+
+**Note:** Version bump only for package @endo/stream
+
 ### [0.3.24](https://github.com/endojs/endo/compare/@endo/stream@0.3.23...@endo/stream@0.3.24) (2023-04-14)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",
@@ -40,13 +40,13 @@
     "test": "ava"
   },
   "dependencies": {
-    "@endo/eventual-send": "^0.17.1",
-    "@endo/promise-kit": "^0.2.55",
-    "ses": "^0.18.3"
+    "@endo/eventual-send": "^0.17.2",
+    "@endo/promise-kit": "^0.2.56",
+    "ses": "^0.18.4"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.55",
-    "@endo/ses-ava": "^0.2.39",
+    "@endo/init": "^0.5.56",
+    "@endo/ses-ava": "^0.2.40",
     "@typescript-eslint/parser": "^5.53.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
- @michaelfig - exo: Parse `$DEBUG` as comma-separated
- @michaelfig - ses: Pass through the start compartment's `globalThis.harden` if defined
- @michaelfig - Enable JS type checking by default in the monorepo, and fix types accordingly
