### PR TITLE
feat(ses): Add assert.raw for embedding unquoted strings in details

### DIFF
--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -34,7 +34,7 @@ import {
 
 /// <reference types="ses"/>
 
-const { quote: q, raw: r, details: X, Fail } = assert;
+const { quote: q, bare: b, details: X, Fail } = assert;
 const { entries, values } = Object;
 const { ownKeys } = Reflect;
 
@@ -254,7 +254,9 @@ const makePatternKit = () => {
       return true;
     }
     if (check !== identChecker) {
-      check(false, X`${r(realKind)} ${specimen} - Must be a ${r(kind)}`);
+      // `kind` and `realKind` can be embedded without quotes
+      // because they are drawn from the enumerated collection of known Kinds.
+      check(false, X`${b(realKind)} ${specimen} - Must be a ${b(kind)}`);
     }
     return false;
   };
@@ -931,7 +933,9 @@ const makePatternKit = () => {
       const { label } = remotableDesc;
       return check(
         false,
-        X`${r(specimenKind)} ${specimen} - Must be a remotable (${r(label)})`,
+        // `label` can be embedded without quotes because it is provided by
+        // local code like `M.remotable("...")`.
+        X`${q(specimenKind)} ${specimen} - Must be a remotable (${b(label)})`,
       );
     },
 

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -926,16 +926,20 @@ const makePatternKit = () => {
       if (check === identChecker) {
         return false;
       }
-      let specimenKind = passStyleOf(specimen);
-      if (specimenKind === 'tagged') {
-        specimenKind = getTag(specimen);
-      }
       const { label } = remotableDesc;
+      const passStyle = passStyleOf(specimen);
+      const kindDetails =
+        passStyle !== 'tagged'
+          ? // Pass style can be embedded in details without quotes.
+            b(passStyle)
+          : // Tag must be quoted because it is potentially attacker-controlled
+            // (unlike `kindOf`, this does not reject unrecognized tags).
+            q(getTag(specimen));
       return check(
         false,
         // `label` can be embedded without quotes because it is provided by
         // local code like `M.remotable("...")`.
-        X`${q(specimenKind)} ${specimen} - Must be a remotable (${b(label)})`,
+        X`${specimen} - Must be a remotable ${b(label)}, not ${kindDetails}`,
       );
     },
 

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -34,7 +34,7 @@ import {
 
 /// <reference types="ses"/>
 
-const { quote: q, details: X, Fail } = assert;
+const { quote: q, raw: r, details: X, Fail } = assert;
 const { entries, values } = Object;
 const { ownKeys } = Reflect;
 
@@ -254,9 +254,7 @@ const makePatternKit = () => {
       return true;
     }
     if (check !== identChecker) {
-      // quoting without quotes
-      const details = X([`${realKind} `, ` - Must be a ${kind}`], specimen);
-      check(false, details);
+      check(false, X`${r(realKind)} ${specimen} - Must be a ${r(kind)}`);
     }
     return false;
   };
@@ -931,13 +929,10 @@ const makePatternKit = () => {
         specimenKind = getTag(specimen);
       }
       const { label } = remotableDesc;
-
-      // quoting without quotes
-      const details = X(
-        [`${specimenKind} `, ` - Must be a remotable (${label})`],
-        specimen,
+      return check(
+        false,
+        X`${r(specimenKind)} ${specimen} - Must be a remotable (${r(label)})`,
       );
-      return check(false, details);
     },
 
     checkIsWellFormed: (allegedRemotableDesc, check) =>

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -341,6 +341,7 @@
  *   details: DetailsTag,
  *   Fail: FailTag,
  *   quote: AssertQuote,
+ *   raw: AssertQuote,
  *   makeAssert: MakeAssert,
  * } } Assert
  */

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -341,7 +341,7 @@
  *   details: DetailsTag,
  *   Fail: FailTag,
  *   quote: AssertQuote,
- *   raw: AssertQuote,
+ *   bare: AssertQuote,
  *   makeAssert: MakeAssert,
  * } } Assert
  */

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -188,7 +188,7 @@ test('a causal tree falls silently', t => {
   );
 });
 
