### PR TITLE
fix(Daemon): node file powers write lock

### DIFF
--- a/packages/daemon/src/mutex.js
+++ b/packages/daemon/src/mutex.js
@@ -1,0 +1,30 @@
+import { makeQueue } from '@endo/stream';
+
+/**
+ * @returns {{ lock: () => Promise<void>, unlock: () => void, enqueue: (asyncFn: () => Promise<any>) => Promise<any> }}
+ */
+export const makeMutex = () => {
+  /** @type {import('@endo/stream').AsyncQueue<void>} */
+  const queue = makeQueue();
+  const lock = () => {
+    return queue.get();
+  };
+  const unlock = () => {
+    queue.put();
+  };
+  unlock();
+
+  return {
+    lock,
+    unlock,
+    // helper for correct usage
+    enqueue: async asyncFn => {
+      await lock();
+      try {
+        return await asyncFn();
+      } finally {
+        unlock();
+      }
+    },
+  };
+};


### PR DESCRIPTION
use mutex to ensure serial file operations

all updates happen synchronously in memory
all disk operations are queued to ensure that the previous operation completed before continuing