### PR TITLE
fix: Expressly forbid deep imports through captp, far, lockdown, marshal

### DIFF
--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -12,6 +12,10 @@
   "homepage": "https://github.com/endojs/endo#readme",
   "license": "Apache-2.0",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json"
+  },
   "module": "src/index.js",
   "directories": {
     "src": "src",

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -4,6 +4,10 @@
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -4,6 +4,14 @@
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",
+  "exports": {
+    ".": "./pre.js",
+    "./pre.js": "./pre.js",
+    "./post.js": "./post.js",
+    "./commit.js": "./commit.js",
+    "./commit-debug.js": "./commit-debug.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -4,6 +4,10 @@
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
To limit exposure to Hyrum’s Law, this change introduces an `"exports"` property to the four packages in Endo that currently lack one. Node.js 16+ and Endo’s bundler forbid deep imports to modules not expressly mentioned in `"exports"`.