### PR TITLE
feat(compartment-mapper): add policy-related types

### DIFF
--- a/packages/compartment-mapper/demo/policy/index.mjs
+++ b/packages/compartment-mapper/demo/policy/index.mjs
@@ -8,7 +8,11 @@ lockdown({
 
 import fs from 'fs';
 
-import { importLocation, makeArchive, parseArchive } from '../../index.js';
+import {
+  importLocation,
+  makeArchive,
+  parseArchive,
+} from '@endo/compartment-mapper';
 
 const readPower = async location =>
   fs.promises.readFile(new URL(location).pathname);
@@ -18,6 +22,7 @@ const entrypointPath = new URL('./app.js', import.meta.url).href;
 const ApiSubsetOfBuffer = harden({ from: Buffer.from });
 
 const options = {
+  /** @type {import('@endo/compartment-mapper').Policy} */
   policy: {
     defaultAttenuator:
       '@endo/compartment-mapper-demo-lavamoat-style-attenuator',

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -636,7 +636,7 @@ const translateGraph = (
               name,
               path,
             },
-            packagePolicy,
+            /** @type {import('./types.js').PackagePolicy} */ (packagePolicy),
           )
         ) {
           moduleDescriptors[localPath] = {

--- a/packages/compartment-mapper/src/policy-format.js
+++ b/packages/compartment-mapper/src/policy-format.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-/** @typedef {import('./types.js').AttenuationDefinition} AttenuationDefinition */
-/** @typedef {import('./types.js').UnifiedAttenuationDefinition} UnifiedAttenuationDefinition */
-
 const { entries, keys } = Object;
 const { isArray } = Array;
 const q = JSON.stringify;
@@ -10,14 +7,18 @@ const q = JSON.stringify;
 const ATTENUATOR_KEY = 'attenuate';
 const ATTENUATOR_PARAMS_KEY = 'params';
 const WILDCARD_POLICY_VALUE = 'any';
-const POLICY_FIELDS_LOOKUP = ['builtins', 'globals', 'packages'];
+const POLICY_FIELDS_LOOKUP = /** @type {const} */ ([
+  'builtins',
+  'globals',
+  'packages',
+]);
 
 /**
  *
- * @param {object} packagePolicy
- * @param {string} field
+ * @param {import('./types.js').PackagePolicy} packagePolicy
+ * @param {'builtins'|'globals'|'packages'} field
  * @param {string} itemName
- * @returns {boolean | object}
+ * @returns {boolean | import('./types.js').AttenuationDefinition}
  */
 export const policyLookupHelper = (packagePolicy, field, itemName) => {
   if (!POLICY_FIELDS_LOOKUP.includes(field)) {
@@ -34,38 +35,42 @@ export const policyLookupHelper = (packagePolicy, field, itemName) => {
   if (packagePolicy[field] === WILDCARD_POLICY_VALUE) {
     return true;
   }
-  if (packagePolicy[field][itemName]) {
-    return packagePolicy[field][itemName];
+
+  const value = /** @type {import('./types.js').AttenuationDefinition} */ (
+    packagePolicy[field]
+  );
+  if (itemName in value) {
+    return value[itemName];
   }
   return false;
 };
 
 /**
- * Checks if the policy value is set to wildcard to allow everything
+ * Type guard; checks if the policy value is set to the wildcard value to allow everything
  *
- * @param {*} policyValue
- * @returns {boolean}
+ * @param {unknown} policyValue
+ * @returns {policyValue is import('./types.js').WildcardPolicy}
  */
 export const isAllowingEverything = policyValue =>
   policyValue === WILDCARD_POLICY_VALUE;
 
 /**
- *
- * @param {AttenuationDefinition} potentialDefinition
- * @returns {boolean}
+ * Type guard for `AttenuationDefinition`
+ * @param {unknown} allegedDefinition
+ * @returns {allegedDefinition is import('./types.js').AttenuationDefinition}
  */
-export const isAttenuationDefinition = potentialDefinition => {
+export const isAttenuationDefinition = allegedDefinition => {
   return (
-    (typeof potentialDefinition === 'object' &&
-      typeof potentialDefinition[ATTENUATOR_KEY] === 'string') || // object with attenuator name
-    isArray(potentialDefinition) // params for default attenuator
+    (typeof allegedDefinition === 'object' &&
+      typeof allegedDefinition?.[ATTENUATOR_KEY] === 'string') || // object with attenuator name
+    isArray(allegedDefinition) // params for default attenuator
   );
 };
 
 /**
  *
- * @param {AttenuationDefinition} attenuationDefinition
- * @returns {UnifiedAttenuationDefinition}
+ * @param {import('./types.js').AttenuationDefinition} attenuationDefinition
+ * @returns {import('./types.js').UnifiedAttenuationDefinition}
  */
 export const getAttenuatorFromDefinition = attenuationDefinition => {
   if (!isAttenuationDefinition(attenuationDefinition)) {
@@ -90,32 +95,49 @@ export const getAttenuatorFromDefinition = attenuationDefinition => {
   }
 };
 
+// TODO: should be a type guard
 const isRecordOf = (item, predicate) => {
   if (typeof item !== 'object' || item === null || isArray(item)) {
     return false;
   }
   return entries(item).every(([key, value]) => predicate(value, key));
 };
+
+/**
+ * Type guard for `boolean`
+ * @param {unknown} item
+ * @returns {item is boolean}
+ */
 const isBoolean = item => typeof item === 'boolean';
+
+// TODO: should be a type guard
 const predicateOr =
   (...predicates) =>
   item =>
     predicates.some(p => p(item));
+
+/**
+ * @param {unknown} item
+ * @returns {item is import('./types.js').PolicyItem}
+ */
 const isPolicyItem = item =>
   item === undefined ||
   item === WILDCARD_POLICY_VALUE ||
   isRecordOf(item, isBoolean);
 
 /**
+ * This asserts (i.e., throws) that `allegedPackagePolicy` is a valid `PackagePolicy`.
  *
- * @param {unknown} allegedPackagePolicy
- * @param {string} path
- * @param {string} [url]
- * @returns {void}
+ * Mild-mannered during the day, but fights crime at night as a type guard.
+ *
+ * @param {unknown} allegedPackagePolicy - Alleged `PackagePolicy` to test
+ * @param {string} path - Path in the `Policy` object; used for error messages only
+ * @param {string} [url] - URL of the policy file; used for error messages only
+ * @returns {allegedPackagePolicy is import('./types.js').PackagePolicy}
  */
 export const assertPackagePolicy = (allegedPackagePolicy, path, url) => {
   if (allegedPackagePolicy === undefined) {
-    return;
+    return true;
   }
   const inUrl = url ? ` in ${q(url)}` : '';
 
@@ -169,16 +191,20 @@ export const assertPackagePolicy = (allegedPackagePolicy, path, url) => {
         builtins,
       })}${inUrl}`,
     );
+  return true;
 };
 
 /**
+ * This asserts (i.e., throws) that `allegedPolicy` is a valid `Policy`
  *
- * @param {unknown} allegedPolicy
- * @returns {void}
+ * It also moonlights as a type guard.
+ *
+ * @param {unknown} allegedPolicy - Alleged `Policy` to test
+ * @returns {allegedPolicy is import('./types.js').Policy}
  */
 export const assertPolicy = allegedPolicy => {
   if (allegedPolicy === undefined) {
-    return;
+    return true;
   }
   const policy = Object(allegedPolicy);
   assert(
@@ -206,4 +232,5 @@ export const assertPolicy = allegedPolicy => {
   for (const [key, value] of entries(resources)) {
     assertPackagePolicy(value, `policy.resources["${key}"]`);
   }
+  return true;
 };

--- a/packages/compartment-mapper/src/policy.js
+++ b/packages/compartment-mapper/src/policy.js
@@ -1,15 +1,5 @@
 // @ts-check
 
-/** @typedef {import('./types.js').PackageNamingKit} PackageNamingKit */
-/** @typedef {import('./types.js').AttenuationDefinition} AttenuationDefinition */
-/** @typedef {import('./types.js').FullAttenuationDefinition} FullAttenuationDefinition */
-/** @typedef {import('./types.js').ImplicitAttenuationDefinition} ImplicitAttenuationDefinition */
-/** @typedef {import('./types.js').Attenuator} Attenuator */
-/** @typedef {import('./types.js').DeferredAttenuatorsProvider} DeferredAttenuatorsProvider */
-/** @typedef {import('./types.js').CompartmentDescriptor} CompartmentDescriptor */
-// get StaticModuleRecord from the ses package's types
-/** @typedef {import('ses').ThirdPartyStaticModuleInterface} ThirdPartyStaticModuleInterface */
-
 import {
   policyLookupHelper,
   isAttenuationDefinition,
@@ -46,8 +36,15 @@ const selectiveCopy = (from, to, list) => {
   return to;
 };
 
+/**
+ * Parses an attenuation definition for attenuator names
+ *
+ * Note: this function is recursive
+ * @param {string[]} attenuators - List of attenuator names; may be mutated
+ * @param {import('./types.js').AttenuationDefinition|import('./types.js').Policy} policyFragment
+ */
 const collectAttenuators = (attenuators, policyFragment) => {
-  if (policyFragment.attenuate) {
+  if ('attenuate' in policyFragment) {
     attenuators.push(policyFragment.attenuate);
   }
   for (const value of values(policyFragment)) {
@@ -58,11 +55,12 @@ const collectAttenuators = (attenuators, policyFragment) => {
 };
 
 const attenuatorsCache = new WeakMap();
+
 /**
  * Goes through policy and lists all attenuator specifiers used.
  * Memoization keyed on policy object reference
  *
- * @param {object} policy
+ * @param {import('./types.js').Policy} [policy]
  * @returns {Array<string>} attenuators
  */
 export const detectAttenuators = policy => {
@@ -83,7 +81,7 @@ export const detectAttenuators = policy => {
 /**
  * Generates a string identifying a package for policy lookup purposes.
  *
- * @param {PackageNamingKit} namingKit
+ * @param {import('./types.js').PackageNamingKit} namingKit
  * @returns {string}
  */
 const generateCanonicalName = ({ isEntry = false, name, path }) => {
@@ -97,11 +95,11 @@ const generateCanonicalName = ({ isEntry = false, name, path }) => {
 };
 
 /**
- * Verifies if a module identified by namingKit can be a dependency of a package per packagePolicy.
- * packagePolicy is required, when policy is not set, skipping needs to be handled by the caller.
+ * Verifies if a module identified by `namingKit` can be a dependency of a package per `packagePolicy`.
+ * `packagePolicy` is required, when policy is not set, skipping needs to be handled by the caller.
  *
- * @param {PackageNamingKit} namingKit
- * @param {*} packagePolicy
+ * @param {import('./types.js').PackageNamingKit} namingKit
+ * @param {import('./types.js').PackagePolicy} packagePolicy
  * @returns {boolean}
  */
 export const dependencyAllowedByPolicy = (namingKit, packagePolicy) => {
@@ -113,8 +111,14 @@ export const dependencyAllowedByPolicy = (namingKit, packagePolicy) => {
   return !!policyLookupHelper(packagePolicy, 'packages', canonicalName);
 };
 
-const validateDependencies = (policy, canonicalName) => {
-  const packages = policy.resources[canonicalName].packages;
+/**
+ * Asserts dependencies in a policy are defined
+ * @param {import('./types.js').Policy} policy
+ * @param {string} canonicalName
+ * @returns {void}
+ */
+const assertDependencies = (policy, canonicalName) => {
+  const packages = policy.resources[canonicalName]?.packages;
   if (!packages || isAllowingEverything(packages)) {
     return;
   }
@@ -139,9 +143,9 @@ const validateDependencies = (policy, canonicalName) => {
 /**
  * Returns the policy applicable to the canonicalName of the package
  *
- * @param {PackageNamingKit} namingKit - a key in the policy resources spec is derived frm these
- * @param {object|undefined} policy - user supplied policy
- * @returns {object|undefined} packagePolicy if policy was specified
+ * @param {import('./types.js').PackageNamingKit} namingKit - a key in the policy resources spec is derived frm these
+ * @param {import('./types.js').Policy} [policy] - user supplied policy
+ * @returns {import('./types.js').PackagePolicy|undefined} packagePolicy if policy was specified
  */
 export const getPolicyForPackage = (namingKit, policy) => {
   if (!policy) {
@@ -161,7 +165,7 @@ export const getPolicyForPackage = (namingKit, policy) => {
     };
   }
   if (policy.resources && policy.resources[canonicalName]) {
-    validateDependencies(policy, canonicalName);
+    assertDependencies(policy, canonicalName);
     return policy.resources[canonicalName];
   } else {
     console.warn(
@@ -171,21 +175,27 @@ export const getPolicyForPackage = (namingKit, policy) => {
   }
 };
 
+/**
+ * Get list of globals from package policy
+ * @param {import('./types.js').PackagePolicy} [packagePolicy]
+ * @returns {Array<string>}
+ */
 const getGlobalsList = packagePolicy => {
-  if (!packagePolicy.globals) {
+  if (!packagePolicy?.globals) {
     return [];
   }
-  return entries(packagePolicy.globals)
+  return entries(packagePolicy?.globals)
     .filter(([_key, value]) => value)
     .map(([key, _vvalue]) => key);
 };
 
 const GLOBAL_ATTENUATOR = 'attenuateGlobals';
 const MODULE_ATTENUATOR = 'attenuateModule';
+
 /**
- *
- * @param {AttenuationDefinition} attenuationDefinition
- * @param {DeferredAttenuatorsProvider} attenuatorsProvider
+ * Imports attenuator per its definition and provider
+ * @param {import('./types.js').AttenuationDefinition} attenuationDefinition
+ * @param {import('./types.js').DeferredAttenuatorsProvider} attenuatorsProvider
  * @param {string} attenuatorExportName
  * @returns {Promise<Function>}
  */
@@ -212,10 +222,10 @@ const importAttenuatorForDefinition = async (
 };
 
 /**
- *
+ * Makes an async provider for attenuators
  * @param {Record<string, Compartment>} compartments
- * @param {Record<string, CompartmentDescriptor>} compartmentDescriptors
- * @returns {DeferredAttenuatorsProvider}
+ * @param {Record<string, import('./types.js').CompartmentDescriptor>} compartmentDescriptors
+ * @returns {import('./types.js').DeferredAttenuatorsProvider}
  */
 export const makeDeferredAttenuatorsProvider = (
   compartments,
@@ -239,7 +249,7 @@ export const makeDeferredAttenuatorsProvider = (
     /**
      *
      * @param {string} attenuatorSpecifier
-     * @returns {Promise<Attenuator>}
+     * @returns {Promise<import('./types.js').Attenuator>}
      */
     importAttenuator = async attenuatorSpecifier => {
       if (!attenuatorSpecifier) {
@@ -261,10 +271,11 @@ export const makeDeferredAttenuatorsProvider = (
 };
 
 /**
+ * Attenuates the `globalThis` object
  *
  * @param {object} options
- * @param {DeferredAttenuatorsProvider} options.attenuators
- * @param {AttenuationDefinition} options.attenuationDefinition
+ * @param {import('./types.js').DeferredAttenuatorsProvider} options.attenuators
+ * @param {import('./types.js').AttenuationDefinition} options.attenuationDefinition
  * @param {object} options.globalThis
  * @param {object} options.globals
  */
@@ -303,8 +314,8 @@ async function attenuateGlobalThis({
  *
  * @param {object} globalThis
  * @param {object} globals
- * @param {object} packagePolicy
- * @param {DeferredAttenuatorsProvider} attenuators
+ * @param {import('./types.js').PackagePolicy} packagePolicy
+ * @param {import('./types.js').DeferredAttenuatorsProvider} attenuators
  * @param {Array<Promise>} pendingJobs
  * @param {string} name
  * @returns {void}
@@ -391,12 +402,12 @@ export const enforceModulePolicy = (specifier, compartmentDescriptor, info) => {
 };
 
 /**
- *
+ * Attenuates a module
  * @param {object} options
- * @param {DeferredAttenuatorsProvider} options.attenuators
- * @param {AttenuationDefinition} options.attenuationDefinition
- * @param {ThirdPartyStaticModuleInterface} options.originalModuleRecord
- * @returns {Promise<ThirdPartyStaticModuleInterface>}
+ * @param {import('./types.js').DeferredAttenuatorsProvider} options.attenuators
+ * @param {import('./types.js').AttenuationDefinition} options.attenuationDefinition
+ * @param {import('ses').ThirdPartyStaticModuleInterface} options.originalModuleRecord
+ * @returns {Promise<import('ses').ThirdPartyStaticModuleInterface>}
  */
 async function attenuateModule({
   attenuators,
@@ -426,14 +437,15 @@ async function attenuateModule({
     },
   });
 }
+
 /**
  * Throws if importing of the specifier is not allowed by the policy
  *
  * @param {string} specifier - exit module name
- * @param {ThirdPartyStaticModuleInterface} originalModuleRecord - reference to the exit module
- * @param {object} policy - local compartment policy
- * @param {DeferredAttenuatorsProvider} attenuators - a key-value where attenuations can be found
- * @returns {Promise<ThirdPartyStaticModuleInterface>} - the attenuated module
+ * @param {import('ses').ThirdPartyStaticModuleInterface} originalModuleRecord - reference to the exit module
+ * @param {import('./types.js').PackagePolicy} policy - local compartment policy
+ * @param {import('./types.js').DeferredAttenuatorsProvider} attenuators - a key-value where attenuations can be found
+ * @returns {Promise<import('ses').ThirdPartyStaticModuleInterface>} - the attenuated module
  */
 export const attenuateModuleHook = async (
   specifier,
@@ -461,6 +473,7 @@ export const attenuateModuleHook = async (
 };
 
 const padDiagnosis = text => ` (${text})`;
+
 /**
  * Provide dignostic information for a missing compartment error
  *

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -399,16 +399,19 @@ export {};
  */
 
 /**
+ * An object representing a full attenuation definition.
  * @typedef {object} FullAttenuationDefinition
- * @property {string} name
- * @property {Array<any>} params
+ * @property {string} attenuate - The type of attenuation.
+ * @property {ImplicitAttenuationDefinition} params - The parameters for the attenuation.
  */
 
 /**
- * @typedef {Array<any>} ImplicitAttenuationDefinition
+ * An array of any type representing an implicit attenuation definition.
+ * @typedef {[any, ...any[]]} ImplicitAttenuationDefinition
  */
 
 /**
+ * A type representing an attenuation definition, which can be either a full or implicit definition.
  * @typedef {FullAttenuationDefinition | ImplicitAttenuationDefinition} AttenuationDefinition
  */
 
@@ -420,12 +423,79 @@ export {};
  */
 
 /**
- * @typedef {object} Attenuator
- * @property {Function} [attenuateGlobals]
- * @property {Function} [attenuateModule]
+ * @template {[any, ...any[]]} [GlobalParams=[any, ...any[]]]
+ * @template {[any, ...any[]]} [ModuleParams=[any, ...any[]]]
+ * @typedef Attenuator
+ * @property {GlobalAttenuatorFn<GlobalParams>} [attenuateGlobals]
+ * @property {ModuleAttenuatorFn<ModuleParams>} [attenuateModule]
+ */
+
+/**
+ * @template {[any, ...any[]]} [Params=[any, ...any[]]]
+ * @callback GlobalAttenuatorFn
+ * @param {Params} params
+ * @param {Record<PropertyKey, any>} originalObject
+ * @param {Record<PropertyKey, any>} globalThis
+ * @returns {void}
+ * @todo Unsure if we can do much typing of `originalObject` and `globalThis` here.
+ */
+
+/**
+ * @template {[any, ...any[]]} [Params=[any, ...any[]]]
+ * @template [T=unknown]
+ * @template [U=T]
+ * @callback ModuleAttenuatorFn
+ * @param {Params} params
+ * @param {T} ns
+ * @returns {U}
  */
 
 /**
  * @typedef {object} DeferredAttenuatorsProvider
  * @property {(attenuatorSpecifier: string|null) => Promise<Attenuator>} import
+ */
+
+/**
+ * A type representing a wildcard policy, which can be 'any'.
+ * @typedef {'any'} WildcardPolicy
+ */
+
+/**
+ * A type representing a property policy, which is a record of string keys and boolean values.
+ * @typedef {Record<string, boolean>} PropertyPolicy
+ */
+
+/**
+ * A type representing a policy item, which can be a {@link WildcardPolicy wildcard policy}, a property policy, `undefined`, or defined by an attenuator
+ * @template [T=void]
+ * @typedef {WildcardPolicy|PropertyPolicy|T} PolicyItem
+ */
+
+/**
+ * An object representing a nested attenuation definition.
+ * @typedef {Record<string, AttenuationDefinition | boolean>} NestedAttenuationDefinition
+ */
+
+/**
+ * An object representing a base package policy.
+ * @template [PackagePolicyItem=void]
+ * @template [GlobalsPolicyItem=void]
+ * @template [BuiltinsPolicyItem=void]
+ * @typedef {object} PackagePolicy
+ * @property {string} [defaultAttenuator] - The default attenuator.
+ * @property {PolicyItem<PackagePolicyItem>} [packages] - The policy item for packages.
+ * @property {PolicyItem<GlobalsPolicyItem>|AttenuationDefinition} [globals] - The policy item or full attenuation definition for globals.
+ * @property {PolicyItem<BuiltinsPolicyItem>|NestedAttenuationDefinition} [builtins] - The policy item or nested attenuation definition for builtins.
+ * @property {boolean} [noGlobalFreeze] - Whether to disable global freeze.
+ */
+
+/**
+ * An object representing a base policy.
+ * @template [PackagePolicyItem=void]
+ * @template [GlobalsPolicyItem=void]
+ * @template [BuiltinsPolicyItem=void]
+ * @typedef {object} Policy
+ * @property {Record<string, PackagePolicy<PackagePolicyItem, GlobalsPolicyItem, BuiltinsPolicyItem>>} resources - The package policies for the resources.
+ * @property {string} [defaultAttenuator] - The default attenuator.
+ * @property {PackagePolicy<PackagePolicyItem, GlobalsPolicyItem, BuiltinsPolicyItem>} [entry] - The package policy for the entry.
  */

--- a/packages/compartment-mapper/types.d.ts
+++ b/packages/compartment-mapper/types.d.ts
@@ -14,3 +14,17 @@ export {
 export { search } from './src/search.js';
 export { compartmentMapForNodeModules } from './src/node-modules.js';
 export { makeBundle, writeBundle } from './src/bundle.js';
+export type {
+  Policy,
+  PackagePolicy,
+  PolicyItem,
+  AttenuationDefinition,
+  FullAttenuationDefinition,
+  ImplicitAttenuationDefinition,
+  NestedAttenuationDefinition,
+  PropertyPolicy,
+  WildcardPolicy,
+  Attenuator,
+  GlobalAttenuatorFn,
+  ModuleAttenuatorFn,
+} from './src/types.js';


### PR DESCRIPTION
closes: #1776

## Description

- Add some types for the policy and export them from `compartment-mapper`.
- Remove some "alias"-style typedefs
- Change `assertPackagePolicy` to be a type guard.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

This could cause compiler errors in consumers already using policies (if those consumers exist), since the types have been narrowed.  

### Testing Considerations

This adds tests using `tsd`, which requires adding that dev dependency to `compartment-mapper` and modifying its `test` script.

### Upgrade Considerations

This should not impact live production systems; it may impact builds.  Because it may impact builds, this could be construed as a breaking change, depending on Endo's policy or lack thereof.  

* * *

This is currently a **DRAFT** and should be considered in-progress.
