### PR TITLE
fix(ses): error stack consistency

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -152,6 +152,7 @@ export const uncurryThis = bind.bind(bind.call); // eslint-disable-line @endo/no
 
 export const objectHasOwnProperty = uncurryThis(objectPrototype.hasOwnProperty);
 //
+export const arrayEvery = uncurryThis(arrayPrototype.every);
 export const arrayFilter = uncurryThis(arrayPrototype.filter);
 export const arrayForEach = uncurryThis(arrayPrototype.forEach);
 export const arrayIncludes = uncurryThis(arrayPrototype.includes);

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -213,6 +213,7 @@ export const weaksetAdd = uncurryThis(weaksetPrototype.add);
 export const weaksetHas = uncurryThis(weaksetPrototype.has);
 //
 export const functionToString = uncurryThis(functionPrototype.toString);
+export const errorToString = uncurryThis(Error.prototype.toString);
 //
 const { all } = Promise;
 export const promiseAll = promises => apply(all, Promise, [promises]);

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -20,15 +20,13 @@ import {
   arrayPop,
   arrayPush,
   assign,
+  errorToString,
   freeze,
   globalThis,
   is,
   isError,
   regexpTest,
-  stringIndexOf,
   stringReplace,
-  stringSlice,
-  stringStartsWith,
   weakmapDelete,
   weakmapGet,
   weakmapHas,
@@ -331,14 +329,9 @@ freeze(note);
  */
 const defaultGetStackString = error => {
   if (!('stack' in error)) {
-    return '';
+    return errorToString(error);
   }
-  const stackString = `${error.stack}`;
-  const pos = stringIndexOf(stackString, '\n');
-  if (stringStartsWith(stackString, ' ') || pos === -1) {
-    return stackString;
-  }
-  return stringSlice(stackString, pos + 1); // exclude the initial newline
+  return `${error.stack}`;
 };
 
 /** @type {LoggedErrorHandler} */

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -15,6 +15,9 @@ import {
   fromEntries,
   isError,
   stringEndsWith,
+  stringSlice,
+  stringSplit,
+  stringStartsWith,
   weaksetAdd,
   weaksetHas,
 } from '../commons.js';
@@ -268,6 +271,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
       return;
     }
     const errorTag = tagError(error);
+    const errorMessage = error.message;
     weaksetAdd(errorsLogged, error);
     const subErrors = [];
     const messageLogArgs = takeMessageLogArgs(error);
@@ -280,7 +284,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
       // If there is no message log args, then just show the message that
       // the error itself carries.
       // eslint-disable-next-line @endo/no-polymorphic-call
-      baseConsole[severity](`${errorTag}:`, error.message);
+      baseConsole[severity](`${errorTag}:`, errorMessage);
     } else {
       // If there is one, we take it to be strictly more informative than the
       // message string carried by the error, so show it *instead*.
@@ -294,12 +298,19 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     }
     // After the message but before any other annotations, show the stack.
     let stackString = getStackString(error);
