### PR TITLE
clean up assert exports

### DIFF
--- a/packages/assert/index.js
+++ b/packages/assert/index.js
@@ -42,32 +42,17 @@ if (missing.length > 0) {
   );
 }
 
-const {
-  bare,
-  details,
-  equal,
-  error,
-  Fail,
-  note,
-  quote,
-  makeAssert,
-  string: assertString,
-  typeof: assertTypeof,
-} = globalAssert;
+const { bare, details, error, Fail, note, quote, makeAssert } = globalAssert;
 
 export {
-  // the global
+  // the global, with assertions
   globalAssert as assert,
-  // properties
+  // related utilities that aren't assertions
   bare,
   details,
-  equal,
   error,
   Fail,
   makeAssert,
   note,
   quote,
-  // properties with syntax collision
-  assertString,
-  assertTypeof,
 };

--- a/packages/assert/index.js
+++ b/packages/assert/index.js
@@ -42,11 +42,17 @@ if (missing.length > 0) {
   );
 }
 
-const { bare, details, error, Fail, note, quote, makeAssert } = globalAssert;
+const { bare, details, error, Fail, note, quote, makeAssert, ...assertions } =
+  globalAssert;
+/** @type {import("ses").AssertionFunctions } */
+// @ts-expect-error missing properties assigned next
+const assert = (value, optDetails, optErrorContructor) =>
+  globalAssert(value, optDetails, optErrorContructor);
+Object.assign(assert, assertions);
 
 export {
-  // the global, with assertions
-  globalAssert as assert,
+  // assertions
+  assert,
   // related utilities that aren't assertions
   bare,
   details,

--- a/packages/assert/index.js
+++ b/packages/assert/index.js
@@ -42,8 +42,18 @@ if (missing.length > 0) {
   );
 }
 
-const { bare, details, error, Fail, note, quote, makeAssert, ...assertions } =
-  globalAssert;
+// The global assert mixed assertions and utility functions. This module splits them apart
+// and also updates the names of the utility functions.
+const {
+  bare,
+  details: redacted,
+  error,
+  Fail: throwRedacted,
+  makeAssert,
+  note,
+  quote,
+  ...assertions
+} = globalAssert;
 /** @type {import("ses").AssertionFunctions } */
 // @ts-expect-error missing properties assigned next
 const assert = (value, optDetails, optErrorContructor) =>
@@ -55,10 +65,10 @@ export {
   assert,
   // related utilities that aren't assertions
   bare,
-  details,
   error,
-  Fail,
   makeAssert,
   note,
   quote,
+  redacted,
+  throwRedacted,
 };

--- a/packages/assert/test/test-index.js
+++ b/packages/assert/test/test-index.js
@@ -1,11 +1,39 @@
 // Sets up a SES environment with 'assert' global
 import { test } from './prepare-test-env-ava.js';
 
-import { Fail } from '../index.js';
+import { assert, Fail } from '../index.js';
 
 test('Fail', t => {
   t.notThrows(() => true || Fail`Should not be thrown`);
   t.throws(() => false || Fail`Should be thrown`, {
     message: 'Should be thrown',
   });
+});
+
+test('assert()', t => {
+  t.notThrows(() => assert(true));
+  t.throws(() => assert(false));
+});
+
+test('assert.equal()', t => {
+  t.notThrows(() => assert.equal(123n, 123n));
+  t.throws(() => assert.equal(123, 123n));
+});
+
+test('assert.string()', t => {
+  t.notThrows(() => assert.string('123'));
+  t.throws(() => assert.string(123));
+});
+
+test('assert.typeof()', t => {
+  t.notThrows(() => assert.typeof(123n, 'bigint'));
+  t.throws(() => assert.typeof(123, 'bigint'));
+});
+
+test('omitted from global', t => {
+  t.false('bare' in assert);
+  t.false('error' in assert);
+  t.false('makeAssert' in assert);
+  t.false('note' in assert);
+  t.false('quote' in assert);
 });

--- a/packages/assert/test/test-index.js
+++ b/packages/assert/test/test-index.js
@@ -1,11 +1,11 @@
 // Sets up a SES environment with 'assert' global
 import { test } from './prepare-test-env-ava.js';
 
-import { assert, Fail } from '../index.js';
+import { assert, throwRedacted } from '../index.js';
 
-test('Fail', t => {
-  t.notThrows(() => true || Fail`Should not be thrown`);
-  t.throws(() => false || Fail`Should be thrown`, {
+test('throwRedacted', t => {
+  t.notThrows(() => true || throwRedacted`Should not be thrown`);
+  t.throws(() => false || throwRedacted`Should be thrown`, {
     message: 'Should be thrown',
   });
 });
@@ -36,4 +36,6 @@ test('omitted from global', t => {
   t.false('makeAssert' in assert);
   t.false('note' in assert);
   t.false('quote' in assert);
+  t.false('redacted' in assert);
+  t.false('throwRedacted' in assert);
 });

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -172,19 +172,13 @@ export type Raise = (reason: Error) => void;
 // eslint-disable-next-line no-use-before-define
 export type MakeAssert = (raise?: Raise, unredacted?: boolean) => Assert;
 
-export interface Assert {
+export interface AssertionFunctions {
   (
     value: any,
     details?: Details,
     errorConstructor?: ErrorConstructor,
   ): asserts value;
   typeof: AssertTypeof;
-  error(
-    details?: Details,
-    errorConstructor?: ErrorConstructor,
-    options?: AssertMakeErrorOptions,
-  ): Error;
-  fail(details?: Details, errorConstructor?: ErrorConstructor): never;
   equal(
     left: any,
     right: any,
@@ -192,6 +186,15 @@ export interface Assert {
     errorConstructor?: ErrorConstructor,
   ): void;
   string(specimen: any, details?: Details): asserts specimen is string;
+}
+
+export interface AssertionUtilities {
+  error(
+    details?: Details,
+    errorConstructor?: ErrorConstructor,
+    options?: AssertMakeErrorOptions,
+  ): Error;
+  fail(details?: Details, errorConstructor?: ErrorConstructor): never;
   note(error: Error, details: Details): void;
   details(
     template: TemplateStringsArray | string[],
@@ -202,6 +205,8 @@ export interface Assert {
   bare(payload: any, spaces?: string | number): ToStringable;
   makeAssert: MakeAssert;
 }
+
+export type Assert = AssertionFunctions & AssertionUtilities;
 
 interface CompartmentEvaluateOptions {
   sloppyGlobalsMode?: boolean;


### PR DESCRIPTION
refs: #1717

## Description

Fewer exports per https://github.com/endojs/endo/pull/1717#discussion_r1295130523
Clearer names per https://github.com/endojs/endo/pull/1717#discussion_r1297908833

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?  -->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

These are breaking changes to master, but not to what's been published.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?  -->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->
