### PR TITLE
fix(ses): prepare for Array Grouping proposal

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -442,7 +442,7 @@ export const permitted = {
     setPrototypeOf: fn,
     values: fn,
     // https://github.com/tc39/proposal-array-grouping
-    groupBy: 'boolean',
+    groupBy: fn,
   },
 
   '%ObjectPrototype%': {
@@ -1069,6 +1069,8 @@ export const permitted = {
     '[[Proto]]': '%FunctionPrototype%',
     '@@species': getter,
     prototype: '%MapPrototype%',
+    // https://github.com/tc39/proposal-array-grouping
+    groupBy: fn,
   },
 
   '%MapPrototype%': {


### PR DESCRIPTION
https://github.com/endojs/endo/pull/1643
corrected problems with
https://github.com/endojs/endo/pull/1618
but says
>  I remain confused about where group and groupToMap came from. I also noticed groupBy missing. 

Indeed, I was confused.

Endo master is current with those PRs and is not consistent with the current state of https://github.com/tc39/proposal-array-grouping , which is now at stage 3.

This proposal is apparently implemented by
* V8 11.8.28 of latest Chrome Canary, Version 118.0.5944.0 (Official Build) canary (arm64)

I verified that it is not yet implemented by
* V8 11.5.150.22 of latest Chrome, Version 115.0.5790.170 (Official Build) (arm64)
* V8 11.5.150.22 of latest Brave, 1.56.20 Chromium: 115.0.5790.171 (Official Build) (arm64) 
* V8 11.3.244.8-node.10 of latest Node, 20.5.1

I detected SES's inconsistency with the Array when trying to run the [SES Demo Console](https://github.com/endojs/endo/tree/master/packages/ses/demos/console) in that latest Chrome Canary. There are two problems in the SES permit.js list, both of which are fixed by this PR:
   * Omission of `Map.groupBy`.
   * I mistyped `Object.groupBy` as `'boolean'` rather than `fn`, probably by accidentally copy-pasting from `Array.prototype[@@unscopables].groupBy` rather than `Array.groupBy`. Note that the `Array.prototype[@@unscopables].groupBy: 'boolean'` and some similar permits setting is non-standard and generally unneeded. It remains as a just-in-case based on my understanding of previous states of this proposal and possibly some deployments. (If you know that it was never deployed, please let me know so I can remove it. But that would be in another PR anyway. As merely a boolean on @@unscopables, it is rather harmless until then.)

The first problem just resulted in the normal minor annoyance of a warning that an unexpected property was seen, followed by removal of the property. From the spec (and from verbal discussion at TC39 meetings) it is safe to permit this function, which also suppresses the annoying warning.

The second problem resulted in SES failing to initialize, because it was a permitted property whose type is not what it expected. This is correct behavior of SES initialization, bringing the inconsistent permit to our attention loudly. In fact, it was the failure of the SES Demo Console to start that got me to look at the console anyway.

I have manually checked that with this PR, the SES Demo Console starts and works fine with no warnings on the console.

Since these properties do not yet exist on any available Node version, I'm not sure what else to do to test this PR. Reviewers, advice?

@ljharb and @jridgewell, I cannot add you as additional reviewers. But as champions of the stage 3 Array Grouping proposal, I would be interested in your review comments. Thanks.
