### PR TITLE
feat(daemon): Undeniable host INFO tool

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -621,13 +621,8 @@ const makeEndoBootstrap = (
       if (formulaIdentifier === undefined) {
         throw new Error(`Unknown pet name ${petName}`);
       }
-      const delimiterIndex = formulaIdentifier.indexOf(':');
-      // eslint-disable-next-line @endo/restrict-comparison-operands
-      if (delimiterIndex < 0) {
-        return undefined;
-      }
-      const prefix = formulaIdentifier.slice(0, delimiterIndex);
-      const formulaNumber = formulaIdentifier.slice(delimiterIndex + 1);
+      const { type: formulaType, number: formulaNumber } =
+        parseFormulaIdentifier(formulaIdentifier);
       if (
         ![
           'eval-id512',
@@ -635,12 +630,12 @@ const makeEndoBootstrap = (
           'import-bundle-id512',
           'guest-id512',
           'web-bundle',
-        ].includes(prefix)
+        ].includes(formulaType)
       ) {
-        return makeInfo(prefix, formulaNumber, harden({}));
+        return makeInfo(formulaType, formulaNumber, harden({}));
       }
       const formula = await persistencePowers.readFormula(
-        prefix,
+        formulaType,
         formulaNumber,
       );
       if (formula.type === 'eval') {

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -37,6 +37,17 @@ const delay = async (ms, cancelled) => {
   });
 };
 
