### PR TITLE
Fix(daemon): work around for "yarn endo cat"

### DIFF
--- a/packages/cli/src/cat.js
+++ b/packages/cli/src/cat.js
@@ -13,4 +13,6 @@ export const cat = async ({ name, partyNames }) =>
     for await (const chunk of reader) {
       process.stdout.write(chunk);
     }
+    // "yarn endo" will not display output unless we write a newline
+    process.stdout.write('\n');
   });


### PR DESCRIPTION
yarn v1 seems to require a newline at the end of stdout in order to display. not sure why

works fine without the yarn invocation wrapper

```
❯ yarn -v
1.22.19
```

test setup (note lack of newline):
```
❯ cat test.txt                        
hello world%  
❯ yarn endo store test.txt --name text
```


before:
```
❯ yarn endo cat text                  
yarn run v1.22.19
$ /home/xyz/Development/endo/node_modules/.bin/endo cat text
Done in 0.25s.
```

after:
```
❯ yarn endo cat text             
yarn run v1.22.19
$ /home/xyz/Development/endo/node_modules/.bin/endo cat text
hello world
Done in 0.25s.
```

