### PR TITLE
update Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,14 +115,10 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          # 14.2 not longer tested because the test's runner, Ava, now requires 14.19+ and fails with:
-          #   Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader
-          # - '14.2' # last version before promise fast-path without destroy
-          # - '14.17' # last version before unconditional promise fast-path
-          - '14.18' # first version after unconditional promise fast-path
           - '16.1' # last version before some significant promise hooks changes
           - '16.5' # last version before unconditional promise fast-path
           - '16.6' # first version after unconditional promise fast-path
+          - '18' # Active LTS
         platform:
           - ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         platform: [ubuntu-latest, windows-latest]
 
     steps:
@@ -172,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -218,7 +218,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -264,7 +264,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -310,7 +310,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         platform: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x']
+        node-version: ['16.x']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16"
   },
   "devDependencies": {
     "@jessie.js/eslint-plugin": "^0.3.0",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@endo/ses-ava": "^0.2.40",
-    "@types/node": ">=14.0",
+    "@types/node": "^16.6.0",
     "ava": "^5.2.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,10 +2194,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@>=14.0":
+"@types/node@*":
   version "18.11.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
+
+"@types/node@^16.6.0":
+  version "16.18.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.34.tgz#62d2099b30339dec4b1b04a14c96266459d7c8b2"
+  integrity sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
closes: https://github.com/endojs/endo/issues/1540

Node 14 is EOL and Node 18 is now the Active LTS. 

This updates engines, types deps, and CI accordingly.