### PR TITLE
refactor(ses): tolerate core-js better

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -518,6 +518,10 @@ export const permitted = {
     toPrimitive: 'symbol',
     toStringTag: 'symbol',
     unscopables: 'symbol',
+    // Seen at core-js https://github.com/zloirock/core-js#ecmascript-symbol
+    useSimple: false,
+    // Seen at core-js https://github.com/zloirock/core-js#ecmascript-symbol
+    useSetter: false,
   },
 
   '%SymbolPrototype%': {


### PR DESCRIPTION
At https://github.com/zloirock/core-js#ecmascript-symbol we see that core-js adds the non-standard `Symbol.useSimple` and `Symbol.useSetter`. Before this PR, our whitelisting mechanism, having never heard of these, safely removes them during `lockdown`. But because they're unexpected, ses also emits a console diagnostic.

This PR enhances our whitelist so that these two properties are silently removed.