### PR TITLE
fix(compartment-mapper): Root alias search

### DIFF
--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -251,10 +251,8 @@ export const makeImportHookMaker = (
       // Collate candidate locations for the moduleSpecifier,
       // to support Node.js conventions and similar.
       const candidates = [moduleSpecifier];
-      if (moduleSpecifier !== '.') {
-        for (const candidateSuffix of searchSuffixes) {
-          candidates.push(`${moduleSpecifier}${candidateSuffix}`);
-        }
+      for (const candidateSuffix of searchSuffixes) {
+        candidates.push(`${moduleSpecifier}${candidateSuffix}`);
       }
 
       const { maybeRead } = unpackReadPowers(readPowers);


### PR DESCRIPTION
I’ve so far been unable to reproduce a problem @kumavis found in compartment-mapper with an obvious solution.