### PR TITLE
refactor(ses): Improve the performance of error serialization

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -15,7 +15,6 @@ import {
   RangeError,
   TypeError,
   WeakMap,
-  arrayJoin,
   arrayMap,
   arrayPop,
   arrayPush,
@@ -110,7 +109,7 @@ const hiddenDetailsMap = new WeakMap();
  * @returns {string}
  */
 const getMessageString = ({ template, args }) => {
-  const parts = [template[0]];
+  let result = `${template[0]}`;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     let argStr;
@@ -121,9 +120,9 @@ const getMessageString = ({ template, args }) => {
     } else {
       argStr = `(${an(typeof arg)})`;
     }
-    arrayPush(parts, argStr, template[i + 1]);
+    result += argStr + template[i + 1];
   }
-  return arrayJoin(parts, '');
+  return result;
 };
 
 /**


### PR DESCRIPTION
## Description

Noticed in passing: building a string by successive concatenation rather than pushing into an eventually-`join`ed array is faster in both V8 (+63%) and XS (+39%), presumably because of [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) optimizations.

<details>

```console
$ esbench --eshost-option '-h V8,*XS*' '
  const { raw: StringRaw } = String;
  const [arrayIncludes, arrayMap, arrayPush, arrayJoin] = ["includes", "map", "push", "join"].map(
    m => Function.prototype.call.bind(Array.prototype[m]),
  );

  const useRaw = (template, ...args) =>
    StringRaw({ raw: template }, ...arrayMap(args, arg => `${arg}`));

  const useJoin = (template, ...args) => {
    const parts = [template[0]];
    for (let i = 0; i < args.length; i += 1) {
      const arg = args[i];
      const argStr = `${arg}`;
      arrayPush(parts, argStr, template[i + 1]);
    }
    return arrayJoin(parts, "");
  };

  const usePlus = (template, ...args) => {
    let result = `${template[0]}`;
    for (let i = 0; i < args.length; i += 1) {
      const arg = args[i];
      const argStr = `${arg}`;
      result += argStr + template[i + 1];
    }
    return result;
  };

  const useTemplates = (template, ...args) => {
    let result = `${template[0]}`;
    for (let i = 0; i < args.length; i += 1) {
      const arg = args[i];
      const argStr = `${arg}`;
      result += `${argStr}${template[i + 1]}`;
    }
    return result;
  };

  for (const [name, fn] of Object.entries({ useRaw, useJoin, usePlus, useTemplates })) {
    const actual = fn`a ${0.0} ${1e0}`;
    const expected = "a 0 1";
    if (actual === expected) continue;
    print(JSON.stringify({ actual, expected }));
    throw Error(`bad ${name}`);
  }' '{
    useRaw: "result = useRaw`problem ${0}: ${[`blue`, 42]}`",
    useJoin: "result = useJoin`problem ${0}: ${[`blue`, 42]}`",
    usePlus: "result = usePlus`problem ${0}: ${[`blue`, 42]}`",
    useTemplates: "result = useTemplates`problem ${0}: ${[`blue`, 42]}`",
  }'
```

</details>

#### Moddable XS
useRaw: 0.61 ops/ms
useJoin: 0.62 ops/ms
usePlus: 0.86 ops/ms
useTemplates: 0.72 ops/ms

#### V8
useRaw: 2.72 ops/ms
useJoin: 4.65 ops/ms
usePlus: 7.58 ops/ms
useTemplates: 7.35 ops/ms

### Security Considerations

n/a

### Scaling Considerations

:+1:

### Documentation Considerations

n/a

### Testing Considerations

all tests continue to pass

### Upgrade Considerations

None beyond the usual concerns about changing vat bundles.