### PR TITLE
prevent dependency cycles

### DIFF
--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -21,5 +21,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: check dependencies
+      - name: Install graphviz
+        run: sudo apt install -y graphviz
+
+      - name: Check for cycles
+        run: scripts/check-dependency-cycles.sh 0
+      - name: check mismatched dependencies
         run: yarn depcheck

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,5 @@ typings/
 # dist
 dist/
 
-/packages.png
+/packages-graph*
+

--- a/scripts/check-dependency-cycles.sh
+++ b/scripts/check-dependency-cycles.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Errors if number of cycle edges detected is too great
+set -ueo pipefail
+
+MAX_EDGES=$1
+
+# one of these lines is "Cycles detected"
+LINE_COUNT=$(scripts/graph.sh |wc -l)
+
+CYCLIC_EDGE_COUNT=$((LINE_COUNT - 1))
+
+echo CYCLIC_EDGE_COUNT $CYCLIC_EDGE_COUNT
+
+if [[ $CYCLIC_EDGE_COUNT -gt $MAX_EDGES ]];
+then
+  echo Greater than MAX_EDGES "$MAX_EDGES"
+  exit 1
+fi
+
+echo Less than or equal to MAX_EDGES "$MAX_EDGES"

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# scripts/graph.sh generates packages.png, a visualization of the internal
-# package dependency graph.
+# Generates visualizations of the internal package dependency graph.
 set -ueo pipefail
 DIR=$(dirname -- "${BASH_SOURCE[0]}")
 {
     echo 'digraph {'
+    # Left is depended upon the least and right the most.
     echo 'rankdir=LR'
     cat "$DIR"/../packages/*/package.json | jq -r --slurp '
         . as $all |
@@ -19,4 +19,15 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
         "\"\(.from)\" -> \"\(.to)\""
     '
     echo '}'
-} | dot -Tpng > "$DIR"/../packages.png
+    # normalize
+} | dot -Tcanon >packages-graph.dot
+dot -Tpng <packages-graph.dot >"$DIR"/../packages-graph.png
+
+dot -Tsvg <packages-graph.dot >"$DIR"/../packages-graph.svg
+
+if acyclic packages-graph.dot | dot -Tcanon >packages-graph-sans-cycles.dot; then
+    echo "No cycles in 'dependencies' of packages."
+else
+    echo "Cycles detected. These lines appear only in the original graph and not the acyclic variant:"
+    comm -23 <(sort packages-graph.dot) <(sort packages-graph-sans-cycles.dot)
+fi


### PR DESCRIPTION
Adapts `scripts/graph.sh` to detect cycles and adds a job to CI to fail if there are any.

This only detects cycles among `dependencies` declarations and ignores `devDependencies`. Lerna's check includes the latter:
```
lerna WARN ECYCLE @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper
lerna WARN ECYCLE @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send
lerna WARN ECYCLE @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown
lerna WARN ECYCLE @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit
lerna WARN ECYCLE @endo/ses-ava -> (nested cycle: @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit) -> @endo/ses-ava
lerna WARN ECYCLE @endo/static-module-record -> (nested cycle: @endo/ses-ava -> (nested cycle: @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit) -> @endo/ses-ava) -> @endo/static-module-record
lerna WARN ECYCLE (nested cycle: @endo/static-module-record -> (nested cycle: @endo/ses-ava -> (nested cycle: @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit) -> @endo/ses-ava) -> @endo/static-module-record) -> (nested cycle: @endo/static-module-record -> (nested cycle: @endo/ses-ava -> (nested cycle: @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit) -> @endo/ses-ava) -> @endo/static-module-record)
```

I think we should avoid even dev dependencies so that we can optimize CI with checks for "affected" packages. But meanwhile this ensures that no cycles are created among non-dev dependencies.