### PR TITLE
fix(exo): allow richer behaviorMethods

### DIFF
--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -18,6 +18,12 @@
     "lint:types": "tsc",
     "lint:eslint": "eslint '**/*.js'"
   },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/no-shim.js",
+    "./shim.js": "./shim.js",
+    "./utils.js": "./utils.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/endojs/endo.git"

--- a/packages/eventual-send/utils.js
+++ b/packages/eventual-send/utils.js
@@ -1,0 +1,1 @@
+export { getMethodNames } from './src/local.js';

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@endo/env-options": "^0.1.4",
+    "@endo/eventual-send": "^0.17.6",
     "@endo/far": "^0.2.22",
     "@endo/pass-style": "^0.1.7",
     "@endo/patterns": "^0.2.6"

--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -1,5 +1,5 @@
+import { getMethodNames } from '@endo/eventual-send/src/local.js';
 import { E, Far } from '@endo/far';
-import { hasOwnPropertyOf } from '@endo/pass-style';
 import {
   listDifference,
   objectMap,
@@ -12,7 +12,6 @@ import {
   getInterfaceGuardPayload,
   getCopyMapEntries,
 } from '@endo/patterns';
-
 import { GET_INTERFACE_GUARD } from './get-interface.js';
 
 /** @typedef {import('@endo/patterns').Method} Method */
@@ -378,21 +377,6 @@ const bindMethod = (
 };
 
 /**
- *
- * @template {Record<PropertyKey, CallableFunction>} T
- * @param {T} behaviorMethods
- * @param {InterfaceGuard<{ [M in keyof T]: MethodGuard }>} interfaceGuard
- * @returns {T & import('./get-interface.js').GetInterfaceGuard<T>}
- */
-const withGetInterfaceGuardMethod = (behaviorMethods, interfaceGuard) =>
-  harden({
-    [GET_INTERFACE_GUARD]() {
-      return interfaceGuard;
-    },
-    ...behaviorMethods,
-  });
-
-/**
  * @template {Record<PropertyKey, CallableFunction>} T
  * @param {string} tag
  * @param {ContextProvider} contextProvider
@@ -408,13 +392,20 @@ export const defendPrototype = (
   interfaceGuard = undefined,
 ) => {
   const prototype = {};
-  if (hasOwnPropertyOf(behaviorMethods, 'constructor')) {
-    // By ignoring any method named "constructor", we can use a
+  const methodNames = getMethodNames(behaviorMethods).filter(
+    // By ignoring any method that seems to be a constructor, we can use a
     // class.prototype as a behaviorMethods.
-    const { constructor: _, ...methods } = behaviorMethods;
-    // @ts-expect-error TS misses that hasOwn check makes this safe
-    behaviorMethods = harden(methods);
-  }
+    key => {
+      if (key !== 'constructor') {
+        return true;
+      }
+      const constructor = behaviorMethods.constructor;
+      return !(
+        constructor.prototype &&
+        constructor.prototype.constructor === constructor
+      );
+    },
+  );
   /** @type {Record<PropertyKey, MethodGuard> | undefined} */
   let methodGuards;
   /** @type {import('@endo/patterns').DefaultGuardType} */
@@ -432,10 +423,9 @@ export const defendPrototype = (
       ...(symbolMethodGuards &&
         fromEntries(getCopyMapEntries(symbolMethodGuards))),
     });
+    assert(methodGuards !== undefined);
     defaultGuards = dg;
     {
-      const methodNames = ownKeys(behaviorMethods);
-      assert(methodGuards);
       const methodGuardNames = ownKeys(methodGuards);
       const unimplemented = listDifference(methodGuardNames, methodNames);
       unimplemented.length === 0 ||
@@ -446,12 +436,9 @@ export const defendPrototype = (
           Fail`methods ${q(unguarded)} not guarded by ${q(interfaceName)}`;
       }
     }
-    behaviorMethods = withGetInterfaceGuardMethod(
-      behaviorMethods,
-      interfaceGuard,
-    );
   }
