### PR TITLE
fix(ses): add more missing permits

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -852,6 +852,7 @@ export const permitted = {
     dotAll: getter,
     flags: getter,
     global: getter,
+    hasIndices: getter,
     ignoreCase: getter,
     '@@match': fn,
     '@@matchAll': fn,
@@ -864,12 +865,10 @@ export const permitted = {
     test: fn,
     toString: fn,
     unicode: getter,
+    unicodeSets: getter,
 
     // Annex B: Additional Properties of the RegExp.prototype Object
     compile: false, // UNSAFE and suppressed.
-    // Seen on FF Nightly 88.0a1, Chrome Canary 91.0.4446.0,
-    // Safari Tech Preview Release 122 (Safari 14.2, WebKit 16612.1.6.2)
-    hasIndices: false,
   },
 
   '%RegExpStringIteratorPrototype%': {


### PR DESCRIPTION
Both `RegExp.prototype.hasIndices` and `RegExp.prototype.unicodeSets` are standard at least as of EcmaScript 2024, as seen at https://tc39.es/ecma262/multipage/text-processing.html#sec-properties-of-the-regexp-prototype-object

I noticed the missing `RegExp.prototype.unicodeSets` because of the ses initialization warning only starting on Node 20. While investigating, I saw that `permits.js` had classified `RegExp.prototype.hasIndices` as an expected anomaly to be silently removed, but that it is now standard.