### PR TITLE
Spike feat(exo): take 1: opt out individual arguments

### DIFF
--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -6,6 +6,7 @@ import {
   mustMatch,
   M,
   isAwaitArgGuard,
+  // isRawValueGuard,
   assertMethodGuard,
   assertInterfaceGuard,
 } from '@endo/patterns';
@@ -18,10 +19,17 @@ const { apply, ownKeys } = Reflect;
 const { defineProperties } = Object;
 
 /**
+ * A method guard, for inclusion in an interface guard, that does not
+ * enforce any constraints of incoming arguments or return results.
+ */
+// const RawMethodGuard = M.call().rest(M.rawValue()).returns(M.rawValue());
+
+/**
  * A method guard, for inclusion in an interface guard, that enforces only that
  * all arguments are passable and that the result is passable. (In far classes,
- * "any" means any *passable*.) This is the least possible enforcement for a
- * method guard, and is implied by all other method guards.
+ * "any" means any *passable*.) This is the least possible non-raw
+ * enforcement for a method guard, and is implied by all other
+ * non-raw method guards.
  */
 const MinMethodGuard = M.call().rest(M.any()).returns(M.any());
 

--- a/packages/patterns/index.js
+++ b/packages/patterns/index.js
@@ -54,6 +54,8 @@ export {
   mustMatch,
   isAwaitArgGuard,
   assertAwaitArgGuard,
+  isRawValueGuard,
+  assertRawValueGuard,
   assertMethodGuard,
   assertInterfaceGuard,
 } from './src/patterns/patternMatchers.js';

--- a/packages/patterns/src/patterns/internal-types.js
+++ b/packages/patterns/src/patterns/internal-types.js
@@ -10,7 +10,9 @@
 /** @typedef {import('@endo/marshal').RankCover} RankCover */
 
 /** @typedef {import('../types.js').AwaitArgGuard} AwaitArgGuard */
+/** @typedef {import('../types.js').RawValueGuard} RawValueGuard */
 /** @typedef {import('../types.js').ArgGuard} ArgGuard */
+/** @typedef {import('../types.js').SyncValueGuard} SyncValueGuard */
 /** @typedef {import('../types.js').MethodGuard} MethodGuard */
 /** @typedef {import('../types.js').InterfaceGuard} InterfaceGuard */
 /** @typedef {import('../types.js').MethodGuardMaker0} MethodGuardMaker0 */

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -493,14 +493,42 @@ export {};
  * @property {MakeInterfaceGuard} interface
  * Guard the interface of an exo object
  *
- * @property {(...argPatterns: Pattern[]) => MethodGuardMaker0} call
+ * @property {(...argPatterns: SyncValueGuard[]) => MethodGuardMaker0} call
  * Guard a synchronous call
  *
  * @property {(...argGuards: ArgGuard[]) => MethodGuardMaker0} callWhen
  * Guard an async call
  *
  * @property {(argPattern: Pattern) => AwaitArgGuard} await
