### PR TITLE
docs(marshal): Update README

### DIFF
--- a/packages/marshal/README.md
+++ b/packages/marshal/README.md
@@ -74,26 +74,27 @@ console.log(m2.toCapData(NaN));
 `marshal` makes a distinction between objects that are pass-by-presence, and
 those which are pass-by-copy.
 
-To qualify as pass-by-presence, all enumerable properties of an object (and of
-all objects in its inheritance hierarchy) must be methods, not data.
-Pass-by-presence objects are usually treated as having identity (assuming the
-`convertValToSlot` and `convertSlotToVal` callbacks behave well), so passing the
-same object through multiple calls will result in multiple references to the
-same output object.
+To qualify as pass-by-presence, all properties of an object (and of all objects
+in its inheritance hierarchy) must be methods, not data. Pass-by-presence objects
+are usually treated as having identity (assuming the `convertValToSlot` and
+`convertSlotToVal` callbacks behave well), so passing the same object through
+multiple calls will result in multiple references to the same output object.
 
-To qualify as pass-by-copy, the enumerable string-named properties of the
-object must data, not methods: they can be Arrays, strings, numbers, and
-other pass-by-copy objects, but not functions. In addition, the object must
-either inherit from `Object.prototype` or `null`. Pass-by-copy objects do not
-generally have identity: the unserializer is not obligated to produce the
-same output object for multiple appearances of the input object.
+To qualify as pass-by-copy, all properties of an object must be string-named and
+enumerable and not accessors and not methods: their values can be primitives such
+as bigints, booleans, `null`, numbers, and strings, and they can be arrays and
+pass-by-copy objects, but they cannot be functions. In addition, the object must
+inherit directly from `Object.prototype`. Pass-by-copy objects are not treated as
+having identity: `fromCapData` does not produce the same output object for
+multiple appearances of the same pass-by-copy serialization.
 
 Mixed objects having both methods and data properties are rejected.
 
-Empty objects (which qualify as both types) are treated as pass-by-presence,
-so they can be used as marker objects which can be compared for identity.
-These are especially useful as keys WeakMaps for the "rights amplification"
-pattern.
+Empty objects (which vacuously satisfy requirements for both pass-by-presence and
+pass-by-copy) are treated as pass-by-copy, although it is also possible to use
+`Far` (from `@endo/far`) for creating empty marker objects which _can_ be
+compared for identity and are especially useful as WeakMap keys in the "rights
+amplification" pattern.
 
 ## `convertValToSlot` / `convertSlotToVal`
 

--- a/packages/marshal/README.md
+++ b/packages/marshal/README.md
@@ -7,9 +7,9 @@ The `marshal` module helps with conversion of "capability-bearing data", in
 which some portion of the structured input represents "pass-by-proxy" or
 "pass-by-presence" objects. These should be serialized into markers that
 refer to special "reference identifiers". These identifiers are collected in
-an array, and the `serialize()` function returns a two-element structure
+an array, and the `toCapData()` function returns a two-element structure
 known as "CapData": a `body` that contains the usual string, and a new
-`slots` array that holds the reference identifiers. `unserialize()` takes
+`slots` array that holds the reference identifiers. `fromCapData()` takes
 this CapData structure and returns the object graph. The marshaller must be
 taught (with a pair of callbacks) how to create the presence markers, and how
 to turn these markers back into proxies/presences.
@@ -22,7 +22,7 @@ Javascript objects that cannot be expressed directly as JSON, such as
 
 This module exports a `makeMarshal()` function, which can be called with two
 optional callbacks (`convertValToSlot` and `convertSlotToVal`), and returns
-an object with `serialize` and `unserialize` properties. If the callback
+an object with `toCapData` and `fromCapData` properties. If the callback
 arguments are omitted, they default to the identity function.
 
 ```js
@@ -31,9 +31,9 @@ import { makeMarshal } from '@endo/marshal';
 
 const m = makeMarshal();
 const o = harden({a: 1});
-const s = m.serialize(o);
+const s = m.toCapData(o);
 console.log(s); // { body: '{"a":1}', slots: [] }
-const o2 = m.unserialize(s);
+const o2 = m.fromCapData(s);
 console.log(o2); // { a: 1 }
 ```
 
@@ -51,7 +51,7 @@ which cannot be expressed directly in JSON. This marker uses a property named
 `NaN` is serialized into:
 
 ```
-m.serialize(NaN);
+m.toCapData(NaN);
 // { body: '{"@qclass":"NaN"}', slots: [] }
 ```
 
@@ -88,7 +88,7 @@ pattern.
 
 ## `convertValToSlot` / `convertSlotToVal`
 
-When `m.serialize()` encounters a pass-by-presence object, it will call the
+When `m.toCapData()` encounters a pass-by-presence object, it will call the
 `convertValToSlot` callback with the value to be serialized. Its return value
 will be used at the slot identifier to be placed into the slots array. In the
 serialized body, this will be represented by the record
@@ -100,7 +100,7 @@ where `index` is the index in the slots array of that slot.
 The array of slot identifiers is returned as the `slots` portion of the
 CapData structure.
 
-Each time `m.unserialize()` encounters such a record, it calls
+Each time `m.fromCapData()` encounters such a record, it calls
 `convertSlotToVal` with that slot from the slots array. `convertSlotToVal`
 should create and return a proxy (or other representative) of the
 pass-by-presence object.

--- a/packages/marshal/README.md
+++ b/packages/marshal/README.md
@@ -71,8 +71,8 @@ console.log(m2.toCapData(NaN));
 
 ## Pass-by-Presence vs Pass-by-Copy
 
-`marshal` makes a distinction between objects that are pass-by-presence, and
-those which are pass-by-copy.
+`marshal` relies upon `@endo/pass-style` to distinguish between objects that are
+pass-by-presence and those that are pass-by-copy.
 
 To qualify as pass-by-presence, all properties of an object (and of all objects
 in its inheritance hierarchy) must be methods, not data. Pass-by-presence objects


### PR DESCRIPTION
Fixes #1683
Fixes #1680

* Reference toCapData/fromCapData
* Emphasize smallcaps over the original encoding
* Tweak phrasing
* Fix inaccurate claims