### PR TITLE
feat(exo): lightweight inter-facet rights amplification

### DIFF
--- a/packages/exo/test/test-amplify-heap-class-kits.js
+++ b/packages/exo/test/test-amplify-heap-class-kits.js
@@ -8,21 +8,14 @@ import { M } from '@endo/patterns';
 import { defineExoClass, defineExoClassKit } from '../src/exo-makers.js';
 
 const UpCounterI = M.interface('UpCounter', {
-  incr: M.call()
-    // TODO M.number() should not be needed to get a better error message
-    .optional(M.and(M.number(), M.gte(0)))
-    .returns(M.number()),
+  incr: M.call().optional(M.gte(0)).returns(M.number()),
 });
 
 const DownCounterI = M.interface('DownCounter', {
-  decr: M.call()
-    // TODO M.number() should not be needed to get a better error message
-    .optional(M.and(M.number(), M.gte(0)))
-    .returns(M.number()),
+  decr: M.call().optional(M.gte(0)).returns(M.number()),
 });
 
 test('test amplify defineExoClass fails', t => {
-  // let amp;
   t.throws(
     () =>
       defineExoClass(
@@ -38,9 +31,7 @@ test('test amplify defineExoClass fails', t => {
           },
         },
         {
-          receiveAmplifier(a) {
-            // amp = a;
-          },
+          receiveAmplifier(_) {},
         },
       ),
     {

--- a/packages/exo/test/test-amplify-heap-class-kits.js
+++ b/packages/exo/test/test-amplify-heap-class-kits.js
@@ -1,0 +1,115 @@
+// modeled on test-revoke-heap-classes.js
+
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { M } from '@endo/patterns';
+import { defineExoClass, defineExoClassKit } from '../src/exo-makers.js';
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call()
+    // TODO M.number() should not be needed to get a better error message
+    .optional(M.and(M.number(), M.gte(0)))
+    .returns(M.number()),
+});
+
+test('test amplify defineExoClass fails', t => {
+  // let amp;
+  t.throws(
+    () =>
+      defineExoClass(
+        'UpCounter',
+        UpCounterI,
+        /** @param {number} x */
+        (x = 0) => ({ x }),
+        {
+          incr(y = 1) {
+            const { state } = this;
+            state.x += y;
+            return state.x;
+          },
+        },
+        {
+          receiveAmplifier(a) {
+            // amp = a;
+          },
+        },
+      ),
+    {
+      message: 'Only facets of an exo class kit can be amplified "UpCounter"',
+    },
+  );
+});
+
+test('test amplify defineExoClassKit', t => {
+  let revoke;
+  let amp;
+  const makeCounterKit = defineExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+      receiveAmplifier(a) {
+        amp = a;
+      },
+    },
+  );
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  t.is(upCounter.incr(5), 8);
+  t.is(downCounter.decr(), 7);
+
+  t.throws(() => amp(upCounter, 'sideways'), {
+    message: '"sideways" must be a facet name of "Counter"',
+  });
+  t.throws(() => amp(harden({}), 'down'), {
+    message: 'Must be an unrevoked facet of "Counter": {}',
+  });
+  t.is(amp(upCounter, 'down'), downCounter);
+  t.is(amp(upCounter, 'up'), upCounter);
+  t.is(amp(downCounter, 'up'), upCounter);
+  t.is(amp(downCounter, 'down'), downCounter);
+
+  t.is(revoke(upCounter), true);
+
+  t.throws(() => amp(upCounter, 'down'), {
+    message: 'Must be an unrevoked facet of "Counter": "[Alleged: Counter up]"',
+  });
+  t.throws(() => amp(upCounter, 'up'), {
+    message: 'Must be an unrevoked facet of "Counter": "[Alleged: Counter up]"',
+  });
+  t.is(amp(downCounter, 'up'), upCounter);
+  t.throws(() => upCounter.incr(3), {
+    message:
+      '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
+  });
+  t.is(amp(downCounter, 'down'), downCounter);
+  t.is(downCounter.decr(), 6);
+});

--- a/packages/exo/test/test-revoke-heap-classes.js
+++ b/packages/exo/test/test-revoke-heap-classes.js
@@ -8,17 +8,11 @@ import { defineExoClass, defineExoClassKit } from '../src/exo-makers.js';
 const { apply } = Reflect;
 
 const UpCounterI = M.interface('UpCounter', {
-  incr: M.call()
-    // TODO M.number() should not be needed to get a better error message
-    .optional(M.and(M.number(), M.gte(0)))
-    .returns(M.number()),
+  incr: M.call().optional(M.gte(0)).returns(M.number()),
 });
 
 const DownCounterI = M.interface('DownCounter', {
-  decr: M.call()
-    // TODO M.number() should not be needed to get a better error message
-    .optional(M.and(M.number(), M.gte(0)))
-    .returns(M.number()),
+  decr: M.call().optional(M.gte(0)).returns(M.number()),
 });
 
 test('test revoke defineExoClass', t => {


### PR DESCRIPTION

towards: https://github.com/Agoric/agoric-sdk/issues/8664
refs: #1666 

## Description

Adds a `receiveAmplifier` option to `definedExoClassKit` to parallel the existing `receiveRevoker`. The amplifier function you receive is a two argument function of `aFacet` and a `facetName`. If `aFacet` is an unrevoked facet instance of a cohort of that exo class kit, and `facetName` is the name of a facet column of that exo class kit, then the named element of `aFacet`'s cohort is returned.

See https://github.com/Agoric/agoric-sdk/issues/8664 for more explanation.

This PR does not by itself finish https://github.com/Agoric/agoric-sdk/issues/8664 . Rather, we need to wait for an endo release incorporating this PR followed by an agoric-sdk-endo sync before we can get started implementing this same feature for virtual and durable class kits.

### Security Considerations

As explained at https://github.com/Agoric/agoric-sdk/issues/8664 , this makes one particular pattern of rights amplification easier to express, and more auditable when expressed in this manner.

This is in contrast to systems like JS's or Joe-E class-private instance variables, where inter-instance intra-class amplification is implicit and easy to overlook in a review.

### Scaling Considerations

As explained at https://github.com/Agoric/agoric-sdk/issues/8664 , this avoids the need for the additional weak store that would otherwise be needed to express such rights amplification, without losing the explicitness of the separate weak store. 

### Documentation Considerations

Yet another thing to document. But should probably wait until https://github.com/Agoric/agoric-sdk/issues/8664 is closed, i.e., until the feature is available for virtual and durable exo kits. Probably should wait until revocability is as well, and then both should be documented together.

### Testing Considerations

Should enable more secure "jig" testing, where an exo class kit also defines a facet to be used for privileged testing/debugging, and the testing framework is, ***somehow***, endowed with the needed amplifier. We would still need to figure out how to wire that up so the amplifier cannot otherwise be obtained or used.

### Upgrade Considerations

Assuming that implementing this feature for virtual and durable exos is similar and as straightforward, this PR should not cause any change to virtual or durable state, enabling exo class kit instance state defined without amplifiers (likewise revokers) to be upgraded into an exo class kit which does.
