### PR TITLE
Read carefully

### DIFF
--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -1,3 +1,4 @@
+/* global performance */
 // @ts-check
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
@@ -350,7 +351,7 @@ export const makeNodeBundleCache = async (dest, options, loadModule) => {
   ]);
 
   const readPowers = {
-    ...makeReadPowers({ fs, url, crypto }),
+    ...makeReadPowers({ fs, url, crypto, now: performance.now }),
     delay: ms => new Promise(resolve => timers.setTimeout(resolve, ms)),
     basename: path.basename,
   };

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -1,4 +1,4 @@
-/* global process */
+/* global process performance */
 
 import fs from 'fs';
 import { rollup as rollup0 } from 'rollup';
@@ -34,7 +34,7 @@ const HTML_COMMENT_END_RE = new RegExp(`--${'>'}`, 'g');
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
-const readPowers = makeReadPowers({ fs, url, crypto });
+const readPowers = makeReadPowers({ fs, url, crypto, now: performance.now });
 
 /**
  * Finds the longest common prefix in an array of strings.

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -5,6 +5,13 @@ User-visible changes to the compartment mapper:
 - Introduces support for source map generation.
   Look for `computeSourceMapLocation` and `sourceMapHook` in
   [`README.md`](README.md).
+- This version reads more carefully, adding a control loop around concurrent
+  reads and classifying read errors caused by interrupts, resource exhaustion,
+  non-existant files, and existence of non-files.
+  To preserve backward compatibility and object capability principles, the
+  governor uses a low resolution timer by default and can be endowed with
+  `performance.now` for a better signal.
+  These changes will put file descriptor exhaustion firmly behind us.
 
 # 0.8.5 (2023-07-17)
 

--- a/packages/compartment-mapper/src/governor.js
+++ b/packages/compartment-mapper/src/governor.js
@@ -1,0 +1,157 @@
+/// <refs types="ses"/>
+
+// This module provides a control-loop for governing the concurrency of reads
+// as a mitigation for exhausting file descriptors, retrying over interrupts,
+// and maximizing throughput regardless of the underlying transport.
+//
+// It does not escape the notice of the author that in practice concurrent
+// reads from a file system do not tend to increase throughput.
+
+// At time of writing, the compartment mapper can be used with or without
+// lockdown, so these superficial duplicates of makeQueue and makePromiseKit
+// are necessary only because harden is not available without lockdown.
+// We may revisit this design if it becomes possible to use the generalized
+// versions of these utilities before application of lockdown as discussed:
+// https://github.com/endojs/endo/issues/1686
+
+const { Fail, quote: q } = assert;
+
+const makePromiseKit = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+export const makeQueue = () => {
+  let { promise: tailPromise, resolve: tailResolve } = makePromiseKit();
+  return {
+    put(value) {
+      const { resolve, promise } = makePromiseKit();
+      tailResolve({ value, promise });
+      tailResolve = resolve;
+    },
+    get() {
+      const promise = tailPromise.then(next => next.value);
+      tailPromise = tailPromise.then(next => next.promise);
+      return promise;
+    },
+  };
+};
+
+/**
+ * @param {object} args
+ * @param {number} [args.initialConcurrency]
+ * @param {number} [args.minimumConcurrency]
+ * @param {number} [args.maximumConcurrency]
+ * @param {() => number} args.now - a clock of arbitrary precision and
+ * magnitude.
+ * @param {(error: {message: string}) => boolean} args.isExhaustedError
+ * @param {(error: {message: string}) => boolean} args.isInterruptedError
+ */
+export const makeGovernor = ({
+  minimumConcurrency = 1,
+  initialConcurrency = minimumConcurrency,
+  maximumConcurrency = Infinity,
+  now,
+  isExhaustedError,
+  isInterruptedError,
+}) => {
+  minimumConcurrency >= 1 || Fail`Minimum concurrency limit must be at least 1`;
+  initialConcurrency >= minimumConcurrency ||
+    Fail`Initial concurrency limit must be at least ${q(minimumConcurrency)}`;
+  initialConcurrency <= maximumConcurrency ||
+    Fail`Initial concurrency limit must be at most ${q(maximumConcurrency)}`;
+  const queue = makeQueue();
+  let limit = initialConcurrency;
+  let concurrency = initialConcurrency;
+  for (let i = 0; i < initialConcurrency; i += 1) {
+    queue.put();
+  }
+
+  let prev = 0;
+
+  const wrapRead = read => {
+    // We cannot govern throughput without a timer of some resolution.
+    // Inside a SES compartment the fallback of Date.now produces NaN.
+    if (Number.isNaN(now())) {
+      return read;
+    }
+
+    /**
+     * @param {string} location
+     */
+    const wrappedRead = async location => {
+      await queue.get();
+      const start = now();
+
+      try {
+        const result = await read(location);
+
+        // Adjust concurrency limit in proportion to the change in
+        // throughput.
+        // A reduction in throughput indicates saturation over the bus from the
+        // underlying storage and suggests that we should reduce concurrent
+        // reads.
+        // An increase in throughput suggests an opportunity to exploit further
+        // concurrency.
+        const end = now();
+        // Make no adjustment if the resolution of the timer is not sufficient
+        // to measure any duration between the beginning and end of the read.
+        if (prev > 0 && end !== start) {
+          const next = result.byteLength / (end - start);
+          const change = next / prev;
+          if (change > 1) {
+            // Until we have saturated the bus, we cannot expect throughput to
+            // increase except due to noise.
+            // So, to exaggerate that noise, we increment the concurrency
+            // limit, which causes this algorithm to degenerate to the AIMD
+            // behavior similar to TCP slow start.
+            limit = Math.min(maximumConcurrency, limit + 1);
+          } else if (change < 1) {
+            // With decreasing throughput, at least allow one concurrent read, or
+            // we will never recover.
+            limit = Math.max(minimumConcurrency, limit * change);
+          }
+          // console.log('concurrency', concurrency, 'limit', limit);
+          prev = next;
+        }
+
+        return result;
+      } catch (error) {
+        if (isInterruptedError(error)) {
+          // Interruptions do not indicate resource exhaustion, but the
+          // duration of a read that spans an interrupt does no indicate a
+          // reduction of throughput.
+          // We do not await the promise returned so our finally block runs
+          // before the promise settles.
+          return wrappedRead(location);
+        }
+        if (isExhaustedError(error)) {
+          // Multiplicative back-off if concurrency has caused the depletion of
+          // a resource, specifically file descriptors.
+          limit = Math.max(minimumConcurrency, limit / 2);
+          // We do not await the promise returned so our finally block runs
+          // before the promise settles.
+          return wrappedRead(location);
+        } else {
+          throw error;
+        }
+      } finally {
+        // Unblock further concurrent reads.
+        concurrency -= 1;
+        for (let i = 0; i <= limit - concurrency; i += 1) {
+          concurrency += 1;
+          queue.put();
+          // console.log('concurrency', concurrency);
+        }
+      }
+    };
+    return wrappedRead;
+  };
+
+  return { wrapRead };
+};

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -257,7 +257,7 @@ export const makeImportHookMaker = (
         }
       }
 
