### PR TITLE
fix(daemon): pet-store removes petname when overwriting with write

### DIFF
--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -77,6 +77,15 @@ export const makePetStoreMaker = (filePowers, locator) => {
         throw new Error(`Invalid formula identifier ${q(formulaIdentifier)}`);
       }
 
+      if (petNames.has(petName)) {
+        // Perform cleanup on the overwritten pet name.
+        const formulaPetNames = formulaIdentifiers.get(petName);
+        if (formulaPetNames !== undefined) {
+          formulaPetNames.delete(petName);
+        }
+        changesTopic.publisher.next({ remove: petName });
+      }
+
       petNames.set(petName, formulaIdentifier);
 
       const formulaPetNames = formulaIdentifiers.get(formulaIdentifier);


### PR DESCRIPTION
when overwriting a value in pet-store, we should remove the previous value.
This ensures we run proper cleanup:
- delete petname files
- remove known pet name for formula
- report deletion to subscribers