### PR TITLE
feat(cli): Extract install from open command

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -29,15 +29,15 @@ export const main = async rawArgs => {
   program.name('endo').version(packageDescriptor.version);
 
   program
-    .command('open <name> [filePath]')
-    .description('opens a web page (weblet)')
+    .command('install <name> [filePath]')
+    .description('installs a web page (weblet)')
     .option(
       '-a,--as <party>',
       'Pose as named party (as named by current party)',
       collect,
       [],
     )
-    .option('-b,--bundle <bundle>', 'Bundle for a web page to open')
+    .option('-b,--bundle <bundle>', 'Bundle for a web page (weblet)')
     .option(
       '-p,--powers <endowment>',
       'Endowment to give the weblet (a name, NONE, HOST, or ENDO)',
@@ -48,8 +48,8 @@ export const main = async rawArgs => {
         powers: powersName = 'NONE',
         as: partyNames,
       } = cmd.opts();
-      const { open } = await import('./open.js');
-      return open({
+      const { install } = await import('./install.js');
+      return install({
         webPageName,
         programPath,
         bundleName,
@@ -58,6 +58,23 @@ export const main = async rawArgs => {
       });
     });
 
+  program
+    .command('open <name>')
+    .description('opens a web page (weblet)')
+    .option(
+      '-a,--as <party>',
+      'Pose as named party (as named by current party)',
+      collect,
+      [],
+    )
+    .action(async (webPageName, cmd) => {
+      const { as: partyNames } = cmd.opts();
+      const { open } = await import('./open.js');
+      return open({
+        webPageName,
+        partyNames,
+      });
+    });
   program
     .command('run [<file>] [<args>...]')
     .description('runs a program (runlet)')

--- a/packages/cli/src/install.js
+++ b/packages/cli/src/install.js
@@ -1,0 +1,64 @@
+/* global process */
+
+import os from 'os';
+
+import { E } from '@endo/far';
+import { makeReaderRef } from '@endo/daemon';
+import bundleSource from '@endo/bundle-source';
+
+import { withEndoParty } from './context.js';
+import { randomHex16 } from './random.js';
+
+const textEncoder = new TextEncoder();
+
+export const install = async ({
+  bundleName,
+  partyNames,
+  powersName,
+  webPageName,
+  programPath,
+}) => {
+  /** @type {import('@endo/eventual-send').ERef<import('@endo/stream').Reader<string>> | undefined} */
+  let bundleReaderRef;
+  /** @type {string | undefined} */
+  let temporaryBundleName;
+  if (programPath !== undefined) {
+    if (bundleName === undefined) {
+      // TODO alternately, make a temporary session-scoped GC pet store
+      // overshadowing the permanent one, which gets implicitly dropped
+      // when this CLI CapTP session ends.
+      temporaryBundleName = `tmp-bundle-${await randomHex16()}`;
+      bundleName = temporaryBundleName;
+    }
+    const bundle = await bundleSource(programPath);
+    const bundleText = JSON.stringify(bundle);
+    const bundleBytes = textEncoder.encode(bundleText);
+    bundleReaderRef = makeReaderRef([bundleBytes]);
+  }
+
+  await withEndoParty(partyNames, { os, process }, async ({ party }) => {
+    // Prepare a bundle, with the given name.
+    if (bundleReaderRef !== undefined) {
+      await E(party).store(bundleReaderRef, bundleName);
+    }
+
+    try {
+      /** @type {string | undefined} */
+      let webPageUrl;
+      if (bundleName !== undefined) {
+        ({ url: webPageUrl } = await E(party).provideWebPage(
+          webPageName,
+          bundleName,
+          powersName,
+        ));
+      } else {
+        ({ url: webPageUrl } = await E(party).lookup(webPageName));
+      }
+      process.stdout.write(`${webPageUrl}\n`);
+    } finally {
+      if (temporaryBundleName) {
+        await E(party).remove(temporaryBundleName);
+      }
+    }
+  });
+};

--- a/packages/cli/src/open.js
+++ b/packages/cli/src/open.js
@@ -4,61 +4,13 @@ import os from 'os';
 
 import openWebPage from 'open';
 import { E } from '@endo/far';
-import { makeReaderRef } from '@endo/daemon';
-import bundleSource from '@endo/bundle-source';
 
 import { withEndoParty } from './context.js';
-import { randomHex16 } from './random.js';
 
-const textEncoder = new TextEncoder();
-
-export const open = async ({
-  bundleName,
-  partyNames,
-  powersName,
-  webPageName,
-  programPath,
-}) => {
-  /** @type {import('@endo/eventual-send').ERef<import('@endo/stream').Reader<string>> | undefined} */
-  let bundleReaderRef;
-  /** @type {string | undefined} */
-  let temporaryBundleName;
-  if (programPath !== undefined) {
-    if (bundleName === undefined) {
-      // TODO alternately, make a temporary session-scoped GC pet store
-      // overshadowing the permanent one, which gets implicitly dropped
-      // when this CLI CapTP session ends.
-      temporaryBundleName = `tmp-bundle-${await randomHex16()}`;
-      bundleName = temporaryBundleName;
-    }
-    const bundle = await bundleSource(programPath);
-    const bundleText = JSON.stringify(bundle);
-    const bundleBytes = textEncoder.encode(bundleText);
-    bundleReaderRef = makeReaderRef([bundleBytes]);
-  }
-
+export const open = async ({ webPageName, partyNames }) => {
   await withEndoParty(partyNames, { os, process }, async ({ party }) => {
-    // Prepare a bundle, with the given name.
-    if (bundleReaderRef !== undefined) {
-      await E(party).store(bundleReaderRef, bundleName);
-    }
-
-    /** @type {string | undefined} */
-    let webPageUrl;
-    if (bundleName !== undefined) {
-      ({ url: webPageUrl } = await E(party).provideWebPage(
-        webPageName,
-        bundleName,
-        powersName,
-      ));
-    } else {
-      ({ url: webPageUrl } = await E(party).lookup(webPageName));
-    }
+    const { url: webPageUrl } = await E(party).lookup(webPageName);
     process.stdout.write(`${webPageUrl}\n`);
     openWebPage(webPageUrl);
-
-    if (temporaryBundleName) {
-      await E(party).remove(temporaryBundleName);
-    }
   });
 };


### PR DESCRIPTION
This change factors an `endo install` command out of `endo open`, clarifying that you can install a weblet once and open it by name thereafter.