### PR TITLE
feat(daemon): Terminator DAG

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -481,6 +481,21 @@ export const main = async rawArgs => {
       return mkguest({ name, partyNames });
     });
 
+  program
+    .command('kill <name>')
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
+    .description('terminate a value and its deps, recovering resources')
+    .action(async (name, cmd) => {
+      const { as: partyNames } = cmd.opts();
+      const { killCommand } = await import('./kill.js');
+      return killCommand({ name, partyNames });
+    });
+
   const where = program
     .command('where')
     .description('prints paths for state, logs, caches, socket, pids');

--- a/packages/cli/src/kill.js
+++ b/packages/cli/src/kill.js
@@ -1,0 +1,9 @@
+/* global process */
+import os from 'os';
+import { E } from '@endo/far';
+import { withEndoParty } from './context.js';
+
+export const killCommand = async ({ name, partyNames }) =>
+  withEndoParty(partyNames, { os, process }, async ({ party }) => {
+    await E(party).terminate(name);
+  });

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -476,17 +476,15 @@ const makeEndoBootstrap = (
     return value;
   };
 
-  const { makeMailbox, partyReceiveFunctions, partyRequestFunctions } =
-    makeMailboxMaker({
-      formulaIdentifierForRef,
-      provideValueForFormulaIdentifier,
-      provideControllerForFormulaIdentifier,
-    });
+  const makeMailbox = makeMailboxMaker({
+    formulaIdentifierForRef,
+    provideValueForFormulaIdentifier,
+    provideControllerForFormulaIdentifier,
+  });
 
   const makeIdentifiedGuest = makeGuestMaker({
     provideValueForFormulaIdentifier,
-    partyReceiveFunctions,
-    partyRequestFunctions,
+    provideControllerForFormulaIdentifier,
     makeMailbox,
   });
 
