### PR TITLE
feat(pass-style): Use endowed passStyleOf if at global symbol

### DIFF
--- a/packages/pass-style/endow.js
+++ b/packages/pass-style/endow.js
@@ -1,0 +1,1 @@
+export { PassStyleOfEndowmentSymbol } from './src/passStyleOf.js';

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -19,6 +19,7 @@
   "exports": {
     ".": "./index.js",
     "./tools.js": "./tools.js",
+    "./endow.js": "./endow.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -190,10 +190,13 @@ const makePassStyleOf = passStyleHelpers => {
   return harden(passStyleOf);
 };
 
+export const PassStyleOfEndowmentSymbol = Symbol.for('@endo passStyleOf');
+
 /**
- * If there is already a `VataData` global containing a `passStyleOf`,
- * then presumably it was endowed for us by liveslots, so we should use
- * and export that one instead. Other software may have left it for us here,
+ * If there is already a PassStyleOfEndowmentSymbol property on the global,
+ * then presumably it was endowed for us by liveslots with a `passStyleOf`
+ * function, so we should use and export that one instead.
+ * Other software may have left it for us here,
  * but it would require write access to our global, or the ability to
  * provide endowments to our global, both of which seems adequate as a test of
  * whether it is authorized to serve the same role as liveslots.
@@ -205,9 +208,7 @@ const makePassStyleOf = passStyleHelpers => {
  * @type {PassStyleOf}
  */
 export const passStyleOf =
-  // UNTIL https://github.com/endojs/endo/issues/1514
-  // Prefer: globalThis?.VatData?.passStyleOf ||
-  (globalThis && globalThis.VatData && globalThis.VatData.passStyleOf) ||
+  (globalThis && globalThis[PassStyleOfEndowmentSymbol]) ||
   makePassStyleOf([
     CopyArrayHelper,
     CopyRecordHelper,


### PR DESCRIPTION
Implement @gibson042 's suggestion at https://github.com/endojs/endo/pull/1676/files#r1264339663 as agreed in the thread starting at https://github.com/Agoric/agoric-sdk/pull/8051#issuecomment-1638454456

An advantage of using a symbol-named property on the global instead of a string-named property is that it is not aliased to a global variable name.