### PR TITLE
fix: Settle the readable types

### DIFF
--- a/packages/cli/src/cat.js
+++ b/packages/cli/src/cat.js
@@ -8,7 +8,7 @@ import { withEndoParty } from './context.js';
 export const cat = async ({ name, partyNames }) =>
   withEndoParty(partyNames, { os, process }, async ({ party }) => {
     const readable = await E(party).lookup(name);
-    const readerRef = E(readable).stream();
+    const readerRef = E(readable).streamBase64();
     const reader = makeRefReader(readerRef);
     for await (const chunk of reader) {
       process.stdout.write(chunk);

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -504,11 +504,11 @@ export const makeDaemonicPersistencePowers = (
       },
       /**
        * @param {string} sha512
-       * @returns {import('./types.js').AlmostEndoReadable}
+       * @returns {import('./types.js').EndoReadable}
        */
       fetch(sha512) {
         const storagePath = filePowers.joinPath(storageDirectoryPath, sha512);
-        const stream = () => {
+        const streamBase64 = () => {
           const reader = filePowers.makeFileReader(storagePath);
           return makeReaderRef(reader);
         };
@@ -520,10 +520,9 @@ export const makeDaemonicPersistencePowers = (
         };
         return harden({
           sha512: () => sha512,
-          stream,
+          streamBase64,
           text,
           json,
-          [Symbol.asyncIterator]: () => stream(),
         });
       },
     });

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -70,13 +70,12 @@ const makeEndoBootstrap = (
    * @param {string} sha512
    */
   const makeReadableBlob = sha512 => {
-    const { text, json, stream } = contentStore.fetch(sha512);
+    const { text, json, streamBase64 } = contentStore.fetch(sha512);
     return Far(`Readable file with SHA-512 ${sha512.slice(0, 8)}...`, {
       sha512: () => sha512,
-      stream,
+      streamBase64,
       text,
       json,
-      [Symbol.asyncIterator]: stream,
     });
   };
 

--- a/packages/daemon/src/reader-ref.js
+++ b/packages/daemon/src/reader-ref.js
@@ -27,7 +27,7 @@ export const asyncIterate = iterable => {
 /**
  * @template T
  * @param {import('./types').SomehowAsyncIterable<T>} iterable The iterable object.
- * @returns {import('@endo/far').FarRef<import('@endo/stream').Stream<T>>}
+ * @returns {import('@endo/far').FarRef<import('@endo/stream').Reader<T>>}
  */
 export const makeIteratorRef = iterable => {
   const iterator = asyncIterate(iterable);

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -182,10 +182,9 @@ export type ReceiveFn = (
 
 export interface EndoReadable {
   sha512(): string;
-  stream(): FarRef<Reader<Uint8Array>>;
+  streamBase64(): FarRef<Reader<string>>;
   text(): Promise<string>;
   json(): Promise<unknown>;
-  [Symbol.asyncIterator]: Reader<Uint8Array>;
 }
 
 export interface EndoWorker {
@@ -305,20 +304,11 @@ export type NetworkPowers = {
   ) => { started: Promise<void>; stopped: Promise<void> };
 };
 
-// The return type here is almost an EndoReadable, but not quite. Should fix.
-export type AlmostEndoReadable = {
-  sha512(): string;
-  stream(): FarRef<Stream<string>>;
-  text(): Promise<string>;
-  json(): Promise<unknown>;
-  [Symbol.asyncIterator]: any;
-};
-
 export type DaemonicPersistencePowers = {
   initializePersistence: () => Promise<void>;
   makeContentSha512Store: () => {
     store: (readable: AsyncIterable<Uint8Array>) => Promise<string>;
-    fetch: (sha512: string) => AlmostEndoReadable;
+    fetch: (sha512: string) => EndoReadable;
   };
   readFormula: (prefix: string, formulaNumber: string) => Promise<Formula>;
   writeFormula: (


### PR DESCRIPTION
This change lines up the EndoReadable type for content address store nodes.

This also renames the `stream()` method to `streamBase64()` in hopes that someday we can add a `stream()` method that transits pass-by-copy immutable bytes instead.