### PR TITLE
fix(patterns): pass type parameter from interface guard to payload

### DIFF
--- a/packages/patterns/src/patterns/internal-types.js
+++ b/packages/patterns/src/patterns/internal-types.js
@@ -14,7 +14,10 @@
 /** @typedef {import('../types.js').ArgGuard} ArgGuard */
 /** @typedef {import('../types.js').MethodGuardPayload} MethodGuardPayload */
 /** @typedef {import('../types.js').MethodGuard} MethodGuard */
-/** @typedef {import('../types.js').InterfaceGuardPayload} InterfaceGuardPayload */
+/**
+ * @template {Record<PropertyKey, MethodGuard>} [T=Record<PropertyKey, MethodGuard>]
+ * @typedef {import('../types.js').InterfaceGuardPayload<T>} InterfaceGuardPayload
+ */
 /**
  * @template {Record<PropertyKey, MethodGuard>} [T = Record<PropertyKey, MethodGuard>]
  * @typedef {import('../types.js').InterfaceGuard<T>} InterfaceGuard

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -1880,8 +1880,9 @@ harden(assertInterfaceGuard);
  * By using this abstraction rather than accessing the properties directly,
  * we smooth the transition to https://github.com/endojs/endo/pull/1712
  *
- * @param {InterfaceGuard} interfaceGuard
- * @returns {InterfaceGuardPayload}
+ * @template {Record<PropertyKey, MethodGuard>} [T=Record<PropertyKey, MethodGuard>]
+ * @param {InterfaceGuard<T>} interfaceGuard
+ * @returns {InterfaceGuardPayload<T>}
  */
 export const getInterfaceGuardPayload = interfaceGuard => {
   assertInterfaceGuard(interfaceGuard);


### PR DESCRIPTION
The previous endo release added `getInterfaceGuardPayload` so that agoric-sdk could start to use it, rather than accessing the fields of an interface guard directly. This paves the way for https://github.com/endojs/endo/pull/1712 . However, because the type of `getInterfaceGuardPayload` did not propagate the type parameter from the guard argument to the returned payload, thehttps://github.com/Agoric/agoric-sdk/pull/8339  attempt to switch to it causes type errors due to the loss of this type information.