### PR TITLE
fix(ses): missing native function markings

### DIFF
--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -250,6 +250,10 @@ export const repairIntrinsics = (options = {}) => {
 
   tameDomains(domainTaming);
 
+  // Replace Function.prototype.toString with one that recognizes
+  // shimmed functions as honorary native functions.
+  const markVirtualizedNativeFunction = tameFunctionToString();
+
   const { addIntrinsics, completePrototypes, finalIntrinsics } =
     makeIntrinsicsCollector();
 
@@ -303,10 +307,6 @@ export const repairIntrinsics = (options = {}) => {
 
   // Replace *Locale* methods with their non-locale equivalents
   tameLocaleMethods(intrinsics, localeTaming);
-
-  // Replace Function.prototype.toString with one that recognizes
-  // shimmed functions as honorary native functions.
-  const markVirtualizedNativeFunction = tameFunctionToString();
 
   /**
    * 2. WHITELIST to standardize the environment.

--- a/packages/ses/src/permits-intrinsics.js
+++ b/packages/ses/src/permits-intrinsics.js
@@ -240,7 +240,6 @@ export default function whitelistIntrinsics(
     }
 
     if (typeof obj === 'function') {
-      markVirtualizedNativeFunction(obj);
       if (objectHasOwnProperty(FunctionInstance, permitProp)) {
         return FunctionInstance[permitProp];
       }
@@ -260,6 +259,10 @@ export default function whitelistIntrinsics(
 
     const protoName = permit['[[Proto]]'];
     visitPrototype(path, obj, protoName);
+
+    if (typeof obj === 'function') {
+      markVirtualizedNativeFunction(obj);
+    }
 
     for (const prop of ownKeys(obj)) {
       const propString = asStringPropertyName(path, prop);

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -481,9 +481,9 @@ export const permitted = {
     constructor: '%InertFunction%',
     toString: fn,
     '@@hasInstance': fn,
-    // proposed but not yet std yet. To be removed if there
+    // proposed but not yet std. To be removed if there
     caller: false,
-    // proposed but not yet std yet. To be removed if there
+    // proposed but not yet std. To be removed if there
     arguments: false,
   },
 

--- a/packages/ses/test/test-evalTaming-default.js
+++ b/packages/ses/test/test-evalTaming-default.js
@@ -16,4 +16,6 @@ test('safe eval when evalTaming is undefined.', t => {
   compartment.evaluate('(1, eval)("1 + 1")');
   // eslint-disable-next-line no-eval
   t.is(eval.toString(), 'function eval() { [native code] }');
+  // eslint-disable-next-line no-eval
+  t.is(eval.toString.toString(), 'function toString() { [native code] }');
 });


### PR DESCRIPTION
Fixes #1228 
Fixes https://github.com/endojs/endo/issues/835

The replacement `Function.prototype.toString`, which uses the synthetic native function marking, should itself have been marked as a native function, so that it would recognize itself as such. First, I saw I needed to install it early. But it still wasn't being marked, which was quite puzzling. Turns out there was a bug in the marking logic in the whitelist-intrinsics code, where functions could both skip being marked, or could be pointlessly marked redundantly.

@Jack-Works , please consider yourself a reviewer of this PR. I look forward to your comments. And thanks for the original report! If I hadn't investigated I would not have found this deeper bug.

Turns out that this deeper bug was already reported by @kriskowal at #835 