### PR TITLE
fix(exo): reform exo amplifier API

### DIFF
--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -70,29 +70,47 @@ export const initEmpty = () => emptyRecord;
  */
 
 /**
- * @callback Revoker
+ * Template for function-valued options for exo class or exo class kit
+ * definitions, for receiving powers back at definition time. For example,
+ * ```js
+ * let amplify;
+ * const makeFoo = defineExoClassKit(
+ *   tag,
+ *   interfaceGuardKit,
+ *   initFn,
+ *   behaviorKit,
+ *   {
+ *     receiveAmplifier(a) { amplify = a; },
+ *   },
+ * );
+ * ```
+ * uses the `receiveAmplifier` option to receive, during the
+ * definition of this exo class kit, the power to amplify a facet of the kit.
+ *
+ * @template {any} P
+ * @typedef {(power: P) => void} ReceivePower
+ */
+
+/**
+ * The power to revoke a live instance of the associated exo class, or the
+ * power to revoke a live facet instance of the associated exo class kit.
+ * If called with such a live instance, it revokes it and returns true. Once
+ * revoked, it is no longer live, and calling any of its methods throw
+ * an informative diagnostic with no further effects.
+ *
+ * @callback Revoke
  * @param {any} exo
  * @returns {boolean}
  */
 
 /**
- * @callback ReceiveRevoker
- * @param {Revoker} revoke
- * @returns {void}
- */
-
-/**
- * @template {any} F
- * @callback Amplifier
- * @param {any} exo
+ * The power to amplify a live facet instance of the associated exo class kit
+ * into the record of all facets of this facet instance's cohort.
+ *
+ * @template {any} [F=any]
+ * @callback Amplify
+ * @param {any} exoFacet
  * @returns {F}
- */
-
-/**
- * @template {any} F
- * @callback ReceiveAmplifier
- * @param {Amplifier<F>} amplifier
- * @returns {void}
  */
 
 // TODO Should we split FarClassOptions into distinct types for
@@ -122,23 +140,23 @@ export const initEmpty = () => emptyRecord;
  * enforce the `stateShape` invariant. The heap exos defined in this
  * package currently ignore `stateShape`, but will enforce this in the future.
  *
- * @property {ReceiveRevoker} [receiveRevoker]
+ * @property {ReceivePower<Revoke>} [receiveRevoker]
  * If a `receiveRevoker` function is provided, it will be called during
- * definition of the exo class or exo class kit with a `Revoker` function.
- * A `Revoker` function is a function of one argument. If you call the revoker
+ * definition of the exo class or exo class kit with a `Revoke` function.
+ * A `Revoke` function is a function of one argument. If you call the revoke
  * function with a live instance of this exo class, or a live facet instance
  * of this exo class kit, then it will "revoke" it and return true. Once
  * revoked, this instance is no longer "live": Any attempt to invoke any of
  * its methods will fail without further effect.
  *
- * @property {ReceiveAmplifier<F>} [receiveAmplifier]
+ * @property {ReceivePower<Amplify<F>>} [receiveAmplifier]
  * If a `receiveAmplifier` function is provided, it will be called during
- * definition of the exo class kit with an `Amplifier` function. If called
+ * definition of the exo class kit with an `Amplify` function. If called
  * during the definition of a normal exo or exo class, it will throw, since
  * only exo kits can be amplified.
- * An `Amplifier` function is a function that takes a live facet instance of
+ * An `Amplify` function is a function that takes a live facet instance of
  * this class kit as an argument, in which case it will return the facets
- * record, giving access to all the other facet instances of the same cohort.
+ * record, giving access to all the facet instances of the same cohort.
  */
 
 /**
@@ -232,7 +250,10 @@ harden(defineExoClass);
  * } | undefined} interfaceGuardKit
  * @param {I} init
  * @param {F & { [K in keyof F]: ThisType<{ facets: GuardedKit<F>, state: ReturnType<I> }> }} methodsKit
- * @param {FarClassOptions<KitContext<ReturnType<I>, GuardedKit<F>>>} [options]
+ * @param {FarClassOptions<
+ *   KitContext<ReturnType<I>, GuardedKit<F>>,
+ *   GuardedKit<F>
+ * >} [options]
  * @returns {(...args: Parameters<I>) => GuardedKit<F>}
  */
 export const defineExoClassKit = (

--- a/packages/exo/test/test-amplify-heap-class-kits.js
+++ b/packages/exo/test/test-amplify-heap-class-kits.js
@@ -73,34 +73,27 @@ test('test amplify defineExoClassKit', t => {
       },
     },
   );
-  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  const counterKit = makeCounterKit(3);
+  const { up: upCounter, down: downCounter } = counterKit;
   t.is(upCounter.incr(5), 8);
   t.is(downCounter.decr(), 7);
 
-  t.throws(() => amp(upCounter, 'sideways'), {
-    message: '"sideways" must be a facet name of "Counter"',
-  });
-  t.throws(() => amp(harden({}), 'down'), {
+  t.throws(() => amp(harden({})), {
     message: 'Must be an unrevoked facet of "Counter": {}',
   });
-  t.is(amp(upCounter, 'down'), downCounter);
-  t.is(amp(upCounter, 'up'), upCounter);
-  t.is(amp(downCounter, 'up'), upCounter);
-  t.is(amp(downCounter, 'down'), downCounter);
+  t.deepEqual(amp(upCounter), counterKit);
+  t.deepEqual(amp(downCounter), counterKit);
 
   t.is(revoke(upCounter), true);
 
-  t.throws(() => amp(upCounter, 'down'), {
+  t.throws(() => amp(upCounter), {
     message: 'Must be an unrevoked facet of "Counter": "[Alleged: Counter up]"',
   });
-  t.throws(() => amp(upCounter, 'up'), {
-    message: 'Must be an unrevoked facet of "Counter": "[Alleged: Counter up]"',
-  });
-  t.is(amp(downCounter, 'up'), upCounter);
+  t.deepEqual(amp(downCounter), counterKit);
   t.throws(() => upCounter.incr(3), {
     message:
       '"In \\"incr\\" method of (Counter up)" may only be applied to a valid instance: "[Alleged: Counter up]"',
   });
-  t.is(amp(downCounter, 'down'), downCounter);
+  t.deepEqual(amp(downCounter), counterKit);
   t.is(downCounter.decr(), 6);
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #1902 

## Description

At https://github.com/endojs/endo/pull/1902#issuecomment-1874451253 @mhofman rightly points out

> In the kernel meeting a couple weeks ago, we discussed having the shape of this rights amplification function be a simple function that accepts a facet, and returns the cohort. I think I preferred that shape vs taking a facet name, but I do realize I didn't capture that feedback in this pull request.

This PR fixes that oversight.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?  -->

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?  -->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?  -->

### Upgrade Considerations

I flagged this PR with a `fix(exo)!: ...` because this fix is not a compat change from #1902. OTOH, it is unlikely that anyone is using the #1902 API yet, in which case this PR is a compat change from the prior endo state. The last endo release was before #1902, so this PR is also a compat change from the last release.

Should I downgrade to `fix(exo): ...` ?