### PR TITLE
feat(ses): allow new dispose symbols

### DIFF
--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -495,7 +495,9 @@ export const whitelist = {
   Symbol: {
     // Properties of the Symbol Constructor
     '[[Proto]]': '%FunctionPrototype%',
+    asyncDispose: 'symbol',
     asyncIterator: 'symbol',
+    dispose: 'symbol',
     for: fn,
     hasInstance: 'symbol',
     isConcatSpreadable: 'symbol',


### PR DESCRIPTION
Purposely making this change by itself, separate from addressing
https://github.com/endojs/endo/issues/1577 

Either one would solve the immediate problem, but both must happen. This PR is needed for SES programmer to use https://github.com/tc39/proposal-async-explicit-resource-management as intended.

(See also https://github.com/tc39/proposal-explicit-resource-management/pull/154 )