### PR TITLE
doc: fix wrong quote in import example code

### DIFF
--- a/packages/exo/README.md
+++ b/packages/exo/README.md
@@ -10,7 +10,7 @@ When an exo is defined with an InterfaceGuard, the exo is augmented by default w
 
 ```js
 // `GET_INTERFACE_GUARD` holds the name of the meta-method
-import { GET_INTERFACE_GUARD } from `@endo/exo`;
+import { GET_INTERFACE_GUARD } from '@endo/exo';
 
 ...
    const interfaceGuard = await E(exo)[GET_INTERFACE_GUARD]();

--- a/packages/ses/docs/secure-coding-guide.md
+++ b/packages/ses/docs/secure-coding-guide.md
@@ -177,7 +177,7 @@ in SES.
 
 ```js
 // even more secure
-import harden from `@agoric/harden`;
+import harden from '@agoric/harden';
 function makeLogger() {
   const log = [];
   function write(msg) {
@@ -268,7 +268,7 @@ To avoid this, we should `harden` the array before returning it:
 
 ```js
 // most secure
-import harden from `@agoric/harden`;
+import harden from '@agoric/harden';
 function makeLogger() {
   const log = [];
   function write(msg) {
@@ -530,4 +530,3 @@ applies the enforced-Promise wrapper with a nicer syntax:
 ```
 
 ### More to Come
-


### PR DESCRIPTION
Saw https://github.com/endojs/endo/pull/1740/files?short_path=12f0146#diff-12f0146121857891eaea02008892eb51e98883364bc9ed4dfc544b7676e96c43 and wondered if it was a common mistake. Not too common, but not unique either.

See also https://github.com/Agoric/agoric-sdk/pull/8260