### PR TITLE
fix(compartment-mapper): fix for bundling of appended cjs exports

### DIFF
--- a/packages/compartment-mapper/src/bundle-cjs.js
+++ b/packages/compartment-mapper/src/bundle-cjs.js
@@ -5,7 +5,9 @@ const exportsCellRecord = exportsList =>
   ''.concat(
     ...exportsList.map(
       exportName => `\
-      ${exportName}: cell(${q(exportName)}),
+      ${q(exportName)}: cell(${q(exportName)}${
+        exportName !== 'default' ? '' : `, {}`
+      }),
 `,
     ),
   );
@@ -14,15 +16,28 @@ const exportsCellRecord = exportsList =>
 const runtime = function wrapCjsFunctor(num) {
   /* eslint-disable no-undef */
   return ({ imports = {} }) => {
+    const moduleCells = cells[num];
     const cModule = Object.freeze(
-      Object.defineProperty({}, 'exports', cells[num].default),
+      Object.defineProperty({}, 'exports', moduleCells.default),
     );
     // TODO: specifier not found handling
     const requireImpl = specifier => cells[imports[specifier]].default.get();
     functors[num](Object.freeze(requireImpl), cModule.exports, cModule);
-    Object.keys(cells[num])
+    // Update all named cells from module.exports.
+    Object.keys(moduleCells)
       .filter(k => k !== 'default' && k !== '*')
-      .map(k => cells[num][k].set(cModule.exports[k]));
+      .map(k => moduleCells[k].set(cModule.exports[k]));
+    // Add new named cells from module.exports.
+    Object.keys(cModule.exports)
+      .filter(k => k !== 'default' && k !== '*')
+      .filter(k => moduleCells[k] === undefined)
+      .map(k => (moduleCells[k] = cell(k, cModule.exports[k])));
+    // Update the star cell from all cells.
+    const starExports = Object.create(null);
+    Object.keys(moduleCells)
+      .filter(k => k !== '*')
+      .map(k => Object.defineProperty(starExports, k, moduleCells[k]));
+    moduleCells['*'].set(Object.freeze(starExports));
   };
   /* eslint-enable no-undef */
 }.toString();

--- a/packages/compartment-mapper/test/test-bundle.js
+++ b/packages/compartment-mapper/test/test-bundle.js
@@ -77,3 +77,44 @@ test('equivalent archive behaves the same as bundle', async t => {
   });
   t.deepEqual(log, expectedLog);
 });
+
+// This is failing because it requires support for missing dependencies.
+// Cannot bundle: encountered deferredError Cannot find file for internal module "./spam"
+test.failing('bundle cjs-compat', async t => {
+  const cjsFixture = new URL(
+    'fixtures-cjs-compat/node_modules/app/index.js',
+    import.meta.url,
+  ).toString();
+
+  const bundle = await makeBundle(read, cjsFixture);
+  const log = [];
+  const print = entry => {
+    log.push(entry);
+  };
+  const compartment = new Compartment({ print });
+  compartment.evaluate(bundle);
+  t.deepEqual(log, expectedLog);
+});
+
+test('bundle cjs-compat default-difficulties', async t => {
+  const cjsFixture = new URL(
+    'fixtures-cjs-compat/node_modules/default-difficulties/index.mjs',
+    import.meta.url,
+  ).toString();
+
+  const bundle = await makeBundle(read, cjsFixture);
+  const compartment = new Compartment();
+  const { results } = compartment.evaluate(bundle);
+  const resultExports = results.map(result => {
+    return Object.keys(result).sort();
+  });
+  t.deepEqual(resultExports, [
+    ['default', 'even'],
+    ['default', 'even', 'version'],
+    ['__esModule', 'default', 'even', 'version'],
+    ['__esModule', 'default', 'even', 'version'],
+    ['default', 'even', 'version'],
+    ['default', 'even'],
+    ['default', 'even'],
+  ]);
+});


### PR DESCRIPTION
bug fix for bundler for supporting the following commonjs exports patterns 
```js
module.exports.abc = 123
exports.xyz = 456
```

Originally tried to fix it with https://github.com/endojs/endo/commit/7daba15b88752898ab1f9a1895d5cf479ea3575f
but this was insufficient, need to add missing cells and update the `*` cell

not sure if this is the correct change or just a bandaid but it got tests passing