### PR TITLE
fix(marshal): Add a smaller and more efficient passable encoding

### DIFF
--- a/packages/marshal/README.md
+++ b/packages/marshal/README.md
@@ -41,6 +41,25 @@ console.log(o1 === o2);
 // false
 ```
 
+Additionally, this module exports a `makePassableKit` function for encoding into
+and decoding from a directly-serialized format in which string comparison
+corresponds with arbitrary value comparison (cf.
+[Patterns: Rank order and key order](https://github.com/endojs/endo/blob/master/packages/patterns/README.md#rank-order-and-key-order).
+Rather than accepting `convertValToSlot` and `convertSlotToVal` functions and
+keeping a "slots" side table, `makePassableKit` expects
+{encode,decode}{Remotable,Promise,Error} functions that directly convert between
+instances of the respective pass styles and properly-formatted encodings
+(in which Remotable encodings start with "r", Promise encodings start with "?",
+Error encodings start with "!", and all other details are left to the provided
+functions).
+`makePassableKit` supports two variations of this format: "legacyOrdered" and
+"compactOrdered". The former is the default for historical reasons (see
+https://github.com/endojs/endo/pull/1594 for background) but the latter is
+preferred for its better handling of deep structure. The ordering guarantees are
+upheld within each format variation, but not across them (i.e., it is not
+correct to treat a string comparison of legacyOrdered vs. compactOrdered as a
+corresponding value comparison).
+
 ## Frozen Objects Only
 
 The entire object graph must be "hardened" (recursively frozen), such as done

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -7,6 +7,7 @@ export { stringify, parse } from './src/marshal-stringify.js';
 export { decodeToJustin } from './src/marshal-justin.js';
 
 export {
+  makePassableKit,
   makeEncodePassable,
   makeDecodePassable,
   isEncodedRemotable,

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -561,8 +561,8 @@ export const makeEncodePassable = (encodeOptions = {}) => {
     }
   };
   const encodePassable = xxx
-    ? // A leading "#" indicates the v2 encoding (with escaping in strings rather than arrays).
-      passable => `#${innerEncode(passable)}`
+    ? // A leading "~" indicates the v2 encoding (with escaping in strings rather than arrays).
+      passable => `~${innerEncode(passable)}`
     : innerEncode;
   return harden(encodePassable);
 };
