### PR TITLE
fix: updated test code

### DIFF
--- a/packages/grain/test/test-index.js
+++ b/packages/grain/test/test-index.js
@@ -1,5 +1,5 @@
-import { makePromiseKit } from '@endo/promise-kit';
 import { test } from './prepare-test-env-ava.js';
+import { makePromiseKit } from '@endo/promise-kit';
 import { makeSyncGrain, makeSyncArrayGrain, makeSyncGrainMap } from '../src/index.js';
 import { makeReadonlyGrainMapFromRemote, makeRemoteGrainMap } from '../src/captp.js';
 


### PR DESCRIPTION
@kumavis i'm not sure what the end goal is for the grain package but i thought this fix might be appreciated. 

below is a screenshot of my console from a moment ago. i'm running the test with the `-w` flag so the passing tests show as soon as the update is saved.

![grain-pkg-test-fix](https://github.com/endojs/endo/assets/6646552/21ae1762-cf6e-4804-8776-b3c0245e6a92)

*note - you're likely aware of the text below but adding it in for context*

this is something i frequently run into when testing hardened js code. ava needs `prepare-test-env-ava.js` to be the first import. just a guess here but its likely that vscode's prettier extension which automatically rearranges imports so that relative imports follow any dependency import. 