### PR TITLE
parameterize InterfaceGuard

### DIFF
--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -177,7 +177,7 @@ harden(defineExoClassKit);
 /**
  * @template {Methods} T
  * @param {string} tag
- * @param {import('@endo/patterns').InterfaceGuard | undefined} interfaceGuard CAVEAT: static typing does not yet support `callWhen` transformation
+ * @param {import('@endo/patterns').InterfaceGuard<{ [M in keyof T]: import('@endo/patterns').MethodGuard }> | undefined} interfaceGuard CAVEAT: static typing does not yet support `callWhen` transformation
  * @param {T} methods
  * @param {FarClassOptions<ClassContext<{},T>>} [options]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}

--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -4,7 +4,6 @@ import { listDifference, objectMap, mustMatch, M } from '@endo/patterns';
 
 /** @typedef {import('@endo/patterns').Method} Method */
 /** @typedef {import('@endo/patterns').MethodGuard} MethodGuard */
-/** @typedef {import('@endo/patterns').InterfaceGuard} InterfaceGuard */
 
 const { quote: q, Fail } = assert;
 const { apply, ownKeys } = Reflect;
@@ -221,7 +220,7 @@ export const GET_INTERFACE_GUARD = Symbol.for('getInterfaceGuard');
  * @template {Record<string | symbol, CallableFunction>} T
  * @param {T} behaviorMethods
  * @param {(string | symbol)[]} methodNames
- * @param {InterfaceGuard} interfaceGuard
+ * @param {import('@endo/patterns').InterfaceGuard} interfaceGuard
  */
 const addGetInterfaceGuardMethod = (
   behaviorMethods,
@@ -255,7 +254,7 @@ const addGetInterfaceGuardMethod = (
  * @param {ContextProvider} contextProvider
  * @param {T} behaviorMethods
  * @param {boolean} [thisfulMethods]
- * @param {InterfaceGuard} [interfaceGuard]
+ * @param {import('@endo/patterns').InterfaceGuard<{ [M in keyof T]: MethodGuard }>} [interfaceGuard]
  * @returns {T & import('@endo/eventual-send').RemotableBrand<{}, T>}
  */
 export const defendPrototype = (
@@ -315,7 +314,7 @@ harden(defendPrototype);
  * @param {Record<FacetName, KitContextProvider>} contextProviderKit
  * @param {Record<FacetName, Record<string | symbol, CallableFunction>>} behaviorMethodsKit
  * @param {boolean} [thisfulMethods]
- * @param {Record<string, InterfaceGuard>} [interfaceGuardKit]
+ * @param {Record<string, import('@endo/patterns').InterfaceGuard>} [interfaceGuardKit]
  */
 export const defendPrototypeKit = (
   tag,

--- a/packages/patterns/jsconfig.json
+++ b/packages/patterns/jsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../jsconfig.eslint-base.json",
-  "include": ["*.js", "*.ts", "src/**/*.js", "src/**/*.ts"]
+  "include": [
+    "*.js",
+    "*.ts",
+    "src/**/*.js",
+    "src/**/*.ts",
+    "test/**/*.js",
+    "test/**/*.ts"
+  ]
 }

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -1576,7 +1576,7 @@ const makePatternKit = () => {
       },
       returns: (returnGuard = UndefinedShape) =>
         harden({
-          klass: 'methodGuard',
+          klass: /** @type {const} */ ('methodGuard'),
           callKind,
           argGuards,
           optionalArgGuards,
@@ -1587,7 +1587,7 @@ const makePatternKit = () => {
 
   const makeAwaitArgGuard = argGuard =>
     harden({
-      klass: 'awaitArg',
+      klass: /** @type {const} */ ('awaitArg'),
       argGuard,
     });
 
@@ -1685,7 +1685,7 @@ const makePatternKit = () => {
           Fail`unrecognize method guard ${methodGuard}`;
       }
       return harden({
-        klass: 'Interface',
+        klass: /** @type {const} */ ('Interface'),
         interfaceName,
         methodGuards,
         sloppy,

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -477,12 +477,19 @@ export {};
  */
 
 /**
- * @typedef {object} GuardMakers
- * @property {<M extends Record<any, any>>(interfaceName: string,
+ * @typedef {{
+ * <M extends Record<any, MethodGuard>>(interfaceName: string,
  *             methodGuards: M,
- *             options?: {sloppy?: boolean}
- * ) => InterfaceGuard} interface Guard an interface to a far object or facet
- *
+ *             options?: {sloppy?: false}): InterfaceGuard<M>;
+ * (interfaceName: string,
+ *             methodGuards: any,
+ *             options?: {sloppy?: true}): InterfaceGuard<any>;
+ * }} MakeInterfaceGuard
+ */
+
+/**
+ * @typedef {object} GuardMakers
+ * @property {MakeInterfaceGuard} interface Guard an interface to a far object or facet
  * @property {(...argGuards: ArgGuard[]) => MethodGuardMaker} call Guard a synchronous call
  *
  * @property {(...argGuards: ArgGuard[]) => MethodGuardMaker} callWhen Guard an async call
@@ -496,12 +503,12 @@ export {};
 
 /** @typedef {(...args: any[]) => any} Method */
 
-// TODO parameterize this to match the behavior object it guards
 /**
+ * @template {Record<string | symbol, MethodGuard>} [T=Record<string | symbol, MethodGuard>]
  * @typedef {{
  * klass: 'Interface',
  * interfaceName: string,
- * methodGuards: Record<string | symbol, MethodGuard>
+ * methodGuards: T
  * sloppy?: boolean
  * }} InterfaceGuard
  */

--- a/packages/patterns/test/test-pattern-limits.js
+++ b/packages/patterns/test/test-pattern-limits.js
@@ -6,7 +6,9 @@ import {
   M,
   defaultLimits,
 } from '../src/patterns/patternMatchers.js';
-import '../src/types.js';
+
+/** @typedef {import('@endo/marshal').Passable} Passable */
+/** @typedef {import('../src/types.js').Pattern} Pattern */
 
 /**
  * @typedef MatchTest

--- a/packages/patterns/test/test-patterns.js
+++ b/packages/patterns/test/test-patterns.js
@@ -10,7 +10,7 @@ const { Fail } = assert;
 
 const runTests = (successCase, failCase) => {
   /**
-   * @callback makeErrorMessage
+   * @callback MakeErrorMessage
    * @param {string} repr
    * @param {string} [kind]
    * @param {string} [type]
@@ -19,7 +19,7 @@ const runTests = (successCase, failCase) => {
   /**
    * Methods corresponding with pattern matchers that don't look past type.
    *
-   * @type {Record<methodName: string, makeErrorMessage: makeErrorMessage}
+   * @type {Record<string, MakeErrorMessage>}
    */
   const simpleMethods = {
     any: _repr => Fail`must not expect rejection by M.any()`,


### PR DESCRIPTION
Replaces https://github.com/Agoric/agoric-sdk/pull/7375/ now that it's in Endo.

Parameterizes the `InterfaceGuard` type.

The immediate benefit is getting static errors for mismatch between interface guards and behavior methods.
