### PR TITLE
docs(exo): Update NEWS.md

### DIFF
--- a/packages/exo/NEWS.md
+++ b/packages/exo/NEWS.md
@@ -1,5 +1,15 @@
 User-visible changes in `@endo/exo`:
 
+# Next
+
+- Adds support for symbol-keyed methods in interface guards, e.g.
+  ```
+  const LabeledIterableI = M.interface('LabeledIterable', {
+    getLabel: M.call().returns(M.string()),
+    [Symbol.asyncIterator]: M.call().returns(M.remotable('Iterator')),
+  });
+  ```
+
 # v0.2.2 (2023-04-20)
 
 - Parse `$DEBUG` as comma-separated


### PR DESCRIPTION
Ref #1740

Note also that we've got quite a bit of variance in NEWS.md files; should that be corrected?

```sh
$ awk 'FNR==1 && $0!=""' packages/*/NEWS.md | sort
User-visible changes in base64:
User-visible changes in `@endo/captp`:
User-visible changes in `@endo/exo`:
User-visible changes in `@endo/marshal`:
User-visible changes in `@endo/promise-kit`:
User-visible changes in eventual-send:
User-visible changes in SES:
User-visible changes in SES-Ava:
User-visible changes in Static Module Record, née Transform Module:
User-visible changes in Zip:
User-visible changes to netstring:
User-visible changes to the CommonJS module analyzer:
User-visible changes to the compartment mapper:
User-visible changes to the Endo environment initializer:
```