### PR TITLE
fix: stub censored properties

### DIFF
--- a/packages/ses/test/test-tame-symbol-constructor.js
+++ b/packages/ses/test/test-tame-symbol-constructor.js
@@ -31,7 +31,10 @@ test('Symbol cleaned by permits', t => {
   const SharedSymbol = c.globalThis.Symbol;
   t.is(Symbol.prototype, SharedSymbol.prototype);
 
-  t.false('dummy' in SharedSymbol);
+  t.throws(() => SharedSymbol.dummy, {
+    message:
+      'property intrinsics.%SharedSymbol%.dummy removed from Hardened JS',
+  });
   t.false(gopd(SharedSymbol, 'iterator').configurable);
   t.false(isExtensible(SharedSymbol));
   t.true(isFrozen(SharedSymbol));


### PR DESCRIPTION
Fixes #910 

Staged on https://github.com/endojs/endo/pull/1677

@phoddie I'm starting with a more severe behavior: Making the replacement property be a poisoned access instead. What do you think of this approach? I like this better than a throwing method because the censored property may not be a function-valued property.