### PR TITLE
feat(exo): internal revocables

### DIFF
--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -125,15 +125,20 @@ const defendMethod = (method, methodGuard, label) => {
  */
 
 /**
+ * @callback RevokeExo
+ * @returns {boolean}
+ */
+
+/**
  * @template [S = any]
  * @template {Methods} [M = any]
- * @typedef {{ state: S, self: M }} ClassContext
+ * @typedef {{ state: S, self: M, revoke: RevokeExo }} ClassContext
  */
 
 /**
  * @template [S = any]
  * @template {Record<FacetName, Methods>} [F = any]
- * @typedef {{ state: S, facets: F }} KitContext
+ * @typedef {{ state: S, facets: F, revoke: RevokeExo }} KitContext
  */
 
 /**

--- a/packages/exo/test/test-revoke-heap-classes.js
+++ b/packages/exo/test/test-revoke-heap-classes.js
@@ -1,0 +1,125 @@
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { M } from '@endo/patterns';
+import { defineExoClass, defineExoClassKit } from '../src/exo-makers.js';
+
+const { apply } = Reflect;
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+  done: M.call().returns(M.boolean()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test revoke defineExoClass', t => {
+  const makeUpCounter = defineExoClass(
+    'UpCounter',
+    UpCounterI,
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+      done() {
+        const { revoke } = this;
+        return revoke();
+      },
+    },
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.done(), true);
+  t.throws(() => upCounter.incr(1), {
+    message:
+      '"In \\"incr\\" method of (UpCounter)" may only be applied to a valid instance: "[Alleged: UpCounter]"',
+  });
+});
+
+test('test revoke defineExoClassKit', t => {
+  const makeCounterKit = defineExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+        done() {
+          const { revoke } = this;
+          return revoke();
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+  t.is(upCounter.done(), true);
+  t.throws(() => upCounter.incr(3), {
+    message:
+      '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
+  });
+  t.throws(() => downCounter.decr(), {
+    message:
+      '"In \\"decr\\" method of (Counter down)" may only be applied to a valid instance: "[Alleged: Counter down]"',
+  });
+});
+
+test('test facet cross-talk', t => {
+  const makeCounterKit = defineExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+        done() {
+          const { revoke } = this;
+          return revoke();
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.throws(() => apply(upCounter.incr, downCounter, [2]), {
+    message:
+      '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter down]"',
+  });
+});


### PR DESCRIPTION
Alternative to https://github.com/endojs/endo/pull/1666

Background: Exos already have a level of indirection between the exposed method with the protective method guard vs the raw method. In order to enable prototype-based method sharing of the protective methods, they lookup the context from their `this`, which is the exo object itself. The context is then passed as the `this` to the raw method. Having paid for this level of indirection, we already use it for many benefits, like enforcing that the exposed methods cannot be applied to unrelated instances.

We do this by having all the context (`this`) objects for a given class (or classKit) inherit a common `revoke(obj)` method. Thus, `revoke(obj)` is available from inside instances of a class (or classKit), but not available outside. However, in the current design, this is a per-class (or classKit) power, not a per-instance power. Any instance of a class (or classKit) can revoke any other that it has a reference to. Revoking any facet of a kit revokes all facets of that kit.

This is motivated by the benefits of direct support for revocation for exos at the liveslots level, which needs a parallel implementation with the same observable semantics. As the liveslots level, the benefits would be
   * A step towards dropping exports of used-up exo objects such as payments, relieving distributed gc pressure.
   * A step towards Zoe2 use objects that can be turned (back) into transferable invitations.

Once this support is uniform across heap exos (from this PR) and virtual and durable exos (a future agoric-sdk PR), then zones can mirror this universal support. Further, zones themselves could conceivably absorb the revocation support, to provide batch revocation according to creating zone.