### PR TITLE
feat(ses): Freeze evaluators, Compartment constructor and Symbol

### DIFF
--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -110,10 +110,12 @@ export const setGlobalObjectMutableProperties = (
     globalThis: globalObject,
   };
 
-  perCompartmentGlobals.Compartment = makeCompartmentConstructor(
-    makeCompartmentConstructor,
-    intrinsics,
-    markVirtualizedNativeFunction,
+  perCompartmentGlobals.Compartment = freeze(
+    makeCompartmentConstructor(
+      makeCompartmentConstructor,
+      intrinsics,
+      markVirtualizedNativeFunction,
+    ),
   );
 
   // TODO These should still be tamed according to the whitelist before
@@ -145,7 +147,7 @@ export const setGlobalObjectEvaluators = (
   markVirtualizedNativeFunction,
 ) => {
   {
-    const f = makeEvalFunction(evaluator);
+    const f = freeze(makeEvalFunction(evaluator));
     markVirtualizedNativeFunction(f);
     defineProperty(globalObject, 'eval', {
       value: f,
@@ -155,7 +157,7 @@ export const setGlobalObjectEvaluators = (
     });
   }
   {
-    const f = makeFunctionConstructor(evaluator);
+    const f = freeze(makeFunctionConstructor(evaluator));
     markVirtualizedNativeFunction(f);
     defineProperty(globalObject, 'Function', {
       value: f,

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -25,6 +25,7 @@ import {
   ownKeys,
   stringSplit,
   noEvalEvaluate,
+  getOwnPropertyNames,
 } from './commons.js';
 import { makeHardener } from './make-hardener.js';
 import { makeIntrinsicsCollector } from './intrinsics.js';
@@ -384,6 +385,18 @@ export const repairIntrinsics = (options = {}) => {
     // Finally register and optionally freeze all the intrinsics. This
     // must be the operation that modifies the intrinsics.
     tamedHarden(intrinsics);
+
+    // Harden evaluators
+    tamedHarden(globalThis.Function);
+    tamedHarden(globalThis.eval);
+    // @ts-ignore Compartment does exist on globalThis
+    tamedHarden(globalThis.Compartment);
+
+    // Harden Symbol and properties for initialGlobalPropertyNames in the host realm
+    tamedHarden(globalThis.Symbol);
+    for (const prop of getOwnPropertyNames(initialGlobalPropertyNames)) {
+      tamedHarden(globalThis[prop]);
+    }
 
     return tamedHarden;
   };

--- a/packages/ses/test/test-compartment-instance.js
+++ b/packages/ses/test/test-compartment-instance.js
@@ -2,9 +2,15 @@ import test from 'ava';
 import '../index.js';
 
 test('Compartment instance', t => {
-  t.plan(9);
+  t.plan(12);
 
   const c = new Compartment();
+
+  t.truthy(c.globalThis.eval && Object.isFrozen(c.globalThis.eval));
+  t.truthy(c.globalThis.Function && Object.isFrozen(c.globalThis.Function));
+  t.truthy(
+    c.globalThis.Compartment && Object.isFrozen(c.globalThis.Compartment),
+  );
 
   t.is(typeof c, 'object', 'typeof');
   t.truthy(c instanceof Compartment, 'instanceof');

--- a/packages/ses/test/test-tame-symbol-constructor.js
+++ b/packages/ses/test/test-tame-symbol-constructor.js
@@ -23,8 +23,8 @@ lockdown();
 test('Symbol cleaned by permits', t => {
   t.true('dummy' in Symbol);
   t.false(gopd(Symbol, 'iterator').configurable);
-  t.true(isExtensible(Symbol));
-  t.false(isFrozen(Symbol));
+  t.false(isExtensible(Symbol));
+  t.true(isFrozen(Symbol));
   t.not(Symbol.constructor, Symbol);
 
   const c = new Compartment();


### PR DESCRIPTION
## Description

This is a small PR to enhance security by:
1. Freezing some Compartment-endowed capabilities that aren't currently frozen due to them being non-identical instances of their original version from the start Compartment
	* Being:
		* evaluators: `Compartment`, `eval` and `Function`
2. Hardening some start-Compartment capabilities that aren't currently hardened
	*  Being:
		* evaluators: `Compartment`, `eval` and `Function`
		* `initialGlobalPropertyNames`: `Date`, `Error`, `RegExp`, `Math`, (?`getStackString`)
			* Also `Symbol` although not belonging officially to the `initialGlobalPropertyNames` list

### Security Considerations

Not as far as I can tell

### Scaling Considerations

Not as far as I can tell

### Documentation Considerations

* Some Intrinsics are now being hardened on the globalThis of the start Compartment, meaning this PR isn't backward compatible with programs that attempt to modify their behaviour by redefining properties of them
	* See [section #2](https://github.com/endojs/endo/pull/1731#Description) for the list
* Some Intrinsics are now being hardened on the globalThis of each new Compartment, meaning this PR isn't backward compatible with programs that attempt to modify their behaviour by redefining properties of them
	* See [section #1](https://github.com/endojs/endo/pull/1731#Description) for the list

### Testing Considerations

Added tests

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?  -->

### Upgrade Considerations

Not as far as I can tell
