### PR TITLE
refactor: hasOwn replaces hasOwnPropertyOf

### DIFF
--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -1,5 +1,4 @@
 import { E, Far } from '@endo/far';
-import { hasOwnPropertyOf } from '@endo/pass-style';
 import { listDifference, objectMap, mustMatch, M } from '@endo/patterns';
 
 /** @typedef {import('@endo/patterns').Method} Method */
@@ -7,7 +6,7 @@ import { listDifference, objectMap, mustMatch, M } from '@endo/patterns';
 
 const { quote: q, Fail } = assert;
 const { apply, ownKeys } = Reflect;
-const { defineProperties } = Object;
+const { defineProperties, hasOwn } = Object;
 
 /**
  * A method guard, for inclusion in an interface guard, that enforces only that
@@ -248,7 +247,7 @@ export const defendPrototype = (
   interfaceGuard = undefined,
 ) => {
   const prototype = {};
-  if (hasOwnPropertyOf(behaviorMethods, 'constructor')) {
+  if (hasOwn(behaviorMethods, 'constructor')) {
     // By ignoring any method named "constructor", we can use a
     // class.prototype as a behaviorMethods.
     const { constructor: _, ...methods } = behaviorMethods;

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -12,7 +12,6 @@ import {
   makeTagged,
   isObject,
   getTag,
-  hasOwnPropertyOf,
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
@@ -32,6 +31,7 @@ const {
   entries,
   fromEntries,
   freeze,
+  hasOwn,
 } = Object;
 const { details: X, Fail, quote: q } = assert;
 
@@ -43,10 +43,10 @@ const QCLASS = '@qclass';
 export { QCLASS };
 
 /**
- * @param {Encoding} encoded
+ * @param {Encoding & object} encoded
  * @returns {encoded is EncodingUnion}
  */
-const hasQClass = encoded => hasOwnPropertyOf(encoded, QCLASS);
+const hasQClass = encoded => hasOwn(encoded, QCLASS);
 
 /**
  * @param {Encoding} encoded
@@ -166,7 +166,7 @@ export const makeEncodeToCapData = (encodeOptions = {}) => {
         };
       }
       case 'copyRecord': {
-        if (hasOwnPropertyOf(passable, QCLASS)) {
+        if (hasQClass(passable)) {
           // Hilbert hotel
           const { [QCLASS]: qclassValue, ...rest } = passable;
           /** @type {Encoding} */
@@ -417,11 +417,11 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
           // @ts-ignore inadequate type inference
           // See https://github.com/endojs/endo/pull/1259#discussion_r954561901
           const { original, rest } = jsonEncoded;
-          hasOwnPropertyOf(jsonEncoded, 'original') ||
+          hasOwn(jsonEncoded, 'original') ||
             Fail`Invalid Hilbert Hotel encoding ${jsonEncoded}`;
           // Don't harden since we're not done mutating it
           const result = { [QCLASS]: decodeFromCapData(original) };