- * Guard an await
+ * In parameter position, guard a parameter by awaiting it. Can only be used in
+ * parameter position of an `M.callWhen`.
+ * `M.await(M.nat())`, for example, with `await` the corresponding argument,
+ * check that the fulfillment of the `await` satisfies the `M.nat()`
+ * pattern, and only then proceed to call the raw method with that fulfillment.
+ * If the argument already passes the `M.nat()` pattern, then the result of
+ * `await`ing it will still pass, and the `M.callWhen` will still delay the
+ * raw method call to a future turn.
+ * If the argument is a promise that rejects rather than fulfills, or if its
+ * fulfillment does not satisfy the nested pattern, then the call is rejected
+ * without ever calling the raw method.
+ *
+ * Any `AwaitArgGuard` may not appear as a rest pattern or a result pattern,
+ * only a top-level single parameter pattern.
+ *
+ * HAZARD: Until https://github.com/endojs/endo/pull/1712 an `AwaitArgGuard`
+ * is itself a `CopyRecord`. If used nested within a pattern, rather than
+ * at top level, it may be mistaken for a CopyRecord pattern that would match
+ * only a specimen shaped like an `AwaitArgGuard`.
+ *
+ * @property {(() => RawValueGuard)} rawValue
+ * In parameter position, pass this argument through without any checking.
+ * In rest position, pass the rest of the arguments through without any checking.
+ * In return position, return the result without any checking.
+ *
+ * HAZARD: Until https://github.com/endojs/endo/pull/1712 a `RawValueGuard`
+ * is itself a `CopyRecord`. If used nested within a pattern, rather than
+ * at top level, it may be mistaken for a CopyRecord pattern that would match
+ * only a specimen shaped like a `RawValueGuard`.
  */
 
 /**
@@ -514,12 +542,15 @@ export {};
  * @typedef {{
  *   klass: 'Interface',
  *   interfaceName: string,
- *   methodGuards: T
- *   sloppy?: boolean
+ *   methodGuards: T,
+ *   sloppy?: boolean,
+ *   raw?: boolean
  * }} InterfaceGuard
  *
  * TODO https://github.com/endojs/endo/pull/1712 to make it into a genuine
  * guard that is distinct from a copyRecord
+ *
+ * At most one of `sloppy` or `raw` can be true.
  */
 
 /**
@@ -536,8 +567,8 @@ export {};
  * }
  * ```
  * @property {(...optArgGuards: ArgGuard[]) => MethodGuardMaker1} optional
- * @property {(rArgGuard: Pattern) => MethodGuardMaker2} rest
- * @property {(returnGuard?: Pattern) => MethodGuard} returns
+ * @property {(rArgGuard: SyncValueGuard) => MethodGuardMaker2} rest
+ * @property {(returnGuard?: SyncValueGuard) => MethodGuard} returns
  */
 
 /**
@@ -553,8 +584,8 @@ export {};
  *   foo: M.call(AShape, BShape).optional(CShape).rest(EShape).returns(FShape),
  * }
  * ```
- * @property {(rArgGuard: Pattern) => MethodGuardMaker2} rest
- * @property {(returnGuard?: Pattern) => MethodGuard} returns
+ * @property {(rArgGuard: SyncValueGuard) => MethodGuardMaker2} rest
+ * @property {(returnGuard?: SyncValueGuard) => MethodGuard} returns
  */
 
 /**
@@ -570,17 +601,17 @@ export {};
  *   foo: M.call(AShape, BShape).optional(CShape).rest(EShape).returns(FShape),
  * }
  * ```
- * @property {(returnGuard?: Pattern) => MethodGuard} returns
+ * @property {(returnGuard?: SyncValueGuard) => MethodGuard} returns
  */
 
 /**
  * @typedef {{
  *   klass: 'methodGuard',
  *   callKind: 'sync' | 'async',
- *   argGuards: ArgGuard[]
- *   optionalArgGuards?: ArgGuard[]
- *   restArgGuard?: Pattern
- *   returnGuard: Pattern
+ *   argGuards: ArgGuard[],
+ *   optionalArgGuards?: ArgGuard[],
+ *   restArgGuard?: SyncValueGuard,
+ *   returnGuard: SyncValueGuard
  * }} MethodGuard
  *
  * TODO https://github.com/endojs/endo/pull/1712 to make it into a genuine
@@ -607,4 +638,17 @@ export {};
  * non-pattern guard.
  */
 
-/** @typedef {AwaitArgGuard | Pattern} ArgGuard */
+/**
+ * @typedef {{
+ *   klass: 'rawValueGuard'
+ * }} RawValueGuard
+ *
+ * TODO https://github.com/endojs/endo/pull/1712 to make it into a genuine
+ * guard that is distinct from a copyRecord.
+ * Unlike InterfaceGuard or MethodGuard, for RawValueGuard it is a correctness
+ * issue, so that the guard not be mistaken for the copyRecord as key/pattern.
+ */
+
+/** @typedef {RawValueGuard | Pattern} SyncValueGuard */
+
+/** @typedef {AwaitArgGuard | RawValueGuard | Pattern} ArgGuard */


### PR DESCRIPTION
Staged on https://github.com/endojs/endo/pull/1715 , though if feasible I would have preferred to stage it on https://github.com/endojs/endo/pull/1712

This take 1 is a failed experiment, or at least an incomplete one.

Add an `M.rawValue()` guard as kind of a peer to `M.await()`, whole purpose is to allow the argument in that position to pass through as is, with no checking or enforcement, to be bound to the corresponding raw method parameter.

This experiment failed when I got to exo's use of `M.splitArray` to process the matching of required, optional, and rest arguments. A lot of work went into generating good error messages, all of which would need to be redone if the argument list is not a Passable list, and the components are not Pattern lists.

Attn @michaelfig , though not a reviewer because I do not consider this PR a candidate for merging.