### PR TITLE
feat(eventual-send): breakpoint on delivery by env-options

### DIFF
--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -130,7 +130,6 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
       );
     },
     apply: (_target, _thisArg, argsArray = []) => {
-      HandledPromise.applyFunctionSendOnly(recipient, argsArray);
       if (onSend && onSend.shouldBreakpoint(recipient, undefined)) {
         // eslint-disable-next-line no-debugger
         debugger; // LOOK UP THE STACK
@@ -138,6 +137,7 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
         // so that you can walk back on the stack to see how we came to
         // make this eventual-send
       }
+      HandledPromise.applyFunctionSendOnly(recipient, argsArray);
       return undefined;
     },
     has: (_target, _p) => {

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -1,7 +1,10 @@
 import { trackTurns } from './track-turns.js';
+import { makeMessageBreakpointTester } from './message-breakpoints.js';
 
 const { details: X, quote: q, Fail } = assert;
 const { assign, create } = Object;
+
+const onSend = makeMessageBreakpointTester('ENDO_SEND_BREAKPOINTS');
 
 /** @type {ProxyHandler<any>} */
 const baseFreezableProxyHandler = {
@@ -31,38 +34,55 @@ const baseFreezableProxyHandler = {
 /**
  * A Proxy handler for E(x).
  *
- * @param {any} x Any value passed to E(x)
+ * @param {any} recipient Any value passed to E(x)
  * @param {import('./types').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
-const makeEProxyHandler = (x, HandledPromise) =>
+const makeEProxyHandler = (recipient, HandledPromise) =>
   harden({
     ...baseFreezableProxyHandler,
-    get: (_target, p, receiver) => {
+    get: (_target, propertyKey, receiver) => {
       return harden(
         {
           // This function purposely checks the `this` value (see above)
           // In order to be `this` sensitive it is defined using concise method
           // syntax rather than as an arrow function. To ensure the function
           // is not constructable, it also avoids the `function` syntax.
-          [p](...args) {
+          [propertyKey](...args) {
             if (this !== receiver) {
               // Reject the async function call
               return HandledPromise.reject(
                 assert.error(
-                  X`Unexpected receiver for "${p}" method of E(${q(x)})`,
+                  X`Unexpected receiver for "${propertyKey}" method of E(${q(
+                    recipient,
+                  )})`,
                 ),
               );
             }
 
-            return HandledPromise.applyMethod(x, p, args);
+            if (onSend && onSend.shouldBreakpoint(recipient, propertyKey)) {
+              // eslint-disable-next-line no-debugger
+              debugger; // LOOK UP THE STACK
+              // Stopped at a breakpoint on eventual-send of a method-call
+              // message,
+              // so that you can walk back on the stack to see how we came to
+              // make this eventual-send
+            }
+            return HandledPromise.applyMethod(recipient, propertyKey, args);
           },
           // @ts-expect-error https://github.com/microsoft/TypeScript/issues/50319
-        }[p],
+        }[propertyKey],
       );
     },
     apply: (_target, _thisArg, argArray = []) => {
-      return HandledPromise.applyFunction(x, argArray);
+      if (onSend && onSend.shouldBreakpoint(recipient, undefined)) {
+        // eslint-disable-next-line no-debugger
+        debugger; // LOOK UP THE STACK
+        // Stopped at a breakpoint on eventual-send of a function-call message,
+        // so that you can walk back on the stack to see how we came to
+        // make this eventual-send
+      }
+      return HandledPromise.applyFunction(recipient, argArray);
     },
     has: (_target, _p) => {
       // We just pretend everything exists.
@@ -74,35 +94,50 @@ const makeEProxyHandler = (x, HandledPromise) =>
  * A Proxy handler for E.sendOnly(x)
  * It is a variant on the E(x) Proxy handler.
  *
- * @param {any} x Any value passed to E.sendOnly(x)
+ * @param {any} recipient Any value passed to E.sendOnly(x)
  * @param {import('./types').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
-const makeESendOnlyProxyHandler = (x, HandledPromise) =>
+const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
   harden({
     ...baseFreezableProxyHandler,
-    get: (_target, p, receiver) => {
+    get: (_target, propertyKey, receiver) => {
       return harden(
         {
           // This function purposely checks the `this` value (see above)
           // In order to be `this` sensitive it is defined using concise method
           // syntax rather than as an arrow function. To ensure the function
           // is not constructable, it also avoids the `function` syntax.
-          [p](...args) {
+          [propertyKey](...args) {
             // Throw since the function returns nothing
             this === receiver ||
-              Fail`Unexpected receiver for "${q(p)}" method of E.sendOnly(${q(
-                x,
-              )})`;
-            HandledPromise.applyMethodSendOnly(x, p, args);
+              Fail`Unexpected receiver for "${q(
+                propertyKey,
+              )}" method of E.sendOnly(${q(recipient)})`;
+            if (onSend && onSend.shouldBreakpoint(recipient, propertyKey)) {
+              // eslint-disable-next-line no-debugger
+              debugger; // LOOK UP THE STACK
+              // Stopped at a breakpoint on eventual-send of a method-call
+              // message,
+              // so that you can walk back on the stack to see how we came to
+              // make this eventual-send
+            }
+            HandledPromise.applyMethodSendOnly(recipient, propertyKey, args);
             return undefined;
           },
           // @ts-expect-error https://github.com/microsoft/TypeScript/issues/50319
-        }[p],
+        }[propertyKey],
       );
     },
     apply: (_target, _thisArg, argsArray = []) => {
-      HandledPromise.applyFunctionSendOnly(x, argsArray);
+      HandledPromise.applyFunctionSendOnly(recipient, argsArray);
+      if (onSend && onSend.shouldBreakpoint(recipient, undefined)) {
+        // eslint-disable-next-line no-debugger
+        debugger; // LOOK UP THE STACK
+        // Stopped at a breakpoint on eventual-send of a function-call message,
+        // so that you can walk back on the stack to see how we came to
+        // make this eventual-send
+      }
       return undefined;
     },
     has: (_target, _p) => {

--- a/packages/eventual-send/src/message-breakpoints.js
+++ b/packages/eventual-send/src/message-breakpoints.js
@@ -7,7 +7,7 @@ const { hasOwn, freeze, entries } = Object;
 /**
  * @typedef {string | '*'} MatchStringTag
  *   A star `'*'` matches any recipient. Otherwise, the string is
- *   matched against the value of a recipient's` @@toStringTag`
+ *   matched against the value of a recipient's `@@toStringTag`
  *   after stripping out any leading `'Alleged: '` or `'DebugName: '`
  *   prefix. For objects defined with `Far` this is the first argument,
  *   known as the `farName`. For exos, this is the tag.
@@ -22,7 +22,7 @@ const { hasOwn, freeze, entries } = Object;
 /**
  * @typedef {number | '*'} MatchCountdown
  *   A star `'*'` will always breakpoint. Otherwise, the string
- *   must be a non-negative integer. Once zero, that always breakpoint.
+ *   must be a non-negative integer. Once that is zero, always breakpoint.
  *   Otherwise decrement by one each time it matches until it reaches zero.
  *   In other words, the countdown represents the number of
  *   breakpoint occurrences to skip before actually breakpointing.

--- a/packages/eventual-send/src/message-breakpoints.js
+++ b/packages/eventual-send/src/message-breakpoints.js
@@ -1,0 +1,148 @@
+import { getEnvironmentOption } from '@endo/env-options';
+
+const { quote: q, Fail } = assert;
+
+const { hasOwn, freeze, entries } = Object;
+
+/**
+ * This is the external JSON representation, in which
+ * - the outer property name is the class-like tag or '*',
+ * - the inner property name is the method name or '*',
+ * - the value is a non-negative integer countdown or '*'.
+ *
+ * @typedef {Record<string, Record<string, number | '*'>>} MessageBreakpoints
+ */
+
+/**
+ * This is the internal JSON representation, in which
+ * - the outer property name is the method name or '*',
+ * - the inner property name is the class-like tag or '*',
+ * - the value is a non-negative integer countdown or '*'.
+ *
+ * @typedef {Record<string, Record<string, number | '*'>>} BreakpointTable
+ */
+
+/**
+ * @typedef {object} MessageBreakpointTester
+ * @property {() => MessageBreakpoints} getBreakpoints
+ * @property {(newBreakpoints?: MessageBreakpoints) => void} setBreakpoints
+ * @property {(
+ *   recipient: object,
+ *   methodName: string | symbol | undefined
+ * ) => boolean} shouldBreakpoint
+ */
+
+/**
+ * @param {any} val
+ * @returns {val is Record<string, any>}
+ */
+const isJSONRecord = val =>
+  typeof val === 'object' && val !== null && !Array.isArray(val);
+
+/**
+ * @param {string} tag
+ * @returns {string}
+ */
+const simplifyTag = tag => {
+  for (const prefix of ['Alleged: ', 'DebugName: ']) {
+    if (tag.startsWith(prefix)) {
+      return tag.slice(prefix.length);
+    }
+  }
+  return tag;
+};
+
+/**
+ * @param {string} optionName
+ * @returns {MessageBreakpointTester | undefined}
+ */
+export const makeMessageBreakpointTester = optionName => {
+  let breakpoints = JSON.parse(getEnvironmentOption(optionName, 'null'));
+
+  if (breakpoints === null) {
+    return undefined;
+  }
+
+  /** @type {BreakpointTable} */
+  let breakpointsTable;
+
+  const getBreakpoints = () => breakpoints;
+  freeze(getBreakpoints);
+
+  const setBreakpoints = (newBreakpoints = breakpoints) => {
+    isJSONRecord(newBreakpoints) ||
+      Fail`Expected ${q(optionName)} option to be a JSON breakpoints record`;
+
+    /** @type {BreakpointTable} */
+    // @ts-expect-error confused by __proto__
+    const newBreakpointsTable = { __proto__: null };
+
+    for (const [tag, methodBPs] of entries(newBreakpoints)) {
+      tag === simplifyTag(tag) ||
+        Fail`Just use simple tag ${q(simplifyTag(tag))} rather than ${q(tag)}`;
+      isJSONRecord(methodBPs) ||
+        Fail`Expected ${q(optionName)} option's ${q(
+          tag,
+        )} to be a JSON methods breakpoints record`;
+      for (const [methodName, count] of entries(methodBPs)) {
+        count === '*' ||
+          (typeof count === 'number' &&
+            Number.isSafeInteger(count) &&
+            count >= 0) ||
+          Fail`Expected ${q(optionName)} option's ${q(tag)}.${q(
+            methodName,
+          )} to be "*" or a non-negative integer`;
+
+        const classBPs = hasOwn(newBreakpointsTable, methodName)
+          ? newBreakpointsTable[methodName]
+          : (newBreakpointsTable[methodName] = {
+              // @ts-expect-error confused by __proto__
+              __proto__: null,
+            });
+        classBPs[tag] = count;
+      }
+    }
+    breakpoints = newBreakpoints;
+    breakpointsTable = newBreakpointsTable;
+  };
+  freeze(setBreakpoints);
+
+  const shouldBreakpoint = (recipient, methodName) => {
+    if (methodName === undefined) {
+      // TODO enable function breakpointing
+      return false;
+    }
+    const classBPs = breakpointsTable[methodName] || breakpointsTable['*'];
+    if (classBPs === undefined) {
+      return false;
+    }
+    let tag = simplifyTag(recipient[Symbol.toStringTag]);
+    let count = classBPs[tag];
+    if (count === undefined) {
+      tag = '*';
+      count = classBPs[tag];
+      if (count === undefined) {
+        return false;
+      }
+    }
+    if (count === '*') {
+      return true;
+    }
+    if (count === 0) {
+      return true;
+    }
+    assert(typeof count === 'number' && count >= 1);
+    classBPs[tag] = count - 1;
+    return false;
+  };
+  freeze(shouldBreakpoint);
+
+  const breakpointTester = freeze({
+    getBreakpoints,
+    setBreakpoints,
+    shouldBreakpoint,
+  });
+  breakpointTester.setBreakpoints();
+  return breakpointTester;
+};
+freeze(makeMessageBreakpointTester);

--- a/packages/eventual-send/utils.js
+++ b/packages/eventual-send/utils.js
@@ -1,1 +1,2 @@
 export { getMethodNames } from './src/local.js';
+export { makeMessageBreakpointTester } from './src/message-breakpoints.js';

--- a/packages/pass-style/test/prepare-breakpoints.js
+++ b/packages/pass-style/test/prepare-breakpoints.js
@@ -1,0 +1,21 @@
+/* global process */
+
+process.env.ENDO_DELIVERY_BREAKPOINTS = `{
+  "Bob": {
+    "foo": "*"
+  },
+  "*": {
+    "bar": 0
+  }
+}`;
+
+process.env.ENDO_SEND_BREAKPOINTS = `{
+  "Bob": {
+    "foo": "*",
+    "zap": 3
+  },
+  "*": {
+    "bar": 0,
+    "zip": 3
+  }
+}`;

--- a/packages/pass-style/test/test-message-breakpoints-demo.js
+++ b/packages/pass-style/test/test-message-breakpoints-demo.js
@@ -1,0 +1,28 @@
+import './prepare-breakpoints.js';
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { E } from '@endo/eventual-send';
+import { Far } from '../src/make-far.js';
+
+// Example from test-deep-send.js in @endo/eventual-send
+
+const carol = Far('Carol', {
+  bar: () => console.log('Wut?'),
+});
+
+const bob = Far('Bob', {
+  foo: carolP => E(carolP).bar(),
+});
+
+const alice = Far('Alice', {
+  test: () => E(bob).foo(carol),
+});
+
+// This is not useful as an automated test. Its purpose is to run it under a
+// debugger and see where it breakpoints. To play with it, adjust the
+// settings in prepare-breakpoints.js and try again.
+test('test breakpoints on delivery', async t => {
+  await alice.test();
+  t.pass('introduced');
+});

--- a/packages/pass-style/test/test-message-breakpoints.js
+++ b/packages/pass-style/test/test-message-breakpoints.js
@@ -1,0 +1,104 @@
+import './prepare-breakpoints.js';
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+import { makeMessageBreakpointTester } from '@endo/eventual-send/utils.js';
+import { E } from '@endo/eventual-send';
+
+import { Far } from '../src/make-far.js';
+
+const { values } = Object;
+
+// Example from test-deep-send.js in @endo/eventual-send
+
+const carol = Far('Carol', {
+  bar: () => console.log('Wut?'),
+});
+
+const bob = Far('Bob', {
+  foo: carolP => E(carolP).bar(),
+});
+
+const alice = Far('Alice', {
+  test: () => E(bob).foo(carol),
+});
+
+const onSend = makeMessageBreakpointTester('ENDO_SEND_BREAKPOINTS');
+
+test('message breakpoint tester', t => {
+  t.is(onSend.shouldBreakpoint(alice, 'test'), false);
+  t.is(onSend.shouldBreakpoint(bob, 'test'), false);
+  t.is(onSend.shouldBreakpoint(bob, 'foo'), true);
+  t.is(onSend.shouldBreakpoint(alice, 'bar'), true);
+
+  t.is(onSend.shouldBreakpoint(bob, 'zap'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'zap'), false);
+  t.is(onSend.shouldBreakpoint(carol, 'zap'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'zap'), false);
+  t.is(onSend.shouldBreakpoint(bob, 'zap'), false);
+  t.is(onSend.shouldBreakpoint(bob, 'zap'), false);
+  t.is(onSend.shouldBreakpoint(bob, 'zap'), true);
+  t.is(onSend.shouldBreakpoint(bob, 'zap'), true);
+
+  t.is(onSend.shouldBreakpoint(bob, 'zip'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'zip'), false);
+  t.is(onSend.shouldBreakpoint(carol, 'zip'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'zip'), true);
+  t.is(onSend.shouldBreakpoint(bob, 'zip'), true);
+
+  onSend.setBreakpoints(); // Should refresh the counts
+
+  t.is(onSend.shouldBreakpoint(bob, 'zip'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'zip'), false);
+  t.is(onSend.shouldBreakpoint(carol, 'zip'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'zip'), true);
+  t.is(onSend.shouldBreakpoint(bob, 'zip'), true);
+
+  // Approx what you would do interactively
+  const bps = onSend.getBreakpoints();
+  t.is(
+    values(bps).some(meths => '*' in meths),
+    false,
+  );
+  bps.Bob['*'] = 3;
+  bps['*']['*'] = 1;
+  onSend.setBreakpoints();
+  const bps2 = onSend.getBreakpoints();
+  t.is(
+    values(bps2).every(meths => '*' in meths),
+    true,
+  );
+
+  t.is(onSend.shouldBreakpoint(alice, 'test'), false);
+  t.is(onSend.shouldBreakpoint(bob, 'test'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'test'), true);
+  t.is(onSend.shouldBreakpoint(bob, 'test'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'test'), true);
+  t.is(onSend.shouldBreakpoint(bob, 'test'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'test'), true);
+  t.is(onSend.shouldBreakpoint(bob, 'test'), true);
+
+  onSend.setBreakpoints();
+
+  t.is(onSend.shouldBreakpoint(alice, 'test'), false);
+  t.is(onSend.shouldBreakpoint(bob, 'test'), false);
+  t.is(onSend.shouldBreakpoint(alice, 'test'), true);
+});
+
+test('message breakpoint validation', t => {
+  t.throws(() => onSend.setBreakpoints([]), {
+    message:
+      'Expected "ENDO_SEND_BREAKPOINTS" option to be a JSON breakpoints record',
+  });
+  t.throws(() => onSend.setBreakpoints({ 'Alleged: Bob': {} }), {
+    message: 'Just use simple tag "Bob" rather than "Alleged: Bob"',
+  });
+  t.throws(() => onSend.setBreakpoints({ Bob: 3 }), {
+    message:
+      'Expected "ENDO_SEND_BREAKPOINTS" option\'s "Bob" to be a JSON methods breakpoints record',
+  });
+  t.throws(() => onSend.setBreakpoints({ Bob: { foo: 3n } }), {
+    message:
+      'Expected "ENDO_SEND_BREAKPOINTS" option\'s "Bob"."foo" to be "*" or a non-negative integer',
+  });
+});


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

Given an environment variable setting of

```console
$ export ENDO_DELIVERY_BREAKPOINTS="quatloos issuer.getAmountOf=*"
```

then when `E` invokes a `getAmountOf` method on an object with @@toStringTag of `'Alleged: quatloos issuer'`, it should first execute a JavaScript `debugger;` statement. When run normally, i.e., not under a debugger, the `debugger;` statement has no effect. But when run under a debugger, this statement acts as a breakpoint, causing execution to pause there.

If the "*" at the end is replaced by a number, then each time execution matches, the number is decremented by 1. When it reaches zero, it executes `debugger;`.

If the "getAmountOf" is replaced with "*", then it breakpoints on any method of a quatloos issuer.

If the "quatloos issuer" is replaced with "*", then it breakpoints on calling a method named "getAmountOf" on anything. 

Similarly

```console
$ export ENDO_SEND_BREAKPOINTS="quatloos issuer.getAmountOf=*"
```

will breakpoint when the message is eventually sent, so that you can look up the stack in the debugger to understand why it was sent. The name only matches if the object itself, or a remote presence for the object, is the target and so has the correct @@toStringTag. This does not work when eventually sending to a promise. To catch those cases, use "Promise" or "*" for the target name.

### Security Considerations

As with all use of env-options, we should worry about whether an adversary can read or write these options, and so interfere with code that is supposed to use these options.

### Scaling Considerations

If the `ENDO_DELIVERY_BREAKPOINTS` env-option is not even set, this implementation takes a fast path which should have essentially no penalty compared to the absence of these mechanisms.

When `ENDO_DELIVERY_BREAKPOINTS` is present but has no "*" on the method name, we still try to minimize the overhead on non-matching method names. But once we have a method name match, then we do a linear search among these directives on each such call.

Likewise for `ENDO_SEND_BREAKPOINTS`

### Documentation Considerations

Let's get some road experience ourselves first. But if it proves useful, it'll be a great debugging aid to explain.

It will be interesting to figure out how to show how to use it interactively from inside a debugger well, including dynamically changing breakpoints. Probably a short video?

### Testing Considerations

Since this alters only the behavior seen from a debugger, it is unclear how to write an automated test.

### Upgrade Considerations

None.