### PR TITLE
fix(netstring): Early return during chunked write

### DIFF
--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@endo/init": "^0.5.60",
+    "@endo/promise-kit": "^0.2.60",
     "@endo/stream": "^0.3.29",
     "ses": "^0.18.8"
   },


### PR DESCRIPTION

## Description

@kumavis identified in review a defect in the chunked mode for netstring writer. This change includes tests for the case where the target writer closes while we attempt to write netstring chunks, and provides the fix. Both tests previously failed.

### Security Considerations

Previously, writing to a netstring writer could mistakenly indicate that the stream was still open after the target closed, possibly reducing availability.

### Scaling Considerations

This should not have a material impact on scale, but might plug a memory leak.

### Documentation Considerations

No changes.

### Testing Considerations

The behaviors changed are covered by the unit tests.

### Upgrade Considerations

This should not create an obstacle for upgrades.