### PR TITLE
fix(eslint-plugin): fix overzealous jsdoc typechecks

### DIFF
--- a/packages/eslint-plugin/lib/configs/style.js
+++ b/packages/eslint-plugin/lib/configs/style.js
@@ -1,5 +1,9 @@
 module.exports = {
-  extends: ['airbnb-base', 'plugin:jsdoc/recommended', 'prettier'],
+  extends: [
+    'airbnb-base',
+    'plugin:jsdoc/recommended-typescript-flavor',
+    'prettier',
+  ],
   rules: {
     quotes: [
       'error',
@@ -38,7 +42,6 @@ module.exports = {
     'no-inner-declarations': 'off',
 
     'jsdoc/no-multi-asterisks': ['warn', { allowWhitespace: true }],
-    'jsdoc/no-undefined-types': 'off',
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/require-property-description': 'off',
     'jsdoc/require-param-description': 'off',
@@ -47,6 +50,10 @@ module.exports = {
     'jsdoc/require-yields': 'off',
     'jsdoc/tag-lines': 'off',
     'jsdoc/valid-types': 'off',
+    'jsdoc/check-types': [
+      'warn',
+      { exemptTagContexts: [{ tag: 'typedef', types: ['Object'] }] },
+    ],
 
     'no-unused-vars': [
       'error',


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #1755

## Description

**TL;DR:** ; ESLint will no longer coerce `Object` to `object` in `@typedef` tags.

This does two things:

- Uses the `recommended-typescript-flavor` config from `eslint-plugin-jsdoc`, which is recommended for the types-in-JavaScript set.  This only disables `jsdoc/no-undefined-types`, which can be safely removed from the rule overrides.
- Configures rule `jsdoc/check-types` to allow `Object` in `@typedef` tags _only_; see #1755 for explanation of why coercing `Object` to `object` has potentially unintended consequences but otherwise can be used interchangeably in the vast majority of circumstances.

You may read [the rule docs](https://github.com/gajus/eslint-plugin-jsdoc/blob/3d052ba/docs/rules/check-types.md#readme) about why it is the way it is.  I find the rationale to be entirely reasonable _excepting_ in the case of `Object` vs `object`--which is why I did not disable the rule entirely.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

none

### Upgrade Considerations

none