### PR TITLE
fix(eventual-send): unwrap PromiseLikes before EOnly surrounds them with ERef

### DIFF
--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -360,12 +360,12 @@ export default makeE;
  *
  * @template T
  * @typedef {(
- *   T extends (...args: infer P) => infer R
- *     ? (...args: P) => ERef<EOnly<R>>
+ *   T extends import('./types').Callable
+ *     ? (...args: Parameters<T>) => ERef<Awaited<EOnly<ReturnType<T>>>>
  *     : T extends Record<PropertyKey, import('./types').Callable>
  *     ? {
  *         [K in keyof T]: T[K] extends import('./types').Callable
- *           ? (...args: Parameters<T[K]>) => ERef<EOnly<ReturnType<T[K]>>>
+ *           ? (...args: Parameters<T[K]>) => ERef<Awaited<EOnly<ReturnType<T[K]>>>>
  *           : T[K];
  *       }
  *     : T


### PR DESCRIPTION
This is needed for compatibility with Typescript pre-5.x (Agoric/agoric-sdk is still on v4.7.4).

The symptom of the error is a tsc failure like:

```
      The types returned by 'getPromise(...)' are incompatible between these types.
        Type 'ERef<ERef<PriceQuote>>' is not assignable to type 'ERef<PriceQuote>'.
          Type 'PromiseLike<ERef<PriceQuote>>' is not assignable to type 'ERef<PriceQuote>'.
            Type 'PromiseLike<ERef<PriceQuote>>' is not assignable to type 'PromiseLike<PriceQuote>'.
              Type 'ERef<PriceQuote>' is not assignable to type 'PriceQuote'.
                Type 'PromiseLike<PriceQuote>' is missing the following properties from type 'PriceQuote': quoteAmount, quotePayment

```

note the nested `ERef<ERef<` on the second line.  After Typescript 5.x, the nested PromiseLikes seem to be automatically merged, resulting in `PromiseLike<PriceQuote> | PriceQuote` which is structurally the same as `ERef<PriceQuote>`.