### PR TITLE
fix: Fix scaffold and transforms yarn pack

### DIFF
--- a/packages/skel/tsconfig.build.json
+++ b/packages/skel/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./jsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "declaration": true,

--- a/packages/transforms/tsconfig.build.json
+++ b/packages/transforms/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./jsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "declaration": true,


### PR DESCRIPTION

This fixes the `yarn pack` behavior for the new packages `skel` and `transforms`. The TypeScript build configuration was misaligned with the TypeScript configuration rename.
