### PR TITLE
refactor(patterns): Omit needless stackframes

### DIFF
--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -589,12 +589,23 @@ const makePatternKit = () => {
    * @param {string|number} [label]
    */
   const mustMatch = (specimen, patt, label = undefined) => {
-    if (checkMatches(specimen, patt, identChecker, label)) {
-      return;
+    let innerError;
+    try {
+      if (checkMatches(specimen, patt, identChecker, undefined)) {
+        return;
+      }
+    } catch (er) {
+      innerError = er;
     }
     // should only throw
     checkMatches(specimen, patt, assertChecker, label);
-    Fail`internal: ${label}: inconsistent pattern match: ${q(patt)}`;
+    const outerError = assert.error(
+      X`internal: ${label}: inconsistent pattern match: ${q(patt)}`,
+    );
+    if (innerError !== undefined) {
+      assert.note(outerError, X`caused by ${innerError}`);
+    }
+    throw outerError;
   };
 
   // /////////////////////// getRankCover //////////////////////////////////////


### PR DESCRIPTION
By passing `label` here, we missed an intended optimization by `applyLabelingError`, and instead created needless stackframes with a try/catch for every level of a recursive pattern match, even for the `mustMatch` success case. With the `undefined`, when `mustMatch` succeeds, we should avoid all these. When `mustMatch` fails, we'll cut the number of these in half.

I do *NOT* know whether or not this change will make a significant performance difference. I also do not know if the significance will be different on v8 vs XS. I want to use this as my benchmarking + profiling "hello world" exercise, to get to know our performance measurement tooling.

This PR itself only makes the change. It does not measure anything.