### PR TITLE
refactor(daemon): Rename provide to endow

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -809,9 +809,9 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('import-unsafe0 <path> <outbox>')
+    .command('import-unsafe <path> <guest>')
     .description(
-      'imports the module at the given path and runs its provide0 function with all of your authority',
+      'imports the module at the given path and runs its endow function with all of your authority',
     )
     .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
     .option(
@@ -839,7 +839,7 @@ export const main = async rawArgs => {
         for (const inboxName of inboxNames) {
           inbox = E(inbox).provide(inboxName);
         }
-        const result = await E(inbox).importUnsafe0(
+        const result = await E(inbox).importUnsafeAndEndow(
           workerPetName,
           path.resolve(importPath),
           outboxPetName,
@@ -853,9 +853,9 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('import-bundle0 <readableBundleName> <outboxName>')
+    .command('import-bundle <readableBundleName> <guestName>')
     .description(
-      'imports the named bundle in a confined space within a worker and runs its provide0 without any initial authority',
+      'imports the named bundle in a confined space within a worker and runs its endow without any initial authority',
     )
     .option('-i,--inbox <inbox>', 'An alternate inbox', collect, [])
     .option(
@@ -883,7 +883,7 @@ export const main = async rawArgs => {
         for (const inboxName of inboxNames) {
           inbox = E(inbox).provide(inboxName);
         }
-        const result = await E(inbox).importBundle0(
+        const result = await E(inbox).importBundleAndEndow(
           workerPetName,
           readableBundleName,
           outboxName,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -273,7 +273,7 @@ const makeEndoBootstrap = (
       // eslint-disable-next-line no-use-before-define
       provideValueForFormulaIdentifier(outboxFormulaIdentifier)
     );
-    return E(workerBootstrap).importUnsafe0(importPath, outboxP);
+    return E(workerBootstrap).importUnsafeAndEndow(importPath, outboxP);
   };
 
   /**
@@ -306,7 +306,7 @@ const makeEndoBootstrap = (
       // eslint-disable-next-line no-use-before-define
       provideValueForFormulaIdentifier(outboxFormulaIdentifier)
     );
-    return E(workerBootstrap).importBundle0(readableBundleP, outboxP);
+    return E(workerBootstrap).importBundleAndEndow(readableBundleP, outboxP);
   };
 
   /**
@@ -689,7 +689,7 @@ const makeEndoBootstrap = (
      * @param {string} outboxName
      * @param {string} resultName
      */
-    const importUnsafe0 = async (
+    const importUnsafeAndEndow = async (
       workerName,
       importPath,
       outboxName,
@@ -704,8 +704,8 @@ const makeEndoBootstrap = (
       );
 
       const formula = {
-        /** @type {'import-unsafe0'} */
-        type: 'import-unsafe0',
+        /** @type {'import-unsafe'} */
+        type: 'import-unsafe',
         worker: workerFormulaIdentifier,
         outbox: outboxFormulaIdentifier,
         importPath,
@@ -715,7 +715,7 @@ const makeEndoBootstrap = (
       // eslint-disable-next-line no-use-before-define
       const { formulaIdentifier, value } = await provideValueForFormula(
         formula,
-        'import-unsafe0-id512',
+        'import-unsafe-id512',
       );
       if (resultName !== undefined) {
         await petStore.write(resultName, formulaIdentifier);
@@ -729,7 +729,7 @@ const makeEndoBootstrap = (
      * @param {string} outboxName
      * @param {string} resultName
      */
-    const importBundle0 = async (
+    const importBundleAndEndow = async (
       workerName,
       bundleName,
       outboxName,
@@ -749,8 +749,8 @@ const makeEndoBootstrap = (
       );
 
       const formula = {
-        /** @type {'import-bundle0'} */
-        type: 'import-bundle0',
+        /** @type {'import-bundle'} */
+        type: 'import-bundle',
         worker: workerFormulaIdentifier,
         outbox: outboxFormulaIdentifier,
         bundle: bundleFormulaIdentifier,
@@ -760,7 +760,7 @@ const makeEndoBootstrap = (
       // eslint-disable-next-line no-use-before-define
       const { value, formulaIdentifier } = await provideValueForFormula(
         formula,
-        'import-bundle0-id512',
+        'import-bundle-id512',
       );
 
       if (resultName !== undefined) {
@@ -820,8 +820,8 @@ const makeEndoBootstrap = (
       makeInbox,
       makeWorker,
       evaluate,
-      importUnsafe0,
-      importBundle0,
+      importUnsafeAndEndow,
+      importBundleAndEndow,
     });
 
     inboxRequestFunctions.set(inbox, request);
@@ -841,13 +841,13 @@ const makeEndoBootstrap = (
         formula.names,
         formula.values,
       );
-    } else if (formula.type === 'import-unsafe0') {
+    } else if (formula.type === 'import-unsafe') {
       return makeValueForImportUnsafe0(
         formula.worker,
         formula.outbox,
         formula.importPath,
       );
-    } else if (formula.type === 'import-bundle0') {
+    } else if (formula.type === 'import-bundle') {
       return makeValueForImportBundle0(
         formula.worker,
         formula.outbox,
@@ -948,8 +948,8 @@ const makeEndoBootstrap = (
     } else if (
       [
         'eval-id512',
-        'import-unsafe0-id512',
-        'import-bundle0-id512',
+        'import-unsafe-id512',
+        'import-bundle-id512',
         'outbox-id512',
       ].includes(prefix)
     ) {

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -5,7 +5,7 @@ const { quote: q } = assert;
 const validNamePattern = /^[a-zA-Z][a-zA-Z0-9]{0,127}$/;
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:inbox|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe0-id512|import-bundle0-id512|inbox-id512|outbox-id512):[0-9a-f]{128})$/;
+  /^(?:inbox|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe-id512|import-bundle-id512|inbox-id512|outbox-id512):[0-9a-f]{128})$/;
 
 /**
  * @param {import('./types.js').DaemonicPowers} powers

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -86,16 +86,16 @@ type EvalFormula = {
   // TODO formula slots
 };
 
-type ImportUnsafe0Formula = {
-  type: 'import-unsafe0';
+type ImportUnsafeFormula = {
+  type: 'import-unsafe';
   worker: string;
   outbox: string;
   importPath: string;
   // TODO formula slots
 };
 
-type ImportBundle0Formula = {
-  type: 'import-bundle0';
+type ImportBundleFormula = {
+  type: 'import-bundle';
   worker: string;
   outbox: string;
   bundle: string;
@@ -106,8 +106,8 @@ export type Formula =
   | InboxFormula
   | OutboxFormula
   | EvalFormula
-  | ImportUnsafe0Formula
-  | ImportBundle0Formula;
+  | ImportUnsafeFormula
+  | ImportBundleFormula;
 
 export type Label = {
   number: number;
@@ -189,13 +189,13 @@ export interface EndoInbox {
     petNames: Array<string>,
     resultName?: string,
   );
-  importUnsafe0(
+  importUnsafeAndEndow(
     workerPetName: string | undefined,
     importPath: string,
     outboxName: string,
     resultName?: string,
   ): Promise<unknown>;
-  importBundle0(
+  importBundleAndEndow(
     workerPetName: string | undefined,
     bundleName: string,
     outboxName: string,

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -53,19 +53,19 @@ export const makeWorkerFacet = ({
 
     /**
      * @param {string} path
-     * @param {import('@endo/eventual-send').ERef<import('./types.js').EndoOutbox>} outboxP
+     * @param {unknown} powersP
      */
-    importUnsafe0: async (path, outboxP) => {
+    importUnsafeAndEndow: async (path, powersP) => {
       const url = pathToFileURL(path);
       const namespace = await import(url);
-      return namespace.provide0(outboxP);
+      return namespace.endow(powersP);
     },
 
     /**
      * @param {import('@endo/eventual-send').ERef<import('./types.js').EndoReadable>} readableP
-     * @param {import('@endo/eventual-send').ERef<import('./types.js').EndoOutbox>} outboxP
+     * @param {unknown} powersP
      */
-    importBundle0: async (readableP, outboxP) => {
+    importBundleAndEndow: async (readableP, powersP) => {
       const bundleText = await E(readableP).text();
       const bundle = JSON.parse(bundleText);
 
@@ -75,7 +75,7 @@ export const makeWorkerFacet = ({
       const namespace = await importBundle(bundle, {
         endowments,
       });
-      return namespace.provide0(await outboxP);
+      return namespace.endow(powersP);
     },
   });
 };

--- a/packages/daemon/test/service.js
+++ b/packages/daemon/test/service.js
@@ -1,6 +1,6 @@
 import { E, Far } from '@endo/far';
 
-export const provide0 = powers => {
+export const endow = powers => {
   return Far('Service', {
     async ask() {
       return E(powers).request(

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -298,9 +298,9 @@ test('closure state lost by restart', async t => {
   }
 });
 
-test('persist import-unsafe0 services and their requests', async t => {
+test('persist unsafe services and their requests', async t => {
   const { promise: cancelled } = makePromiseKit();
-  const locator = makeLocator('tmp', 'import-unsafe0');
+  const locator = makeLocator('tmp', 'import-unsafe');
 
   await stop(locator).catch(() => {});
   await reset(locator);
@@ -347,7 +347,7 @@ test('persist import-unsafe0 services and their requests', async t => {
     await E(inbox).makeWorker('w1');
     await E(inbox).makeOutbox('o1');
     const servicePath = path.join(dirname, 'test', 'service.js');
-    await E(inbox).importUnsafe0('w1', servicePath, 'o1', 's1');
+    await E(inbox).importUnsafeAndEndow('w1', servicePath, 'o1', 's1');
 
     await E(inbox).makeWorker('w2');
     const answer = await E(inbox).evaluate(


### PR DESCRIPTION
This change toys with a different name for the caplet and plugin calling convention. Where before, we were experimenting with:

```js
export const provide0 = async powers => Far('Caplet', {});
```

we are now trying out:

```js
export const endow = async powers => Far('Caplet', {});
```

Consider that we’re gradually reaching out to host four kinds of program:

- a web app caplet (weblet)
- a worker caplet (worklet)
- a CLI command caplet (runlet)
- a plugin (which is not a caplet because it is not confined)

I’m evaluating this change against the alternative `make`, in the expectation that a “runlet” would use `main` and would not make a public API object, since it is disposable.

```js
export const main = async powers => {}
```

The verb `endow` makes sense for the others (weblet, worklet, and plugin), but `make` doesn’t fit weblet, since its return value is also disposable.