### PR TITLE
fix(ses)! make `LOCKDOWN_...` options less noisy

### DIFF
--- a/packages/env-options/README.md
+++ b/packages/env-options/README.md
@@ -52,8 +52,9 @@ not authority beyond the ability to read this global state.
 
 The `makeEnvironmentCaptor` function also returns a
 `getCapturedEnvironmentOptionNames` function for use to give feedback about
-which environment variables were actually read, for diagnostic purposes. The
-ses-shim `lockdown` contains code such as the following, to explain which
+which environment variables were actually read, for diagnostic purposes.
+For example, the
+ses-shim `lockdown` once contained code such as the following, to explain which
 environment variables were read to provide `lockdown` settings.
 
 ```js

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -20,14 +20,12 @@ import {
   FERAL_EVAL,
   TypeError,
   arrayFilter,
-  arrayMap,
   globalThis,
   is,
   ownKeys,
   stringSplit,
   noEvalEvaluate,
 } from './commons.js';
-import { enJoin } from './error/stringify-utils.js';
 import { makeHardener } from './make-hardener.js';
 import { makeIntrinsicsCollector } from './intrinsics.js';
 import whitelistIntrinsics from './whitelist-intrinsics.js';
@@ -154,8 +152,7 @@ export const repairIntrinsics = (options = {}) => {
   // [`stackFiltering` options](https://github.com/Agoric/SES-shim/blob/master/packages/ses/lockdown-options.md#stackfiltering-options)
   // for an explanation.
 
-  const { getEnvironmentOption: getenv, getCapturedEnvironmentOptionNames } =
-    makeEnvironmentCaptor(globalThis);
+  const { getEnvironmentOption: getenv } = makeEnvironmentCaptor(globalThis);
 
   const {
     errorTaming = getenv('LOCKDOWN_ERROR_TAMING', 'safe'),
@@ -181,17 +178,6 @@ export const repairIntrinsics = (options = {}) => {
     mathTaming = 'safe', // deprecated
     ...extraOptions
   } = options;
-
-  const capturedEnvironmentOptionNames = getCapturedEnvironmentOptionNames();
-  if (capturedEnvironmentOptionNames.length > 0) {
-    // eslint-disable-next-line @endo/no-polymorphic-call
-    console.warn(
-      `SES Lockdown using options from environment variables ${enJoin(
-        arrayMap(capturedEnvironmentOptionNames, q),
-        'and',
-      )}`,
-    );
-  }
 
   evalTaming === 'unsafeEval' ||
     evalTaming === 'safeEval' ||


### PR DESCRIPTION
Remove the `console.warn` logic for reporting which `LOCKDOWN_...` options were used. The extra noise does not seem to serve any purpose.
