### PR TITLE
test(static-module-record): Validate export var

### DIFF
--- a/packages/static-module-record/test/fixtures/browserfs.js
+++ b/packages/static-module-record/test/fixtures/browserfs.js
@@ -1,0 +1,26 @@
+
+// src/ApiError.ts
+var ErrorCode = /* @__PURE__ */ ((ErrorCode2) => {
+  ErrorCode2[ErrorCode2["EPERM"] = 1] = "EPERM";
+  ErrorCode2[ErrorCode2["ENOENT"] = 2] = "ENOENT";
+  ErrorCode2[ErrorCode2["EIO"] = 5] = "EIO";
+  ErrorCode2[ErrorCode2["EBADF"] = 9] = "EBADF";
+  ErrorCode2[ErrorCode2["EACCES"] = 13] = "EACCES";
+  ErrorCode2[ErrorCode2["EBUSY"] = 16] = "EBUSY";
+  ErrorCode2[ErrorCode2["EEXIST"] = 17] = "EEXIST";
+  ErrorCode2[ErrorCode2["ENOTDIR"] = 20] = "ENOTDIR";
+  ErrorCode2[ErrorCode2["EISDIR"] = 21] = "EISDIR";
+  ErrorCode2[ErrorCode2["EINVAL"] = 22] = "EINVAL";
+  ErrorCode2[ErrorCode2["EFBIG"] = 27] = "EFBIG";
+  ErrorCode2[ErrorCode2["ENOSPC"] = 28] = "ENOSPC";
+  ErrorCode2[ErrorCode2["EROFS"] = 30] = "EROFS";
+  ErrorCode2[ErrorCode2["ENOTEMPTY"] = 39] = "ENOTEMPTY";
+  ErrorCode2[ErrorCode2["ENOTSUP"] = 95] = "ENOTSUP";
+  return ErrorCode2;
+})(ErrorCode || {});
+
+ErrorCode[1];
+
+export {
+  ErrorCode
+}

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -792,3 +792,19 @@ test('should handle package "immer" source', t => {
     setUseProxies: ['vn', true],
   });
 });
+
+// Regression test for https://github.com/jvilk/BrowserFS
+test.failing('should handle package "browserfs" source', t => {
+  const { __syncModuleProgram__ } = new StaticModuleRecord(
+    readFixture('fixtures/browserfs.js'),
+  );
+  t.notThrows(() => {
+    // This is throwing a ReferenceError for "ErrorCode"
+    eval(__syncModuleProgram__)({
+      'imports': () => {},
+      'liveVar': {
+        ErrorCode: () => {},
+      }
+    });
+  });
+});

--- a/packages/static-module-record/test/test-static-module-record.js
+++ b/packages/static-module-record/test/test-static-module-record.js
@@ -745,6 +745,72 @@ test('source map generation', t => {
   t.assert(/must-appear/.test(__syncModuleProgram__));
 });
 
+test('should export a var', t => {
+  const { __syncModuleProgram__ } = new StaticModuleRecord(`
+    export var x = 10;
+  `);
+  const c = new Compartment();
+  t.notThrows(() => {
+    c.evaluate(__syncModuleProgram__, {
+      __moduleShimLexicals__: {
+        x: undefined,
+      },
+    })({
+      imports: () => {},
+      liveVar: {
+        x: () => {},
+      },
+    });
+  });
+});
+
+// Isolation test for https://github.com/jvilk/BrowserFS
+test('var should be able to initialize with its own value', t => {
+  const { __syncModuleProgram__ } = new StaticModuleRecord(`
+    export var x = x, y = (y, y);
+  `);
+  t.log(__syncModuleProgram__);
+  const c = new Compartment();
+  t.notThrows(() => {
+    // This is throwing a ReferenceError for "ErrorCode"
+    c.evaluate(__syncModuleProgram__, {
+      __moduleShimLexicals__: {
+        x: undefined,
+        y: undefined,
+      },
+    })({
+      imports: () => {},
+      liveVar: {
+        x: () => {},
+        y: () => {},
+      },
+    });
+  });
+});
+
+test('should hoist and reinitialize var', t => {
+  const { __syncModuleProgram__ } = new StaticModuleRecord(`
+    var x;
+    var x = x;
+    export { x };
+  `);
+  t.log(__syncModuleProgram__);
+  const c = new Compartment();
+  t.notThrows(() => {
+    // This is throwing a ReferenceError for "ErrorCode"
+    c.evaluate(__syncModuleProgram__, {
+      __moduleShimLexicals__: {
+        x: undefined,
+      },
+    })({
+      imports: () => {},
+      liveVar: {
+        x: () => {},
+      },
+    });
+  });
+});
+
 // Regression test for #823
 test('static module records can name Map in scope', t => {
   t.notThrows(() => initialize(t, `const { Map } = globalThis;`));
@@ -794,17 +860,22 @@ test('should handle package "immer" source', t => {
 });
 
 // Regression test for https://github.com/jvilk/BrowserFS
-test.failing('should handle package "browserfs" source', t => {
+test('should handle package "browserfs" source', t => {
   const { __syncModuleProgram__ } = new StaticModuleRecord(
     readFixture('fixtures/browserfs.js'),
   );
+  const c = new Compartment();
   t.notThrows(() => {
-    // This is throwing a ReferenceError for "ErrorCode"
-    eval(__syncModuleProgram__)({
-      'imports': () => {},
-      'liveVar': {
+    // This was throwing a ReferenceError for "ErrorCode"
+    c.evaluate(__syncModuleProgram__, {
+      __moduleShimLexicals__: {
+        ErrorCode: undefined,
+      },
+    })({
+      imports: () => {},
+      liveVar: {
         ErrorCode: () => {},
-      }
+      },
     });
   });
 });


### PR DESCRIPTION
closes: #1805

This change adds tests that validate the `StaticModuleRecord` treatment for exported vars.

The search to isolate the defect @kumavis found continues.