### PR TITLE
fix: Add repository directory to all package descriptors

### DIFF
--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -12,7 +12,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/base64/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/base64"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -56,7 +56,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo"
+    "url": "git+https://github.com/endojs/endo",
+    "directory": "packages/bundle-source"
   },
   "author": "Endo contributors",
   "license": "Apache-2.0",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -30,7 +30,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/captp"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -14,7 +14,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/check-bundle#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/check-bundle"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/cjs-module-analyzer#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/cjs-module-analyzer"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/cli/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/cli"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -13,7 +13,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/compartment-mapper#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/compartment-mapper"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -11,7 +11,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/daemon/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/daemon"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/env-options#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/env-options"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/errors#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/errors"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,5 +31,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "directory": "packages/eslint-plugin"
+  }
 }

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -11,7 +11,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/evasive-transform#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/evasive-transform"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/eventual-send"
   },
   "author": "Endo contributors",
   "license": "Apache-2.0",

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/exo/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/exo"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -23,7 +23,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/far"
   },
   "author": "Endo contributors",
   "license": "Apache-2.0",

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -2,6 +2,18 @@
   "name": "@endo/import-bundle",
   "version": "1.0.2",
   "description": "load modules created by @endo/bundle-source",
+  "keywords": [],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/import-bundle",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/import-bundle"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
   "type": "module",
   "main": "src/index.js",
   "module": "src/index.js",
@@ -47,12 +59,6 @@
     "*.js",
     "*.ts"
   ],
-  "author": "Endo contributors",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/endojs/endo/issues"
-  },
-  "homepage": "https://github.com/endojs/endo/tree/master/packages/import-bundle",
   "eslintConfig": {
     "extends": [
       "plugin:@endo/internal"

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -48,7 +48,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/init"
   },
   "author": "Endo contributors",
   "license": "Apache-2.0",

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -32,7 +32,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/lockdown"
   },
   "author": "Agoric",
   "license": "Apache-2.0",

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/lp32/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/lp32"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -28,7 +28,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/marshal"
   },
   "keywords": [
     "marshal"

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/memoize#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/memoize"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/nat"
   },
   "author": "Endo contributors",
   "license": "Apache-2.0",

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/netstring/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/netstring"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/pass-style#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/pass-style"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/patterns/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/patterns"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -10,7 +10,8 @@
   "homepage": "https://github.com/endojs/endo#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/promise-kit"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -11,7 +11,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/ses-ava#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/ses-ava"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/ses-integration-test#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Agoric/SES-shim.git"
+    "url": "git+https://github.com/Agoric/SES-shim.git",
+    "directory": "packages/ses-integration-test"
   },
   "bugs": {
     "url": "https://github.com/Agoric/SES-shim/issues"

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/ses#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/ses"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/skel#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/skel"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -13,7 +13,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/static-module-record#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/static-module-record"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -14,7 +14,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/stream-node#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/stream-node"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/endojs/endo/tree/master/packages/stream-types-test#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/stream-types-test"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -15,7 +15,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/stream/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/stream"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -12,7 +12,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/syrup/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/syrup"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -25,5 +25,8 @@
     "extends": [
       "plugin:@endo/internal"
     ]
+  },
+  "repository": {
+    "directory": "packages/test262-runner"
   }
 }

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/where/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/where"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -12,7 +12,8 @@
   "homepage": "https://github.com/endojs/endo/blob/master/packages/zip/README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/endojs/endo.git"
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/zip"
   },
   "bugs": {
     "url": "https://github.com/endojs/endo/issues"

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -45,6 +45,7 @@ NEWPKGJSONHASH=$(
     name: (.name // "@endo/\($name)"),
     version: (.version // "0.1.0"),
     homepage: (.homepage // "https://github.com/endojs/endo/tree/master/packages/\($name)#readme"),
+    repository: (.repository + { directory: "packages/\($name)" }),
     scripts: ((.scripts // {}) | to_entries | sort_by(.key) | from_entries),
     dependencies: ((.dependencies // {}) | to_entries | sort_by(.key) | from_entries),
     devDependencies: ((.devDependencies // {}) | to_entries | sort_by(.key) | from_entries),


### PR DESCRIPTION
fixes: #1754 

This adds a repository directory to every package’s descriptor `package.json` so that `npmjs.com` can render relative links correctly.