### PR TITLE
fix(ses): normalize `bestEffortsStringify` property order

### DIFF
--- a/packages/marshal/test/test-marshal-smallcaps.js
+++ b/packages/marshal/test/test-marshal-smallcaps.js
@@ -351,7 +351,7 @@ test('smallcaps encoding examples', t => {
   harden(nonPassableErr);
   t.throws(() => passStyleOf(nonPassableErr), {
     message:
-      /Passed Error has extra unpassed properties {"extraProperty":{"value":"something bad","writable":.*,"enumerable":true,"configurable":.*}}/,
+      /Passed Error has extra unpassed properties {"extraProperty":{"configurable":.*,"enumerable":true,"value":"something bad","writable":.*}}/,
   });
   assertSer(
     nonPassableErr,

--- a/packages/patterns/test/test-pattern-limits.js
+++ b/packages/patterns/test/test-pattern-limits.js
@@ -164,7 +164,7 @@ const runTests = (successCase, failCase) => {
     failCase(
       specimen,
       M.record(harden({ numPropertiesLimit: 2 })),
-      'Must not have more than 2 properties: {"z":"[1000000n]","x0123456789":"[379n]","a":"[10000000n]"}',
+      'Must not have more than 2 properties: {"a":"[10000000n]","x0123456789":"[379n]","z":"[1000000n]"}',
     );
     failCase(
       specimen,

--- a/packages/patterns/test/test-patterns.js
+++ b/packages/patterns/test/test-patterns.js
@@ -224,7 +224,7 @@ const runTests = (successCase, failCase) => {
       failCase(
         specimen,
         M[method](),
-        makeMessage('{"foo":3,"bar":4}', 'copyRecord'),
+        makeMessage('{"bar":4,"foo":3}', 'copyRecord'),
       );
     }
     successCase(specimen, { foo: M.number(), bar: M.any() });
@@ -263,7 +263,7 @@ const runTests = (successCase, failCase) => {
     failCase(
       specimen,
       { foo: 4, bar: 3 },
-      '{"foo":3,"bar":4} - Must be: {"foo":4,"bar":3}',
+      '{"bar":4,"foo":3} - Must be: {"bar":3,"foo":4}',
     );
     failCase(
       specimen,
@@ -273,44 +273,44 @@ const runTests = (successCase, failCase) => {
     failCase(
       specimen,
       M.lte({ foo: 3, bar: 3 }),
-      '{"foo":3,"bar":4} - Must be <= {"foo":3,"bar":3}',
+      '{"bar":4,"foo":3} - Must be <= {"bar":3,"foo":3}',
     );
     failCase(
       specimen,
       M.gte({ foo: 4, bar: 4 }),
-      '{"foo":3,"bar":4} - Must be >= {"foo":4,"bar":4}',
+      '{"bar":4,"foo":3} - Must be >= {"bar":4,"foo":4}',
     );
 
     // Incommensurates are neither greater nor less
     failCase(
       specimen,
       M.gte({ foo: 3 }),
-      '{"foo":3,"bar":4} - Must be >= {"foo":3}',
+      '{"bar":4,"foo":3} - Must be >= {"foo":3}',
     );
     failCase(
       specimen,
       M.lte({ foo: 3 }),
-      '{"foo":3,"bar":4} - Must be <= {"foo":3}',
+      '{"bar":4,"foo":3} - Must be <= {"foo":3}',
     );
     failCase(
       specimen,
       M.gte({ foo: 3, bar: 4, baz: 5 }),
-      '{"foo":3,"bar":4} - Must be >= {"foo":3,"bar":4,"baz":5}',
+      '{"bar":4,"foo":3} - Must be >= {"bar":4,"baz":5,"foo":3}',
     );
     failCase(
       specimen,
       M.lte({ foo: 3, bar: 4, baz: 5 }),
-      '{"foo":3,"bar":4} - Must be <= {"foo":3,"bar":4,"baz":5}',
+      '{"bar":4,"foo":3} - Must be <= {"bar":4,"baz":5,"foo":3}',
     );
     failCase(
       specimen,
       M.lte({ baz: 3 }),
-      '{"foo":3,"bar":4} - Must be <= {"baz":3}',
+      '{"bar":4,"foo":3} - Must be <= {"baz":3}',
     );
     failCase(
       specimen,
       M.gte({ baz: 3 }),
-      '{"foo":3,"bar":4} - Must be >= {"baz":3}',
+      '{"bar":4,"foo":3} - Must be >= {"baz":3}',
     );
 
     failCase(
@@ -331,7 +331,7 @@ const runTests = (successCase, failCase) => {
     failCase(
       specimen,
       M.split([]),
-      'copyRecord {"foo":3,"bar":4} - Must be a copyArray',
+      'copyRecord {"bar":4,"foo":3} - Must be a copyArray',
     );
     failCase(
       specimen,
@@ -341,7 +341,7 @@ const runTests = (successCase, failCase) => {
     failCase(
       specimen,
       M.split({ foo: 3 }, { foo: 3, bar: 4 }),
-      '...rest: {"bar":4} - Must be: {"foo":3,"bar":4}',
+      '...rest: {"bar":4} - Must be: {"bar":4,"foo":3}',
     );
     failCase(
       specimen,
@@ -357,12 +357,12 @@ const runTests = (successCase, failCase) => {
     failCase(
       specimen,
       M.scalar(),
-      'A "copyRecord" cannot be a scalar key: {"foo":3,"bar":4}',
+      'A "copyRecord" cannot be a scalar key: {"bar":4,"foo":3}',
     );
     failCase(
       specimen,
       M.map(),
-      'copyRecord {"foo":3,"bar":4} - Must be a copyMap',
+      'copyRecord {"bar":4,"foo":3} - Must be a copyMap',
     );
     failCase(
       specimen,

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -3,8 +3,13 @@
 import {
   Set,
   String,
+  isArray,
   arrayJoin,
   arraySlice,
+  arraySort,
+  arrayMap,
+  keys,
+  fromEntries,
   freeze,
   is,
   isError,
@@ -120,7 +125,26 @@ const bestEffortStringify = (payload, spaces = undefined) => {
           // and their remote presences in the first place.
           return `[${val[toStringTagSymbol]}]`;
         }
-        return val;
+        if (isArray(val)) {
+          return val;
+        }
+        const names = keys(val);
+        if (names.length < 2) {
+          return val;
+        }
+        let sorted = true;
+        for (let i = 1; i < names.length; i += 1) {
+          if (names[i - 1] >= names[i]) {
+            sorted = false;
+            break;
+          }
+        }
+        if (sorted) {
+          return val;
+        }
+        arraySort(names);
+        const entries = arrayMap(names, name => [name, val[name]]);
+        return fromEntries(entries);
       }
       case 'function': {
         return `[Function ${val.name || '<anon>'}]`;

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -452,7 +452,7 @@ test('assert.quote as best efforts stringify', t => {
   ];
   t.is(
     `${q(challenges)}`,
-    '["[Promise]","[Function foo]","[[hilbert]]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"NaN":"[NaN]","Infinity":"[Infinity]","neg":"[-Infinity]"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":"[Tagged]"},{}]',
+    '["[Promise]","[Function foo]","[[hilbert]]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"Infinity":"[Infinity]","NaN":"[NaN]","neg":"[-Infinity]"},18014398509481984,{"subTagged":"[Tagged]","subTaggedNonEmpty":"[Tagged]","superTagged":"[Tagged]"},{}]',
   );
   t.is(
     `${q(challenges, '  ')}`,
@@ -471,15 +471,15 @@ test('assert.quote as best efforts stringify', t => {
     "[Symbol(Symbol.asyncIterator)]"
   ],
   {
-    "NaN": "[NaN]",
     "Infinity": "[Infinity]",
+    "NaN": "[NaN]",
     "neg": "[-Infinity]"
   },
   18014398509481984,
   {
-    "superTagged": "[Tagged]",
     "subTagged": "[Tagged]",
-    "subTaggedNonEmpty": "[Tagged]"
+    "subTaggedNonEmpty": "[Tagged]",
+    "superTagged": "[Tagged]"
   },
   {}
 ]`,

--- a/packages/ses/test/error/test-stringfy-utils.js
+++ b/packages/ses/test/error/test-stringfy-utils.js
@@ -1,0 +1,16 @@
+import test from 'ava';
+import { assert } from '../../src/error/assert.js';
+
+const { Fail, quote: q } = assert;
+
+const obj = {
+  y: 8,
+  a: 1,
+  x: 7,
+};
+
+test('prop order', t => {
+  t.throws(() => Fail`oops: ${q(obj)}`, {
+    message: 'oops: {"a":1,"x":7,"y":8}',
+  });
+});


### PR DESCRIPTION
Currently `bestEffortsStringify` uses the default property enumeration order, which is insertion order. As a result, semantically neutral changes that happen to change property insertion order accidentally cause error messages to change, breaking golden tests of error messages.

See example breakage at https://github.com/Agoric/agoric-sdk/actions/runs/5572658660/jobs/10178998419?pr=5422#step:5:212

With expository whitespace:
```js
({
  "want": {
    "TokenJ": {
      "brand": "[Alleged: moola brand]",
      "value": "[3n]"
    }
  },
  "give": {
    "TokenK": {
      "brand": "[Alleged: bucks brand]",
      "value": "[5n]"
    }
  },
  "multiples": "[1n]",
  "exit": {"onDemand": null}
})
```
vs
```js
({
  "exit": {"onDemand": null},
  "give": {
    "TokenK": {
      "brand": "[Alleged: bucks brand]",
      "value": "[5n]"
    }
  },
  "multiples": "[1n]",
  "want": {
    "TokenJ": {
      "brand": "[Alleged: moola brand]",
      "value": "[3n]"
    }
  }
})
```

Amusingly, at least in this case, the golden is in property-name sorted order, so this change will not break that one golden. However, this PR may very well break other golden error tests; but only those that were inherently fragile anyway.