### PR TITLE
fix(eslint-plugin): Relax null coalescing and optional chaining to wa…

### DIFF
--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -68,7 +68,7 @@ module.exports = {
     // Agoric still uses Endo dependencies under an emulation of ESM we call RESM
     // because it is invoked with `node -r esm`.
     // RESM does not support ?? nor ?. operators, so we must avoid them expressly.
-    '@endo/no-optional-chaining': 'error',
-    '@endo/no-nullish-coalescing': 'error',
+    '@endo/no-optional-chaining': 'warn',
+    '@endo/no-nullish-coalescing': 'warn',
   },
 };


### PR DESCRIPTION
…rning.

In #1905 we introduced lint rules to appease the one use we still have for `node -r esm` in Agoric’s stack (the testnet load generator). We found that these rules were useful for identifying usage that would not work under `node -r esm` but that the rule caused to many false positives in Agoric SDK. This change relaxes these rules to issue warnings.