### PR TITLE
chore(errors): Prepare for first publish

### DIFF
--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@endo/errors",
   "version": "0.1.1",
-  "private": true,
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",


### PR DESCRIPTION
I accidentally omitted the `@endo/errors` package from the last publish. This makes the package public.