### PR TITLE
test(ses): Test freezing of anonymous intrinsics

### DIFF
--- a/packages/ses/test/test-frozen-anon-intrinsics.js
+++ b/packages/ses/test/test-frozen-anon-intrinsics.js
@@ -1,0 +1,19 @@
+import test from 'ava';
+import '../index.js';
+
+function makeArguments() {
+  // eslint-disable-next-line prefer-rest-params
+  return arguments;
+}
+
+test.before(() => {
+  lockdown();
+});
+
+test('arguments.callee getter is frozen', t => {
+  t.truthy(
+    Object.isFrozen(
+      Object.getOwnPropertyDescriptor(makeArguments(), 'callee').get,
+    ),
+  );
+});


### PR DESCRIPTION
closes: #167

Expressly verifies that lockdown freezes at least one anonymous intrinsic even though it is a special category.