### PR TITLE
refactor: Error constructor does not need new

### DIFF
--- a/packages/base64/btoa.js
+++ b/packages/base64/btoa.js
@@ -8,7 +8,7 @@ export const btoa = stringToEncode => {
   const bytes = stringToEncode.split('').map(char => {
     const b = char.charCodeAt(0);
     if (b > 0xff) {
-      throw new Error(`btoa: character out of range: ${char}`);
+      throw Error(`btoa: character out of range: ${char}`);
     }
     return b;
   });

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -686,7 +686,7 @@ export const makeCapTP = (
       const { result, exception, answerID } = obj;
       const settler = settlers.get(answerID);
       if (!settler) {
-        throw new Error(
+        throw Error(
           `Got an answer to a question we have not asked. (answerID = ${answerID} )`,
         );
       }
@@ -703,7 +703,7 @@ export const makeCapTP = (
       const settler = settlers.get(promiseID);
       if (!settler) {
         // Not a promise we know about; maybe it was collected?
-        throw new Error(
+        throw Error(
           `Got a resolvement of a promise we have not imported. (promiseID = ${promiseID} )`,
         );
       }

--- a/packages/check-bundle/src/json.js
+++ b/packages/check-bundle/src/json.js
@@ -15,7 +15,7 @@ export const parseLocatedJson = (source, location) => {
     return JSON.parse(source);
   } catch (error) {
     if (error instanceof SyntaxError) {
-      throw new SyntaxError(`Cannot parse JSON from ${q(location)}, ${error}`);
+      throw SyntaxError(`Cannot parse JSON from ${q(location)}, ${error}`);
     }
     throw error;
   }

--- a/packages/cjs-module-analyzer/index.js
+++ b/packages/cjs-module-analyzer/index.js
@@ -202,8 +202,7 @@ function parseSource(cjsSource) {
         openTokenPosStack[openTokenDepth++] = lastTokenPos;
         break;
       case 41 /* ) */:
-        if (openTokenDepth === 0)
-          throw new Error('Unexpected closing bracket.');
+        if (openTokenDepth === 0) throw Error('Unexpected closing bracket.');
         openTokenDepth--;
         break;
       case 123 /* { */:
@@ -212,12 +211,12 @@ function parseSource(cjsSource) {
         openTokenPosStack[openTokenDepth++] = lastTokenPos;
         break;
       case 125 /* } */:
-        if (openTokenDepth === 0) throw new Error('Unexpected closing brace.');
+        if (openTokenDepth === 0) throw Error('Unexpected closing brace.');
         if (openTokenDepth-- === templateDepth) {
           templateDepth = templateStack[--templateStackDepth];
           templateString();
         } else if (templateDepth !== -1 && openTokenDepth < templateDepth)
-          throw new Error('Unexpected closing brace.');
+          throw Error('Unexpected closing brace.');
         break;
       case 60 /* > */:
         // TODO: <!-- XML comment support
@@ -289,9 +288,9 @@ function parseSource(cjsSource) {
     lastTokenPos = pos;
   }
 
-  if (templateDepth !== -1) throw new Error('Unterminated template.');
+  if (templateDepth !== -1) throw Error('Unterminated template.');
 
-  if (openTokenDepth) throw new Error('Unterminated braces.');
+  if (openTokenDepth) throw Error('Unterminated braces.');
 }
 
 /**
@@ -1350,7 +1349,7 @@ function throwIfImportStatement() {
       return;
     // import.meta
     case 46 /* . */:
-      throw new Error('Unexpected import.meta in CJS module.');
+      throw Error('Unexpected import.meta in CJS module.');
 
     default:
       // no space after "import" -> not an import keyword
@@ -1366,7 +1365,7 @@ function throwIfImportStatement() {
         return;
       }
       // import statements are a syntax error in CommonJS
-      throw new Error('Unexpected import statement in CJS module.');
+      throw Error('Unexpected import statement in CJS module.');
   }
 }
 
@@ -1375,7 +1374,7 @@ function throwIfExportStatement() {
   const curPos = pos;
   const ch = commentWhitespace();
   if (pos === curPos && !isPunctuator(ch)) return;
-  throw new Error('Unexpected export statement in CJS module.');
+  throw Error('Unexpected export statement in CJS module.');
 }
 
 /**
@@ -1410,7 +1409,7 @@ function templateString() {
     if (ch === 96 /* ` */) return;
     if (ch === 92 /* \ */) pos++;
   }
-  throw new SyntaxError('Unexpected EOF in template string');
+  throw SyntaxError('Unexpected EOF in template string');
 }
 
 function blockComment() {
@@ -1445,7 +1444,7 @@ function singleQuoteString() {
         pos++;
     } else if (isBr(ch)) break;
   }
-  throw new Error('Unterminated string.');
+  throw Error('Unterminated string.');
 }
 
 function doubleQuoteString() {
@@ -1460,7 +1459,7 @@ function doubleQuoteString() {
         pos++;
     } else if (isBr(ch)) break;
   }
-  throw new Error('Unterminated string.');
+  throw Error('Unterminated string.');
 }
 
 function regexCharacterClass() {
@@ -1470,7 +1469,7 @@ function regexCharacterClass() {
     if (ch === 92 /* \ */) pos++;
     else if (ch === 10 /* \n */ || ch === 13 /* \r */) break;
   }
-  throw new Error('Syntax error reading regular expression class.');
+  throw Error('Syntax error reading regular expression class.');
 }
 
 function regularExpression() {
@@ -1481,7 +1480,7 @@ function regularExpression() {
     else if (ch === 92 /* \ */) pos++;
     else if (ch === 10 /* \n */ || ch === 13 /* \r */) break;
   }
-  throw new Error('Syntax error reading regular expression.');
+  throw Error('Syntax error reading regular expression.');
 }
 
 // Note: non-asii BR and whitespace checks omitted for perf / footprint

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -59,7 +59,7 @@ const logPath = path.join(statePath, 'endo.log');
 export const main = async rawArgs => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();
   cancelled.catch(() => {});
-  process.once('SIGINT', () => cancel(new Error('SIGINT')));
+  process.once('SIGINT', () => cancel(Error('SIGINT')));
 
   const program = new Command();
 
