### PR TITLE
feat(exo): instance testing

### DIFF
--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -88,7 +88,7 @@ export const initEmpty = () => emptyRecord;
  */
 
 /**
- * The power to amplify a live facet instance of the associated exo class kit
+ * The power to amplify a facet instance of the associated exo class kit
  * into the record of all facets of this facet instance's cohort.
  *
  * @template {any} [F=any]
@@ -98,13 +98,13 @@ export const initEmpty = () => emptyRecord;
  */
 
 /**
- * The power to test if a value is a live instance of the
- * associated exo class, or a live facet instance of the
+ * The power to test if a value is an instance of the
+ * associated exo class, or a facet instance of the
  * associated exo class kit. In the later case, if a `facetName` is provided,
  * then it tests only whether the argument is a facet instance of that
  * facet of the associated exo class kit.
  *
- * @callback IsLiveInstance
+ * @callback IsInstance
  * @param {any} exo
  * @param {string} [facetName]
  * @returns {boolean}
@@ -142,14 +142,14 @@ export const initEmpty = () => emptyRecord;
  * definition of the exo class kit with an `Amplify` function. If called
  * during the definition of a normal exo or exo class, it will throw, since
  * only exo kits can be amplified.
- * An `Amplify` function is a function that takes a live facet instance of
+ * An `Amplify` function is a function that takes a facet instance of
  * this class kit as an argument, in which case it will return the facets
  * record, giving access to all the facet instances of the same cohort.
  *
- * @property {ReceivePower<IsLiveInstance>} [receiveInstanceTester]
+ * @property {ReceivePower<IsInstance>} [receiveInstanceTester]
  * If a `receiveInstanceTester` function is provided, it will be called
  * during the definition of the exo class or exo class kit with an
- * `IsLiveInstance` function. The first argument of `IsLiveInstance`
+ * `IsInstance` function. The first argument of `IsInstance`
  * is the value to be tested. When it may be a facet instance of an
  * exo class kit, the optional second argument, if provided, is
  * a `facetName`. In that case, the function tests only if the first
@@ -229,15 +229,15 @@ export const defineExoClass = (
   };
 
   if (receiveInstanceTester) {
-    const isLiveInstance = (exo, facetName = undefined) => {
+    const isInstance = (exo, facetName = undefined) => {
       facetName === undefined ||
         Fail`facetName can only be used with an exo class kit: ${q(
           tag,
         )} has no facet ${q(facetName)}`;
       return contextMap.has(exo);
     };
-    harden(isLiveInstance);
-    receiveInstanceTester(isLiveInstance);
+    harden(isInstance);
+    receiveInstanceTester(isInstance);
   }
 
   return harden(makeInstance);
@@ -324,7 +324,7 @@ export const defineExoClassKit = (
   }
 
   if (receiveInstanceTester) {
-    const isLiveInstance = (exoFacet, facetName = undefined) => {
+    const isInstance = (exoFacet, facetName = undefined) => {
       if (facetName === undefined) {
         return values(contextMapKit).some(contextMap =>
           contextMap.has(exoFacet),
@@ -336,8 +336,8 @@ export const defineExoClassKit = (
         Fail`exo class kit ${q(tag)} has no facet named ${q(facetName)}`;
       return contextMap.has(exoFacet);
     };
-    harden(isLiveInstance);
-    receiveInstanceTester(isLiveInstance);
+    harden(isInstance);
+    receiveInstanceTester(isInstance);
   }
 
   return harden(makeInstanceKit);

--- a/packages/exo/test/test-amplify-heap-class-kits.js
+++ b/packages/exo/test/test-amplify-heap-class-kits.js
@@ -1,4 +1,4 @@
-// modeled on test-revoke-heap-classes.js
+// modeled on test-heap-classes.js
 
 // eslint-disable-next-line import/order
 import { test } from './prepare-test-env-ava.js';

--- a/packages/exo/test/test-is-instance-heap-class-kits.js
+++ b/packages/exo/test/test-is-instance-heap-class-kits.js
@@ -15,8 +15,8 @@ const DownCounterI = M.interface('DownCounter', {
   decr: M.call().optional(M.gte(0)).returns(M.number()),
 });
 
-test('test isLiveInstance defineExoClass', t => {
-  let isLiveInstance;
+test('test isInstance defineExoClass', t => {
+  let isInstance;
   const makeUpCounter = defineExoClass(
     'UpCounter',
     UpCounterI,
@@ -31,27 +31,27 @@ test('test isLiveInstance defineExoClass', t => {
     },
     {
       receiveInstanceTester(i) {
-        isLiveInstance = i;
+        isInstance = i;
       },
     },
   );
-  t.is(isLiveInstance(harden({})), false);
-  t.throws(() => isLiveInstance(harden({}), 'up'), {
+  t.is(isInstance(harden({})), false);
+  t.throws(() => isInstance(harden({}), 'up'), {
     message:
       'facetName can only be used with an exo class kit: "UpCounter" has no facet "up"',
   });
 
   const upCounter = makeUpCounter(3);
 
-  t.is(isLiveInstance(upCounter), true);
-  t.throws(() => isLiveInstance(upCounter, 'up'), {
+  t.is(isInstance(upCounter), true);
+  t.throws(() => isInstance(upCounter, 'up'), {
     message:
       'facetName can only be used with an exo class kit: "UpCounter" has no facet "up"',
   });
 });
 
-test('test isLiveInstance defineExoClassKit', t => {
-  let isLiveInstance;
+test('test isInstance defineExoClassKit', t => {
+  let isInstance;
   const makeCounterKit = defineExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
@@ -75,23 +75,23 @@ test('test isLiveInstance defineExoClassKit', t => {
     },
     {
       receiveInstanceTester(i) {
-        isLiveInstance = i;
+        isInstance = i;
       },
     },
   );
 
-  t.is(isLiveInstance(harden({})), false);
-  t.is(isLiveInstance(harden({}), 'up'), false);
-  t.throws(() => isLiveInstance(harden({}), 'foo'), {
+  t.is(isInstance(harden({})), false);
+  t.is(isInstance(harden({}), 'up'), false);
+  t.throws(() => isInstance(harden({}), 'foo'), {
     message: 'exo class kit "Counter" has no facet named "foo"',
   });
 
   const { up: upCounter } = makeCounterKit(3);
 
-  t.is(isLiveInstance(upCounter), true);
-  t.is(isLiveInstance(upCounter, 'up'), true);
-  t.is(isLiveInstance(upCounter, 'down'), false);
-  t.throws(() => isLiveInstance(upCounter, 'foo'), {
+  t.is(isInstance(upCounter), true);
+  t.is(isInstance(upCounter, 'up'), true);
+  t.is(isInstance(upCounter, 'down'), false);
+  t.throws(() => isInstance(upCounter, 'foo'), {
     message: 'exo class kit "Counter" has no facet named "foo"',
   });
 });

--- a/packages/exo/test/test-live-instance-heap-class-kits.js
+++ b/packages/exo/test/test-live-instance-heap-class-kits.js
@@ -1,4 +1,4 @@
-// modeled on test-revoke-heap-classes.js
+// modeled on test-heap-classes.js
 
 // eslint-disable-next-line import/order
 import { test } from './prepare-test-env-ava.js';
@@ -15,8 +15,7 @@ const DownCounterI = M.interface('DownCounter', {
   decr: M.call().optional(M.gte(0)).returns(M.number()),
 });
 
-test('test revoke defineExoClass', t => {
-  let revoke;
+test('test isLiveInstance defineExoClass', t => {
   let isLiveInstance;
   const makeUpCounter = defineExoClass(
     'UpCounter',
@@ -31,9 +30,6 @@ test('test revoke defineExoClass', t => {
       },
     },
     {
-      receiveRevoker(r) {
-        revoke = r;
-      },
       receiveInstanceTester(i) {
         isLiveInstance = i;
       },
@@ -52,12 +48,9 @@ test('test revoke defineExoClass', t => {
     message:
       'facetName can only be used with an exo class kit: "UpCounter" has no facet "up"',
   });
-  t.is(revoke(upCounter), true);
-  t.is(isLiveInstance(upCounter), false);
 });
 
-test('test amplify defineExoClassKit', t => {
-  let revoke;
+test('test isLiveInstance defineExoClassKit', t => {
   let isLiveInstance;
   const makeCounterKit = defineExoClassKit(
     'Counter',
@@ -81,9 +74,6 @@ test('test amplify defineExoClassKit', t => {
       },
     },
     {
-      receiveRevoker(r) {
-        revoke = r;
-      },
       receiveInstanceTester(i) {
         isLiveInstance = i;
       },
@@ -96,7 +86,7 @@ test('test amplify defineExoClassKit', t => {
     message: 'exo class kit "Counter" has no facet named "foo"',
   });
 
-  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+  const { up: upCounter } = makeCounterKit(3);
 
   t.is(isLiveInstance(upCounter), true);
   t.is(isLiveInstance(upCounter, 'up'), true);
@@ -104,13 +94,4 @@ test('test amplify defineExoClassKit', t => {
   t.throws(() => isLiveInstance(upCounter, 'foo'), {
     message: 'exo class kit "Counter" has no facet named "foo"',
   });
-
-  t.is(revoke(upCounter), true);
-
-  t.is(isLiveInstance(upCounter), false);
-  t.is(isLiveInstance(upCounter, 'up'), false);
-  t.is(isLiveInstance(upCounter, 'down'), false);
-  t.is(isLiveInstance(downCounter), true);
-  t.is(isLiveInstance(downCounter, 'up'), false);
-  t.is(isLiveInstance(downCounter, 'down'), true);
 });

--- a/packages/exo/test/test-live-instance-heap-class-kits.js
+++ b/packages/exo/test/test-live-instance-heap-class-kits.js
@@ -1,0 +1,116 @@
+// modeled on test-revoke-heap-classes.js
+
+// eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { M } from '@endo/patterns';
+import { defineExoClass, defineExoClassKit } from '../src/exo-makers.js';
+
+const UpCounterI = M.interface('UpCounter', {
+  incr: M.call().optional(M.gte(0)).returns(M.number()),
+});
+
+const DownCounterI = M.interface('DownCounter', {
+  decr: M.call().optional(M.gte(0)).returns(M.number()),
+});
+
+test('test revoke defineExoClass', t => {
+  let revoke;
+  let isLiveInstance;
+  const makeUpCounter = defineExoClass(
+    'UpCounter',
+    UpCounterI,
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      incr(y = 1) {
+        const { state } = this;
+        state.x += y;
+        return state.x;
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+      receiveInstanceTester(i) {
+        isLiveInstance = i;
+      },
+    },
+  );
+  t.is(isLiveInstance(harden({})), false);
+  t.throws(() => isLiveInstance(harden({}), 'up'), {
+    message:
+      'facetName can only be used with an exo class kit: "UpCounter" has no facet "up"',
+  });
+
+  const upCounter = makeUpCounter(3);
+
+  t.is(isLiveInstance(upCounter), true);
+  t.throws(() => isLiveInstance(upCounter, 'up'), {
+    message:
+      'facetName can only be used with an exo class kit: "UpCounter" has no facet "up"',
+  });
+  t.is(revoke(upCounter), true);
+  t.is(isLiveInstance(upCounter), false);
+});
+
+test('test amplify defineExoClassKit', t => {
+  let revoke;
+  let isLiveInstance;
+  const makeCounterKit = defineExoClassKit(
+    'Counter',
+    { up: UpCounterI, down: DownCounterI },
+    /** @param {number} x */
+    (x = 0) => ({ x }),
+    {
+      up: {
+        incr(y = 1) {
+          const { state } = this;
+          state.x += y;
+          return state.x;
+        },
+      },
+      down: {
+        decr(y = 1) {
+          const { state } = this;
+          state.x -= y;
+          return state.x;
+        },
+      },
+    },
+    {
+      receiveRevoker(r) {
+        revoke = r;
+      },
+      receiveInstanceTester(i) {
+        isLiveInstance = i;
+      },
+    },
+  );
+
+  t.is(isLiveInstance(harden({})), false);
+  t.is(isLiveInstance(harden({}), 'up'), false);
+  t.throws(() => isLiveInstance(harden({}), 'foo'), {
+    message: 'exo class kit "Counter" has no facet named "foo"',
+  });
+
+  const { up: upCounter, down: downCounter } = makeCounterKit(3);
+
+  t.is(isLiveInstance(upCounter), true);
+  t.is(isLiveInstance(upCounter, 'up'), true);
+  t.is(isLiveInstance(upCounter, 'down'), false);
+  t.throws(() => isLiveInstance(upCounter, 'foo'), {
+    message: 'exo class kit "Counter" has no facet named "foo"',
+  });
+
+  t.is(revoke(upCounter), true);
+
+  t.is(isLiveInstance(upCounter), false);
+  t.is(isLiveInstance(upCounter, 'up'), false);
+  t.is(isLiveInstance(upCounter, 'down'), false);
+  t.is(isLiveInstance(downCounter), true);
+  t.is(isLiveInstance(downCounter, 'up'), false);
+  t.is(isLiveInstance(downCounter, 'down'), true);
+});


