### PR TITLE
feat(exo): revocables

### DIFF
--- a/packages/exo/test/test-revoke-heap-classes.js
+++ b/packages/exo/test/test-revoke-heap-classes.js
@@ -1,0 +1,127 @@
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { M } from '@endo/patterns';
+import { defineExoClass, defineExoClassKit } from '../src/exo-makers.js';
+
+const { apply } = Reflect;
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test revoke defineExoClass', t => {
+  let revoke;
+  const makeUpCounter = defineExoClass(
+    'UpCounter',
+    UpCounterI,
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(revoke(upCounter), true);
+  t.throws(() => upCounter.incr(1), {
+    message:
+      '"In \\"incr\\" method of (UpCounter)" may only be applied to a valid instance: "[Alleged: UpCounter]"',
+  });
+});
+
+test('test revoke defineExoClassKit', t => {
+  let revoke;
+  const makeCounterKit = defineExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  t.is(revoke(upCounter), true);
+  t.is(revoke(upCounter), false);
+  t.throws(() => upCounter.incr(3), {
+    message:
+      '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
+  });
+  t.is(revoke(downCounter), true);
+  t.is(revoke(downCounter), false);
+  t.throws(() => downCounter.decr(), {
+    message:
+      '"In \\"decr\\" method of (Counter down)" may only be applied to a valid instance: "[Alleged: Counter down]"',
+  });
+});
+
+test('test facet cross-talk', t => {
+  const makeCounterKit = defineExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.throws(() => apply(upCounter.incr, downCounter, [2]), {
+    message:
+      '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter down]"',
+  });
+});


### PR DESCRIPTION
Background: Exos already have a level of indirection between the exposed method with the protective method guard vs the raw method. In order to enable prototype-based method sharing of the protective methods, they lookup the context from their `this`, which is the exo object itself. The context is then passed as the `this` to the raw method. Having paid for this level of indirection, we already use it for many benefits, like enforcing that the exposed methods cannot be applied to unrelated instances.

An additional benefit we can obtain from this indirection is revocation. However, creating a revocable exo is the odd case. We don't want the normal case to pay an undue notational cost to accommodate the odd case, even if that raises the notational cost of the odd case a bit. We do so by allowing an additional `getRevoker` option, which is called with a `revoke` function to be called with the exo to be revoked as an argument. 

This seems unduly higher order. But the `getRevoker` option is directly analogous to the `executor` argument of the promise constructor, which is called with a `resolve` function to be called with a resolution.

This is motivated by the benefits of direct support for revocation for exos at the liveslots level, which needs a parallel implementation of exactly the same options with the same observable semantics. At the liveslots level, the benefits would be
   * A step towards dropping exports of used-up exo objects such as payments, relieving distributed gc pressure.
   * A step towards Zoe2 use objects that can be turned (back) into transferable invitations.

Once this support is uniform across heap exos (from this PR) and virtual and durable exos ( https://github.com/Agoric/agoric-sdk/pull/8020 , https://github.com/Agoric/agoric-sdk/pull/8008 ), then perhaps zones can mirror this universal support. Further, zones themselves could conceivably absorb the revocation support, to provide batch revocation according to creating zone.