-          if (hasOwnPropertyOf(jsonEncoded, 'rest')) {
+          if (hasOwn(jsonEncoded, 'rest')) {
             const isNonEmptyObject =
               typeof rest === 'object' &&
               rest !== null &&
@@ -433,7 +433,7 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
             // TODO really should assert that `passStyleOf(rest)` is
             // `'copyRecord'` but we'd have to harden it and it is too
             // early to do that.
-            !hasOwnPropertyOf(restObj, QCLASS) ||
+            !hasQClass(restObj) ||
               Fail`Rest must not contain its own definition of ${q(QCLASS)}`;
             defineProperties(result, getOwnPropertyDescriptors(restObj));
           }

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -11,7 +11,6 @@ import {
   isErrorLike,
   makeTagged,
   getTag,
-  hasOwnPropertyOf,
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
@@ -26,7 +25,7 @@ import {
 
 const { ownKeys } = Reflect;
 const { isArray } = Array;
-const { is, entries, fromEntries } = Object;
+const { is, entries, fromEntries, hasOwn } = Object;
 const { details: X, Fail, quote: q } = assert;
 
 const BANG = '!'.charCodeAt(0);
@@ -125,7 +124,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
   } = encodeOptions;
 
   const assertEncodedError = encoding => {
-    (typeof encoding === 'object' && hasOwnPropertyOf(encoding, '#error')) ||
+    (typeof encoding === 'object' && hasOwn(encoding, '#error')) ||
       Fail`internal: Error encoding must have "#error" property: ${q(
         encoding,
       )}`;
@@ -419,7 +418,7 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
           return encoding.map(val => decodeFromSmallcaps(val));
         }
 
-        if (hasOwnPropertyOf(encoding, '#tag')) {
+        if (hasOwn(encoding, '#tag')) {
           const { '#tag': tag, payload, ...rest } = encoding;
           typeof tag === 'string' ||
             Fail`Value of "#tag", the tag, must be a string: ${encoding}`;
@@ -431,7 +430,7 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
           );
         }
 
-        if (hasOwnPropertyOf(encoding, '#error')) {
+        if (hasOwn(encoding, '#error')) {
           const result = decodeErrorFromSmallcaps(
             encoding,
             decodeFromSmallcaps,

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -5,7 +5,6 @@ import {
   assertPassable,
   getInterfaceOf,
   getErrorConstructor,
-  hasOwnPropertyOf,
 } from '@endo/pass-style';
 
 import {
@@ -28,6 +27,7 @@ import {
 /** @typedef {import('./types.js').Encoding} Encoding */
 /** @typedef {import('@endo/pass-style').RemotableObject} Remotable */
 
+const { hasOwn } = Object;
 const { isArray } = Array;
 const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
@@ -324,7 +324,7 @@ export const makeMarshal = (
 
     const decodeErrorFromSmallcaps = (encoding, decodeRecur) => {
       const { '#error': message, ...restErrData } = encoding;
-      !hasOwnPropertyOf(restErrData, 'message') ||
+      !hasOwn(restErrData, 'message') ||
         Fail`unexpected encoded error property ${q('message')}`;
       return decodeErrorCommon({ message, ...restErrData }, decodeRecur);
     };

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -4,7 +4,6 @@ export {
   isObject,
   assertChecker,
   getTag,
-  hasOwnPropertyOf,
 } from './src/passStyle-helpers.js';
 
 export {
@@ -37,3 +36,9 @@ export {
 
 // eslint-disable-next-line import/export
 export * from './src/types.js';
+
+const { hasOwn: hasOwnPropertyOf } = Object;
+export {
+  /** @deprecated Use `Object.hasOwn` instead */
+  hasOwnPropertyOf,
+};

--- a/packages/pass-style/src/passStyle-helpers.js
+++ b/packages/pass-style/src/passStyle-helpers.js
@@ -9,7 +9,7 @@ const { prototype: functionPrototype } = Function;
 const {
   getOwnPropertyDescriptor,
   getPrototypeOf,
-  hasOwnProperty: objectHasOwnProperty,
+  hasOwn,
   isFrozen,
   prototype: objectPrototype,
 } = Object;
@@ -24,10 +24,6 @@ const typedArrayToStringTagDesc = getOwnPropertyDescriptor(
 assert(typedArrayToStringTagDesc);
 const getTypedArrayToStringTag = typedArrayToStringTagDesc.get;
 assert(typeof getTypedArrayToStringTag === 'function');
-
-export const hasOwnPropertyOf = (obj, prop) =>
-  apply(objectHasOwnProperty, obj, [prop]);
-harden(hasOwnPropertyOf);
 
 export const isObject = val => Object(val) === val;
 harden(isObject);
@@ -100,7 +96,7 @@ export const checkNormalProperty = (
     );
   }
   return (
-    (hasOwnPropertyOf(desc, 'value') ||
+    (hasOwn(desc, 'value') ||
       (reject &&
         reject(
           X`${q(propertyName)} must not be an accessor property: ${candidate}`,

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -3,7 +3,6 @@
 import {
   assertChecker,
   canBeMethod,
-  hasOwnPropertyOf,
   PASS_STYLE,
   checkTagRecord,
   checkFunctionTagRecord,
@@ -25,6 +24,7 @@ const {
   isFrozen,
   prototype: objectPrototype,
   getOwnPropertyDescriptors,
+  hasOwn,
 } = Object;
 
 /**
@@ -207,7 +207,7 @@ export const RemotableHelper = harden({
       return ownKeys(descs).every(key => {
         return (
           // Typecast needed due to https://github.com/microsoft/TypeScript/issues/1863
-          (hasOwnPropertyOf(descs[/** @type {string} */ (key)], 'value') ||
+          (hasOwn(descs[/** @type {string} */ (key)], 'value') ||
             (reject &&
               reject(
                 X`cannot serialize Remotables with accessors like ${q(

--- a/packages/pass-style/src/safe-promise.js
+++ b/packages/pass-style/src/safe-promise.js
@@ -1,12 +1,12 @@
 /// <reference types="ses"/>
 
 import { isPromise } from '@endo/promise-kit';
-import { assertChecker, hasOwnPropertyOf } from './passStyle-helpers.js';
+import { assertChecker } from './passStyle-helpers.js';
 
 /** @typedef {import('./types.js').Checker} Checker */
 
 const { details: X, quote: q } = assert;
-const { isFrozen, getPrototypeOf } = Object;
+const { isFrozen, getPrototypeOf, hasOwn } = Object;
 const { ownKeys } = Reflect;
 
 /**
@@ -23,7 +23,7 @@ const checkPromiseOwnKeys = (pr, check) => {
   }
 
   const unknownKeys = keys.filter(
-    key => typeof key !== 'symbol' || !hasOwnPropertyOf(Promise.prototype, key),
+    key => typeof key !== 'symbol' || !hasOwn(Promise.prototype, key),
   );
 
   if (unknownKeys.length !== 0) {

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -4,7 +4,6 @@ import {
   getTag,
   makeTagged,
   passStyleOf,
-  hasOwnPropertyOf,
   nameForPassableSymbol,
   compareRank,
   getPassStyleCover,
@@ -35,7 +34,7 @@ import {
 /// <reference types="ses"/>
 
 const { quote: q, bare: b, details: X, Fail } = assert;
-const { entries, values } = Object;
+const { entries, values, hasOwn } = Object;
 const { ownKeys } = Reflect;
 
 /** @type {WeakSet<Pattern>} */
@@ -1349,9 +1348,9 @@ const makePatternKit = () => {
     /** @type {[string, Passable][]} */
     const restEntries = [];
     for (const [name, value] of entries(specimen)) {
-      if (hasOwnPropertyOf(requiredPatt, name)) {
+      if (hasOwn(requiredPatt, name)) {
         requiredEntries.push([name, value]);
-      } else if (hasOwnPropertyOf(optionalPatt, name)) {
+      } else if (hasOwn(optionalPatt, name)) {
         optionalEntries.push([name, value]);
       } else {
         restEntries.push([name, value]);

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -70,7 +70,13 @@ export const {
   setPrototypeOf,
   values,
   fromEntries,
+  hasOwn,
 } = Object;
+
+export {
+  /** @deprecated Use `hasOwn` instead */
+  hasOwn as objectHasOwnProperty,
+};
 
 export const {
   species: speciesSymbol,
@@ -150,8 +156,6 @@ const { bind } = functionPrototype;
  */
 export const uncurryThis = bind.bind(bind.call); // eslint-disable-line @endo/no-polymorphic-call
 
-export const objectHasOwnProperty = uncurryThis(objectPrototype.hasOwnProperty);
-//
 export const arrayFilter = uncurryThis(arrayPrototype.filter);
 export const arrayForEach = uncurryThis(arrayPrototype.forEach);
 export const arrayIncludes = uncurryThis(arrayPrototype.includes);

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -13,7 +13,7 @@ import {
   getOwnPropertyDescriptors,
   getOwnPropertyNames,
   isObject,
-  objectHasOwnProperty,
+  hasOwn,
   ownKeys,
   setHas,
 } from './commons.js';
@@ -108,7 +108,7 @@ export default function enablePropertyOverrides(
             )}' of '${path}'`,
           );
         }
-        if (objectHasOwnProperty(this, prop)) {
+        if (hasOwn(this, prop)) {
           this[prop] = newValue;
         } else {
           if (isDebug) {

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -5,7 +5,7 @@ import {
   defineProperty,
   entries,
   freeze,
-  objectHasOwnProperty,
+  hasOwn,
   unscopablesSymbol,
 } from './commons.js';
 import { makeEvalFunction } from './make-eval-function.js';
@@ -85,7 +85,7 @@ export const setGlobalObjectMutableProperties = (
   },
 ) => {
   for (const [name, intrinsicName] of entries(universalPropertyNames)) {
-    if (objectHasOwnProperty(intrinsics, intrinsicName)) {
+    if (hasOwn(intrinsics, intrinsicName)) {
       defineProperty(globalObject, name, {
         value: intrinsics[intrinsicName],
         writable: true,
@@ -96,7 +96,7 @@ export const setGlobalObjectMutableProperties = (
   }
 
   for (const [name, intrinsicName] of entries(newGlobalPropertyNames)) {
-    if (objectHasOwnProperty(intrinsics, intrinsicName)) {
+    if (hasOwn(intrinsics, intrinsicName)) {
       defineProperty(globalObject, name, {
         value: intrinsics[intrinsicName],
         writable: true,

--- a/packages/ses/src/intrinsics.js
+++ b/packages/ses/src/intrinsics.js
@@ -11,7 +11,7 @@ import {
   globalThis,
   is,
   isObject,
-  objectHasOwnProperty,
+  hasOwn,
   values,
   weaksetHas,
 } from './commons.js';
@@ -32,7 +32,7 @@ const isFunction = obj => typeof obj === 'function';
 // get masked as one overwrites the other. Accordingly, the thrown error
 // complains of a "Conflicting definition".
 function initProperty(obj, name, desc) {
-  if (objectHasOwnProperty(obj, name)) {
+  if (hasOwn(obj, name)) {
     const preDesc = getOwnPropertyDescriptor(obj, name);
     if (
       !preDesc ||
@@ -64,7 +64,7 @@ function initProperties(obj, descs) {
 function sampleGlobals(globalObject, newPropertyNames) {
   const newIntrinsics = { __proto__: null };
   for (const [globalName, intrinsicName] of entries(newPropertyNames)) {
-    if (objectHasOwnProperty(globalObject, globalName)) {
+    if (hasOwn(globalObject, globalName)) {
       newIntrinsics[intrinsicName] = globalObject[globalName];
     }
   }
@@ -90,7 +90,7 @@ export const makeIntrinsicsCollector = () => {
         // eslint-disable-next-line no-continue
         continue;
       }
-      if (!objectHasOwnProperty(intrinsic, 'prototype')) {
+      if (!hasOwn(intrinsic, 'prototype')) {
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -104,12 +104,12 @@ export const makeIntrinsicsCollector = () => {
       }
       if (
         typeof namePrototype !== 'string' ||
-        !objectHasOwnProperty(permitted, namePrototype)
+        !hasOwn(permitted, namePrototype)
       ) {
         throw TypeError(`Unrecognized ${name}.prototype whitelist entry`);
       }
       const intrinsicPrototype = intrinsic.prototype;
-      if (objectHasOwnProperty(intrinsics, namePrototype)) {
+      if (hasOwn(intrinsics, namePrototype)) {
         if (intrinsics[namePrototype] !== intrinsicPrototype) {
           throw TypeError(`Conflicting bindings of ${namePrototype}`);
         }

--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -37,7 +37,7 @@ import {
   getPrototypeOf,
   isInteger,
   isObject,
-  objectHasOwnProperty,
+  hasOwn,
   ownKeys,
   preventExtensions,
   setAdd,
@@ -211,7 +211,7 @@ export const makeHardener = () => {
           // test could be confused. We use hasOwnProperty to be sure about
           // whether 'value' is present or not, which tells us for sure that
           // this is a data property.
-          if (objectHasOwnProperty(desc, 'value')) {
+          if (hasOwn(desc, 'value')) {
             enqueue(desc.value, `${pathname}`);
           } else {
             enqueue(desc.get, `${pathname}(get)`);

--- a/packages/ses/src/permits-intrinsics.js
+++ b/packages/ses/src/permits-intrinsics.js
@@ -57,7 +57,7 @@ import {
   getPrototypeOf,
   isObject,
   mapGet,
-  objectHasOwnProperty,
+  hasOwn,
   ownKeys,
   symbolKeyFor,
 } from './commons.js';
@@ -177,7 +177,7 @@ export default function whitelistIntrinsics(
         // Assert: the permit is the name of an intrinsic.
         // Assert: the property value is equal to that intrinsic.
 
-        if (objectHasOwnProperty(intrinsics, permit)) {
+        if (hasOwn(intrinsics, permit)) {
           if (value !== intrinsics[permit]) {
             throw TypeError(`Does not match whitelist ${path}`);
           }
@@ -215,7 +215,7 @@ export default function whitelistIntrinsics(
     }
 
     // Is this a value property?
-    if (objectHasOwnProperty(desc, 'value')) {
+    if (hasOwn(desc, 'value')) {
       if (isAccessorPermit(permit)) {
         throw TypeError(`Accessor expected at ${path}`);
       }
@@ -235,12 +235,12 @@ export default function whitelistIntrinsics(
    */
   function getSubPermit(obj, permit, prop) {
     const permitProp = prop === '__proto__' ? '--proto--' : prop;
-    if (objectHasOwnProperty(permit, permitProp)) {
+    if (hasOwn(permit, permitProp)) {
       return permit[permitProp];
     }
 
     if (typeof obj === 'function') {
-      if (objectHasOwnProperty(FunctionInstance, permitProp)) {
+      if (hasOwn(FunctionInstance, permitProp)) {
         return FunctionInstance[permitProp];
       }
     }

--- a/packages/ses/src/scope-constants.js
+++ b/packages/ses/src/scope-constants.js
@@ -3,7 +3,7 @@ import {
   arrayIncludes,
   getOwnPropertyDescriptor,
   getOwnPropertyNames,
-  objectHasOwnProperty,
+  hasOwn,
   regexpTest,
 } from './commons.js';
 
@@ -131,7 +131,7 @@ function isImmutableDataProperty(obj, name) {
     // can't have accessors and value properties at the same time, therefore
     // this check is sufficient. Using explicit own property deal with the
     // case where Object.prototype has been poisoned.
-    objectHasOwnProperty(desc, 'value')
+    hasOwn(desc, 'value')
   );
 }
 

--- a/packages/static-module-record/test/fixtures/exportheavy.js
+++ b/packages/static-module-record/test/fixtures/exportheavy.js
@@ -7,7 +7,6 @@ export {
   isObject,
   assertChecker,
   getTag,
-  hasOwnPropertyOf,
 } from './src/helpers/passStyle-helpers.js';
 
 export { getErrorConstructor, toPassableError } from './src/helpers/error.js';
@@ -42,9 +41,6 @@ export {
 // eslint-disable-next-line import/export
 export * from './src/types.js';
 
-
-const { details: X, Fail } = assert;
-
 // This is a pathological minimum, but exercised by the unit test.
 export const MIN_DATA_BUFFER_LENGTH = 1;
 
@@ -53,3 +49,9 @@ export const TRANSFER_OVERHEAD_LENGTH =
   BigUint64Array.BYTES_PER_ELEMENT + Int32Array.BYTES_PER_ELEMENT;
 export const MIN_TRANSFER_BUFFER_LENGTH =
   MIN_DATA_BUFFER_LENGTH + TRANSFER_OVERHEAD_LENGTH;
+
+const { hasOwn: hasOwnPropertyOf } = Object;
+export {
+  /** @deprecated Use `Object.hasOwn` instead */
+  hasOwnPropertyOf,
+};


### PR DESCRIPTION
Enabled by https://github.com/endojs/endo/pull/1623 , since Node 14 did not have `Object.hasOwn`.

`Object.hasOwn` replaces `hasOwnPropertyOf` and `objectHasOwnProperty`. However, to avoid breaking external dependencies, the old names are still exported, but now deprecated.

See https://github.com/Agoric/agoric-sdk/pull/7902