### PR TITLE
chore: Clarify Node.js 20 pre-LTS test version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,9 @@ jobs:
           - '16.5' # last version before unconditional promise fast-path
           - '16.6' # first version after unconditional promise fast-path
           - '18' # Active LTS
-          # UNTIL https://github.com/nodejs/node/issues/49497 is released (probably 20.6.1)
-          # - '20' # Future LTS
-          - '20.5' # last good version before breakage in 20.6.0
+          # '20.6' not viable due to https://github.com/nodejs/node/issues/49497
+          # '20.3' to '20.6' not viable due to https://github.com/nodejs/node/pull/49211
+          - '20.7' # Future LTS
         platform:
           - ubuntu-latest
 


### PR DESCRIPTION
This change pushes us to evaluate Node.js 20.7 instead of earlier versions for future LTS in Endo CI. @kumavis found the referenced defect closed prior to this version due to write truncation when experimenting with large bundles over CapTP in the pet daemon.