### PR TITLE
chore: Namespace ses integration test

### DIFF
--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ses-integration-test",
+  "name": "@endo/ses-integration-test",
   "version": "3.0.34",
   "private": true,
   "description": "",


### PR DESCRIPTION
The private `ses-integration-test` package is not published to npm and nothing depends upon it, and we can’t conceive any reason anyone would try to fetch it from npm. However to eliminate any possible confusion, this change puts `ses-integration-test` in the `@endo/` namespace, ensuring that the `endo` org in `npm` controls the existence of the package.