### PR TITLE
fix(static-module-record): Bind `this` and `arguments` more correctly

### DIFF
--- a/packages/ses/test/test-import-gauntlet.js
+++ b/packages/ses/test/test-import-gauntlet.js
@@ -411,3 +411,25 @@ test('importHook returning a ModuleInstance with a precompiled functor', async t
 
   await compartment.import('./main.js');
 });
+
+test('this in module scope must be undefined', async t => {
+  t.plan(1);
+
+  const makeImportHook = makeNodeImporter({
+    'https://example.com/index.js': `
+      t.is(this, undefined, 'this must be undefined in module scope');
+    `,
+  });
+  const importHook = makeImportHook('https://example.com');
+
+  const compartment = new Compartment(
+    { t },
+    {},
+    {
+      resolveHook: resolveNode,
+      importHook,
+    },
+  );
+
+  await compartment.import('./index.js');
+});

--- a/packages/static-module-record/NEWS.md
+++ b/packages/static-module-record/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in Static Module Record, née Transform Module:
 
+# Next
+
+- Ensures that `this` is bound to `undefined` in module scope and that the
+  vestigial and undeniable `arguments` object in module scope is empty.
+
 # 0.8.0 (2023-08-07)
 
 - Introduces `sourceMapHook` as an option for the `StaticModuleRecord` constructor,

--- a/packages/static-module-record/src/transform-analyze.js
+++ b/packages/static-module-record/src/transform-analyze.js
@@ -82,23 +82,24 @@ const makeCreateStaticRecord = transformSource =>
       })
       .join('');
 
-    // The functor captures the SES `arguments`, which is definitely
-    // less bad than the functor's arguments (which we are trying to
-    // hide).
-    //
-    // It must also be strict to enforce strictness of modules.
-    // We use destructuring parameters, so 'use strict' is not allowed
-    // but the function actually is strict.
+    // The outer function destructures the module calling convention's internal
+    // variables into hidden lexical variables.
+    // The inner function binds `this` to `undefined` and overshadows the
+    // evaluator's `arguments` with a completely empty `arguments` object.
+    // There is no avoiding the overshadowing of `globalThis.arguments` if it
+    // exists in this emulation of ESM since the evaluator binds `arguments` as
+    // well.
+    // Relies on the evaluator to ensure these functions are strict.
     let functorSource = `\
-(({ \
+({ \
   imports: ${h.HIDDEN_IMPORTS}, \
   liveVar: ${h.HIDDEN_LIVE}, \
   onceVar: ${h.HIDDEN_ONCE}, \
   importMeta: ${h.HIDDEN_META}, \
- }) => { \
+}) => (function () { \
   ${preamble} \
   ${scriptSource}
-})
+})()
 `;
 
     if (sourceUrl) {

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -211,11 +211,10 @@ test('export default arguments (not technically valid but must be handled)', t =
   const { record, namespace } = initialize(t, `export default arguments`);
   assertDefaultExport(t, record);
   t.is(typeof namespace.default, 'object');
-  t.is(namespace.default[0], record.__syncModuleProgram__);
-  t.is(namespace.default.length, 1);
+  t.is(namespace.default.length, 0);
 });
 
-test.failing('export default this', t => {
+test('export default this', t => {
   const { record, namespace } = initialize(t, `export default this`);
   assertDefaultExport(t, record);
   t.is(namespace.default, undefined);


### PR DESCRIPTION
## Description

Currently, the `this` value in module scope is `globalThis`. This is a gap in fidelity, since it should be `undefined`, but is not a leak. This change alters the signature of the module functor generated by `StaticModuleRecord` such that `this` is bound to `undefined` with the existing instantiation code in `ses`. This also ensures that the undeniable `arguments` lexical name reveals nothing about the evaluator or module calling convention to the module.

This will break any program that depends on `this` being bound to `globalThis`. Since all such programs were already invalid and would not work in other environments like Node.js, I am choosing to treat this as a non-breaking-change, even though it may require bug-fixes elsewhere to reconcile versions.

### Security Considerations

This change does not add or remove any capabilities from the scope of modules, just requires that `globalThis` to be spelled out in full.

### Scaling Considerations

This should not affect scale.

### Documentation Considerations

This makes behavior more consistent with expectations documented for ESM generally.

### Testing Considerations

I’ve included a `ses` test that was breaking before the change to `static-module-record`.

### Upgrade Considerations

This change will alter the hash of the Agoric kernel modules and will get picked up when bundles get regenerated. Some contracts may have bugs where `this` is assumed to be `globalThis`.