### PR TITLE
chore: Improve the explanation of PassStyle "tagged"

### DIFF
--- a/packages/pass-style/src/types.js
+++ b/packages/pass-style/src/types.js
@@ -30,7 +30,7 @@ export {};
  *   * Containers aggregate other Passables into
  *     * sequences as CopyArrays (PassStyle 'copyArray'), or
  *     * string-keyed dictionaries as CopyRecords (PassStyle 'copyRecord'), or
- *     * higher-order types as CopyTaggeds (PassStyle 'tagged').
+ *     * higher-level types as CopyTaggeds (PassStyle 'tagged').
  *   * PassableCaps (PassStyle 'remotable' | 'promise') expose local values to
  *     remote interaction.
  *   * As a special case to support system observability, error objects are


### PR DESCRIPTION
_Originally posted by @erights in https://github.com/Agoric/documentation/pull/876#discussion_r1411146371_

> > _CopyTaggeds_ representing higher-order types
> 
> Not necessarily higher order in general. Probably the intended point is that these concepts are defined at a higher abstraction layer.