### PR TITLE
fix(daemon): Strengthen type checks

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -223,6 +223,12 @@ export const makeNetworkPowers = ({ http, ws, net }) => {
     return readFrom;
   };
 
+  /**
+   * @param {object} args
+   * @param {number} args.port
+   * @param {string} [args.host]
+   * @param {Promise<never>} args.cancelled
+   */
   const servePort = async ({ port, host = '0.0.0.0', cancelled }) =>
     serveListener(
       server =>
@@ -232,6 +238,11 @@ export const makeNetworkPowers = ({ http, ws, net }) => {
       cancelled,
     );
 
+  /**
+   * @param {object} args
+   * @param {string} args.path
+   * @param {Promise<never>} args.cancelled
+   */
   const servePath = async ({ path, cancelled }) =>
     serveListener(
       server =>

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -103,7 +103,9 @@ export const makeMailboxMaker = ({
         }
         return undefined;
       }
-      throw Error(`panic: Unknown message type ${type}`);
+      throw new Error(
+        `panic: Unknown message type ${/** @type {any} */ (message).type}`,
+      );
     };
 
     const listMessages = async () =>

--- a/packages/daemon/src/pet-name.js
+++ b/packages/daemon/src/pet-name.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const { quote: q } = assert;
 
 const validNamePattern = /^[a-z][a-z0-9-]{0,127}$/;

--- a/packages/daemon/src/pubsub.js
+++ b/packages/daemon/src/pubsub.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeStream } from '@endo/stream';
 

--- a/packages/daemon/src/pubsub.js
+++ b/packages/daemon/src/pubsub.js
@@ -11,7 +11,7 @@ const freeze = /** @type {<T>(v: T | Readonly<T>) => T} */ (Object.freeze);
 /**
  * @template TValue TValue
  * @param {TValue} value
- * @returns {import('./types.js').AsyncQueue<TValue, unknown>}
+ * @returns {import('@endo/stream').AsyncQueue<TValue, unknown>}
  */
 export const makeNullQueue = value =>
   harden({

--- a/packages/daemon/src/serve-private-path.js
+++ b/packages/daemon/src/serve-private-path.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { makeNetstringCapTP } from './connection.js';
 
 const { quote: q } = assert;

--- a/packages/daemon/src/serve-private-port-http.js
+++ b/packages/daemon/src/serve-private-port-http.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { E } from '@endo/far';
 import { mapReader, mapWriter } from '@endo/stream';
 import {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -141,13 +141,13 @@ export interface Topic<
 }
 
 export interface PetStore {
-  lookup(petName: string): string | undefined;
-  reverseLookup(formulaIdentifier: string): Array<string>;
   list(): Array<string>;
-  follow(): Promise<FarRef<Stream<unknown>>>;
   write(petName: string, formulaIdentifier: string): Promise<void>;
   remove(petName: string);
   rename(fromPetName: string, toPetName: string);
+  lookup(petName: string): string | undefined;
+  reverseLookup(formulaIdentifier: string): Array<string>;
+  follow(): Promise<FarRef<String<{ add: string } | { remove: string }>>>;
 }
 
 export type RequestFn = (
@@ -184,9 +184,10 @@ export interface EndoGuest {
 export interface EndoHost {
   listMessages(): Promise<Array<Message>>;
   followMessages(): ERef<AsyncIterable<Message>>;
+  lookup(petName: string): Promise<unknown>;
   resolve(requestNumber: number, petName: string);
   reject(requestNumber: number, message: string);
-  lookup(ref: object): Promise<Array<string>>;
+  reverseLookup(ref: object): Promise<Array<string>>;
   remove(petName: string);
   rename(fromPetName: string, toPetName: string);
   list(): Array<string>; // pet names

--- a/packages/daemon/src/web-page-bundler.js
+++ b/packages/daemon/src/web-page-bundler.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // This is a built-in unsafe plugin for lazily constructing the web-page.js
 // bundle for booting up web caplets.
 // The hard-coded 'web-page-js' formula is a hard-coded 'import-unsafe' formula

--- a/packages/daemon/src/web-page.js
+++ b/packages/daemon/src/web-page.js
@@ -22,7 +22,7 @@ const endowments = Object.freeze({
   console,
 });
 
-const url = new URL('/', window.location);
+const url = new URL('/', `${window.location}`);
 url.protocol = 'ws';
 
 const bootstrap = Far('WebFacet', {

--- a/packages/daemon/src/web-page.js
+++ b/packages/daemon/src/web-page.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global window, document */
 
 import '@endo/init/debug.js';

--- a/packages/daemon/src/worker-node.js
+++ b/packages/daemon/src/worker-node.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global process */
 
 // Establish a perimeter:

--- a/packages/daemon/src/worker-node.js
+++ b/packages/daemon/src/worker-node.js
@@ -25,7 +25,7 @@ if (process.argv.length < 7) {
 const [workerUuid, sockPath, statePath, ephemeralStatePath, cachePath] =
   process.argv.slice(2);
 
-/** @type {import('../index.js').Locator} */
+/** @type {import('./types.js').Locator} */
 const locator = {
   sockPath,
   statePath,

--- a/packages/stream/index.js
+++ b/packages/stream/index.js
@@ -54,8 +54,8 @@ harden(makeQueue);
  * @template TWrite
  * @template TReadReturn
  * @template TWriteReturn
- * @param {import('./types.js').AsyncQueue<IteratorResult<TRead, TReadReturn>>} acks
- * @param {import('./types.js').AsyncQueue<IteratorResult<TWrite, TWriteReturn>>} data
+ * @param {import('./types.js').AsyncSpring<IteratorResult<TRead, TReadReturn>>} acks
+ * @param {import('./types.js').AsyncSink<IteratorResult<TWrite, TWriteReturn>>} data
  */
 export const makeStream = (acks, data) => {
   const stream = harden({

--- a/packages/stream/types.d.ts
+++ b/packages/stream/types.d.ts
@@ -1,7 +1,14 @@
-export interface AsyncQueue<TValue> {
+export interface AsyncSink<TValue> {
   put(value: TValue | Promise<TValue>): void;
+}
+
+export interface AsyncSpring<TValue> {
   get(): Promise<TValue>;
 }
+
+export interface AsyncQueue<TSpringValue, TSinkValue = TSpringValue>
+  extends AsyncSpring<TSpringValue>,
+    AsyncSink<TSinkValue> {}
 
 // Stream is nearly identical to AsyncGenerator and AsyncGenerator should
 // probably be identical to this definition of Stream.
@@ -40,8 +47,8 @@ export declare function makeStream<
   TReadReturn = undefined,
   TWriteReturn = undefined,
 >(
-  acks: AsyncQueue<IteratorResult<TRead, TReadReturn>>,
-  data: AsyncQueue<IteratorResult<TWrite, TWriteReturn>>,
+  acks: AsyncSpring<IteratorResult<TRead, TReadReturn>>,
+  data: AsyncSink<IteratorResult<TWrite, TWriteReturn>>,
 ): Stream<TRead, TWrite, TReadReturn, TWriteReturn>;
 
 export declare function makePipe<


### PR DESCRIPTION
Evidently type checks have drifted because `@ts-check` comments are for some reason not redundant with `"checkJs": true` as advertised. This change gets ts-check to pass for all the daemon sources.