### PR TITLE
test(patterns): revert error msg improvement that breaks old tests

### DIFF
--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -953,8 +953,19 @@ const makePatternKit = () => {
         false,
         // `label` can be embedded without quotes because it is provided by
         // local code like `M.remotable("...")`.
-        X`${specimen} - Must be a remotable ${b(label)}, not ${kindDetails}`,
+        X`${kindDetails} ${specimen} - Must be a remotable (${b(label)})`,
       );
+      // We would like to use the commented out code below rather than the
+      // the similar code immediately above. The new code improves the error
+      // message, which is great. However, currently agoric-sdk has tests that
+      // depend on the error message emitted by the code above.
+      // TODO use the code below when we can.
+      //
+      // return check(
+      //   false,
+      //   // `label` can be embedded without quotes because it is provided by
+      //   // local code like `M.remotable("...")`.
+      //   X`${specimen} - Must be a remotable ${b(label)}, not ${kindDetails}`,
     },
 
     checkIsWellFormed: (allegedRemotableDesc, check) =>


### PR DESCRIPTION
Fixes https://github.com/endojs/endo/issues/1640

https://github.com/endojs/endo/pull/1606 improved at least one error message, which is great. However, some tests in current agoric-sdk currently depend on the old error message, which this PR restores. 

Note that this PR restores the message, but not by reverting to the code before #1606. Rather, it continues to use the mechanisms introduced in #1606 to output the earlier message.

TODO: Upgrade the tests in agoric-sdk that depend on the old message to also tolerate the improvement.