### PR TITLE
fix(evasive-transform): RESM treatment

### DIFF
--- a/packages/evasive-transform/src/generate.js
+++ b/packages/evasive-transform/src/generate.js
@@ -4,13 +4,17 @@
  * @module
  */
 
-import babelGenerate from '@agoric/babel-generator';
+import babelGenerator from '@agoric/babel-generator';
 
-/**
- * It works; don't ask.
- * @type {typeof import('@babel/generator')}
- */
-const { default: generator } = /** @type {any} */ (babelGenerate);
+// TODO The following is sufficient on Node.js, but for compatibility with
+// `node -r esm`, we must use the pattern below.
+// Restore after https://github.com/Agoric/agoric-sdk/issues/8671.
+// OR, upgrading to Babel 8 probably addresses this defect.
+// const { default: generator } = /** @type {any} */ (babelGenerator);
+const generator = /** @type {typeof import('@babel/generator')['default']} */ (
+  // @ts-expect-error
+  babelGenerator.default || babelGenerator
+);
 
 /**
  * Options for {@link generateCode} with source map

--- a/packages/evasive-transform/src/transform-ast.js
+++ b/packages/evasive-transform/src/transform-ast.js
@@ -8,11 +8,15 @@ import babelTraverse from '@babel/traverse';
 import { transformComment } from './transform-comment.js';
 import { makeLocationUnmapper } from './location-unmapper.js';
 
-/**
- * This is what happens when you compile Babel using Babel.
- * @type {typeof import('@babel/traverse')}
- */
-const { default: traverse } = /** @type {any} */ (babelTraverse);
+// TODO The following is sufficient on Node.js, but for compatibility with
+// `node -r esm`, we must use the pattern below.
+// Restore after https://github.com/Agoric/agoric-sdk/issues/8671.
+// OR, upgrading to Babel 8 probably addresses this defect.
+// const { default: traverse } = /** @type {any} */ (babelTraverse);
+const traverse = /** @type {typeof import('@babel/traverse')['default']} */ (
+  // @ts-expect-error
+  babelTraverse.default || babelTraverse
+);
 
 /**
  * Options for {@link transformAst}


### PR DESCRIPTION
Agoric still uses an ESM emulation through the pattern `node -r esm` in its testnet load generator, which entrains Endo’s bundler. This change addresses “RESM” compatibility regressions with the recent creation of the `@endo/evasive-transform`, which is not tested under RESM.