### PR TITLE
feat(daemon): List special names

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -288,18 +288,11 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('list')
-    .option(
-      '-a,--as <party>',
-      'Pose as named party (as named by current party)',
-      collect,
-      [],
-    )
+    .command('list [directory]')
     .description('show names')
-    .action(async cmd => {
-      const { as: partyNames } = cmd.opts();
+    .action(async (directoryName, cmd) => {
       const { list } = await import('./list.js');
-      return list({ partyNames });
+      return list({ directoryName });
     });
 
   program

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -289,10 +289,13 @@ export const main = async rawArgs => {
 
   program
     .command('list [directory]')
-    .description('show names')
+    .description('show names (dot delimited pet name path)')
+    .option('-s,--special', 'show special names')
+    .option('-a,--all', 'show all names')
     .action(async (directoryName, cmd) => {
+      const { special, all } = cmd.opts();
       const { list } = await import('./list.js');
-      return list({ directoryName });
+      return list({ directoryName, special, all });
     });
 
   program

--- a/packages/cli/src/list.js
+++ b/packages/cli/src/list.js
@@ -3,12 +3,16 @@ import os from 'os';
 import { E } from '@endo/far';
 import { withEndoHost } from './context.js';
 
-export const list = async ({ directoryName }) =>
-  withEndoHost({ os, process }, async ({ party }) => {
+export const list = async ({ directoryName, special, all }) =>
+  withEndoHost({ os, process }, async ({ host: party }) => {
     if (directoryName !== undefined) {
       party = E(party).lookup(directoryName);
     }
-    const petNames = await E(party).list();
+    const petNames = await (() => {
+      if (all) return E(party).listAll();
+      if (special) return E(party).listSpecial();
+      return E(party).list();
+    })();
     for await (const petName of petNames) {
       console.log(petName);
     }

--- a/packages/cli/src/list.js
+++ b/packages/cli/src/list.js
@@ -1,10 +1,13 @@
 /* global process */
 import os from 'os';
 import { E } from '@endo/far';
-import { withEndoParty } from './context.js';
+import { withEndoHost } from './context.js';
 
-export const list = async ({ partyNames }) =>
-  withEndoParty(partyNames, { os, process }, async ({ party }) => {
+export const list = async ({ directoryName }) =>
+  withEndoHost({ os, process }, async ({ party }) => {
+    if (directoryName !== undefined) {
+      party = E(party).lookup(directoryName);
+    }
     const petNames = await E(party).list();
     for await (const petName of petNames) {
       console.log(petName);

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -59,6 +59,9 @@ export const makeGuestMaker = ({
       request,
       rename,
       remove,
+      list,
+      listSpecial,
+      listAll,
     } = makeMailbox({
       petStore,
       selfFormulaIdentifier: guestFormulaIdentifier,
@@ -69,7 +72,7 @@ export const makeGuestMaker = ({
       terminator,
     });
 
-    const { has, list, follow: followNames } = petStore;
+    const { has, follow: followNames } = petStore;
 
     /** @type {import('@endo/eventual-send').ERef<import('./types.js').EndoGuest>} */
     const guest = Far('EndoGuest', {
@@ -79,6 +82,8 @@ export const makeGuestMaker = ({
       request,
       send,
       list,
+      listSpecial,
+      listAll,
       followNames,
       followMessages,
       listMessages,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -50,6 +50,9 @@ export const makeHostMaker = ({
       send,
       dismiss,
       adopt,
+      list,
+      listAll,
+      listSpecial,
       rename,
       remove,
       terminate,
@@ -417,7 +420,7 @@ export const makeHostMaker = ({
       return value;
     };
 
-    const { has, list, follow: followNames } = petStore;
+    const { has, follow: followNames } = petStore;
 
     /** @type {import('./types.js').EndoHost} */
     const host = Far('EndoHost', {
@@ -433,6 +436,8 @@ export const makeHostMaker = ({
       request,
       send,
       list,
+      listSpecial,
+      listAll,
       followNames,
       remove,
       rename,

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -67,6 +67,13 @@ export const makeMailboxMaker = ({
       return controller.terminator.terminate();
     };
 
+    const list = () => harden(petStore.list());
+
+    const listSpecial = () => harden(Object.keys(specialNames).sort());
+
+    const listAll = () =>
+      harden([...Object.keys(specialNames).sort(), ...petStore.list()]);
+
     /**
      * @param {string} formulaIdentifier
      */
@@ -483,6 +490,9 @@ export const makeMailboxMaker = ({
       send,
       dismiss,
       adopt,
+      list,
+      listSpecial,
+      listAll,
       rename,
       remove,
       terminate,

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -670,3 +670,33 @@ test('terminate because of requested capability', async t => {
     ),
   );
 });
+
+test('list special names', async t => {
+  const { promise: cancelled, reject: cancel } = makePromiseKit();
+  t.teardown(() => cancel(Error('teardown')));
+  const locator = makeLocator('tmp', 'list-names');
+
+  await stop(locator).catch(() => {});
+  await reset(locator);
+  await start(locator);
+
+  const { getBootstrap } = await makeEndoClient(
+    'client',
+    locator.sockPath,
+    cancelled,
+  );
+  const bootstrap = getBootstrap();
+  const host = E(bootstrap).host();
+
+  const readerRef = makeReaderRef([new TextEncoder().encode('hello\n')]);
+  await E(host).store(readerRef, 'hello-text');
+
+  const names = await E(host).list();
+  const specialNames = await E(host).listSpecial();
+  const allNames = await E(host).listAll();
+
+  t.deepEqual(['hello-text'], names);
+  t.assert(specialNames.length > 0);
+  t.assert(specialNames.every(name => name.toUpperCase() === name));
+  t.deepEqual([...specialNames, ...names], allNames);
+});


### PR DESCRIPTION
Hosts and guests have a pet store and also special names. The special names are distinguished by being in `ALL_CAPS` like `SELF` or `HOST` so that they do not collide with `kebab-case` pet names. The special names cannot be deleted or overwritten. Guests and hosts have different special names.

This change makes the list of special names observable by adding `listSpecial()` and `listAll()` methods to the host and guest facets and revealing them in the CLI with `--special` and `--all` flags.

This change also alters the `endo list` command to accept an optional dot-delimited pet name path to the store the user wishes to list. The object at the end of that dot delimited path must implement `list()`, `listAll()`, or `listSpecial()` but can otherwise be an arbitrary object implementing this protocol. This completely subsumes the behavior of the `--as` flag for this command, freeing `-a` up for `--all`.