-    if (
-      typeof stackString === 'string' &&
-      stackString.length >= 1 &&
-      !stringEndsWith(stackString, '\n')
-    ) {
-      stackString += '\n';
+    if (typeof stackString === 'string' && stackString.length >= 1) {
+      const nameFromTag = stringSplit(errorTag, '#', 1)[0];
+      const stackDetailsLine = stringSplit(stackString, '\n', 1)[0];
+      // Remove the error details line if it matches error info we printed out
+      if (
+        stringStartsWith(stackDetailsLine, nameFromTag) &&
+        stringEndsWith(stackDetailsLine, errorMessage)
+      ) {
+        stackString = stringSlice(stackString, stackDetailsLine.length + 1);
+      }
+      if (!stringEndsWith(stackString, '\n')) {
+        stackString += '\n';
+      }
     }
     // eslint-disable-next-line @endo/no-polymorphic-call
     baseConsole[severity](stackString);

--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -21,7 +21,7 @@
 /**
  * @callback GetStackString
  * @param {Error} error
- * @returns {string=}
+ * @returns {string | undefined}
  */
 
 /**

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -19,7 +19,7 @@ const originalConsole = console;
  * @param {"safe" | "unsafe"} consoleTaming
  * @param {"platform" | "exit" | "abort" | "report" | "none"} [errorTrapping]
  * @param {"report" | "none"} [unhandledRejectionTrapping]
- * @param {GetStackString=} optGetStackString
+ * @param {GetStackString} [optGetStackString]
  */
 export const tameConsole = (
   consoleTaming = 'safe',

--- a/packages/ses/src/error/tame-v8-error-constructor.js
+++ b/packages/ses/src/error/tame-v8-error-constructor.js
@@ -8,6 +8,7 @@ import {
   arraySlice,
   create,
   defineProperties,
+  errorToString,
   fromEntries,
   reflectSet,
   regexpExec,
@@ -186,11 +187,11 @@ export const tameV8ErrorConstructor = (
     return `\n  at ${callSiteString}`;
   };
 
-  const stackStringFromSST = (_error, sst) =>
-    arrayJoin(
+  const stackStringFromSST = (error, sst) =>
+    `${errorToString(error)}${arrayJoin(
       arrayMap(arrayFilter(sst, callSiteFilter), callSiteStringifier),
       '',
-    );
+    )}`;
 
   /**
    * @typedef {object} StructuredStackInfo
@@ -260,7 +261,7 @@ export const tameV8ErrorConstructor = (
       if (errorTaming === 'unsafe') {
         const stackString = stackStringFromSST(error, sst);
         weakmapSet(stackInfos, error, { stackString });
-        return `${error}${stackString}`;
+        return stackString;
       } else {
         weakmapSet(stackInfos, error, { callSites: sst });
         return '';

--- a/packages/ses/test/error/test-tame-v8-error-unsafe.js
+++ b/packages/ses/test/error/test-tame-v8-error-unsafe.js
@@ -94,7 +94,9 @@ test('SES compartment error compatibility - endow w Error power', t => {
   const c1 = new Compartment({ t, Error });
   const result = c1.evaluate(`
     const obj = {
-      toString: () => 'Pseudo Error',
+      name: 'PseudoError',
+      message: 'my message',
+      toString: () => 'OverridenError: not the message',
     };
     const limit = Error.stackTraceLimit;
     const newSTL = Math.max(10, limit);
@@ -106,7 +108,7 @@ test('SES compartment error compatibility - endow w Error power', t => {
     Error.stackTraceLimit = limit;
     obj.stack;
   `);
-  t.assert(result.startsWith('Pseudo Error\n  at '));
+  t.regex(result, /^PseudoError: my message\n +at /);
 });
 
 test('SES compartment error compatibility - endow w Error with locally configurable prepareStackTrace', t => {

--- a/packages/ses/test/error/test-tame-v8-error.js
+++ b/packages/ses/test/error/test-tame-v8-error.js
@@ -1,3 +1,4 @@
+/* global getStackString */
 import test from 'ava';
 import '../../index.js';
 
@@ -6,19 +7,29 @@ lockdown();
 test('lockdown Error is safe', t => {
   t.is(typeof Error.captureStackTrace, 'function');
   t.is(typeof Error.stackTraceLimit, 'number');
-  t.is(typeof Error().stack, 'string');
+  t.is(Error().stack, '');
+});
+
+test('getStackString', t => {
+  t.is(typeof getStackString, 'function');
+
+  const error = Error('my message');
+  error.name = 'CustomError';
+  error.toString = () => 'OverridenError: not the message';
+  const stackString = getStackString(error);
+  t.regex(stackString, /^CustomError: my message(\n +[^\n]+)?$/m);
 });
 
 test('lockdown Error in Compartment is safe', t => {
   const c = new Compartment();
   t.is(c.evaluate('typeof Error.captureStackTrace'), 'function');
   t.is(c.evaluate('typeof Error.stackTraceLimit'), 'undefined');
-  t.is(c.evaluate('typeof Error().stack'), 'string');
+  t.is(c.evaluate('Error().stack'), '');
 });
 
 test('lockdown Error in nested Compartment is safe', t => {
   const c = new Compartment().evaluate('new Compartment()');
   t.is(c.evaluate('typeof Error.captureStackTrace'), 'function');
   t.is(c.evaluate('typeof Error.stackTraceLimit'), 'undefined');
-  t.is(c.evaluate('typeof Error().stack'), 'string');
+  t.is(c.evaluate('Error().stack'), '');
 });


### PR DESCRIPTION
closes: #1810

## Description

This change adds some rough normalizing of the shape of stack strings:
- Includes error details in the first line, using the captured `Error.prototype.toString`
- Stack frame lines are indented by at least one space (the shim uses 2 when it inserts them)
- No trailing new line in stack strings

Furthermore it brings consistency to the various stack properties:
- On non-v8, when error taming is safe, the stack prototype getter returns the empty string instead of the error details, like it already does on v8

Because `getStackString` now always includes the error details, I made the `defaultGetStackString` defined by asserts's `loggedErrorHandler` to no longer remove the first line. Accordingly I modified the console taming logic to only remove the first line of the stack string if it includes the error details, as those are already logged explicitly.

### Security Considerations

None

### Scaling Considerations

There will be slightly more processing of non-v8 error stacks when accessed, but it shouldn't impact most operations

### Documentation Considerations

TBD

### Testing Considerations

We don't have a good way to test cross engines. I manually tested the stack string shape normalization with `eshost`

### Upgrade Considerations

The stack string changes may be observable. In particular we're no longer using an own `toString` to print the details.
