### PR TITLE
fix(exo): do NOT mutate behaviorMethods argument

### DIFF
--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -80,6 +80,7 @@ export const initEmpty = () => emptyRecord;
  * @returns {(...args: Parameters<I>) => (M & import('@endo/eventual-send').RemotableBrand<{}, M>)}
  */
 export const defineExoClass = (tag, interfaceGuard, init, methods, options) => {
+  harden(methods);
   const { finish = undefined } = options || {};
   /** @type {WeakMap<M,ClassContext<ReturnType<I>, M>>} */
   const contextMap = new WeakMap();
@@ -133,6 +134,7 @@ export const defineExoClassKit = (
   methodsKit,
   options,
 ) => {
+  harden(methodsKit);
   const { finish = undefined } = options || {};
   const contextMapKit = objectMap(methodsKit, () => new WeakMap());
   const getContextKit = objectMap(


### PR DESCRIPTION
Fixes https://github.com/endojs/endo/issues/1641

OMG I was mutating a passed in argument that originated from a normal program outside the package. Thus, I was inadvertently mutating that program's state that was not supposed to be mutated. When they then reused that argument in another call, they were passing in the mutated one.