### PR TITLE
feat(daemon): Weblets

### DIFF
--- a/packages/cli/demo/cat.js
+++ b/packages/cli/demo/cat.js
@@ -1,0 +1,89 @@
+// This is a demo weblet that demonstrates a permission management UI for the
+// pet daemon itself.
+//
+// This command will set up the cat page, create a URL,
+// and open it.
+//
+// > endo open --file cat.js --bundle catBundle --host catPage
+//
+// Thereafter,
+//
+// > endo open catPage
+//
+// To interact with the permission manager, you can mock requests from a fake
+// guest.
+//
+// > endo eval 42 -n ft
+// > endo mkguest cat
+// > endo request cat 'pet me'
+//
+// At this point, the command will pause, waiting for a response.
+// In the Familiar Chat window, resolve the request with the pet name "ft" and
+// the request will exit with the number 42.
+
+/* global window document */
+
+import { E } from '@endo/far';
+import { makeRefIterator } from '@endo/daemon/ref-reader.js';
+
+const dateFormatter = new window.Intl.DateTimeFormat(undefined, {
+  dateStyle: 'full',
+  timeStyle: 'long',
+});
+
+const followMessagesComponent = async (parentElement, powers) => {
+  for await (const message of makeRefIterator(E(powers).followMessages())) {
+    if (message.type === 'request') {
+      const { number, what, when, who, settled } = message;
+
+      const $message = document.createElement('div');
+      parentElement.appendChild($message);
+
+      const $number = document.createElement('span');
+      $number.innerText = `${number}. `;
+      $message.appendChild($number);
+
+      const $who = document.createElement('b');
+      $who.innerText = `${who}:`;
+      $message.appendChild($who);
+
+      const $what = document.createElement('span');
+      $what.innerText = ` ${what} `;
+      $message.appendChild($what);
+
+      const $when = document.createElement('i');
+      $when.innerText = dateFormatter.format(Date.parse(when));
+      $message.appendChild($when);
+
+      const $input = document.createElement('span');
+      $message.appendChild($input);
+
+      const $pet = document.createElement('input');
+      $input.appendChild($pet);
+
+      const $resolve = document.createElement('button');
+      $resolve.innerText = 'resolve';
+      $resolve.onclick = () => {
+        E(powers).resolve(number, $pet.value).catch(window.reportError);
+      };
+      $input.appendChild($resolve);
+
+      const $reject = document.createElement('button');
+      $reject.innerText = 'reject';
+      $reject.onclick = () => {
+        E(powers).reject(number, $pet.value).catch(window.reportError);
+      };
+      $input.appendChild($reject);
+
+      settled.then(status => {
+        $input.innerText = ` ${status} `;
+      });
+    }
+  }
+};
+
+export const endow = async powers => {
+  document.body.innerHTML =
+    '<h1>🐈‍⬛ Familiar Chat</h1><h2>Or: <i>Le Chat Familier</i></h2>';
+  followMessagesComponent(document.body, powers).catch(window.reportError);
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,7 @@
     "@endo/stream-node": "^0.2.26",
     "@endo/where": "^0.3.1",
     "commander": "^5.0.0",
+    "open": "^9.1.0",
     "ses": "^0.18.4"
   },
   "devDependencies": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -22,6 +22,8 @@
   "types": "./types.d.ts",
   "exports": {
     ".": "./index.js",
+    "./ref-reader.js": "./ref-reader.js",
+    "./reader-ref.js": "./reader-ref.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -40,19 +40,21 @@
   "dependencies": {
     "@endo/base64": "^0.2.31",
     "@endo/captp": "^3.1.1",
+    "@endo/compartment-mapper": "^0.8.4",
     "@endo/eventual-send": "^0.17.2",
     "@endo/far": "^0.2.18",
     "@endo/import-bundle": "^0.3.4",
+    "@endo/init": "^0.5.56",
     "@endo/lockdown": "^0.1.28",
     "@endo/netstring": "^0.3.26",
     "@endo/promise-kit": "^0.2.56",
     "@endo/stream": "^0.3.25",
     "@endo/stream-node": "^0.2.26",
     "@endo/where": "^0.3.1",
-    "ses": "^0.18.4"
+    "ses": "^0.18.4",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
-    "@endo/init": "^0.5.56",
     "@endo/ses-ava": "^0.2.40",
     "ava": "^5.3.0",
     "babel-eslint": "^10.0.3",

--- a/packages/daemon/reader-ref.js
+++ b/packages/daemon/reader-ref.js
@@ -1,0 +1,1 @@
+export * from './src/reader-ref.js';

--- a/packages/daemon/ref-reader.js
+++ b/packages/daemon/ref-reader.js
@@ -1,0 +1,1 @@
+export * from './src/ref-reader.js';

--- a/packages/daemon/src/connection.js
+++ b/packages/daemon/src/connection.js
@@ -15,7 +15,13 @@ const textDecoder = new TextDecoder();
  * @param {Promise<void>} cancelled
  * @param {TBootstrap} bootstrap
  */
-const makeMessageCapTP = (name, writer, reader, cancelled, bootstrap) => {
+export const makeMessageCapTP = (
+  name,
+  writer,
+  reader,
+  cancelled,
+  bootstrap,
+) => {
   /** @param {any} message */
   const send = message => {
     return writer.next(message);
@@ -41,7 +47,7 @@ const makeMessageCapTP = (name, writer, reader, cancelled, bootstrap) => {
 };
 
 /** @param {any} message */
-const messageToBytes = message => {
+export const messageToBytes = message => {
   const text = JSON.stringify(message);
   // console.log('->', text);
   const bytes = textEncoder.encode(text);
@@ -49,7 +55,7 @@ const messageToBytes = message => {
 };
 
 /** @param {Uint8Array} bytes */
-const bytesToMessage = bytes => {
+export const bytesToMessage = bytes => {
   const text = textDecoder.decode(bytes);
   // console.log('<-', text);
   const message = JSON.parse(text);

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -6,6 +6,155 @@ import { makePromiseKit } from '@endo/promise-kit';
 import { makePipe } from '@endo/stream';
 import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
 
+const textEncoder = new TextEncoder();
+const medialIterationResult = harden({ done: false });
+const finalIterationResult = harden({ done: false });
+
+/**
+ * @param {object} modules
+ * @param {typeof import('ws')} modules.ws
+ * @param {typeof import('http')} modules.http
+ */
+export const makeHttpPowers = ({ http, ws }) => {
+  // @ts-ignore Not sure why TypeScript gets this wrong.
+  const { WebSocketServer } = ws;
+  const { createServer } = http;
+
+  /**
+   * @param {object} args
+   * @param {number} args.port
+   * @param {import('./types.js').HttpRespond} [args.respond]
+   * @param {import('./types.js').HttpConnect} [args.connect]
+   * @param {Promise<never>} args.cancelled
+   */
+  const serveHttp = async ({ port, respond, connect, cancelled }) => {
+    const server = createServer();
+
+    server.on('error', error => {
+      console.error(error);
+    });
+
+    if (respond) {
+      server.on('request', (req, res) => {
+        (async () => {
+          if (req.method === undefined) {
+            return;
+          }
+          if (req.url === undefined) {
+            return;
+          }
+          const response = await respond(
+            harden({
+              method: req.method,
+              url: req.url,
+              // TODO Node.js headers are a far more detailed type.
+              headers: harden(
+                /** @type {Record<string, string | Array<string> | undefined>} */ (
+                  req.headers
+                ),
+              ),
+            }),
+          );
+          res.writeHead(response.status, response.headers);
+          if (response.content === undefined) {
+            res.end();
+          } else if (
+            typeof response.content === 'string' ||
+            response.content instanceof Uint8Array
+          ) {
+            res.end(response.content);
+          } else {
+            for await (const chunk of response.content) {
+              res.write(chunk);
+            }
+            res.end();
+          }
+        })();
+      });
+    }
+
+    if (connect) {
+      const wss = new WebSocketServer({ server });
+      wss.on('connection', (socket, req) => {
+        const {
+          promise: closed,
+          resolve: close,
+          reject: abort,
+        } = makePromiseKit();
+
+        closed.finally(() => socket.close());
+
+        const [reader, sink] = makePipe();
+
+        socket.on('message', (bytes, isBinary) => {
+          if (!isBinary) {
+            abort(new Error('expected binary'));
+            return;
+          }
+          // TODO Ignoring back-pressure signal:
+          // Unclear whether WebSocketServer accounts for this possibility.
+          sink.next(bytes);
+        });
+        socket.on('close', () => {
+          sink.return(undefined);
+          socket.close();
+          close(finalIterationResult);
+        });
+
+        const writer = {
+          async next(bytes) {
+            socket.send(bytes, { binary: true });
+            return Promise.race([closed, medialIterationResult]);
+          },
+          async return() {
+            socket.close();
+            return Promise.race([closed, medialIterationResult]);
+          },
+          async throw(error) {
+            socket.close();
+            abort(error);
+            return Promise.race([closed, medialIterationResult]);
+          },
+          [Symbol.asyncIterator]() {
+            return this;
+          },
+        };
+
+        connect(
+          harden({
+            reader,
+            writer,
+            closed: closed.then(() => {}),
+          }),
+          harden({
+            method: req.method,
+            url: req.url,
+            headers: req.headers,
+          }),
+        );
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      server.listen(port, error => {
+        if (error) {
+          reject(error);
+        } else {
+          cancelled.catch(() => server.close());
+          const address = server.address();
+          if (address === null || typeof address === 'string') {
+            reject(new Error('expected listener to be assigned a port'));
+          } else {
+            resolve(address.port);
+          }
+        }
+      });
+    });
+  };
+
+  return harden({ serveHttp });
+};
+
 /**
  * @param {object} modules
  * @param {typeof import('crypto')} modules.crypto
@@ -14,24 +163,34 @@ import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
  * @param {typeof import('path')} modules.path
  * @param {typeof import('child_process')} modules.popen
  * @param {typeof import('url')} modules.url
+ * @param {typeof import('ws')} modules.ws
+ * @param {typeof import('http')} modules.http
+ * @param {Record<string, string | undefined>} modules.env
+ * @param {(pid: number) => void} modules.kill
  * @returns {import('./types.js').DaemonicPowers}
  */
-export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
+export const makePowers = ({
+  crypto,
+  net,
+  fs,
+  path: fspath,
+  popen,
+  url,
+  http,
+  ws,
+  kill,
+  env,
+}) => {
   /** @param {Error} error */
   const sinkError = error => {
     console.error(error);
-  };
-
-  /** @param {Error} error */
-  const exitOnError = error => {
-    console.error(error);
-    process.exit(-1);
   };
 
   const makeSha512 = () => {
     const digester = crypto.createHash('sha512');
     return harden({
       update: chunk => digester.update(chunk),
+      updateText: chunk => digester.update(textEncoder.encode(chunk)),
       digestHex: () => digester.digest('hex'),
     });
   };
@@ -85,12 +244,9 @@ export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
     return readFrom;
   };
 
-  /**
-   * @param {string} path
-   */
-  const informParentWhenListeningOnPath = path => {
+  const informParentWhenReady = () => {
     if (process.send) {
-      process.send({ type: 'listening', path });
+      process.send({ type: 'ready' });
     }
   };
 
@@ -219,17 +375,20 @@ export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
     return { reader, writer, closed, pid: child.pid };
   };
 
-  const endoWorkerPath = url.fileURLToPath(
+  const { fileURLToPath } = url;
+
+  const endoWorkerPath = fileURLToPath(
     new URL('worker-node.js', import.meta.url),
   );
 
   return harden({
+    kill: pid => kill(pid),
+    env: { ...env },
     sinkError,
-    exitOnError,
     makeSha512,
     randomHex512,
     listenOnPath,
-    informParentWhenListeningOnPath,
+    informParentWhenReady,
     makeFileReader,
     makeFileWriter,
     writeFileText,
@@ -242,5 +401,8 @@ export const makePowers = ({ crypto, net, fs, path: fspath, popen, url }) => {
     delay,
     makeWorker,
     endoWorkerPath,
+    fileURLToPath,
+
+    ...makeHttpPowers({ http, ws }),
   });
 };

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -9,8 +9,14 @@ import '@endo/lockdown/commit.js';
 
 import { E, Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
+import { mapReader, mapWriter } from '@endo/stream';
 import { makeChangeTopic } from './pubsub.js';
-import { makeNetstringCapTP } from './connection.js';
+import {
+  makeMessageCapTP,
+  makeNetstringCapTP,
+  messageToBytes,
+  bytesToMessage,
+} from './connection.js';
 import { makeRefReader } from './ref-reader.js';
 import { makeReaderRef, makeIteratorRef } from './reader-ref.js';
 import { makeOwnPetStore, makeIdentifiedPetStore } from './pet-store.js';
@@ -18,10 +24,15 @@ import { makeOwnPetStore, makeIdentifiedPetStore } from './pet-store.js';
 const { quote: q } = assert;
 
 const validNamePattern = /^[a-zA-Z][a-zA-Z0-9]{0,127}$/;
+const zero512 =
+  '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+
+const defaultHttpPort = 8920; // Eight Nine Duo Oh: ENDO.
 
 /**
  * @param {import('./types.js').DaemonicPowers} powers
  * @param {import('./types.js').Locator} locator
+ * @param {number} httpPort
  * @param {object} args
  * @param {Promise<never>} args.cancelled
  * @param {(error: Error) => void} args.cancel
@@ -31,6 +42,7 @@ const validNamePattern = /^[a-zA-Z][a-zA-Z0-9]{0,127}$/;
 const makeEndoBootstrap = (
   powers,
   locator,
+  httpPort,
   { cancelled, cancel, gracePeriodMs, gracePeriodElapsed },
 ) => {
   /** @type {Map<string, unknown>} */
@@ -61,10 +73,14 @@ const makeEndoBootstrap = (
     const text = async () => {
       return powers.readFileText(storagePath);
     };
+    const json = async () => {
+      return JSON.parse(await text());
+    };
     return Far(`Readable file with SHA-512 ${sha512.slice(0, 8)}...`, {
       sha512: () => sha512,
       stream,
       text,
+      json,
       [Symbol.asyncIterator]: stream,
     });
   };
@@ -432,7 +448,16 @@ const makeEndoBootstrap = (
       const settle = () => {
         requests.delete(requestNumber);
       };
-      const settled = promise.then(settle, settle);
+      const settled = promise.then(
+        () => {
+          settle();
+          return 'fulfilled';
+        },
+        () => {
+          settle();
+          return 'rejected';
+        },
+      );
 
       // How does the receiver know the sender?
       const formulaIdentifier = formulaIdentifierForRef.get(whom);
@@ -593,6 +618,7 @@ const makeEndoBootstrap = (
       /** @type {string | undefined} */
       let workerFormulaIdentifier;
       if (workerName === undefined) {
+        // TODO Using worker 0 should be an option, for evaluate formulas.
         const workerId512 = await powers.randomHex512();
         workerFormulaIdentifier = `worker-id512:${workerId512}`;
       } else {
@@ -610,9 +636,12 @@ const makeEndoBootstrap = (
     };
 
     /**
-     * @param {string} outboxName
+     * @param {string} [outboxName]
      */
-    const provideOutboxFormulaIdentifier = async outboxName => {
+    const providePowersFormulaIdentifier = async outboxName => {
+      if (outboxName === undefined) {
+        return inboxFormulaIdentifier;
+      }
       let outboxFormulaIdentifier = petStore.get(outboxName);
       if (outboxFormulaIdentifier === undefined) {
         const outbox = await makeOutbox(outboxName);
@@ -686,7 +715,7 @@ const makeEndoBootstrap = (
     /**
      * @param {string | undefined} workerName
      * @param {string} importPath
-     * @param {string} outboxName
+     * @param {string | undefined} outboxName
      * @param {string} resultName
      */
     const importUnsafeAndEndow = async (
@@ -699,7 +728,7 @@ const makeEndoBootstrap = (
         workerName,
       );
 
-      const outboxFormulaIdentifier = await provideOutboxFormulaIdentifier(
+      const outboxFormulaIdentifier = await providePowersFormulaIdentifier(
         outboxName,
       );
 
@@ -726,7 +755,7 @@ const makeEndoBootstrap = (
     /**
      * @param {string} workerName
      * @param {string} bundleName
-     * @param {string} outboxName
+     * @param {string | undefined} outboxName
      * @param {string} resultName
      */
     const importBundleAndEndow = async (
@@ -744,7 +773,7 @@ const makeEndoBootstrap = (
         throw new TypeError(`Unknown pet name for bundle: ${bundleName}`);
       }
 
-      const outboxFormulaIdentifier = await provideOutboxFormulaIdentifier(
+      const outboxFormulaIdentifier = await providePowersFormulaIdentifier(
         outboxName,
       );
 
@@ -802,6 +831,48 @@ const makeEndoBootstrap = (
       );
     };
 
+    /**
+     * @param {string} webPageName
+     * @param {string} bundleName
+     * @param {string | undefined} powersName
+     */
+    const provideWebPage = async (webPageName, bundleName, powersName) => {
+      const bundleFormulaIdentifier = petStore.get(bundleName);
+      if (bundleFormulaIdentifier === undefined) {
+        throw new Error(`Unknown pet name: ${q(bundleName)}`);
+      }
+
+      const powersFormulaIdentifier = await providePowersFormulaIdentifier(
+        powersName,
+      );
+
+      const digester = powers.makeSha512();
+      digester.updateText(
+        `${bundleFormulaIdentifier},${powersFormulaIdentifier}`,
+      );
+      const formulaNumber = digester.digestHex().slice(32, 64);
+
+      const formula = {
+        type: 'web-bundle',
+        bundle: bundleFormulaIdentifier,
+        powers: powersFormulaIdentifier,
+      };
+
+      // Behold, recursion:
+      // eslint-disable-next-line no-use-before-define
+      const { value, formulaIdentifier } = await provideValueForNumberedFormula(
+        'web-bundle',
+        formulaNumber,
+        formula,
+      );
+
+      if (webPageName !== undefined) {
+        await petStore.write(webPageName, formulaIdentifier);
+      }
+
+      return value;
+    };
+
     const { list, remove, rename } = petStore;
 
     /** @type {import('./types.js').EndoInbox} */
@@ -822,6 +893,7 @@ const makeEndoBootstrap = (
       evaluate,
       importUnsafeAndEndow,
       importBundleAndEndow,
+      provideWebPage,
     });
 
     inboxRequestFunctions.set(inbox, request);
@@ -831,9 +903,14 @@ const makeEndoBootstrap = (
 
   /**
    * @param {string} formulaIdentifier
+   * @param {string} formulaNumber
    * @param {import('./types.js').Formula} formula
    */
-  const makeValueForFormula = async (formulaIdentifier, formula) => {
+  const makeValueForFormula = async (
+    formulaIdentifier,
+    formulaNumber,
+    formula,
+  ) => {
     if (formula.type === 'eval') {
       return makeValueForEval(
         formula.worker,
@@ -859,6 +936,16 @@ const makeEndoBootstrap = (
         formula.inbox,
         formula.store,
       );
+    } else if (formula.type === 'web-bundle') {
+      return harden({
+        url: `http://${formulaNumber}.endo.localhost:${httpPort}`,
+        // Behold, recursion:
+        // eslint-disable-next-line no-use-before-define
+        bundle: provideValueForFormulaIdentifier(formula.bundle),
+        // Behold, recursion:
+        // eslint-disable-next-line no-use-before-define
+        powers: provideValueForFormulaIdentifier(formula.powers),
+      });
     } else {
       throw new TypeError(`Invalid formula: ${q(formula)}`);
     }
@@ -891,15 +978,21 @@ const makeEndoBootstrap = (
   // Persist instructions for revival (this can be collected)
   const writeFormula = async (formula, formulaType, formulaId512) => {
     const { directory, file } = makeFormulaPath(formulaType, formulaId512);
+    // TODO Take care to write atomically with a rename here.
     await powers.makePath(directory);
     await powers.writeFileText(file, `${q(formula)}\n`);
   };
 
   /**
    * @param {string} formulaIdentifier
+   * @param {string} formulaNumber
    * @param {string} formulaPath
    */
-  const makeValueForFormulaAtPath = async (formulaIdentifier, formulaPath) => {
+  const makeValueForFormulaAtPath = async (
+    formulaIdentifier,
+    formulaNumber,
+    formulaPath,
+  ) => {
     const formulaText = await powers.readFileText(formulaPath).catch(() => {
       // TODO handle EMFILE gracefully
       throw new ReferenceError(`No reference exists at path ${formulaPath}`);
@@ -914,36 +1007,45 @@ const makeEndoBootstrap = (
       }
     })();
     // TODO validate
-    return makeValueForFormula(formulaIdentifier, formula);
+    return makeValueForFormula(formulaIdentifier, formulaNumber, formula);
   };
 
   /**
    * @param {string} formulaIdentifier
    */
   const makeValueForFormulaIdentifier = async formulaIdentifier => {
-    if (formulaIdentifier === 'pet-store') {
-      return makeOwnPetStore(powers, locator);
-    } else if (formulaIdentifier === 'inbox') {
-      return makeIdentifiedInbox(formulaIdentifier, 'pet-store');
-    }
     const delimiterIndex = formulaIdentifier.indexOf(':');
     if (delimiterIndex < 0) {
+      if (formulaIdentifier === 'pet-store') {
+        return makeOwnPetStore(powers, locator, 'pet-store');
+      } else if (formulaIdentifier === 'inbox') {
+        return makeIdentifiedInbox(formulaIdentifier, 'pet-store');
+      } else if (formulaIdentifier === 'web-page-js') {
+        return makeValueForFormula('web-page-js', zero512, {
+          type: /** @type {'import-unsafe'} */ ('import-unsafe'),
+          worker: `worker-id512:${zero512}`,
+          outbox: 'inbox',
+          importPath: powers.fileURLToPath(
+            new URL('web-page-bundler.js', import.meta.url).href,
+          ),
+        });
+      }
       throw new TypeError(
         `Formula identifier must have a colon: ${q(formulaIdentifier)}`,
       );
     }
     const prefix = formulaIdentifier.slice(0, delimiterIndex);
-    const suffix = formulaIdentifier.slice(delimiterIndex + 1);
+    const formulaNumber = formulaIdentifier.slice(delimiterIndex + 1);
     if (prefix === 'readable-blob-sha512') {
-      return makeSha512ReadableBlob(suffix);
+      return makeSha512ReadableBlob(formulaNumber);
     } else if (prefix === 'worker-id512') {
-      return makeIdentifiedWorker(suffix);
+      return makeIdentifiedWorker(formulaNumber);
     } else if (prefix === 'pet-store-id512') {
-      return makeIdentifiedPetStore(powers, locator, suffix);
+      return makeIdentifiedPetStore(powers, locator, formulaNumber);
     } else if (prefix === 'inbox-id512') {
       return makeIdentifiedInbox(
         formulaIdentifier,
-        `pet-store-id512:${suffix}`,
+        `pet-store-id512:${formulaNumber}`,
       );
     } else if (
       [
@@ -951,10 +1053,11 @@ const makeEndoBootstrap = (
         'import-unsafe-id512',
         'import-bundle-id512',
         'outbox-id512',
+        'web-bundle',
       ].includes(prefix)
     ) {
-      const { file: path } = makeFormulaPath(prefix, suffix);
-      return makeValueForFormulaAtPath(formulaIdentifier, path);
+      const { file: path } = makeFormulaPath(prefix, formulaNumber);
+      return makeValueForFormulaAtPath(formulaIdentifier, formulaNumber, path);
     } else {
       throw new TypeError(
         `Invalid formula identifier, unrecognized type ${q(formulaIdentifier)}`,
@@ -967,17 +1070,21 @@ const makeEndoBootstrap = (
   // valuePromiseForFormulaIdentifier and formulaIdentifierForRef, since the
   // former bypasses the latter in order to avoid a round trip with disk.
 
-  /**
-   * @param {import('./types.js').Formula} formula
-   * @param {string} formulaType
-   */
-  const provideValueForFormula = async (formula, formulaType) => {
-    const formulaId512 = await powers.randomHex512();
-    const formulaIdentifier = `${formulaType}:${formulaId512}`;
-    await writeFormula(formula, formulaType, formulaId512);
+  const provideValueForNumberedFormula = async (
+    formulaType,
+    formulaNumber,
+    formula,
+  ) => {
+    const formulaIdentifier = `${formulaType}:${formulaNumber}`;
+
+    await writeFormula(formula, formulaType, formulaNumber);
     // Behold, recursion:
     // eslint-disable-next-line no-use-before-define
-    const promiseForValue = makeValueForFormula(formulaIdentifier, formula);
+    const promiseForValue = makeValueForFormula(
+      formulaIdentifier,
+      formulaNumber,
+      formula,
+    );
 
     // Memoize provide.
     valuePromiseForFormulaIdentifier.set(formulaIdentifier, promiseForValue);
@@ -989,6 +1096,15 @@ const makeEndoBootstrap = (
     }
 
     return { formulaIdentifier, value };
+  };
+
+  /**
+   * @param {import('./types.js').Formula} formula
+   * @param {string} formulaType
+   */
+  const provideValueForFormula = async (formula, formulaType) => {
+    const formulaNumber = await powers.randomHex512();
+    return provideValueForNumberedFormula(formulaType, formulaNumber, formula);
   };
 
   /**
@@ -1018,6 +1134,21 @@ const makeEndoBootstrap = (
     },
 
     inbox: () => provideValueForFormulaIdentifier('inbox'),
+
+    webPageJs: () => provideValueForFormulaIdentifier('web-page-js'),
+
+    importAndEndowInWebPage: async (webPageP, webPageNumber) => {
+      const { bundle: bundleBlob, powers: endowedPowers } =
+        /** @type {import('./types.js').EndoWebBundle} */ (
+          await provideValueForFormulaIdentifier(
+            `web-bundle:${webPageNumber}`,
+          ).catch(() => {
+            throw new Error('Not found');
+          })
+        );
+      const bundle = await E(bundleBlob).json();
+      await E(webPageP).importBundleAndEndow(bundle, endowedPowers);
+    },
   });
 
   return endoBootstrap;
@@ -1053,7 +1184,148 @@ export const main = async (powers, locator, pid, cancel, cancelled) => {
     throw error;
   });
 
-  const endoBootstrap = makeEndoBootstrap(powers, locator, {
+  /** @param {Error} error */
+  const exitWithError = error => {
+    cancel(error);
+    cancelGracePeriod(error);
+  };
+
+  let nextConnectionNumber = 0;
+  /** @type {Set<Promise<void>>} */
+  const connectionClosedPromises = new Set();
+
+  const respond = async request => {
+    if (request.method === 'GET') {
+      if (request.url === '/') {
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'text/html', Charset: 'utf-8' },
+          content: `\
+<meta charset="utf-8">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 10 10%22><text y=%228%22 font-size=%228%22>🐈‍⬛</text></svg>">
+<body>
+  <h1>⏳</h1>
+  <script src="bootstrap.js"></script>
+</body>`,
+        };
+      } else if (request.url === '/bootstrap.js') {
+        // TODO readable mutable file formula (with watcher?)
+        // Behold, recursion:
+        // eslint-disable-next-line no-use-before-define
+        const webPageJs = await E(endoBootstrap).webPageJs();
+        return {
+          status: 200,
+          headers: { 'Content-Type': 'application/javascript' },
+          content: webPageJs,
+        };
+      }
+    }
+    return {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain' },
+      content: `Not found: ${request.method} ${request.url}`,
+    };
+  };
+
+  const requestedHttpPortString = powers.env.ENDO_HTTP_PORT;
+  const requestedHttpPort = requestedHttpPortString
+    ? Number(requestedHttpPortString)
+    : defaultHttpPort;
+
+  const httpReadyP = powers.serveHttp({
+    port: requestedHttpPort,
+    respond,
+    connect(connection, request) {
+      // TODO select attenuated bootstrap based on subdomain
+      (async () => {
+        const {
+          reader: frameReader,
+          writer: frameWriter,
+          closed: connectionClosed,
+        } = connection;
+
+        const connectionNumber = nextConnectionNumber;
+        nextConnectionNumber += 1;
+        console.log(
+          `Endo daemon received local web socket connection ${connectionNumber} at ${new Date().toISOString()}`,
+        );
+
+        const messageWriter = mapWriter(frameWriter, messageToBytes);
+        const messageReader = mapReader(frameReader, bytesToMessage);
+
+        const { closed: capTpClosed, getBootstrap } = makeMessageCapTP(
+          'Endo',
+          messageWriter,
+          messageReader,
+          cancelled,
+          undefined, // bootstrap
+        );
+
+        const webBootstrap = getBootstrap();
+
+        // TODO set up heart monitor
+        E.sendOnly(webBootstrap).ping();
+
+        const host = request.headers.host;
+        if (host === undefined) {
+          throw new Error('Host header required');
+        }
+        // TODO parameterize port number
+        const match =
+          /^([0-9a-f]{32})\.endo\.localhost:([1-9][0-9]{0,4})$/.exec(host);
+        if (match === null) {
+          throw new Error(`Invalid host ${host}`);
+        }
+        const [_, formulaNumber, portNumber] = match;
+        // eslint-disable-next-line no-use-before-define
+        if (assignedHttpPort !== +portNumber) {
+          console.error(
+            'Connected browser misreported port number in host header',
+          );
+          E(webBootstrap)
+            .reject(
+              'Your browser misreported your port number in the host header',
+            )
+            .catch(error => {
+              console.error(error);
+            });
+        } else {
+          // eslint-disable-next-line no-use-before-define
+          E(endoBootstrap)
+            .importAndEndowInWebPage(webBootstrap, formulaNumber)
+            .catch(error => {
+              E.sendOnly(webBootstrap).reject(error.message);
+            })
+            .catch(error => {
+              console.error(error);
+            });
+        }
+
+        const closed = Promise.race([connectionClosed, capTpClosed]);
+        connectionClosedPromises.add(closed);
+        closed.finally(() => {
+          connectionClosedPromises.delete(closed);
+          console.log(
+            `Endo daemon closed local web socket connection ${connectionNumber} at ${new Date().toISOString()}`,
+          );
+        });
+      })().catch(exitWithError);
+    },
+    cancelled,
+  });
+
+  const connectionsP = powers.listenOnPath(locator.sockPath, cancelled);
+
+  await Promise.all([connectionsP, httpReadyP]);
+
+  const assignedHttpPort = await httpReadyP;
+  console.log(
+    `Endo daemon listening for HTTP on ${q(
+      assignedHttpPort,
+    )} ${new Date().toISOString()}`,
+  );
+
+  const endoBootstrap = makeEndoBootstrap(powers, locator, assignedHttpPort, {
     cancelled,
     cancel,
     gracePeriodMs,
@@ -1066,29 +1338,37 @@ export const main = async (powers, locator, pid, cancel, cancelled) => {
   await Promise.all([statePathP, cachePathP, ephemeralStatePathP]);
 
   const pidPath = powers.joinPath(locator.ephemeralStatePath, 'endo.pid');
+
+  await powers
+    .readFileText(pidPath)
+    .then(pidText => {
+      const oldPid = Number(pidText);
+      powers.kill(oldPid);
+    })
+    .catch(() => {});
+
   await powers.writeFileText(pidPath, `${pid}\n`);
 
-  const connections = await powers.listenOnPath(locator.sockPath, cancelled);
+  const connections = await connectionsP;
   // Resolve a promise in the Endo CLI through the IPC channel:
-  powers.informParentWhenListeningOnPath(locator.sockPath);
   console.log(
-    `Endo daemon listening on ${q(
+    `Endo daemon listening for CapTP on ${q(
       locator.sockPath,
     )} ${new Date().toISOString()}`,
   );
-  let nextConnectionNumber = 0;
-  /** @type {Set<Promise<void>>} */
-  const connectionClosedPromises = new Set();
-  try {
-    for await (const {
-      reader,
-      writer,
-      closed: connectionClosed,
-    } of connections) {
+
+  powers.informParentWhenReady();
+
+  for await (const {
+    reader,
+    writer,
+    closed: connectionClosed,
+  } of connections) {
+    (async () => {
       const connectionNumber = nextConnectionNumber;
       nextConnectionNumber += 1;
       console.log(
-        `Endo daemon received connection ${connectionNumber} at ${new Date().toISOString()}`,
+        `Endo daemon received domain connection ${connectionNumber} at ${new Date().toISOString()}`,
       );
 
       const { closed: capTpClosed } = makeNetstringCapTP(
@@ -1104,16 +1384,14 @@ export const main = async (powers, locator, pid, cancel, cancelled) => {
       closed.finally(() => {
         connectionClosedPromises.delete(closed);
         console.log(
-          `Endo daemon closed connection ${connectionNumber} at ${new Date().toISOString()}`,
+          `Endo daemon closed domain connection ${connectionNumber} at ${new Date().toISOString()}`,
         );
       });
-    }
-  } catch (error) {
-    cancel(error);
-    cancelGracePeriod(error);
-  } finally {
-    await Promise.all(Array.from(connectionClosedPromises));
-    cancel(new Error('Terminated normally'));
-    cancelGracePeriod(new Error('Terminated normally'));
+    })().catch(exitWithError);
   }
+
+  await Promise.all(Array.from(connectionClosedPromises));
+
+  cancel(new Error('Terminated normally'));
+  cancelGracePeriod(new Error('Terminated normally'));
 };

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -5,7 +5,7 @@ const { quote: q } = assert;
 const validNamePattern = /^[a-zA-Z][a-zA-Z0-9]{0,127}$/;
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:inbox|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe-id512|import-bundle-id512|inbox-id512|outbox-id512):[0-9a-f]{128})$/;
+  /^(?:inbox|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe-id512|import-bundle-id512|inbox-id512|outbox-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').DaemonicPowers} powers
@@ -214,8 +214,9 @@ export const makeIdentifiedPetStore = (powers, locator, id) => {
 /**
  * @param {import('./types.js').DaemonicPowers} powers
  * @param {import('./types.js').Locator} locator
+ * @param {string} name
  */
-export const makeOwnPetStore = (powers, locator) => {
-  const petNameDirectoryPath = powers.joinPath(locator.statePath, 'pet-store');
+export const makeOwnPetStore = (powers, locator, name) => {
+  const petNameDirectoryPath = powers.joinPath(locator.statePath, name);
   return makePetStoreAtPath(powers, petNameDirectoryPath);
 };

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -3,6 +3,7 @@ import type { Reader, Writer, Stream } from '@endo/stream';
 
 export type Locator = {
   statePath: string;
+  httpPort?: number;
   ephemeralStatePath: string;
   cachePath: string;
   sockPath: string;
@@ -10,6 +11,7 @@ export type Locator = {
 
 export type Sha512 = {
   update: (chunk: Uint8Array) => void;
+  updateText: (chunk: string) => void;
   digestHex: () => string;
 };
 
@@ -23,16 +25,40 @@ export type Worker = Connection & {
   pid: number | undefined;
 };
 
+export type HttpRequest = {
+  method: string;
+  url: string;
+  headers: Record<string, string | Array<string> | undefined>;
+};
+
+export type HttpResponse = {
+  status: number;
+  headers: Record<string, string>;
+  content: AsyncIterable<string | Uint8Array> | string | Uint8Array | undefined;
+};
+
+export type HttpRespond = (request: HttpRequest) => Promise<HttpResponse>;
+export type HttpConnect = (
+  connection: Connection,
+  request: HttpRequest,
+) => void;
+
 export type DaemonicPowers = {
+  env: Record<string, string | undefined>;
   sinkError: (error) => void;
-  exitOnError: (error) => void;
   makeSha512: () => Sha512;
   randomHex512: () => Promise<string>;
   listenOnPath: (
     path: string,
     cancelled: Promise<never>,
   ) => Promise<AsyncIterableIterator<Connection>>;
-  informParentWhenListeningOnPath: (path: string) => void;
+  serveHttp: (args: {
+    port: number;
+    respond?: HttpRespond;
+    connect?: HttpConnect;
+    cancelled: Promise<never>;
+  }) => void;
+  informParentWhenReady: () => void;
   makeFileReader: (path: string) => Reader<Uint8Array>;
   makeFileWriter: (path: string) => Writer<Uint8Array>;
   readFileText: (path: string) => Promise<string>;
@@ -55,10 +81,10 @@ export type DaemonicPowers = {
     cancelled: Promise<never>,
   ) => Promise<Worker>;
   endoWorkerPath: string;
+  fileURLToPath: (url: string) => string;
 };
 
 export type MignonicPowers = {
-  exitOnError: (error) => void;
   pathToFileURL: (path: string) => string;
   connection: {
     reader: Reader<Uint8Array>;
@@ -102,12 +128,19 @@ type ImportBundleFormula = {
   // TODO formula slots
 };
 
+type WebBundleFormula = {
+  type: 'web-bundle';
+  bundle: string;
+  powers: string;
+};
+
 export type Formula =
   | InboxFormula
   | OutboxFormula
   | EvalFormula
   | ImportUnsafeFormula
-  | ImportBundleFormula;
+  | ImportBundleFormula
+  | WebBundleFormula;
 
 export type Label = {
   number: number;
@@ -153,6 +186,7 @@ export interface EndoReadable {
   sha512(): string;
   stream(): ERef<Reader<Uint8Array>>;
   text(): Promise<string>;
+  json(): Promise<unknown>;
   [Symbol.asyncIterator]: Reader<Uint8Array>;
 }
 
@@ -202,3 +236,9 @@ export interface EndoInbox {
     resultName?: string,
   ): Promise<unknown>;
 }
+
+export type EndoWebBundle = {
+  url: string;
+  bundle: ERef<EndoReadable>;
+  powers: ERef<unknown>;
+};

--- a/packages/daemon/src/web-page-bundler.js
+++ b/packages/daemon/src/web-page-bundler.js
@@ -1,0 +1,16 @@
+// This is a built-in unsafe plugin for lazily constructing the web-page.js
+// bundle for booting up web caplets.
+// The hard-coded 'web-page-js' formula is a hard-coded 'import-unsafe' formula
+// that runs this program in worker 0.
+// It does not accept its endowed powers.
+
+import 'ses';
+import fs from 'node:fs';
+import { makeBundle } from '@endo/compartment-mapper/bundle.js';
+import { fileURLToPath } from 'url';
+
+const read = async location => fs.promises.readFile(fileURLToPath(location));
+
+export const endow = async () => {
+  return makeBundle(read, new URL('web-page.js', import.meta.url).href);
+};

--- a/packages/daemon/src/web-page.js
+++ b/packages/daemon/src/web-page.js
@@ -1,0 +1,67 @@
+/* global window, document */
+
+import '@endo/init/debug.js';
+import { makeCapTP } from '@endo/captp';
+import { E, Far } from '@endo/far';
+import { importBundle } from '@endo/import-bundle';
+
+const hardenedEndowments = harden({
+  assert,
+  E,
+  Far,
+  TextEncoder,
+  TextDecoder,
+  URL,
+});
+
+const endowments = Object.freeze({
+  ...hardenedEndowments,
+  window,
+  document,
+  console,
+});
+
+const url = new URL('/', window.location);
+url.protocol = 'ws';
+
+const bootstrap = Far('WebFacet', {
+  ping() {
+    console.log('received ping');
+    return 'pong';
+  },
+  async importBundleAndEndow(bundle, powers) {
+    const namespace = await importBundle(bundle, {
+      endowments,
+    });
+    return namespace.endow(powers);
+  },
+  reject(message) {
+    document.body.innerHTML = '';
+    const $title = document.createElement('h1');
+    $title.innerText = `💔 ${message}`;
+    document.body.appendChild($title);
+  },
+});
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const ws = new WebSocket(url.href);
+ws.binaryType = 'arraybuffer';
+ws.addEventListener('open', () => {
+  const send = message => {
+    // console.log('send', message);
+    ws.send(textEncoder.encode(JSON.stringify(message)));
+  };
+  const { dispatch, abort } = makeCapTP('WebClient', send, bootstrap);
+  ws.addEventListener('message', event => {
+    const message = JSON.parse(textDecoder.decode(event.data));
+    // console.log('received', message);
+    dispatch(message);
+  });
+  ws.addEventListener('close', () => {
+    abort();
+  });
+});
+
+document.body.innerHTML = '<h1>⌛️</h1>';

--- a/packages/daemon/src/worker-node-powers.js
+++ b/packages/daemon/src/worker-node-powers.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* global process */
 
 import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
 
@@ -10,12 +9,6 @@ import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
  * @returns {import('./types.js').MignonicPowers}
  */
 export const makePowers = ({ fs, url }) => {
-  /** @param {Error} error */
-  const exitOnError = error => {
-    console.error(error);
-    process.exit(-1);
-  };
-
   // @ts-ignore This is in fact how you open a file descriptor.
   const reader = makeNodeReader(fs.createReadStream(null, { fd: 3 }));
   // @ts-ignore This is in fact how you open a file descriptor.
@@ -29,7 +22,6 @@ export const makePowers = ({ fs, url }) => {
   const { pathToFileURL } = url;
 
   return harden({
-    exitOnError,
     connection,
     pathToFileURL: path => pathToFileURL(path).toString(),
   });

--- a/packages/daemon/src/worker-node.js
+++ b/packages/daemon/src/worker-node.js
@@ -41,6 +41,12 @@ const { promise: cancelled, reject: cancel } =
 
 process.once('SIGINT', () => cancel(new Error('SIGINT')));
 
-main(powers, locator, workerUuid, process.pid, cancel, cancelled).catch(
-  powers.exitOnError,
+process.exitCode = 1;
+main(powers, locator, workerUuid, process.pid, cancel, cancelled).then(
+  () => {
+    process.exitCode = 0;
+  },
+  error => {
+    console.error(error);
+  },
 );

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -28,6 +28,7 @@ const dirname = url.fileURLToPath(new URL('..', import.meta.url)).toString();
 /** @param {Array<string>} root */
 const makeLocator = (...root) => {
   return {
+    httpPort: 0,
     statePath: path.join(dirname, ...root, 'state'),
     ephemeralStatePath: path.join(dirname, ...root, 'run'),
     cachePath: path.join(dirname, ...root, 'cache'),


### PR DESCRIPTION
This change introduces web page caplets or “weblets”. The `endo open` command is responsible for setting up a localhost web page and then opening it in your local web browser, provided a caplet that assumes control of the window and document and receives an endowment, either the host or a named guest.

This includes a `cat.js` weblet that provides a user interface for managing the host’s own messages, which currently are just permission management requests. The demo demonstrates how easy it is to implement a reactive web page using the ordinary DOM and eventual send.