### PR TITLE
Make `AsyncLocalStorage` compatible with `@endo/pass-style`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           - '16.5' # last version before unconditional promise fast-path
           - '16.6' # first version after unconditional promise fast-path
           - '18' # Active LTS
+          - '20' # Future LTS
         platform:
           - ubuntu-latest
 

--- a/packages/init/src/node-async-local-storage-patch.js
+++ b/packages/init/src/node-async-local-storage-patch.js
@@ -1,0 +1,95 @@
+/* eslint-disable no-underscore-dangle */
+
+import { AsyncLocalStorage, executionAsyncResource } from 'node:async_hooks';
+
+const { is: ObjectIs } = Object;
+const { apply: ReflectApply } = Reflect;
+
+/** @type {WeakMap<AsyncLocalStorageInternal, WeakMap>} */
+const resourceStoreMaps = new WeakMap();
+
+/** @type {(key: AsyncLocalStorageInternal) => WeakMap} */
+const getStoreMap = resourceStoreMaps.get.bind(resourceStoreMaps);
+
+/**
+ * @typedef {object} AsyncLocalStorageInternal
+ * @property {boolean} enabled
+ * @property {typeof _propagate} _propagate
+ * @property {(this: AsyncLocalStorage) => void} _enable
+ */
+
+Object.defineProperty(AsyncLocalStorage.prototype, 'kResourceStore', {
+  configurable: true,
+  /**
+   * @this {AsyncLocalStorage & AsyncLocalStorageInternal}
+   */
+  set() {
+    resourceStoreMaps.set(this, new WeakMap());
+  },
+});
+
+/**
+ * @this {AsyncLocalStorage & AsyncLocalStorageInternal}
+ * @param {object} resource
+ * @param {object} triggerResource
+ * @param {string} [type]
+ */
+function _propagate(resource, triggerResource, type) {
+  if (!this.enabled) return;
+
+  const storeMap = getStoreMap(this);
+  storeMap.set(resource, storeMap.get(triggerResource));
+}
+
+// @ts-expect-error propagate is internal
+AsyncLocalStorage.prototype._propagate = _propagate;
+
+/**
+ * @this {AsyncLocalStorage & AsyncLocalStorageInternal}
+ * @param {*} store
+ */
+AsyncLocalStorage.prototype.enterWith = function enterWith(store) {
+  this._enable();
+  const resource = executionAsyncResource();
+  getStoreMap(this).set(resource, store);
+};
+
+/**
+ * @template R
+ * @template {any[]} TArgs
+ * @this {AsyncLocalStorage & AsyncLocalStorageInternal}
+ * @param {any} store
+ * @param {(...args: TArgs) => R} callback
+ * @param  {...TArgs} args
+ * @returns {R}
+ */
+AsyncLocalStorage.prototype.run = function run(store, callback, ...args) {
+  // Avoid creation of an AsyncResource if store is already active
+  if (ObjectIs(store, this.getStore())) {
+    return ReflectApply(callback, null, args);
+  }
+
+  this._enable();
+  const storeMap = getStoreMap(this);
+
+  const resource = executionAsyncResource();
+
+  const oldStore = storeMap.get(resource);
+
+  storeMap.set(resource, store);
+
+  try {
+    return ReflectApply(callback, null, args);
+  } finally {
+    storeMap.set(resource, oldStore);
+  }
+};
+
+/**
+ * @this {AsyncLocalStorage & AsyncLocalStorageInternal}
+ */
+AsyncLocalStorage.prototype.getStore = function getStore() {
+  return this.enabled
+    ? getStoreMap(this).get(executionAsyncResource())
+    : undefined;
+};

--- a/packages/init/src/node-async_hooks-patch.js
+++ b/packages/init/src/node-async_hooks-patch.js
@@ -1,3 +1,4 @@
 import { setup } from './node-async_hooks.js';
+import './node-async-local-storage-patch.js';
 
 setup({ withDestroy: true });

--- a/packages/init/test/test-async_hooks.js
+++ b/packages/init/test/test-async_hooks.js
@@ -80,7 +80,7 @@ test('async_hooks Promise patch', async t => {
     .then(() => new Promise(r => setTimeout(r)));
 });
 
-test.failing('AsyncLocalStorage patch', async t => {
+test('AsyncLocalStorage patch', async t => {
   const als1 = new AsyncLocalStorage();
   const als2 = new AsyncLocalStorage();
 


### PR DESCRIPTION
Fixes #1657 

Monkey patch the `AsyncLocalStorage` implementation to rewrite the handling of stores, replacing the use of symbol expando properties on promises with a WeakMap per instance.

`@endo/pass-style` and more specifically the `safePromise` check asserts that no extra own keys exist on promise instances. Furthermore hardening a promise would also harden any store object added as expando to promise instances.