### PR TITLE
refactor: Change unsafe import formula from path to specifier

### DIFF
--- a/packages/cli/src/make.js
+++ b/packages/cli/src/make.js
@@ -2,6 +2,7 @@
 
 import os from 'os';
 import path from 'path';
+import url from 'url';
 
 import bundleSource from '@endo/bundle-source';
 import { makeReaderRef } from '@endo/daemon';
@@ -68,7 +69,7 @@ export const makeCommand = async ({
       importPath !== undefined
         ? E(party).importUnsafeAndEndow(
             workerName,
-            path.resolve(importPath),
+            url.pathToFileURL(path.resolve(importPath)).href,
             powersName,
             resultName,
           )

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -589,9 +589,7 @@ export const makeDaemonicPersistencePowers = (
         type: /** @type {'import-unsafe'} */ ('import-unsafe'),
         worker: `worker-id512:${zero512}`,
         powers: 'host',
-        importPath: fileURLToPath(
-          new URL('web-page-bundler.js', import.meta.url).href,
-        ),
+        specifier: new URL('web-page-bundler.js', import.meta.url).href,
       }
     : undefined;
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -219,14 +219,14 @@ const makeEndoBootstrap = (
    * @param {string} valueFormulaIdentifier
    * @param {string} workerFormulaIdentifier
    * @param {string} guestFormulaIdentifier
-   * @param {string} importPath
+   * @param {string} specifier
    * @param {import('./types.js').Terminator} terminator
    */
   const makeControllerForUnsafePlugin = async (
     valueFormulaIdentifier,
     workerFormulaIdentifier,
     guestFormulaIdentifier,
-    importPath,
+    specifier,
     terminator,
   ) => {
     terminator.thisDiesIfThatDies(workerFormulaIdentifier);
@@ -249,7 +249,7 @@ const makeEndoBootstrap = (
       provideValueForFormulaIdentifier(guestFormulaIdentifier)
     );
     const external = E(workerDaemonFacet).importUnsafeAndEndow(
-      importPath,
+      specifier,
       guestP,
     );
     return { external, internal: undefined };
@@ -329,7 +329,9 @@ const makeEndoBootstrap = (
         formulaIdentifier,
         formula.worker,
         formula.powers,
-        formula.importPath,
+        formula.specifier ??
+          // @ts-expect-error
+          formula.importPath, // (TODO deprecated)
         terminator,
       );
     } else if (formula.type === 'import-bundle') {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -46,7 +46,6 @@ export type HttpConnect = (
 ) => void;
 
 export type MignonicPowers = {
-  pathToFileURL: (path: string) => string;
   connection: {
     reader: Reader<Uint8Array>;
     writer: Writer<Uint8Array>;
@@ -71,7 +70,7 @@ type ImportUnsafeFormula = {
   type: 'import-unsafe';
   worker: string;
   powers: string;
-  importPath: string;
+  specifier: string;
   // TODO formula slots
 };
 

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -22,13 +22,8 @@ const endowments = harden({
  * @param {object} args
  * @param {() => any} args.getDaemonBootstrap
  * @param {(error: Error) => void} args.cancel
- * @param {(path: string) => string} args.pathToFileURL
  */
-export const makeWorkerFacet = ({
-  getDaemonBootstrap,
-  pathToFileURL,
-  cancel,
-}) => {
+export const makeWorkerFacet = ({ getDaemonBootstrap, cancel }) => {
   return Far('EndoWorkerFacet', {
     terminate: async () => {
       console.error('Endo worker received terminate request');
@@ -55,12 +50,11 @@ export const makeWorkerFacet = ({
     },
 
     /**
-     * @param {string} path
+     * @param {string} specifier
      * @param {unknown} powersP
      */
-    importUnsafeAndEndow: async (path, powersP) => {
-      const url = pathToFileURL(path);
-      const namespace = await import(url);
+    importUnsafeAndEndow: async (specifier, powersP) => {
+      const namespace = await import(specifier);
       return namespace.make(powersP);
     },
 
@@ -97,15 +91,12 @@ export const main = async (powers, locator, uuid, pid, cancel, cancelled) => {
     console.error(`Endo worker exiting on pid ${pid}`);
   });
 
-  const { pathToFileURL } = powers;
-
   const { reader, writer } = powers.connection;
 
   const workerFacet = makeWorkerFacet({
     // Behold: reference cycle
     // eslint-disable-next-line no-use-before-define
     getDaemonBootstrap: () => getBootstrap(),
-    pathToFileURL,
     cancel,
   });
 

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -358,7 +358,8 @@ test('persist unsafe services and their requests', async t => {
     await E(host).makeWorker('w1');
     await E(host).provideGuest('o1');
     const servicePath = path.join(dirname, 'test', 'service.js');
-    await E(host).importUnsafeAndEndow('w1', servicePath, 'o1', 's1');
+    const serviceLocation = url.pathToFileURL(servicePath).href;
+    await E(host).importUnsafeAndEndow('w1', serviceLocation, 'o1', 's1');
 
     await E(host).makeWorker('w2');
     const answer = await E(host).evaluate(
@@ -444,7 +445,13 @@ test('direct termination', async t => {
   await E(host).provideWorker('worker');
 
   const counterPath = path.join(dirname, 'test', 'counter.js');
-  await E(host).importUnsafeAndEndow('worker', counterPath, 'NONE', 'counter');
+  const counterLocation = url.pathToFileURL(counterPath).href;
+  await E(host).importUnsafeAndEndow(
+    'worker',
+    counterLocation,
+    'NONE',
+    'counter',
+  );
   t.is(
     1,
     await E(host).evaluate(
@@ -524,7 +531,13 @@ test('indirect termination', async t => {
   await E(host).provideWorker('worker');
 
   const counterPath = path.join(dirname, 'test', 'counter.js');
-  await E(host).importUnsafeAndEndow('worker', counterPath, 'SELF', 'counter');
+  const counterLocation = url.pathToFileURL(counterPath).href;
+  await E(host).importUnsafeAndEndow(
+    'worker',
+    counterLocation,
+    'SELF',
+    'counter',
+  );
   t.is(
     1,
     await E(host).evaluate(
@@ -606,7 +619,8 @@ test('terminate because of requested capability', async t => {
   const messages = E(host).followMessages();
 
   const counterPath = path.join(dirname, 'test', 'counter-party.js');
-  E(host).importUnsafeAndEndow('worker', counterPath, 'guest', 'counter');
+  const counterLocation = url.pathToFileURL(counterPath).href;
+  E(host).importUnsafeAndEndow('worker', counterLocation, 'guest', 'counter');
 
   await E(host).evaluate('worker', '0', [], [], 'zero');
   await E(messages).next();


### PR DESCRIPTION
In the pet daemon, workers currently require a power to convert paths to URL specifiers. This creates undue coupling to the underlying platform. A module specifier should suffice in this place. This generalizes well between daemon-on-web and daemon-on-node.