### PR TITLE
fix(daemon): makeIdentifiedHost wrapped controller bug

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -445,13 +445,12 @@ const makeEndoBootstrap = (
       const workerFormulaIdentifier = `worker-id512:${formulaNumber}`;
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      const external = makeIdentifiedHost(
+      return makeIdentifiedHost(
         formulaIdentifier,
         storeFormulaIdentifier,
         workerFormulaIdentifier,
         terminator,
       );
-      return { external, internal: undefined };
     } else if (
       [
         'eval-id512',

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -670,3 +670,27 @@ test('terminate because of requested capability', async t => {
     ),
   );
 });
+
+test('make a host', async t => {
+  const { promise: cancelled, reject: cancel } = makePromiseKit();
+  t.teardown(() => cancel(Error('teardown')));
+  const locator = makeLocator('tmp', 'make-host');
+
+  await stop(locator).catch(() => {});
+  await reset(locator);
+  await start(locator);
+
+  const { getBootstrap } = await makeEndoClient(
+    'client',
+    locator.sockPath,
+    cancelled,
+  );
+  const bootstrap = getBootstrap();
+  const host = E(bootstrap).host();
+  const host2 = E(host).provideHost('fellow-host');
+  await E(host2).makeWorker('w1');
+  const ten = await E(host2).evaluate('w1', '10', [], []);
+  t.is(ten, 10);
+
+  await stop(locator);
+});


### PR DESCRIPTION
closes: #1901

## Description

A flaw in the Endo pet daemon prevented the user from creating new user profiles. The flow crept in through the refactor that separated external and internal facets for every entity that endo can create.
