### PR TITLE
fix typedoc-gh-pages config

### DIFF
--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -5,6 +5,8 @@ name: Deploy TypeDoc site with GitHub Pages
 on:
   push:
     branches: [main]
+  # Allow running this workflow manually from the Actions tab
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -4,7 +4,7 @@ name: Deploy TypeDoc site with GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   # Allow running this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

https://github.com/endojs/endo/pull/1883 introduced a new workflow https://github.com/endojs/endo/actions/workflows/typedoc-gh-pages.yml

It hasn't run yet because it was on pushes to `main` and this repo uses `master`.

This PR corrects that and enables manual dispatch too.

### Security Considerations

Manual dispatch can be called anytime, but only by admins

### Scaling Considerations

n/a

### Documentation Considerations

--
### Testing Considerations

🤞

### Upgrade Considerations

n/a