### PR TITLE
fix(pass-style): passable error validation

### DIFF
--- a/packages/pass-style/src/error.js
+++ b/packages/pass-style/src/error.js
@@ -78,10 +78,9 @@ export const ErrorHelper = harden({
       Fail`Errors must inherit from an error class .prototype ${candidate}`;
 
     const {
-      // Must allow `cause`, `errors`
+      // TODO Must allow `cause`, `errors`
       message: mDesc,
-      // Allow but ignore only extraneous own `stack` property.
-      stack: _optStackDesc,
+      stack: stackDesc,
       ...restDescs
     } = getOwnPropertyDescriptors(candidate);
     ownKeys(restDescs).length < 1 ||
@@ -91,6 +90,12 @@ export const ErrorHelper = harden({
         Fail`Passed Error "message" ${mDesc} must be a string-valued data property.`;
       !mDesc.enumerable ||
         Fail`Passed Error "message" ${mDesc} must not be enumerable`;
+    }
+    if (stackDesc) {
+      typeof stackDesc.value === 'string' ||
+        Fail`Passed Error "stack" ${stackDesc} must be a string-valued data property.`;
+      !stackDesc.enumerable ||
+        Fail`Passed Error "stack" ${stackDesc} must not be enumerable`;
     }
     return true;
   },

--- a/packages/pass-style/test/test-passStyleOf.js
+++ b/packages/pass-style/test/test-passStyleOf.js
@@ -400,6 +400,25 @@ test('remotables - safety from the gibson042 attack', t => {
   });
 });
 
+test('Unexpected stack on errors', t => {
+  let err;
+  try {
+    null.error;
+  } catch (e) {
+    err = e;
+  }
+
+  const carrierStack = {};
+  err.stack = carrierStack;
+  Object.freeze(err);
+
+  t.throws(() => passStyleOf(err), {
+    message:
+      'Passed Error "stack" {"configurable":false,"enumerable":false,"value":{},"writable":false} must be a string-valued data property.',
+  });
+  err.stack.foo = 42;
+});
+
 test('Allow toStringTag overrides', t => {
   const alice = Far('Alice', { [Symbol.toStringTag]: 'DebugName: Allison' });
   t.is(passStyleOf(alice), 'remotable');


### PR DESCRIPTION
@mhofman discovered that `passStyleOf` was not validating that an error's `stack` property was a string-valued non-enumerable data property before concluding that it is a passable error. In fact, it was not even validating that the value of the `stack` property is passable. This flaw thus enabled data that was judged passable to carry non-passable data. 

This PR repairs that deficiency.