@@ -495,8 +493,6 @@ const makeEndoBootstrap = (
     provideValueForFormula,
     provideValueForNumberedFormula,
     formulaIdentifierForRef,
-    partyReceiveFunctions,
-    partyRequestFunctions,
     storeReaderRef,
     randomHex512,
     makeSha512,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -10,6 +10,7 @@ import { makeRefReader } from './ref-reader.js';
 import { makeMailboxMaker } from './mail.js';
 import { makeGuestMaker } from './guest.js';
 import { makeHostMaker } from './host.js';
+import { assertPetName } from './pet-name.js';
 
 const { quote: q } = assert;
 
@@ -319,7 +320,7 @@ const makeEndoBootstrap = (
     const delimiterIndex = formulaIdentifier.indexOf(':');
     if (delimiterIndex < 0) {
       if (formulaIdentifier === 'pet-store') {
-        return petStorePowers.makeOwnPetStore('pet-store');
+        return petStorePowers.makeOwnPetStore('pet-store', assertPetName);
       } else if (formulaIdentifier === 'host') {
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
@@ -355,7 +356,10 @@ const makeEndoBootstrap = (
     } else if (prefix === 'worker-id512') {
       return makeIdentifiedWorker(formulaNumber);
     } else if (prefix === 'pet-store-id512') {
-      return petStorePowers.makeIdentifiedPetStore(formulaNumber);
+      return petStorePowers.makeIdentifiedPetStore(
+        formulaNumber,
+        assertPetName,
+      );
     } else if (prefix === 'host-id512') {
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -23,8 +23,8 @@ export const makeGuestMaker = ({
     const petStore = /** @type {import('./types.js').PetStore} */ (
       await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
     );
-    const host = /** @type {object} */ (
-      await provideValueForFormulaIdentifier(hostFormulaIdentifier)
+    const hostController = /** @type {import('./types.js').Controller<>} */ (
+      await provideControllerForFormulaIdentifier(hostFormulaIdentifier)
     );
 
     const deliverToHost = partyRequestFunctions.get(host);
@@ -81,7 +81,7 @@ export const makeGuestMaker = ({
     partyReceiveFunctions.set(guest, receive);
     partyRequestFunctions.set(guest, respond);
 
-    return guest;
+    return { promise: guest };
   };
 
   return makeIdentifiedGuest;

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -9,8 +9,6 @@ export const makeHostMaker = ({
   provideValueForFormulaIdentifier,
   provideValueForFormula,
   provideValueForNumberedFormula,
-  partyReceiveFunctions,
-  partyRequestFunctions,
   formulaIdentifierForRef,
   storeReaderRef,
   makeSha512,
@@ -443,10 +441,9 @@ export const makeHostMaker = ({
       provideWebPage,
     });
 
-    partyReceiveFunctions.set(host, receive);
-    partyRequestFunctions.set(host, respond);
+    const internal = { receive, respond };
 
-    return { promise: host };
+    return { promise: host, internal };
   };
 
   return makeIdentifiedHost;

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -19,12 +19,17 @@ export const makeHostMaker = ({
    * @param {string} hostFormulaIdentifier
    * @param {string} storeFormulaIdentifier
    * @param {string} mainWorkerFormulaIdentifier
+   * @param {import('./types.js').Terminator} terminator
    */
   const makeIdentifiedHost = async (
     hostFormulaIdentifier,
     storeFormulaIdentifier,
     mainWorkerFormulaIdentifier,
+    terminator,
   ) => {
+    terminator.thisDiesIfThatDies(storeFormulaIdentifier);
+    terminator.thisDiesIfThatDies(mainWorkerFormulaIdentifier);
+
     const petStore = /** @type {import('./types.js').PetStore} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
@@ -56,6 +61,7 @@ export const makeHostMaker = ({
         NONE: 'least-authority',
         ENDO: 'endo',
       },
+      terminator,
     });
 
     /**
@@ -441,9 +447,11 @@ export const makeHostMaker = ({
       provideWebPage,
     });
 
-    const internal = { receive, respond };
+    const internal = harden({ receive, respond });
 
-    return { promise: host, internal };
+    await provideValueForFormulaIdentifier(mainWorkerFormulaIdentifier);
+
+    return harden({ external: host, internal });
   };
 
   return makeIdentifiedHost;

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -444,7 +444,7 @@ export const makeHostMaker = ({
     partyReceiveFunctions.set(host, receive);
     partyRequestFunctions.set(host, respond);
 
-    return host;
+    return { promise: host };
   };
 
   return makeIdentifiedHost;

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -49,6 +49,7 @@ export const makeHostMaker = ({
       adopt,
       rename,
       remove,
+      terminate,
     } = makeMailbox({
       petStore,
       selfFormulaIdentifier: hostFormulaIdentifier,
@@ -436,6 +437,7 @@ export const makeHostMaker = ({
       makeWorker,
       provideWorker,
       evaluate,
+      terminate,
       importUnsafeAndEndow,
       importBundleAndEndow,
       provideWebPage,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -54,6 +54,8 @@ export const makeHostMaker = ({
       selfFormulaIdentifier: hostFormulaIdentifier,
       specialNames: {
         SELF: hostFormulaIdentifier,
+        NONE: 'least-authority',
+        ENDO: 'endo',
       },
     });
 
@@ -159,14 +161,6 @@ export const makeHostMaker = ({
      * @param {string | 'NONE' | 'HOST' | 'ENDO'} partyName
      */
     const providePowersFormulaIdentifier = async partyName => {
-      if (partyName === 'NONE') {
-        return 'least-authority';
-      } else if (partyName === 'HOST') {
-        return 'host';
-      } else if (partyName === 'ENDO') {
-        return 'endo';
-      }
-      assertPetName(partyName);
       let guestFormulaIdentifier = lookupFormulaIdentifierForName(partyName);
       if (guestFormulaIdentifier === undefined) {
         const guest = await provideGuest(partyName);

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -377,9 +377,12 @@ export const makeMailboxMaker = ({
       if (recipientFormulaIdentifier === undefined) {
         throw new Error(`Unknown pet name for party: ${recipientName}`);
       }
-      const recipient = /** @type {object} */ (
-        await provideValueForFormulaIdentifier(recipientFormulaIdentifier)
-      );
+      const recipientController =
+        /** @type {import('./types.js').Controller<>} */ (
+          await provideControllerForFormulaIdentifier(
+            recipientFormulaIdentifier,
+          )
+        );
 
       const deliverToRecipient = partyRequestFunctions.get(recipient);
       if (deliverToRecipient === undefined) {

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -9,6 +9,7 @@ const { quote: q } = assert;
 
 export const makeMailboxMaker = ({
   provideValueForFormulaIdentifier,
+  provideControllerForFormulaIdentifier,
   formulaIdentifierForRef,
 }) => {
   /** @type {WeakMap<object, import('./types.js').RequestFn>} */
@@ -50,6 +51,23 @@ export const makeMailboxMaker = ({
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
       return provideValueForFormulaIdentifier(formulaIdentifier);
+    };
+
+    const terminate = async petName => {
+      const formulaIdentifier = lookupFormulaIdentifierForName(petName);
+      if (formulaIdentifier === undefined) {
+        throw new TypeError(`Unknown pet name: ${q(petName)}`);
+      }
+      // Behold, recursion:
+      // eslint-disable-next-line no-use-before-define
+      const controller = await provideControllerForFormulaIdentifier(
+        formulaIdentifier,
+      );
+      if (controller.terminate) {
+        controller.terminate();
+        return controller.terminated;
+      }
+      return undefined;
     };
 
     /**
@@ -454,6 +472,7 @@ export const makeMailboxMaker = ({
       adopt,
       rename,
       remove,
+      terminate,
     });
   };
 

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -63,7 +63,8 @@ export const makePetStoreMaker = (filePowers, locator) => {
     /** @param {string} petName */
     const lookup = petName => {
       assertValidName(petName);
-      return petNames.get(petName);
+      const formulaIdentifier = petNames.get(petName);
+      return formulaIdentifier;
     };
 
     /**

--- a/packages/daemon/src/terminator.js
+++ b/packages/daemon/src/terminator.js
@@ -1,0 +1,76 @@
+// @ts-check
+
+import { makePromiseKit } from '@endo/promise-kit';
+
+export const makeTerminatorMaker = ({
+  controllerForFormulaIdentifier,
+  provideControllerForFormulaIdentifier,
+}) => {
+  /**
+   * @param {string} formulaIdentifier
+   */
+  const makeTerminator = formulaIdentifier => {
+    let terminating = false;
+    const { promise: terminated, resolve: resolveTerminated } =
+      /** @type {import('@endo/promise-kit').PromiseKit<void>} */ (
+        makePromiseKit()
+      );
+
+    /** @type {Map<string, import('./types.js').Terminator>} */
+    const dependents = new Map();
+    /** @type {Array<() => void>} */
+    const hooks = [];
+
+    const terminate = (prefix = '*') => {
+      if (terminating) return terminated;
+      terminating = true;
+
+      console.log(`${prefix} ${formulaIdentifier}`);
+
+      controllerForFormulaIdentifier.delete(formulaIdentifier);
+      for (const dependentTerminator of dependents.values()) {
+        dependentTerminator.terminate(` ${prefix}`);
+      }
+      dependents.clear();
+
+      resolveTerminated(Promise.all(hooks.map(hook => hook())).then(() => {}));
+
+      return terminated;
+    };
+
+    const thatDiesIfThisDies = dependentFormulaIdentifier => {
+      assert(!terminating);
+      const dependentController = provideControllerForFormulaIdentifier(
+        dependentFormulaIdentifier,
+      );
+      dependents.set(
+        dependentFormulaIdentifier,
+        dependentController.terminator,
+      );
+    };
+
+    const thisDiesIfThatDies = dependencyIdentifier => {
+      const dependencyController =
+        provideControllerForFormulaIdentifier(dependencyIdentifier);
+      dependencyController.terminator.thatDiesIfThisDies(formulaIdentifier);
+    };
+
+    /**
+     * @param {() => void} hook
+     */
+    const onTerminate = hook => {
+      assert(!terminating);
+      hooks.push(hook);
+    };
+
+    return {
+      terminate,
+      terminated,
+      thatDiesIfThisDies,
+      thisDiesIfThatDies,
+      onTerminate,
+    };
+  };
+
+  return makeTerminator;
+};

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -140,12 +140,23 @@ export interface Topic<
   subscribe(): Stream<TRead, TWrite, TReadReturn, TWriteReturn>;
 }
 
-export interface Controller<Value = unknown, Internal = unknown> {
-  promise: Promise<Value>;
+export interface Terminator {
+  terminate: (logPrefix?: string) => Promise<void>;
+  terminated: Promise<void>;
+  thisDiesIfThatDies: (formulaIdentifier: string) => void;
+  thatDiesIfThisDies: (formulaIdentifier: string) => void;
+  onTerminate: (hook: () => void | Promise<void>) => void;
+}
+
+export interface InternalExternal<External = unknown, Internal = unknown> {
+  external: External;
   internal: Internal;
-  terminate?: () => {};
-  terminating?: Promise<void>;
-  terminated?: Promise<void>;
+}
+
+export interface Controller<External = unknown, Internal = unknown> {
+  external: Promise<External>;
+  internal: Promise<Internal>;
+  terminator: Terminator;
 }
 
 export interface PetStore {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -140,6 +140,14 @@ export interface Topic<
   subscribe(): Stream<TRead, TWrite, TReadReturn, TWriteReturn>;
 }
 
+export interface Controller<Value = unknown, Internal = unknown> {
+  promise: Promise<Value>;
+  internal: Internal;
+  terminate?: () => {};
+  terminating?: Promise<void>;
+  terminated?: Promise<void>;
+}
+
 export interface PetStore {
   list(): Array<string>;
   write(petName: string, formulaIdentifier: string): Promise<void>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -243,9 +243,17 @@ export type FilePowers = {
   renamePath: (source: string, target: string) => Promise<void>;
 };
 
+export type AssertValidNameFn = (name: string) => void;
+
 export type PetStorePowers = {
-  makeIdentifiedPetStore: (id: string) => Promise<FarRef<PetStore>>;
-  makeOwnPetStore: (name: string) => Promise<FarRef<PetStore>>;
+  makeIdentifiedPetStore: (
+    id: string,
+    assertValidName: AssertValidNameFn,
+  ) => Promise<FarRef<PetStore>>;
+  makeOwnPetStore: (
+    name: string,
+    assertValidName: AssertValidNameFn,
+  ) => Promise<FarRef<PetStore>>;
 };
 
 export type NetworkPowers = {

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -39,11 +39,13 @@ export const makeWorkerFacet = ({
      * @param {string} source
      * @param {Array<string>} names
      * @param {Array<unknown>} values
+     * @param {Promise<never>} cancelled
      */
-    evaluate: async (source, names, values) => {
+    evaluate: async (source, names, values, cancelled) => {
       const compartment = new Compartment(
         harden({
           ...endowments,
+          cancelled,
           ...Object.fromEntries(
             names.map((name, index) => [name, values[index]]),
           ),

--- a/packages/daemon/test/counter-party.js
+++ b/packages/daemon/test/counter-party.js
@@ -1,0 +1,11 @@
+import { E, Far } from '@endo/far';
+
+export const make = async powers => {
+  let counter = await E(powers).request('HOST', 'starting number', 'start');
+  return Far('Counter', {
+    incr() {
+      counter += 1;
+      return counter;
+    },
+  });
+};

--- a/packages/daemon/test/counter.js
+++ b/packages/daemon/test/counter.js
@@ -1,0 +1,11 @@
+import { Far } from '@endo/far';
+
+export const make = () => {
+  let counter = 0;
+  return Far('Counter', {
+    incr() {
+      counter += 1;
+      return counter;
+    },
+  });
+};

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -417,7 +417,7 @@ test('guest facet receives a message for host', async t => {
   const { value: message0 } = await E(iteratorRef).next();
   t.is(message0.number, 0);
   await E(host).resolve(message0.number, 'ten1');
-  await E(guest).send('HOST', 'Hello, World!', ['gift'], ['number']);
+  await E(guest).send('HOST', ['Hello, World!'], ['gift'], ['number']);
   const { value: message1 } = await E(iteratorRef).next();
   t.is(message1.number, 1);
   await E(host).adopt(message1.number, 'gift', 'ten2');

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -60,10 +60,8 @@ test('lifecycle', async t => {
   );
   const bootstrap = getBootstrap();
   const host = E(bootstrap).host();
-  const worker = await E(host).makeWorker();
-  await E(worker)
-    .terminate()
-    .catch(() => {});
+  await E(host).makeWorker('worker');
+  await E(host).terminate('worker');
   cancel(new Error('Cancelled'));
   await closed.catch(() => {});
 


### PR DESCRIPTION
This stack of changes gives us a `terminate(petName)` method on the Endo Host Powers object. This will cause the daemon to forget the current incarnation of that named value and all named values that depend upon it, including parties that  received the value through `request` or `adopt`. This also terminates workers.

The implications of termination are far-reaching and this is only the beginning. New formulas may self-destruct, like a formula that uses a file watcher to invalidate itself when its on-disk dependencies change. Connections may self-destruct if they disconnect. Weblets might auto-reload if their powers are invalidated.

Also, because the formulas form an acyclic DAG, simple ref-counting should suffice for garbage collecting formulas. Formulas can be retained by pet name paths, but also live values, so using a WeakRef in the future should allow us to automatically terminate and collect provably unreachable formulas.

To make this work, the internal memo now envelopes values in a controller object to track the corresponding terminator (synchronously) and the internal and external facets of the formula. This cleans up some side tables previously held for formula-specific internals like the worker bootstrap and the message bus between parties.