-  for (const prop of ownKeys(behaviorMethods)) {
+
+  for (const prop of methodNames) {
     prototype[prop] = bindMethod(
       `In ${q(prop)} method of (${tag})`,
       contextProvider,
@@ -460,6 +447,22 @@ export const defendPrototype = (
       // TODO some tool does not yet understand the `?.[` syntax
       methodGuards && methodGuards[prop],
       defaultGuards,
+    );
+  }
+
+  if (!hasOwnPropertyOf(prototype, GET_INTERFACE_GUARD)) {
+    const getInterfaceGuardMethod = {
+      [GET_INTERFACE_GUARD]() {
+        // Note: May be `undefined`
+        return interfaceGuard;
+      },
+    }[GET_INTERFACE_GUARD];
+    prototype[GET_INTERFACE_GUARD] = bindMethod(
+      `In ${q(GET_INTERFACE_GUARD)} method of (${tag})`,
+      contextProvider,
+      getInterfaceGuardMethod,
+      thisfulMethods,
+      undefined,
     );
   }
 

--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -1,4 +1,5 @@
-import { getMethodNames } from '@endo/eventual-send/src/local.js';
+import { getMethodNames } from '@endo/eventual-send/utils.js';
+import { hasOwnPropertyOf } from '@endo/pass-style';
 import { E, Far } from '@endo/far';
 import {
   listDifference,
@@ -423,7 +424,6 @@ export const defendPrototype = (
       ...(symbolMethodGuards &&
         fromEntries(getCopyMapEntries(symbolMethodGuards))),
     });
-    assert(methodGuards !== undefined);
     defaultGuards = dg;
     {
       const methodGuardNames = ownKeys(methodGuards);

--- a/packages/exo/src/get-interface.js
+++ b/packages/exo/src/get-interface.js
@@ -4,13 +4,16 @@
  * The name of the automatically added default meta-method for
  * obtaining an exo's interface, if it has one.
  *
+ * Intended to be similar to `GET_METHOD_NAMES` from `@endo/pass-style`.
+ *
  * TODO Name to be bikeshed. Perhaps even whether it is a
- * string or symbol to be bikeshed.
+ * string or symbol to be bikeshed. See
+ * https://github.com/endojs/endo/pull/1809#discussion_r1388052454
  *
  * TODO Beware that an exo's interface can change across an upgrade,
  * so remotes that cache it can become stale.
  */
-export const GET_INTERFACE_GUARD = Symbol.for('getInterfaceGuard');
+export const GET_INTERFACE_GUARD = '__getInterfaceGuard__';
 
 /**
  * @template {Record<PropertyKey, CallableFunction>} M

--- a/packages/exo/src/get-interface.js
+++ b/packages/exo/src/get-interface.js
@@ -15,8 +15,9 @@ export const GET_INTERFACE_GUARD = Symbol.for('getInterfaceGuard');
 /**
  * @template {Record<PropertyKey, CallableFunction>} M
  * @typedef {{
- *   [GET_INTERFACE_GUARD]: () => import('@endo/patterns').InterfaceGuard<{
- *     [K in keyof M]: import('@endo/patterns').MethodGuard
- *   }>
+ *   [GET_INTERFACE_GUARD]: () =>
+ *     import('@endo/patterns').InterfaceGuard<{
+ *       [K in keyof M]: import('@endo/patterns').MethodGuard
+ *     }> | undefined
  * }} GetInterfaceGuard
  */

--- a/packages/exo/test/test-exo-class-js-class.js
+++ b/packages/exo/test/test-exo-class-js-class.js
@@ -1,0 +1,77 @@
+/* eslint-disable max-classes-per-file */
+/* eslint-disable class-methods-use-this */
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+import { passStyleOf } from '@endo/pass-style';
+import { M, getInterfaceGuardPayload } from '@endo/patterns';
+import { makeExo, defineExoClass } from '../src/exo-makers.js';
+
+// Based on FarSubclass1 in test-far-class-instances.js
+class DoublerBehaviorClass {
+  double(x) {
+    return x + x;
+  }
+}
+
+const DoublerI = M.interface('Doubler', {
+  double: M.call(M.lte(10)).returns(M.number()),
+});
+
+const doubler = makeExo('doubler', DoublerI, DoublerBehaviorClass.prototype);
+
+test('exo doubler using js classes', t => {
+  t.is(passStyleOf(doubler), 'remotable');
+  t.is(doubler.double(3), 6);
+  t.throws(() => doubler.double('x'), {
+    message: 'In "double" method of (doubler): arg 0: "x" - Must be <= 10',
+  });
+  t.throws(() => doubler.double(), {
+    message:
+      'In "double" method of (doubler): Expected at least 1 arguments: []',
+  });
+  t.throws(() => doubler.double(12), {
+    message: 'In "double" method of (doubler): arg 0: 12 - Must be <= 10',
+  });
+});
+
+// Based on FarSubclass2 in test-far-class-instances.js
+class DoubleAdderBehaviorClass extends DoublerBehaviorClass {
+  doubleAddSelfCall(x) {
+    const {
+      state: { y },
+      self,
+    } = this;
+    return self.double(x) + y;
+  }
+
+  doubleAddSuperCall(x) {
+    const {
+      state: { y },
+    } = this;
+    return super.double(x) + y;
+  }
+}
+
+const DoubleAdderI = M.interface('DoubleAdder', {
+  ...getInterfaceGuardPayload(DoublerI).methodGuards,
+  doubleAddSelfCall: M.call(M.number()).returns(M.number()),
+  doubleAddSuperCall: M.call(M.number()).returns(M.number()),
+});
+
+const makeDoubleAdder = defineExoClass(
+  'doubleAdderClass',
+  DoubleAdderI,
+  y => ({ y }),
+  DoubleAdderBehaviorClass.prototype,
+);
+
+test('exo inheritance self vs super call', t => {
+  const da = makeDoubleAdder(5);
+  t.is(da.doubleAddSelfCall(3), 11);
+  t.throws(() => da.doubleAddSelfCall(12), {
+    message:
+      'In "double" method of (doubleAdderClass): arg 0: 12 - Must be <= 10',
+  });
+  t.is(da.doubleAddSuperCall(12), 29);
+});

--- a/packages/exo/test/test-exo-wobbly-point.js
+++ b/packages/exo/test/test-exo-wobbly-point.js
@@ -10,10 +10,9 @@
 /* eslint-disable-next-line import/order */
 import { test } from './prepare-test-env-ava.js';
 
-// TODO enable import of getMethodNames without deep import
 // eslint-disable-next-line import/order
-import { getMethodNames } from '@endo/eventual-send/src/local.js';
-import { passStyleOf, Far } from '@endo/pass-style';
+import { getMethodNames } from '@endo/eventual-send/utils.js';
+import { passStyleOf, Far, GET_METHOD_NAMES } from '@endo/pass-style';
 import { M } from '@endo/patterns';
 import { defineExoClass } from '../src/exo-makers.js';
 import { GET_INTERFACE_GUARD } from '../src/get-interface.js';
@@ -96,12 +95,18 @@ harden(ExoPoint);
 
 const makeExoPoint = defineExoClassFromJSClass(ExoPoint);
 
+const assertMethodNames = (t, obj, names) => {
+  t.deepEqual(getMethodNames(obj), names);
+  t.deepEqual(obj[GET_METHOD_NAMES](), names);
+};
+
 test('ExoPoint instances', t => {
   const pt = makeExoPoint(3, 5);
   t.is(passStyleOf(pt), 'remotable');
   t.false(pt instanceof ExoPoint);
-  t.deepEqual(getMethodNames(pt), [
+  assertMethodNames(t, pt, [
     GET_INTERFACE_GUARD,
+    GET_METHOD_NAMES,
     'getX',
     'getY',
     'setY',
@@ -152,8 +157,9 @@ test('FarWobblyPoint inheritance', t => {
   t.false(wpt instanceof ExoWobblyPoint);
   t.false(wpt instanceof ExoPoint);
   t.is(passStyleOf(wpt), 'remotable');
-  t.deepEqual(getMethodNames(wpt), [
+  assertMethodNames(t, wpt, [
     GET_INTERFACE_GUARD,
+    GET_METHOD_NAMES,
     'getX',
     'getY',
     'setY',

--- a/packages/exo/test/test-exo-wobbly-point.js
+++ b/packages/exo/test/test-exo-wobbly-point.js
@@ -1,0 +1,205 @@
+/**
+ * Based on the WobblyPoint inheritance examples in
+ * https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/google-caja/caja-spec-2007-12-21.pdf
+ * and
+ * test-far-wobbly-point.js
+ */
+
+/* eslint-disable class-methods-use-this */
+/* eslint-disable max-classes-per-file */
+/* eslint-disable-next-line import/order */
+import { test } from './prepare-test-env-ava.js';
+
+// TODO enable import of getMethodNames without deep import
+// eslint-disable-next-line import/order
+import { getMethodNames } from '@endo/eventual-send/src/local.js';
+import { passStyleOf, Far } from '@endo/pass-style';
+import { M } from '@endo/patterns';
+import { defineExoClass } from '../src/exo-makers.js';
+import { GET_INTERFACE_GUARD } from '../src/get-interface.js';
+
+const { Fail, quote: q } = assert;
+const { apply } = Reflect;
+
+const ExoEmptyI = M.interface('ExoEmpty', {});
+
+class ExoBaseClass {
+  constructor() {
+    Fail`Turn Exo JS classes into Exo classes with defineExoClassFromJSClass: ${q(
+      new.target.name,
+    )}`;
+  }
+
+  static implements = ExoEmptyI;
+
+  static init() {
+    return harden({});
+  }
+}
+
+const defineExoClassFromJSClass = klass =>
+  defineExoClass(klass.name, klass.implements, klass.init, klass.prototype);
+harden(defineExoClassFromJSClass);
+
+const ExoPointI = M.interface('ExoPoint', {
+  toString: M.call().returns(M.string()),
+  getX: M.call().returns(M.gte(0)),
+  getY: M.call().returns(M.number()),
+  setY: M.call(M.number()).returns(),
+});
+
+class ExoAbstractPoint extends ExoBaseClass {
+  static implements = ExoPointI;
+
+  toString() {
+    const { self } = this;
+    return `<${self.getX()},${self.getY()}>`;
+  }
+}
+
+test('cannot make abstract class concrete', t => {
+  t.throws(() => defineExoClassFromJSClass(ExoAbstractPoint), {
+    message:
+      'methods ["getX","getY","setY"] not implemented by "ExoAbstractPoint"',
+  });
+});
+
+class ExoPoint extends ExoAbstractPoint {
+  static init(x, y) {
+    // Heap exos currently use the returned record directly, so
+    // needs to not be frozen for `state.y` to be assignable.
+    // TODO not true for other zones. May make heap zone more like
+    // the others in treatment of `state`.
+    return { x, y };
+  }
+
+  getX() {
+    const {
+      state: { x },
+    } = this;
+    return x;
+  }
+
+  getY() {
+    const {
+      state: { y },
+    } = this;
+    return y;
+  }
+
+  setY(newY) {
+    const { state } = this;
+    state.y = newY;
+  }
+}
+harden(ExoPoint);
+
+const makeExoPoint = defineExoClassFromJSClass(ExoPoint);
+
+test('ExoPoint instances', t => {
+  const pt = makeExoPoint(3, 5);
+  t.is(passStyleOf(pt), 'remotable');
+  t.false(pt instanceof ExoPoint);
+  t.deepEqual(getMethodNames(pt), [
+    GET_INTERFACE_GUARD,
+    'getX',
+    'getY',
+    'setY',
+    'toString',
+  ]);
+  t.is(pt.getX(), 3);
+  t.is(pt.getY(), 5);
+  t.is(`${pt}`, '<3,5>');
+  pt.setY(6);
+  t.is(`${pt}`, '<3,6>');
+
+  const otherPt = makeExoPoint(1, 2);
+  t.is(apply(pt.getX, otherPt, []), 1);
+
+  const negPt = makeExoPoint(-3, 5);
+  t.throws(() => negPt.getX(), {
+    message: 'In "getX" method of (ExoPoint): result: -3 - Must be >= 0',
+  });
+  // `self` calls are guarded
+  t.throws(() => `${negPt}`, {
+    message: 'In "getX" method of (ExoPoint): result: -3 - Must be >= 0',
+  });
+});
+
+class ExoWobblyPoint extends ExoPoint {
+  static init(x, y, getWobble) {
+    return { ...super.init(x, y), getWobble };
+  }
+
+  getX() {
+    const {
+      state: { getWobble },
+    } = this;
+    return super.getX() + getWobble();
+  }
+}
+harden(ExoWobblyPoint);
+
+const makeExoWobblyPoint = defineExoClassFromJSClass(ExoWobblyPoint);
+
+test('FarWobblyPoint inheritance', t => {
+  let wobble = 0;
+  // For heap classes currently, there is no reason to make `getWobble` passable.
+  // But other zones insist on at least passability, and TODO we may eventually
+  // make the heap zone act like this as well.
+  const getWobble = Far('getW', () => (wobble += 1));
+  const wpt = makeExoWobblyPoint(3, 5, getWobble);
+  t.false(wpt instanceof ExoWobblyPoint);
+  t.false(wpt instanceof ExoPoint);
+  t.is(passStyleOf(wpt), 'remotable');
+  t.deepEqual(getMethodNames(wpt), [
+    GET_INTERFACE_GUARD,
+    'getX',
+    'getY',
+    'setY',
+    'toString',
+  ]);
+  t.is(`${wpt}`, '<4,5>');
+  t.is(`${wpt}`, '<5,5>');
+  t.is(`${wpt}`, '<6,5>');
+  wpt.setY(6);
+  t.is(`${wpt}`, '<7,6>');
+
+  const otherPt = makeExoPoint(1, 2);
+  t.false(otherPt instanceof ExoWobblyPoint);
+  t.throws(() => apply(wpt.getX, otherPt, []), {
+    message:
+      '"In \\"getX\\" method of (ExoWobblyPoint)" may only be applied to a valid instance: "[Alleged: ExoPoint]"',
+  });
+  t.throws(() => apply(wpt.getY, otherPt, []), {
+    message:
+      '"In \\"getY\\" method of (ExoWobblyPoint)" may only be applied to a valid instance: "[Alleged: ExoPoint]"',
+  });
+
+  const otherWpt = makeExoWobblyPoint(3, 5, () => 1);
+  t.is(`${otherWpt}`, '<4,5>');
+  t.is(apply(wpt.getX, otherWpt, []), 4);
+
+  // This error behavior shows the absence of the security vulnerability
+  // explained at the corresponding example in `test-far-wobbly-point.js`
+  // for the `@endo/pass-style` / `Far` level of abstraction. At the exo level
+  // of abstraction, a raw-method subclass overriding an inherited superclass
+  // method denies that method to clients of instances of the subclass.
+  // At the same time, this overridden method remains available within
+  // the overriding subclass via unguarded `super` calls.
+  t.throws(() => apply(otherPt.getX, otherWpt, []), {
+    message:
+      '"In \\"getX\\" method of (ExoPoint)" may only be applied to a valid instance: "[Alleged: ExoWobblyPoint]"',
+  });
+
+  const negWpt1 = makeExoWobblyPoint(-3, 5, () => 4);
+  t.is(negWpt1.getX(), 1);
+  // `super` calls are direct, bypassing guards and sharing context
+  t.is(`${negWpt1}`, '<1,5>');
+
+  const negWpt2 = makeExoWobblyPoint(1, 5, () => -4);
+  t.throws(() => `${negWpt2}`, {
+    // `self` calls are guarded
+    message: 'In "getX" method of (ExoWobblyPoint): result: -3 - Must be >= 0',
+  });
+});

--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -345,7 +345,7 @@ test('naked function call', t => {
 
   t.throws(() => gigm(), {
     message:
-      'thisful method "In \\"[Symbol(getInterfaceGuard)]\\" method of (greeter)" called without \'this\' object',
+      'thisful method "In \\"__getInterfaceGuard__\\" method of (greeter)" called without \'this\' object',
   });
   t.deepEqual(gigm.bind(greeter)(), GreeterI);
 });

--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -185,9 +185,7 @@ test('missing interface', t => {
     message:
       'In "makeSayHello" method of (greeterMaker): result: "[Symbol(passStyle)]" property expected: "[Function <anon>]"',
   });
-  t.throws(() => greeterMaker[GET_INTERFACE_GUARD](), {
-    message: 'greeterMaker[GET_INTERFACE_GUARD] is not a function',
-  });
+  t.is(greeterMaker[GET_INTERFACE_GUARD](), undefined);
 });
 
 const SloppyGreeterI = M.interface('greeter', {}, { sloppy: true });

--- a/packages/exo/test/test-non-enumerable-methods.js
+++ b/packages/exo/test/test-non-enumerable-methods.js
@@ -1,0 +1,129 @@
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { getInterfaceMethodKeys, M } from '@endo/patterns';
+import { defineExoClass } from '../src/exo-makers.js';
+import { GET_INTERFACE_GUARD } from '../src/get-interface.js';
+
+const { getPrototypeOf, getOwnPropertyDescriptors, create, fromEntries } =
+  Object;
+
+const { ownKeys } = Reflect;
+
+/**
+ * Borrowed from https://github.com/endojs/endo/pull/1815 to avoid
+ * depending on it being merged. TODO If it is merged, then delete this
+ * copy and import `objectMetaMap` instead.
+ *
+ * Like `objectMap`, but at the reflective level of property descriptors
+ * rather than property values.
+ *
+ * Except for hardening, the edge case behavior is mostly the opposite of
+ * the `objectMap` edge cases.
+ *    * No matter how mutable the original object, the returned object is
+ *      hardened.
+ *    * All own properties of the original are mapped, even if symbol-named
+ *      or non-enumerable.
+ *    * If any of the original properties were accessors, the descriptor
+ *      containing the getter and setter are given to `metaMapFn`.
+ *    * The own properties of the returned are according to the descriptors
+ *      returned by `metaMapFn`.
+ *    * The returned object will always be a plain object whose state is
+ *      only these mapped own properties. It will inherit from the third
+ *      argument if provided, defaulting to `Object.prototype` if omitted.
+ *
+ * Because a property descriptor is distinct from `undefined`, we bundle
+ * mapping and filtering together. When the `metaMapFn` returns `undefined`,
+ * that property is omitted from the result.
+ *
+ * @template {Record<PropertyKey, any>} O
+ * @param {O} original
+ * @param {(
+ *   desc: TypedPropertyDescriptor<O[keyof O]>,
+ *   key: keyof O
+ * ) => (PropertyDescriptor | undefined)} metaMapFn
+ * @param {any} [proto]
+ * @returns {any}
+ */
+export const objectMetaMap = (
+  original,
+  metaMapFn,
+  proto = Object.prototype,
+) => {
+  const descs = getOwnPropertyDescriptors(original);
+  const keys = ownKeys(original);
+
+  const descEntries = /** @type {[PropertyKey,PropertyDescriptor][]} */ (
+    keys
+      .map(key => [key, metaMapFn(descs[key], key)])
+      .filter(([_key, optDesc]) => optDesc !== undefined)
+  );
+  return harden(create(proto, fromEntries(descEntries)));
+};
+harden(objectMetaMap);
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const denumerate = obj =>
+  objectMetaMap(
+    obj,
+    desc => ({ ...desc, enumerable: false }),
+    getPrototypeOf(obj),
+  );
+
+test('test defineExoClass', t => {
+  const makeUpCounter = defineExoClass(
+    'UpCounter',
+    UpCounterI,
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    denumerate({
+      incr(y = 1) {
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    }),
+  );
+  const upCounter = makeUpCounter(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(upCounter.incr(1), 9);
+  t.throws(() => upCounter.incr(-3), {
+    message: 'In "incr" method of (UpCounter): arg 0?: -3 - Must be >= 0',
+  });
+  // @ts-expect-error bad arg
+  t.throws(() => upCounter.incr('foo'), {
+    message:
+      'In "incr" method of (UpCounter): arg 0?: string "foo" - Must be a number',
+  });
+  t.deepEqual(upCounter[GET_INTERFACE_GUARD](), UpCounterI);
+  t.deepEqual(getInterfaceMethodKeys(UpCounterI), ['incr']);
+
+  const symbolic = Symbol.for('symbolic');
+  const FooI = M.interface('Foo', {
+    m: M.call().returns(),
+    [symbolic]: M.call(M.boolean()).returns(),
+  });
+  t.deepEqual(getInterfaceMethodKeys(FooI), ['m', Symbol.for('symbolic')]);
+  const makeFoo = defineExoClass(
+    'Foo',
+    FooI,
+    () => ({}),
+    denumerate({
+      m() {},
+      [symbolic]() {},
+    }),
+  );
+  const foo = makeFoo();
+  t.deepEqual(foo[GET_INTERFACE_GUARD](), FooI);
+  t.throws(() => foo[symbolic]('invalid arg'), {
+    message:
+      'In "[Symbol(symbolic)]" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
+  });
+});

--- a/packages/marshal/test/test-marshal-testing.js
+++ b/packages/marshal/test/test-marshal-testing.js
@@ -1,14 +1,18 @@
 import { test } from './prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { Far, passStyleOf, Remotable } from '@endo/pass-style';
+import { passStyleOf, Remotable } from '@endo/pass-style';
 import { makeMarshal } from '../src/marshal.js';
 
 const { create } = Object;
 
-const alice = Far('alice');
-const bob1 = Far('bob');
-const bob2 = Far('bob');
+// Use the lower level `Remotable` rather than `Far` to make an empty
+// far object, i.e., one without even the miranda meta methods like
+// `GET_METHOD_NAMES`. Such an empty far object should be `t.deepEqual`
+// to its remote presences.
+const alice = Remotable('Alleged: alice');
+const bob1 = Remotable('Alleged: bob');
+const bob2 = Remotable('Alleged: bob');
 
 const convertValToSlot = val =>
   passStyleOf(val) === 'remotable' ? 'far' : val;

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -24,7 +24,12 @@ export {
 export { passStyleOf, assertPassable } from './src/passStyleOf.js';
 
 export { makeTagged } from './src/makeTagged.js';
-export { Remotable, Far, ToFarFunction } from './src/make-far.js';
+export {
+  Remotable,
+  Far,
+  ToFarFunction,
+  GET_METHOD_NAMES,
+} from './src/make-far.js';
 
 export {
   assertRecord,

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -33,11 +33,11 @@
     "test": "ava"
   },
   "dependencies": {
+    "@endo/eventual-send": "^0.17.6",
     "@endo/promise-kit": "^0.2.60",
     "@fast-check/ava": "^1.1.5"
   },
   "devDependencies": {
-    "@endo/eventual-send": "^0.17.6",
     "@endo/init": "^0.5.60",
     "@endo/ses-ava": "^0.2.44",
     "ava": "^5.3.0",

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -37,6 +37,7 @@
     "@fast-check/ava": "^1.1.5"
   },
   "devDependencies": {
+    "@endo/eventual-send": "^0.17.6",
     "@endo/init": "^0.5.60",
     "@endo/ses-ava": "^0.2.44",
     "ava": "^5.3.0",

--- a/packages/pass-style/src/make-far.js
+++ b/packages/pass-style/src/make-far.js
@@ -1,5 +1,6 @@
 /// <reference types="ses"/>
 
+import { getMethodNames } from '@endo/eventual-send/utils.js';
 import { assertChecker, PASS_STYLE } from './passStyle-helpers.js';
 import { assertIface, getInterfaceOf, RemotableHelper } from './remotable.js';
 
@@ -129,7 +130,39 @@ export const Remotable = (
 harden(Remotable);
 
 /**
+ * The name of the automatically added default meta-method for obtaining a
+ * list of all methods of an object declared with `Far`, or an object that
+ * inherits from an object declared with `Far`.
+ *
+ * Modeled on `GET_INTERFACE_GUARD` from `@endo/exo`.
+ *
+ * TODO Name to be bikeshed. Perhaps even whether it is a
+ * string or symbol to be bikeshed. See
+ * https://github.com/endojs/endo/pull/1809#discussion_r1388052454
+ *
+ * HAZARD: Beware that an exo's interface can change across an upgrade,
+ * so remotes that cache it can become stale.
+ */
+export const GET_METHOD_NAMES = '__getMethodNames__';
+
+/**
+ * Note that `getMethodNamesMethod` is a thisful method! It must be so that
+ * it works as expected with far-object inheritance.
+ *
+ * @returns {(string|symbol)[]}
+ */
+const getMethodNamesMethod = harden({
+  [GET_METHOD_NAMES]() {
+    return getMethodNames(this);
+  },
+})[GET_METHOD_NAMES];
+
+/**
  * A concise convenience for the most common `Remotable` use.
+ *
+ * For far objects (as opposed to far functions), also adds a miranda
+ * `GET_METHOD_NAMES` method that returns an array of all the method names,
+ * if there is not yet any method named `GET_METHOD_NAMES`. (Hence "miranda")
  *
  * @template {{}} T
  * @param {string} farName This name will be prepended with `Alleged: `
@@ -138,6 +171,16 @@ harden(Remotable);
  */
 export const Far = (farName, remotable = undefined) => {
   const r = remotable === undefined ? /** @type {T} */ ({}) : remotable;
+  if (typeof r === 'object' && !(GET_METHOD_NAMES in r)) {
+    // This test excludes far functions, since we currently consider them
+    // to only have a call-behavior, with no callable methods.
+    // Beware: Mutates the input argument! But `Remotable`
+    // * requires the object to be mutable
+    // * does further mutations,
+    // * hardens the mutated object before returning it.
+    // so this mutation is not unprecedented. But it is surprising!
+    r[GET_METHOD_NAMES] = getMethodNamesMethod;
+  }
   return Remotable(`Alleged: ${farName}`, undefined, r);
 };
 harden(Far);

--- a/packages/pass-style/test/test-far-class-instances.js
+++ b/packages/pass-style/test/test-far-class-instances.js
@@ -1,0 +1,98 @@
+/* eslint-disable class-methods-use-this */
+/* eslint-disable max-classes-per-file */
+import { test } from './prepare-test-env-ava.js';
+
+// TODO enable import of getMethodNames without deep import
+// eslint-disable-next-line import/order
+import { getMethodNames } from '@endo/eventual-send/src/local.js';
+import { passStyleOf } from '../src/passStyleOf.js';
+import { Far } from '../src/make-far.js';
+
+/**
+ * Classes whose instances should be Far objects may find it convenient to
+ * inherit from this base class. Note that the constructor of this base class
+ * freezes the instance in an empty state, so all is interesting attributes
+ * can only depend on its identity and what it inherits from.
+ * This includes private fields, as those are keyed only on
+ * this object's identity. However, we discourage (but cannot prevent) such
+ * use of private fields, as they cannot easily be refactored into Exo state.
+ */
+export const FarBaseClass = class FarBaseClass {
+  constructor() {
+    harden(this);
+  }
+};
+
+Far('FarBaseClass', FarBaseClass.prototype);
+harden(FarBaseClass);
+
+class FarSubclass1 extends FarBaseClass {
+  double(x) {
+    return x + x;
+  }
+}
+
+class FarSubclass2 extends FarSubclass1 {
+  #y = 0;
+
+  constructor(y) {
+    super();
+    this.#y = y;
+  }
+
+  doubleAdd(x) {
+    return this.double(x) + this.#y;
+  }
+}
+
+test('far class instances', t => {
+  const fb = new FarBaseClass();
+  t.is(passStyleOf(fb), 'remotable');
+  t.deepEqual(getMethodNames(fb), ['constructor']);
+
+  t.assert(new fb.constructor() instanceof FarBaseClass);
+  t.throws(() => fb.constructor(), {
+    // TODO message depends on JS engine, and so is a fragile golden test
+    message: "Class constructor FarBaseClass cannot be invoked without 'new'",
+  });
+
+  const fs1 = new FarSubclass1();
+  t.is(passStyleOf(fs1), 'remotable');
+  t.is(fs1.double(4), 8);
+  t.assert(new fs1.constructor() instanceof FarSubclass1);
+  t.deepEqual(getMethodNames(fs1), ['constructor', 'double']);
+
+  const fs2 = new FarSubclass2(3);
+  t.is(passStyleOf(fs2), 'remotable');
+  t.is(fs2.double(4), 8);
+  t.is(fs2.doubleAdd(4), 11);
+  t.deepEqual(getMethodNames(fs2), ['constructor', 'double', 'doubleAdd']);
+
+  const yField = new WeakMap();
+  class FarSubclass3 extends FarSubclass1 {
+    constructor(y) {
+      super();
+      yField.set(this, y);
+    }
+
+    doubleAdd(x) {
+      return this.double(x) + yField.get(this);
+    }
+  }
+
+  const fs3 = new FarSubclass3(3);
+  t.is(passStyleOf(fs3), 'remotable');
+  t.is(fs3.double(4), 8);
+  t.is(fs3.doubleAdd(4), 11);
+  t.deepEqual(getMethodNames(fs3), ['constructor', 'double', 'doubleAdd']);
+});
+
+test('far class instance hardened empty', t => {
+  class FarClass4 extends FarBaseClass {
+    z = 0;
+  }
+  t.throws(() => new FarClass4(), {
+    // TODO message depends on JS engine, and so is a fragile golden test
+    message: 'Cannot define property z, object is not extensible',
+  });
+});

--- a/packages/pass-style/test/test-far-wobbly-point.js
+++ b/packages/pass-style/test/test-far-wobbly-point.js
@@ -7,11 +7,10 @@
 /* eslint-disable max-classes-per-file */
 import { test } from './prepare-test-env-ava.js';
 
-// TODO enable import of getMethodNames without deep import
 // eslint-disable-next-line import/order
-import { getMethodNames } from '@endo/eventual-send/src/local.js';
+import { getMethodNames } from '@endo/eventual-send/utils.js';
 import { passStyleOf } from '../src/passStyleOf.js';
-import { Far } from '../src/make-far.js';
+import { Far, GET_METHOD_NAMES } from '../src/make-far.js';
 
 const { apply } = Reflect;
 
@@ -61,11 +60,17 @@ class FarPoint extends FarBaseClass {
 }
 harden(FarPoint);
 
+const assertMethodNames = (t, obj, names) => {
+  t.deepEqual(getMethodNames(obj), names);
+  t.deepEqual(obj[GET_METHOD_NAMES](), names);
+};
+
 test('FarPoint instances', t => {
   const pt = new FarPoint(3, 5);
   t.is(passStyleOf(pt), 'remotable');
   t.assert(pt instanceof FarPoint);
-  t.deepEqual(getMethodNames(pt), [
+  assertMethodNames(t, pt, [
+    GET_METHOD_NAMES,
     'constructor',
     'getX',
     'getY',
@@ -103,7 +108,8 @@ test('FarWobblyPoint inheritance', t => {
   t.assert(wpt instanceof FarWobblyPoint);
   t.assert(wpt instanceof FarPoint);
   t.is(passStyleOf(wpt), 'remotable');
-  t.deepEqual(getMethodNames(wpt), [
+  assertMethodNames(t, wpt, [
+    GET_METHOD_NAMES,
     'constructor',
     'getX',
     'getY',

--- a/packages/pass-style/test/test-far-wobbly-point.js
+++ b/packages/pass-style/test/test-far-wobbly-point.js
@@ -1,0 +1,145 @@
+/**
+ * Based on the WobblyPoint inheritance examples in
+ * https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/google-caja/caja-spec-2007-12-21.pdf
+ */
+
+/* eslint-disable class-methods-use-this */
+/* eslint-disable max-classes-per-file */
+import { test } from './prepare-test-env-ava.js';
+
+// TODO enable import of getMethodNames without deep import
+// eslint-disable-next-line import/order
+import { getMethodNames } from '@endo/eventual-send/src/local.js';
+import { passStyleOf } from '../src/passStyleOf.js';
+import { Far } from '../src/make-far.js';
+
+const { apply } = Reflect;
+
+/**
+ * Classes whose instances should be Far objects may find it convenient to
+ * inherit from this base class. Note that the constructor of this base class
+ * freezes the instance in an empty state, so all is interesting attributes
+ * can only depend on its identity and what it inherits from.
+ * This includes private fields, as those are keyed only on
+ * this object's identity. However, we discourage (but cannot prevent) such
+ * use of private fields, as they cannot easily be refactored into Exo state.
+ */
+class FarBaseClass {
+  constructor() {
+    harden(this);
+  }
+}
+Far('FarBaseClass', FarBaseClass.prototype);
+harden(FarBaseClass);
+
+class FarPoint extends FarBaseClass {
+  #x;
+
+  #y;
+
+  constructor(x, y) {
+    super();
+    this.#x = x;
+    this.#y = y;
+  }
+
+  toString() {
+    return `<${this.getX()},${this.getY()}>`;
+  }
+
+  getX() {
+    return this.#x;
+  }
+
+  getY() {
+    return this.#y;
+  }
+
+  setY(newY) {
+    this.#y = newY;
+  }
+}
+harden(FarPoint);
+
+test('FarPoint instances', t => {
+  const pt = new FarPoint(3, 5);
+  t.is(passStyleOf(pt), 'remotable');
+  t.assert(pt instanceof FarPoint);
+  t.deepEqual(getMethodNames(pt), [
+    'constructor',
+    'getX',
+    'getY',
+    'setY',
+    'toString',
+  ]);
+  t.is(pt.getX(), 3);
+  t.is(pt.getY(), 5);
+  t.is(`${pt}`, '<3,5>');
+  pt.setY(6);
+  t.is(`${pt}`, '<3,6>');
+
+  const otherPt = new FarPoint(1, 2);
+  t.is(apply(pt.getX, otherPt, []), 1);
+});
+
+class FarWobblyPoint extends FarPoint {
+  #getWobble;
+
+  constructor(x, y, getWobble) {
+    super(x, y);
+    this.#getWobble = getWobble;
+  }
+
+  getX() {
+    return super.getX() + this.#getWobble();
+  }
+}
+harden(FarWobblyPoint);
+
+test('FarWobblyPoint inheritance', t => {
+  let wobble = 0;
+  const getWobble = () => (wobble += 1);
+  const wpt = new FarWobblyPoint(3, 5, getWobble);
+  t.assert(wpt instanceof FarWobblyPoint);
+  t.assert(wpt instanceof FarPoint);
+  t.is(passStyleOf(wpt), 'remotable');
+  t.deepEqual(getMethodNames(wpt), [
+    'constructor',
+    'getX',
+    'getY',
+    'setY',
+    'toString',
+  ]);
+  t.is(`${wpt}`, '<4,5>');
+  t.is(`${wpt}`, '<5,5>');
+  t.is(`${wpt}`, '<6,5>');
+  wpt.setY(6);
+  t.is(`${wpt}`, '<7,6>');
+
+  const otherPt = new FarPoint(1, 2);
+  t.false(otherPt instanceof FarWobblyPoint);
+  t.throws(() => apply(wpt.getX, otherPt, []), {
+    // TODO great error message, but is a golden specific to v8
+    message:
+      'Cannot read private member #getWobble from an object whose class did not declare it',
+  });
+  t.is(apply(wpt.getY, otherPt, []), 2);
+
+  const otherWpt = new FarWobblyPoint(3, 5, () => 1);
+  t.is(`${otherWpt}`, '<4,5>');
+  t.is(apply(wpt.getX, otherWpt, []), 4);
+
+  // This test, though correct, demonstrates a sucurity weakness of
+  // this approach to JS class inheritance at this
+  // `@endo/pass-style` / `Far` level of abstraction. The weakness
+  // is that the overridden method from a superclass can nevertheless
+  // be directly applied to an instance of the subclass. The
+  // subclass override did not suppress the use of the overridden
+  // method as, effectively, part of the subclass' instance's public
+  // API.
+  //
+  // See the corresponding example at
+  // `test-exo-wobbly-point.js` to see the absence of this vulnerability
+  // at the Exo level of abstraction.
+  t.is(apply(otherPt.getX, otherWpt, []), 3);
+});

--- a/packages/pass-style/test/test-passStyleOf.js
+++ b/packages/pass-style/test/test-passStyleOf.js
@@ -266,7 +266,8 @@ test('passStyleOf testing remotables', t => {
   class NonFarBaseClass9 {}
   class Subclass9 extends NonFarBaseClass9 {}
   t.throws(() => Far('FarType9', Subclass9.prototype), {
-    message: 'For now, remotables cannot inherit from anything unusual, in {}',
+    message:
+      'For now, remotables cannot inherit from anything unusual, in {"__getMethodNames__":"[Function __getMethodNames__]"}',
   });
 
   const unusualTagRecordProtoMessage =

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -1664,7 +1664,8 @@ const makePatternKit = () => {
       ),
     split: (base, rest = undefined) => {
       if (passStyleOf(harden(base)) === 'copyArray') {
-        // @ts-expect-error We know it should be an array
+        // TODO at-ts-expect-error works locally but not from @endo/exo
+        // @ts-ignore We know it should be an array
         return M.splitArray(base, rest && [], rest);
       } else {
         return M.splitRecord(base, rest && {}, rest);
@@ -1672,7 +1673,8 @@ const makePatternKit = () => {
     },
     partial: (base, rest = undefined) => {
       if (passStyleOf(harden(base)) === 'copyArray') {
-        // @ts-expect-error We know it should be an array
+        // TODO at-ts-expect-error works locally but not from @endo/exo
+        // @ts-ignore We know it should be an array
         return M.splitArray([], base, rest);
       } else {
         return M.splitRecord({}, base, rest);
@@ -1945,7 +1947,8 @@ export const getInterfaceMethodKeys = interfaceGuard => {
   const { methodGuards, symbolMethodGuards = emptyCopyMap } =
     getInterfaceGuardPayload(interfaceGuard);
   /** @type {(string | symbol)[]} */
-  // @ts-expect-error inference is too weak to see this is ok
+  // TODO at-ts-expect-error works locally but not from @endo/exo
+  // @ts-ignore inference is too weak to see this is ok
   return harden([
     ...Reflect.ownKeys(methodGuards),
     ...getCopyMapKeys(symbolMethodGuards),


### PR DESCRIPTION
closes: #1817 
refs: #1815 #1808 #1773 #1766 

## Description

The intention of the exo-making methods was to be able to use a JS class' `.prototype` as a source of raw methods. This PR
* fixes the bugs reported in #1817 that prevented use of JS classes as a source of raw methods for an exo class.
* additionally accommodates JS class inheritance so that superclasses can also provide raw classes.
* provides tests that show use of JS classes to construct Exo classes.
* these tests also provide hypothetical helper abstractions for better supporting such use of classes. 
   * These helpers remain in tests because this PR merely demonstrates that such support is possible, without committing to the particular helpers to actually provide. We need at least to bikeshed from the currently awful names (`defineExoClassFromJSClass`).
* these tests demonstrate the use of both `super` and late-bound `self` in inheritance among these methods, with `super` calls bypassing guards, while `self` calls are guarded.

This PR also provides tests demonstrating the use of JS classes to directly provide unguarded behavior at the `@endo/pass-style` / `Far` level of abstraction. This PR makes no changes to the `src/` code at this level, demonstrating what support is already possible. Unlike the above exo-level support, we do *not* recommend the coding style shown in these pass-style level tests. However, neither can we reasonably prevent it, so we need to understand it.

### Security Considerations

Corresponding examples at 
https://github.com/endojs/endo/blob/d50a60bc3e5f477afad92b05d03335205e4b9451/packages/pass-style/test/test-far-wobbly-point.js#L132-L144

and
https://github.com/endojs/endo/blob/d50a60bc3e5f477afad92b05d03335205e4b9451/packages/exo/test/test-exo-wobbly-point.js#L183-L193

demonstrates that the demonstrated non-recommended use of class inheritance at the far level of abstraction has a security vulnerability absent from the use of class inheritance at the exo level of abstraction. This is one reason why we do not recommend the former but may recommend the latter.

### Scaling Considerations

If classes had large number of methods *and* class inheritance chains were deep, this has somewhat worse scaling than a JS class programmer would normally expect. However, if either of these are reasonably small, there should not be any significant scaling problem.

### Documentation Considerations

If we decide that we like and wish to promote the use of JS classes demonstrated by this PR, we should move some support (`defineExoClassFromJSClass`) into exported sources and we should document the whole approach. The purpose of this PR is not to establish such practice or decide on its exact shape, but merely to demonstrate that this PR makes such JS class-based practice possible.

In particular, we may be able to improve of the usability shown in this PR by using JS class decorators. It is a worthy experiment. (attn @mhofman )

### Testing Considerations

The `src` changes that this PR makes are only to `exo-tools.js` code shared among heap, virtual, and durable exos. However, the tests only test the behavior of heap exos. Once agoric-sdk is upgraded to depend on the changes from this PR, we should reproduce these tests for virtual and durable exos. Ideally, we would use Zones to write the tests once and then reuse it to test all three types of zone.

This PR makes no effort to test JS classes used for facets of exo kits. Nor does it provide any hypothetical helper functions to help write such exo kits. If we decide that this code pattern for using JS classes is attractive, a later PR should indeed extend the approach to exo kits.

### Upgrade Considerations

This PR makes no changes to data. For existing exo-making code that only uses object literals for own enumerable methods, this PR should not result in any behavior change or even internal representation change. The only code it should make a difference for is code that previously did not work because it needed the fixes and features provided by this PR. We are not aware of any such code prior to this PR.