### PR TITLE
fix(bundle-source): Backward-compatibility for cache pid argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,9 @@ jobs:
           - '16.5' # last version before unconditional promise fast-path
           - '16.6' # first version after unconditional promise fast-path
           - '18' # Active LTS
-          - '20' # Future LTS
+          # UNTIL https://github.com/nodejs/node/issues/49497 is released (probably 20.6.1)
+          # - '20' # Future LTS
+          - '20.5' # last good version before breakage in 20.6.0
         platform:
           - ubuntu-latest
 

--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -258,7 +258,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
  * @param {string} dest
  * @param {{ format?: string, dev?: boolean }} options
  * @param {(id: string) => Promise<any>} loadModule
- * @param {number} pid
+ * @param {number} [pid]
  */
 export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
   const [fs, path, url, crypto, timers] = await Promise.all([
@@ -268,6 +268,10 @@ export const makeNodeBundleCache = async (dest, options, loadModule, pid) => {
     await loadModule('crypto'),
     await loadModule('timers'),
   ]);
+
+  if (pid === undefined) {
+    pid = crypto.randomInt(0xffff_ffff);
+  }
 
   const readPowers = {
     ...makeReadPowers({ fs, url, crypto }),


### PR DESCRIPTION
In the most recent Endo release, I added a required `pid` argument to the bundle source cache maker, which is a breaking change. This change reverses that mistake by making the argument optional and using a large crypto-random number instead. It transpires that this new, default behavior is better than passing the `pid` for a process with more than one cache.
