### PR TITLE
fix(exo)!: extra undeclared args dropped

### DIFF
--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -20,7 +20,7 @@ test('what happens with extra arguments', t => {
       t.is(x, undefined);
     },
   });
-  exo.foo(8);
+  exo.foo('an extra arg');
 });
 
 const UpCounterI = M.interface('UpCounter', {

--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -10,6 +10,19 @@ import {
 } from '../src/exo-makers.js';
 import { GET_INTERFACE_GUARD } from '../src/exo-tools.js';
 
+const NoExtraI = M.interface('NoExtra', {
+  foo: M.call().returns(),
+});
+
+test('what happens with extra arguments', t => {
+  const exo = makeExo('WithExtra', NoExtraI, {
+    foo(x) {
+      t.is(x, undefined);
+    },
+  });
+  exo.foo(8);
+});
+
 const UpCounterI = M.interface('UpCounter', {
   incr: M.call()
     // TODO M.number() should not be needed to get a better error message


### PR DESCRIPTION
Alternative to https://github.com/endojs/endo/pull/1764 experiment.

Of the options listed there, this one

> Preserve the tolerant behavior, but not pass the values of the extra args through to the protected raw behavior method. This would preserve the input validation intent of method guards while still accommodating API growth and thus version slippage.

As suggested by @mhofman and @turadg 