### PR TITLE
Avoid null coalescing and optional chaining

### DIFF
--- a/packages/bundle-source/src/is-entrypoint.js
+++ b/packages/bundle-source/src/is-entrypoint.js
@@ -3,7 +3,14 @@ import url from 'url';
 import process from 'process';
 import fs from 'fs';
 
+// Agoric still uses Endo dependencies under an emulation of ESM we call RESM
+// because it is invoked with `node -r esm`.
+// RESM does not support ?? nor ?. operators, so we must avoid them expressly.
+// TODO remove when https://github.com/Agoric/agoric-sdk/issues/8671
+const favor = (primary, secondary) =>
+  primary === undefined ? secondary : primary;
+
 // FIXME: Should maybe be exported by '@endo/something'?
 export const isEntrypoint = href =>
   String(href) ===
-  url.pathToFileURL(fs.realpathSync(process.argv[1]) ?? '/').href;
+  url.pathToFileURL(fs.realpathSync(favor(process.argv[1]), '/')).href;

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -65,5 +65,10 @@ module.exports = {
   rules: {
     '@endo/assert-fail-as-throw': 'error',
     'guard-for-in': 'error',
+    // Agoric still uses Endo dependencies under an emulation of ESM we call RESM
+    // because it is invoked with `node -r esm`.
+    // RESM does not support ?? nor ?. operators, so we must avoid them expressly.
+    '@endo/no-optional-chaining': 'error',
+    '@endo/no-nullish-coalescing': 'error',
   },
 };

--- a/packages/eslint-plugin/lib/rules/no-nullish-coalescing.js
+++ b/packages/eslint-plugin/lib/rules/no-nullish-coalescing.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// Agoric still uses Endo dependencies under an emulation of ESM we call RESM
+// because it is invoked with `node -r esm`.
+// RESM does not support ?? nor ?. operators, so we must avoid them expressly.
+// TODO remove when https://github.com/Agoric/agoric-sdk/issues/8671
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow nullish coalescing.',
+      category: 'ES2020',
+      recommended: false,
+      url: 'https://github.com/endojs/endo/blob/master/packages/eslint-plugin/lib/rules/no-nullish-coalescing.js',
+    },
+    fixable: null,
+    messages: {
+      forbidden: 'ES2020 nullish coalescing is forbidden.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  create(context) {
+    return {
+      LogicalExpression(node) {
+        if (node.operator === '??') {
+          context.report({
+            node,
+            messageId: 'forbidden',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/lib/rules/no-optional-chaining.js
+++ b/packages/eslint-plugin/lib/rules/no-optional-chaining.js
@@ -1,0 +1,55 @@
+/** @author Yosuke Ota <https://github.com/ota-meshi> */
+'use strict';
+
+// Agoric still uses Endo dependencies under an emulation of ESM we call RESM
+// because it is invoked with `node -r esm`.
+// RESM does not support ?? nor ?. operators, so we must avoid them expressly.
+// TODO remove when https://github.com/Agoric/agoric-sdk/issues/8671
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow optional chaining.',
+      category: 'ES2020',
+      recommended: false,
+      url: 'http://mysticatea.github.io/eslint-plugin-es/rules/no-optional-chaining.html',
+    },
+    fixable: null,
+    messages: {
+      forbidden: 'ES2020 optional chaining is forbidden.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    /**
+     * @param {Token} token The token to check.
+     * @returns {boolean} whether the token is a `?.` token.
+     */
+    function isQuestionDotToken(token) {
+      return (
+        token.value === '?.' &&
+        (token.type === 'Punctuator' || // espree has been parsed well.
+          // espree@7.1.0 doesn't parse "?." tokens well. Therefore, get the string from the source code and check it.
+          sourceCode.getText(token) === '?.')
+      );
+    }
+
+    return {
+      'CallExpression[optional=true]'(node) {
+        context.report({
+          node: sourceCode.getTokenAfter(node.callee, isQuestionDotToken),
+          messageId: 'forbidden',
+        });
+      },
+      'MemberExpression[optional=true]'(node) {
+        context.report({
+          node: sourceCode.getTokenAfter(node.object, isQuestionDotToken),
+          messageId: 'forbidden',
+        });
+      },
+    };
+  },
+};

--- a/packages/evasive-transform/src/generate.js
+++ b/packages/evasive-transform/src/generate.js
@@ -59,7 +59,9 @@ const { default: generator } = /** @type {any} */ (babelGenerate);
 export const generate =
   /** @type {GenerateAstWithSourceMap & GenerateAstWithoutSourceMap} */ (
     (ast, options) => {
-      const sourceUrl = options?.sourceUrl;
+      // TODO Use options?.sourceUrl when resolved:
+      // https://github.com/Agoric/agoric-sdk/issues/8671
+      const sourceUrl = options ? options.sourceUrl : undefined;
       const result = generator(ast, {
         sourceFileName: sourceUrl,
         sourceMaps: Boolean(sourceUrl),

--- a/packages/evasive-transform/src/index.js
+++ b/packages/evasive-transform/src/index.js
@@ -35,7 +35,9 @@ import { generate } from './generate.js';
  * @public
  */
 export async function evadeCensor(source, options) {
-  const { sourceMap, sourceUrl, useLocationUnmap, sourceType } = options ?? {};
+  // TODO Use options ?? {} when resolved:
+  // https://github.com/Agoric/agoric-sdk/issues/8671
+  const { sourceMap, sourceUrl, useLocationUnmap, sourceType } = options || {};
 
   // See "Chesterton's Fence"
   await null;


### PR DESCRIPTION
Agoric’s load generator test uses `node -r esm` which doesn’t support the `??` nor `?.` operators.

This change introduces a lint rule to help us avoid this trip-fall and then ensures that existing packages pass the new rules.