### PR TITLE
fix(eventual-send): switch DEBUG option to be comma separated

### DIFF
--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -1,5 +1,8 @@
 /* global globalThis */
-import { getEnvironmentOption } from '@endo/env-options';
+import {
+  getEnvironmentOption,
+  environmentOptionsListHas,
+} from '@endo/env-options';
 
 // NOTE: We can't import these because they're not in scope before lockdown.
 // import { assert, details as X, Fail } from '@agoric/assert';
@@ -15,16 +18,8 @@ let hiddenPriorError;
 let hiddenCurrentTurn = 0;
 let hiddenCurrentEvent = 0;
 
-const DEBUG = getEnvironmentOption('DEBUG', '');
-
 // Turn on if you seem to be losing error logging at the top of the event loop
-//
-// TODO This use of colon (`':'`) as a separator is a bad legacy convention.
-// It should be comma (`','`). Once we can switch it to comma, then use the
-// following commented out definition of `VERBOSE` instead.
-// const VERBOSE = environmentOptionsListHas('DEBUG', 'track-turns');
-// See https://github.com/Agoric/agoric-sdk/issues/8096
-const VERBOSE = DEBUG.split(':').includes('track-turns');
+const VERBOSE = environmentOptionsListHas('DEBUG', 'track-turns');
 
 // Track-turns is disabled by default and can be enabled by an environment
 // option.


### PR DESCRIPTION
refs: https://github.com/Agoric/agoric-sdk/pull/8136
refs: https://github.com/Agoric/agoric-sdk/issues/8096
refs: https://github.com/Agoric/agoric-sdk/blob/master/docs/env.md#DEBUG

## Description

As explained at https://github.com/Agoric/agoric-sdk/issues/8096 , prior to this PR, eventual-send's use of the `DEBUG` option mistakenly split it on colons (`':'`). This PR switches that one use to split on commas (`','`) instead. 

### Security Considerations

Following widespread conventions leads to fewer unpleasant surprises.

### Scaling Considerations

none

### Documentation Considerations

https://github.com/Agoric/agoric-sdk/blob/master/docs/env.md#DEBUG already speaks in terms of the value of `DEBUG` being a comma separated list. Prior to this PR, the endo implementation does not conform to that document. But the agoric-sdk implementation would still not conform until fixed by https://github.com/Agoric/agoric-sdk/pull/8136

### Testing Considerations

none

### Upgrade Considerations

none