### PR TITLE
feat(bundle-source): type `bundleSource` more comprehensively

### DIFF
--- a/packages/bundle-source/src/types.js
+++ b/packages/bundle-source/src/types.js
@@ -3,23 +3,60 @@
  */
 
 /**
- * @callback BundleSource
+ * @typedef {BundleSourceEndoZipBase64 & BundleSourceGetExport & BundleSourceNestedEvaluate} BundleSource
+ */
+
+/**
+ * @callback BundleSourceEndoZipBase64
  * @param {string} startFilename - the filepath to start the bundling from
- * @param {(ModuleFormat | BundleOptions)=} moduleFormat
+ * @param {ModuleFormatOrOptions<'endoZipBase64' | undefined>} moduleFormat
  * @param {object=} powers
  * @param {ReadFn=} powers.read
  * @param {CanonicalFn=} powers.canonical
  * @returns {Promise<{
- *   endoZipBase64?: string,
- *   moduleFormat: ModuleFormat;
- *   source?: string,
- *   sourceMap?: string,
+ *  moduleFormat: 'endoZipBase64',
+ *  endoZipBase64: string,
+ *  endoZipBase64Sha512: string,
  * }>}
  */
 
 /**
+ * @callback BundleSourceGetExport
+ * @param {string} startFilename - the filepath to start the bundling from
+ * @param {ModuleFormatOrOptions<'getExport'>} moduleFormat
+ * @param {object=} powers
+ * @param {ReadFn=} powers.read
+ * @param {CanonicalFn=} powers.canonical
+ * @returns {Promise<{
+ *  moduleFormat: 'getExport',
+ *  source: string,
+ *  sourceMap: string,
+ * }>}
+ */
+
+/**
+ * @callback BundleSourceNestedEvaluate
+ * @param {string} startFilename - the filepath to start the bundling from
+ * @param {ModuleFormatOrOptions<'nestedEvaluate'>} moduleFormat
+ * @param {object=} powers
+ * @param {ReadFn=} powers.read
+ * @param {CanonicalFn=} powers.canonical
+ * @returns {Promise<{
+ *  moduleFormat: 'nestedEvaluate',
+ *  source: string,
+ *  sourceMap: string,
+ * }>}
+ */
+
+/**
+ * @template {ModuleFormat | undefined} T
+ * @typedef {T | BundleOptions<T>} ModuleFormatOrOptions
+ */
+
+/**
+ * @template {ModuleFormat | undefined} T
  * @typedef {object} BundleOptions
- * @property {ModuleFormat} [format]
+ * @property {T} format
  * @property {boolean} [dev] - development mode, for test bundles that need
  * access to devDependencies of the entry package.
  */

--- a/packages/bundle-source/test/sanity.js
+++ b/packages/bundle-source/test/sanity.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { lockdown } from '@endo/lockdown';
 
 import url from 'url';
@@ -30,12 +31,12 @@ export function makeSanityTests(stackFiltering) {
       url.fileURLToPath(new URL('../demo/dir1/encourage.js', import.meta.url)),
       'endoZipBase64',
     );
-    assert(endoZipBase64);
+
     const bytes = decodeBase64(endoZipBase64);
     const archive = await parseArchive(bytes);
     // Call import by property to bypass SES censoring for dynamic import.
     // eslint-disable-next-line dot-notation
-    const { namespace } = await archive['import']('.');
+    const { namespace } = await archive['import']();
     const { message, encourage } = namespace;
 
     t.is(message, `You're great!`);
@@ -138,7 +139,8 @@ export function makeSanityTests(stackFiltering) {
     const srcMap2 = `(${src2})\n${map2}`;
 
     // eslint-disable-next-line no-eval
-    const ex2 = (1, eval)(srcMap2)();
+    const eval2 = eval;
+    const ex2 = eval2(srcMap2)();
     t.is(ex2.message, `You're great!`, 'exported message matches');
     t.is(
       ex2.encourage('Nick'),
@@ -171,6 +173,7 @@ export function makeSanityTests(stackFiltering) {
     t.truthy(!src1.match(/beforeExpr,;/), 'source is not mangled that one way');
     // the mangled form wasn't syntactically valid, do a quick check
     // eslint-disable-next-line no-eval
-    (1, eval)(`(${src1})`);
+    const eval2 = eval;
+    eval2(`(${src1})`);
   });
 }

--- a/packages/bundle-source/test/test-bigint-transform.js
+++ b/packages/bundle-source/test/test-bigint-transform.js
@@ -1,3 +1,4 @@
+// @ts-check
 import url from 'url';
 import { test } from './prepare-test-env-ava.js';
 import bundleSource from '../src/index.js';
@@ -8,6 +9,5 @@ test('bigint transform', async t => {
     'getExport',
   );
   // console.log(bundle.source);
-  assert(bundle.source);
   t.assert(bundle.source.indexOf('37n') >= 0);
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Recently, #1704 was a good step forward to introduce typing for the return value of `@endo/bundle-source`.  However, it came at the cost of requiring all callers to narrow the return type using assertions, knowing the moduleFormat they were using.

This PR discriminates between the different ModuleFormats to return an appropriate type that requires no assertions or narrowing (unless the supplied ModuleFormat cannot be inferred in the calling context).
<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review.  -->

### Security Considerations

n/a
<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?  -->

### Scaling Considerations

n/a
<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

n/a
<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?  -->

### Testing Considerations

The types could be tested more thoroughly, but they are at least exercised in `@endo/bundle-source` unit tests.
<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?  -->

### Upgrade Considerations

n/a
<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
