### PR TITLE
feat(patterns): Support CopyMap Patterns

### DIFF
--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -16,6 +16,7 @@ export {
 } from './src/encodePassable.js';
 
 export {
+  trivialComparator,
   assertRankSorted,
   compareRank,
   isRankSorted,

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -46,7 +46,7 @@ const { entries, fromEntries, setPrototypeOf, is } = Object;
  */
 const sameValueZero = (x, y) => x === y || is(x, y);
 
-const trivialComparator = (left, right) =>
+export const trivialComparator = (left, right) =>
   // eslint-disable-next-line no-nested-ternary, @endo/restrict-comparison-operands
   left < right ? -1 : left === right ? 0 : 1;
 

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -1,0 +1,5 @@
+User-visible changes in `@endo/patterns`:
+
+# Next
+
+- Adds support for CopyMap patterns (e.g., `matches(specimen, makeCopyMap([]))`).

--- a/packages/patterns/index.js
+++ b/packages/patterns/index.js
@@ -19,6 +19,9 @@ export {
 export { coerceToElements } from './src/keys/copySet.js';
 export { coerceToBagEntries } from './src/keys/copyBag.js';
 export {
+  bagCompare,
+  setCompare,
+  mapCompare,
   compareKeys,
   keyLT,
   keyLTE,
@@ -36,7 +39,6 @@ export {
   elementsDisjointSubtract,
   setIsSuperset,
   setIsDisjoint,
-  setCompare,
   setUnion,
   setDisjointUnion,
   setIntersection,
@@ -45,7 +47,6 @@ export {
 
 export {
   bagIsSuperbag,
-  bagCompare,
   bagUnion,
   bagIntersection,
   bagDisjointSubtract,

--- a/packages/patterns/index.js
+++ b/packages/patterns/index.js
@@ -21,7 +21,6 @@ export { coerceToBagEntries } from './src/keys/copyBag.js';
 export {
   bagCompare,
   setCompare,
-  mapCompare,
   compareKeys,
   keyLT,
   keyLTE,

--- a/packages/patterns/src/keys/checkKey.js
+++ b/packages/patterns/src/keys/checkKey.js
@@ -433,6 +433,23 @@ export const getCopyMapValues = m => {
 harden(getCopyMapValues);
 
 /**
+ * Returns an array of a CopyMap's entries in storage order.
+ *
+ * @template {Key} K
+ * @template {Passable} V
+ * @param {CopyMap<K,V>} m
+ * @returns {Array<[K,V]>}
+ */
+export const getCopyMapEntryArray = m => {
+  assertCopyMap(m);
+  const {
+    payload: { keys, values },
+  } = m;
+  return harden(keys.map((key, i) => [key, values[i]]));
+};
+harden(getCopyMapEntryArray);
+
+/**
  * @template {Key} K
  * @template {Passable} V
  * @param {CopyMap<K,V>} m

--- a/packages/patterns/src/keys/compareKeys.js
+++ b/packages/patterns/src/keys/compareKeys.js
@@ -51,8 +51,11 @@ export const bagCompare = makeCompareCollection(
 );
 harden(bagCompare);
 
+// TODO The desired semantics for CopyMap comparison have not yet been decided.
+// See https://github.com/endojs/endo/pull/1737#pullrequestreview-1596595411
+// The below is a currently-unused extension of CopyBag semantics (i.e., absent
+// entries treated as present with a value that is smaller than everything).
 const ABSENT = Symbol('absent');
-
 /**
  * CopyMap X is smaller than CopyMap Y iff all of these conditions hold:
  * 1. X and Y are both Keys (i.e., neither contains non-comparable data).
@@ -61,7 +64,8 @@ const ABSENT = Symbol('absent');
  *
  * X is equivalent to Y iff conditions 1 and 2 hold but condition 3 does not.
  */
-export const mapCompare = makeCompareCollection(
+// eslint-disable-next-line no-underscore-dangle
+const _mapCompare = makeCompareCollection(
   getCopyMapEntries,
   ABSENT,
   (leftValue, rightValue) => {
@@ -77,7 +81,7 @@ export const mapCompare = makeCompareCollection(
     }
   },
 );
-harden(mapCompare);
+harden(_mapCompare);
 
 /** @type {import('../types').KeyCompare} */
 export const compareKeys = (left, right) => {
@@ -196,7 +200,9 @@ export const compareKeys = (left, right) => {
           return bagCompare(left, right);
         }
         case 'copyMap': {
-          return mapCompare(left, right);
+          // TODO The desired semantics for CopyMap comparison have not yet been decided.
+          // See https://github.com/endojs/endo/pull/1737#pullrequestreview-1596595411
+          throw Fail`Map comparison not yet implemented: ${left} vs ${right}`;
         }
         default: {
           throw Fail`unexpected tag ${q(leftTag)}: ${left}`;

--- a/packages/patterns/src/keys/compareKeys.js
+++ b/packages/patterns/src/keys/compareKeys.js
@@ -55,6 +55,10 @@ harden(bagCompare);
 // See https://github.com/endojs/endo/pull/1737#pullrequestreview-1596595411
 // The below is a currently-unused extension of CopyBag semantics (i.e., absent
 // entries treated as present with a value that is smaller than everything).
+/**
+ * A unique local value that is guaranteed to not exist in any inbound data
+ * structure (which would not be the case if we used `Symbol.for`).
+ */
 const ABSENT = Symbol('absent');
 /**
  * CopyMap X is smaller than CopyMap Y iff all of these conditions hold:

--- a/packages/patterns/src/keys/compareKeys.js
+++ b/packages/patterns/src/keys/compareKeys.js
@@ -11,7 +11,7 @@ import {
 import {
   assertKey,
   getCopyBagEntries,
-  getCopyMapEntries,
+  getCopyMapEntryArray,
   getCopySetKeys,
 } from './checkKey.js';
 import { makeCompareCollection } from './keycollection-operators.js';
@@ -70,7 +70,7 @@ const ABSENT = Symbol('absent');
  */
 // eslint-disable-next-line no-underscore-dangle
 const _mapCompare = makeCompareCollection(
-  getCopyMapEntries,
+  getCopyMapEntryArray,
   ABSENT,
   (leftValue, rightValue) => {
     if (leftValue === ABSENT && rightValue === ABSENT) {

--- a/packages/patterns/src/keys/copySet.js
+++ b/packages/patterns/src/keys/copySet.js
@@ -45,7 +45,7 @@ const checkNoDuplicates = (elements, fullCompare, check) => {
     const k0 = elements[i - 1];
     const k1 = elements[i];
     if (fullCompare(k0, k1) === 0) {
-      return check(false, X`value has duplicates: ${k0}`);
+      return check(false, X`value has duplicate keys: ${k0}`);
     }
   }
   return true;

--- a/packages/patterns/src/keys/keycollection-operators.js
+++ b/packages/patterns/src/keys/keycollection-operators.js
@@ -1,0 +1,226 @@
+// @ts-check
+import {
+  assertRankSorted,
+  compareAntiRank,
+  makeFullOrderComparatorKit,
+  sortByRank,
+} from '@endo/marshal';
+import { makeIterator, makeArrayIterator } from '../utils.js';
+
+/** @typedef {import('@endo/marshal').RankCompare} RankCompare */
+/** @typedef {import('../types').KeyComparison} KeyComparison */
+/** @typedef {import('../types').KeyCompare} KeyCompare */
+/** @typedef {import('../types').FullCompare} FullCompare */
+/** @typedef {import('../types').KeyCollection} KeyCollection */
+
+const { quote: q, Fail } = assert;
+
+/**
+ * Refines a sequence of entries that is already sorted over its keys by the
+ * `rankCompare` preorder, where there may be internal runs tied for the same
+ * rank, into an iterable that resolves those ties using `fullCompare`.
+ *
+ * @template [V=unknown]
+ * @param {Iterable<[Key, V]>} rankSorted
+ * @param {RankCompare} rankCompare
+ * @param {FullCompare} fullCompare
+ * @returns {IterableIterator<[Key, V]>}
+ */
+const generateFullSortedEntries = (rankSorted, rankCompare, fullCompare) => {
+  /** @type {Array<[Key, V]>} */
+  let arrEntries;
+  if (Array.isArray(rankSorted)) {
+    arrEntries = rankSorted;
+  } else {
+    arrEntries = harden([...rankSorted]);
+  }
+  assertRankSorted(arrEntries, rankCompare);
+  const { length } = arrEntries;
+  let i = 0;
+  let sameRankIterator;
+  return makeIterator(() => {
+    if (sameRankIterator) {
+      const result = sameRankIterator.next();
+      if (!result.done) {
+        return result;
+      }
+      sameRankIterator = undefined;
+    }
+    if (i < length) {
+      const entry = arrEntries[i];
+      // Look ahead for same-rank ties.
+      let j = i + 1;
+      while (j < length && rankCompare(entry[0], arrEntries[j][0]) === 0) {
+        j += 1;
+      }
+      if (j === i + 1) {
+        // No ties found.
+        i = j;
+        return harden({ done: false, value: entry });
+      }
+      const ties = arrEntries.slice(i, j);
+      i = j;
+
+      // Sort the ties by `fullCompare`, enforce key uniqueness, and delegate to
+      // a sub-iterator.
+      const sortedTies = sortByRank(ties, fullCompare);
+      for (let k = 1; k < sortedTies.length; k += 1) {
+        const [key0] = sortedTies[k - 1];
+        const [key1] = sortedTies[k];
+        Math.sign(fullCompare(key0, key1)) ||
+          Fail`Duplicate entry key: ${key0}`;
+      }
+      sameRankIterator = makeArrayIterator(sortedTies);
+      return sameRankIterator.next();
+    }
+    return harden({ done: true, value: undefined });
+  });
+};
+harden(generateFullSortedEntries);
+
+/**
+ * Returns an iterator that merges reverse-rank-sorted [key, value] entries of
+ * two KeyCollections into a reverse-full-sorted [key, value1, value2] entries
+ * by the key they have in common, representing the value for an absent entry in
+ * either collection as `absentValue`.
+ *
+ * @template [C=KeyCollection]
+ * @template [V=unknown]
+ * @param {C} c1
+ * @param {C} c2
+ * @param {(collection: C) => Iterable<[Key, V]>} getEntries
+ * @param {any} absentValue
+ * @returns {IterableIterator<[Key, V | absentValue, V | absentValue]>}
+ */
+export const generateCollectionPairEntries = (
+  c1,
+  c2,
+  getEntries,
+  absentValue,
+) => {
+  const e1 = getEntries(c1);
+  const e2 = getEntries(c2);
+
+  // Establish a history-dependent comparison scoped to the active invocation
+  // and use it to map reverse-preordered entries into an iterator with a
+  // narrower total order.
+  const fullCompare = makeFullOrderComparatorKit().antiComparator;
+  const x = generateFullSortedEntries(e1, compareAntiRank, fullCompare);
+  const y = generateFullSortedEntries(e2, compareAntiRank, fullCompare);
+
+  // Maintain a single-result { done, key, value } buffer for each iterator
+  // so they can be merged.
+  let xDone;
+  let xKey;
+  let xValue;
+  let yDone;
+  let yKey;
+  let yValue;
+  const nonEntry = [undefined, undefined];
+  const nextX = () => {
+    !xDone || Fail`Internal: nextX must not be called once done`;
+    const result = xValue;
+    ({ done: xDone, value: [xKey, xValue] = nonEntry } = x.next());
+    return result;
+  };
+  nextX();
+  const nextY = () => {
+    !yDone || Fail`Internal: nextY must not be called once done`;
+    const result = yValue;
+    ({ done: yDone, value: [yKey, yValue] = nonEntry } = y.next());
+    return result;
+  };
+  nextY();
+  return makeIterator(() => {
+    let done = false;
+    /** @type {[Key, V | absentValue, V | absentValue]} */
+    let value;
+    if (xDone && yDone) {
+      done = true;
+      value = [undefined, absentValue, absentValue];
+    } else if (xDone) {
+      value = [yKey, absentValue, nextY()];
+    } else if (yDone) {
+      value = [xKey, nextX(), absentValue];
+    } else {
+      // Compare the keys to determine if we should return a merged result
+      // or a one-sided result.
+      const comp = fullCompare(xKey, yKey);
+      if (comp === 0) {
+        value = [xKey, nextX(), nextY()];
+      } else if (comp < 0) {
+        value = [xKey, nextX(), absentValue];
+      } else if (comp > 0) {
+        value = [yKey, absentValue, nextY()];
+      } else {
+        throw Fail`Unexpected key comparison ${q(comp)} for ${xKey} vs ${yKey}`;
+      }
+    }
+    return harden({ done, value });
+  });
+};
+harden(generateCollectionPairEntries);
+
+/**
+ * Returns a function for comparing two KeyCollections of the same type using
+ * the provided entries factory and same-key entry value comparator (where the
+ * value for an absent entry in one collection is `absentValue`).
+ *
+ * If the corresponding entries for any single key are incomparable or the
+ * comparison result has the opposite sign of the result for a different key,
+ * then the KeyCollections are incomparable. Otherwise, the collections compare
+ * by the result of any non-equal entry comparison, or compare equal if there is
+ * no non-equal entry comparison result.
+ * For example, given CopyBags X and Y and a value comparator that goes by count
+ * (defaulting absent keys to a count of 0), X is smaller than Y (`result < 0`)
+ * iff there are no keys in X that are either absent from Y
+ * (`compareValues(xCount, absentValue) > 0`) or present in Y with a lower count
+ * (`compareValues(xCount, yCount) > 0`) AND there is at least one key in Y that
+ * is either absent from X (`compareValues(absentValue, yCount) < 0`) or present
+ * with a lower count (`compareValues(xCount, yCount) < 0`).
+ *
+ * This can be generalized to virtual collections in the future by replacing
+ * `getEntries => Array` with `generateEntries => IterableIterator`.
+ *
+ * @template [C=KeyCollection]
+ * @template [V=unknown]
+ * @param {(collection: C) => Iterable<[Key, V]>} getEntries
+ * @param {any} absentValue
+ * @param {KeyCompare} compareValues
+ * @returns {(left: C, right: C) => KeyComparison}
+ */
+export const makeCompareCollection = (getEntries, absentValue, compareValues) =>
+  harden((left, right) => {
+    const merged = generateCollectionPairEntries(
+      left,
+      right,
+      getEntries,
+      absentValue,
+    );
+    let leftIsBigger = false;
+    let rightIsBigger = false;
+    for (const [_key, leftValue, rightValue] of merged) {
+      const comp = compareValues(leftValue, rightValue);
+      if (comp === 0) {
+        // eslint-disable-next-line no-continue
+        continue;
+      } else if (comp < 0) {
+        // Based on this key, left < right.
+        rightIsBigger = true;
+      } else if (comp > 0) {
+        // Based on this key, left > right.
+        leftIsBigger = true;
+      } else {
+        Number.isNaN(comp) ||
+          // prettier-ignore
+          Fail`Unexpected value comparison ${q(comp)} for ${leftValue} vs ${rightValue}`;
+        return NaN;
+      }
+      if (leftIsBigger && rightIsBigger) {
+        return NaN;
+      }
+    }
+    // eslint-disable-next-line no-nested-ternary
+    return leftIsBigger ? 1 : rightIsBigger ? -1 : 0;
+  });
+harden(makeCompareCollection);

--- a/packages/patterns/src/keys/keycollection-operators.js
+++ b/packages/patterns/src/keys/keycollection-operators.js
@@ -21,21 +21,14 @@ const { quote: q, Fail } = assert;
  * rank, into an iterable that resolves those ties using `fullCompare`.
  *
  * @template [V=unknown]
- * @param {Iterable<[Key, V]>} rankSorted
+ * @param {Array<[Key, V]>} entries
  * @param {RankCompare} rankCompare
  * @param {FullCompare} fullCompare
  * @returns {IterableIterator<[Key, V]>}
  */
-const generateFullSortedEntries = (rankSorted, rankCompare, fullCompare) => {
-  /** @type {Array<[Key, V]>} */
-  let arrEntries;
-  if (Array.isArray(rankSorted)) {
-    arrEntries = rankSorted;
-  } else {
-    arrEntries = harden([...rankSorted]);
-  }
-  assertRankSorted(arrEntries, rankCompare);
-  const { length } = arrEntries;
+const generateFullSortedEntries = (entries, rankCompare, fullCompare) => {
+  assertRankSorted(entries, rankCompare);
+  const { length } = entries;
   let i = 0;
   let sameRankIterator;
   return makeIterator(() => {
@@ -47,10 +40,10 @@ const generateFullSortedEntries = (rankSorted, rankCompare, fullCompare) => {
       sameRankIterator = undefined;
     }
     if (i < length) {
-      const entry = arrEntries[i];
+      const entry = entries[i];
       // Look ahead for same-rank ties.
       let j = i + 1;
-      while (j < length && rankCompare(entry[0], arrEntries[j][0]) === 0) {
+      while (j < length && rankCompare(entry[0], entries[j][0]) === 0) {
         j += 1;
       }
       if (j === i + 1) {
@@ -58,7 +51,7 @@ const generateFullSortedEntries = (rankSorted, rankCompare, fullCompare) => {
         i = j;
         return harden({ done: false, value: entry });
       }
-      const ties = arrEntries.slice(i, j);
+      const ties = entries.slice(i, j);
       i = j;
 
       // Sort the ties by `fullCompare`, enforce key uniqueness, and delegate to
@@ -88,7 +81,7 @@ harden(generateFullSortedEntries);
  * @template [V=unknown]
  * @param {C} c1
  * @param {C} c2
- * @param {(collection: C) => Iterable<[Key, V]>} getEntries
+ * @param {(collection: C) => Array<[Key, V]>} getEntries
  * @param {any} absentValue
  * @returns {IterableIterator<[Key, V | absentValue, V | absentValue]>}
  */
@@ -184,7 +177,7 @@ harden(generateCollectionPairEntries);
  *
  * @template [C=KeyCollection]
  * @template [V=unknown]
- * @param {(collection: C) => Iterable<[Key, V]>} getEntries
+ * @param {(collection: C) => Array<[Key, V]>} getEntries
  * @param {any} absentValue
  * @param {KeyCompare} compareValues
  * @returns {(left: C, right: C) => KeyComparison}

--- a/packages/patterns/src/keys/merge-bag-operators.js
+++ b/packages/patterns/src/keys/merge-bag-operators.js
@@ -13,8 +13,7 @@ const { quote: q, Fail } = assert;
 /** @typedef {import('@endo/marshal').RankCompare} RankCompare */
 
 // Based on merge-set-operators.js, but altered for the bag representation.
-// TODO share more code with merge-set-operators.js, rather than
-// duplicating with changes.
+// TODO share more code with that file and keycollection-operators.js.
 
 /**
  * Asserts that `bagEntries` is already rank sorted by `rankCompare`, where
@@ -221,40 +220,6 @@ const bagIterIsDisjoint = xyi => {
   return true;
 };
 
-// We should be able to use this for iterCompare as well.
-// The generalization is free.
-/**
- * @template T
- * @param {Iterable<[T,bigint,bigint]>} xyi
- * @returns {KeyComparison}
- */
-const bagIterCompare = xyi => {
-  let loneY = false;
-  let loneX = false;
-  for (const [_m, xc, yc] of xyi) {
-    if (xc < yc) {
-      // something in y is not in x, so x is not a superbag of y
-      loneY = true;
-    }
-    if (xc > yc) {
-      // something in x is not in y, so y is not a superbag of x
-      loneX = true;
-    }
-    if (loneX && loneY) {
-      return NaN;
-    }
-  }
-  if (loneX) {
-    return 1;
-  } else if (loneY) {
-    return -1;
-  } else {
-    (!loneX && !loneY) ||
-      Fail`Internal: Unexpected lone pair ${q([loneX, loneY])}`;
-    return 0;
-  }
-};
-
 /**
  * @template T
  * @param {[T,bigint,bigint][]} xyi
@@ -308,7 +273,6 @@ const mergeify = bagIterOp => (xbagEntries, ybagEntries) =>
 
 const bagEntriesIsSuperbag = mergeify(bagIterIsSuperbag);
 const bagEntriesIsDisjoint = mergeify(bagIterIsDisjoint);
-const bagEntriesCompare = mergeify(bagIterCompare);
 const bagEntriesUnion = mergeify(bagIterUnion);
 const bagEntriesIntersection = mergeify(bagIterIntersection);
 const bagEntriesDisjointSubtract = mergeify(bagIterDisjointSubtract);
@@ -321,7 +285,6 @@ const bagify = bagEntriesOp => (xbag, ybag) =>
 
 export const bagIsSuperbag = rawBagify(bagEntriesIsSuperbag);
 export const bagIsDisjoint = rawBagify(bagEntriesIsDisjoint);
-export const bagCompare = rawBagify(bagEntriesCompare);
 export const bagUnion = bagify(bagEntriesUnion);
 export const bagIntersection = bagify(bagEntriesIntersection);
 export const bagDisjointSubtract = bagify(bagEntriesDisjointSubtract);

--- a/packages/patterns/src/keys/merge-set-operators.js
+++ b/packages/patterns/src/keys/merge-set-operators.js
@@ -12,6 +12,8 @@ const { quote: q, Fail } = assert;
 /** @typedef {import('../types').FullCompare} FullCompare */
 /** @typedef {import('@endo/marshal').RankCompare} RankCompare */
 
+// TODO share more code with keycollection-operators.js.
+
 /**
  * Asserts that `elements` is already rank sorted by `rankCompare`, where there
  * may be contiguous regions of elements tied for the same rank.
@@ -317,7 +319,6 @@ const setify = elementsOp => (xset, yset) =>
 
 export const setIsSuperset = rawSetify(elementsIsSuperset);
 export const setIsDisjoint = rawSetify(elementsIsDisjoint);
-export const setCompare = rawSetify(elementsCompare);
 export const setUnion = setify(elementsUnion);
 export const setDisjointUnion = setify(elementsDisjointUnion);
 export const setIntersection = setify(elementsIntersection);

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -30,8 +30,10 @@ import {
   checkCopyMap,
   copyMapKeySet,
   checkCopyBag,
+  getCopyMapEntries,
   makeCopyMap,
 } from '../keys/checkKey.js';
+import { generateCollectionPairEntries } from '../keys/keycollection-operators.js';
 
 import './internal-types.js';
 
@@ -518,23 +520,28 @@ const makePatternKit = () => {
             )}`,
           );
         }
-        const { payload: pattPayload } = patt;
-        const { payload: specimenPayload } = specimen;
+        // Compare keys as copySets
         const pattKeySet = copyMapKeySet(patt);
         const specimenKeySet = copyMapKeySet(specimen);
-        // Compare keys as copySets
         if (!checkMatches(specimenKeySet, pattKeySet, check)) {
           return false;
         }
-        const pattValues = pattPayload.values;
-        const specimenValues = specimenPayload.values;
-        // compare values as copyArrays
-        // TODO BUG: this assumes that the keys appear in the
-        // same order, so we can compare values in that order.
-        // However, we're only guaranteed that they appear in
-        // the same rankOrder. Thus we must search one of these
-        // in the other's rankOrder.
-        return checkMatches(specimenValues, pattValues, check);
+        // Compare values as copyArrays after applying a shared total order.
+        // This is necessary because the antiRankOrder sorting of each map's
+        // entries is a preorder that admits ties.
+        const pattValues = [];
+        const specimenValues = [];
+        const entryPairs = generateCollectionPairEntries(
+          patt,
+          specimen,
+          getCopyMapEntries,
+          undefined,
+        );
+        for (const [_key, pattValue, specimenValue] of entryPairs) {
+          pattValues.push(pattValue);
+          specimenValues.push(specimenValue);
+        }
+        return checkMatches(harden(specimenValues), harden(pattValues), check);
       }
       default: {
         const matchHelper = maybeMatchHelper(patternKind);

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -30,7 +30,7 @@ import {
   checkCopyMap,
   copyMapKeySet,
   checkCopyBag,
-  getCopyMapEntries,
+  getCopyMapEntryArray,
   makeCopyMap,
 } from '../keys/checkKey.js';
 import { generateCollectionPairEntries } from '../keys/keycollection-operators.js';
@@ -534,7 +534,7 @@ const makePatternKit = () => {
         const entryPairs = generateCollectionPairEntries(
           patt,
           specimen,
-          getCopyMapEntries,
+          getCopyMapEntryArray,
           undefined,
         );
         for (const [_key, pattValue, specimenValue] of entryPairs) {

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -135,6 +135,13 @@ export {};
  * each with a corresponding Passable value.
  */
 
+/**
+ * @typedef {CopySet | CopyBag | CopyMap} KeyCollection
+ *
+ * CopySet, CopyBag, and CopyMap all store Keys in reverse rankOrder,
+ * which supports generalized utilities.
+ */
+
 // TODO: enumerate Matcher tag values?
 /**
  * @typedef {CopyTagged & {

--- a/packages/patterns/src/utils.js
+++ b/packages/patterns/src/utils.js
@@ -167,3 +167,43 @@ export const applyLabelingError = (func, args, label = undefined) => {
   }
 };
 harden(applyLabelingError);
+
+/**
+ * Makes a one-shot iterable iterator from a provided `next` function.
+ *
+ * @template [T=unknown]
+ * @param {() => IteratorResult<T>} next
+ * @returns {IterableIterator<T>}
+ */
+export const makeIterator = next => {
+  const iter = harden({
+    [Symbol.iterator]: () => iter,
+    next,
+  });
+  return iter;
+};
+harden(makeIterator);
+
+/**
+ * A `harden`ing analog of Array.prototype[Symbol.iterator].
+ *
+ * @template [T=unknown]
+ * @param {Array<T>} arr
+ * @returns {IterableIterator<T>}
+ */
+export const makeArrayIterator = arr => {
+  const { length } = arr;
+  let i = 0;
+  return makeIterator(() => {
+    /** @type {T} */
+    let value;
+    if (i < length) {
+      value = arr[i];
+      i += 1;
+      return harden({ done: false, value });
+    }
+    // @ts-expect-error The terminal value doesn't matter
+    return harden({ done: true, value });
+  });
+};
+harden(makeArrayIterator);

--- a/packages/patterns/test/test-copyBag.js
+++ b/packages/patterns/test/test-copyBag.js
@@ -1,21 +1,204 @@
 import { test } from './prepare-test-env-ava.js';
-import { makeCopyBag } from '../src/keys/checkKey.js';
+// eslint-disable-next-line import/order
+import { makeTagged, getTag, passStyleOf } from '@endo/marshal';
+import {
+  isCopyBag,
+  assertCopyBag,
+  makeCopyBag,
+  makeCopyBagFromElements,
+  getCopyBagEntries,
+} from '../src/keys/checkKey.js';
+import { matches } from '../src/patterns/patternMatchers.js';
 
 import '../src/types.js';
 
-test('ordering', t => {
+const assertIsCopyBag = (t, bag) => {
+  t.is(passStyleOf(bag), 'tagged');
+  t.is(getTag(bag), 'copyBag');
+  t.notThrows(() => assertCopyBag(bag));
+  t.true(isCopyBag(bag));
+};
+
+const assertIsInvalidCopyBag = (t, bag, message) => {
+  t.is(passStyleOf(bag), 'tagged');
+  t.is(getTag(bag), 'copyBag');
+  t.throws(() => assertCopyBag(bag), { message });
+  t.is(isCopyBag(bag), false);
+};
+
+test('makeCopyBag', t => {
   const bag = makeCopyBag([
     ['z', 26n],
     ['a', 1n],
-    ['b', 2n],
+    ['b', 10n],
     ['c', 3n],
   ]);
-  t.deepEqual(bag.payload, [
+  assertIsCopyBag(t, bag);
+  t.deepEqual(
+    getCopyBagEntries(bag),
+    [
+      ['z', 26n],
+      ['c', 3n],
+      ['b', 10n],
+      ['a', 1n],
+    ],
+    'entries are reverse-sorted by key',
+  );
+});
+
+test('makeCopyBagFromElements', t => {
+  function* generateKeys() {
+    yield* ['z', 'c', 'b', 'a'];
+    yield* ['z', 'c', 'b', 'a'];
+    yield 'b';
+  }
+  const bag = makeCopyBagFromElements(generateKeys());
+  assertIsCopyBag(t, bag);
+  t.deepEqual(
+    getCopyBagEntries(bag),
+    [
+      ['z', 2n],
+      ['c', 2n],
+      ['b', 3n],
+      ['a', 2n],
+    ],
+    'entries are reverse-sorted by key',
+  );
+});
+
+test('backwards-compatible static shape', t => {
+  const manualBag = harden(
+    Object.defineProperties(
+      {},
+      {
+        [Symbol.for('passStyle')]: { value: 'tagged' },
+        [Symbol.toStringTag]: { value: 'copyBag' },
+        payload: {
+          enumerable: true,
+          value: [
+            ['z', 2n],
+            ['c', 1n],
+            ['b', 3n],
+            ['a', 2n],
+          ],
+        },
+      },
+    ),
+  );
+  assertIsCopyBag(t, manualBag);
+  const bags = {
+    makeTagged: makeTagged('copyBag', [
+      ['z', 2n],
+      ['c', 1n],
+      ['b', 3n],
+      ['a', 2n],
+    ]),
+    makeCopyBag: makeCopyBag([
+      ['z', 2n],
+      ['a', 2n],
+      ['b', 3n],
+      ['c', 1n],
+    ]),
+    makeCopyBagFromElements: makeCopyBagFromElements('zabczabb'.split('')),
+  };
+  for (const [label, bag] of Object.entries(bags)) {
+    t.deepEqual(
+      Object.getOwnPropertyDescriptors(bag),
+      Object.getOwnPropertyDescriptors(manualBag),
+      label,
+    );
+  }
+});
+
+test('key uniqueness', t => {
+  t.throws(
+    () =>
+      makeCopyBag([
+        ['a', 1n],
+        ['a', 1n],
+      ]),
+    { message: /value has duplicate keys/ },
+  );
+  assertIsInvalidCopyBag(
+    t,
+    makeTagged('copyBag', [
+      ['a', 1n],
+      ['a', 1n],
+    ]),
+    /value has duplicate keys/,
+  );
+});
+
+// TODO: incorporate fast-check for property-based testing that construction
+// reverse rank sorts keys and validation rejects any other key order.
+
+test('matching', t => {
+  const bag = makeCopyBag([
     ['z', 26n],
     ['c', 3n],
     ['b', 2n],
     ['a', 1n],
   ]);
+  const missingKey = makeCopyBag([
+    ['z', 26n],
+    ['c', 3n],
+    ['b', 2n],
+  ]);
+  const extraKey = makeCopyBag([
+    ['z', 26n],
+    ['d', 4n],
+    ['c', 3n],
+    ['b', 2n],
+    ['a', 1n],
+  ]);
+  const differentCount = makeCopyBag([
+    ['z', 1n],
+    ['c', 1n],
+    ['b', 1n],
+    ['a', 1n],
+  ]);
+
+  const assertNoMatch = bags => {
+    const [[label1, bag1], [label2, bag2]] = Object.entries(bags);
+    t.is(
+      matches(bag1, bag2),
+      false,
+      `${label1} specimen must not be matched by ${label2} pattern`,
+    );
+    t.is(
+      matches(bag2, bag1),
+      false,
+      `${label2} specimen must not be matched by ${label1} pattern`,
+    );
+  };
+  assertNoMatch({
+    'non-empty': bag,
+    empty: makeCopyBag([]),
+  });
+  assertNoMatch({ bag, missingKey });
+  assertNoMatch({ bag, extraKey });
+  assertNoMatch({ bag, differentCount });
+
+  t.true(matches(bag, bag), 'matches itself');
+  t.true(
+    matches(bag, makeTagged('copyBag', [...getCopyBagEntries(bag)])),
+    'matches a manually-cloned pattern',
+  );
+
+  t.throws(
+    () =>
+      matches(
+        bag,
+        makeTagged('copyBag', [...getCopyBagEntries(bag)].reverse()),
+      ),
+    { message: /pattern expected/ },
+    'key-reversed pattern is rejected',
+  );
+  t.is(
+    matches(makeTagged('copyBag', [...getCopyBagEntries(bag)].reverse()), bag),
+    false,
+    "key-reversed specimen doesn't match",
+  );
 });
 
 test('types', t => {
@@ -28,15 +211,4 @@ test('types', t => {
   count + 1n; // bigint
 
   t.pass();
-});
-
-test('duplicate keys', t => {
-  t.throws(
-    () =>
-      makeCopyBag([
-        ['a', 1n],
-        ['a', 1n],
-      ]),
-    { message: 'value has duplicate keys: "a"' },
-  );
 });

--- a/packages/patterns/test/test-copyMap.js
+++ b/packages/patterns/test/test-copyMap.js
@@ -6,6 +6,7 @@ import {
   assertCopyMap,
   makeCopyMap,
   getCopyMapEntries,
+  getCopyMapEntryArray,
 } from '../src/keys/checkKey.js';
 import { matches } from '../src/patterns/patternMatchers.js';
 
@@ -120,16 +121,17 @@ test('key uniqueness', t => {
 // TODO: incorporate fast-check for property-based testing that construction
 // reverse rank sorts keys and validation rejects any other key order.
 
-test('iterators are passable', t => {
+test('getCopyMapEntries', t => {
   const m = makeCopyMap([
     ['x', 8],
     ['y', 7],
   ]);
-  const i = getCopyMapEntries(m);
-  t.is(passStyleOf(i), 'remotable');
-  const iter = i[Symbol.iterator]();
-  t.is(passStyleOf(iter), 'remotable');
-  const iterResult = iter.next();
+  t.deepEqual([...getCopyMapEntries(m)], getCopyMapEntryArray(m));
+  const entriesIterable = getCopyMapEntries(m);
+  t.is(passStyleOf(entriesIterable), 'remotable');
+  const entriesIterator = entriesIterable[Symbol.iterator]();
+  t.is(passStyleOf(entriesIterator), 'remotable');
+  const iterResult = entriesIterator.next();
   t.is(passStyleOf(iterResult), 'copyRecord');
 });
 

--- a/packages/patterns/test/test-copyMap.js
+++ b/packages/patterns/test/test-copyMap.js
@@ -11,6 +11,8 @@ import { matches } from '../src/patterns/patternMatchers.js';
 
 import '../src/types.js';
 
+const { Fail } = assert;
+
 const assertIsCopyMap = (t, m) => {
   t.is(passStyleOf(m), 'tagged');
   t.is(getTag(m), 'copyMap');
@@ -132,6 +134,18 @@ test('iterators are passable', t => {
 });
 
 test('matching', t => {
+  // TODO CopyMap matching depends upon comparison, the semantics for which have
+  // not yet been decided.
+  // See https://github.com/endojs/endo/pull/1737#pullrequestreview-1596595411
+  try {
+    matches(makeCopyMap([]), makeCopyMap([])) || Fail`Unexpected match failure`;
+    t.fail('CopyMap comparison support (time to test unconditionally?)');
+  } catch (err) {
+    // no CopyMap comparison support
+    t.pass();
+    return;
+  }
+
   const copyMap = makeCopyMap([
     ['z', null],
     ['a', undefined],

--- a/packages/patterns/test/test-copyMap.js
+++ b/packages/patterns/test/test-copyMap.js
@@ -1,21 +1,193 @@
 import { test } from './prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
-import { getTag, passStyleOf } from '@endo/marshal';
-import { getCopyMapEntries, makeCopyMap } from '../src/keys/checkKey.js';
+import { makeTagged, getTag, passStyleOf } from '@endo/marshal';
+import {
+  isCopyMap,
+  assertCopyMap,
+  makeCopyMap,
+  getCopyMapEntries,
+} from '../src/keys/checkKey.js';
+import { matches } from '../src/patterns/patternMatchers.js';
+
 import '../src/types.js';
 
-test('copyMap - iters are passable', t => {
-  // See test 'passability of store iters'
+const assertIsCopyMap = (t, m) => {
+  t.is(passStyleOf(m), 'tagged');
+  t.is(getTag(m), 'copyMap');
+  t.notThrows(() => assertCopyMap(m));
+  t.true(isCopyMap(m));
+};
+
+const assertIsInvalidCopyMap = (t, m, message) => {
+  t.is(passStyleOf(m), 'tagged');
+  t.is(getTag(m), 'copyMap');
+  t.throws(() => assertCopyMap(m), { message });
+  t.is(isCopyMap(m), false);
+};
+
+test('makeCopyMap', t => {
+  // @ts-ignore Mixed-type values
+  const m = makeCopyMap([
+    ['z', undefined],
+    ['a', null],
+    ['b', true],
+    ['c', 4],
+    ['d', 5n],
+    ['e', 'foo'],
+    ['f', 'bar'],
+    ['g', 'baz'],
+  ]);
+  assertIsCopyMap(t, m);
+  t.deepEqual(
+    [...getCopyMapEntries(m)],
+    [
+      ['z', undefined],
+      ['g', 'baz'],
+      ['f', 'bar'],
+      ['e', 'foo'],
+      ['d', 5n],
+      ['c', 4],
+      ['b', true],
+      ['a', null],
+    ],
+    'entries are reverse-sorted by key',
+  );
+});
+
+test('backwards-compatible static shape', t => {
+  // @ts-ignore Mixed-type values
+  const sortedEntries = new Map([
+    ['z', undefined],
+    ['g', 'baz'],
+    ['f', 'bar'],
+    ['e', 'foo'],
+    ['d', 5n],
+    ['c', 4],
+    ['b', true],
+    ['a', null],
+  ]);
+  const manualMap = harden(
+    Object.defineProperties(
+      {},
+      {
+        [Symbol.for('passStyle')]: { value: 'tagged' },
+        [Symbol.toStringTag]: { value: 'copyMap' },
+        payload: {
+          enumerable: true,
+          value: {
+            keys: [...sortedEntries.keys()],
+            values: [...sortedEntries.values()],
+          },
+        },
+      },
+    ),
+  );
+  assertIsCopyMap(t, manualMap);
+  const maps = {
+    makeTagged: makeTagged('copyMap', {
+      keys: [...sortedEntries.keys()],
+      values: [...sortedEntries.values()],
+    }),
+    makeCopyMap: makeCopyMap([...sortedEntries].reverse()),
+  };
+  for (const [label, m] of Object.entries(maps)) {
+    t.deepEqual(
+      Object.getOwnPropertyDescriptors(m),
+      Object.getOwnPropertyDescriptors(manualMap),
+      label,
+    );
+  }
+});
+
+test('key uniqueness', t => {
+  t.throws(
+    () =>
+      makeCopyMap([
+        ['a', 1n],
+        ['a', 1n],
+      ]),
+    { message: /value has duplicate keys/ },
+  );
+  assertIsInvalidCopyMap(
+    t,
+    makeTagged('copyMap', { keys: ['a', 'a'], values: [1n, 1n] }),
+    /value has duplicate keys/,
+  );
+});
+
+// TODO: incorporate fast-check for property-based testing that construction
+// reverse rank sorts keys and validation rejects any other key order.
+
+test('iterators are passable', t => {
   const m = makeCopyMap([
     ['x', 8],
     ['y', 7],
   ]);
-  t.is(passStyleOf(m), 'tagged');
-  t.is(getTag(m), 'copyMap');
   const i = getCopyMapEntries(m);
   t.is(passStyleOf(i), 'remotable');
   const iter = i[Symbol.iterator]();
   t.is(passStyleOf(iter), 'remotable');
   const iterResult = iter.next();
   t.is(passStyleOf(iterResult), 'copyRecord');
+});
+
+test('matching', t => {
+  const copyMap = makeCopyMap([
+    ['z', null],
+    ['a', undefined],
+  ]);
+  const missingKey = makeCopyMap([['z', null]]);
+  const extraKey = makeCopyMap([
+    ['z', null],
+    ['m', 'foo'],
+    ['a', undefined],
+  ]);
+  const differentValue = makeCopyMap([
+    ['z', null],
+    ['a', null],
+  ]);
+
+  const assertNoMatch = maps => {
+    const [[label1, map1], [label2, map2]] = Object.entries(maps);
+    t.is(
+      matches(map1, map2),
+      false,
+      `${label1} specimen must not be matched by ${label2} pattern`,
+    );
+    t.is(
+      matches(map2, map1),
+      false,
+      `${label2} specimen must not be matched by ${label1} pattern`,
+    );
+  };
+  assertNoMatch({
+    'non-empty': copyMap,
+    empty: makeCopyMap([]),
+  });
+  assertNoMatch({ copyMap, missingKey });
+  assertNoMatch({ copyMap, extraKey });
+  assertNoMatch({ copyMap, differentValue });
+
+  const tagEntries = entries =>
+    makeTagged('copyMap', {
+      keys: entries.map(entry => entry[0]),
+      values: entries.map(entry => entry[1]),
+    });
+  t.true(matches(copyMap, copyMap), 'matches itself');
+  t.true(
+    matches(copyMap, tagEntries([...getCopyMapEntries(copyMap)])),
+    'matches a manually-cloned pattern',
+  );
+
+  t.throws(
+    () =>
+      matches(copyMap, tagEntries([...getCopyMapEntries(copyMap)].reverse())),
+    { message: /pattern expected/ },
+    'key-reversed pattern is rejected',
+  );
+  t.is(
+    matches(tagEntries([...getCopyMapEntries(copyMap)].reverse()), copyMap),
+    false,
+    "key-reversed specimen doesn't match",
+  );
 });

--- a/packages/patterns/test/test-copySet.js
+++ b/packages/patterns/test/test-copySet.js
@@ -1,7 +1,12 @@
 import { test } from './prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
-import { makeTagged } from '@endo/marshal';
-import { makeCopySet } from '../src/keys/checkKey.js';
+import { makeTagged, getTag, passStyleOf } from '@endo/marshal';
+import {
+  isCopySet,
+  assertCopySet,
+  makeCopySet,
+  getCopySetKeys,
+} from '../src/keys/checkKey.js';
 import {
   setIsSuperset,
   setIsDisjoint,
@@ -14,7 +19,73 @@ import { M, matches } from '../src/patterns/patternMatchers.js';
 
 import '../src/types.js';
 
-test('operations on copySets', t => {
+const assertIsCopySet = (t, s) => {
+  t.is(passStyleOf(s), 'tagged');
+  t.is(getTag(s), 'copySet');
+  t.notThrows(() => assertCopySet(s));
+  t.true(isCopySet(s));
+};
+
+const assertIsInvalidCopySet = (t, s, message) => {
+  t.is(passStyleOf(s), 'tagged');
+  t.is(getTag(s), 'copySet');
+  t.throws(() => assertCopySet(s), { message });
+  t.is(isCopySet(s), false);
+};
+
+test('makeCopySet', t => {
+  const s = makeCopySet(['z', 'a', 'b', 'c']);
+  assertIsCopySet(t, s);
+  t.deepEqual(
+    getCopySetKeys(s),
+    ['z', 'c', 'b', 'a'],
+    'keys are reverse-sorted',
+  );
+});
+
+test('backwards-compatible static shape', t => {
+  const manualSet = harden(
+    Object.defineProperties(
+      {},
+      {
+        [Symbol.for('passStyle')]: { value: 'tagged' },
+        [Symbol.toStringTag]: { value: 'copySet' },
+        payload: {
+          enumerable: true,
+          value: ['z', 'c', 'b', 'a'],
+        },
+      },
+    ),
+  );
+  assertIsCopySet(t, manualSet);
+  const sets = {
+    makeTagged: makeTagged('copySet', ['z', 'c', 'b', 'a']),
+    makeCopySet: makeCopySet(['z', 'a', 'b', 'c']),
+  };
+  for (const [label, s] of Object.entries(sets)) {
+    t.deepEqual(
+      Object.getOwnPropertyDescriptors(s),
+      Object.getOwnPropertyDescriptors(manualSet),
+      label,
+    );
+  }
+});
+
+test('key uniqueness', t => {
+  t.throws(() => makeCopySet(['a', 'a']), {
+    message: /value has duplicates/,
+  });
+  assertIsInvalidCopySet(
+    t,
+    makeTagged('copySet', ['a', 'a']),
+    /value has duplicates/,
+  );
+});
+
+// TODO: incorporate fast-check for property-based testing that construction
+// reverse rank sorts keys and validation rejects any other key order.
+
+test('operations', t => {
   const x = makeCopySet(['b', 'a', 'c']);
   const y = makeCopySet(['a', 'b']);
   const z = makeCopySet(['c', 'b']);
@@ -46,4 +117,54 @@ test('operations on copySets', t => {
   t.deepEqual(z, makeTagged('copySet', ['c', 'b']));
   t.deepEqual(xMy, makeTagged('copySet', ['c']));
   t.deepEqual(yIz, makeTagged('copySet', ['b']));
+});
+
+test('matching', t => {
+  const copySet = makeCopySet(['z', 'c', 'b', 'a']);
+  const missingKey = makeCopySet(['z', 'c', 'b']);
+  const extraKey = makeCopySet(['z', 'd', 'c', 'b', 'a']);
+
+  const assertNoMatch = sets => {
+    const [[label1, set1], [label2, set2]] = Object.entries(sets);
+    t.is(
+      matches(set1, set2),
+      false,
+      `${label1} specimen must not be matched by ${label2} pattern`,
+    );
+    t.is(
+      matches(set2, set1),
+      false,
+      `${label2} specimen must not be matched by ${label1} pattern`,
+    );
+  };
+  assertNoMatch({
+    'non-empty': copySet,
+    empty: makeCopySet([]),
+  });
+  assertNoMatch({ copySet, missingKey });
+  assertNoMatch({ copySet, extraKey });
+
+  t.true(matches(copySet, copySet), 'matches itself');
+  t.true(
+    matches(copySet, makeTagged('copySet', [...getCopySetKeys(copySet)])),
+    'matches a manually-cloned pattern',
+  );
+
+  t.throws(
+    () =>
+      matches(
+        copySet,
+        makeTagged('copySet', [...getCopySetKeys(copySet)].reverse()),
+      ),
+    { message: /pattern expected/ },
+    'key-reversed pattern is rejected',
+  );
+  t.is(
+    matches(
+      makeTagged('copySet', [...getCopySetKeys(copySet)].reverse()),
+      copySet,
+    ),
+    false,
+    "key-reversed specimen doesn't match",
+  );
 });

--- a/packages/patterns/test/test-copySet.js
+++ b/packages/patterns/test/test-copySet.js
@@ -73,12 +73,12 @@ test('backwards-compatible static shape', t => {
 
 test('key uniqueness', t => {
   t.throws(() => makeCopySet(['a', 'a']), {
-    message: /value has duplicates/,
+    message: /value has duplicate keys/,
   });
   assertIsInvalidCopySet(
     t,
     makeTagged('copySet', ['a', 'a']),
-    /value has duplicates/,
+    /value has duplicate keys/,
   );
 });
 

--- a/packages/patterns/test/test-patterns.js
+++ b/packages/patterns/test/test-patterns.js
@@ -15,7 +15,17 @@ import '../src/types.js';
 
 const { Fail } = assert;
 
-const runTests = (successCase, failCase) => {
+// TODO The desired semantics for CopyMap comparison have not yet been decided.
+// See https://github.com/endojs/endo/pull/1737#pullrequestreview-1596595411
+const copyMapComparison = (() => {
+  try {
+    return matches(makeCopyMap([]), makeCopyMap([]));
+  } catch (err) {
+    return false;
+  }
+})();
+
+const runTests = (t, successCase, failCase) => {
   /**
    * @callback MakeErrorMessage
    * @param {string} repr
@@ -511,7 +521,15 @@ const runTests = (successCase, failCase) => {
         makeMessage('"[copyMap]"', 'copyMap', 'tagged'),
       );
     }
-    successCase(specimen, M.gt(makeCopyMap([])));
+    // TODO Remove `t.throws` and `Fail` when CopyMap comparison is implemented
+    t.throws(
+      () => {
+        copyMapComparison || Fail`No CopyMap comparison support`;
+        successCase(specimen, M.gt(makeCopyMap([])));
+      },
+      { message: 'No CopyMap comparison support' },
+      'CopyMap comparison support (time to unwrap assertions?)',
+    );
     successCase(specimen, M.mapOf(M.record(), M.string()));
 
     failCase(
@@ -697,7 +715,7 @@ test('test simple matches', t => {
       `${noPattern}`,
     );
   };
-  runTests(successCase, failCase);
+  runTests(t, successCase, failCase);
 });
 
 test('masking match failure', t => {
@@ -765,16 +783,24 @@ test('collection contents rankOrder tie insensitivity', t => {
       [r1, 2n],
     ]),
   });
-  assertMutualMatch({
-    map1: makeCopyMap([
-      [r1, 'value'],
-      [r2, 'value'],
-    ]),
-    map2: makeCopyMap([
-      [r2, 'value'],
-      [r1, 'value'],
-    ]),
-  });
+  // TODO Remove `t.throws` and `Fail` when CopyMap comparison is implemented
+  t.throws(
+    () => {
+      copyMapComparison || Fail`No CopyMap comparison support`;
+      assertMutualMatch({
+        map1: makeCopyMap([
+          [r1, 'value'],
+          [r2, 'value'],
+        ]),
+        map2: makeCopyMap([
+          [r2, 'value'],
+          [r1, 'value'],
+        ]),
+      });
+    },
+    { message: 'No CopyMap comparison support' },
+    'CopyMap comparison support (time to unwrap assertions?)',
+  );
 
   const map1 = makeCopyMap([
     [r1, 1],

--- a/packages/patterns/test/test-patterns.js
+++ b/packages/patterns/test/test-patterns.js
@@ -683,18 +683,19 @@ test('test simple matches', t => {
   const successCase = (specimen, yesPattern) => {
     harden(specimen);
     harden(yesPattern);
-    t.notThrows(() => mustMatch(specimen, yesPattern), `${yesPattern}`);
-    t.assert(matches(specimen, yesPattern), `${yesPattern}`);
+    assertMatch(t, specimen, yesPattern, `${yesPattern}`);
   };
   const failCase = (specimen, noPattern, message, isUnmatchable) => {
     harden(specimen);
     harden(noPattern);
-    t.throws(() => mustMatch(specimen, noPattern), { message }, `${noPattern}`);
-    if (isUnmatchable) {
-      t.throws(() => matches(specimen, noPattern), { message }, `${noPattern}`);
-    } else {
-      t.false(matches(specimen, noPattern), `${noPattern}`);
-    }
+    assertNoMatch(
+      t,
+      specimen,
+      noPattern,
+      message,
+      isUnmatchable,
+      `${noPattern}`,
+    );
   };
   runTests(successCase, failCase);
 });
@@ -706,15 +707,24 @@ test('masking match failure', t => {
     'copyMap',
     harden({ keys: [M.string()], values: ['x'] }),
   );
-  t.throws(() => mustMatch(nonSet, M.set()), {
-    message: 'A passable tagged "match:string" is not a key: "[match:string]"',
-  });
-  t.throws(() => mustMatch(nonBag, M.bag()), {
-    message: 'A passable tagged "match:string" is not a key: "[match:string]"',
-  });
-  t.throws(() => mustMatch(nonMap, M.map()), {
-    message: 'A passable tagged "match:string" is not a key: "[match:string]"',
-  });
+  assertNoMatch(
+    t,
+    nonSet,
+    M.set(),
+    'A passable tagged "match:string" is not a key: "[match:string]"',
+  );
+  assertNoMatch(
+    t,
+    nonBag,
+    M.bag(),
+    'A passable tagged "match:string" is not a key: "[match:string]"',
+  );
+  assertNoMatch(
+    t,
+    nonMap,
+    M.map(),
+    'A passable tagged "match:string" is not a key: "[match:string]"',
+  );
 });
 
 test('collection contents rankOrder tie insensitivity', t => {


### PR DESCRIPTION
closes: #1727

## Description

Supports CopyMap patterns by building value arrays from consistently-sorted merged entries after verifying key agreement.

Also implements but disables support for CopyMap comparison in alignment with CopySet and in particular CopyBag patterns—CopyMap X < CopyMap Y iff 
1. X and Y are both Keys, and 
2. ∀ x ∈ X (x ∈ Y ∧ X[x] ≤ Y[x]) [_every key in X is also in Y with an equivalent or bigger value_], and 
3. ∃ y ∈ Y (y ∉ X ∨ X[y] < Y[y]) [_at least one key in Y is either not in X or is in X with a smaller value_]. 

Note that this matches a commented-out `successCase(specimen, M.gt(makeCopyMap([])))` assertion in test-patterns.js but **differs** from some comments in compareKeys.js implying that maps with different keys should not be comparable (aligning with CopyRecord). I think the bag-like treatment of missing keys makes more sense, but perhaps there's a reason why we shouldn't go this route?

It revamps a lot of testing, and also introduces some general `makeIterator` and `makeArrayIterator` utilities for (respectively) one-shot IterableIterators and `harden`-compliant array iterators.

Further details:
* For alignment with CopyBag and CopyMap, I have changed a CopySet error message from "value has duplicates" to "value has duplicate keys". But it's in an isolated commit and could easily be reverted upon request.

### Security Considerations

Just the above question about whether CopyMaps with different key sets should be comparable.

### Scaling Considerations

None anticipated.

### Documentation Considerations

I think inline comments cover this change, which fixes what is currently a gap. But maybe I should update NEWS.md?

### Testing Considerations

I would still like to integrate fast-check for key ordering and for dependencies between `compareRank` and `compareKeys`, but have not done so in this PR.

### Upgrade Considerations

I don't think this has special considerations beyond any other endo update.