+const makeInfo = (type, number, record) =>
+  Far(`Inspector (${type} ${number})`, {
+    lookup: async petName => {
+      if (!Object.hasOwn(record, petName)) {
+        return undefined;
+      }
+      return record[petName];
+    },
+    list: () => Object.keys(record),
+  });
+
 /**
  * @param {import('./types.js').DaemonicPowers} powers
  * @param {Promise<number>} webletPortP
@@ -371,14 +382,21 @@ const makeEndoBootstrap = (
         assertPetName,
       );
       return { external, internal: undefined };
+    } else if (formulaIdentifier === 'pet-inspector') {
+      // Behold, unavoidable forward-reference:
+      // eslint-disable-next-line no-use-before-define
+      const external = makeIdentifiedInspector('pet-store');
+      return { external, internal: undefined };
     } else if (formulaIdentifier === 'host') {
       const storeFormulaIdentifier = 'pet-store';
+      const infoFormulaIdentifier = 'pet-inspector';
       const workerFormulaIdentifier = `worker-id512:${zero512}`;
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
       return makeIdentifiedHost(
         formulaIdentifier,
         storeFormulaIdentifier,
+        infoFormulaIdentifier,
         workerFormulaIdentifier,
         terminator,
       );
@@ -407,6 +425,13 @@ const makeEndoBootstrap = (
       return { external, internal: undefined };
     } else if (formulaType === 'worker-id512') {
       return makeIdentifiedWorkerController(formulaNumber, terminator);
+    } else if (formulaType === 'pet-inspector-id512') {
+      // Behold, unavoidable forward-reference:
+      // eslint-disable-next-line no-use-before-define
+      const external = makeIdentifiedInspector(
+        `pet-store-id512:${formulaNumber}`,
+      );
+      return { external, internal: undefined };
     } else if (formulaType === 'pet-store-id512') {
       const external = petStorePowers.makeIdentifiedPetStore(
         formulaNumber,
@@ -415,12 +440,14 @@ const makeEndoBootstrap = (
       return { external, internal: undefined };
     } else if (formulaType === 'host-id512') {
       const storeFormulaIdentifier = `pet-store-id512:${formulaNumber}`;
+      const infoFormulaIdentifier = `pet-inspector-id512:${formulaNumber}`;
       const workerFormulaIdentifier = `worker-id512:${formulaNumber}`;
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
       return makeIdentifiedHost(
         formulaIdentifier,
         storeFormulaIdentifier,
+        infoFormulaIdentifier,
         workerFormulaIdentifier,
         terminator,
       );
@@ -582,6 +609,108 @@ const makeEndoBootstrap = (
     makeSha512,
     makeMailbox,
   });
+
+  const makeIdentifiedInspector = async petStoreFormulaIdentifier => {
+    const petStore = await provideValueForFormulaIdentifier(
+      petStoreFormulaIdentifier,
+    );
+
+    /** @param {string} petName */
+    const lookup = async petName => {
+      const formulaIdentifier = petStore.lookup(petName);
+      if (formulaIdentifier === undefined) {
+        throw new Error(`Unknown pet name ${petName}`);
+      }
+      const delimiterIndex = formulaIdentifier.indexOf(':');
+      // eslint-disable-next-line @endo/restrict-comparison-operands
+      if (delimiterIndex < 0) {
+        return undefined;
+      }
+      const prefix = formulaIdentifier.slice(0, delimiterIndex);
+      const formulaNumber = formulaIdentifier.slice(delimiterIndex + 1);
+      if (
+        ![
+          'eval-id512',
+          'import-unsafe-id512',
+          'import-bundle-id512',
+          'guest-id512',
+          'web-bundle',
+        ].includes(prefix)
+      ) {
+        return makeInfo(prefix, formulaNumber, harden({}));
+      }
+      const formula = await persistencePowers.readFormula(
+        prefix,
+        formulaNumber,
+      );
+      if (formula.type === 'eval') {
+        return makeInfo(
+          formula.type,
+          formulaNumber,
+          harden({
+            SOURCE: formula.source,
+            WORKER: provideValueForFormulaIdentifier(formula.worker),
+            ENDOWMENTS: Object.fromEntries(
+              formula.names.map((name, index) => {
+                return [
+                  name,
+                  provideValueForFormulaIdentifier(formula.values[index]),
+                ];
+              }),
+            ),
+          }),
+        );
+      } else if (formula.type === 'import-unsafe') {
+        return makeInfo(
+          formula.type,
+          formulaNumber,
+          harden({
+            SPECIFIER: formula.type,
+            WORKER: provideValueForFormulaIdentifier(formula.worker),
+            POWERS: provideValueForFormulaIdentifier(formula.powers),
+          }),
+        );
+      } else if (formula.type === 'import-bundle') {
+        return makeInfo(
+          formula.type,
+          formulaNumber,
+          harden({
+            WORKER: provideValueForFormulaIdentifier(formula.worker),
+            BUNDLE: provideValueForFormulaIdentifier(formula.bundle),
+            POWERS: provideValueForFormulaIdentifier(formula.powers),
+          }),
+        );
+      } else if (formula.type === 'guest') {
+        return makeInfo(
+          formula.type,
+          formulaNumber,
+          harden({
+            HOST: provideValueForFormulaIdentifier(formula.host),
+          }),
+        );
+      } else if (formula.type === 'web-bundle') {
+        return makeInfo(
+          formula.type,
+          formulaNumber,
+          harden({
+            BUNDLE: provideValueForFormulaIdentifier(formula.bundle),
+            POWERS: provideValueForFormulaIdentifier(formula.powers),
+          }),
+        );
+      }
+      // @ts-expect-error this should never occur
+      return makeInfo(formula.type, formulaNumber, harden({}));
+    };
+
+    const list = () => petStore.list();
+
+    const info = Far('Endo info facet', {
+      lookup,
+      list,
+    });
+
+    return info;
+  };
 
   const endoBootstrap = Far('Endo private facet', {
     // TODO for user named

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -1,10 +1,11 @@
 const { quote: q } = assert;
 
 const numberlessFormulasIdentifiers = new Set([
-  'pet-store',
-  'host',
   'endo',
+  'host',
   'least-authority',
+  'pet-inspector',
+  'pet-store',
   'web-page-js',
 ]);
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -18,14 +18,14 @@ export const makeHostMaker = ({
   /**
    * @param {string} hostFormulaIdentifier
    * @param {string} storeFormulaIdentifier
-   * @param {string} infoFormulaIdentifier
+   * @param {string} inspectorFormulaIdentifier
    * @param {string} mainWorkerFormulaIdentifier
    * @param {import('./types.js').Terminator} terminator
    */
   const makeIdentifiedHost = async (
     hostFormulaIdentifier,
     storeFormulaIdentifier,
-    infoFormulaIdentifier,
+    inspectorFormulaIdentifier,
     mainWorkerFormulaIdentifier,
     terminator,
   ) => {
@@ -60,7 +60,7 @@ export const makeHostMaker = ({
       selfFormulaIdentifier: hostFormulaIdentifier,
       specialNames: {
         SELF: hostFormulaIdentifier,
-        INFO: infoFormulaIdentifier,
+        INFO: inspectorFormulaIdentifier,
         NONE: 'least-authority',
         ENDO: 'endo',
       },

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -18,12 +18,14 @@ export const makeHostMaker = ({
   /**
    * @param {string} hostFormulaIdentifier
    * @param {string} storeFormulaIdentifier
+   * @param {string} infoFormulaIdentifier
    * @param {string} mainWorkerFormulaIdentifier
    * @param {import('./types.js').Terminator} terminator
    */
   const makeIdentifiedHost = async (
     hostFormulaIdentifier,
     storeFormulaIdentifier,
+    infoFormulaIdentifier,
     mainWorkerFormulaIdentifier,
     terminator,
   ) => {
@@ -58,6 +60,7 @@ export const makeHostMaker = ({
       selfFormulaIdentifier: hostFormulaIdentifier,
       specialNames: {
         SELF: hostFormulaIdentifier,
+        INFO: infoFormulaIdentifier,
         NONE: 'least-authority',
         ENDO: 'endo',
       },

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -9,7 +9,7 @@ const { quote: q } = assert;
 
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:host|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
+  /^(?:host|pet-store|pet-inspector|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -247,6 +247,21 @@ export interface EndoHost {
   ): Promise<unknown>;
 }
 
+export type EndoInspector<Record = string> = {
+  lookup: (petName: Record) => Promise<unknown>;
+  list: () => Record[];
+};
+
+export type KnownEndoInspectors = {
+  'eval-id512': EndoInspector<'endowments' | 'source' | 'worker'>;
+  'make-unconfined-id512': EndoInspector<'host'>;
+  'make-bundle-id512': EndoInspector<'bundle' | 'powers' | 'worker'>;
+  'guest-id512': EndoInspector<'bundle' | 'powers'>;
+  'web-bundle': EndoInspector<'powers' | 'specifier' | 'worker'>;
+  // This is an "empty" inspector, in that there is nothing to `lookup()` or `list()`.
+  [formulaType: string]: EndoInspector<string>;
+};
+
 export type EndoWebBundle = {
   url: string;
   bundle: ERef<EndoReadable>;

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -735,3 +735,52 @@ test('name and reuse inspector', async t => {
 
   await stop(locator);
 });
+
+// TODO: This test verifies existing behavior when pet-naming workers.
+// This behavior is undesirable. See: https://github.com/endojs/endo/issues/2021
+test('eval-mediated worker name', async t => {
+  const { promise: cancelled, reject: cancel } = makePromiseKit();
+  t.teardown(() => cancel(Error('teardown')));
+  const locator = makeLocator('tmp', 'eval-worker-name');
+
+  await stop(locator).catch(() => {});
+  await reset(locator);
+  await start(locator);
+
+  const { getBootstrap } = await makeEndoClient(
+    'client',
+    locator.sockPath,
+    cancelled,
+  );
+  const bootstrap = getBootstrap();
+  const host = E(bootstrap).host();
+  await E(host).provideWorker('worker');
+
+  const counterPath = path.join(dirname, 'test', 'counter.js');
+  await E(host).makeUnconfined('worker', counterPath, 'NONE', 'counter');
+
+  // We create a petname for the worker of `counter`.
+  // Note that while `worker === counter-worker`, it doesn't matter here.
+  const counterWorker = await E(host).evaluate(
+    'worker',
+    'E(E(INFO).lookup("counter")).lookup("worker")',
+    ['INFO'],
+    ['INFO'],
+    'counter-worker',
+  );
+  t.regex(String(counterWorker), /Alleged: EndoWorker/u);
+
+  try {
+    await E(host).evaluate(
+      'counter-worker', // Our worker pet name
+      'E(counter).incr()',
+      ['counter'],
+      ['counter'],
+    );
+    t.fail('should have thrown');
+  } catch (error) {
+    // This is the error that we don't want
+    t.regex(error.message, /typeof target is "undefined"/u);
+    await stop(locator);
+  }
+});


### PR DESCRIPTION
Problem: Commands like `endo make counter.js --name counter` implicitly create a unique worker for the counter. This makes it impossible to address the worker for follow-up commands, like an `eval` co-located with the `counter`.

This change introduces an undeniable `INFO` name to all hosts that allows the host to address the values used to create pet named values. For example, `INFO -> counter -> worker` addresses the worker that was used to create `counter`. Until we have pet name path lookup (#1915), you need multiple invocations of `E()` to perform of depth greater than 1, for example:

```text
> endo make counter.js --name counter
  Object [Alleged: Counter] {}
> endo eval 'E(INFO).lookup("counter")' INFO --name inspector
  Object [Alleged: Inspector (make-bundle ... )]
> endo eval 'E(inspector).lookup("worker")' inspector
  Object [Alleged: EndoWorker] {}
```

This facility is intended to compose well with follow-up changes for inspecting a worker’s log or copy one of these “unnamed” capabilities to a name.