-test('assert equals', t => {
+test('assert.equal', t => {
   assert.equal(2 + 3, 5);
   throwsAndLogs(
     t,
@@ -247,7 +247,7 @@ test('assert equals', t => {
   );
 });
 
-test('assert typeof', t => {
+test('assert.typeof', t => {
   assert.typeof(2, 'number');
   throwsAndLogs(
     t,
@@ -260,7 +260,7 @@ test('assert typeof', t => {
   ]);
 });
 
-test('assert error default', t => {
+test('assert.error default type', t => {
   const err = assert.error(d`<${'bar'},${q('baz')}>`);
   t.is(err.message, '<(a string),"baz">');
   t.is(err.name, 'Error');
@@ -287,7 +287,7 @@ test('assert error default', t => {
   );
 });
 
-test('assert error explicit', t => {
+test('assert.error explicit type', t => {
   const err = assert.error(d`<${'bar'},${q('baz')}>`, URIError);
   t.is(err.message, '<(a string),"baz">');
   t.is(err.name, 'URIError');
@@ -314,7 +314,7 @@ test('assert error explicit', t => {
   );
 });
 
-test('assert error named', t => {
+test('assert.error named', t => {
   const err = assert.error(d`<${'bar'},${q('baz')}>`, URIError, {
     errorName: 'Foo-Err',
   });
@@ -343,7 +343,7 @@ test('assert error named', t => {
   );
 });
 
-test('assert q', t => {
+test('assert.quote', t => {
   throwsAndLogs(
     t,
     () => assert.fail(d`<${'bar'},${q('baz')}>`),
@@ -385,7 +385,7 @@ test('assert q', t => {
   );
 });
 
-test('assert b', t => {
+test('assert.bare', t => {
   throwsAndLogs(t, () => assert.fail(d`${b('foo')}`), 'foo', [
     ['log', 'Caught', Error],
   ]);
@@ -407,7 +407,7 @@ test('assert b', t => {
   ]);
 });
 
-test('q as best efforts stringify', t => {
+test('assert.quote as best efforts stringify', t => {
   t.is(`${q('baz')}`, '"baz"');
   const list = ['a', 'b', 'c'];
   t.is(`${q(list)}`, '["a","b","c"]');
@@ -493,7 +493,7 @@ test('printing detailsToken', t => {
   });
 });
 
-test('q tolerates always throwing exotic', t => {
+test('assert.quote tolerates always throwing exotic', t => {
   /**
    * alwaysThrowHandler
    * This is an object that throws if any propery is read. It's used as

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import { assertLogs, throwsAndLogs } from './throws-and-logs.js';
 import { assert } from '../../src/error/assert.js';
 
-const { details: d, quote: q } = assert;
+const { details: d, quote: q, bare: b } = assert;
 
 // Self-test of the example from the throwsAndLogs comment.
 test('throwsAndLogs with data', t => {
@@ -383,6 +383,28 @@ test('assert q', t => {
     /{"x":\["a","\[Seen\]","c"\],"y":"\[Seen\]"}/,
     [['log', 'Caught', Error]],
   );
+});
+
+test('assert b', t => {
+  throwsAndLogs(t, () => assert.fail(d`${b('foo')}`), 'foo', [
+    ['log', 'Caught', Error],
+  ]);
+  // Spaces are allowed in bare values.
+  throwsAndLogs(t, () => assert.fail(d`${b('foo bar')}`), 'foo bar', [
+    ['log', 'Caught', Error],
+  ]);
+  // Multiple consecutive spaces are disallowed and fall back to quote.
+  throwsAndLogs(t, () => assert.fail(d`${b('foo  bar')}`), '"foo  bar"', [
+    ['log', 'Caught', Error],
+  ]);
+  // Strings with non-word punctuation also fall back.
+  throwsAndLogs(t, () => assert.fail(d`${b('foo%bar')}`), '"foo%bar"', [
+    ['log', 'Caught', Error],
+  ]);
+  // Non-strings also fall back.
+  throwsAndLogs(t, () => assert.fail(d`${b(undefined)}`), '"[undefined]"', [
+    ['log', 'Caught', Error],
+  ]);
 });
 
 test('q as best efforts stringify', t => {

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -199,7 +199,7 @@ export interface Assert {
   ): DetailsToken;
   Fail(template: TemplateStringsArray | string[], ...args: any): never;
   quote(payload: any, spaces?: string | number): ToStringable;
-  raw(payload: any, spaces?: string | number): ToStringable;
+  bare(payload: any, spaces?: string | number): ToStringable;
   makeAssert: MakeAssert;
 }
 

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -199,6 +199,7 @@ export interface Assert {
   ): DetailsToken;
   Fail(template: TemplateStringsArray | string[], ...args: any): never;
   quote(payload: any, spaces?: string | number): ToStringable;
+  raw(payload: any, spaces?: string | number): ToStringable;
   makeAssert: MakeAssert;
 }
 


### PR DESCRIPTION
When working on #1600 and #1605, I noticed patterns like
```js
// quoting without quotes
const details = X([`${realKind} `, ` - Must be a ${kind}`], specimen);
```

Rather than manually manipulating the input of a function intended for use in tagged templates (and mixing up the order in which parts appear), it seems more clear to have a function that is like `quote` but does not add quotes (replacing the above with ```const details = X`${r(realKind)} ${specimen} - Must be a ${r(kind)}`;```). Also tagging @FUDCo, who IIRC has asked for this in the past.