### PR TITLE
fix(ses): fixup async iterator helpers

### DIFF
--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -146,7 +146,7 @@ export const getAnonymousIntrinsics = () => {
     );
   }
 
-  if (globalThis.AsyncInterator) {
+  if (globalThis.AsyncIterator) {
     intrinsics['%AsyncIteratorHelperPrototype%'] = getPrototypeOf(
       // eslint-disable-next-line @endo/no-polymorphic-call
       globalThis.AsyncIterator.from([]).take(0),

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1317,7 +1317,7 @@ export const permitted = {
 
   // https://github.com/tc39/proposal-async-iterator-helpers
   '%AsyncIteratorHelperPrototype%': {
-    '[[Proto]]': 'Async%IteratorPrototype%',
+    '[[Proto]]': '%AsyncIteratorPrototype%',
     next: fn,
     return: fn,
     '@@toStringTag': 'string',

--- a/packages/ses/test/core-js-configuration.js
+++ b/packages/ses/test/core-js-configuration.js
@@ -1,0 +1,3 @@
+import configurator from 'core-js/configurator.js';
+
+configurator({ USE_FUNCTION_CONSTRUCTOR: true });

--- a/packages/ses/test/enforce-cjs-strict.js
+++ b/packages/ses/test/enforce-cjs-strict.js
@@ -1,0 +1,3 @@
+import module from 'node:module';
+
+module.wrapper[0] += '"use strict";';

--- a/packages/ses/test/test-anticipate-async-iterator-helpers-shimmed.js
+++ b/packages/ses/test/test-anticipate-async-iterator-helpers-shimmed.js
@@ -1,27 +1,11 @@
-// KLUDGE HAZARD The core-js shims are written as sloppy code
-// and so introduce sloppy functions.
+import './enforce-cjs-strict.js';
+import './core-js-configuration.js';
 import 'core-js/actual/async-iterator/index.js';
-import test from 'ava';
 import '../index.js';
+import './lockdown-safe.js';
+import test from 'ava';
 
-// KLUDGE HAZARD only for testing with the sloppy modules of the
-// core-js iterator shim.
-// We mutate the permits to tolerates the sloppy functions for testing
-// by sacrificing security. The caller and arguments properties of
-// sloppy functions violate ocap encapsulation rules.
-import { AsyncFunctionInstance } from '../src/permits.js';
-
-AsyncFunctionInstance.arguments = {};
-AsyncFunctionInstance.caller = {};
-
-// Skipped because the core-js shim seems to miss the
-// actual %AsyncIteratorPrototype%,
-// so it creates a new one, causing us to fail because lockdown correctly
-// detects the conflicting definitions.
-// TODO report the bug to core-js
-test.skip('shimmed async-iterator helpers', async t => {
-  lockdown();
-  
+test('shimmed async-iterator helpers', async t => {
   t.deepEqual(
     await (async function* g(i) {
       // eslint-disable-next-line no-plusplus

--- a/packages/ses/test/test-anticipate-async-iterator-helpers-shimmed.js
+++ b/packages/ses/test/test-anticipate-async-iterator-helpers-shimmed.js
@@ -19,8 +19,21 @@ AsyncFunctionInstance.caller = {};
 // so it creates a new one, causing us to fail because lockdown correctly
 // detects the conflicting definitions.
 // TODO report the bug to core-js
-test.skip('shimmed async-iterator helpers', t => {
+test.skip('shimmed async-iterator helpers', async t => {
   lockdown();
+  
+  t.deepEqual(
+    await (async function* g(i) {
+      // eslint-disable-next-line no-plusplus
+      while (true) yield i++;
+    })(1)
+      .drop(1)
+      .take(5)
+      .filter(it => it % 2)
+      .map(it => it ** 2)
+      .toArray(),
+    [9, 25],
+  );
 
   const AsyncIteratorHelperPrototype = Object.getPrototypeOf(
     AsyncIterator.from([]).take(0),

--- a/packages/ses/test/test-anticipate-iterator-helpers-shimmed.js
+++ b/packages/ses/test/test-anticipate-iterator-helpers-shimmed.js
@@ -1,22 +1,11 @@
-// KLUDGE HAZARD The core-js shims are written as sloppy code
-// and so introduce sloppy functions.
+import './enforce-cjs-strict.js';
+import './core-js-configuration.js';
 import 'core-js/actual/iterator/index.js';
-import test from 'ava';
 import '../index.js';
-
-// KLUDGE HAZARD only for testing with the sloppy modules of the
-// core-js iterator shim.
-// We mutate the permits to tolerates the sloppy functions for testing
-// by sacrificing security. The caller and arguments properties of
-// sloppy functions violate ocap encapsulation rules.
-import { FunctionInstance } from '../src/permits.js';
-
-FunctionInstance.arguments = {};
-FunctionInstance.caller = {};
+import './lockdown-safe.js';
+import test from 'ava';
 
 test('shimmed iterator helpers', t => {
-  lockdown();
-
   t.deepEqual(
     (function* g(i) {
       // eslint-disable-next-line no-plusplus


### PR DESCRIPTION
#1655 introduced support for iterator helpers, but due to a limitation in the core-js shim usage, the async iterator helper test was disabled, and the PR missed a couple errors in the implementation of permits for the async iterator helpers.

This PR fixes these errors, and addresses the testing limitations so that the iterator helpers tests (both sync and async) can behave more like normal tests.

Closes #1669 
Closes #1289 