@@ -654,8 +654,8 @@ export const makeDecodePassable = (decodeOptions = {}) => {
     return innerDecode;
   };
   const decodePassable = encoded => {
-    // A leading "#" indicates the v2 encoding (with escaping in strings rather than arrays).
-    if (encoded.startsWith('#')) {
+    // A leading "~" indicates the v2 encoding (with escaping in strings rather than arrays).
+    if (encoded.startsWith('~')) {
       const innerDecode = makeInnerDecode(
         decodeStringWithEscapes,
         decodeArrayWithoutEscapes,

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -272,7 +272,7 @@ const encodeCompactStringSuffix = str =>
  * @type {(encoded: string) => string}
  */
 const decodeCompactStringSuffix = encoded => {
-  return encoded.replace(/([!_])(.|\n)?/g, (esc, prefix, suffix) => {
+  return encoded.replace(/([\0-!_])(.|\n)?/g, (esc, prefix, suffix) => {
     switch (esc) {
       case '!_':
         return ' ';
@@ -284,7 +284,7 @@ const decodeCompactStringSuffix = encoded => {
         return '_';
       default: {
         const ch = /** @type {string} */ (suffix);
-        // The range of valid escapes is [(0x00+0x21)..(0x1F+0x21)], i.e.
+        // The range of valid `!`-escape suffixes is [(0x00+0x21)..(0x1F+0x21)], i.e.
         // [0x21..0x40] (U+0021 EXCLAMATION MARK to U+0040 COMMERCIAL AT).
         (prefix === '!' && suffix !== undefined && ch >= '!' && ch <= '@') ||
           Fail`invalid string escape: ${q(esc)}`;

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -250,28 +250,26 @@ stringEscapes['^'.charCodeAt(0)] = '_@';
 stringEscapes['_'.charCodeAt(0)] = '__';
 
 const encodeStringWithEscapes = str =>
-  `s${str.replaceAll(/[\0-!^_]/g, ch => stringEscapes[ch.charCodeAt(0)])}`;
+  `s${str.replace(/[\0-!^_]/g, ch => stringEscapes[ch.charCodeAt(0)])}`;
 const decodeStringWithEscapes = encoded => {
-  return encoded
-    .slice(1)
-    .replaceAll(/([!_])(.|\n)?/g, (esc, prefix, suffix) => {
-      switch (esc) {
-        case '!_':
-          return ' ';
-        case '!|':
-          return '!';
-        case '_@':
-          return '^';
-        case '__':
-          return '_';
-        default: {
-          const ch = /** @type {string} */ (suffix);
-          (prefix === '!' && ch >= '!' && ch <= '@') ||
-            Fail`invalid string escape: ${q(esc)}`;
-          return String.fromCharCode(ch.charCodeAt(0) - 0x21);
-        }
+  return encoded.slice(1).replace(/([!_])(.|\n)?/g, (esc, prefix, suffix) => {
+    switch (esc) {
+      case '!_':
+        return ' ';
+      case '!|':
+        return '!';
+      case '_@':
+        return '^';
+      case '__':
+        return '_';
+      default: {
+        const ch = /** @type {string} */ (suffix);
+        (prefix === '!' && ch >= '!' && ch <= '@') ||
+          Fail`invalid string escape: ${q(esc)}`;
+        return String.fromCharCode(ch.charCodeAt(0) - 0x21);
       }
-    });
+    }
+  });
 };
 
 const encodeStringWithoutEscapes = str => `s${str}`;

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -224,11 +224,140 @@ const decodeBigInt = encoded => {
   return n;
 };
 
-// `'\u0000'` is the terminator after elements.
-// `'\u0001'` is the backslash-like escape character, for
-// escaping both of these characters.
+// Escape all characters from U+0000 NULL to U+001F INFORMATION SEPARATOR ONE
+// like `!<character offset by 0x21>` to avoid JSON.stringify expansion to
+// `\uHHHH`, and specially escape U+0020 SPACE (the array element terminator)
+// as `!_` and U+0021 EXCLAMATION MARK (the escape prefix) as `!|`.
+// Relative lexicographic ordering is preserved by this mapping of any character
+// at or before `!` in the contiguous range [0x00..0x21] to a respective
+// character in [0x21..0x40, 0x5F, 0x7C] preceded by `!` (which is itself in the
+// replaced range).
+// Similarly, escape `^` as `_@` and `_` as `__` because `^` indicates the start
+// of an encoded array.
+const stringEscapes = Array(0x22)
+  .fill(undefined)
+  .map((_, cp) => {
+    switch (String.fromCharCode(cp)) {
+      case ' ':
+        return '!_';
+      case '!':
+        return '!|';
+      default:
+        return `!${String.fromCharCode(cp + 0x21)}`;
+    }
+  });
+stringEscapes['^'.charCodeAt(0)] = '_@';
+stringEscapes['_'.charCodeAt(0)] = '__';
 
-const encodeArray = (array, encodePassable) => {
+const encodeStringWithEscapes = str =>
+  `s${str.replaceAll(/[\0-!^_]/g, ch => stringEscapes[ch.charCodeAt(0)])}`;
+const decodeStringWithEscapes = encoded => {
+  return encoded
+    .slice(1)
+    .replaceAll(/([!_])(.|\n)?/g, (esc, prefix, suffix) => {
+      switch (esc) {
+        case '!_':
+          return ' ';
+        case '!|':
+          return '!';
+        case '_@':
+          return '^';
+        case '__':
+          return '_';
+        default: {
+          const ch = /** @type {string} */ (suffix);
+          (prefix === '!' && ch >= '!' && ch <= '@') ||
+            Fail`invalid string escape: ${q(esc)}`;
+          return String.fromCharCode(ch.charCodeAt(0) - 0x21);
+        }
+      }
+    });
+};
+
+const encodeStringWithoutEscapes = str => `s${str}`;
+const decodeStringWithoutEscapes = encoded => encoded.slice(1);
+
+/**
+ * Encodes an array into a sequence of encoded elements, each terminated by a
+ * space (which is part of the escaped range in encoded strings).
+ *
+ * @param {unknown[]} array
+ * @param {(p: Passable) => string} encodePassable
+ * @returns {string}
+ */
+const encodeArrayWithoutEscapes = (array, encodePassable) => {
+  const chars = ['^'];
+  for (const element of array) {
+    const enc = encodePassable(element);
+    chars.push(enc, ' ');
+  }
+  return chars.join('');
+};
+
+/**
+ * @param {string} encoded
+ * @param {(encoded: string) => Passable} decodePassable
+ * @param {number} [skip]
+ * @returns {Array}
+ */
+const decodeArrayWithoutEscapes = (encoded, decodePassable, skip = 0) => {
+  const elements = [];
+  let depth = 0;
+  // Scan encoded rather than its tail to avoid slow `substring` in XS.
+  // https://github.com/endojs/endo/issues/1984
+  let nextIndex = skip + 1;
+  let currentElementStart = skip + 1;
+  for (const { 0: ch, index: i } of encoded.matchAll(/[\^ ]/g)) {
+    const index = /** @type {number} */ (i);
+    if (index <= skip) {
+      if (index === skip) {
+        ch === '^' || Fail`Encoded array expected: ${encoded.slice(skip)}`;
+      }
+    } else if (ch === '^') {
+      // This is the start of a nested array.
+      // TODO: Since the syntax of nested arrays must be validated as part of
+      // decoding the outer one, consider decoding them here into a shared cache
+      // rather than discarding information about their contents until the later
+      // decodePassable.
+      depth += 1;
+    } else {
+      // This is a terminated element.
+      if (index === nextIndex) {
+        // A terminator after `[` or an another terminator indicates that an array is done.
+        depth -= 1;
+        depth >= 0 ||
+          // prettier-ignore
+          Fail`unexpected array element terminator: ${encoded.slice(skip, index + 2)}`;
+      }
+      if (depth === 0) {
+        // We have a complete element of the topmost array.
+        elements.push(
+          decodePassable(encoded.slice(currentElementStart, index)),
+        );
+        currentElementStart = index + 1;
+      }
+    }
+    // Advance the index.
+    nextIndex = index + 1;
+  }
+  depth === 0 || Fail`unterminated array: ${encoded.slice(skip)}`;
+  nextIndex === encoded.length ||
+    Fail`unterminated array element: ${encoded.slice(currentElementStart)}`;
+  return harden(elements);
+};
+
+/**
+ * Performs the original array encoding, which escapes all array elements rather
+ * than just strings (`\u0000` as the element terminator and `\u0001` as the
+ * escape prefix for `\u0000` or `\u0001`).
+ * This necessitated an undesirable amount of iteration and expansion; see
+ * https://github.com/endojs/endo/pull/1260#discussion_r960369826
+ *
+ * @param {unknown[]} array
+ * @param {(p: Passable) => string} encodePassable
+ * @returns {string}
+ */
+const encodeArrayWithEscapes = (array, encodePassable) => {
   const chars = ['['];
   for (const element of array) {
     const enc = encodePassable(element);
@@ -249,7 +378,7 @@ const encodeArray = (array, encodePassable) => {
  * @param {number} [skip]
  * @returns {Array}
  */
-const decodeArray = (encoded, decodePassable, skip = 0) => {
+const decodeArrayWithEscapes = (encoded, decodePassable, skip = 0) => {
   const elements = [];
   const elemChars = [];
   // Use a string iterator to avoid slow indexed access in XS.
@@ -287,13 +416,13 @@ const decodeArray = (encoded, decodePassable, skip = 0) => {
   return harden(elements);
 };
 
-const encodeRecord = (record, encodePassable) => {
+const encodeRecord = (record, encodeArray, encodePassable) => {
   const names = recordNames(record);
   const values = recordValues(record, names);
   return `(${encodeArray(harden([names, values]), encodePassable)}`;
 };
 
-const decodeRecord = (encoded, decodePassable) => {
+const decodeRecord = (encoded, decodeArray, decodePassable) => {
   assert(encoded.charAt(0) === '(');
   // Skip the "(" inside `decodeArray` to avoid slow `substring` in XS.
   // https://github.com/endojs/endo/issues/1984
@@ -312,10 +441,10 @@ const decodeRecord = (encoded, decodePassable) => {
   return record;
 };
 
-const encodeTagged = (tagged, encodePassable) =>
+const encodeTagged = (tagged, encodeArray, encodePassable) =>
   `:${encodeArray(harden([getTag(tagged), tagged.payload]), encodePassable)}`;
 
-const decodeTagged = (encoded, decodePassable) => {
+const decodeTagged = (encoded, decodeArray, decodePassable) => {
   assert(encoded.charAt(0) === ':');
   // Skip the ":" inside `decodeArray` to avoid slow `substring` in XS.
   // https://github.com/endojs/endo/issues/1984
@@ -341,6 +470,7 @@ const decodeTagged = (encoded, decodePassable) => {
  *   error: Error,
  *   encodeRecur: (p: Passable) => string,
  * ) => string} [encodeError]
+ * @property {boolean} [xxx]
  */
 
 /**
@@ -352,11 +482,17 @@ export const makeEncodePassable = (encodeOptions = {}) => {
     encodeRemotable = (rem, _) => Fail`remotable unexpected: ${rem}`,
     encodePromise = (prom, _) => Fail`promise unexpected: ${prom}`,
     encodeError = (err, _) => Fail`error unexpected: ${err}`,
+    xxx = false,
   } = encodeOptions;
 
-  const encodePassable = passable => {
+  const encodeString = xxx
+    ? encodeStringWithEscapes
+    : encodeStringWithoutEscapes;
+  const encodeArray = xxx ? encodeArrayWithoutEscapes : encodeArrayWithEscapes;
+
+  const innerEncode = passable => {
     if (isErrorLike(passable)) {
-      return encodeError(passable, encodePassable);
+      return encodeError(passable, innerEncode);
     }
     const passStyle = passStyleOf(passable);
     switch (passStyle) {
@@ -370,7 +506,7 @@ export const makeEncodePassable = (encodeOptions = {}) => {
         return encodeBinary64(passable);
       }
       case 'string': {
-        return `s${passable}`;
+        return encodeString(passable);
       }
       case 'boolean': {
         return `b${passable}`;
@@ -379,40 +515,45 @@ export const makeEncodePassable = (encodeOptions = {}) => {
         return encodeBigInt(passable);
       }
       case 'remotable': {
-        const result = encodeRemotable(passable, encodePassable);
+        const result = encodeRemotable(passable, innerEncode);
         result.charAt(0) === 'r' ||
           Fail`internal: Remotable encoding must start with "r": ${result}`;
         return result;
       }
       case 'error': {
-        const result = encodeError(passable, encodePassable);
+        const result = encodeError(passable, innerEncode);
         result.charAt(0) === '!' ||
           Fail`internal: Error encoding must start with "!": ${result}`;
         return result;
       }
       case 'promise': {
-        const result = encodePromise(passable, encodePassable);
+        const result = encodePromise(passable, innerEncode);
         result.charAt(0) === '?' ||
           Fail`internal: Promise encoding must start with "?": ${result}`;
         return result;
       }
       case 'symbol': {
-        return `y${nameForPassableSymbol(passable)}`;
+        const encName = encodeString(nameForPassableSymbol(passable));
+        return `y${encName.slice(1)}`;
       }
       case 'copyArray': {
-        return encodeArray(passable, encodePassable);
+        return encodeArray(passable, innerEncode);
       }
       case 'copyRecord': {
-        return encodeRecord(passable, encodePassable);
+        return encodeRecord(passable, encodeArray, innerEncode);
       }
       case 'tagged': {
-        return encodeTagged(passable, encodePassable);
+        return encodeTagged(passable, encodeArray, innerEncode);
       }
       default: {
         throw Fail`a ${q(passStyle)} cannot be used as a collection passable`;
       }
     }
   };
+  const encodePassable = xxx
+    ? // A leading "#" indicates the v2 encoding (with escaping in strings rather than arrays).
+      passable => `#${innerEncode(passable)}`
+    : innerEncode;
   return harden(encodePassable);
 };
 harden(makeEncodePassable);
@@ -444,57 +585,77 @@ export const makeDecodePassable = (decodeOptions = {}) => {
     decodeError = (err, _) => Fail`error unexpected: ${err}`,
   } = decodeOptions;
 
-  const decodePassable = encoded => {
-    switch (encoded.charAt(0)) {
-      case 'v': {
-        return null;
-      }
-      case 'z': {
-        return undefined;
-      }
-      case 'f': {
-        return decodeBinary64(encoded);
-      }
-      case 's': {
-        return encoded.substring(1);
-      }
-      case 'b': {
-        if (encoded === 'btrue') {
-          return true;
-        } else if (encoded === 'bfalse') {
-          return false;
+  const makeInnerDecode = (decodeString, decodeArray) => {
+    const innerDecode = encoded => {
+      switch (encoded.charAt(0)) {
+        case 'v': {
+          return null;
         }
-        throw Fail`expected encoded boolean to be "btrue" or "bfalse": ${encoded}`;
+        case 'z': {
+          return undefined;
+        }
+        case 'f': {
+          return decodeBinary64(encoded);
+        }
+        case 's': {
+          return decodeString(encoded);
+        }
+        case 'b': {
+          if (encoded === 'btrue') {
+            return true;
+          } else if (encoded === 'bfalse') {
+            return false;
+          }
+          throw Fail`expected encoded boolean to be "btrue" or "bfalse": ${encoded}`;
+        }
+        case 'n':
+        case 'p': {
+          return decodeBigInt(encoded);
+        }
+        case 'r': {
+          return decodeRemotable(encoded, innerDecode);
+        }
+        case '?': {
+          return decodePromise(encoded, innerDecode);
+        }
+        case '!': {
+          return decodeError(encoded, innerDecode);
+        }
+        case 'y': {
+          const name = decodeString(`s${encoded.slice(1)}`);
+          return passableSymbolForName(name);
+        }
+        case '[':
+        case '^': {
+          return decodeArray(encoded, innerDecode);
+        }
+        case '(': {
+          return decodeRecord(encoded, decodeArray, innerDecode);
+        }
+        case ':': {
+          return decodeTagged(encoded, decodeArray, innerDecode);
+        }
+        default: {
+          throw Fail`invalid database key: ${encoded}`;
+        }
       }
-      case 'n':
-      case 'p': {
-        return decodeBigInt(encoded);
-      }
-      case 'r': {
-        return decodeRemotable(encoded, decodePassable);
-      }
-      case '?': {
-        return decodePromise(encoded, decodePassable);
-      }
-      case '!': {
-        return decodeError(encoded, decodePassable);
-      }
-      case 'y': {
-        return passableSymbolForName(encoded.substring(1));
-      }
-      case '[': {
-        return decodeArray(encoded, decodePassable);
-      }
-      case '(': {
-        return decodeRecord(encoded, decodePassable);
-      }
-      case ':': {
-        return decodeTagged(encoded, decodePassable);
-      }
-      default: {
-        throw Fail`invalid database key: ${encoded}`;
-      }
+    };
+    return innerDecode;
+  };
+  const decodePassable = encoded => {
+    // A leading "#" indicates the v2 encoding (with escaping in strings rather than arrays).
+    if (encoded.startsWith('#')) {
+      const innerDecode = makeInnerDecode(
+        decodeStringWithEscapes,
+        decodeArrayWithoutEscapes,
+      );
+      return innerDecode(encoded.slice(1));
     }
+    const innerDecode = makeInnerDecode(
+      decodeStringWithoutEscapes,
+      decodeArrayWithEscapes,
+    );
+    return innerDecode(encoded);
   };
   return harden(decodePassable);
 };
@@ -508,11 +669,13 @@ harden(isEncodedRemotable);
 /**
  * @type {Record<PassStyle, string>}
  * The single prefix characters to be used for each PassStyle category.
- * `bigint` is a two character string because each of those characters
- * individually is a valid bigint prefix. `n` for "negative" and `p` for
- * "positive". The ordering of these prefixes is the same as the
- * rankOrdering of their respective PassStyles. This table is imported by
- * rankOrder.js for this purpose.
+ * `bigint` is a two-character string because each of those characters
+ * individually is a valid bigint prefix (`n` for "negative" and `p` for
+ * "positive"), and copyArray is a two-character string because one encoding
+ * prefixes arrays with `[` while the other uses `^` (which is prohibited from
+ * appearing in an encoded string).
+ * The ordering of these prefixes is the same as the rankOrdering of their
+ * respective PassStyles, and rankOrder.js imports the table for this purpose.
  *
  * In addition, `|` is the remotable->ordinal mapping prefix:
  * This is not used in covers but it is
@@ -525,7 +688,7 @@ export const passStylePrefixes = {
   copyRecord: '(',
   tagged: ':',
   promise: '?',
-  copyArray: '[',
+  copyArray: '[^',
   boolean: 'b',
   number: 'f',
   bigint: 'np',

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -257,9 +257,20 @@ const stringEscapes = Array(0x22)
 stringEscapes['^'.charCodeAt(0)] = '_@';
 stringEscapes['_'.charCodeAt(0)] = '__';
 
-const encodeStringWithEscapes = str =>
+/**
+ * Encodes a string with escape sequences for use in the "compactOrdered" format.
+ *
+ * @type {(str: string) => string}
+ */
+const encodeCompactString = str =>
   `s${str.replace(/[\0-!^_]/g, ch => stringEscapes[ch.charCodeAt(0)])}`;
-const decodeStringWithEscapes = encoded => {
+
+/**
+ * Decodes a string from the "compactOrdered" format.
+ *
+ * @type {(encoded: string) => string}
+ */
+const decodeCompactString = encoded => {
   return encoded.slice(1).replace(/([!_])(.|\n)?/g, (esc, prefix, suffix) => {
     switch (esc) {
       case '!_':
@@ -282,18 +293,30 @@ const decodeStringWithEscapes = encoded => {
   });
 };
 
-const encodeStringWithoutEscapes = str => `s${str}`;
-const decodeStringWithoutEscapes = encoded => encoded.slice(1);
+/**
+ * Encodes a string by simple prefixing for use in the "legacyOrdered" format.
+ *
+ * @type {(str: string) => string}
+ */
+const encodeLegacyString = str => `s${str}`;
 
 /**
- * Encodes an array into a sequence of encoded elements, each terminated by a
- * space (which is part of the escaped range in encoded strings).
+ * Decodes a string from the "legacyOrdered" format.
+ *
+ * @type {(encoded: string) => string}
+ */
+const decodeLegacyString = encoded => encoded.slice(1);
+
+/**
+ * Encodes an array into a sequence of encoded elements for use in the "compactOrdered"
+ * format, each terminated by a space (which is part of the escaped range in
+ * "compactOrdered" encoded strings).
  *
  * @param {unknown[]} array
  * @param {(p: Passable) => string} encodePassable
  * @returns {string}
  */
-const encodeArrayWithoutEscapes = (array, encodePassable) => {
+const encodeCompactArray = (array, encodePassable) => {
   const chars = ['^'];
   for (const element of array) {
     const enc = encodePassable(element);
@@ -308,7 +331,7 @@ const encodeArrayWithoutEscapes = (array, encodePassable) => {
  * @param {number} [skip]
  * @returns {Array}
  */
-const decodeArrayWithoutEscapes = (encoded, decodePassable, skip = 0) => {
+const decodeCompactArray = (encoded, decodePassable, skip = 0) => {
   const elements = [];
   let depth = 0;
   // Scan encoded rather than its tail to avoid slow `substring` in XS.
@@ -355,9 +378,9 @@ const decodeArrayWithoutEscapes = (encoded, decodePassable, skip = 0) => {
 };
 
 /**
- * Performs the original array encoding, which escapes all array elements rather
- * than just strings (`\u0000` as the element terminator and `\u0001` as the
- * escape prefix for `\u0000` or `\u0001`).
+ * Performs the original array encoding, which escapes all encoded array
+ * elements rather than just strings (`\u0000` as the element terminator and
+ * `\u0001` as the escape prefix for `\u0000` or `\u0001`).
  * This necessitated an undesirable amount of iteration and expansion; see
  * https://github.com/endojs/endo/pull/1260#discussion_r960369826
  *
@@ -365,7 +388,7 @@ const decodeArrayWithoutEscapes = (encoded, decodePassable, skip = 0) => {
  * @param {(p: Passable) => string} encodePassable
  * @returns {string}
  */
-const encodeArrayWithEscapes = (array, encodePassable) => {
+const encodeLegacyArray = (array, encodePassable) => {
   const chars = ['['];
   for (const element of array) {
     const enc = encodePassable(element);
@@ -386,7 +409,7 @@ const encodeArrayWithEscapes = (array, encodePassable) => {
  * @param {number} [skip]
  * @returns {Array}
  */
-const decodeArrayWithEscapes = (encoded, decodePassable, skip = 0) => {
+const decodeLegacyArray = (encoded, decodePassable, skip = 0) => {
   const elements = [];
   const elemChars = [];
   // Use a string iterator to avoid slow indexed access in XS.
@@ -493,7 +516,7 @@ const assertEncodedError = encoding => {
  *   error: Error,
  *   encodeRecur: (p: Passable) => string,
  * ) => string} [encodeError]
- * @property {boolean} [xxx]
+ * @property {'legacyOrdered' | 'compactOrdered'} [format]
  */
 
 /**
@@ -505,13 +528,23 @@ export const makeEncodePassable = (encodeOptions = {}) => {
     encodeRemotable = (rem, _) => Fail`remotable unexpected: ${rem}`,
     encodePromise = (prom, _) => Fail`promise unexpected: ${prom}`,
     encodeError = (err, _) => Fail`error unexpected: ${err}`,
-    xxx = false,
+    format = 'legacyOrdered',
   } = encodeOptions;
 
-  const encodeString = xxx
-    ? encodeStringWithEscapes
-    : encodeStringWithoutEscapes;
-  const encodeArray = xxx ? encodeArrayWithoutEscapes : encodeArrayWithEscapes;
+  let formatPrefix;
+  let encodeString;
+  let encodeArray;
+  if (format === 'legacyOrdered') {
+    formatPrefix = '';
+    encodeString = encodeLegacyString;
+    encodeArray = encodeLegacyArray;
+  } else if (format === 'compactOrdered') {
+    formatPrefix = '~';
+    encodeString = encodeCompactString;
+    encodeArray = encodeCompactArray;
+  } else {
+    Fail`Unrecognized format: ${q(format)}`;
+  }
 
   const innerEncode = passable => {
     if (isErrorLike(passable)) {
@@ -584,10 +617,7 @@ export const makeEncodePassable = (encodeOptions = {}) => {
       }
     }
   };
-  const encodePassable = xxx
-    ? // A leading "~" indicates the v2 encoding (with escaping in strings rather than arrays).
-      passable => `~${innerEncode(passable)}`
-    : innerEncode;
+  const encodePassable = passable => `${formatPrefix}${innerEncode(passable)}`;
   return harden(encodePassable);
 };
 harden(makeEncodePassable);
@@ -681,15 +711,12 @@ export const makeDecodePassable = (decodeOptions = {}) => {
     // A leading "~" indicates the v2 encoding (with escaping in strings rather than arrays).
     if (encoded.startsWith('~')) {
       const innerDecode = makeInnerDecode(
-        decodeStringWithEscapes,
-        decodeArrayWithoutEscapes,
+        decodeCompactString,
+        decodeCompactArray,
       );
       return innerDecode(encoded.slice(1));
     }
-    const innerDecode = makeInnerDecode(
-      decodeStringWithoutEscapes,
-      decodeArrayWithEscapes,
-    );
+    const innerDecode = makeInnerDecode(decodeLegacyString, decodeLegacyArray);
     return innerDecode(encoded);
   };
   return harden(decodePassable);

--- a/packages/marshal/test/test-encodePassable.js
+++ b/packages/marshal/test/test-encodePassable.js
@@ -70,7 +70,7 @@ const encodePassableInternal2 = makeEncodePassable({
   encodeRemotable: r => encodeThing('r', r),
   encodePromise: p => encodeThing('?', p),
   encodeError: er => encodeThing('!', er),
-  xxx: true,
+  format: 'compactOrdered',
 });
 
 const encodePassable = passable => {
@@ -92,6 +92,24 @@ const decodePassable = encoded => {
   resetCursors();
   return decodePassableInternal(encoded);
 };
+
+test('makeEncodePassable argument validation', t => {
+  t.notThrows(() => makeEncodePassable(), 'must accept zero arguments');
+  t.notThrows(() => makeEncodePassable({}), 'must accept empty options');
+  t.notThrows(
+    () => makeEncodePassable({ format: 'legacyOrdered' }),
+    'must accept format: "legacyOrdered"',
+  );
+  t.notThrows(
+    () => makeEncodePassable({ format: 'compactOrdered' }),
+    'must accept format: "compactOrdered"',
+  );
+  t.throws(
+    () => makeEncodePassable({ format: 'newHotness' }),
+    { message: /^Unrecognized format\b/ },
+    'must reject unknown format',
+  );
+});
 
 const { comparator: compareFull } = makeComparatorKit(compareRemotables);
 

--- a/packages/marshal/test/test-encodePassable.js
+++ b/packages/marshal/test/test-encodePassable.js
@@ -170,30 +170,19 @@ const orderInvariants = (x, y) => {
   }
 };
 
-test('Passables round-trip', async t => {
+const testRoundTrip = test.macro(async (t, encode) => {
   await fc.assert(
     fc.property(arbPassable, n => {
-      const en = encodePassable(n);
+      const en = encode(n);
       const rt = decodePassable(en);
-      const er = encodePassable(rt);
+      const er = encode(rt);
       t.is(en, er);
       t.is(compareFull(n, rt), 0);
     }),
   );
 });
-// TODO: Implement via macro
-// https://github.com/avajs/ava/blob/main/docs/01-writing-tests.md#reusing-test-logic-through-macros
-test('Small-encoded passables round-trip', async t => {
-  await fc.assert(
-    fc.property(arbPassable, n => {
-      const en = encodePassable2(n);
-      const rt = decodePassable(en);
-      const er = encodePassable2(rt);
-      t.is(en, er);
-      t.is(compareFull(n, rt), 0);
-    }),
-  );
-});
+test('original encoding round-trips', testRoundTrip, encodePassable);
+test('small encoding round-trips', testRoundTrip, encodePassable2);
 
 test('BigInt encoding comparison corresponds with numeric comparison', async t => {
   await fc.assert(

--- a/packages/marshal/test/test-encodePassable.js
+++ b/packages/marshal/test/test-encodePassable.js
@@ -133,10 +133,10 @@ const goldenPairs = harden([
 test('golden round trips', t => {
   for (const [k, e] of goldenPairs) {
     t.is(encodePassable(k), e, 'does k encode as expected');
-    t.is(encodePassable2(k), `#${e}`, 'does k small-encode as expected');
+    t.is(encodePassable2(k), `~${e}`, 'does k small-encode as expected');
     t.is(decodePassable(e), k, 'does the key round trip through the encoding');
     t.is(
-      decodePassable(`#${e}`),
+      decodePassable(`~${e}`),
       k,
       'does the small-encoded key round trip through the encoding',
     );


### PR DESCRIPTION
Fixes #1349

Open questions:
- [x] [**REJECTED**] Should we push for extra compactness, e.g. `bfalse` → `bf`/`btrue` → `bt` (booleans) and/or `p1:0` → `o` (0n)?
- [x] [**REJECTED**] Should we allow custom remotable/promise/error encoding to use sequences and/or characters that would not otherwise be allowed, such as raw control characters U+0000 through U+001F or raw string escape characters `!`/`_`?
- [x] [**REPLACE ALL C0 CONTROLS**] For that matter, should we replace the full U+0000 through U+001F range in strings, or just a subset? The full range is necessary if U+0020 SPACE is the array element separator, but that could alternatively be U+0009 TAB and escapes could be limited to code points at or before that. This is really a tradeoff around expectations of character frequency inside strings, limiting blowup when embedding encodings in JSON-serialized containers such as current CapData communication, and (to some extent) human comprehensibility. There's not really a performance difference and at most a linear compactness difference, so it's really a question of aesthetics—for example, JSON-serializing the encoding of `{ "metasyntactic variables": ["foo", "bar", "baz"], tab: "\t", null: "\0" }` would change as follows if we used tab-termination rather than space-termination:
  ```diff
  -"~(^^stab snull smetasyntactic!_variables  ^s!* s!! ^sfoo sbar sbaz   "
  +"~(^^stab\tsnull\tsmetasyntactic variables\t\t^s\n9\ts\n0\t^sfoo\tsbar\tsbaz\t\t\t"
  ```