### PR TITLE
fix(ses): use prepareStackTrace for error stack string

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -213,6 +213,7 @@ export const weaksetAdd = uncurryThis(weaksetPrototype.add);
 export const weaksetHas = uncurryThis(weaksetPrototype.has);
 //
 export const functionToString = uncurryThis(functionPrototype.toString);
+export const errorToString = uncurryThis(Error.prototype.toString);
 //
 const { all } = Promise;
 export const promiseAll = promises => apply(all, Promise, [promises]);

--- a/packages/ses/test/error/test-tame-v8-error-unsafe.js
+++ b/packages/ses/test/error/test-tame-v8-error-unsafe.js
@@ -94,7 +94,7 @@ test('SES compartment error compatibility - endow w Error power', t => {
   const c1 = new Compartment({ t, Error });
   const result = c1.evaluate(`
     const obj = {
-      toString: () => 'Pseudo Error',
+      name: 'Pseudo Error',
     };
     const limit = Error.stackTraceLimit;
     const newSTL = Math.max(10, limit);

--- a/packages/ses/test/test-v8-callsite-properties.js
+++ b/packages/ses/test/test-v8-callsite-properties.js
@@ -8,10 +8,14 @@ test('callSite properties', t => {
     let sst;
     const orig = Error.prepareStackTrace;
     try {
-      const pst = (_err, sst0) => sst0;
+      const pst = (_err, sst0) => {
+        sst = sst0;
+        return '';
+      };
       Error.prepareStackTrace = pst;
       const e = Error();
-      sst = e.stack;
+      // eslint-disable-next-line no-void
+      void e.stack;
     } finally {
       Error.prepareStackTrace = orig;
     }


### PR DESCRIPTION
closes: #1798

## Description

Fixes `Error.prepareStackTrace` with the following behavior changes:
- If it generates a stack trace string, use it instead of generating our own
- do not leak the stack string if `errorTaming` is not `'unsafe'` 
  - but keep the workaround for `depd` and similar that return the callSites array
- Restore a made safe `Error.prepareStackTrace` that existed before SES loaded (e.g. Node.js uses it to enable source maps)

### Security Considerations

This change defers to a `prepareStackTrace` set in the start compartment to generate SES stack strings. The assumption is that such overrides are vetted.

### Scaling Considerations

The new implementation uses `try`/`catch` which is often more expensive, but it likely dwarfs in comparison to the call sites wrapping we are already doing.

### Documentation Considerations

How should this change be documented? I somewhat expected this to be the behavior in the first place

### Testing Considerations

Passes existing unit test.

### Upgrade Considerations

None
