### PR TITLE
fix: enable compatibility with node16/nodenext module resolution

### DIFF
--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -22,7 +22,10 @@
   "main": "./index.js",
   "types": "./types.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types.d.ts",
+      "default": "./index.js"
+    },
     "./import.js": "./import.js",
     "./archive.js": "./archive.js",
     "./import-archive.js": "./import-archive.js",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -21,7 +21,10 @@
   "module": "./index.js",
   "types": "./types.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types.d.ts",
+      "default": "./index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -29,7 +29,10 @@
   "module": "./index.js",
   "types": "./types.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types.d.ts",
+      "default": "./index.js"
+    },
     "./reader.js": "./reader.js",
     "./writer.js": "./writer.js",
     "./package.json": "./package.json"

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -35,11 +35,13 @@
   "types": "./types.d.ts",
   "exports": {
     ".": {
+      "types": "./types.d.ts",
       "import": "./index.js",
       "require": "./dist/ses.cjs",
       "types": "./types.d.ts"
     },
     "./lockdown": {
+      "types": "./types.d.ts",
       "import": "./index.js",
       "require": "./dist/ses.cjs",
       "types": "./types.d.ts"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -25,7 +25,10 @@
   "module": "./index.js",
   "types": "./types.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types.d.ts",
+      "default": "./index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -18,7 +18,10 @@
   "module": "./index.js",
   "types": "./types.d.ts",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./types.d.ts",
+      "default": "./index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
Closes #1802 

## Description

TypeScript's `node16` and `nodenext` module resolution algorithms attempt to adhere more closely to the behavior of the `exports` field.  To that end, if an `exports` field is present in a package, the `types` field is ignored; instead, a `types` conditional export is expected.

Without this change, any consumer using one of these newer--_officially recommended_--module resolution algorithms will be unable to load any `types.d.ts` file from any package.  We retain the `types` field because of backwards compatibility with the legacy `node` module resolution algorithm.

[Read more about how I came to this conclusion](https://gist.github.com/boneskull/ae1faac253379a7d6f24749c9ba12c24)

### Should the `types` field be used at all?

_It depends._  While this file is not _truly_ needed for type support if type declarations are shipped alongside each `.js` source file, it's awkward to export any types created via `@typedef` without it.

For instance, say we have a function `foo(opts: FooOpts)`.  `foo` lives in `a.js`, and `FooOpts` is a `@typedef` in `b.js`. The parameter `opts` is tagged as `@param {import('./b.js').FooOpts} opts`, as it should.  Entry point `index.js` re-exports `foo()` from `a.js`.  However, the definition for `FooOpts` _will not be available to consumers_--which will cause compilation errors.  We must, then, re-export this type from the entry point.  To avoid this, we have precious few tools at our disposal:

1. Create a reference of `FooOpts` in `index.js` via `@typedef`, which will export the `FooOpts` type.  If `FooOpts` is generic, this becomes more of a headache, as we have to _copy_ the generics from the original.  This is a hazard, because the generics could become out-of-sync.
2. Create a `.d.ts` (it could also be a `.ts`, which we can assume will generate the associated `.d.ts`; this doesn't matter for our purposes) which re-exports `FooOpts` from `b.js`.  This file will be the titular `types.d.ts`.

The question we need to ask, then, is "do we need to export any `@typedef`s?" If the answer is _yes_, then a `types.d.ts` makes sense.

I didn't actually check to see if `types.d.ts` is appropriate in all of these packages; I just fixed the problem I was encountering.  For `@endo/compartment-mapper`, some work I'm doing will mean re-exporting some `@typedef`s, even if that's not happening currently.  Furthermore, I ignored the packages with `"types": null`, since I don't understand what that's supposed to mean.

### Testing Considerations

I did not add any tests, as the test needs to happen on the result of `npm pack`, which is more of a fixture than I wanted to build out.  However, I am working on a [tool](https://github.com/boneskull/midnight-smoker) which will (hopefully soon) automatically check for problems like this.  Once that's ready, I can open a new PR to add the checks and you can see what you think.
