### PR TITLE
refactor(daemon): Rename inbox/outbox to host/guest

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -294,7 +294,12 @@ export const main = async rawArgs => {
 
   program
     .command('archive <application-path>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option('-n,--name <name>', 'Store the archive into Endo')
     .option('-f,--file <archive-path>', 'Store the archive into a file')
     .description('captures an archive from an entry module path')
@@ -302,7 +307,7 @@ export const main = async rawArgs => {
       const {
         name: archiveName,
         file: archivePath,
-        inbox: inboxNames,
+        as: partyNames,
       } = cmd.opts();
       const applicationLocation = url.pathToFileURL(applicationPath);
       if (archiveName !== undefined) {
@@ -315,11 +320,11 @@ export const main = async rawArgs => {
         );
         try {
           const bootstrap = getBootstrap();
-          let inbox = E(bootstrap).inbox();
-          for (const inboxName of inboxNames) {
-            inbox = E(inbox).provide(inboxName);
+          let party = E(bootstrap).host();
+          for (const partyName of partyNames) {
+            party = E(party).provide(partyName);
           }
-          await E(inbox).store(readerRef, archiveName);
+          await E(party).store(readerRef, archiveName);
         } catch (error) {
           console.error(error);
           cancel(error);
@@ -339,13 +344,18 @@ export const main = async rawArgs => {
 
   program
     .command('bundle <application-path>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option('-n,--name <name>', 'Store the bundle into Endo')
     .description(
       'captures a JSON bundle containing an archive for an entry module path',
     )
     .action(async (applicationPath, cmd) => {
-      const { name: bundleName, inbox: inboxNames } = cmd.opts();
+      const { name: bundleName, as: partyNames } = cmd.opts();
       const bundle = await bundleSource(applicationPath);
       console.log(bundle.endoZipBase64Sha512);
       const bundleText = JSON.stringify(bundle);
@@ -358,11 +368,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        await E(inbox).store(readerRef, bundleName);
+        await E(party).store(readerRef, bundleName);
       } catch (error) {
         console.error(error);
         cancel(error);
@@ -371,14 +381,19 @@ export const main = async rawArgs => {
 
   program
     .command('store <path>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option(
       '-n,--name <name>',
       'Assigns a pet name to the result for future reference',
     )
     .description('stores a readable file')
     .action(async (storablePath, cmd) => {
-      const { name, inbox: inboxNames } = cmd.opts();
+      const { name, as: partyNames } = cmd.opts();
       const nodeReadStream = fs.createReadStream(storablePath);
       const reader = makeNodeReader(nodeReadStream);
       const readerRef = makeReaderRef(reader);
@@ -390,11 +405,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        await E(inbox).store(readerRef, name);
+        await E(party).store(readerRef, name);
       } catch (error) {
         console.error(error);
         cancel(error);
@@ -404,9 +419,14 @@ export const main = async rawArgs => {
   program
     .command('spawn [names...]')
     .description('creates workers for evaluating or importing programs')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .action(async (petNames, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -414,12 +434,12 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
         for (const petName of petNames) {
-          await E(inbox).makeWorker(petName);
+          await E(party).makeWorker(petName);
         }
       } catch (error) {
         console.error(error);
@@ -429,10 +449,15 @@ export const main = async rawArgs => {
 
   program
     .command('show <name>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .description('prints the named value')
     .action(async (name, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -440,11 +465,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const pet = await E(inbox).provide(name);
+        const pet = await E(party).provide(name);
         console.log(pet);
       } catch (error) {
         console.error(error);
@@ -454,12 +479,17 @@ export const main = async rawArgs => {
 
   program
     .command('follow <name>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .description(
       'prints a representation of each value from the named async iterable as it arrives',
     )
     .action(async (name, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -467,11 +497,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const iterable = await E(inbox).provide(name);
+        const iterable = await E(party).provide(name);
         for await (const iterand of makeRefIterator(iterable)) {
           console.log(iterand);
         }
@@ -483,10 +513,15 @@ export const main = async rawArgs => {
 
   program
     .command('cat <name>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .description('prints the content of the named readable file')
     .action(async (name, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -494,11 +529,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const readable = await E(inbox).provide(name);
+        const readable = await E(party).provide(name);
         const readerRef = E(readable).stream();
         const reader = makeRefReader(readerRef);
         for await (const chunk of reader) {
@@ -512,10 +547,15 @@ export const main = async rawArgs => {
 
   program
     .command('list')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .description('lists pet names')
     .action(async cmd => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -523,11 +563,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const petNames = await E(inbox).list();
+        const petNames = await E(party).list();
         for await (const petName of petNames) {
           console.log(petName);
         }
@@ -540,9 +580,14 @@ export const main = async rawArgs => {
   program
     .command('remove [names...]')
     .description('removes pet names')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .action(async (petNames, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -550,11 +595,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        await Promise.all(petNames.map(petName => E(inbox).remove(petName)));
+        await Promise.all(petNames.map(petName => E(party).remove(petName)));
       } catch (error) {
         console.error(error);
         cancel(error);
@@ -564,9 +609,14 @@ export const main = async rawArgs => {
   program
     .command('rename <from> <to>')
     .description('renames a value')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .action(async (fromName, toName, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -574,11 +624,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        await E(inbox).rename(fromName, toName);
+        await E(party).rename(fromName, toName);
       } catch (error) {
         console.error(error);
         cancel(error);
@@ -586,11 +636,16 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('make-inbox <name>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
-    .description('creates a new inbox')
+    .command('mkhost <name>')
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
+    .description('creates new host powers, pet store, and mailbox')
     .action(async (name, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -598,12 +653,12 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const newInbox = await E(inbox).makeInbox(name);
-        console.log(newInbox);
+        const newHost = await E(party).provideHost(name);
+        console.log(newHost);
       } catch (error) {
         console.error(error);
         cancel(error);
@@ -611,11 +666,16 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('make-outbox <name>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
-    .description('creates a new outbox')
+    .command('mkguest <name>')
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
+    .description('creates new guest powers, pet store, and mailbox')
     .action(async (name, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -623,12 +683,12 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const newOutbox = await E(inbox).makeOutbox(name);
-        console.log(newOutbox);
+        const newGuest = await E(party).provideGuest(name);
+        console.log(newGuest);
       } catch (error) {
         console.error(error);
         cancel(error);
@@ -637,11 +697,16 @@ export const main = async rawArgs => {
 
   program
     .command('inbox')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option('-f,--follow', 'Follow the inbox for messages as they arrive')
     .description('prints pending requests that have been sent to you')
     .action(async cmd => {
-      const { inbox: inboxNames, follow } = cmd.opts();
+      const { as: partyNames, follow } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -649,18 +714,30 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const requests = follow
-          ? makeRefIterator(E(inbox).followMessages())
-          : await E(inbox).listMessages();
-        for await (const { number, who, what } of requests) {
-          if (who !== undefined) {
-            // TODO ensure the description is all printable ASCII and so
-            // contains no TTY control codes.
-            console.log(`${number}. ${who}: ${what}`);
+        const messages = follow
+          ? makeRefIterator(E(party).followMessages())
+          : await E(party).listMessages();
+        for await (const message of messages) {
+          const { number, who, when } = message;
+          if (message.type === 'request') {
+            const { what } = message;
+            console.log(
+              `${number}. ${JSON.stringify(who)} requested ${JSON.stringify(
+                what,
+              )} at ${JSON.stringify(when)}`,
+            );
+          } else {
+            console.log(
+              `${number}. ${JSON.stringify(
+                who,
+              )} sent an unrecognizable message at ${JSON.stringify(
+                when,
+              )}. Consider upgrading.`,
+            );
           }
         }
       } catch (error) {
@@ -670,16 +747,21 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('request <outbox-name> <informal-description>')
+    .command('request <guest-name> <informal-description>')
     .description('requests a reference with the given description')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option(
       '-n,--name <name>',
       'Assigns a name to the result for future reference, persisted between restarts',
     )
     .option('-w,--wait', 'Waits for and prints the response')
-    .action(async (outboxName, description, cmd) => {
-      const { name: resultPetName, inbox: inboxNames, wait } = cmd.opts();
+    .action(async (guestName, description, cmd) => {
+      const { name: resultPetName, as: partyNames, wait } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
         sockPath,
@@ -687,12 +769,12 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const outboxP = E(inbox).provide(outboxName);
-        const resultP = E(outboxP).request(description, resultPetName);
+        const guestP = E(party).provide(guestName);
+        const resultP = E(guestP).request(description, resultPetName);
         if (wait || resultPetName === undefined) {
           const result = await resultP;
           console.log(result);
@@ -705,10 +787,15 @@ export const main = async rawArgs => {
 
   program
     .command('resolve <request-number> <resolution-name>')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .description('responds to a pending request with the named value')
     .action(async (requestNumberText, resolutionName, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       // TODO less bad number parsing.
       const requestNumber = Number(requestNumberText);
       const { getBootstrap } = await provideEndoClient(
@@ -718,11 +805,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        await E(inbox).resolve(requestNumber, resolutionName);
+        await E(party).resolve(requestNumber, resolutionName);
       } catch (error) {
         console.error(error);
         cancel(error);
@@ -732,9 +819,14 @@ export const main = async rawArgs => {
   program
     .command('reject <request-number> [message]')
     .description('responds to a pending request with the rejection message')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .action(async (requestNumberText, message, cmd) => {
-      const { inbox: inboxNames } = cmd.opts();
+      const { as: partyNames } = cmd.opts();
       // TODO less bad number parsing.
       const requestNumber = Number(requestNumberText);
       const { getBootstrap } = await provideEndoClient(
@@ -744,11 +836,11 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        await E(inbox).reject(requestNumber, message);
+        await E(party).reject(requestNumber, message);
       } catch (error) {
         console.error(error);
         cancel(error);
@@ -758,7 +850,12 @@ export const main = async rawArgs => {
   program
     .command('eval <source> [names...]')
     .description('evaluates a string with the endowed values in scope')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option(
       '-w,--worker <worker>',
       'Reuse an existing worker rather than create a new one',
@@ -771,7 +868,7 @@ export const main = async rawArgs => {
       const {
         name: resultPetName,
         worker: workerPetName,
-        inbox: inboxNames,
+        as: partyNames,
       } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
@@ -780,9 +877,9 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
 
         const pairs = names.map(name => {
@@ -795,7 +892,7 @@ export const main = async rawArgs => {
         const codeNames = pairs.map(pair => pair[0]);
         const petNames = pairs.map(pair => pair[1]);
 
-        const result = await E(inbox).evaluate(
+        const result = await E(party).evaluate(
           workerPetName,
           source,
           codeNames,
@@ -814,7 +911,12 @@ export const main = async rawArgs => {
     .description(
       'imports the module at the given path and runs its endow function with all of your authority',
     )
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option(
       '-n,--name <name>',
       'Assigns a name to the result for future reference, persisted between restarts',
@@ -823,11 +925,11 @@ export const main = async rawArgs => {
       '-w,--worker <worker>',
       'Reuse an existing worker rather than create a new one',
     )
-    .action(async (importPath, outboxPetName, cmd) => {
+    .action(async (importPath, guestPetName, cmd) => {
       const {
         name: resultPetName,
         worker: workerPetName,
-        inboxNames,
+        partyNames,
       } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
@@ -836,14 +938,14 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const result = await E(inbox).importUnsafeAndEndow(
+        const result = await E(party).importUnsafeAndEndow(
           workerPetName,
           path.resolve(importPath),
-          outboxPetName,
+          guestPetName,
           resultPetName,
         );
         console.log(result);
@@ -858,7 +960,12 @@ export const main = async rawArgs => {
     .description(
       'imports the named bundle in a confined space within a worker and runs its endow without any initial authority',
     )
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option(
       '-n,--name <name>',
       'Assigns a name to the result for future reference, persisted between restarts',
@@ -867,11 +974,11 @@ export const main = async rawArgs => {
       '-w,--worker <worker>',
       'Reuse an existing worker rather than create a new one',
     )
-    .action(async (readableBundleName, outboxName, cmd) => {
+    .action(async (readableBundleName, guestName, cmd) => {
       const {
         name: resultPetName,
         worker: workerPetName,
-        inbox: inboxNames,
+        as: partyNames,
       } = cmd.opts();
       const { getBootstrap } = await provideEndoClient(
         'cli',
@@ -880,14 +987,14 @@ export const main = async rawArgs => {
       );
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
-        const result = await E(inbox).importBundleAndEndow(
+        const result = await E(party).importBundleAndEndow(
           workerPetName,
           readableBundleName,
-          outboxName,
+          guestName,
           resultPetName,
         );
         console.log(result);
@@ -900,14 +1007,19 @@ export const main = async rawArgs => {
   program
     .command('open <webPageName>')
     .description('opens a web page')
-    .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
     .option('-b,--bundle <bundle>', 'Bundle for a web page to open')
     .option('-f,--file <file>', 'Build the named bundle from JavaScript file')
     .option('-g,--guest <endowment>', 'Endowment to give the web page')
     .option('-h,--host', 'Endow the web page with the powers of the host')
     .action(async (webPageName, cmd) => {
       const {
-        inbox: inboxNames,
+        as: partyNames,
         file: programPath,
         bundle: bundleName,
         guest: guestName,
@@ -936,14 +1048,14 @@ export const main = async rawArgs => {
 
       try {
         const bootstrap = getBootstrap();
-        let inbox = E(bootstrap).inbox();
-        for (const inboxName of inboxNames) {
-          inbox = E(inbox).provide(inboxName);
+        let party = E(bootstrap).host();
+        for (const partyName of partyNames) {
+          party = E(party).provide(partyName);
         }
 
         // Prepare a bundle, with the given name.
         if (bundleReaderRef !== undefined) {
-          await E(inbox).store(bundleReaderRef, bundleName);
+          await E(party).store(bundleReaderRef, bundleName);
         }
 
         /** @type {string | undefined} */
@@ -954,13 +1066,13 @@ export const main = async rawArgs => {
           bundleName !== undefined &&
           (guestName !== undefined || endowHost)
         ) {
-          ({ url: webPageUrl } = await E(inbox).provideWebPage(
+          ({ url: webPageUrl } = await E(party).provideWebPage(
             webPageName,
             bundleName,
             guestName, // undefined if endowHost
           ));
         } else if (bundleName === undefined && guestName === undefined) {
-          ({ url: webPageUrl } = await E(inbox).provide(webPageName));
+          ({ url: webPageUrl } = await E(party).provide(webPageName));
         } else if (webPageUrl === undefined) {
           // webPageUrl will always be undefined if we fall through to here,
           // but calling it out helps narrow the type below.

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -51,8 +51,8 @@ const makeEndoBootstrap = (
   // reference", and not for "what is my name for this promise".
   /** @type {WeakMap<object, string>} */
   const formulaIdentifierForRef = new WeakMap();
-  /** @type {WeakMap<import('./types.js').EndoInbox, import('./types.js').RequestFn>} */
-  const inboxRequestFunctions = new WeakMap();
+  /** @type {WeakMap<import('./types.js').EndoHost, import('./types.js').RequestFn>} */
+  const hostRequestFunctions = new WeakMap();
 
   /** @type {WeakMap<object, import('@endo/eventual-send').ERef<import('./worker.js').WorkerBootstrap>>} */
   const workerBootstraps = new WeakMap();
@@ -269,12 +269,12 @@ const makeEndoBootstrap = (
 
   /**
    * @param {string} workerFormulaIdentifier
-   * @param {string} outboxFormulaIdentifier
+   * @param {string} guestFormulaIdentifier
    * @param {string} importPath
    */
   const makeValueForImportUnsafe0 = async (
     workerFormulaIdentifier,
-    outboxFormulaIdentifier,
+    guestFormulaIdentifier,
     importPath,
   ) => {
     // Behold, recursion:
@@ -284,22 +284,22 @@ const makeEndoBootstrap = (
     );
     const workerBootstrap = workerBootstraps.get(workerFacet);
     assert(workerBootstrap);
-    const outboxP = /** @type {Promise<import('./types.js').EndoOutbox>} */ (
+    const guestP = /** @type {Promise<import('./types.js').EndoGuest>} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      provideValueForFormulaIdentifier(outboxFormulaIdentifier)
+      provideValueForFormulaIdentifier(guestFormulaIdentifier)
     );
-    return E(workerBootstrap).importUnsafeAndEndow(importPath, outboxP);
+    return E(workerBootstrap).importUnsafeAndEndow(importPath, guestP);
   };
 
   /**
    * @param {string} workerFormulaIdentifier
-   * @param {string} outboxFormulaIdentifier
+   * @param {string} guestFormulaIdentifier
    * @param {string} bundleFormulaIdentifier
    */
   const makeValueForImportBundle0 = async (
     workerFormulaIdentifier,
-    outboxFormulaIdentifier,
+    guestFormulaIdentifier,
     bundleFormulaIdentifier,
   ) => {
     // Behold, recursion:
@@ -317,42 +317,42 @@ const makeEndoBootstrap = (
         // eslint-disable-next-line no-use-before-define
         provideValueForFormulaIdentifier(bundleFormulaIdentifier)
       );
-    const outboxP = /** @type {Promise<import('./types.js').EndoOutbox>} */ (
+    const guestP = /** @type {Promise<import('./types.js').EndoGuest>} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      provideValueForFormulaIdentifier(outboxFormulaIdentifier)
+      provideValueForFormulaIdentifier(guestFormulaIdentifier)
     );
-    return E(workerBootstrap).importBundleAndEndow(readableBundleP, outboxP);
+    return E(workerBootstrap).importBundleAndEndow(readableBundleP, guestP);
   };
 
   /**
-   * @param {string} outboxFormulaIdentifier
-   * @param {string} inboxFormulaIdentifier
+   * @param {string} guestFormulaIdentifier
+   * @param {string} hostFormulaIdentifier
    * @param {string} petStoreFormulaIdentifier
    */
-  const makeIdentifiedOutbox = async (
-    outboxFormulaIdentifier,
-    inboxFormulaIdentifier,
+  const makeIdentifiedGuest = async (
+    guestFormulaIdentifier,
+    hostFormulaIdentifier,
     petStoreFormulaIdentifier,
   ) => {
     /** @type {Map<string, Promise<unknown>>} */
     const responses = new Map();
 
-    const outboxPetStore = /** @type {import('./types.js').PetStore} */ (
+    const guestPetStore = /** @type {import('./types.js').PetStore} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
       await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
     );
-    const inbox = /** @type {object} */ (
+    const host = /** @type {object} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      await provideValueForFormulaIdentifier(inboxFormulaIdentifier)
+      await provideValueForFormulaIdentifier(hostFormulaIdentifier)
     );
 
-    const request = inboxRequestFunctions.get(inbox);
+    const request = hostRequestFunctions.get(host);
     if (request === undefined) {
       throw new Error(
-        `Programmer invariant failed: an inbox request function must exist for every inbox`,
+        `Programmer invariant failed: a host request function must exist for every host`,
       );
     }
 
@@ -360,7 +360,7 @@ const makeEndoBootstrap = (
      * @param {string} petName
      */
     const provide = async petName => {
-      const formulaIdentifier = outboxPetStore.get(petName);
+      const formulaIdentifier = guestPetStore.get(petName);
       if (formulaIdentifier === undefined) {
         throw new TypeError(`Unknown pet name: ${q(petName)}`);
       }
@@ -369,15 +369,15 @@ const makeEndoBootstrap = (
       return provideValueForFormulaIdentifier(formulaIdentifier);
     };
 
-    const { list, remove, rename } = outboxPetStore;
+    const { list, remove, rename } = guestPetStore;
 
-    /** @type {import('@endo/eventual-send').ERef<import('./types.js').EndoOutbox>} */
-    const outbox = Far('EndoOutbox', {
+    /** @type {import('@endo/eventual-send').ERef<import('./types.js').EndoGuest>} */
+    const guest = Far('EndoGuest', {
       request: async (what, responseName) => {
         if (responseName === undefined) {
           // Behold, recursion:
           // eslint-disable-next-line no-use-before-define
-          return request(what, responseName, outbox, outboxPetStore);
+          return request(what, responseName, guest, guestPetStore);
         }
         const responseP = responses.get(responseName);
         if (responseP !== undefined) {
@@ -385,12 +385,7 @@ const makeEndoBootstrap = (
         }
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
-        const newResponseP = request(
-          what,
-          responseName,
-          outbox,
-          outboxPetStore,
-        );
+        const newResponseP = request(what, responseName, guest, guestPetStore);
         responses.set(responseName, newResponseP);
         return newResponseP;
       },
@@ -400,15 +395,15 @@ const makeEndoBootstrap = (
       provide,
     });
 
-    return outbox;
+    return guest;
   };
 
   /**
-   * @param {string} inboxFormulaIdentifier
+   * @param {string} hostFormulaIdentifier
    * @param {string} storeFormulaIdentifier
    */
-  const makeIdentifiedInbox = async (
-    inboxFormulaIdentifier,
+  const makeIdentifiedHost = async (
+    hostFormulaIdentifier,
     storeFormulaIdentifier,
   ) => {
     const petStore = /** @type {import('./types.js').PetStore} */ (
@@ -463,7 +458,7 @@ const makeEndoBootstrap = (
       const formulaIdentifier = formulaIdentifierForRef.get(whom);
       if (formulaIdentifier === undefined) {
         throw new Error(
-          `Programmer invariant failed: requestFormulaIdentifier must be called with an Outbox (who) that was obtained through provideValueFor*`,
+          `Programmer invariant failed: requestFormulaIdentifier must be called with a party (who) that was obtained through provideValueFor*`,
         );
       }
       const [who] = petStore.lookup(formulaIdentifier);
@@ -489,16 +484,16 @@ const makeEndoBootstrap = (
     /**
      * @param {string} what
      * @param {string} responseName
-     * @param {import('./types.js').EndoOutbox} who
-     * @param {import('./types.js').PetStore} outboxPetStore
+     * @param {import('./types.js').EndoGuest} who
+     * @param {import('./types.js').PetStore} guestPetStore
      */
-    const request = async (what, responseName, who, outboxPetStore) => {
+    const request = async (what, responseName, who, guestPetStore) => {
       if (responseName !== undefined) {
         /** @type {string | undefined} */
-        let formulaIdentifier = outboxPetStore.get(responseName);
+        let formulaIdentifier = guestPetStore.get(responseName);
         if (formulaIdentifier === undefined) {
           formulaIdentifier = await requestFormulaIdentifier(what, who);
-          await outboxPetStore.write(responseName, formulaIdentifier);
+          await guestPetStore.write(responseName, formulaIdentifier);
         }
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
@@ -551,25 +546,43 @@ const makeEndoBootstrap = (
     /**
      * @param {string} petName
      */
-    const makeOutbox = async petName => {
-      const outboxStoreId512 = await powers.randomHex512();
-      const outboxStoreFormulaIdentifier = `pet-store-id512:${outboxStoreId512}`;
-      /** @type {import('./types.js').OutboxFormula} */
-      const formula = {
-        type: /* @type {'outbox'} */ 'outbox',
-        inbox: inboxFormulaIdentifier,
-        store: outboxStoreFormulaIdentifier,
-      };
-      // Behold, recursion:
-      // eslint-disable-next-line no-use-before-define
-      const { value, formulaIdentifier } = await provideValueForFormula(
-        formula,
-        'outbox-id512',
-      );
+    const provideGuest = async petName => {
+      /** @type {string | undefined} */
+      let formulaIdentifier;
       if (petName !== undefined) {
-        await petStore.write(petName, formulaIdentifier);
+        formulaIdentifier = petStore.get(petName);
       }
-      return /** @type {Promise<import('./types.js').EndoOutbox>} */ (value);
+      if (formulaIdentifier === undefined) {
+        const id512 = await powers.randomHex512();
+        const guestStoreFormulaIdentifier = `pet-store-id512:${id512}`;
+        /** @type {import('./types.js').GuestFormula} */
+        const formula = {
+          type: /* @type {'guest'} */ 'guest',
+          host: hostFormulaIdentifier,
+          store: guestStoreFormulaIdentifier,
+        };
+        // Behold, recursion:
+        // eslint-disable-next-line no-use-before-define
+        const { value, formulaIdentifier } = await provideValueForFormula(
+          formula,
+          'guest-id512',
+        );
+        if (petName !== undefined) {
+          await petStore.write(petName, formulaIdentifier);
+        }
+        return value;
+      } else if (!formulaIdentifier.startsWith('guest-id512:')) {
+        throw new Error(
+          `Existing pet name does not designate a guest powers capability: ${q(
+            petName,
+          )}`,
+        );
+      }
+      return /** @type {Promise<import('./types.js').EndoHost>} */ (
+        // Behold, recursion:
+        // eslint-disable-next-line no-use-before-define
+        provideValueForFormulaIdentifier(formulaIdentifier)
+      );
     };
 
     /**
@@ -636,23 +649,23 @@ const makeEndoBootstrap = (
     };
 
     /**
-     * @param {string} [outboxName]
+     * @param {string} [guestName]
      */
-    const providePowersFormulaIdentifier = async outboxName => {
-      if (outboxName === undefined) {
-        return inboxFormulaIdentifier;
+    const providePowersFormulaIdentifier = async guestName => {
+      if (guestName === undefined) {
+        return hostFormulaIdentifier;
       }
-      let outboxFormulaIdentifier = petStore.get(outboxName);
-      if (outboxFormulaIdentifier === undefined) {
-        const outbox = await makeOutbox(outboxName);
-        outboxFormulaIdentifier = formulaIdentifierForRef.get(outbox);
-        if (outboxFormulaIdentifier === undefined) {
+      let guestFormulaIdentifier = petStore.get(guestName);
+      if (guestFormulaIdentifier === undefined) {
+        const guest = await makeGuest(guestName);
+        guestFormulaIdentifier = formulaIdentifierForRef.get(guest);
+        if (guestFormulaIdentifier === undefined) {
           throw new Error(
-            `Programmer invariant violated: makeOutbox must return an outbox with a corresponding formula identifier`,
+            `Programmer invariant violated: makeGuest must return an guest with a corresponding formula identifier`,
           );
         }
       }
-      return outboxFormulaIdentifier;
+      return guestFormulaIdentifier;
     };
 
     /**
@@ -715,28 +728,28 @@ const makeEndoBootstrap = (
     /**
      * @param {string | undefined} workerName
      * @param {string} importPath
-     * @param {string | undefined} outboxName
+     * @param {string | undefined} guestName
      * @param {string} resultName
      */
     const importUnsafeAndEndow = async (
       workerName,
       importPath,
-      outboxName,
+      guestName,
       resultName,
     ) => {
       const workerFormulaIdentifier = await provideWorkerFormulaIdentifier(
         workerName,
       );
 
-      const outboxFormulaIdentifier = await providePowersFormulaIdentifier(
-        outboxName,
+      const guestFormulaIdentifier = await providePowersFormulaIdentifier(
+        guestName,
       );
 
       const formula = {
         /** @type {'import-unsafe'} */
         type: 'import-unsafe',
         worker: workerFormulaIdentifier,
-        outbox: outboxFormulaIdentifier,
+        powers: guestFormulaIdentifier,
         importPath,
       };
 
@@ -755,13 +768,13 @@ const makeEndoBootstrap = (
     /**
      * @param {string} workerName
      * @param {string} bundleName
-     * @param {string | undefined} outboxName
+     * @param {string | undefined} guestName
      * @param {string} resultName
      */
     const importBundleAndEndow = async (
       workerName,
       bundleName,
-      outboxName,
+      guestName,
       resultName,
     ) => {
       const workerFormulaIdentifier = await provideWorkerFormulaIdentifier(
@@ -773,15 +786,15 @@ const makeEndoBootstrap = (
         throw new TypeError(`Unknown pet name for bundle: ${bundleName}`);
       }
 
-      const outboxFormulaIdentifier = await providePowersFormulaIdentifier(
-        outboxName,
+      const guestFormulaIdentifier = await providePowersFormulaIdentifier(
+        guestName,
       );
 
       const formula = {
         /** @type {'import-bundle'} */
         type: 'import-bundle',
         worker: workerFormulaIdentifier,
-        outbox: outboxFormulaIdentifier,
+        guest: guestFormulaIdentifier,
         bundle: bundleFormulaIdentifier,
       };
 
@@ -818,13 +831,26 @@ const makeEndoBootstrap = (
     /**
      * @param {string} [petName]
      */
-    const makeInbox = async petName => {
-      const inboxId512 = await powers.randomHex512();
-      const formulaIdentifier = `inbox-id512:${inboxId512}`;
+    const provideHost = async petName => {
+      /** @type {string | undefined} */
+      let formulaIdentifier;
       if (petName !== undefined) {
-        await petStore.write(petName, formulaIdentifier);
+        formulaIdentifier = petStore.get(petName);
       }
-      return /** @type {Promise<import('./types.js').EndoInbox>} */ (
+      if (formulaIdentifier === undefined) {
+        const id512 = await powers.randomHex512();
+        formulaIdentifier = `host-id512:${id512}`;
+        if (petName !== undefined) {
+          await petStore.write(petName, formulaIdentifier);
+        }
+      } else if (!formulaIdentifier.startsWith('host-id512:')) {
+        throw new Error(
+          `Existing pet name does not designate a host powers capability: ${q(
+            petName,
+          )}`,
+        );
+      }
+      return /** @type {Promise<import('./types.js').EndoHost>} */ (
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
         provideValueForFormulaIdentifier(formulaIdentifier)
@@ -875,8 +901,8 @@ const makeEndoBootstrap = (
 
     const { list, remove, rename } = petStore;
 
-    /** @type {import('./types.js').EndoInbox} */
-    const inbox = Far('EndoInbox', {
+    /** @type {import('./types.js').EndoHost} */
+    const host = Far('EndoHost', {
       listMessages,
       followMessages,
       provide,
@@ -887,8 +913,8 @@ const makeEndoBootstrap = (
       remove,
       rename,
       store,
-      makeOutbox,
-      makeInbox,
+      provideGuest,
+      provideHost,
       makeWorker,
       evaluate,
       importUnsafeAndEndow,
@@ -896,9 +922,9 @@ const makeEndoBootstrap = (
       provideWebPage,
     });
 
-    inboxRequestFunctions.set(inbox, request);
+    hostRequestFunctions.set(host, request);
 
-    return inbox;
+    return host;
   };
 
   /**
@@ -921,19 +947,19 @@ const makeEndoBootstrap = (
     } else if (formula.type === 'import-unsafe') {
       return makeValueForImportUnsafe0(
         formula.worker,
-        formula.outbox,
+        formula.powers,
         formula.importPath,
       );
     } else if (formula.type === 'import-bundle') {
       return makeValueForImportBundle0(
         formula.worker,
-        formula.outbox,
+        formula.powers,
         formula.bundle,
       );
-    } else if (formula.type === 'outbox') {
-      return makeIdentifiedOutbox(
+    } else if (formula.type === 'guest') {
+      return makeIdentifiedGuest(
         formulaIdentifier,
-        formula.inbox,
+        formula.host,
         formula.store,
       );
     } else if (formula.type === 'web-bundle') {
@@ -1018,13 +1044,13 @@ const makeEndoBootstrap = (
     if (delimiterIndex < 0) {
       if (formulaIdentifier === 'pet-store') {
         return makeOwnPetStore(powers, locator, 'pet-store');
-      } else if (formulaIdentifier === 'inbox') {
-        return makeIdentifiedInbox(formulaIdentifier, 'pet-store');
+      } else if (formulaIdentifier === 'host') {
+        return makeIdentifiedHost(formulaIdentifier, 'pet-store');
       } else if (formulaIdentifier === 'web-page-js') {
         return makeValueForFormula('web-page-js', zero512, {
           type: /** @type {'import-unsafe'} */ ('import-unsafe'),
           worker: `worker-id512:${zero512}`,
-          outbox: 'inbox',
+          powers: 'host',
           importPath: powers.fileURLToPath(
             new URL('web-page-bundler.js', import.meta.url).href,
           ),
@@ -1042,8 +1068,8 @@ const makeEndoBootstrap = (
       return makeIdentifiedWorker(formulaNumber);
     } else if (prefix === 'pet-store-id512') {
       return makeIdentifiedPetStore(powers, locator, formulaNumber);
-    } else if (prefix === 'inbox-id512') {
-      return makeIdentifiedInbox(
+    } else if (prefix === 'host-id512') {
+      return makeIdentifiedHost(
         formulaIdentifier,
         `pet-store-id512:${formulaNumber}`,
       );
@@ -1052,7 +1078,7 @@ const makeEndoBootstrap = (
         'eval-id512',
         'import-unsafe-id512',
         'import-bundle-id512',
-        'outbox-id512',
+        'guest-id512',
         'web-bundle',
       ].includes(prefix)
     ) {
@@ -1133,7 +1159,7 @@ const makeEndoBootstrap = (
       cancel(new Error('Termination requested'));
     },
 
-    inbox: () => provideValueForFormulaIdentifier('inbox'),
+    host: () => provideValueForFormulaIdentifier('host'),
 
     webPageJs: () => provideValueForFormulaIdentifier('web-page-js'),
 

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -5,7 +5,7 @@ const { quote: q } = assert;
 const validNamePattern = /^[a-zA-Z][a-zA-Z0-9]{0,127}$/;
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:inbox|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe-id512|import-bundle-id512|inbox-id512|outbox-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
+  /^(?:host|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe-id512|import-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').DaemonicPowers} powers

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -97,10 +97,10 @@ type InboxFormula = {
   store: string;
 };
 
-type OutboxFormula = {
-  type: 'outbox';
+type GuestFormula = {
+  type: 'guest';
   store: string;
-  inbox: string;
+  host: string;
 };
 
 type EvalFormula = {
@@ -115,7 +115,7 @@ type EvalFormula = {
 type ImportUnsafeFormula = {
   type: 'import-unsafe';
   worker: string;
-  outbox: string;
+  powers: string;
   importPath: string;
   // TODO formula slots
 };
@@ -123,7 +123,7 @@ type ImportUnsafeFormula = {
 type ImportBundleFormula = {
   type: 'import-bundle';
   worker: string;
-  outbox: string;
+  powers: string;
   bundle: string;
   // TODO formula slots
 };
@@ -136,7 +136,7 @@ type WebBundleFormula = {
 
 export type Formula =
   | InboxFormula
-  | OutboxFormula
+  | GuestFormula
   | EvalFormula
   | ImportUnsafeFormula
   | ImportBundleFormula
@@ -145,12 +145,12 @@ export type Formula =
 export type Label = {
   number: number;
   who: string;
-  what: string;
   when: string;
 };
 
 export type Request = {
   type: 'request';
+  what: string;
   settled: Promise<void>;
 };
 
@@ -178,8 +178,8 @@ export interface PetStore {
 export type RequestFn = (
   what: string,
   responseName: string,
-  outbox: object,
-  outboxPetStore: PetStore,
+  guest: object,
+  guestPetStore: PetStore,
 ) => Promise<unknown>;
 
 export interface EndoReadable {
@@ -195,7 +195,7 @@ export interface EndoWorker {
   whenTerminated(): Promise<void>;
 }
 
-export interface EndoOutbox {
+export interface EndoGuest {
   request(what: string, responseName: string): Promise<unknown>;
 }
 
@@ -213,7 +213,7 @@ export interface EndoInbox {
     readerRef: ERef<AsyncIterableIterator<string>>,
     petName: string,
   ): Promise<void>;
-  makeOutbox(petName?: string): Promise<EndoOutbox>;
+  makeGuest(petName?: string): Promise<EndoGuest>;
   makeInbox(petName?: string): Promise<EndoInbox>;
   makeWorker(petName: string): Promise<EndoWorker>;
   evaluate(
@@ -226,13 +226,13 @@ export interface EndoInbox {
   importUnsafeAndEndow(
     workerPetName: string | undefined,
     importPath: string,
-    outboxName: string,
+    powersName: string,
     resultName?: string,
   ): Promise<unknown>;
   importBundleAndEndow(
     workerPetName: string | undefined,
     bundleName: string,
-    outboxName: string,
+    powersName: string,
     resultName?: string,
   ): Promise<unknown>;
 }


### PR DESCRIPTION
Per feedback from @epopt, this change toys with the names host and guest to designate the user’s own pet store and mailbox, as opposed to one of their guests. I expect to converge the host and guest API such that they’re mostly interchangeable, with the difference in behavior just being that the guest actions are gated on permission from the host.