### PR TITLE
fix(marshal): Avoid bigint literals for Google Apps Script compatibility

### DIFF
--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -208,7 +208,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
       }
       case 'bigint': {
         const str = String(passable);
-        return /** @type {bigint} */ (passable) < 0n ? str : `+${str}`;
+        return str.startsWith('-') ? str : `+${str}`;
       }
       case 'symbol': {
         assertPassableSymbol(passable);


### PR DESCRIPTION
Ref #1582

This doesn't fix the redefined issue, but hopefully does remove the incompatibility that originally prompted it.