### PR TITLE
fix(daemon): Various bug fixes

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -244,13 +244,22 @@ export const makeNetworkPowers = ({ http, ws, net }) => {
    * @param {Promise<never>} args.cancelled
    */
   const servePath = async ({ path, cancelled }) =>
-    serveListener(
-      server =>
-        new Promise(resolve =>
-          server.listen({ path }, () => resolve(undefined)),
-        ),
-      cancelled,
-    );
+    serveListener(server => {
+      return new Promise((resolve, reject) =>
+        server.listen({ path }, error => {
+          if (error) {
+            if (path.length >= 104) {
+              console.warn(
+                `Warning: Length of path for domain socket or named path exceeeds common maximum (104, possibly 108) for some platforms (length: ${path.length}, path: ${path})`,
+              );
+            }
+            reject(error);
+          } else {
+            resolve(undefined);
+          }
+        }),
+      );
+    }, cancelled);
 
   const connectionNumbers = (function* generateNumbers() {
     let n = 0;

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -265,7 +265,7 @@ export const makeNetworkPowers = ({ http, ws, net }) => {
    * @param {string} sockPath
    * @param {Promise<never>} cancelled
    * @param {(error: Error) => void} exitWithError
-   * @returns {{ started: () => Promise<void>, stopped: Promise<void> }}
+   * @returns {{ started: Promise<void>, stopped: Promise<void> }}
    */
   const makePrivatePathService = (
     endoBootstrap,
@@ -288,7 +288,7 @@ export const makeNetworkPowers = ({ http, ws, net }) => {
    * @param {(port: Promise<number>) => void} assignWebletPort
    * @param {Promise<never>} cancelled
    * @param {(error: Error) => void} exitWithError
-   * @returns {{ started: () => Promise<void>, stopped: Promise<void> }}
+   * @returns {{ started: Promise<void>, stopped: Promise<void> }}
    */
   const makePrivateHttpService = (
     endoBootstrap,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -407,7 +407,7 @@ const makeEndoBootstrap = (
       formula,
     );
 
-    // Memoize provide.
+    // Memoize for lookup.
     valuePromiseForFormulaIdentifier.set(formulaIdentifier, promiseForValue);
 
     // Prepare an entry for reverse-lookup of formula for presence.

--- a/packages/daemon/src/serve-private-path.js
+++ b/packages/daemon/src/serve-private-path.js
@@ -11,15 +11,15 @@ export const servePrivatePath = (
 ) => {
   const connectionsP = servePath({ path: sockPath, cancelled });
 
-  const started = async () => {
+  const started = (async () => {
     await connectionsP;
     // Resolve a promise in the Endo CLI through the IPC channel:
     console.log(
-      `Endo daemon listening for CapTP on ${q(
+      `Endo daemon listening for private CapTP on ${q(
         sockPath,
       )} ${new Date().toISOString()}`,
     );
-  };
+  })();
 
   const stopped = (async () => {
     /** @type {Set<Promise<void>>} */
@@ -33,7 +33,7 @@ export const servePrivatePath = (
       closed: connectionClosed,
     } of connections) {
       (async () => {
-        const connectionNumber = connectionNumbers.next();
+        const { value: connectionNumber } = connectionNumbers.next();
         console.log(
           `Endo daemon received domain connection ${connectionNumber} at ${new Date().toISOString()}`,
         );

--- a/packages/daemon/src/serve-private-port-http.js
+++ b/packages/daemon/src/serve-private-port-http.js
@@ -65,7 +65,7 @@ export const servePrivatePortHttp = (
           closed: connectionClosed,
         } = connection;
 
-        const connectionNumber = connectionNumbers.next();
+        const { value: connectionNumber } = connectionNumbers.next();
         console.log(
           `Endo daemon received local web socket connection ${connectionNumber} at ${new Date().toISOString()}`,
         );

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -271,14 +271,14 @@ export type NetworkPowers = {
     sockPath: string,
     cancelled: Promise<never>,
     exitWithError: (error: Error) => void,
-  ) => { started: () => Promise<void>; stopped: Promise<void> };
+  ) => { started: Promise<void>; stopped: Promise<void> };
   makePrivateHttpService: (
     endoBootstrap: FarRef<unknown>,
     port: number,
     assignWebletPort: (portP: Promise<number>) => void,
     cancelled: Promise<never>,
     exitWithError: (error: Error) => void,
-  ) => { started: () => Promise<void>; stopped: Promise<void> };
+  ) => { started: Promise<void>; stopped: Promise<void> };
 };
 
 // The return type here is almost an EndoReadable, but not quite. Should fix.


### PR DESCRIPTION
These are various bug fixes. There was a problem for services reporting that they started too early, due to a type mismatch for the `started` promise. Also, domain sockets evidently have a path length limit, so certain configurations will fail. The change here makes those errors more transparent to the user.