-      const { read } = unpackReadPowers(readPowers);
+      const { maybeRead } = unpackReadPowers(readPowers);
 
       for (const candidateSpecifier of candidates) {
         const candidateModuleDescriptor = moduleDescriptors[candidateSpecifier];
@@ -298,9 +298,7 @@ export const makeImportHookMaker = (
           packageLocation,
         );
         // eslint-disable-next-line no-await-in-loop
-        const moduleBytes = await read(moduleLocation).catch(
-          _error => undefined,
-        );
+        const moduleBytes = await maybeRead(moduleLocation);
         if (moduleBytes !== undefined) {
           /** @type {string | undefined} */
           let sourceMap;

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -114,6 +114,14 @@ export {};
  */
 
 /**
+ * A resolution of `undefined` indicates `ENOENT` or the equivalent.
+ *
+ * @callback MaybeReadFn
+ * @param {string} location
+ * @returns {Promise<Uint8Array | undefined>} bytes
+ */
+
+/**
  * Returns a canonical URL for a given URL, following redirects or symbolic
  * links if any exist along the path.
  * Must return the given logical location if the real location does not exist.
@@ -154,6 +162,11 @@ export {};
  * @property {Function} [fileURLToPath]
  * @property {Function} [pathToFileURL]
  * @property {Function} [requireResolve]
+ */
+
+/**
+ * @typedef {ReadPowers | object} MaybeReadPowers
+ * @property {MaybeReadFn} maybeRead
  */
 
 /**

--- a/packages/compartment-mapper/test/scaffold.js
+++ b/packages/compartment-mapper/test/scaffold.js
@@ -1,3 +1,5 @@
+/* global performance */
+
 import 'ses';
 import fs from 'fs';
 import crypto from 'crypto';
@@ -15,7 +17,12 @@ import {
 } from '../index.js';
 import { makeReadPowers } from '../src/node-powers.js';
 
-export const readPowers = makeReadPowers({ fs, crypto, url });
+export const readPowers = makeReadPowers({
+  fs,
+  crypto,
+  url,
+  now: performance.now,
+});
 
 export const sanitizePaths = (text = '', tolerateLineChange = false) => {
   if (tolerateLineChange) {


### PR DESCRIPTION
Fixes #1593, the bundler and compartment-mapper read many files to build a bundle and these reads are by default aggressively concurrent. This can lead to the exhaustion of file descriptors. This is generally silly because a file system does not tend to improve throughput with any amount of concurrency.

However, the compartment mapper is sufficiently general to run on any read powers, so it would be poor form to use a synchronous read function.

With this change, the compartment mapper classifies read errors in Node.js:

- those that indicate that a read was interrupted, as can occur if reading when the process receives a signal
- those that indicate that a read failed because file descriptors were exhausted
- those that indicate that a read failed because a file did not exist, or an entry existed but was not a file

…and monitors the throughput of reads. The governor implements an hybrid control loop based on AIMD (additive increase, multiplicative decrease) and CoDel (control delay).

- if throughput increases, we increase the concurrency limit by 1
- if throughput decreases, we apply a proportional decrease to the concurrency limit
- if we exhaust file descriptors, we halve the concurrency limit
- if we are interrupted, we try again and do not apply the delay against the throughput

And we also incidentally are more careful to distinguish these errors from missing entries when searching for a file (`maybeRead`).

A worthy critique of this PR is: perhaps instead of this level of sophistication you could just limit the Node.js read powers to a single concurrent read.