### PR TITLE
WIP test(pass-style): demonstrate safe promise loophole for @FUDCo

### DIFF
--- a/packages/marshal/test/test-use-safe-promise-loophole.js
+++ b/packages/marshal/test/test-use-safe-promise-loophole.js
@@ -1,0 +1,54 @@
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { passStyleOf } from '@endo/pass-style';
+import { makeMarshal } from '../src/marshal.js';
+
+const { getOwnPropertyDescriptor, defineProperty } = Object;
+
+const { toStringTag } = Symbol;
+
+test('use safe promise loophole', t => {
+  const convertSlotToVal = (slot, _iface) => {
+    const p = Promise.resolve(`${slot} placeholder`);
+    defineProperty(p, toStringTag, {
+      get: reveal => (reveal ? slot : NaN),
+      enumerable: false,
+    });
+    harden(p);
+    t.is(passStyleOf(p), 'promise');
+    return p;
+  };
+  const convertValToSlot = p => {
+    t.is(passStyleOf(p), 'promise');
+    const desc = getOwnPropertyDescriptor(p, toStringTag);
+    assert(desc !== undefined);
+    const getter = desc.get;
+    assert(typeof getter === 'function');
+    // @ts-expect-error We violate the normal expectation that getters
+    // have zero parameters.
+    const slot = getter(true);
+    t.is(typeof slot, 'string');
+    return slot;
+  };
+  const { toCapData, fromCapData } = makeMarshal(
+    convertValToSlot,
+    convertSlotToVal,
+    {
+      serializeBodyFormat: 'smallcaps',
+    },
+  );
+
+  const markedPromise = convertSlotToVal('I am kref 3');
+
+  const passable1 = harden([{ markedPromise }]);
+  const capData1 = toCapData(passable1);
+  t.deepEqual(capData1, {
+    body: '#[{"markedPromise":"&0"}]',
+    slots: ['I am kref 3'],
+  });
+  const passable2 = fromCapData(capData1);
+  t.deepEqual(passable1, passable2);
+  const capData2 = toCapData(passable2);
+  t.deepEqual(capData1, capData2);
+});

--- a/packages/pass-style/src/safe-promise.js
+++ b/packages/pass-style/src/safe-promise.js
@@ -22,6 +22,12 @@ const checkPromiseOwnKeys = (pr, check) => {
     return true;
   }
 
+  // Loophole: Even without async_hooks, this will allow the promise instance to
+  // override `Promise.prototype[Symbol.toStringTag]`.
+  // See test-safe-promise-loophole.js
+  // TODO Decide whether to use this loophole for now to solve Chip's problem.
+  // TODO Decide whether to close this loophole, which would preclude
+  // using it to solve Chip's problem.
   const unknownKeys = keys.filter(
     key => typeof key !== 'symbol' || !hasOwnPropertyOf(Promise.prototype, key),
   );
@@ -38,7 +44,7 @@ const checkPromiseOwnKeys = (pr, check) => {
    *
    * ```js
    * function destroyTracking(promise, parent) {
-   * trackPromise(promise, parent);
+   *   trackPromise(promise, parent);
    *   const asyncId = promise[async_id_symbol];
    *   const destroyed = { destroyed: false };
    *   promise[destroyedSymbol] = destroyed;

--- a/packages/pass-style/test/test-safe-promise-loophole.js
+++ b/packages/pass-style/test/test-safe-promise-loophole.js
@@ -1,0 +1,50 @@
+import { test } from './prepare-test-env-ava.js';
+
+import { passStyleOf } from '../src/passStyleOf.js';
+
+const { getOwnPropertyDescriptor, defineProperty } = Object;
+
+const { toStringTag } = Symbol;
+
+test('safe promise loophole', t => {
+  const p1 = Promise.resolve('p1');
+  t.is(passStyleOf(harden(p1)), 'promise');
+  t.is(p1[toStringTag], 'Promise');
+  t.is(`${p1}`, '[object Promise]');
+
+  const p2 = Promise.resolve('p2');
+  p2.silly = 'silly own property';
+  t.throws(() => passStyleOf(harden(p2)), {
+    message: '"[Promise]" - Must not have any own properties: ["silly"]',
+  });
+  t.is(p2[toStringTag], 'Promise');
+  t.is(`${p2}`, '[object Promise]');
+
+  const p3 = Promise.resolve('p3');
+  t.throws(
+    () => {
+      p3[toStringTag] = 3;
+    },
+    {
+      // Override mistake
+      message:
+        "Cannot assign to read only property 'Symbol(Symbol.toStringTag)' of object '[object Promise]'",
+    },
+  );
+  defineProperty(p3, toStringTag, {
+    value: 3,
+  });
+  t.is(passStyleOf(harden(p3)), 'promise');
+  t.is(p3[toStringTag], 3);
+  t.is(`${p3}`, '[object Object]');
+
+  const p4 = Promise.resolve('p4');
+  defineProperty(p4, toStringTag, {
+    get: reveal => (reveal ? 'I am p4' : 4),
+  });
+  t.is(passStyleOf(harden(p4)), 'promise');
+  t.is(p4[toStringTag], 4);
+  t.is(`${p4}`, '[object Object]');
+  const getter = getOwnPropertyDescriptor(p4, toStringTag).get;
+  t.is(getter(true), 'I am p4');
+});


### PR DESCRIPTION
In https://github.com/endojs/endo/pull/1275 I loosened the safe-promise.js checks used by `passStyleOf` in order to accommodate our workaround for the extra symbol-named own properties that Node's current `async_hooks` might add to promise instances. This checks these possible extra own properties against symbol-named own properties that would otherwise be inherited from `Promise.prototype`.

However, in doing so I seem to have forgotten that, even without async_hooks, `Promise.prototype` always has an own property named `Symbol.toStringTag`. Thus, the safe-promise rules currently allow that, but only if the property's "value" passes further checks. However, apparently by design, this "value" is obtained by a normal property GET (`pr[key]`), which might invoke a getter, allowing these overriding properties to be accessors. The easiest way for the value to pass the subsequent checks is to be a number.

The getter can be a per-instance function that, when called with a truthy argument, returns something else, like the string @FUDCo  needs. The normal builtin `toString` use of `pr[Symbol.toStringTag]` expects a string value, which would not pass the test, causing a conflict. However, when `pr[Symbol.toStringTag]` is instead a number, the builtin `toString` behavior falls back to printing `[object Object]` rather than `[object Promise]`, which is harmless enough for the very specialized case in which @FUDCo  would use this loophole.