### PR TITLE
ci: yarn install before typedoc

### DIFF
--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -25,8 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v4
+      # Without this the inter-package imports don't resolve
+      - run: yarn install
       # Generate the TypeDoc site
-      - run: npx typedoc
+      - run: yarn docs
       - uses: actions/upload-pages-artifact@v2
         with:
           path: ./api-docs # the "out" path in typedoc.json


### PR DESCRIPTION
## Description

The latest failure (https://github.com/endojs/endo/actions/runs/7107980418/job/19350413938) is that the imports don't resolve:
```
Run npx typedoc
npm WARN exec The following package was not found and will be installed: typedoc@0.25.4
[info] Converting project at ./packages/base[6](https://github.com/endojs/endo/actions/runs/7107980418/job/19350413938#step:4:7)4
[warning] No entry points were provided, this is likely a misconfiguration.
[info] Converting project at ./packages/bundle-source
[info] Converting project at ./packages/captp
packages/captp/src/atomics.js:1:23 - error TS26[8](https://github.com/endojs/endo/actions/runs/7107980418/job/19350413938#step:4:9)8: Cannot find type definition file for 'ses'.

1 /// <reference types="ses"/>
```

That's because there was no yarn install. So this does that. No more npx.

### Testing Considerations

I did a fresh checkout of the repo and ran `npx typedoc` to confirm the hypothesis. Then I ran `yarn install && yarn docs` and that worked.

EDIT: and I discovered that `workflow_dispatch` lets you pick a branch to load and run a workflow. https://github.com/endojs/endo/actions/runs/7108099837/job/19350750851 shows the site building now, just not deploying because of branch permissions.