### PR TITLE
feat(pass-style): Safe promises can override @@toStringTag with a string

### DIFF
--- a/packages/marshal/test/test-encode-slot-in-promise.js
+++ b/packages/marshal/test/test-encode-slot-in-promise.js
@@ -1,0 +1,54 @@
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { passStyleOf } from '@endo/pass-style';
+import { makeMarshal } from '../src/marshal.js';
+
+const { getOwnPropertyDescriptor, defineProperty } = Object;
+
+const { toStringTag } = Symbol;
+
+test('use safe promise loophole', t => {
+  const convertSlotToVal = (slot, _iface) => {
+    const p = Promise.resolve(`${slot} placeholder`);
+    defineProperty(p, toStringTag, {
+      value: `Promise ${slot}`,
+    });
+    harden(p);
+    t.is(passStyleOf(p), 'promise');
+    return p;
+  };
+
+  const PromiseNameRE = /^Promise (.*)$/;
+
+  const convertValToSlot = p => {
+    t.is(passStyleOf(p), 'promise');
+    const desc = getOwnPropertyDescriptor(p, toStringTag);
+    assert(desc !== undefined);
+    const name = desc.value;
+    t.is(typeof name, 'string');
+    const match = PromiseNameRE.exec(name);
+    assert(Array.isArray(match));
+    return match[1];
+  };
+  const { toCapData, fromCapData } = makeMarshal(
+    convertValToSlot,
+    convertSlotToVal,
+    {
+      serializeBodyFormat: 'smallcaps',
+    },
+  );
+
+  const markedPromise = convertSlotToVal('I am kref 3');
+
+  const passable1 = harden([{ markedPromise }]);
+  const capData1 = toCapData(passable1);
+  t.deepEqual(capData1, {
+    body: '#[{"markedPromise":"&0"}]',
+    slots: ['I am kref 3'],
+  });
+  const passable2 = fromCapData(capData1);
+  t.deepEqual(passable1, passable2);
+  const capData2 = toCapData(passable2);
+  t.deepEqual(capData1, capData2);
+});

--- a/packages/pass-style/test/test-safe-promise.js
+++ b/packages/pass-style/test/test-safe-promise.js
@@ -1,0 +1,66 @@
+import { test } from './prepare-test-env-ava.js';
+
+import { passStyleOf } from '../src/passStyleOf.js';
+
+const { defineProperty } = Object;
+
+const { toStringTag } = Symbol;
+
+test('safe promise loophole', t => {
+  {
+    const p1 = Promise.resolve('p1');
+    t.is(passStyleOf(harden(p1)), 'promise');
+    t.is(p1[toStringTag], 'Promise');
+    t.is(`${p1}`, '[object Promise]');
+  }
+
+  {
+    const p2 = Promise.resolve('p2');
+    p2.silly = 'silly own property';
+    t.throws(() => passStyleOf(harden(p2)), {
+      message: '"[Promise]" - Must not have any own properties: ["silly"]',
+    });
+    t.is(p2[toStringTag], 'Promise');
+    t.is(`${p2}`, '[object Promise]');
+  }
+
+  {
+    const p3 = Promise.resolve('p3');
+    t.throws(
+      () => {
+        p3[toStringTag] = 3;
+      },
+      {
+        // Override mistake
+        message:
+          "Cannot assign to read only property 'Symbol(Symbol.toStringTag)' of object '[object Promise]'",
+      },
+    );
+    defineProperty(p3, toStringTag, {
+      value: 3,
+    });
+    t.throws(() => passStyleOf(harden(p3)), {
+      message: 'Own @@toStringTag value must be a string: 3',
+    });
+  }
+
+  {
+    const p4 = Promise.resolve('p4');
+    defineProperty(p4, toStringTag, {
+      value: 'Promise p4',
+      enumerable: true,
+    });
+    t.throws(() => passStyleOf(harden(p4)), {
+      message:
+        'Own @@toStringTag must not be enumerable: {"configurable":false,"enumerable":true,"value":"Promise p4","writable":false}',
+    });
+
+    const p5 = Promise.resolve('p5');
+    defineProperty(p5, toStringTag, {
+      value: 'Promise p5',
+    });
+    t.is(passStyleOf(harden(p5)), 'promise');
+    t.is(p5[toStringTag], 'Promise p5');
+    t.is(`${p5}`, '[object Promise p5]');
+  }
+});


### PR DESCRIPTION
https://github.com/endojs/endo/pull/1781 demonstrates that the current endo (and it just so happens, the already-released endo) enables a passable promise to carry the string that @FUDCo needs to support testing. However, its way of carrying a string was terribly obtuse. 

This PR implements part of the plan explained at https://github.com/endojs/endo/pull/1781#issuecomment-1727080735 . Specifically, to have passable promises follow the precedent of passable far objects and exos, which also allow them to override the inherited @@toStringTag property with an own data property carrying a string value. However, agoric-sdk would not be able to use this more pleasant way of carrying a string until it is upgraded to depend on an endo containing this PR.