### PR TITLE
refactor(env-options): migrate test to reduce cyclic dependencies

### DIFF
--- a/packages/env-options/README.md
+++ b/packages/env-options/README.md
@@ -74,3 +74,8 @@ if (capturedEnvironmentOptionNames.length > 0) {
   );
 }
 ```
+
+# Note of test migration
+
+To reduce cyclic dependencies, the tests of this module have been moved to
+@endo/ses-ava. Doing `yarn test` here currently does nothing.

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -32,11 +32,9 @@
     "lint:types": "tsc",
     "build:types": "tsc --build tsconfig.build.json",
     "clean:types": "git clean -f '*.d.ts*'",
-    "test": "ava"
+    "test": "exit 0"
   },
   "devDependencies": {
-    "@endo/init": "^1.0.0",
-    "@endo/ses-ava": "^1.0.0",
     "ava": "^5.3.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^8.46.0",

--- a/packages/env-options/test/prepare-test-env-ava.js
+++ b/packages/env-options/test/prepare-test-env-ava.js
@@ -1,9 +1,0 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@endo/init/debug.js';
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { wrapTest } from '@endo/ses-ava';
-import rawTest from 'ava';
-
-/** @type {typeof rawTest} */
-export const test = wrapTest(rawTest);

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -12,9 +12,6 @@
     "lint-fix": "eslint --fix '**/*.js'",
     "lint": "eslint '**/*.js'"
   },
-  "devDependencies": {
-    "ava": "^5.1.1"
-  },
   "dependencies": {
     "ses": "^1.0.0"
   },

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -38,6 +38,8 @@
     "ses": "^1.0.0"
   },
   "devDependencies": {
+    "@endo/env-options": "^1.0.0",
+    "@endo/lockdown": "^1.0.0",
     "ava": "^5.3.0",
     "babel-eslint": "^10.0.3",
     "c8": "^7.14.0",

--- a/packages/ses-ava/test/prepare-test-env-ava.js
+++ b/packages/ses-ava/test/prepare-test-env-ava.js
@@ -1,0 +1,7 @@
+import '@endo/lockdown/commit-debug.js';
+
+import rawTest from 'ava';
+import { wrapTest } from '../src/ses-ava-test.js';
+
+/** @type {typeof rawTest} */
+export const test = wrapTest(rawTest);

--- a/packages/ses-ava/test/test-env-options.js
+++ b/packages/ses-ava/test/test-env-options.js
@@ -1,5 +1,7 @@
 import { test } from './prepare-test-env-ava.js';
-import { makeEnvironmentCaptor } from '../src/env-options.js';
+
+// eslint-disable-next-line import/order
+import { makeEnvironmentCaptor } from '@endo/env-options';
 
 test('test env options empty env', async t => {
   const c1 = new Compartment();


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

This PR is non-urgent, and so should wait for the current endo-release-agoric_sdk-upgrade dance to settle down.

Currently, before this PR, we get the following cyclic dependency warnings from `yarn build`

```
lerna WARN ECYCLE Dependency cycles detected, you should fix these!
lerna WARN ECYCLE @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper
lerna WARN ECYCLE @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send
lerna WARN ECYCLE @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown
lerna WARN ECYCLE @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit
lerna WARN ECYCLE @endo/ses-ava -> (nested cycle: @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit) -> @endo/ses-ava
lerna WARN ECYCLE @endo/static-module-record -> (nested cycle: @endo/ses-ava -> (nested cycle: @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit) -> @endo/ses-ava) -> @endo/static-module-record
lerna WARN ECYCLE (nested cycle: @endo/static-module-record -> (nested cycle: @endo/ses-ava -> (nested cycle: @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit) -> @endo/ses-ava) -> @endo/static-module-record) -> (nested cycle: @endo/static-module-record -> (nested cycle: @endo/ses-ava -> (nested cycle: @endo/promise-kit -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/eventual-send -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/env-options -> @endo/init -> @endo/compartment-mapper) -> @endo/eventual-send) -> @endo/lockdown) -> @endo/promise-kit) -> @endo/ses-ava) -> @endo/static-module-record)
```

The @endo/env-option package participates in many of these, due only to a devDependency in support of a test. This PR moves that test to @endo/ses-ava to reduce cyclic dependencies.

Even with the PR, we still get the following cyclic dependency warnings:

```
lerna WARN ECYCLE Dependency cycles detected, you should fix these!
lerna WARN ECYCLE @endo/compartment-mapper -> ses -> @endo/compartment-mapper
lerna WARN ECYCLE @endo/lockdown -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/compartment-mapper) -> @endo/static-module-record -> @endo/ses-ava -> @endo/lockdown
lerna WARN ECYCLE (nested cycle: @endo/lockdown -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/compartment-mapper) -> @endo/static-module-record -> @endo/ses-ava -> @endo/lockdown) -> (nested cycle: @endo/lockdown -> (nested cycle: @endo/compartment-mapper -> ses -> @endo/compartment-mapper) -> @endo/static-module-record -> @endo/ses-ava -> @endo/lockdown)
```

These seem also to be cycles through devDependencies, and so should be fixable by the same means (and with the same costs). However, at least one supports usage from a `scripts/*.js` rather than a `test/*.js` . Could these be migrated too? What else would need to be adjusted?

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

It is weird that the tests of a package are not in that package. As we repair other cyclic dependencies, we're likely to cause more of these surprises.

### Testing Considerations

After this PR, no tests remain in @endo/env-options . However, the normal `yarn test` definition is not tolerant of that, so this PR also changes it to `"exit 0"`. However, this means that if tests are added in the future, they may silently be ignored. 

***Reviewers, to avoid this problem, should this PR instead leave `yarn test` alone and add a placeholder test instead?***

### Upgrade Considerations

None