### PR TITLE
fix(patterns,exo): abstract guard getters

### DIFF
--- a/packages/exo/README.md
+++ b/packages/exo/README.md
@@ -11,20 +11,13 @@ When an exo is defined with an InterfaceGuard, the exo is augmented by default w
 ```js
 // `GET_INTERFACE_GUARD` holds the name of the meta-method
 import { GET_INTERFACE_GUARD } from '@endo/exo';
-import { getCopyMapEntries } from '@endo/patterns';
+import { getInterfaceMethodKeys } from '@endo/patterns';
 
 ...
    const interfaceGuard = await E(exo)[GET_INTERFACE_GUARD]();
    // `methodNames` omits names of automatically added meta-methods like
    // the value of `GET_INTERFACE_GUARD`.
-   // Others may also be omitted if `interfaceGuard.partial`
-   const methodNames = [
-     ...Reflect.ownKeys(interfaceGuard.methodGuards),
-     ...(interfaceGuard.symbolMethodGuards
-       ? [...getCopyMapEntries(interfaceGuard.symbolMethodGuards)].map(
-           entry => entry[0],
-         )
-       : []),
-   ];
+   // Others may also be omitted if allowed by interfaceGuard options
+   const methodNames = getInterfaceMethodKeys(interfaceGuard);
 ...
 ```

--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -2,15 +2,13 @@
 import { test } from './prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { getCopyMapEntries, M } from '@endo/patterns';
+import { getInterfaceMethodKeys, M } from '@endo/patterns';
 import {
   defineExoClass,
   defineExoClassKit,
   makeExo,
 } from '../src/exo-makers.js';
 import { GET_INTERFACE_GUARD } from '../src/exo-tools.js';
-
-const { ownKeys } = Reflect;
 
 const UpCounterI = M.interface('UpCounter', {
   incr: M.call()
@@ -52,19 +50,14 @@ test('test defineExoClass', t => {
       'In "incr" method of (UpCounter): arg 0?: string "foo" - Must be a number',
   });
   t.deepEqual(upCounter[GET_INTERFACE_GUARD](), UpCounterI);
-  t.deepEqual(ownKeys(UpCounterI.methodGuards), ['incr']);
-  t.is(UpCounterI.symbolMethodGuards, undefined);
+  t.deepEqual(getInterfaceMethodKeys(UpCounterI), ['incr']);
 
   const symbolic = Symbol.for('symbolic');
   const FooI = M.interface('Foo', {
     m: M.call().returns(),
     [symbolic]: M.call(M.boolean()).returns(),
   });
-  t.deepEqual(ownKeys(FooI.methodGuards), ['m']);
-  t.deepEqual(
-    [...getCopyMapEntries(FooI.symbolMethodGuards)].map(entry => entry[0]),
-    [Symbol.for('symbolic')],
-  );
+  t.deepEqual(getInterfaceMethodKeys(FooI), ['m', Symbol.for('symbolic')]);
   const makeFoo = defineExoClass('Foo', FooI, () => ({}), {
     m() {},
     [symbolic]() {},

--- a/packages/patterns/index.js
+++ b/packages/patterns/index.js
@@ -60,8 +60,12 @@ export {
   mustMatch,
   isAwaitArgGuard,
   assertAwaitArgGuard,
+  getAwaitArgGuardPayload,
   assertMethodGuard,
+  getMethodGuardPayload,
+  getInterfaceMethodKeys,
   assertInterfaceGuard,
+  getInterfaceGuardPayload,
 } from './src/patterns/patternMatchers.js';
 
 // ////////////////// Temporary, until these find their proper home ////////////

--- a/packages/patterns/src/patterns/internal-types.js
+++ b/packages/patterns/src/patterns/internal-types.js
@@ -9,9 +9,12 @@
 /** @typedef {import('@endo/marshal').RankCompare} RankCompare */
 /** @typedef {import('@endo/marshal').RankCover} RankCover */
 
+/** @typedef {import('../types.js').AwaitArgGuardPayload} AwaitArgGuardPayload */
 /** @typedef {import('../types.js').AwaitArgGuard} AwaitArgGuard */
 /** @typedef {import('../types.js').ArgGuard} ArgGuard */
+/** @typedef {import('../types.js').MethodGuardPayload} MethodGuardPayload */
 /** @typedef {import('../types.js').MethodGuard} MethodGuard */
+/** @typedef {import('../types.js').InterfaceGuardPayload} InterfaceGuardPayload */
 /** @typedef {import('../types.js').InterfaceGuard} InterfaceGuard */
 /** @typedef {import('../types.js').MethodGuardMaker0} MethodGuardMaker0 */
 

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -526,15 +526,23 @@ export {};
 /**
  * @template {Record<string | symbol, MethodGuard>} [T=Record<string | symbol, MethodGuard>]
  * @typedef {{
- *   klass: 'Interface',
  *   interfaceName: string,
  *   methodGuards: { [K in keyof T]: K extends symbol ? never : T[K] },
  *   symbolMethodGuards?: CopyMap<(keyof T) & symbol, MethodGuard>,
  *   sloppy?: boolean,
- * }} InterfaceGuard
+ * }} InterfaceGuardPayload
+ */
+
+/**
+ * @template {Record<string | symbol, MethodGuard>} [T=Record<string | symbol, MethodGuard>]
+ * @typedef {{ klass: 'Interface' } & InterfaceGuardPayload<T> } InterfaceGuard
  *
  * TODO https://github.com/endojs/endo/pull/1712 to make it into a genuine
  * guard that is distinct from a copyRecord
+ */
+
+/**
+ * @typedef {Record<string, InterfaceGuard>} InterfaceGuardKit
  */
 
 /**
@@ -590,13 +598,16 @@ export {};
 
 /**
  * @typedef {{
- *   klass: 'methodGuard',
  *   callKind: 'sync' | 'async',
  *   argGuards: ArgGuard[]
  *   optionalArgGuards?: ArgGuard[]
  *   restArgGuard?: Pattern
  *   returnGuard: Pattern
- * }} MethodGuard
+ * }} MethodGuardPayload
+ */
+
+/**
+ * @typedef {{ klass: 'methodGuard' } & MethodGuardPayload} MethodGuard
  *
  * TODO https://github.com/endojs/endo/pull/1712 to make it into a genuine
  * guard that is distinct from a copyRecord.
@@ -608,9 +619,12 @@ export {};
 
 /**
  * @typedef {{
- *   klass: 'awaitArg',
  *   argGuard: Pattern
- * }} AwaitArgGuard
+ * }} AwaitArgGuardPayload
+ */
+
+/**
+ * @typedef {{ klass: 'awaitArg' } & AwaitArgGuardPayload} AwaitArgGuard
  *
  * TODO https://github.com/endojs/endo/pull/1712 to make it into a genuine
  * guard that is distinct from a copyRecord.


### PR DESCRIPTION
To prepare for https://github.com/endojs/endo/pull/1712 , first abstract access to the contents of the guards. Once agoric-sdk is updated to a version of endo with this PR, its use of guards can be switched from directly accessing record properties, which would break on transition to #1712 , to calling the getters defined here, which will work before and after.

Once all such access is changed, we can then do a later endo release incorporating #1712 without breaking agoric-sdk.