### PR TITLE
feat(compartment-mapper): throw error with context when requiring unresolved module

### DIFF
--- a/packages/compartment-mapper/src/parse-cjs-shared-export-wrapper.js
+++ b/packages/compartment-mapper/src/parse-cjs-shared-export-wrapper.js
@@ -132,6 +132,11 @@ export const wrap = ({
   });
 
   const require = (/** @type {string} */ importSpecifier) => {
+    if (!has(resolvedImports, importSpecifier)) {
+      throw new Error(
+        `Cannot find module "${importSpecifier}" in "${location}"`,
+      );
+    }
     const namespace = compartment.importNow(resolvedImports[importSpecifier]);
     // If you read this file carefully, you'll see it's not possible for a cjs module to not have the default anymore.
     // It's currently possible to require modules that were not created by this file though.


### PR DESCRIPTION
here is the error  before this change
```
➜ (cd trials/bify-simple && PERF_N=100 node ../../endo.js)
(TypeError#1)
TypeError#1: first argument of importNow() must be a string

  at nr (packages/perf/trials/bify-simple/node_modules/module-deps/index.js:307:21)
  at eval (packages/perf/trials/bify-simple/node_modules/resolve/lib/async.js:93:25)
  at eval (packages/perf/trials/bify-simple/node_modules/resolve/lib/async.js:32:18)
  at LOOP (node:fs:2624:14)
```
