### PR TITLE
npx typedoc

### DIFF
--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v4
       # Generate the TypeDoc site
-      - run: yarn docs
+      - run: npx typedocs
       - uses: actions/upload-pages-artifact@v2
         with:
           path: ./api-docs # the "out" path in typedoc.json

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean": "lerna clean",
     "cover": "lerna run cover",
     "depcheck": "node scripts/check-mismatched-dependencies.js",
-    "docs": "typedoc --tsconfig tsconfig.build.json",
+    "docs": "typedoc",
     "update": "lernaupdate --dedupe",
     "format": "yarn prettier --write .github packages",
     "lint": "yarn prettier --check .github packages && lerna run lint",


### PR DESCRIPTION
## Description

The job is running now but failing because the `typedoc` dep isn't installed: https://github.com/endojs/endo/actions/runs/7107676143/job/19349573778

This solves it with `npx typedoc`, instead of doing the full yarn install. 
