### PR TITLE
stricter TypeScript checks

### DIFF
--- a/jsconfig.eslint-base.json
+++ b/jsconfig.eslint-base.json
@@ -5,9 +5,14 @@
     "checkJs": true,
     "noEmit": true,
     "downlevelIteration": true,
+    "strict": true,
     "strictNullChecks": true,
-    "moduleResolution": "node"
+    "useUnknownInCatchVariables": false,
+    "moduleResolution": "node",
+    "noImplicitAny": false
   },
   "include": [],
-  "exclude": ["packages/test262-runner/test262"]
+  "exclude": [
+    "packages/test262-runner/test262"
+  ]
 }

--- a/packages/captp/src/loopback.js
+++ b/packages/captp/src/loopback.js
@@ -102,6 +102,7 @@ export const makeLoopback = (ourId, nearOptions, farOptions) => {
       const myNonce = lastNonce;
       const val = await x;
       nonceToRef.set(myNonce, harden(val));
+      // @ts-expect-error xxx EProxy: getRef typed as 'never'
       return E(refGetter).getRef(myNonce);
     };
 

--- a/packages/cjs-module-analyzer/index.js
+++ b/packages/cjs-module-analyzer/index.js
@@ -73,9 +73,11 @@ export function analyzeCommonJS(cjsSource, name = '<unknown>') {
   try {
     parseSource(cjsSource);
   } catch (e) {
-    e.message += `\n  at ${name}:${
-      cjsSource.slice(0, pos).split('\n').length
-    }:${pos - cjsSource.lastIndexOf('\n', pos - 1)}`;
+    if (e instanceof Error) {
+      e.message += `\n  at ${name}:${
+        cjsSource.slice(0, pos).split('\n').length
+      }:${pos - cjsSource.lastIndexOf('\n', pos - 1)}`;
+    }
     e.loc = pos;
     throw e;
   }

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -126,7 +126,7 @@ const makeExtensionParser = (
       } catch (err) {
         throw Error(
           `Error transforming ${q(language)} source in ${q(location)}: ${
-            err.message
+            err instanceof Error ? err.message : err
           }`,
           { cause: err },
         );
@@ -514,6 +514,7 @@ export const link = (
         const errors = results
           .filter(result => result.status === 'rejected')
           .map(
+            // @ts-expect-error 'result' and 'value' are incompatible
             /** @param {PromiseRejectedResult} result */ result =>
               result.reason,
           );

--- a/packages/compartment-mapper/src/node-powers.js
+++ b/packages/compartment-mapper/src/node-powers.js
@@ -48,7 +48,10 @@ const makeReadPowersSloppy = ({ fs, url = undefined, crypto = undefined }) => {
       const path = fileURLToPath(location);
       return await fs.promises.readFile(path);
     } catch (error) {
-      throw Error(error.message);
+      if (error instanceof Error) {
+        throw Error(error.message);
+      }
+      throw Error('unknown catch value');
     }
   };
 
@@ -126,7 +129,10 @@ const makeWritePowersSloppy = ({ fs, url = undefined }) => {
     try {
       return await fs.promises.writeFile(fileURLToPath(location), data);
     } catch (error) {
-      throw Error(error.message);
+      if (error instanceof Error) {
+        throw Error(error.message);
+      }
+      throw Error('unknown catch value');
     }
   };
 

--- a/packages/compartment-mapper/src/policy.js
+++ b/packages/compartment-mapper/src/policy.js
@@ -239,15 +239,15 @@ export const makeDeferredAttenuatorsProvider = (
     // the import function being called.
     /**
      *
-     * @param {string} attenuatorSpecifier
+     * @param {string?} attenuatorSpecifier
      * @returns {Promise<Attenuator>}
      */
     importAttenuator = async attenuatorSpecifier => {
       if (!attenuatorSpecifier) {
-        if (!defaultAttenuator) {
+        attenuatorSpecifier = defaultAttenuator;
+        if (!attenuatorSpecifier) {
           throw Error(`No default attenuator specified in policy`);
         }
-        attenuatorSpecifier = defaultAttenuator;
       }
       const { namespace } = await compartments[ATTENUATORS_COMPARTMENT].import(
         attenuatorSpecifier,

--- a/packages/marshal/src/dot-membrane.js
+++ b/packages/marshal/src/dot-membrane.js
@@ -110,7 +110,7 @@ const makeConverter = (mirrorConverter = undefined) => {
   };
   // We need to pass this while convertYoursToMine is still in temporal
   // dead zone, so we wrap it in convertSlotToVal.
-  const convertSlotToVal = (slot, optIface = undefined) =>
+  const convertSlotToVal = (slot, optIface) =>
     convertYoursToMine(slot, optIface);
   const { serialize: mySerialize, unserialize: myUnserialize } = makeMarshal(
     convertMineToYours,

--- a/packages/marshal/test/test-marshal-testing.js
+++ b/packages/marshal/test/test-marshal-testing.js
@@ -12,7 +12,7 @@ const bob2 = Far('bob');
 
 const convertValToSlot = val =>
   passStyleOf(val) === 'remotable' ? 'far' : val;
-const convertSlotToVal = (slot, iface = undefined) =>
+const convertSlotToVal = (slot, iface) =>
   slot === 'far' ? Remotable(iface) : slot;
 const { fromCapData, toCapData } = makeMarshal(
   convertValToSlot,

--- a/packages/pass-style/jsconfig.json
+++ b/packages/pass-style/jsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "../../jsconfig.eslint-base.json",
-  "include": ["*.js", "*.ts", "src/**/*.js", "src/**/*.ts"]
+  "include": [
+    "*.js",
+    "*.ts",
+    "src/**/*.js",
+    "src/**/*.ts"
+  ]
 }

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -1517,7 +1517,7 @@ const makePatternKit = () => {
     return makeMatcher(tag, payload);
   };
 
-  const makeRemotableMatcher = (label = undefined) =>
+  const makeRemotableMatcher = label =>
     label === undefined
       ? RemotableShape
       : makeMatcher('match:remotable', harden({ label }));

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -1054,6 +1054,7 @@ const makePatternKit = () => {
         entries(specimen).every(
           ([key, value]) =>
             applyLabelingError(
+              // @ts-expect-error xxx Argument of type 'Checker' is not assignable to parameter of type '(...args: (boolean | DetailsToken)[]) => boolean'.
               check,
               [
                 key.length <= propertyNameLengthLimit,

--- a/packages/promise-kit/index.js
+++ b/packages/promise-kit/index.js
@@ -45,6 +45,9 @@ harden(makePromiseKit);
  * @returns {Promise<Awaited<T>>} A new Promise.
  */
 export function racePromises(values) {
-  return harden(memoRace.call(BestPipelinablePromise, values));
+  const p = /** @type {Promise<Awaited<T>>} */ (
+    memoRace.call(BestPipelinablePromise, values)
+  );
+  return harden(p);
 }
 harden(racePromises);

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -199,6 +199,7 @@ export const stringReplace = /** @type {any} */ (
 export const stringSearch = uncurryThis(stringPrototype.search);
 export const stringSlice = uncurryThis(stringPrototype.slice);
 /** @type {(thisArg: string, splitter: string | RegExp | { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number) => string[]} */
+// @ts-expect-error Type '(thisArg: unknown, splitter: { [Symbol.split](string: string, limit?: number | undefined): string[]; }, limit?: number | undefined) => string[]' is not assignable to type '(thisArg: string, splitter: string | RegExp | { [Symbol.split](string: string, limit?: number | undefined): string[]; }, limit?: number | undefined) => string[]'.
 export const stringSplit = uncurryThis(stringPrototype.split);
 export const stringStartsWith = uncurryThis(stringPrototype.startsWith);
 export const iterateString = uncurryThis(stringPrototype[iteratorSymbol]);

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -269,6 +269,7 @@ export const makeCompartmentConstructor = (
 
     assign(globalObject, endowments);
 
+    // @ts-expect-error 'this' implicitly has type 'any' because it does not have a type annotation.
     weakmapSet(privateFields, this, {
       name: `${name}`,
       globalTransforms,

--- a/packages/zip/src/buffer-reader.js
+++ b/packages/zip/src/buffer-reader.js
@@ -16,6 +16,7 @@ const q = JSON.stringify;
 const privateFields = new WeakMap();
 
 /** @type {(bufferReader: BufferReader) => BufferReaderState} */
+// @ts-expect-error could be undefined
 const privateFieldsGet = privateFields.get.bind(privateFields);
 
 export class BufferReader {


### PR DESCRIPTION
Enables stricter TypesScript config. Punts on `noImplicitAny` and `useUnknownInCatchVariables` (so they can continue to be any). Before adding `useUnknownInCatchVariables` I fixed some cases.

Removes some `= undefined` so the checker doesn't get a faulty type hint.
**before**
![Screenshot 2023-07-11 at 11 52 21 AM](https://github.com/endojs/endo/assets/21505/e9616230-f3f3-419b-a12e-91308c8b18dd)
**after**
![Screenshot 2023-07-11 at 11 55 27 AM](https://github.com/endojs/endo/assets/21505/84cc7488-99ae-461b-b0e4-d4a55ad5a91b)


Suppresses errors I didn't know how to fix.