### PR TITLE
fix(compartment-mapper): Missing entries and conflated namespace

### DIFF
--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -330,26 +330,26 @@ const digestLocation = async (powers, moduleLocation, options) => {
 
   const {
     compartments,
-    entry: { module: entryModuleSpecifier },
+    entry: { module: entryModuleSpecifier, compartment: entryCompartmentName },
   } = compartmentMap;
 
   /** @type {Sources} */
   const sources = Object.create(null);
 
-  const compartmentExitModuleImportHook = exitModuleImportHookMaker({
+  const consolidatedExitModuleImportHook = exitModuleImportHookMaker({
     modules: exitModules,
     exitModuleImportHook,
   });
 
-  const makeImportHook = makeImportHookMaker({
-    readPowers: read,
-    baseLocation: packageLocation,
+  const makeImportHook = makeImportHookMaker(read, packageLocation, {
     sources,
     compartmentDescriptors: compartments,
-    exitModuleImportHook: compartmentExitModuleImportHook,
     archiveOnly: true,
     computeSha512,
     searchSuffixes,
+    entryCompartmentName,
+    entryModuleSpecifier,
+    exitModuleImportHook: consolidatedExitModuleImportHook,
   });
   // Induce importHook to record all the necessary modules to import the given module specifier.
   const { compartment, attenuatorsCompartment } = link(compartmentMap, {

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -165,8 +165,8 @@ function getBundlerKitForModule(module) {
  * @param {ModuleTransforms} [options.moduleTransforms]
  * @param {boolean} [options.dev]
  * @param {Set<string>} [options.tags]
- * @param {Array<string>} [options.searchSuffixes]
  * @param {object} [options.commonDependencies]
+ * @param {Array<string>} [options.searchSuffixes]
  * @returns {Promise<string>}
  */
 export const makeBundle = async (read, moduleLocation, options) => {
@@ -206,13 +206,14 @@ export const makeBundle = async (read, moduleLocation, options) => {
   /** @type {Sources} */
   const sources = Object.create(null);
 
-  const makeImportHook = makeImportHookMaker({
-    readPowers: read,
-    baseLocation: packageLocation,
+  const makeImportHook = makeImportHookMaker(read, packageLocation, {
     sources,
     compartmentDescriptors: compartments,
     searchSuffixes,
+    entryCompartmentName,
+    entryModuleSpecifier,
   });
+
   // Induce importHook to record all the necessary modules to import the given module specifier.
   const { compartment } = link(compartmentMap, {
     resolve,

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -45,14 +45,12 @@ const parserForLanguage = {
 /**
  * @param {Record<string, CompartmentDescriptor>} compartmentDescriptors
  * @param {Record<string, CompartmentSources>} compartmentSources
- * @param {Record<string, ResolveHook>} compartmentResolvers
  * @param {string} entryCompartmentName
  * @param {string} entryModuleSpecifier
  */
 const sortedModules = (
   compartmentDescriptors,
   compartmentSources,
-  compartmentResolvers,
   entryCompartmentName,
   entryModuleSpecifier,
 ) => {
@@ -71,7 +69,6 @@ const sortedModules = (
     }
     seen.add(key);
 
-    const resolve = compartmentResolvers[compartmentName];
     const source = compartmentSources[compartmentName][moduleSpecifier];
     if (source !== undefined) {
       const { record, parser, deferredError } = source;
@@ -85,6 +82,9 @@ const sortedModules = (
           /** @type {PrecompiledStaticModuleInterface} */ (record);
         const resolvedImports = Object.create(null);
         for (const importSpecifier of [...imports, ...reexports]) {
+          // If we ever support another module resolution algorithm, that
+          // should be indicated in the compartment descriptor by name and the
+          // corresponding behavior selected here.
           const resolvedSpecifier = resolve(importSpecifier, moduleSpecifier);
           resolvedImports[importSpecifier] = recur(
             compartmentName,
@@ -214,7 +214,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
     searchSuffixes,
   });
   // Induce importHook to record all the necessary modules to import the given module specifier.
-  const { compartment, resolvers } = link(compartmentMap, {
+  const { compartment } = link(compartmentMap, {
     resolve,
     makeImportHook,
     moduleTransforms,
@@ -225,7 +225,6 @@ export const makeBundle = async (read, moduleLocation, options) => {
   const { modules, aliases } = sortedModules(
     compartmentMap.compartments,
     sources,
-    resolvers,
     entryCompartmentName,
     entryModuleSpecifier,
   );

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -85,13 +85,13 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
       modules,
       exitModuleImportHook,
     });
-    const makeImportHook = makeImportHookMaker({
-      readPowers,
-      baseLocation: packageLocation,
+    const makeImportHook = makeImportHookMaker(readPowers, packageLocation, {
       compartmentDescriptors: compartmentMap.compartments,
-      exitModuleImportHook: compartmentExitModuleImportHook,
-      archiveOnly: false,
       searchSuffixes,
+      archiveOnly: false,
+      entryCompartmentName: packageLocation,
+      entryModuleSpecifier: moduleSpecifier,
+      exitModuleImportHook: compartmentExitModuleImportHook,
     });
     const { compartment, pendingJobsPromise } = link(compartmentMap, {
       makeImportHook,

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -345,9 +345,6 @@ export const link = (
     compartmentDescriptors,
   );
 
-  /** @type {Record<string, ResolveHook>} */
-  const resolvers = Object.create(null);
-
   const pendingJobs = [];
 
   for (const [compartmentName, compartmentDescriptor] of entries(
@@ -383,6 +380,9 @@ export const link = (
       }
     };
 
+    // If we ever need an alternate resolution algorithm, it should be
+    // indicated in the compartment descriptor and a behavior selected here.
+    const resolveHook = resolve;
     const importHook = makeImportHook({
       packageLocation: location,
       packageName: name,
@@ -398,8 +398,6 @@ export const link = (
       modules,
       scopes,
     );
-    const resolveHook = resolve;
-    resolvers[compartmentName] = resolve;
 
     const compartment = new Compartment(Object.create(null), undefined, {
       resolveHook,
@@ -437,7 +435,6 @@ export const link = (
   return {
     compartment,
     compartments,
-    resolvers,
     attenuatorsCompartment,
     pendingJobsPromise: promiseAllSettled(pendingJobs).then(
       /** @param {PromiseSettledResult<unknown>[]} results */ results => {

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/left/index.cjs
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/left/index.cjs
@@ -1,0 +1,4 @@
+try {
+  // Does not exist in parent directory.
+  require('../inconsistent.js');
+} catch {}

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/main.js
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/main.js
@@ -1,0 +1,2 @@
+import './left/index.cjs';
+import './right/child/index.mjs';

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/package.json
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}
+

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/right/child/index.mjs
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/right/child/index.mjs
@@ -1,0 +1,2 @@
+// Does exist in the parent directory and is strictly retained.
+import '../inconsistent.js';

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/right/inconsistent.js
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-directories/right/inconsistent.js
@@ -1,0 +1,1 @@
+// Exists in this directory!

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/main.js
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/main.js
@@ -1,0 +1,2 @@
+import 'left';
+import 'right';

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/left/main.js
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/left/main.js
@@ -1,0 +1,4 @@
+if (false) {
+  // Does not exist in this package, so not strictly required.
+  require('./inconsistent.js');
+}

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/left/package.json
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/left/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "left",
+  "version": "1.0.0",
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/right/inconsistent.js
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/right/inconsistent.js
@@ -1,0 +1,1 @@
+// A file with this name exists in this package.

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/right/main.js
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/right/main.js
@@ -1,0 +1,1 @@
+import './inconsistent.js'; // Exists in this package!

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/right/package.json
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/node_modules/right/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "right",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/package.json
+++ b/packages/compartment-mapper/test/fixtures-strictly-inconsistent-packages/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./main.js",
+  "dependencies": {
+    "left": "^1.0.0",
+    "right": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}
+

--- a/packages/compartment-mapper/test/test-missing-entry.js
+++ b/packages/compartment-mapper/test/test-missing-entry.js
@@ -1,0 +1,23 @@
+import 'ses';
+import test from 'ava';
+import path from 'path';
+import fs from 'fs';
+import url from 'url';
+import crypto from 'crypto';
+
+import { makeAndHashArchive } from '../archive.js';
+import { makeReadPowers } from '../node-powers.js';
+
+const readPowers = makeReadPowers({ fs, url, crypto });
+
+test('missing entry', async t => {
+  const entry = url.pathToFileURL(
+    path.resolve('i-solemnly-swear-i-do-not-exist.js'),
+  );
+  await t.throwsAsync(
+    makeAndHashArchive(readPowers, entry, {}).then(() => {}),
+    {
+      message: /Failed to load/,
+    },
+  );
+});

--- a/packages/compartment-mapper/test/test-strictly-inconsistent.js
+++ b/packages/compartment-mapper/test/test-strictly-inconsistent.js
@@ -1,0 +1,23 @@
+import 'ses';
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+
+scaffold(
+  'inconsistently strictly required between directories',
+  test,
+  new URL('fixtures-strictly-inconsistent-directories/main.js', import.meta.url)
+    .href,
+  t => {
+    t.pass();
+  },
+  1,
+);
+
+scaffold(
+  'inconsistently strictly required between packages',
+  test,
+  new URL('fixtures-strictly-inconsistent-packages/main.js', import.meta.url)
+    .href,
+  t => t.pass(),
+  1,
+);


### PR DESCRIPTION
This change includes related fixes in the compartment mapper and a drive-by refactor.

In order to allow CommonJS to conditionally import a dependency, it must be possible for that dependency to be absent. To that end, the Compartment Mapper tracks which modules are strictly required (because they’re retained by an ESM, as opposed to CJS).

Fixes https://github.com/endojs/endo/issues/1206: `bundleSource` generates invalid bundles if the entry module does not exist, where it should simply fail to generate a bundle. The fix is to include the entry module in the set of strictly required modules.

This also fixes overlapping bugs I missed in review:

Each compartment must have a separate set of strictly required module specifiers. This change includes a test that illustrates that a compartment map may include two packages that have the same module name, but retain that module weakly in one but strictly in the other. This test failed before the fix.

The entries in the strictly required sets must also be resolved. A single package can use the same import specifier to refer to different full module specifiers, retaining one but not the other. Teasing out a failing test for this was a bit more tricky. The test relies on a dependency upon `../inconsistent.js` being strictly retained from ESM and weakly retained from a different CJS. In order to cause the collision, such that the relative import specifiers collided but the full module specifiers did not, it was necessary for the importing modules to have different directory depths.

As for a drive-by: currently, we only support Node.js-style resolve hooks. If we supported other forms, they would have to be mentioned by name in the compartment map. Since we don’t, we can pretend the compartment maps have an invisible `"resolve": "node"` and that this would be the default going forward. Since we don’t have other resolution algorithms, nothing is achieved in parameterizing the Compartment Mapper. In all the places we would have consulted a table of resolver hooks for each package, we also have direct access to the compartment map, so we would use that instead.