### PR TITLE
fix(exo): Extend InterfaceGuard to support symbol-keyed methods

### DIFF
--- a/packages/exo/README.md
+++ b/packages/exo/README.md
@@ -11,12 +11,20 @@ When an exo is defined with an InterfaceGuard, the exo is augmented by default w
 ```js
 // `GET_INTERFACE_GUARD` holds the name of the meta-method
 import { GET_INTERFACE_GUARD } from '@endo/exo';
+import { getCopyMapEntries } from '@endo/patterns';
 
 ...
    const interfaceGuard = await E(exo)[GET_INTERFACE_GUARD]();
    // `methodNames` omits names of automatically added meta-methods like
    // the value of `GET_INTERFACE_GUARD`.
    // Others may also be omitted if `interfaceGuard.partial`
-   const methodNames = Reflect.ownKeys(interfaceGuard.methodGuards);
+   const methodNames = [
+     ...Reflect.ownKeys(interfaceGuard.methodGuards),
+     ...(interfaceGuard.symbolMethodGuards
+       ? [...getCopyMapEntries(interfaceGuard.symbolMethodGuards)].map(
+           entry => entry[0],
+         )
+       : []),
+   ];
 ...
 ```

--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -8,6 +8,7 @@ import {
   isAwaitArgGuard,
   assertMethodGuard,
   assertInterfaceGuard,
+  getCopyMapEntries,
 } from '@endo/patterns';
 
 /** @typedef {import('@endo/patterns').Method} Method */
@@ -15,7 +16,7 @@ import {
 
 const { quote: q, Fail } = assert;
 const { apply, ownKeys } = Reflect;
-const { defineProperties } = Object;
+const { defineProperties, fromEntries } = Object;
 
 /**
  * A method guard, for inclusion in an interface guard, that enforces only that
@@ -263,8 +264,17 @@ export const defendPrototype = (
   let methodGuards;
   if (interfaceGuard) {
     assertInterfaceGuard(interfaceGuard);
-    const { interfaceName, methodGuards: mg, sloppy = false } = interfaceGuard;
-    methodGuards = mg;
+    const {
+      interfaceName,
+      methodGuards: mg,
+      symbolMethodGuards,
+      sloppy = false,
+    } = interfaceGuard;
+    methodGuards = harden({
+      ...mg,
+      ...(symbolMethodGuards &&
+        fromEntries(getCopyMapEntries(symbolMethodGuards))),
+    });
     {
       const methodNames = ownKeys(behaviorMethods);
       const methodGuardNames = ownKeys(methodGuards);

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -521,8 +521,9 @@ export {};
  * @typedef {{
  *   klass: 'Interface',
  *   interfaceName: string,
- *   methodGuards: T
- *   sloppy?: boolean
+ *   methodGuards: { [K in keyof T]: K extends symbol ? never : T[K] },
+ *   symbolMethodGuards?: CopyMap<(keyof T) & symbol, MethodGuard>,
+ *   sloppy?: boolean,
  * }} InterfaceGuard
  *
  * TODO https://github.com/endojs/endo/pull/1712 to make it into a genuine


### PR DESCRIPTION
Fixes #1728

## Description

Extend InterfaceGuard with a `symbolMethodGuards` field whose value is a CopyMap\<symbol, MethodGuard> when the interface has symbol-keyed methods such as Symbol.asyncIterator. The current implementation expresses it as completely optional and does not create it when there are no symbol-keyed methods, but we could also set it to an empty CopyMap in that case.

### Security Considerations

None AFAICT.

### Scaling Considerations

None AFAICT, even if we always add the CopyMap.

### Documentation Considerations

None.

### Testing Considerations

Just unit tests.

### Upgrade Considerations

None special; the new functionality should be fully backwards compatible.
