### PR TITLE
docs: identify language in some markdown blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Initial setup
 
-```
+```sh
 git clone git@github.com:endojs/endo.git
 cd endo
 yarn

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -6,14 +6,14 @@ Endo-specific plugin
 
 You'll first need to install [ESLint](http://eslint.org):
 
-```
-$ npm i eslint --save-dev
+```sh
+npm i eslint --save-dev
 ```
 
 Next, install `@endo/eslint-plugin`:
 
-```
-$ npm install @endo/eslint-plugin --save-dev
+```sh
+npm install @endo/eslint-plugin --save-dev
 ```
 
 **Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `@endo/eslint-plugin` globally.
@@ -52,8 +52,3 @@ You can configure individual rules you want to use under the rules section.
 ## Supported Rules
 
 * Fill in provided rules here
-
-
-
-
-

--- a/packages/marshal/README.md
+++ b/packages/marshal/README.md
@@ -54,7 +54,7 @@ be expressed directly in JSON. These special values are usually strings with
 reserved prefixes in the preferred "smallcaps" encoding, but in the original
 encoding were objects with a property named `@qclass`. For example:
 
-```
+```js
 import '@endo/init';
 import { makeMarshal } from '@endo/marshal';
 
@@ -104,7 +104,7 @@ will be used as the slot identifier to be placed into the slots array, and the
 serialized `body`, in place of the object, will contain a special value
 referencing that slot identifier by its index in the slots array. For example:
 
-```
+```js
 import '@endo/init';
 import { makeMarshal } from '@endo/marshal';
 

--- a/packages/ses/package.json.md
+++ b/packages/ses/package.json.md
@@ -69,7 +69,7 @@ A pragma can be used in any JavaScript file to import the global type
 definitions from SES into environments that assume SES has been initialized and
 do not directly import the shim.
 
-```
+```js
 /// <reference types="ses"/>
 ```
 


### PR DESCRIPTION
I really like syntax highlighting.

See https://github.com/Agoric/agoric-sdk/pull/8415