### PR TITLE
feat(daemon): Reify inboxes and outboxes

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -36,7 +36,16 @@ export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
     });
   };
 
-  const randomUuid = () => crypto.randomUUID();
+  const randomHex512 = () =>
+    new Promise((resolve, reject) =>
+      crypto.randomBytes(64, (err, bytes) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(bytes.toString('hex'));
+        }
+      }),
+    );
 
   const listenOnPath = async (sockPath, cancelled) => {
     const [
@@ -155,7 +164,7 @@ export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
   };
 
   /**
-   * @param {string} uuid
+   * @param {string} id
    * @param {string} path
    * @param {string} logPath
    * @param {string} pidPath
@@ -166,7 +175,7 @@ export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
    * @param {Promise<never>} cancelled
    */
   const makeWorker = async (
-    uuid,
+    id,
     path,
     logPath,
     pidPath,
@@ -179,7 +188,7 @@ export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
     const log = fs.openSync(logPath, 'a');
     const child = popen.fork(
       path,
-      [uuid, sockPath, statePath, ephemeralStatePath, cachePath],
+      [id, sockPath, statePath, ephemeralStatePath, cachePath],
       {
         stdio: ['ignore', log, log, 'pipe', 'pipe', 'ipc'],
         // @ts-ignore Stale Node.js type definition.
@@ -218,7 +227,7 @@ export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
     sinkError,
     exitOnError,
     makeSha512,
-    randomUuid,
+    randomHex512,
     listenOnPath,
     informParentWhenListeningOnPath,
     makeFileReader,

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -5,7 +5,7 @@ const { quote: q } = assert;
 const validNamePattern = /^[a-zA-Z][a-zA-Z0-9]{0,127}$/;
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe0-id512|import-bundle0-id512):[0-9a-f]{128}$/;
+  /^(?:inbox|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe0-id512|import-bundle0-id512|inbox-id512|outbox-id512):[0-9a-f]{128})$/;
 
 /**
  * @param {import('./types.js').DaemonicPowers} powers
@@ -70,7 +70,16 @@ const makePetStoreAtPath = async (powers, petNameDirectoryPath) => {
     if (!validFormulaPattern.test(formulaIdentifier)) {
       throw new Error(`Invalid formula identifier ${q(formulaIdentifier)}`);
     }
+
     petNames.set(petName, formulaIdentifier);
+
+    const formulaPetNames = formulaIdentifiers.get(formulaIdentifier);
+    if (formulaPetNames === undefined) {
+      formulaIdentifiers.set(formulaIdentifier, new Set([petName]));
+    } else {
+      formulaPetNames.add(petName);
+    }
+
     const petNamePath = powers.joinPath(petNameDirectoryPath, petName);
     const petNameText = `${formulaIdentifier}\n`;
     await powers.writeFileText(petNamePath, petNameText);

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -3,10 +3,9 @@ import { Far } from '@endo/far';
 const { quote: q } = assert;
 
 const validNamePattern = /^[a-zA-Z][a-zA-Z0-9]{0,127}$/;
-const validUuidPattern =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:readable-blob-sha512:[0-9a-f]{128}|(?:worker-uuid|pet-store-uuid|eval-uuid|import-unsafe0-uuid|import-bundle0-uuid):(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}))$/;
+  /^(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe0-id512|import-bundle0-id512):[0-9a-f]{128}$/;
 
 /**
  * @param {import('./types.js').DaemonicPowers} powers
@@ -186,17 +185,17 @@ const makePetStoreAtPath = async (powers, petNameDirectoryPath) => {
 /**
  * @param {import('./types.js').DaemonicPowers} powers
  * @param {import('./types.js').Locator} locator
- * @param {string} uuid
+ * @param {string} id
  */
-export const makeUuidPetStore = (powers, locator, uuid) => {
-  if (!validUuidPattern.test(uuid)) {
-    throw new Error(`Invalid UUID for pet store ${q(uuid)}`);
+export const makeIdentifiedPetStore = (powers, locator, id) => {
+  if (!validIdPattern.test(id)) {
+    throw new Error(`Invalid identifier for pet store ${q(id)}`);
   }
-  const prefix = uuid.slice(0, 2);
-  const suffix = uuid.slice(3);
+  const prefix = id.slice(0, 2);
+  const suffix = id.slice(3);
   const petNameDirectoryPath = powers.joinPath(
     locator.statePath,
-    'pet-store-uuid',
+    'pet-store-id512',
     prefix,
     suffix,
   );

--- a/packages/daemon/src/reader-ref.js
+++ b/packages/daemon/src/reader-ref.js
@@ -16,7 +16,8 @@ export const asyncIterate = iterable => {
   return iterator;
 };
 
-export const makeIteratorRef = iterator => {
+export const makeIteratorRef = iterable => {
+  const iterator = asyncIterate(iterable);
   return Far('AsyncIterator', {
     async next() {
       return iterator.next();

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -26,7 +26,7 @@ export type DaemonicPowers = {
   sinkError: (error) => void;
   exitOnError: (error) => void;
   makeSha512: () => Sha512;
-  randomUuid: () => string;
+  randomHex512: () => Promise<string>;
   listenOnPath: (
     path: string,
     cancelled: Promise<never>,
@@ -43,7 +43,7 @@ export type DaemonicPowers = {
   joinPath: (...components: Array<string>) => string;
   delay: (ms: number, cancelled: Promise<never>) => Promise<void>;
   makeWorker: (
-    uuid: string,
+    id: string,
     path: string,
     logPath: string,
     pidPath: string,

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -64,7 +64,7 @@ export const makeWorkerFacet = ({
     importUnsafe0: async path => {
       const url = pathToFileURL(path);
       const namespace = await import(url);
-      return namespace.main0(powerBox);
+      return namespace.provide0(powerBox);
     },
 
     importBundle0: async readable => {
@@ -77,7 +77,7 @@ export const makeWorkerFacet = ({
       const namespace = await importBundle(bundle, {
         endowments,
       });
-      return namespace.main0(powerBox);
+      return namespace.provide0(powerBox);
     },
   });
 };

--- a/packages/daemon/test/service.js
+++ b/packages/daemon/test/service.js
@@ -1,6 +1,6 @@
 import { E, Far } from '@endo/far';
 
-export const main0 = powers => {
+export const provide0 = powers => {
   return Far('Service', {
     async ask() {
       return E(powers).request(


### PR DESCRIPTION
This change introduces inboxes and outboxes, and makes major changes to the CLI.

An inbox is a capability to receive and respond to messages, specifically requests for more data or powers.

An outbox is a capability to request additional powers from a specific inbox. An inbox can have multiple outboxes. Each confined program should be given a different outbox. The intention is for the user to eventually be able to give an outbox to each of their peers.

Inboxes and outboxes have independent pet name stores (hereafter, pet stores). The CLI now reflects this. Most commands use or add pet names, and these are now rooted on an inbox or outbox.

These commands now accept a `-i` or `--inbox` flag to designate the pet name of an alternate inbox, starting at the user’s own inbox. Inboxes can designate the pet names of other inboxes, so this flag can be specified multiple times. For the `list`, `rename`, and `remove` commands, this can also follow into outboxes.

The new `request` command allows the user to pretend to make a request on behalf of another party for testing purposes, or if the user creates inboxes for different topics, using `endo make-inbox`. Here are some sample interactions:

Alice:
```
> endo make-outbox bob
> endo inbox --follow
0. bob: meaning of life
^C
> endo eval 42 -n ft
42
> endo resolve 0 ft
```

Bob:
```
> endo request bob 'meaning of life' --name meaning --wait
…some time passes…
42
```

---

Run a counter service.

Assuming `counter.js`:
```js
import { Far } from '@endo/far';

export const provide0 = () => {
  let counter = 0;
  return Far('Counter', {
    incr() {
      counter += 1;
      return counter;
    },
  });
};
```

```
> endo bundle counter.js -n counterBundle
> endo list
counterBundle
> endo import-bundle0 counterBundle counterPowers -n counter
> endo list
counter
counterBundle
counterPowers
> endo eval 'E(counter).incr()' counter
1
> endo eval 'E(counter).incr()' counter
2
> endo eval 'E(counter).incr()' counter
3
> endo remove counterBundle counterPowers
> endo restart
> endo eval 'E(counter).incr()' counter
1
> endo eval 'E(counter).incr()' counter
2
> endo eval 'E(counter).incr()' counter
3
```

Then, to demonstrate how bundled extensions can compose, using references granted by the user, we create another bundled application and give it the API of the other. So, with `doubler.js`:

```
import { E, Far } from '@endo/far';

export const provide0 = powers => {
  const slowCounterP = E(powers).request('please give me a counter', 'counter');
  return Far('Doubler', {
    async incr() {
      const n = await E(slowCounterP).incr();
      return n * 2;
    }
  });
};
```

```
> endo bundle doubler.js -n doublerBundle
> endo import-bundle0 doublerBundle doublerPowers -n doubler
> endo inbox
0. doublerPowers: please give me a counter
> endo resolve 0 counter
> endo eval 'E(doubler).incr()' doubler
8
> endo eval 'E(doubler).incr()' doubler
10
> endo eval 'E(doubler).incr()' doubler
12
```