### PR TITLE
refactor(patterns): remove evasive blank line

### DIFF
--- a/packages/patterns/src/utils.js
+++ b/packages/patterns/src/utils.js
@@ -123,8 +123,6 @@ harden(listDifference);
  * @param {ErrorConstructor=} ErrorConstructor
  * @returns {never}
  */
-
-// Evade https://github.com/endojs/endo/issues/1450 using blank line
 export const throwLabeled = (innerErr, label, ErrorConstructor = undefined) => {
   if (typeof label === 'number') {
     label = `[${label}]`;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #1450 
refs: #XXXX

## Description

Remove evasive blank line that was needed to work around a TypeScript problem #1450 but is no longer needed.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Should ease transition to using TS types for generated documentation. But does not yet actually help.

### Testing Considerations

None

### Upgrade Considerations

None