### PR DESCRIPTION
Now staged on #1964 

closes: #XXXX
refs: #1924 #1964 

## Description

This PR adds a third meta-level rights amplification power: the power to tell if an object is a live instance of an exo class, or a live facet instance of an exo class kit.

After revoking and amplifying, the remaining obvious meta-level rights amplification power normally associated with classes is unforgeable instance testing. (In some ocap literature, this is sometimes referred to as "brand testing". But given ERTP's conflicting use of the term "brand", this is best avoided.)

Given revocability and our desire that all these meta-level powers be essentially free, these test only that an object is a live instance of the associated class, or a live facet instance of the associated class kit. In neither case do we distinguish between a revoked former instance vs any other non-live-instance value.

### Security Considerations

In many OO languages, such as Java, access to a class bundles the ability to instantiate the class with the ability to reliably test for membership in the class. For exo classes and exo class kits, to follow the principles of least authority and information hiding, we decided to separate the two. As with the other meta-level rights amplification powers, these are not provided by default, and it is easy for a code review to see it they are provided at all, and where these powers might be used.

The obvious JavaScript test, `instanceof`, is not reliable. However, JavaScript classes do provide a reliable test via
private fields. Like the design in this PR, this power is initially present only within the lexical scope of the class. It is up to code within that lexical scope whether to make that power available to code elsewhere.

### Scaling Considerations

Should be free, as it uses the `contextMap` indirection already present in exos.

### Documentation Considerations

For all these meta-level rights amplification powers, the inline doc-comments now contains adequate text to seed real documentation, especially when consulting the tests for illustrative examples. However, none of these are yet implemented for virtual or durable exos, and cannot be until agoric-sdk is upgraded to depend on an endo release incorporating this PR. Until then, we should probably hold back on more public documentation of these APIs.

### Testing Considerations

This PR provided only tests for the heap-based exo implementations, which are all that the @endo/exo package provided. Once base-zone is migrated from agoric-sdk to endo, we should rewrite these tests using Zones so they are reusable for virtual and durable exos as well.

### Upgrade Considerations

For all these meta-level rights amplification powers, which powers are provided might vary per incarnation. Since amplification and live instance testing are query only powers against representation that exists anyway, having these vary per incarnation should not be a problem. It remains to be seen whether this will also be true for revocation.