### PR TITLE
fix(patterns): Implement M.null() and M.undefined() as Key Patterns

### DIFF
--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -270,7 +270,7 @@ const makePatternKit = () => {
    * @returns {boolean}
    */
   const checkAsKeyPatt = (specimen, keyAsPattern, check) => {
-    if (keyEQ(specimen, keyAsPattern)) {
+    if (isKey(specimen) && keyEQ(specimen, keyAsPattern)) {
       return true;
     }
     return (

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -167,6 +167,12 @@ const makePatternKit = () => {
    * that the store level associates with that kind.
    */
 
+  /** @type {Map<Kind, unknown>} */
+  const singletonKinds = new Map([
+    ['null', null],
+    ['undefined', undefined],
+  ]);
+
   /**
    * @type {WeakMap<CopyTagged, Kind>}
    * Only for tagged records of recognized kinds whose store-level invariants
@@ -251,6 +257,12 @@ const makePatternKit = () => {
    * @returns {boolean}
    */
   const checkKind = (specimen, kind, check) => {
+    // check null and undefined as Keys
+    if (singletonKinds.has(kind)) {
+      // eslint-disable-next-line no-use-before-define
+      return checkAsKeyPatt(specimen, singletonKinds.get(kind), check);
+    }
+
     const realKind = kindOf(specimen, check);
     if (kind === realKind) {
       return true;

--- a/packages/patterns/test/test-patterns.js
+++ b/packages/patterns/test/test-patterns.js
@@ -43,9 +43,11 @@ const runTests = (successCase, failCase) => {
     remotable: (repr, kind) => `${kind} ${repr} - Must be a remotable`,
     error: (repr, kind) => `${kind} ${repr} - Must be a error`,
     promise: (repr, kind) => `${kind} ${repr} - Must be a promise`,
-    undefined: (repr, kind) => `${kind} ${repr} - Must be a undefined`,
+    // M.undefined() and M.null() match as exact Keys rather than kinds.
+    undefined: repr => `${repr} - Must be: "[undefined]"`,
     null: repr => `${repr} - Must be: null`,
   };
+  const tagIgnorantMethods = ['scalar', 'key', 'undefined', 'null'];
 
   {
     const specimen = 3;
@@ -525,7 +527,7 @@ const runTests = (successCase, failCase) => {
         continue;
       }
       // This specimen is not a Key, so testing is less straightforward.
-      if (method === 'scalar' || method === 'key' || method === 'null') {
+      if (tagIgnorantMethods.includes(method)) {
         successCase(specimen, M.not(M[method]()));
         failCase(
           specimen,
@@ -567,10 +569,9 @@ const runTests = (successCase, failCase) => {
         continue;
       }
       // This specimen has an invalid payload for its tag, so testing is less straightforward.
-      const message =
-        method === 'scalar' || method === 'key' || method === 'null'
-          ? makeMessage('"[match:any]"', 'match:any', 'tagged')
-          : 'match:any payload: 88 - Must be undefined';
+      const message = tagIgnorantMethods.includes(method)
+        ? makeMessage('"[match:any]"', 'match:any', 'tagged')
+        : 'match:any payload: 88 - Must be undefined';
       successCase(specimen, M.not(M[method]()));
       failCase(specimen, M[method](), message);
     }
@@ -584,7 +585,7 @@ const runTests = (successCase, failCase) => {
         continue;
       }
       // This specimen is not a Key, so testing is less straightforward.
-      if (method === 'scalar' || method === 'key' || method === 'null') {
+      if (tagIgnorantMethods.includes(method)) {
         successCase(specimen, M.not(M[method]()));
         failCase(
           specimen,

--- a/packages/patterns/test/test-patterns.js
+++ b/packages/patterns/test/test-patterns.js
@@ -525,19 +525,12 @@ const runTests = (successCase, failCase) => {
         continue;
       }
       // This specimen is not a Key, so testing is less straightforward.
-      if (method === 'scalar' || method === 'key') {
+      if (method === 'scalar' || method === 'key' || method === 'null') {
         successCase(specimen, M.not(M[method]()));
         failCase(
           specimen,
           M[method](),
           makeMessage('"[mysteryTag]"', 'mysteryTag', 'tagged'),
-        );
-      } else if (method === 'null') {
-        failCase(
-          specimen,
-          M[method](),
-          simpleMethods.key('"[mysteryTag]"', 'mysteryTag', 'tagged'),
-          true,
         );
       } else {
         failCase(
@@ -557,21 +550,12 @@ const runTests = (successCase, failCase) => {
         continue;
       }
       // This specimen is not a Key, so testing is less straightforward.
-      if (method !== 'null') {
-        successCase(specimen, M.not(M[method]()));
-        failCase(
-          specimen,
-          M[method](),
-          makeMessage('"[match:any]"', 'match:any', 'tagged'),
-        );
-      } else {
-        failCase(
-          specimen,
-          M[method](),
-          simpleMethods.key('"[match:any]"', 'match:any', 'tagged'),
-          true,
-        );
-      }
+      successCase(specimen, M.not(M[method]()));
+      failCase(
+        specimen,
+        M[method](),
+        makeMessage('"[match:any]"', 'match:any', 'tagged'),
+      );
     }
   }
   {
@@ -583,21 +567,12 @@ const runTests = (successCase, failCase) => {
         continue;
       }
       // This specimen has an invalid payload for its tag, so testing is less straightforward.
-      if (method !== 'null') {
-        const message =
-          method === 'scalar' || method === 'key'
-            ? makeMessage('"[match:any]"', 'match:any', 'tagged')
-            : 'match:any payload: 88 - Must be undefined';
-        successCase(specimen, M.not(M[method]()));
-        failCase(specimen, M[method](), message);
-      } else {
-        failCase(
-          specimen,
-          M[method](),
-          simpleMethods.key('"[match:any]"', 'match:any', 'tagged'),
-          true,
-        );
-      }
+      const message =
+        method === 'scalar' || method === 'key' || method === 'null'
+          ? makeMessage('"[match:any]"', 'match:any', 'tagged')
+          : 'match:any payload: 88 - Must be undefined';
+      successCase(specimen, M.not(M[method]()));
+      failCase(specimen, M[method](), message);
     }
   }
   {
@@ -609,19 +584,12 @@ const runTests = (successCase, failCase) => {
         continue;
       }
       // This specimen is not a Key, so testing is less straightforward.
-      if (method === 'scalar' || method === 'key') {
+      if (method === 'scalar' || method === 'key' || method === 'null') {
         successCase(specimen, M.not(M[method]()));
         failCase(
           specimen,
           M[method](),
           makeMessage('"[match:remotable]"', 'match:remotable', 'tagged'),
-        );
-      } else if (method === 'null') {
-        failCase(
-          specimen,
-          M[method](),
-          simpleMethods.key('"[match:remotable]"', 'match:remotable', 'tagged'),
-          true,
         );
       } else {
         failCase(


### PR DESCRIPTION
Fixes #1601

stacked on #1600: https://github.com/endojs/endo/compare/gibson-1597-nat-matcher-requires-bigint...gibson-1601-null-undefined-pattern