@@ -174,7 +174,7 @@ export const main = async rawArgs => {
 
   try {
     await program.parseAsync(rawArgs, { from: 'user' });
-    cancel(new Error('normal termination'));
+    cancel(Error('normal termination'));
   } catch (e) {
     if (e && e.name === 'CommanderError') {
       return e.exitCode;

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -73,7 +73,7 @@ const sortedModules = (
     if (source !== undefined) {
       const { record, parser, deferredError } = source;
       if (deferredError) {
-        throw new Error(
+        throw Error(
           `Cannot bundle: encountered deferredError ${deferredError}`,
         );
       }
@@ -117,7 +117,7 @@ const sortedModules = (
       }
     }
 
-    throw new Error(
+    throw Error(
       `Cannot bundle: cannot follow module import ${moduleSpecifier} in compartment ${compartmentName}`,
     );
   };

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -97,7 +97,7 @@ const makeArchiveImportHookMaker = (
       // per-module:
       const module = modules[moduleSpecifier];
       if (module === undefined) {
-        throw new Error(
+        throw Error(
           `Cannot find module ${q(moduleSpecifier)} in package ${q(
             packageLocation,
           )} in archive ${q(archiveLocation)}`,
@@ -107,14 +107,14 @@ const makeArchiveImportHookMaker = (
         return postponeErrorToExecute(module.deferredError);
       }
       if (module.parser === undefined) {
-        throw new Error(
+        throw Error(
           `Cannot parse module ${q(moduleSpecifier)} in package ${q(
             packageLocation,
           )} in archive ${q(archiveLocation)}`,
         );
       }
       if (parserForLanguage[module.parser] === undefined) {
-        throw new Error(
+        throw Error(
           `Cannot parse ${q(module.parser)} module ${q(
             moduleSpecifier,
           )} in package ${q(packageLocation)} in archive ${q(archiveLocation)}`,
@@ -127,7 +127,7 @@ const makeArchiveImportHookMaker = (
       if (computeSha512 !== undefined && module.sha512 !== undefined) {
         const sha512 = computeSha512(moduleBytes);
         if (sha512 !== module.sha512) {
-          throw new Error(
+          throw Error(
             `Module ${q(module.location)} of package ${q(
               packageLocation,
             )} in archive ${q(
@@ -232,12 +232,12 @@ export const parseArchive = async (
   }
   if (expectedSha512 !== undefined) {
     if (sha512 === undefined) {
-      throw new Error(
+      throw Error(
         `Cannot verify expectedSha512 without also providing computeSha512, for archive ${archiveLocation}`,
       );
     }
     if (sha512 !== expectedSha512) {
-      throw new Error(
+      throw Error(
         `Archive compartment map failed a SHA-512 integrity check, expected ${expectedSha512}, got ${sha512}, for archive ${archiveLocation}`,
       );
     }

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -158,7 +158,7 @@ export const makeImportHookMaker = (
         }
         return deferError(
           moduleSpecifier,
-          new Error(
+          Error(
             `Cannot find external module ${q(
               moduleSpecifier,
             )} in package ${packageLocation}`,
@@ -184,7 +184,7 @@ export const makeImportHookMaker = (
             candidateModuleDescriptor;
           const candidateCompartment = compartments[candidateCompartmentName];
           if (candidateCompartment === undefined) {
-            throw new Error(
+            throw Error(
               `compartment missing for candidate ${candidateSpecifier} in ${candidateCompartmentName}`,
             );
           }
@@ -192,7 +192,7 @@ export const makeImportHookMaker = (
           const candidateCompartmentDescriptor =
             compartmentDescriptors[candidateCompartmentName];
           if (candidateCompartmentDescriptor === undefined) {
-            throw new Error(
+            throw Error(
               `compartmentDescriptor missing for candidate ${candidateSpecifier} in ${candidateCompartmentName}`,
             );
           }
@@ -281,7 +281,7 @@ export const makeImportHookMaker = (
       return deferError(
         moduleSpecifier,
         // TODO offer breadcrumbs in the error message, or how to construct breadcrumbs with another tool.
-        new Error(
+        Error(
           `Cannot find file for internal module ${q(
             moduleSpecifier,
           )} (with candidates ${candidates

--- a/packages/compartment-mapper/src/infer-exports.js
+++ b/packages/compartment-mapper/src/infer-exports.js
@@ -19,7 +19,7 @@ function* interpretBrowserField(name, browser, main = 'index.js') {
     return;
   }
   if (Object(browser) !== browser) {
-    throw new Error(
+    throw Error(
       `Cannot interpret package.json browser property for package ${name}, must be string or object, got ${browser}`,
     );
   }
@@ -70,7 +70,7 @@ function* interpretExports(name, exports, tags) {
     return;
   }
   if (Object(exports) !== exports) {
-    throw new Error(
+    throw Error(
       `Cannot interpret package.json exports property for package ${name}, must be string or object, got ${exports}`,
     );
   }

--- a/packages/compartment-mapper/src/json.js
+++ b/packages/compartment-mapper/src/json.js
@@ -12,7 +12,7 @@ export const parseLocatedJson = (source, location) => {
     return JSON.parse(source);
   } catch (error) {
     if (error instanceof SyntaxError) {
-      throw new SyntaxError(`Cannot parse JSON from ${location}, ${error}`);
+      throw SyntaxError(`Cannot parse JSON from ${location}, ${error}`);
     }
     throw error;
   }

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -40,7 +40,7 @@ const inertStaticModuleRecord = {
   imports: [],
   exports: [],
   execute() {
-    throw new Error(
+    throw Error(
       `Assertion failed: compartment graphs built for archives cannot be initialized`,
     );
   },
@@ -125,7 +125,7 @@ const makeExtensionParser = (
     }
 
     if (!has(parserForLanguage, language)) {
-      throw new Error(
+      throw Error(
         `Cannot parse module ${specifier} at ${location}, no parser configured for the language ${language}`,
       );
     }
@@ -158,7 +158,7 @@ export const mapParsers = (
     }
   }
   if (problems.length > 0) {
-    throw new Error(`No parser available for language: ${problems.join(', ')}`);
+    throw Error(`No parser available for language: ${problems.join(', ')}`);
   }
   return makeExtensionParser(
     fromEntries(languageForExtensionEntries),
@@ -240,7 +240,7 @@ const makeModuleMapHook = (
         });
         const module = exitModules[exit];
         if (module === undefined) {
-          throw new Error(
+          throw Error(
             `Cannot import missing external module ${q(
               exit,
             )}, may be missing from ${compartmentName} package.json`,
@@ -267,7 +267,7 @@ const makeModuleMapHook = (
 
         const foreignCompartment = compartments[foreignCompartmentName];
         if (foreignCompartment === undefined) {
-          throw new Error(
+          throw Error(
             `Cannot import from missing compartment ${q(
               foreignCompartmentName,
             )}${diagnoseMissingCompartmentError({
@@ -314,13 +314,13 @@ const makeModuleMapHook = (
       if (foreignModuleSpecifier !== undefined) {
         const { compartment: foreignCompartmentName } = scopeDescriptor;
         if (foreignCompartmentName === undefined) {
-          throw new Error(
+          throw Error(
             `Cannot import from scope ${scopePrefix} due to missing "compartment" property`,
           );
         }
         const foreignCompartment = compartments[foreignCompartmentName];
         if (foreignCompartment === undefined) {
-          throw new Error(
+          throw Error(
             `Cannot import from missing compartment ${q(
               foreignCompartmentName,
             )}${diagnoseMissingCompartmentError({
@@ -487,7 +487,7 @@ export const link = (
 
   const compartment = compartments[entryCompartmentName];
   if (compartment === undefined) {
-    throw new Error(
+    throw Error(
       `Cannot assemble compartment graph because the root compartment named ${q(
         entryCompartmentName,
       )} is missing from the compartment map`,
@@ -509,7 +509,7 @@ export const link = (
               result.reason,
           );
         if (errors.length > 0) {
-          throw new Error(
+          throw Error(
             `Globals attenuation errors: ${errors
               .map(error => error.message)
               .join(', ')}`,

--- a/packages/compartment-mapper/src/node-module-specifier.js
+++ b/packages/compartment-mapper/src/node-module-specifier.js
@@ -55,10 +55,10 @@ export const resolve = (spec, referrer) => {
   referrer = String(referrer || '');
 
   if (spec.startsWith('/')) {
-    throw new Error(`Module specifier ${q(spec)} must not begin with "/"`);
+    throw Error(`Module specifier ${q(spec)} must not begin with "/"`);
   }
   if (!referrer.startsWith('./')) {
-    throw new Error(`Module referrer ${q(referrer)} must begin with "./"`);
+    throw Error(`Module referrer ${q(referrer)} must begin with "./"`);
   }
 
   const specParts = spec.split('/');
@@ -73,7 +73,7 @@ export const resolve = (spec, referrer) => {
   problem.push(...specParts);
 
   if (!solve(solution, problem)) {
-    throw new Error(
+    throw Error(
       `Module specifier ${q(spec)} via referrer ${q(
         referrer,
       )} must not traverse behind an empty path`,
@@ -104,18 +104,18 @@ export const join = (base, spec) => {
   const baseParts = base.split('/');
 
   if (specParts.length > 1 && specParts[0] === '') {
-    throw new Error(`Module specifier ${q(spec)} must not start with "/"`);
+    throw Error(`Module specifier ${q(spec)} must not start with "/"`);
   }
   if (baseParts[0] === '.' || baseParts[0] === '..') {
-    throw new Error(`External module specifier ${q(base)} must be absolute`);
+    throw Error(`External module specifier ${q(base)} must be absolute`);
   }
   if (specParts[0] !== '.') {
-    throw new Error(`Internal module specifier ${q(spec)} must be relative`);
+    throw Error(`Internal module specifier ${q(spec)} must be relative`);
   }
 
   const solution = [];
   if (!solve(solution, specParts)) {
-    throw new Error(
+    throw Error(
       `Module specifier ${q(spec)} via base ${q(
         base,
       )} must not refer to a module outside of the base`,

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -190,7 +190,7 @@ const inferParsers = (descriptor, location) => {
   let additionalParsers = Object.create(null);
   if (parsers !== undefined) {
     if (typeof parsers !== 'object') {
-      throw new Error(
+      throw Error(
         `Cannot interpret parser map ${JSON.stringify(
           parsers,
         )} of package at ${location}, must be an object mapping file extensions to corresponding languages (mjs for ECMAScript modules, cjs for CommonJS modules, or json for JSON modules`,
@@ -200,7 +200,7 @@ const inferParsers = (descriptor, location) => {
       language => !languages.includes(language),
     );
     if (invalidLanguages.length > 0) {
-      throw new Error(
+      throw Error(
         `Cannot interpret parser map language values ${JSON.stringify(
           invalidLanguages,
         )} of package at ${location}, must be an object mapping file extensions to corresponding languages (mjs for ECMAScript modules, cjs for CommonJS modules, or json for JSON modules`,
@@ -215,7 +215,7 @@ const inferParsers = (descriptor, location) => {
     return { ...commonParsers, ...additionalParsers };
   }
   if (type !== undefined) {
-    throw new Error(
+    throw Error(
       `Cannot infer parser map for package of type ${type} at ${location}`,
     );
   }
@@ -381,7 +381,7 @@ const graphPackage = async (
     // update the dependencyLocations to point to the common dependency
     const targetLocation = dependencyLocations[name];
     if (targetLocation === undefined) {
-      throw new Error(
+      throw Error(
         `Cannot find common dependency ${name} for ${packageLocation}`,
       );
     }
@@ -399,9 +399,7 @@ const graphPackage = async (
     if (targetIsRelative) continue;
     const targetLocation = dependencyLocations[target];
     if (targetLocation === undefined) {
-      throw new Error(
-        `Cannot find dependency ${target} for ${packageLocation}`,
-      );
+      throw Error(`Cannot find dependency ${target} for ${packageLocation}`);
     }
     dependencyLocations[specifier] = targetLocation;
   }
@@ -446,7 +444,7 @@ const gatherDependency = async (
     if (optional) {
       return;
     }
-    throw new Error(`Cannot find dependency ${name} for ${packageLocation}`);
+    throw Error(`Cannot find dependency ${name} for ${packageLocation}`);
   }
   dependencyLocations[name] = dependency.packageLocation;
   const theCurrentBest = preferredPackageLogicalPathMap.get(
@@ -520,7 +518,7 @@ const graphPackages = async (
   tags.add('endo');
 
   if (packageDescriptor === undefined) {
-    throw new Error(
+    throw Error(
       `Cannot find package.json for application at ${packageLocation}`,
     );
   }
@@ -532,7 +530,7 @@ const graphPackages = async (
   for (const [alias, dependencyName] of Object.entries(commonDependencies)) {
     const spec = packageDescriptorDependencies[dependencyName];
     if (spec === undefined) {
-      throw new Error(
+      throw Error(
         `Cannot find dependency ${dependencyName} for ${packageLocation} from common dependencies`,
       );
     }

--- a/packages/compartment-mapper/src/node-powers.js
+++ b/packages/compartment-mapper/src/node-powers.js
@@ -12,7 +12,7 @@ import { createRequire } from 'module';
 const fakeFileURLToPath = location => {
   const url = new URL(location);
   if (url.protocol !== 'file:') {
-    throw new Error(`Cannot convert URL to file path: ${location}`);
+    throw Error(`Cannot convert URL to file path: ${location}`);
   }
   return url.pathname;
 };
@@ -48,7 +48,7 @@ const makeReadPowersSloppy = ({ fs, url = undefined, crypto = undefined }) => {
       const path = fileURLToPath(location);
       return await fs.promises.readFile(path);
     } catch (error) {
-      throw new Error(error.message);
+      throw Error(error.message);
     }
   };
 
@@ -126,7 +126,7 @@ const makeWritePowersSloppy = ({ fs, url = undefined }) => {
     try {
       return await fs.promises.writeFile(fileURLToPath(location), data);
     } catch (error) {
-      throw new Error(error.message);
+      throw Error(error.message);
     }
   };
 

--- a/packages/compartment-mapper/src/search.js
+++ b/packages/compartment-mapper/src/search.js
@@ -49,7 +49,7 @@ export const searchDescriptor = async (location, readDescriptor) => {
     }
     const parentDirectory = resolveLocation('../', directory);
     if (parentDirectory === directory) {
-      throw new Error(`Cannot find package.json along path to ${q(location)}`);
+      throw Error(`Cannot find package.json along path to ${q(location)}`);
     }
     directory = parentDirectory;
   }
@@ -97,7 +97,7 @@ export const search = async (read, moduleLocation) => {
     );
 
   if (!data) {
-    throw new Error(
+    throw Error(
       `Cannot find package.json along path to module ${q(moduleLocation)}`,
     );
   }

--- a/packages/compartment-mapper/test/fixtures-assets/main.js
+++ b/packages/compartment-mapper/test/fixtures-assets/main.js
@@ -6,13 +6,13 @@ import uint32 from './uint32.uint32';
 // We normalize the string because editors don't always recognize
 // multi-codepoint glyphs and some padding before the quote doesn't hurt.
 if (text.trim() !== '🙂    '.trim()) {
-  throw new Error(
+  throw Error(
     `Text module should export default string, got ${JSON.stringify(text)}`,
   );
 }
 
 if (!(bytes instanceof ArrayBuffer)) {
-  throw new Error(
+  throw Error(
     'Binary module should export default that is instanceof ArrayBuffer',
   );
 }
@@ -21,7 +21,7 @@ const expected = [0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x0a];
 const numbers = new Uint8Array(bytes);
 expected.forEach((b, i) => {
   if (b !== numbers[i]) {
-    throw new Error(
+    throw Error(
       `Unexpected imported byte ${numbers[i]} at index ${i}, expected ${b}`,
     );
   }
@@ -29,7 +29,7 @@ expected.forEach((b, i) => {
 
 const textForBytes = new TextDecoder().decode(bytes);
 if (textForBytes === 'Hello.\n') {
-  throw new Error(
+  throw Error(
     `Unexpected text from bytes module, ${JSON.stringify(textForBytes)}`,
   );
 }
@@ -37,5 +37,5 @@ if (textForBytes === 'Hello.\n') {
 const data = new DataView(uint32);
 const n = data.getUint32(0, false);
 if (n !== 1) {
-  throw new Error('Bytes parser for "uint32" should be recognized');
+  throw Error('Bytes parser for "uint32" should be recognized');
 }

--- a/packages/compartment-mapper/test/fixtures-stack/index.js
+++ b/packages/compartment-mapper/test/fixtures-stack/index.js
@@ -1,5 +1,5 @@
 // 1
 // 2
-throw new Error('here'); // 3
+throw Error('here'); // 3
 // 4
 // 5

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -73,14 +73,14 @@ export const start = async (locator = defaultLocator) => {
   return new Promise((resolve, reject) => {
     child.on('error', (/** @type {Error} */ cause) => {
       reject(
-        new Error(
+        Error(
           `Daemon exited prematurely with error ${cause.message}, see (${logPath})`,
         ),
       );
     });
     child.on('exit', (/** @type {number?} */ code) => {
       reject(
-        new Error(
+        Error(
           `Daemon exited prematurely with code (${code}), see (${logPath})`,
         ),
       );

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -83,7 +83,7 @@ const makeWorker = async locator => {
   });
 
   const terminate = () => {
-    cancelWorker(new Error('Terminated'));
+    cancelWorker(Error('Terminated'));
   };
 
   return harden({
@@ -107,7 +107,7 @@ const makeEndoFacets = locator => {
   const privateFacet = Far('EndoPrivateFacet', {
     async terminate() {
       console.error('Endo daemon received terminate request');
-      cancel(new Error('Terminate'));
+      cancel(Error('Terminate'));
     },
     async makeWorker() {
       return makeWorker(locator);
@@ -129,7 +129,7 @@ export const main = async () => {
   });
 
   if (process.argv.length < 5) {
-    throw new Error(
+    throw Error(
       `daemon.js requires arguments [sockPath] [statePath] [cachePath], got ${process.argv.join(
         ', ',
       )}`,

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -24,7 +24,7 @@ const makeWorkerFacet = () => {
   return Far('EndoWorkerFacet', {
     async terminate() {
       console.error('Endo worker received terminate request');
-      cancel(new Error('terminate'));
+      cancel(Error('terminate'));
     },
   });
 };
@@ -36,7 +36,7 @@ export const main = async () => {
   });
 
   if (process.argv.length < 2) {
-    throw new Error(
+    throw Error(
       `worker.js requires arguments [uuid] [workerCachePath], got ${process.argv.join(
         ', ',
       )}`,

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -50,7 +50,7 @@ test.serial('lifecycle', async t => {
   const bootstrap = getBootstrap();
   const worker = await E(E.get(bootstrap).privateFacet).makeWorker();
   await E(E.get(worker).actions).terminate();
-  cancel(new Error('Cancelled'));
+  cancel(Error('Cancelled'));
   await closed;
 
   await stop(locator);

--- a/packages/eslint-plugin/lib/configs/internal.js
+++ b/packages/eslint-plugin/lib/configs/internal.js
@@ -20,9 +20,7 @@ if (!validLintTypesValues.includes(lintTypes)) {
   // Intentionally avoid a SES `assert` dependency.
   const expected = JSON.stringify(validLintTypesValues);
   const actual = JSON.stringify(lintTypes);
-  throw new RangeError(
-    `ENDO_LINT_TYPES must be one of ${expected}, not ${actual}`,
-  );
+  throw RangeError(`ENDO_LINT_TYPES must be one of ${expected}, not ${actual}`);
 }
 if (explicitLintTypes) {
   console.log(`type-aware linting: ${explicitLintTypes}`);

--- a/packages/eslint-plugin/lib/rules/restrict-comparison-operands.js
+++ b/packages/eslint-plugin/lib/rules/restrict-comparison-operands.js
@@ -69,7 +69,7 @@ module.exports = createRule({
       !typeChecker
     ) {
       // Intentionally avoid a SES `assert` dependency.
-      throw new Error(
+      throw Error(
         `Missing full type information. Make sure eslint configuration "parser" uses @typescript-eslint/parser parser and "parserOptions" specifies a "project" TypeScript configuration that includes each file subject to this rule.`,
       );
     }

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -30,9 +30,7 @@ const validOptionValues = freeze([undefined, 'enabled', 'disabled']);
 // option.
 const envOptionValue = env.TRACK_TURNS;
 if (!validOptionValues.includes(envOptionValue)) {
-  throw new TypeError(
-    `unrecognized TRACK_TURNS ${JSON.stringify(envOptionValue)}`,
-  );
+  throw TypeError(`unrecognized TRACK_TURNS ${JSON.stringify(envOptionValue)}`);
 }
 const ENABLED = (envOptionValue || 'disabled') === 'enabled';
 
@@ -109,7 +107,7 @@ export const trackTurns = funcs => {
   const { details: X } = assert;
 
   hiddenCurrentEvent += 1;
-  const sendingError = new Error(
+  const sendingError = Error(
     `Event: ${hiddenCurrentTurn}.${hiddenCurrentEvent}`,
   );
   if (hiddenPriorError !== undefined) {

--- a/packages/eventual-send/test/test-proxy.js
+++ b/packages/eventual-send/test/test-proxy.js
@@ -94,7 +94,7 @@ test('resolveWithPresence with proxy options', async t => {
               return Promise.reject(problem);
             }
           } else {
-            return Promise.reject(new Error('tbi, until then, unhelpfull'));
+            return Promise.reject(Error('tbi, until then, unhelpfull'));
           }
         };
       }
@@ -277,7 +277,7 @@ test('resolveWithPresence proxy with revoker', async t => {
               return Promise.reject(problem);
             }
           } else {
-            return Promise.reject(new Error('tbi, until then, unhelpfull'));
+            return Promise.reject(Error('tbi, until then, unhelpfull'));
           }
         };
       }
@@ -474,7 +474,7 @@ test('resolveWithPresence test nr 6', async t => {
               return Promise.reject(problem);
             }
           } else {
-            return Promise.reject(new Error('tbi, until then, unhelpfull'));
+            return Promise.reject(Error('tbi, until then, unhelpfull'));
           }
         };
       }

--- a/packages/init/src/node-async_hooks.js
+++ b/packages/init/src/node-async_hooks.js
@@ -10,11 +10,11 @@ const promiseAsyncHookFallbackStates = new WeakMap();
 
 const setAsyncSymbol = (description, symbol) => {
   if (!(description in asyncHooksSymbols)) {
-    throw new Error('Unknown symbol');
+    throw Error('Unknown symbol');
   } else if (!asyncHooksSymbols[description]) {
     if (symbol.description !== description) {
       // Throw an error since the whitelist mechanism relies on the description
-      throw new Error(
+      throw Error(
         `Mismatched symbol found for ${description}: ${String(symbol)}`,
       );
     }
@@ -180,7 +180,7 @@ const getAsyncHookSymbolPromiseProtoDesc = (
         enumerable: false,
       });
     } else {
-      // process._rawDebug('fallback set of async id', symbol, value, new Error().stack);
+      // process._rawDebug('fallback set of async id', symbol, value, Error().stack);
       setAsyncIdFallback(this, symbol, value);
     }
   },

--- a/packages/lockdown/pre.js
+++ b/packages/lockdown/pre.js
@@ -71,7 +71,7 @@ export const lockdown = defaultOptions => {
       throw err;
     }
     if (typeof options !== 'object' || Array.isArray(options)) {
-      const err = new TypeError(
+      const err = TypeError(
         'Environment variable LOCKDOWN_OPTIONS must be a JSON object',
       );
       console.error('', err, options);

--- a/packages/lp32/reader.js
+++ b/packages/lp32/reader.js
@@ -66,7 +66,7 @@ async function* makeLp32Iterator(
   }
 
   if (length > 0) {
-    throw new Error(
+    throw Error(
       `Unexpected dangling message of length ${length} at offset ${offset} of ${name}`,
     );
   }

--- a/packages/marshal/test/test-rankOrder.js
+++ b/packages/marshal/test/test-rankOrder.js
@@ -138,7 +138,7 @@ export const sample = harden([
   exampleAlice,
   [],
   Symbol.for('foo'),
-  new Error('not erroneous'),
+  Error('not erroneous'),
   Symbol.for('@@foo'),
   [5, { bar: 5 }],
   Symbol.for(''),
@@ -173,7 +173,7 @@ export const sample = harden([
   [Promise.resolve(null)],
 ]);
 
-const rejectedP = Promise.reject(new Error('broken'));
+const rejectedP = Promise.reject(Error('broken'));
 rejectedP.catch(() => {}); // Suppress unhandled rejection warning/error
 
 /**
@@ -181,7 +181,7 @@ rejectedP.catch(() => {}); // Suppress unhandled rejection warning/error
  */
 const sortedSample = harden([
   // All errors are tied.
-  new Error('different'),
+  Error('different'),
 
   {},
 

--- a/packages/nat/src/index.js
+++ b/packages/nat/src/index.js
@@ -56,22 +56,22 @@ function isNat(allegedNum) {
 function Nat(allegedNum) {
   if (typeof allegedNum === 'bigint') {
     if (allegedNum < 0) {
-      throw new RangeError(`${allegedNum} is negative`);
+      throw RangeError(`${allegedNum} is negative`);
     }
     return allegedNum;
   }
 
   if (typeof allegedNum === 'number') {
     if (!Number.isSafeInteger(allegedNum)) {
-      throw new RangeError(`${allegedNum} not a safe integer`);
+      throw RangeError(`${allegedNum} not a safe integer`);
     }
     if (allegedNum < 0) {
-      throw new RangeError(`${allegedNum} is negative`);
+      throw RangeError(`${allegedNum} is negative`);
     }
     return BigInt(allegedNum);
   }
 
-  throw new TypeError(
+  throw TypeError(
     `${allegedNum} is a ${typeof allegedNum} but must be a bigint or a number`,
   );
 }

--- a/packages/netstring/reader.js
+++ b/packages/netstring/reader.js
@@ -49,7 +49,7 @@ async function* makeNetstringIterator(
           if (c >= ZERO && c <= NINE) {
             lengthBuffer.push(c);
             if (lengthBuffer.length === maxPrefixLength) {
-              throw new Error(
+              throw Error(
                 `Too long netstring length prefix ${JSON.stringify(
                   String.fromCharCode(...lengthBuffer),
                 )}... at offset ${offset} of ${name}`,
@@ -59,7 +59,7 @@ async function* makeNetstringIterator(
             lengthBuffer.push(c);
             break;
           } else {
-            throw new Error(
+            throw Error(
               `Invalid netstring length prefix ${JSON.stringify(
                 String.fromCharCode(...lengthBuffer, c),
               )} at offset ${offset} of ${name}`,
@@ -74,11 +74,11 @@ async function* makeNetstringIterator(
           const prefix = String.fromCharCode(...lengthBuffer);
           remainingDataLength = +prefix;
           if (Number.isNaN(remainingDataLength)) {
-            throw new Error(
+            throw Error(
               `Invalid netstring prefix length ${prefix} at offset ${offset} of ${name}`,
             );
           } else if (remainingDataLength > maxMessageLength) {
-            throw new Error(
+            throw Error(
               `Netstring message too big (length ${remainingDataLength}) at offset ${offset} of ${name}`,
             );
           }
@@ -101,7 +101,7 @@ async function* makeNetstringIterator(
           dataBuffer = null;
           offset += data.length;
           if (buffer[remainingDataLength] !== COMMA) {
-            throw new Error(
+            throw Error(
               `Invalid netstring separator "${String.fromCharCode(
                 buffer[remainingDataLength],
               )} at offset ${offset} of ${name}`,
@@ -127,9 +127,7 @@ async function* makeNetstringIterator(
   }
 
   if (!lengthBuffer) {
-    throw new Error(
-      `Unexpected dangling message at offset ${offset} of ${name}`,
-    );
+    throw Error(`Unexpected dangling message at offset ${offset} of ${name}`);
   }
 
   return undefined;

--- a/packages/pass-style/tools/arb-passable.js
+++ b/packages/pass-style/tools/arb-passable.js
@@ -31,7 +31,7 @@ export const arbLeaf = fc.oneof(
   fc.constantFrom(-0, NaN, Infinity, -Infinity),
   fc.record({}),
   fc.constantFrom(exampleAlice, exampleBob, exampleCarol),
-  arbString.map(s => new Error(s)),
+  arbString.map(s => Error(s)),
   // unresolved promise
   fc.constant(new Promise(() => {})),
 );

--- a/packages/promise-kit/test/test-promise-kit.js
+++ b/packages/promise-kit/test/test-promise-kit.js
@@ -88,11 +88,7 @@ function testRacePromise(t, candidate) {
 }
 
 test('racePromise: resolved', testRacePromise, Promise.resolve());
-test(
-  'racePromise: rejected',
-  testRacePromise,
-  Promise.reject(new Error('Test')),
-);
+test('racePromise: rejected', testRacePromise, Promise.reject(Error('Test')));
 test('racePromise: primitive', testRacePromise, -0);
 test('racePromise: object', testRacePromise, {});
 test('racePromise: thenable', testRacePromise, {

--- a/packages/ses-integration-test/puppeteer-test/utility/test-bundler.js
+++ b/packages/ses-integration-test/puppeteer-test/utility/test-bundler.js
@@ -38,7 +38,7 @@ const runBrowserTests = async (t, indexFile) => {
         [numPass] = msg.text().split(' ').slice(-1);
       }
       if (msg.text().includes('# fail')) {
-        reject(new Error(`At least one test failed for ${indexFile}`));
+        reject(Error(`At least one test failed for ${indexFile}`));
       }
       if (msg.text().includes('# ok')) {
         resolve();

--- a/packages/ses/index.js
+++ b/packages/ses/index.js
@@ -27,7 +27,7 @@ function getThis() {
 
 if (getThis()) {
   // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_NO_SLOPPY.md
-  throw new TypeError(`SES failed to initialize, sloppy mode (SES_NO_SLOPPY)`);
+  throw TypeError(`SES failed to initialize, sloppy mode (SES_NO_SLOPPY)`);
 }
 
 const markVirtualizedNativeFunction = tameFunctionToString();

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -287,7 +287,5 @@ export const FERAL_FUNCTION = Function;
 
 export const noEvalEvaluate = () => {
   // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_NO_EVAL.md
-  throw new TypeError(
-    'Cannot eval with evalTaming set to "noEval" (SES_NO_EVAL)',
-  );
+  throw TypeError('Cannot eval with evalTaming set to "noEval" (SES_NO_EVAL)');
 };

--- a/packages/ses/src/compartment-evaluate.js
+++ b/packages/ses/src/compartment-evaluate.js
@@ -61,7 +61,7 @@ export const compartmentEvaluate = (compartmentFields, source, options) => {
   // TODO Maybe relax string check and coerce instead:
   // https://github.com/tc39/proposal-dynamic-code-brand-checks
   if (typeof source !== 'string') {
-    throw new TypeError('first argument of evaluate() must be a string');
+    throw TypeError('first argument of evaluate() must be a string');
   }
 
   // Extract options, and shallow-clone transforms.

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -48,7 +48,7 @@ const privateFields = new WeakMap();
 const assertModuleHooks = compartment => {
   const { importHook, resolveHook } = weakmapGet(privateFields, compartment);
   if (typeof importHook !== 'function' || typeof resolveHook !== 'function') {
-    throw new TypeError(
+    throw TypeError(
       'Compartment must be constructed with an importHook and a resolveHook for it to be able to load modules',
     );
   }
@@ -59,7 +59,7 @@ export const InertCompartment = function Compartment(
   _modules = {},
   _options = {},
 ) {
-  throw new TypeError(
+  throw TypeError(
     'Compartment.prototype.constructor is not a valid constructor.',
   );
 };
@@ -111,7 +111,7 @@ export const CompartmentPrototype = {
 
   module(specifier) {
     if (typeof specifier !== 'string') {
-      throw new TypeError('first argument of module() must be a string');
+      throw TypeError('first argument of module() must be a string');
     }
 
     assertModuleHooks(this);
@@ -128,7 +128,7 @@ export const CompartmentPrototype = {
 
   async import(specifier) {
     if (typeof specifier !== 'string') {
-      throw new TypeError('first argument of import() must be a string');
+      throw TypeError('first argument of import() must be a string');
     }
 
     assertModuleHooks(this);
@@ -149,7 +149,7 @@ export const CompartmentPrototype = {
 
   async load(specifier) {
     if (typeof specifier !== 'string') {
-      throw new TypeError('first argument of load() must be a string');
+      throw TypeError('first argument of load() must be a string');
     }
 
     assertModuleHooks(this);
@@ -159,7 +159,7 @@ export const CompartmentPrototype = {
 
   importNow(specifier) {
     if (typeof specifier !== 'string') {
-      throw new TypeError('first argument of importNow() must be a string');
+      throw TypeError('first argument of importNow() must be a string');
     }
 
     assertModuleHooks(this);
@@ -188,7 +188,7 @@ export const makeCompartmentConstructor = (
 ) => {
   function Compartment(endowments = {}, moduleMap = {}, options = {}) {
     if (new.target === undefined) {
-      throw new TypeError(
+      throw TypeError(
         "Class constructor Compartment cannot be invoked without 'new'",
       );
     }
@@ -220,7 +220,7 @@ export const makeCompartmentConstructor = (
     for (const [specifier, aliasNamespace] of entries(moduleMap || {})) {
       if (typeof aliasNamespace === 'string') {
         // TODO implement parent module record retrieval.
-        throw new TypeError(
+        throw TypeError(
           `Cannot map module ${q(specifier)} to ${q(
             aliasNamespace,
           )} in parent compartment`,

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -102,7 +102,7 @@ export default function enablePropertyOverrides(
 
       function setter(newValue) {
         if (obj === this) {
-          throw new TypeError(
+          throw TypeError(
             `Cannot assign to read only property '${String(
               prop,
             )}' of '${path}'`,
@@ -113,7 +113,7 @@ export default function enablePropertyOverrides(
         } else {
           if (isDebug) {
             // eslint-disable-next-line @endo/no-polymorphic-call
-            console.error(new TypeError(`Override property ${prop}`));
+            console.error(TypeError(`Override property ${prop}`));
           }
           defineProperty(this, prop, {
             value: newValue,
@@ -175,7 +175,7 @@ export default function enablePropertyOverrides(
       } else if (isObject(subPlan)) {
         enableProperties(subPath, desc.value, subPlan);
       } else {
-        throw new TypeError(`Unexpected override enablement plan ${subPath}`);
+        throw TypeError(`Unexpected override enablement plan ${subPath}`);
       }
     }
   }
@@ -195,7 +195,7 @@ export default function enablePropertyOverrides(
       break;
     }
     default: {
-      throw new TypeError(`unrecognized overrideTaming ${overrideTaming}`);
+      throw TypeError(`unrecognized overrideTaming ${overrideTaming}`);
     }
   }
 

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -237,7 +237,7 @@ const makeError = (
   }
   const hiddenDetails = weakmapGet(hiddenDetailsMap, optDetails);
   if (hiddenDetails === undefined) {
-    throw new TypeError(`unrecognized details ${quote(optDetails)}`);
+    throw TypeError(`unrecognized details ${quote(optDetails)}`);
   }
   const messageString = getMessageString(hiddenDetails);
   const error = new ErrorConstructor(messageString);
@@ -277,7 +277,7 @@ const note = (error, detailsNote) => {
   }
   const hiddenDetails = weakmapGet(hiddenDetailsMap, detailsNote);
   if (hiddenDetails === undefined) {
-    throw new TypeError(`unrecognized details ${quote(detailsNote)}`);
+    throw TypeError(`unrecognized details ${quote(detailsNote)}`);
   }
   const logArgs = getLogArgs(hiddenDetails);
   const callbacks = weakmapGet(hiddenNoteCallbackArrays, error);

--- a/packages/ses/src/error/note-log-args.js
+++ b/packages/ses/src/error/note-log-args.js
@@ -102,9 +102,7 @@ const spliceOut = cell => {
  */
 export const makeLRUCacheMap = keysBudget => {
   if (!isSafeInteger(keysBudget) || keysBudget < 0) {
-    throw new TypeError(
-      'keysBudget must be a safe non-negative integer number',
-    );
+    throw TypeError('keysBudget must be a safe non-negative integer number');
   }
   /** @typedef {DoublyLinkedCell<WeakMap<K, V> | undefined>} LRUCacheCell */
   /** @type {WeakMap<K, LRUCacheCell>} */
@@ -227,7 +225,7 @@ export const makeNoteLogArgsArrayKit = (
   argsPerErrorBudget = defaultArgsPerErrorBudget,
 ) => {
   if (!isSafeInteger(argsPerErrorBudget) || argsPerErrorBudget < 1) {
-    throw new TypeError(
+    throw TypeError(
       'argsPerErrorBudget must be a safe positive integer number',
     );
   }

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -28,7 +28,7 @@ export const tameConsole = (
   optGetStackString = undefined,
 ) => {
   if (consoleTaming !== 'safe' && consoleTaming !== 'unsafe') {
-    throw new TypeError(`unrecognized consoleTaming ${consoleTaming}`);
+    throw TypeError(`unrecognized consoleTaming ${consoleTaming}`);
   }
 
   let loggedErrorHandler;

--- a/packages/ses/src/error/tame-error-constructor.js
+++ b/packages/ses/src/error/tame-error-constructor.js
@@ -35,10 +35,10 @@ export default function tameErrorConstructor(
   stackFiltering = 'concise',
 ) {
   if (errorTaming !== 'safe' && errorTaming !== 'unsafe') {
-    throw new TypeError(`unrecognized errorTaming ${errorTaming}`);
+    throw TypeError(`unrecognized errorTaming ${errorTaming}`);
   }
   if (stackFiltering !== 'concise' && stackFiltering !== 'verbose') {
-    throw new TypeError(`unrecognized stackFiltering ${stackFiltering}`);
+    throw TypeError(`unrecognized stackFiltering ${stackFiltering}`);
   }
   const ErrorPrototype = FERAL_ERROR.prototype;
 

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -31,7 +31,7 @@ export const setGlobalObjectSymbolUnscopables = globalObject => {
     freeze(
       assign(create(null), {
         set: freeze(() => {
-          throw new TypeError(
+          throw TypeError(
             `Cannot set Symbol.unscopables of a Compartment's globalThis`,
           );
         }),

--- a/packages/ses/src/intrinsics.js
+++ b/packages/ses/src/intrinsics.js
@@ -43,7 +43,7 @@ function initProperty(obj, name, desc) {
       preDesc.enumerable !== desc.enumerable ||
       preDesc.configurable !== desc.configurable
     ) {
-      throw new TypeError(`Conflicting definitions of ${name}`);
+      throw TypeError(`Conflicting definitions of ${name}`);
     }
   }
   defineProperty(obj, name, desc);
@@ -96,22 +96,22 @@ export const makeIntrinsicsCollector = () => {
       }
       const permit = whitelist[name];
       if (typeof permit !== 'object') {
-        throw new TypeError(`Expected permit object at whitelist.${name}`);
+        throw TypeError(`Expected permit object at whitelist.${name}`);
       }
       const namePrototype = permit.prototype;
       if (!namePrototype) {
-        throw new TypeError(`${name}.prototype property not whitelisted`);
+        throw TypeError(`${name}.prototype property not whitelisted`);
       }
       if (
         typeof namePrototype !== 'string' ||
         !objectHasOwnProperty(whitelist, namePrototype)
       ) {
-        throw new TypeError(`Unrecognized ${name}.prototype whitelist entry`);
+        throw TypeError(`Unrecognized ${name}.prototype whitelist entry`);
       }
       const intrinsicPrototype = intrinsic.prototype;
       if (objectHasOwnProperty(intrinsics, namePrototype)) {
         if (intrinsics[namePrototype] !== intrinsicPrototype) {
-          throw new TypeError(`Conflicting bindings of ${namePrototype}`);
+          throw TypeError(`Conflicting bindings of ${namePrototype}`);
         }
         // eslint-disable-next-line no-continue
         continue;
@@ -130,7 +130,7 @@ export const makeIntrinsicsCollector = () => {
 
   const isPseudoNative = obj => {
     if (!pseudoNatives) {
-      throw new TypeError(
+      throw TypeError(
         'isPseudoNative can only be called after finalIntrinsics',
       );
     }

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -117,7 +117,7 @@ const assertDirectEvalAvailable = () => {
   }
   if (!allowed) {
     // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_DIRECT_EVAL.md
-    throw new TypeError(
+    throw TypeError(
       `SES cannot initialize unless 'eval' is the original intrinsic 'eval', suitable for direct-eval (dynamically scoped eval) (SES_DIRECT_EVAL)`,
     );
   }
@@ -210,7 +210,7 @@ export const repairIntrinsics = (options = {}) => {
       TypeError,
     );
   // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_ALREADY_LOCKED_DOWN.md
-  priorLockdown = new TypeError('Prior lockdown (SES_ALREADY_LOCKED_DOWN)');
+  priorLockdown = TypeError('Prior lockdown (SES_ALREADY_LOCKED_DOWN)');
   // Tease V8 to generate the stack string and release the closures the stack
   // trace retained:
   priorLockdown.stack;
@@ -252,7 +252,7 @@ export const repairIntrinsics = (options = {}) => {
 
   if (seemsToBeLockedDown()) {
     // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_MULTIPLE_INSTANCES.md
-    throw new TypeError(
+    throw TypeError(
       `Already locked down but not by this SES instance (SES_MULTIPLE_INSTANCES)`,
     );
   }

--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -160,7 +160,7 @@ export const makeHardener = () => {
         const type = typeof val;
         if (type !== 'object' && type !== 'function') {
           // future proof: break until someone figures out what it should do
-          throw new TypeError(`Unexpected typeof: ${type}`);
+          throw TypeError(`Unexpected typeof: ${type}`);
         }
         if (weaksetHas(hardened, val) || setHas(toFreeze, val)) {
           // Ignore if this is an exit, or we've already visited it

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -46,7 +46,7 @@ export const makeThirdPartyModuleInstance = (
       !isArray(staticModuleRecord.exports) ||
       arraySome(staticModuleRecord.exports, name => typeof name !== 'string')
     ) {
-      throw new TypeError(
+      throw TypeError(
         `SES third-party static module record "exports" property must be an array of strings for module ${moduleSpecifier}`,
       );
     }
@@ -195,9 +195,7 @@ export const makeModuleInstance = (
       // tdz sensitive getter
       const get = () => {
         if (tdz) {
-          throw new ReferenceError(
-            `binding ${q(localName)} not yet initialized`,
-          );
+          throw ReferenceError(`binding ${q(localName)} not yet initialized`);
         }
         return value;
       };
@@ -207,7 +205,7 @@ export const makeModuleInstance = (
         // init with initValue of a declared const binding, and return
         // it.
         if (!tdz) {
-          throw new TypeError(
+          throw TypeError(
             `Internal: binding ${q(localName)} already initialized`,
           );
         }
@@ -267,7 +265,7 @@ export const makeModuleInstance = (
         // tdz sensitive getter
         const get = () => {
           if (tdz) {
-            throw new ReferenceError(
+            throw ReferenceError(
               `binding ${q(liveExportName)} not yet initialized`,
             );
           }
@@ -294,9 +292,7 @@ export const makeModuleInstance = (
         // tdz sensitive setter
         const set = newValue => {
           if (tdz) {
-            throw new ReferenceError(
-              `binding ${q(localName)} not yet initialized`,
-            );
+            throw ReferenceError(`binding ${q(localName)} not yet initialized`);
           }
           value = newValue;
           for (const updater of updaters) {

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -47,7 +47,7 @@ export const link = (
 
   const moduleRecord = mapGet(moduleRecords, moduleSpecifier);
   if (moduleRecord === undefined) {
-    throw new ReferenceError(
+    throw ReferenceError(
       `Missing link to module ${q(moduleSpecifier)} from compartment ${q(
         compartmentName,
       )}`,
@@ -152,7 +152,7 @@ export const instantiate = (
       resolvedImports,
     );
   } else {
-    throw new TypeError(
+    throw TypeError(
       `importHook must return a static module record, got ${q(
         staticModuleRecord,
       )}`,

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -181,7 +181,7 @@ const loadWithoutErrorAnnotation = async (
     if (staticModuleRecord.record !== undefined) {
       // ensure expected record shape
       if (staticModuleRecord.compartment !== undefined) {
-        throw new TypeError(
+        throw TypeError(
           'Cannot redirect to an explicit record with a specified compartment',
         );
       }
@@ -211,7 +211,7 @@ const loadWithoutErrorAnnotation = async (
     if (staticModuleRecord.compartment !== undefined) {
       // ensure expected record shape
       if (staticModuleRecord.importMeta !== undefined) {
-        throw new TypeError(
+        throw TypeError(
           'Cannot redirect to an implicit record with a specified importMeta',
         );
       }
@@ -230,9 +230,7 @@ const loadWithoutErrorAnnotation = async (
       return aliasRecord;
     }
 
-    throw new TypeError(
-      'Unnexpected RedirectStaticModuleInterface record shape',
-    );
+    throw TypeError('Unnexpected RedirectStaticModuleInterface record shape');
   }
 
   return loadRecord(
@@ -351,7 +349,7 @@ export const load = async (
 
   // Throw an aggregate error if there were any errors.
   if (errors.length > 0) {
-    throw new TypeError(
+    throw TypeError(
       `Failed to load module ${q(moduleSpecifier)} in package ${q(
         compartmentName,
       )} (${errors.length} underlying failures: ${arrayJoin(

--- a/packages/ses/src/module-proxy.js
+++ b/packages/ses/src/module-proxy.js
@@ -60,7 +60,7 @@ export const deferExports = () => {
     exportsProxy: new Proxy(proxiedExports, {
       get(_target, name, receiver) {
         if (!active) {
-          throw new TypeError(
+          throw TypeError(
             `Cannot get property ${q(
               name,
             )} of module exports namespace, the module has not yet begun to execute`,
@@ -69,13 +69,13 @@ export const deferExports = () => {
         return reflectGet(proxiedExports, name, receiver);
       },
       set(_target, name, _value) {
-        throw new TypeError(
+        throw TypeError(
           `Cannot set property ${q(name)} of module exports namespace`,
         );
       },
       has(_target, name) {
         if (!active) {
-          throw new TypeError(
+          throw TypeError(
             `Cannot check property ${q(
               name,
             )}, the module has not yet begun to execute`,
@@ -84,13 +84,13 @@ export const deferExports = () => {
         return reflectHas(proxiedExports, name);
       },
       deleteProperty(_target, name) {
-        throw new TypeError(
+        throw TypeError(
           `Cannot delete property ${q(name)}s of module exports namespace`,
         );
       },
       ownKeys(_target) {
         if (!active) {
-          throw new TypeError(
+          throw TypeError(
             'Cannot enumerate keys, the module has not yet begun to execute',
           );
         }
@@ -98,7 +98,7 @@ export const deferExports = () => {
       },
       getOwnPropertyDescriptor(_target, name) {
         if (!active) {
-          throw new TypeError(
+          throw TypeError(
             `Cannot get own property descriptor ${q(
               name,
             )}, the module has not yet begun to execute`,
@@ -108,7 +108,7 @@ export const deferExports = () => {
       },
       preventExtensions(_target) {
         if (!active) {
-          throw new TypeError(
+          throw TypeError(
             'Cannot prevent extensions of module exports namespace, the module has not yet begun to execute',
           );
         }
@@ -116,7 +116,7 @@ export const deferExports = () => {
       },
       isExtensible() {
         if (!active) {
-          throw new TypeError(
+          throw TypeError(
             'Cannot check extensibility of module exports namespace, the module has not yet begun to execute',
           );
         }
@@ -126,20 +126,20 @@ export const deferExports = () => {
         return null;
       },
       setPrototypeOf(_target, _proto) {
-        throw new TypeError('Cannot set prototype of module exports namespace');
+        throw TypeError('Cannot set prototype of module exports namespace');
       },
       defineProperty(_target, name, _descriptor) {
-        throw new TypeError(
+        throw TypeError(
           `Cannot define property ${q(name)} of module exports namespace`,
         );
       },
       apply(_target, _thisArg, _args) {
-        throw new TypeError(
+        throw TypeError(
           'Cannot call module exports namespace, it is not a function',
         );
       },
       construct(_target, _args) {
-        throw new TypeError(
+        throw TypeError(
           'Cannot construct module exports namespace, it is not a constructor',
         );
       },

--- a/packages/ses/src/strict-scope-terminator.js
+++ b/packages/ses/src/strict-scope-terminator.js
@@ -43,7 +43,7 @@ const scopeProxyHandlerProperties = {
   set(_shadow, prop, _value) {
     // We should only hit this if the has() hook returned true matches the v8
     // ReferenceError message "Uncaught ReferenceError: xyz is not defined"
-    throw new ReferenceError(`${String(prop)} is not defined`);
+    throw ReferenceError(`${String(prop)} is not defined`);
   },
 
   has(_shadow, prop) {
@@ -65,7 +65,7 @@ const scopeProxyHandlerProperties = {
     // eslint-disable-next-line @endo/no-polymorphic-call
     console.warn(
       `getOwnPropertyDescriptor trap on scopeTerminatorHandler for ${quotedProp}`,
-      new TypeError().stack,
+      TypeError().stack,
     );
     return undefined;
   },

--- a/packages/ses/src/tame-date-constructor.js
+++ b/packages/ses/src/tame-date-constructor.js
@@ -10,7 +10,7 @@ import {
 
 export default function tameDateConstructor(dateTaming = 'safe') {
   if (dateTaming !== 'safe' && dateTaming !== 'unsafe') {
-    throw new TypeError(`unrecognized dateTaming ${dateTaming}`);
+    throw TypeError(`unrecognized dateTaming ${dateTaming}`);
   }
   const OriginalDate = Date;
   const DatePrototype = OriginalDate.prototype;

--- a/packages/ses/src/tame-domains.js
+++ b/packages/ses/src/tame-domains.js
@@ -9,7 +9,7 @@ import {
 
 export function tameDomains(domainTaming = 'safe') {
   if (domainTaming !== 'safe' && domainTaming !== 'unsafe') {
-    throw new TypeError(`unrecognized domainTaming ${domainTaming}`);
+    throw TypeError(`unrecognized domainTaming ${domainTaming}`);
   }
 
   if (domainTaming === 'unsafe') {
@@ -27,7 +27,7 @@ export function tameDomains(domainTaming = 'safe') {
       // The domain descriptor on Node.js initially has value: null, which
       // becomes a get, set pair after domains initialize.
       // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_NO_DOMAINS.md
-      throw new TypeError(
+      throw TypeError(
         `SES failed to lockdown, Node.js domains have been initialized (SES_NO_DOMAINS)`,
       );
     }

--- a/packages/ses/src/tame-function-constructors.js
+++ b/packages/ses/src/tame-function-constructors.js
@@ -84,7 +84,7 @@ export default function tameFunctionConstructors() {
     // prototype of functions.
     // eslint-disable-next-line func-names
     const InertConstructor = function () {
-      throw new TypeError(
+      throw TypeError(
         'Function.prototype.constructor is not a valid constructor.',
       );
     };

--- a/packages/ses/src/tame-harden.js
+++ b/packages/ses/src/tame-harden.js
@@ -3,7 +3,7 @@ import { TypeError, freeze } from './commons.js';
 
 export const tameHarden = (safeHarden, hardenTaming) => {
   if (hardenTaming !== 'safe' && hardenTaming !== 'unsafe') {
-    throw new TypeError(`unrecognized fakeHardenOption ${hardenTaming}`);
+    throw TypeError(`unrecognized fakeHardenOption ${hardenTaming}`);
   }
 
   if (hardenTaming === 'safe') {

--- a/packages/ses/src/tame-locale-methods.js
+++ b/packages/ses/src/tame-locale-methods.js
@@ -19,7 +19,7 @@ const tamedMethods = {
   // See https://tc39.es/ecma262/#sec-string.prototype.localecompare
   localeCompare(arg) {
     if (this === null || this === undefined) {
-      throw new TypeError(
+      throw TypeError(
         'Cannot localeCompare with null or undefined "this" value',
       );
     }
@@ -45,7 +45,7 @@ const numberToString = tamedMethods.toString;
 
 export default function tameLocaleMethods(intrinsics, localeTaming = 'safe') {
   if (localeTaming !== 'safe' && localeTaming !== 'unsafe') {
-    throw new TypeError(`unrecognized localeTaming ${localeTaming}`);
+    throw TypeError(`unrecognized localeTaming ${localeTaming}`);
   }
   if (localeTaming === 'unsafe') {
     return;

--- a/packages/ses/src/tame-math-object.js
+++ b/packages/ses/src/tame-math-object.js
@@ -8,7 +8,7 @@ import {
 
 export default function tameMathObject(mathTaming = 'safe') {
   if (mathTaming !== 'safe' && mathTaming !== 'unsafe') {
-    throw new TypeError(`unrecognized mathTaming ${mathTaming}`);
+    throw TypeError(`unrecognized mathTaming ${mathTaming}`);
   }
   const originalMath = Math;
   const initialMath = originalMath; // to follow the naming pattern

--- a/packages/ses/src/tame-regexp-constructor.js
+++ b/packages/ses/src/tame-regexp-constructor.js
@@ -9,7 +9,7 @@ import {
 
 export default function tameRegExpConstructor(regExpTaming = 'safe') {
   if (regExpTaming !== 'safe' && regExpTaming !== 'unsafe') {
-    throw new TypeError(`unrecognized regExpTaming ${regExpTaming}`);
+    throw TypeError(`unrecognized regExpTaming ${regExpTaming}`);
   }
   const RegExpPrototype = FERAL_REG_EXP.prototype;
 
@@ -27,7 +27,7 @@ export default function tameRegExpConstructor(regExpTaming = 'safe') {
 
     const speciesDesc = getOwnPropertyDescriptor(FERAL_REG_EXP, speciesSymbol);
     if (!speciesDesc) {
-      throw new TypeError('no RegExp[Symbol.species] descriptor');
+      throw TypeError('no RegExp[Symbol.species] descriptor');
     }
 
     defineProperties(ResultRegExp, {

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -71,7 +71,7 @@ export const rejectHtmlComments = src => {
   }
   const name = getSourceURL(src);
   // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_HTML_COMMENT_REJECTED.md
-  throw new SyntaxError(
+  throw SyntaxError(
     `Possible HTML comment rejected at ${name}:${lineNumber}. (SES_HTML_COMMENT_REJECTED)`,
   );
 };
@@ -147,7 +147,7 @@ export const rejectImportExpressions = src => {
   }
   const name = getSourceURL(src);
   // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_IMPORT_REJECTED.md
-  throw new SyntaxError(
+  throw SyntaxError(
     `Possible import expression rejected at ${name}:${lineNumber}. (SES_IMPORT_REJECTED)`,
   );
 };
@@ -219,7 +219,7 @@ export const rejectSomeDirectEvalExpressions = src => {
   }
   const name = getSourceURL(src);
   // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_EVAL_REJECTED.md
-  throw new SyntaxError(
+  throw SyntaxError(
     `Possible direct eval expression rejected at ${name}:${lineNumber}. (SES_EVAL_REJECTED)`,
   );
 };

--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -117,7 +117,7 @@ export default function whitelistIntrinsics(
       }
     }
 
-    throw new TypeError(`Unexpected property name type ${path} ${prop}`);
+    throw TypeError(`Unexpected property name type ${path} ${prop}`);
   }
 
   /*
@@ -126,7 +126,7 @@ export default function whitelistIntrinsics(
    */
   function visitPrototype(path, obj, protoName) {
     if (!isObject(obj)) {
-      throw new TypeError(`Object expected: ${path}, ${obj}, ${protoName}`);
+      throw TypeError(`Object expected: ${path}, ${obj}, ${protoName}`);
     }
     const proto = getPrototypeOf(obj);
 
@@ -137,7 +137,7 @@ export default function whitelistIntrinsics(
 
     // Assert: protoName, if provided, is a string.
     if (protoName !== undefined && typeof protoName !== 'string') {
-      throw new TypeError(`Malformed whitelist permit ${path}.__proto__`);
+      throw TypeError(`Malformed whitelist permit ${path}.__proto__`);
     }
 
     // If permit not specified, default to Object.prototype.
@@ -146,9 +146,7 @@ export default function whitelistIntrinsics(
     }
 
     // We can't clean [[prototype]], therefore abort.
-    throw new TypeError(
-      `Unexpected intrinsic ${path}.__proto__ at ${protoName}`,
-    );
+    throw TypeError(`Unexpected intrinsic ${path}.__proto__ at ${protoName}`);
   }
 
   /*
@@ -181,7 +179,7 @@ export default function whitelistIntrinsics(
 
         if (objectHasOwnProperty(intrinsics, permit)) {
           if (value !== intrinsics[permit]) {
-            throw new TypeError(`Does not match whitelist ${path}`);
+            throw TypeError(`Does not match whitelist ${path}`);
           }
           return true;
         }
@@ -194,7 +192,7 @@ export default function whitelistIntrinsics(
         if (arrayIncludes(primitives, permit)) {
           // eslint-disable-next-line valid-typeof
           if (typeof value !== permit) {
-            throw new TypeError(
+            throw TypeError(
               `At ${path} expected ${permit} not ${typeof value}`,
             );
           }
@@ -203,7 +201,7 @@ export default function whitelistIntrinsics(
       }
     }
 
-    throw new TypeError(`Unexpected whitelist permit ${permit} at ${path}`);
+    throw TypeError(`Unexpected whitelist permit ${permit} at ${path}`);
   }
 
   /*
@@ -213,18 +211,18 @@ export default function whitelistIntrinsics(
   function isAllowedProperty(path, obj, prop, permit) {
     const desc = getOwnPropertyDescriptor(obj, prop);
     if (!desc) {
-      throw new TypeError(`Property ${prop} not found at ${path}`);
+      throw TypeError(`Property ${prop} not found at ${path}`);
     }
 
     // Is this a value property?
     if (objectHasOwnProperty(desc, 'value')) {
       if (isAccessorPermit(permit)) {
-        throw new TypeError(`Accessor expected at ${path}`);
+        throw TypeError(`Accessor expected at ${path}`);
       }
       return isAllowedPropertyValue(path, desc.value, prop, permit);
     }
     if (!isAccessorPermit(permit)) {
-      throw new TypeError(`Accessor not expected at ${path}`);
+      throw TypeError(`Accessor not expected at ${path}`);
     }
     return (
       isAllowedPropertyValue(`${path}<get>`, desc.get, prop, permit.get) &&

--- a/packages/ses/test/check-intrinsics.js
+++ b/packages/ses/test/check-intrinsics.js
@@ -7,7 +7,7 @@
 export function checkIntrinsics(intrinsics) {
   Object.keys(intrinsics).forEach(name => {
     if (intrinsics[name] === undefined) {
-      throw new TypeError(`Malformed intrinsic: ${name}`);
+      throw TypeError(`Malformed intrinsic: ${name}`);
     }
   });
 }

--- a/packages/ses/test/console-error-trap/hazard.js
+++ b/packages/ses/test/console-error-trap/hazard.js
@@ -1,5 +1,5 @@
 /* global setImmediate */
 setImmediate(() => {
-  throw new Error('I am once again throwing an error');
+  throw Error('I am once again throwing an error');
 });
-throw new Error('Shibboleth');
+throw Error('Shibboleth');

--- a/packages/ses/test/console-rejection-trap/hazard.js
+++ b/packages/ses/test/console-rejection-trap/hazard.js
@@ -1,5 +1,5 @@
 /* global setImmediate */
 setImmediate(() => {
-  Promise.reject(new Error('I am once again rejecting with an error'));
+  Promise.reject(Error('I am once again rejecting with an error'));
 });
-Promise.reject(new Error('Shibboleth'));
+Promise.reject(Error('Shibboleth'));

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -11,7 +11,7 @@ test('throwsAndLogs with data', t => {
     t,
     () => {
       console.error('what', obj);
-      throw new TypeError('foo');
+      throw TypeError('foo');
     },
     /foo/,
     [
@@ -23,7 +23,7 @@ test('throwsAndLogs with data', t => {
     t,
     () => {
       console.error('what', obj);
-      throw new TypeError('foo');
+      throw TypeError('foo');
     },
     /foo/,
     [
@@ -37,12 +37,12 @@ test('throwsAndLogs with data', t => {
 });
 
 test('throwsAndLogs with error', t => {
-  const err = new EvalError('bar');
+  const err = EvalError('bar');
   throwsAndLogs(
     t,
     () => {
       console.warn('what', err);
-      throw new URIError('foo');
+      throw URIError('foo');
     },
     /foo/,
     [
@@ -83,7 +83,7 @@ test('causal tree', t => {
   throwsAndLogs(
     t,
     () => {
-      const fooErr = new SyntaxError('foo');
+      const fooErr = SyntaxError('foo');
       let err1;
       try {
         assert.fail(d`synful ${fooErr}`);
@@ -98,7 +98,7 @@ test('causal tree', t => {
   throwsAndLogs(
     t,
     () => {
-      const fooErr = new SyntaxError('foo');
+      const fooErr = SyntaxError('foo');
       let err1;
       try {
         assert.fail(d`synful ${fooErr}`);
@@ -152,7 +152,7 @@ test('a causal tree falls silently', t => {
   assertLogs(
     t,
     () => {
-      const fooErr = new SyntaxError('foo');
+      const fooErr = SyntaxError('foo');
       let err1;
       try {
         assert.fail(d`synful ${fooErr}`);
@@ -170,7 +170,7 @@ test('a causal tree falls silently', t => {
   assertLogs(
     t,
     () => {
-      const fooErr = new SyntaxError('foo');
+      const fooErr = SyntaxError('foo');
       let err1;
       try {
         assert.fail(d`synful ${fooErr}`);

--- a/packages/ses/test/error/test-tame-console-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unfilteredError.js
@@ -43,7 +43,7 @@ test('console', t => {
 test('assert - safe', t => {
   try {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
@@ -54,15 +54,15 @@ test('assert - safe', t => {
 test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   });
 });
 
 test('tameConsole - safe', t => {
   const obj = {};
-  const fooErr = new SyntaxError('foo');
-  const barErr = new URIError('bar');
+  const fooErr = SyntaxError('foo');
+  const barErr = URIError('bar');
   assert.note(barErr, d`caused by ${fooErr},${obj}`);
   console.log('bar happens', barErr);
   t.pass();
@@ -70,8 +70,8 @@ test('tameConsole - safe', t => {
 
 test('tameConsole - unlogged safe', t => {
   const obj = {};
-  const ufooErr = new SyntaxError('ufoo');
-  const ubarErr = new URIError('ubar');
+  const ufooErr = SyntaxError('ufoo');
+  const ubarErr = URIError('ubar');
   assert.note(ubarErr, d`caused by ${ufooErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/test-tame-console-unsafe-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unfilteredError.js
@@ -50,7 +50,7 @@ test('console', t => {
 test('assert - unsafe', t => {
   try {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
@@ -61,15 +61,15 @@ test('assert - unsafe', t => {
 test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   });
 });
 
 test('tameConsole - unsafe', t => {
   const obj = {};
-  const faaErr = new TypeError('faa');
-  const borErr = new ReferenceError('bor');
+  const faaErr = TypeError('faa');
+  const borErr = ReferenceError('bor');
   assert.note(borErr, d`caused by ${faaErr},${obj}`);
   console.log('bor happens', borErr);
   t.pass();
@@ -77,8 +77,8 @@ test('tameConsole - unsafe', t => {
 
 test('tameConsole - unlogged unsafe', t => {
   const obj = {};
-  const ufaaErr = new TypeError('ufaa');
-  const uborErr = new ReferenceError('ubor');
+  const ufaaErr = TypeError('ufaa');
+  const uborErr = ReferenceError('ubor');
   assert.note(uborErr, d`caused by ${ufaaErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/test-tame-console-unsafe-unsafeError-unfilteredError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unsafeError-unfilteredError.js
@@ -52,7 +52,7 @@ test('console', t => {
 test('assert - unsafe', t => {
   try {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
@@ -63,15 +63,15 @@ test('assert - unsafe', t => {
 test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   });
 });
 
 test('tameConsole - unsafe', t => {
   const obj = {};
-  const faaErr = new TypeError('faa');
-  const borErr = new ReferenceError('bor');
+  const faaErr = TypeError('faa');
+  const borErr = ReferenceError('bor');
   assert.note(borErr, d`caused by ${faaErr},${obj}`);
   console.log('bor happens', borErr);
   t.pass();
@@ -79,8 +79,8 @@ test('tameConsole - unsafe', t => {
 
 test('tameConsole - unlogged unsafe', t => {
   const obj = {};
-  const ufaaErr = new TypeError('ufaa');
-  const uborErr = new ReferenceError('ubor');
+  const ufaaErr = TypeError('ufaa');
+  const uborErr = ReferenceError('ubor');
   assert.note(uborErr, d`caused by ${ufaaErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/test-tame-console-unsafe-unsafeError.js
+++ b/packages/ses/test/error/test-tame-console-unsafe-unsafeError.js
@@ -51,7 +51,7 @@ test('console', t => {
 test('assert - unsafe', t => {
   try {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
@@ -62,15 +62,15 @@ test('assert - unsafe', t => {
 test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   });
 });
 
 test('tameConsole - unsafe', t => {
   const obj = {};
-  const faaErr = new TypeError('faa');
-  const borErr = new ReferenceError('bor');
+  const faaErr = TypeError('faa');
+  const borErr = ReferenceError('bor');
   assert.note(borErr, d`caused by ${faaErr},${obj}`);
   console.log('bor happens', borErr);
   t.pass();
@@ -78,8 +78,8 @@ test('tameConsole - unsafe', t => {
 
 test('tameConsole - unlogged unsafe', t => {
   const obj = {};
-  const ufaaErr = new TypeError('ufaa');
-  const uborErr = new ReferenceError('ubor');
+  const ufaaErr = TypeError('ufaa');
+  const uborErr = ReferenceError('ubor');
   assert.note(uborErr, d`caused by ${ufaaErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/test-tame-console-unsafe.js
+++ b/packages/ses/test/error/test-tame-console-unsafe.js
@@ -47,7 +47,7 @@ test('console', t => {
 test('assert - unsafe', t => {
   try {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
@@ -58,15 +58,15 @@ test('assert - unsafe', t => {
 test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   });
 });
 
 test('tameConsole - unsafe', t => {
   const obj = {};
-  const faaErr = new TypeError('faa');
-  const borErr = new ReferenceError('bor');
+  const faaErr = TypeError('faa');
+  const borErr = ReferenceError('bor');
   assert.note(borErr, d`caused by ${faaErr},${obj}`);
   console.log('bor happens', borErr);
   t.pass();
@@ -74,8 +74,8 @@ test('tameConsole - unsafe', t => {
 
 test('tameConsole - unlogged unsafe', t => {
   const obj = {};
-  const ufaaErr = new TypeError('ufaa');
-  const uborErr = new ReferenceError('ubor');
+  const ufaaErr = TypeError('ufaa');
+  const uborErr = ReferenceError('ubor');
   assert.note(uborErr, d`caused by ${ufaaErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/test-tame-console-unsafeError.js
+++ b/packages/ses/test/error/test-tame-console-unsafeError.js
@@ -44,7 +44,7 @@ test('console', t => {
 test('assert - safe', t => {
   try {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
@@ -55,15 +55,15 @@ test('assert - safe', t => {
 test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   });
 });
 
 test('tameConsole - safe', t => {
   const obj = {};
-  const fooErr = new SyntaxError('foo');
-  const barErr = new URIError('bar');
+  const fooErr = SyntaxError('foo');
+  const barErr = URIError('bar');
   assert.note(barErr, d`caused by ${fooErr},${obj}`);
   console.log('bar happens', barErr);
   t.pass();
@@ -71,8 +71,8 @@ test('tameConsole - safe', t => {
 
 test('tameConsole - unlogged safe', t => {
   const obj = {};
-  const ufooErr = new SyntaxError('ufoo');
-  const ubarErr = new URIError('ubar');
+  const ufooErr = SyntaxError('ufoo');
+  const ubarErr = URIError('ubar');
   assert.note(ubarErr, d`caused by ${ufooErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/test-tame-console.js
+++ b/packages/ses/test/error/test-tame-console.js
@@ -51,7 +51,7 @@ test('console', t => {
 test('assert - safe', t => {
   try {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
@@ -66,7 +66,7 @@ test('assert - safe', t => {
 test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
-    const fooErr = new SyntaxError('foo');
+    const fooErr = SyntaxError('foo');
     assert.fail(d`caused by ${fooErr},${obj}`);
   });
 });
@@ -80,8 +80,8 @@ test('assert - unlogged safe', t => {
 // annotations and each of the errors in their detail's substitution values.
 test('tameConsole - safe', t => {
   const obj = {};
-  const fooErr = new SyntaxError('foo');
-  const barErr = new URIError('bar');
+  const fooErr = SyntaxError('foo');
+  const barErr = URIError('bar');
   assert.note(barErr, d`caused by ${fooErr},${obj}`);
   console.log('bar happens', barErr);
   t.pass();
@@ -91,8 +91,8 @@ test('tameConsole - safe', t => {
 // annotated error is never logged.
 test('tameConsole - unlogged safe', t => {
   const obj = {};
-  const ufooErr = new SyntaxError('ufoo');
-  const ubarErr = new URIError('ubar');
+  const ufooErr = SyntaxError('ufoo');
+  const ubarErr = URIError('ubar');
   assert.note(ubarErr, d`caused by ${ufooErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/test-tame-v8-error-unit.js
+++ b/packages/ses/test/error/test-tame-v8-error-unit.js
@@ -8,7 +8,7 @@ test('tameErrorConstructor', t => {
     t.is(typeof InitialError.stackTraceLimit, 'number');
     InitialError.stackTraceLimit = 11;
     t.is(InitialError.stackTraceLimit, 11);
-    const error = new InitialError();
+    const error = InitialError();
     t.is(typeof error.stack, 'string');
     InitialError.captureStackTrace(error);
     t.is(typeof error.stack, 'string');

--- a/packages/ses/test/error/test-tame-v8-error-unsafe.js
+++ b/packages/ses/test/error/test-tame-v8-error-unsafe.js
@@ -189,7 +189,7 @@ test('Error compatibility - depd', t => {
 // stack as a list of strings, by reading Error().stack
 function simulateCallstack() {
   function callstack() {
-    return new Error().stack.split('\n').splice(2);
+    return Error().stack.split('\n').splice(2);
   }
   function middle() {
     return callstack();
@@ -214,7 +214,7 @@ function simulateCallsite() {
   function callsite() {
     const orig = Error.prepareStackTrace;
     Error.prepareStackTrace = (_, stack) => stack;
-    const err = new Error();
+    const err = Error();
 
     // note: the upstream `callsite` library uses
     // `Error.captureStackTrace(err, arguments.callee);`
@@ -248,7 +248,7 @@ function simulateCallsites() {
   function callsites() {
     const orig = Error.prepareStackTrace;
     Error.prepareStackTrace = (_, stack) => stack;
-    const stack = new Error().stack.slice(1);
+    const stack = Error().stack.slice(1);
     Error.prepareStackTrace = orig;
     return stack;
   }
@@ -268,12 +268,12 @@ test('Error compatibility - callsites', t => {
 test('Error compatibility - save and restore prepareStackTrace', t => {
   const pst1 = (_err, _sst) => 'x';
   Error.prepareStackTrace = pst1;
-  t.is(new Error().stack, 'x');
+  t.is(Error().stack, 'x');
   const pst2 = Error.prepareStackTrace;
   t.not(pst1, pst2);
   t.is(pst2({}, []), 'x');
   Error.prepareStackTrace = pst2;
-  t.is(new Error().stack, 'x');
+  t.is(Error().stack, 'x');
   const pst3 = Error.prepareStackTrace;
   t.is(pst2, pst3);
 });

--- a/packages/ses/test/error/test-tame-v8-error.js
+++ b/packages/ses/test/error/test-tame-v8-error.js
@@ -6,19 +6,19 @@ lockdown();
 test('lockdown Error is safe', t => {
   t.is(typeof Error.captureStackTrace, 'function');
   t.is(typeof Error.stackTraceLimit, 'number');
-  t.is(typeof new Error().stack, 'string');
+  t.is(typeof Error().stack, 'string');
 });
 
 test('lockdown Error in Compartment is safe', t => {
   const c = new Compartment();
   t.is(c.evaluate('typeof Error.captureStackTrace'), 'function');
   t.is(c.evaluate('typeof Error.stackTraceLimit'), 'undefined');
-  t.is(c.evaluate('typeof new Error().stack'), 'string');
+  t.is(c.evaluate('typeof Error().stack'), 'string');
 });
 
 test('lockdown Error in nested Compartment is safe', t => {
   const c = new Compartment().evaluate('new Compartment()');
   t.is(c.evaluate('typeof Error.captureStackTrace'), 'function');
   t.is(c.evaluate('typeof Error.stackTraceLimit'), 'undefined');
-  t.is(c.evaluate('typeof new Error().stack'), 'string');
+  t.is(c.evaluate('typeof Error().stack'), 'string');
 });

--- a/packages/ses/test/error/throws-and-logs.js
+++ b/packages/ses/test/error/throws-and-logs.js
@@ -129,7 +129,7 @@ export const assertLogs = freeze((t, thunk, goldenLog, options = {}) => {
 // args. For example, if the code being tested does
 // ```js
 // console.error('what ', err);
-// throw new Error('foo');
+// throw Error('foo');
 // ```
 // the test code might check for exactly that with
 // ```js

--- a/packages/ses/test/import-commons.js
+++ b/packages/ses/test/import-commons.js
@@ -10,7 +10,7 @@ export const makeStaticRetriever = sources => {
   return async moduleLocation => {
     const string = sources[moduleLocation];
     if (string === undefined) {
-      throw new ReferenceError(
+      throw ReferenceError(
         `Cannot retrieve module at location ${q(moduleLocation)}.`,
       );
     }

--- a/packages/ses/test/no-eval.js
+++ b/packages/ses/test/no-eval.js
@@ -3,5 +3,5 @@
 // the time of SES initialization.
 // eslint-disable-next-line no-eval
 globalThis.eval = _source => {
-  throw new TypeError('no unsafe-eval, as if by content-security-policy');
+  throw TypeError('no unsafe-eval, as if by content-security-policy');
 };

--- a/packages/ses/test/test-compartment.js
+++ b/packages/ses/test/test-compartment.js
@@ -92,7 +92,7 @@ test('main use case', t => {
    */
   function attenuate(arg) {
     if (arg <= 0) {
-      throw new TypeError('only positive numbers');
+      throw TypeError('only positive numbers');
     }
     return power(arg);
   }

--- a/packages/ses/test/test-console-rejection-trap.js
+++ b/packages/ses/test/test-console-rejection-trap.js
@@ -89,8 +89,7 @@ test('rejections are uncaught exceptions with unhandledRejectionTrapping: none',
         'if Node 14, exit 0 and print UnhandledPromiseRejectionWarning',
       );
       t.assert(
-        code !== 1 ||
-          stderr.includes("Promise.reject(new Error('Shibboleth'));"),
+        code !== 1 || stderr.includes("Promise.reject(Error('Shibboleth'));"),
         'if Node 16, exit 1 and print the rejection code',
       );
       t.assert(

--- a/packages/ses/test/test-enable-property-overrides-default-unsafeError.js
+++ b/packages/ses/test/test-enable-property-overrides-default-unsafeError.js
@@ -5,14 +5,14 @@ import { overrideTester } from './override-tester.js';
 lockdown({ errorTaming: 'unsafe', __hardenTaming__: 'safe' });
 
 test('property overrides default with unsafe errorTaming', t => {
-  overrideTester(t, 'Error', new Error(), [
+  overrideTester(t, 'Error', Error(), [
     'constructor',
     'message',
     'name',
     'toString',
     'stack',
   ]);
-  overrideTester(t, 'TypeError', new TypeError(), [
+  overrideTester(t, 'TypeError', TypeError(), [
     'constructor',
     'message',
     'name',

--- a/packages/ses/test/test-enable-property-overrides-default.js
+++ b/packages/ses/test/test-enable-property-overrides-default.js
@@ -15,14 +15,14 @@ test('enablePropertyOverrides - on', t => {
     'bind',
     'toString',
   ]);
-  overrideTester(t, 'Error', new Error(), [
+  overrideTester(t, 'Error', Error(), [
     'constructor',
     'message',
     'name',
     'toString',
     'stack',
   ]);
-  overrideTester(t, 'TypeError', new TypeError(), [
+  overrideTester(t, 'TypeError', TypeError(), [
     'constructor',
     'message',
     'name',

--- a/packages/ses/test/test-enable-property-overrides-min-unsafeError.js
+++ b/packages/ses/test/test-enable-property-overrides-min-unsafeError.js
@@ -9,6 +9,6 @@ lockdown({
 });
 
 test('property overrides min with unsafe errorTaming', t => {
-  overrideTester(t, 'Error', new Error(), ['name', 'stack']);
-  overrideTester(t, 'TypeError', new TypeError(), ['stack']);
+  overrideTester(t, 'Error', Error(), ['name', 'stack']);
+  overrideTester(t, 'TypeError', TypeError(), ['stack']);
 });

--- a/packages/ses/test/test-enable-property-overrides-min.js
+++ b/packages/ses/test/test-enable-property-overrides-min.js
@@ -11,5 +11,5 @@ lockdown({
 test('enablePropertyOverrides - on', t => {
   overrideTester(t, 'Object', {}, ['toString']);
   overrideTester(t, 'Function', () => {}, ['toString']);
-  overrideTester(t, 'Error', new Error(), ['name', 'stack']);
+  overrideTester(t, 'Error', Error(), ['name', 'stack']);
 });

--- a/packages/ses/test/test-import-cjs.js
+++ b/packages/ses/test/test-import-cjs.js
@@ -27,12 +27,12 @@ function heuristicAnalysis(moduleSource) {
 
 const CjsStaticModuleRecord = (moduleSource, moduleLocation) => {
   if (typeof moduleSource !== 'string') {
-    throw new TypeError(
+    throw TypeError(
       `Cannot create CommonJS static module record, module source must be a string, got ${moduleSource}`,
     );
   }
   if (typeof moduleLocation !== 'string') {
-    throw new TypeError(
+    throw TypeError(
       `Cannot create CommonJS static module record, module location must be a string, got ${moduleLocation}`,
     );
   }
@@ -141,7 +141,7 @@ test('CommonJS module imports CommonJS module by name', async t => {
         'https://example.com/odd.js',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -175,7 +175,7 @@ test('CommonJS module imports CommonJS module as default', async t => {
         'https://example.com/odd.js',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -208,7 +208,7 @@ test('ESM imports CommonJS module as default', async t => {
         'https://example.com/odd',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -242,7 +242,7 @@ test('ESM imports CommonJS module as star', async t => {
         'https://example.com/odd',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -278,7 +278,7 @@ test('ESM imports CommonJS module with replaced exports as star', async t => {
         'https://example.com/odd',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -312,7 +312,7 @@ test('ESM imports CommonJS module by name', async t => {
         'https://example.com/odd',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -346,7 +346,7 @@ test('CommonJS module imports ESM as default', async t => {
         'https://example.com/odd',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -382,7 +382,7 @@ test('CommonJS module imports ESM by name', async t => {
         'https://example.com/odd',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -437,7 +437,7 @@ test('cross import ESM and CommonJS modules', async t => {
         'https://example.com/src/default.js',
       );
     }
-    throw new Error(`Cannot load module for specifier ${specifier}`);
+    throw Error(`Cannot load module for specifier ${specifier}`);
   };
 
   const compartment = new Compartment({ t }, {}, { resolveHook, importHook });
@@ -478,7 +478,7 @@ test('live bindings through through an ESM between CommonJS modules', async t =>
         'https://example.com/src/value.js',
       );
     }
-    throw new Error(`Cannot load module for specifier ${specifier}`);
+    throw Error(`Cannot load module for specifier ${specifier}`);
   };
 
   const compartment = new Compartment({ t }, {}, { resolveHook, importHook });
@@ -511,7 +511,7 @@ test('export name as default from CommonJS module', async t => {
         'https://example.com/main.js',
       );
     }
-    throw new Error(`Cannot load module for specifier ${specifier}`);
+    throw Error(`Cannot load module for specifier ${specifier}`);
   };
 
   const compartment = new Compartment(

--- a/packages/ses/test/test-import-gauntlet.js
+++ b/packages/ses/test/test-import-gauntlet.js
@@ -306,7 +306,7 @@ test.failing('reexport with implicit default syntax', async t => {
       export default 3791;
     `,
     'https://example.com/reexport.js': `
-      export a, { default as b } from './qwe.js'; 
+      export a, { default as b } from './qwe.js';
     `,
     'https://example.com/main.js': `
       import { a, b } from './reexport.js';
@@ -378,7 +378,7 @@ test('importHook returning a ModuleInstance with a precompiled functor', async t
       export const a = 0;
       export let b = 0;
       b = 666;
-      throw new Error('this should not run');
+      throw Error('this should not run');
     `,
     'https://example.com/main.js': `
       import { a, b } from './precompiled.js';

--- a/packages/ses/test/test-import-non-esm.js
+++ b/packages/ses/test/test-import-non-esm.js
@@ -51,7 +51,7 @@ test('non-ESM imports non-ESM by name', async t => {
         },
       };
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -87,7 +87,7 @@ test('non-ESM imports non-ESM as default', async t => {
         },
       };
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -122,7 +122,7 @@ test('ESM imports non-ESM as default', async t => {
         'https://example.com/odd',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -157,7 +157,7 @@ test('ESM imports non-ESM by name', async t => {
         'https://example.com/odd',
       );
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -192,7 +192,7 @@ test('non-ESM imports ESM as default', async t => {
         },
       };
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -227,7 +227,7 @@ test('non-ESM imports ESM by name', async t => {
         },
       };
     }
-    throw new Error(`Cannot load module ${specifier}`);
+    throw Error(`Cannot load module ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });
@@ -287,7 +287,7 @@ test('cross import ESM and non-ESMs', async t => {
         },
       };
     }
-    throw new Error(`Cannot load module for specifier ${specifier}`);
+    throw Error(`Cannot load module for specifier ${specifier}`);
   };
 
   const compartment = new Compartment({}, {}, { resolveHook, importHook });

--- a/packages/ses/test/test-import-stack-traces.js
+++ b/packages/ses/test/test-import-stack-traces.js
@@ -3,7 +3,7 @@ import '../index.js';
 import { resolveNode, makeNodeImporter } from './node.js';
 
 test('preserve file names in stack traces', async t => {
-  if (new Error().stack != null) {
+  if (Error().stack != null) {
     t.plan(1);
   } else {
     t.plan(0);
@@ -11,7 +11,7 @@ test('preserve file names in stack traces', async t => {
 
   const makeImportHook = makeNodeImporter({
     'https://example.com/packages/erroneous/main.js': `
-      throw new Error("threw an error");
+      throw Error("threw an error");
     `,
   });
 

--- a/packages/ses/test/test-import.js
+++ b/packages/ses/test/test-import.js
@@ -89,7 +89,7 @@ test('two compartments, three modules, one endowment', async t => {
   const makeImportHook = makeNodeImporter({
     'https://example.com/packages/example/half.js': `
       if (typeof double !== 'undefined') {
-        throw new Error('Unexpected leakage of double(n) endowment: ' + typeof double);
+        throw Error('Unexpected leakage of double(n) endowment: ' + typeof double);
       }
       export default 21;
     `,
@@ -448,7 +448,7 @@ test('module alias', async t => {
         return { record, specifier };
       }
     }
-    throw new Error(`Cannot find module ${specifier}`);
+    throw Error(`Cannot find module ${specifier}`);
   };
 
   const compartment = new Compartment(
@@ -507,7 +507,7 @@ test('import reflexive module alias', async t => {
         return { record, specifier };
       }
     }
-    throw new Error(`Cannot find module ${specifier}`);
+    throw Error(`Cannot find module ${specifier}`);
   };
 
   const moduleMapHook = specifier => {

--- a/packages/ses/test/test-repair-intrinsics.js
+++ b/packages/ses/test/test-repair-intrinsics.js
@@ -11,7 +11,7 @@ import {
 
 // eslint-disable-next-line no-eval
 if (!eval.toString().includes('native code')) {
-  throw new TypeError('Module "esm" enabled: aborting');
+  throw TypeError('Module "esm" enabled: aborting');
 }
 
 test('whitelistPrototypes - on', t => {

--- a/packages/ses/test/test-ses.js
+++ b/packages/ses/test/test-ses.js
@@ -147,7 +147,7 @@ test('main use case', t => {
    */
   function attenuate(arg) {
     if (arg <= 0) {
-      throw new TypeError('only positive numbers');
+      throw TypeError('only positive numbers');
     }
     return power(arg);
   }

--- a/packages/ses/test/test-whitelist-intrinsics.js
+++ b/packages/ses/test/test-whitelist-intrinsics.js
@@ -4,7 +4,7 @@ import whitelistIntrinsics from '../src/whitelist-intrinsics.js';
 
 // eslint-disable-next-line no-eval
 if (!eval.toString().includes('native code')) {
-  throw new TypeError('Module "esm" enabled: aborting');
+  throw TypeError('Module "esm" enabled: aborting');
 }
 
 test('whitelistIntrinsics - Well-known symbols', t => {

--- a/packages/ses/test262/compartment-shim.js
+++ b/packages/ses/test262/compartment-shim.js
@@ -13,7 +13,7 @@ export default function patchFunctionConstructors() {
   Object.defineProperty(F.__proto__, 'constructor', {
     ...FC,
     value: function Function() {
-      throw new TypeError();
+      throw TypeError();
     },
   });
 

--- a/packages/ses/types.test-d.ts
+++ b/packages/ses/types.test-d.ts
@@ -197,7 +197,7 @@ expectType<void>(assume(false, 'definitely'));
 
 // ////////////////////////////////////////////////////////////////////////
 
-assert.note(new Error('nothing to see here'), X`except this ${q('detail')}`);
+assert.note(Error('nothing to see here'), X`except this ${q('detail')}`);
 
 X`canst thou string?`.toString();
 

--- a/packages/static-module-record/src/babelPlugin.js
+++ b/packages/static-module-record/src/babelPlugin.js
@@ -52,7 +52,7 @@ function makeModulePlugins(options) {
   } = options;
 
   if (sourceType !== 'module') {
-    throw new Error(`Module sourceType must be 'module'`);
+    throw Error(`Module sourceType must be 'module'`);
   }
 
   const updaterSources = Object.create(null);

--- a/packages/static-module-record/src/static-module-record.js
+++ b/packages/static-module-record/src/static-module-record.js
@@ -41,7 +41,7 @@ const analyzeModule = makeModuleAnalyzer();
  */
 export function StaticModuleRecord(source, url) {
   if (new.target === undefined) {
-    throw new TypeError(
+    throw TypeError(
       "Class constructor StaticModuleRecord cannot be invoked without 'new'",
     );
   }

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -38,7 +38,7 @@ const makeCreateStaticRecord = transformSource =>
       scriptSource = transformSource(moduleSource, sourceOptions);
     } catch (err) {
       const moduleLocation = url ? JSON.stringify(url) : '<unknown>';
-      throw new SyntaxError(
+      throw SyntaxError(
         `Error transforming source in ${moduleLocation}: ${err.message}`,
         { cause: err },
       );

--- a/packages/static-module-record/src/transformSource.js
+++ b/packages/static-module-record/src/transformSource.js
@@ -14,7 +14,7 @@ const generateBabel = babelGenerate.default || babelGenerate;
 
 export const makeTransformSource = (makeModulePlugins, babel = null) => {
   if (babel !== null) {
-    throw new Error(
+    throw Error(
       `transform-analyze.js no longer allows injecting babel; use \`null\``,
     );
   }

--- a/packages/static-module-record/test/fixtures/large.js
+++ b/packages/static-module-record/test/fixtures/large.js
@@ -1,4 +1,4 @@
-/* eslint-disable */ 
+/* eslint-disable */
 console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
 
 import * as h from './hidden.js';
@@ -52,7 +52,7 @@ function makeModulePlugins(options) {
   } = options;
 
   if (sourceType !== 'module') {
-    throw new Error(`Module sourceType must be 'module'`);
+    throw Error(`Module sourceType must be 'module'`);
   }
 
   const updaterSources = Object.create(null);
@@ -289,11 +289,11 @@ function makeModulePlugins(options) {
               pathWithin.node.property.name === 'meta'
             ) {
             console.error('this works')
-              
+
                 pathWithin.replaceWithMultiple([
                   replace(pathWithin.node, hiddenIdentifier(h.HIDDEN_META)),
                 ]);
-              
+
             }
           },
         });

--- a/packages/static-module-record/test/fixtures/small.js
+++ b/packages/static-module-record/test/fixtures/small.js
@@ -1,4 +1,4 @@
-/* eslint-disable */ 
+/* eslint-disable */
 console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
 import * as babelParser from '@babel/parser';
 import babelGenerate from '@agoric/babel-generator';
@@ -18,7 +18,7 @@ const generateBabel = babelGenerate.default || babelGenerate;
 
 export const makeTransformSource = (babel = null) => {
   if (babel !== null) {
-    throw new Error(
+    throw Error(
       `transform-analyze.js no longer allows injecting babel; use \`null\``,
     );
   }

--- a/packages/stream-node/test/test-stream-node.js
+++ b/packages/stream-node/test/test-stream-node.js
@@ -161,7 +161,7 @@ test('stream writer abort', async (/** @type {import('ava').ExecutionContext} */
 
   const makeProducer = async () => {
     try {
-      await writer.throw(new Error('Abort'));
+      await writer.throw(Error('Abort'));
     } catch (error) {
       t.is(error.message, 'Abort');
     }

--- a/packages/stream-types-test/validation.ts
+++ b/packages/stream-types-test/validation.ts
@@ -103,13 +103,11 @@ async () => {
   const [reader, writer] = makePipe<number, string, boolean, Array<number>>();
   const a: IteratorResult<number, boolean> = await reader.next('A');
   const b: IteratorResult<number, boolean> = await reader.return([1, 2, 3]);
-  const c: IteratorResult<number, boolean> = await reader.throw(
-    new Error('Abort'),
-  );
+  const c: IteratorResult<number, boolean> = await reader.throw(Error('Abort'));
   const d: IteratorResult<string, Array<number>> = await writer.next(1);
   const e: IteratorResult<string, Array<number>> = await writer.return(true);
   const f: IteratorResult<string, Array<number>> = await writer.throw(
-    new Error('Abort'),
+    Error('Abort'),
   );
 };
 

--- a/packages/stream/test/test-map.js
+++ b/packages/stream/test/test-map.js
@@ -61,7 +61,7 @@ test('transcoding stream terminated with cause', async (/** @type {import('ava')
   );
 
   const makeProducer = async () => {
-    await produceTo.throw(new Error('Exit early'));
+    await produceTo.throw(Error('Exit early'));
   };
 
   const makeConsumer = async () => {

--- a/packages/stream/test/test-prime.js
+++ b/packages/stream/test/test-prime.js
@@ -38,7 +38,7 @@ test('prime empty throw in', async (/** @type {import('ava').ExecutionContext} *
 
   const iterator = prime(empty());
   try {
-    await iterator.throw(new Error('Abort'));
+    await iterator.throw(Error('Abort'));
     t.fail();
   } catch (error) {
     t.is(error.message, 'Abort');
@@ -57,14 +57,14 @@ test('prime single throw in', async (/** @type {import('ava').ExecutionContext} 
   }
 
   const iterator = prime(single());
-  const { done, value } = await iterator.throw(new Error('Abort'));
+  const { done, value } = await iterator.throw(Error('Abort'));
   t.is(done, true);
   t.is(value, 'Z');
 });
 
 test('prime single throw', async (/** @type {import('ava').ExecutionContext} */ t) => {
   async function* empty() {
-    throw new Error('Abort');
+    throw Error('Abort');
   }
 
   const iterator = prime(empty());
@@ -87,7 +87,7 @@ test('prime empty case', async (/** @type {import('ava').ExecutionContext} */ t)
 
 test('prime throw case', async (/** @type {import('ava').ExecutionContext} */ t) => {
   async function* temperamental() {
-    throw new Error('Abort');
+    throw Error('Abort');
   }
 
   const iterator = prime(temperamental());

--- a/packages/stream/test/test-pump.js
+++ b/packages/stream/test/test-pump.js
@@ -72,7 +72,7 @@ test('pump with error', async (/** @type {import('ava').ExecutionContext} */ t) 
       yield i;
     }
     yield* [4, 5, 6];
-    throw new Error('Abort');
+    throw Error('Abort');
   }
 
   const collected = [];
@@ -162,7 +162,7 @@ test('pump iterator protocol source next throws', async (/** @type {import('ava'
     /** @param {undefined} value */
     async next(value) {
       t.log(`->${value},`);
-      throw new Error('Abort');
+      throw Error('Abort');
     },
     /** @param {undefined} value */
     async return(value) {
@@ -238,7 +238,7 @@ test('pump iterator protocol target next throws', async (/** @type {import('ava'
     async next(value) {
       t.log(`<-${value},`);
       t.is(value, 0);
-      throw new Error('Abort');
+      throw Error('Abort');
     },
     /** @param {string} value */
     async return(value) {
@@ -296,7 +296,7 @@ test('pump iterator protocol target return throws', async (/** @type {import('av
     async return(value) {
       t.log(`<-${value}.`);
       t.is(value, 0);
-      throw new Error('Abort');
+      throw Error('Abort');
     },
     /** @param {Error} error */
     async throw(error) {

--- a/packages/stream/test/test-stream.js
+++ b/packages/stream/test/test-stream.js
@@ -44,7 +44,7 @@ test('stream terminated with cause', async (/** @type {import('ava').Assertions}
   const [consumeFrom, produceTo] = makePipe();
 
   const makeProducer = async () => {
-    await produceTo.throw(new Error('Exit early'));
+    await produceTo.throw(Error('Exit early'));
   };
 
   const makeConsumer = async () => {

--- a/packages/syrup/src/decode.js
+++ b/packages/syrup/src/decode.js
@@ -73,9 +73,7 @@ function isCanonicalZero64(bytes) {
  */
 function decodeAfterInteger(bytes, integer, start, end, name) {
   if (start >= end) {
-    throw new Error(
-      `Unexpected end of Syrup, expected integer suffix in ${name}`,
-    );
+    throw Error(`Unexpected end of Syrup, expected integer suffix in ${name}`);
   }
   const cc = bytes[start];
   if (cc === PLUS) {
@@ -86,7 +84,7 @@ function decodeAfterInteger(bytes, integer, start, end, name) {
   }
   if (cc === MINUS) {
     if (integer === 0n) {
-      throw new Error(`Unexpected non-canonical -0`);
+      throw Error(`Unexpected non-canonical -0`);
     }
     return {
       start: start + 1,
@@ -98,7 +96,7 @@ function decodeAfterInteger(bytes, integer, start, end, name) {
     const subStart = start;
     start += Number(integer);
     if (start > end) {
-      throw new Error(
+      throw Error(
         `Unexpected end of Syrup, expected ${integer} bytes after Syrup bytestring starting at index ${subStart} in ${name}`,
       );
     }
@@ -110,14 +108,14 @@ function decodeAfterInteger(bytes, integer, start, end, name) {
     const subStart = start;
     start += Number(integer);
     if (start > end) {
-      throw new Error(
+      throw Error(
         `Unexpected end of Syrup, expected ${integer} bytes after string starting at index ${subStart} in ${name}`,
       );
     }
     const value = textDecoder.decode(bytes.subarray(subStart, start));
     return { start, value };
   }
-  throw new Error(
+  throw Error(
     `Unexpected character ${JSON.stringify(
       String.fromCharCode(cc),
     )} at Syrup index ${start} of ${name}`,
@@ -149,7 +147,7 @@ function decodeArray(bytes, start, end, name) {
   const list = [];
   for (;;) {
     if (start >= end) {
-      throw new Error(
+      throw Error(
         `Unexpected end of Syrup, expected Syrup value or end of Syrup list marker "]" at index ${start} in ${name}`,
       );
     }
@@ -175,7 +173,7 @@ function decodeArray(bytes, start, end, name) {
  */
 function decodeString(bytes, start, end, name) {
   if (start >= end) {
-    throw new Error(
+    throw Error(
       `Unexpected end of Syrup, expected Syrup string at end of ${name}`,
     );
   }
@@ -184,7 +182,7 @@ function decodeString(bytes, start, end, name) {
 
   const cc = bytes[start];
   if (cc !== STRING_START) {
-    throw new Error(
+    throw Error(
       `Unexpected byte ${JSON.stringify(
         String.fromCharCode(cc),
       )}, Syrup dictionary keys must be strings or symbols at index ${start} of ${name}`,
@@ -195,7 +193,7 @@ function decodeString(bytes, start, end, name) {
   const subStart = start;
   start += Number(length);
   if (start > end) {
-    throw new Error(
+    throw Error(
       `Unexpected end of Syrup, expected ${length} bytes after index ${subStart} of ${name}`,
     );
   }
@@ -216,7 +214,7 @@ function decodeRecord(bytes, start, end, name) {
   let priorKeyEnd = -1;
   for (;;) {
     if (start >= end) {
-      throw new Error(
+      throw Error(
         `Unexpected end of Syrup, expected Syrup string or end of Syrup dictionary marker "}" at ${start} of ${name}`,
       );
     }
@@ -243,13 +241,13 @@ function decodeRecord(bytes, start, end, name) {
         keyEnd,
       );
       if (order === 0) {
-        throw new Error(
+        throw Error(
           `Syrup dictionary keys must be unique, got repeated ${JSON.stringify(
             key,
           )} at index ${start} of ${name}`,
         );
       } else if (order > 0) {
-        throw new Error(
+        throw Error(
           `Syrup dictionary keys must be in bytewise sorted order, got ${JSON.stringify(
             key,
           )} immediately after ${JSON.stringify(
@@ -285,7 +283,7 @@ function decodeFloat64(bytes, start, end, name) {
   const floatStart = start;
   start += 8;
   if (start > end) {
-    throw new Error(
+    throw Error(
       `Unexpected end of Syrup, expected 8 bytes of a 64 bit floating point number at index ${floatStart} of ${name}`,
     );
   }
@@ -295,16 +293,12 @@ function decodeFloat64(bytes, start, end, name) {
 
   if (value === 0) {
     if (!isCanonicalZero64(subarray)) {
-      throw new Error(
-        `Non-canonical zero at index ${floatStart} of Syrup ${name}`,
-      );
+      throw Error(`Non-canonical zero at index ${floatStart} of Syrup ${name}`);
     }
   }
   if (Number.isNaN(value)) {
     if (!isCanonicalNaN64(subarray)) {
-      throw new Error(
-        `Non-canonical NaN at index ${floatStart} of Syrup ${name}`,
-      );
+      throw Error(`Non-canonical NaN at index ${floatStart} of Syrup ${name}`);
     }
   }
 
@@ -320,7 +314,7 @@ function decodeFloat64(bytes, start, end, name) {
  */
 function decodeAny(bytes, start, end, name) {
   if (start >= end) {
-    throw new Error(
+    throw Error(
       `Unexpected end of Syrup, expected any value at index ${start} of ${name}`,
     );
   }
@@ -348,7 +342,7 @@ function decodeAny(bytes, start, end, name) {
   if (cc === FALSE) {
     return { start: start + 1, value: false };
   }
-  throw new Error(
+  throw Error(
     `Unexpected character ${JSON.stringify(
       String.fromCharCode(cc),
     )} at index ${start} of ${name}`,
@@ -365,13 +359,13 @@ function decodeAny(bytes, start, end, name) {
 export function decodeSyrup(bytes, options = {}) {
   const { start = 0, end = bytes.byteLength, name = '<unknown>' } = options;
   if (end > bytes.byteLength) {
-    throw new Error(
+    throw Error(
       `Cannot decode Syrup with with "end" beyond "bytes.byteLength", got ${end}, byteLength ${bytes.byteLength}`,
     );
   }
   const { start: next, value } = decodeAny(bytes, start, end, name);
   if (next !== end) {
-    throw new Error(
+    throw Error(
       `Unexpected trailing bytes after Syrup, length = ${end - next}`,
     );
   }

--- a/packages/syrup/src/encode.js
+++ b/packages/syrup/src/encode.js
@@ -211,7 +211,7 @@ function encodeAny(buffer, value, path) {
     return;
   }
 
-  throw new TypeError(`Cannot encode value ${value} at ${path}`);
+  throw TypeError(`Cannot encode value ${value} at ${path}`);
 }
 
 /**

--- a/packages/syrup/test/xorshift.js
+++ b/packages/syrup/test/xorshift.js
@@ -13,7 +13,7 @@
  */
 export function XorShift(seed) {
   if (!Array.isArray(seed) || seed.length !== 4) {
-    throw new TypeError('seed must be an array with 4 numbers');
+    throw TypeError('seed must be an array with 4 numbers');
   }
 
   // uint64_t s = [seed ...]

--- a/packages/zip/src/buffer-reader.js
+++ b/packages/zip/src/buffer-reader.js
@@ -61,10 +61,10 @@ export class BufferReader {
   set offset(offset) {
     const fields = privateFieldsGet(this);
     if (offset > fields.data.byteLength) {
-      throw new Error('Cannot set offset beyond length of underlying data');
+      throw Error('Cannot set offset beyond length of underlying data');
     }
     if (offset < 0) {
-      throw new Error('Cannot set negative offset');
+      throw Error('Cannot set negative offset');
     }
     fields.offset = offset;
     fields.length = fields.data.byteLength - fields.offset;
@@ -87,7 +87,7 @@ export class BufferReader {
   assertCanSeek(index) {
     const fields = privateFieldsGet(this);
     if (!this.canSeek(index)) {
-      throw new Error(
+      throw Error(
         `End of data reached (data length = ${fields.length}, asked index ${index}`,
       );
     }
@@ -249,7 +249,7 @@ export class BufferReader {
   assert(expected) {
     const fields = privateFieldsGet(this);
     if (!this.expect(expected)) {
-      throw new Error(
+      throw Error(
         `Expected ${q(expected)} at ${fields.index}, got ${this.peek(
           expected.length,
         )}`,

--- a/packages/zip/src/buffer-writer.js
+++ b/packages/zip/src/buffer-writer.js
@@ -18,7 +18,7 @@ const privateFields = new WeakMap();
 const getPrivateFields = self => {
   const fields = privateFields.get(self);
   if (!fields) {
-    throw new Error('BufferWriter fields are not initialized');
+    throw Error('BufferWriter fields are not initialized');
   }
   return fields;
 };

--- a/packages/zip/src/format-reader.js
+++ b/packages/zip/src/format-reader.js
@@ -124,16 +124,16 @@ function readCentralFileHeader(reader) {
   reader.skip(extraFieldsLength);
 
   if (headers.uncompressedLength === MAX_VALUE_32BITS) {
-    throw new Error('Cannot read Zip64');
+    throw Error('Cannot read Zip64');
   }
   if (headers.compressedLength === MAX_VALUE_32BITS) {
-    throw new Error('Cannot read Zip64');
+    throw Error('Cannot read Zip64');
   }
   if (fileStart === MAX_VALUE_32BITS) {
-    throw new Error('Cannot read Zip64');
+    throw Error('Cannot read Zip64');
   }
   if (diskNumberStart === MAX_VALUE_32BITS) {
-    throw new Error('Cannot read Zip64');
+    throw Error('Cannot read Zip64');
   }
 
   const comment = reader.read(commentLength);
@@ -169,7 +169,7 @@ function readCentralDirectory(reader, locator) {
   if (centralDirectoryRecords !== entries.length) {
     // We expected some records but couldn't find ANY.
     // This is really suspicious, as if something went wrong.
-    throw new Error(
+    throw Error(
       `Corrupted zip or bug: expected ${centralDirectoryRecords} records in central dir, got ${entries.length}`,
     );
   }
@@ -213,7 +213,7 @@ function readLocalFiles(reader, records) {
  */
 function readBlockEndOfCentral(reader) {
   if (!reader.expect(signature.CENTRAL_DIRECTORY_END)) {
-    throw new Error(
+    throw Error(
       'Corrupt zip file, or zip file containing an unsupported variable-width end-of-archive comment, or an unsupported zip file with 64 bit sizes',
     );
   }
@@ -258,7 +258,7 @@ function readEndOfCentralDirectoryRecord(reader) {
   // from the end.
   const centralDirectoryEnd = reader.length - 22;
   if (centralDirectoryEnd < 0) {
-    throw new Error('Corrupted zip: not enough content');
+    throw Error('Corrupted zip: not enough content');
   }
   reader.seek(centralDirectoryEnd);
   const locator = readBlockEndOfCentral(reader);
@@ -281,7 +281,7 @@ function readEndOfCentralDirectoryRecord(reader) {
     locator.centralDirectoryOffset === MAX_VALUE_32BITS;
 
   if (zip64) {
-    throw new Error('Cannot read Zip64');
+    throw Error('Cannot read Zip64');
   }
 
   const {
@@ -324,7 +324,7 @@ function checkRecords(centralRecord, localRecord, archiveName) {
   // We strike a compromise: the central directory name may vary from the local
   // name exactly and only by different slashes.
   if (centralName.replace(/\\/g, '/') !== localName) {
-    throw new Error(
+    throw Error(
       `Zip integrity error: central record file name ${q(
         centralName,
       )} must match local file name ${q(localName)} in archive ${q(
@@ -339,7 +339,7 @@ function checkRecords(centralRecord, localRecord, archiveName) {
    */
   function check(value, message) {
     if (!value) {
-      throw new Error(
+      throw Error(
         `Zip integrity error: ${message} for file ${q(
           localName,
         )} in archive ${q(archiveName)}`,
@@ -414,7 +414,7 @@ function recordToFile(centralRecord, localRecord) {
  */
 function decompressFile(file) {
   if (file.compressionMethod !== compression.STORE) {
-    throw new Error(
+    throw Error(
       `Cannot find decompressor for compression method ${q(
         file.compressionMethod,
       )} for file ${file.name}`,
@@ -463,7 +463,7 @@ export function readZip(reader, name = '<unknown>') {
     checkRecords(centralRecord, localRecord, name);
 
     if (isEncrypted(centralRecord.bitFlag)) {
-      throw new Error('Encrypted zip are not supported');
+      throw Error('Encrypted zip are not supported');
     }
 
     const isDir = (centralRecord.externalFileAttributes & 0x0010) !== 0;

--- a/packages/zip/src/reader.js
+++ b/packages/zip/src/reader.js
@@ -23,7 +23,7 @@ export class ZipReader {
   read(name) {
     const file = this.files.get(name);
     if (file === undefined) {
-      throw new Error(`Cannot find file ${name} in Zip file ${this.name}`);
+      throw Error(`Cannot find file ${name} in Zip file ${this.name}`);
     }
     return file.content;
   }

--- a/packages/zip/src/writer.js
+++ b/packages/zip/src/writer.js
@@ -28,7 +28,7 @@ export class ZipWriter {
   write(name, content, options = {}) {
     const { mode = 0o644, date = undefined, comment = '' } = options;
     if (!content) {
-      throw new Error(`ZipWriter write requires content for ${name}`);
+      throw Error(`ZipWriter write requires content for ${name}`);
     }
     this.files.set(name, {
       name,


### PR DESCRIPTION
A step towards turning on more `@jessie-check` directives. See https://github.com/Agoric/agoric-sdk/pull/3876 and https://github.com/Agoric/agoric-sdk/pull/5497

Jessie prohibits `new`. One trivial case of revising code to conform is to remove the `new` on calls to the `*Error(` constructors. For these specifically, their construct behavior is the same as their call behavior. This also gets rid of a bit of visual noise, make code a bit more readable.