### PR TITLE
feat: explicitly harden some shared prototypes

### DIFF
--- a/packages/captp/src/atomics.js
+++ b/packages/captp/src/atomics.js
@@ -56,7 +56,7 @@ export const makeAtomicsTrapHost = transferBuffer => {
 
   const te = new TextEncoder();
 
-  return async function* trapHost([isReject, serialized]) {
+  return harden(async function* trapHost([isReject, serialized]) {
     // Get the complete encoded message buffer.
     const json = JSON.stringify(serialized);
     const encoded = te.encode(json);
@@ -94,7 +94,7 @@ export const makeAtomicsTrapHost = transferBuffer => {
         yield;
       }
     }
-  };
+  });
 };
 
 /**

--- a/packages/exo/test/test-exo-wobbly-point.js
+++ b/packages/exo/test/test-exo-wobbly-point.js
@@ -35,6 +35,7 @@ class ExoBaseClass {
     return harden({});
   }
 }
+harden(ExoBaseClass);
 
 const defineExoClassFromJSClass = klass =>
   defineExoClass(klass.name, klass.implements, klass.init, klass.prototype);
@@ -55,6 +56,7 @@ class ExoAbstractPoint extends ExoBaseClass {
     return `<${self.getX()},${self.getY()}>`;
   }
 }
+harden(ExoAbstractPoint);
 
 test('cannot make abstract class concrete', t => {
   t.throws(() => defineExoClassFromJSClass(ExoAbstractPoint), {

--- a/packages/far/test/test-e.js
+++ b/packages/far/test/test-e.js
@@ -83,16 +83,16 @@ test('E call missing method', async t => {
 });
 
 test('E call missing inherited methods', async t => {
-  const x = {
-    __proto__: {
+  const x = harden({
+    __proto__: harden({
       half(n) {
         return n / 2;
       },
-    },
+    }),
     double(n) {
       return 2 * n;
     },
-  };
+  });
   await t.throwsAsync(() => E(x).triple(6), {
     message: 'target has no method "triple", has ["double","half"]',
   });
@@ -108,6 +108,7 @@ test('E call missing class methods', async t => {
       return n / 2;
     }
   }
+  harden(X1);
   class X2 extends X1 {
     constructor() {
       super();
@@ -118,6 +119,7 @@ test('E call missing class methods', async t => {
       return 2 * n;
     }
   }
+  harden(X2);
   const x = new X2();
   await t.throwsAsync(() => E(x).triple(6), {
     message:

--- a/packages/lp32/reader.js
+++ b/packages/lp32/reader.js
@@ -71,6 +71,7 @@ async function* makeLp32Iterator(
     );
   }
 }
+harden(makeLp32Iterator);
 
 /**
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} reader

--- a/packages/marshal/test/test-marshal-capdata.js
+++ b/packages/marshal/test/test-marshal-capdata.js
@@ -264,9 +264,12 @@ test('serialize errors', t => {
   }
 
   // Bad prototype and bad "message" property
-  const nonErrorProto1 = { __proto__: Error.prototype, name: 'included' };
-  const nonError1 = { __proto__: nonErrorProto1, message: [] };
-  t.deepEqual(ser(harden(nonError1)), {
+  const nonErrorProto1 = harden({
+    __proto__: Error.prototype,
+    name: 'included',
+  });
+  const nonError1 = harden({ __proto__: nonErrorProto1, message: [] });
+  t.deepEqual(ser(nonError1), {
     body: '{"@qclass":"error","errorId":"error:anon-marshal#10004","message":"","name":"included"}',
     slots: [],
   });

--- a/packages/marshal/test/test-marshal-smallcaps.js
+++ b/packages/marshal/test/test-marshal-smallcaps.js
@@ -124,9 +124,12 @@ test('smallcaps serialize errors', t => {
   }
 
   // Bad prototype and bad "message" property
-  const nonErrorProto1 = { __proto__: Error.prototype, name: 'included' };
-  const nonError1 = { __proto__: nonErrorProto1, message: [] };
-  t.deepEqual(ser(harden(nonError1)), {
+  const nonErrorProto1 = harden({
+    __proto__: Error.prototype,
+    name: 'included',
+  });
+  const nonError1 = harden({ __proto__: nonErrorProto1, message: [] });
+  t.deepEqual(ser(nonError1), {
     body: '#{"#error":"","name":"included"}',
     slots: [],
   });

--- a/packages/marshal/test/test-marshal-testing.js
+++ b/packages/marshal/test/test-marshal-testing.js
@@ -49,10 +49,10 @@ const bob6 = harden({
 });
 const bob7 = harden({ __proto__: bob6 });
 const bob8 = harden({
-  __proto__: {
+  __proto__: harden({
     [Symbol.toStringTag]: 'Alleged: bob',
     foo: 'x',
-  },
+  }),
 });
 
 test('ava deepEqual related edge cases', t => {

--- a/packages/netstring/reader.js
+++ b/packages/netstring/reader.js
@@ -132,6 +132,7 @@ async function* makeNetstringIterator(
 
   return undefined;
 }
+harden(makeNetstringIterator);
 
 /**
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} input

--- a/packages/pass-style/test/test-far-class-instances.js
+++ b/packages/pass-style/test/test-far-class-instances.js
@@ -30,6 +30,7 @@ class FarSubclass1 extends FarBaseClass {
     return x + x;
   }
 }
+harden(FarSubclass1);
 
 class FarSubclass2 extends FarSubclass1 {
   #y = 0;
@@ -43,6 +44,7 @@ class FarSubclass2 extends FarSubclass1 {
     return this.double(x) + this.#y;
   }
 }
+harden(FarSubclass2);
 
 const assertMethodNames = (t, obj, names) => {
   t.deepEqual(getMethodNames(obj), names);
@@ -88,6 +90,7 @@ test('far class instances', t => {
       return this.double(x) + yField.get(this);
     }
   }
+  harden(FarSubclass3);
 
   const fs3 = new FarSubclass3(3);
   t.is(passStyleOf(fs3), 'remotable');
@@ -105,6 +108,7 @@ test('far class instance hardened empty', t => {
   class FarClass4 extends FarBaseClass {
     z = 0;
   }
+  harden(FarClass4);
   t.throws(() => new FarClass4(), {
     // TODO message depends on JS engine, and so is a fragile golden test
     message: 'Cannot define property z, object is not extensible',

--- a/packages/pass-style/test/test-passStyleOf.js
+++ b/packages/pass-style/test/test-passStyleOf.js
@@ -62,7 +62,7 @@ test('some passStyleOf rejections', t => {
   });
 
   const prbad1 = Promise.resolve();
-  Object.setPrototypeOf(prbad1, { __proto__: Promise.prototype });
+  Object.setPrototypeOf(prbad1, harden({ __proto__: Promise.prototype }));
   harden(prbad1);
   t.throws(() => passStyleOf(prbad1), {
     message:
@@ -125,7 +125,7 @@ test('passStyleOf testing tagged records', t => {
   t.is(passStyleOf(harden(makeTagRecordVariant())), 'tagged');
   t.is(passStyleOf(harden(makeTagRecordVariant({ passable: true }))), 'tagged');
 
-  for (const proto of [null, {}]) {
+  for (const proto of [null, harden({})]) {
     const tagRecordBadProto = makeTagRecordVariant(undefined, proto);
     t.throws(
       () => passStyleOf(harden(tagRecordBadProto)),
@@ -176,7 +176,7 @@ test('passStyleOf testing remotables', t => {
   t.is(passStyleOf(Far('foo', {})), 'remotable');
   t.is(passStyleOf(Far('foo', () => 'far function')), 'remotable');
 
-  const tagRecord1 = makeTagishRecord('Alleged: manually constructed');
+  const tagRecord1 = harden(makeTagishRecord('Alleged: manually constructed'));
   const farObj1 = harden({
     __proto__: tagRecord1,
   });
@@ -203,13 +203,13 @@ test('passStyleOf testing remotables', t => {
   });
   t.is(passStyleOf(farObj3), 'remotable');
 
-  const tagRecord4 = makeTagishRecord('Remotable');
+  const tagRecord4 = harden(makeTagishRecord('Remotable'));
   const farObj4 = harden({
     __proto__: tagRecord4,
   });
   t.is(passStyleOf(farObj4), 'remotable');
 
-  const tagRecord5 = makeTagishRecord('Not alleging');
+  const tagRecord5 = harden(makeTagishRecord('Not alleging'));
   const farObj5 = harden({
     __proto__: tagRecord5,
   });
@@ -218,7 +218,7 @@ test('passStyleOf testing remotables', t => {
       /For now, iface "Not alleging" must be "Remotable" or begin with "Alleged: " or "DebugName: "; unimplemented/,
   });
 
-  const tagRecord6 = makeTagishRecord('Alleged: manually constructed');
+  const tagRecord6 = harden(makeTagishRecord('Alleged: manually constructed'));
   const farObjProto6 = harden({
     __proto__: tagRecord6,
   });
@@ -259,6 +259,7 @@ test('passStyleOf testing remotables', t => {
       return this.add(4) + this.add(4);
     }
   }
+  harden(FarSubclass8);
   const farObj8 = new FarSubclass8(3);
   t.is(passStyleOf(farObj8), 'remotable');
   t.is(farObj8.twice(), 14);
@@ -272,9 +273,8 @@ test('passStyleOf testing remotables', t => {
   const unusualTagRecordProtoMessage =
     /A tagRecord must inherit from Object.prototype/;
 
-  const tagRecordA1 = makeTagishRecord(
-    'Alleged: null-proto tagRecord proto',
-    null,
+  const tagRecordA1 = harden(
+    makeTagishRecord('Alleged: null-proto tagRecord proto', null),
   );
   const farObjA1 = harden({ __proto__: tagRecordA1 });
   t.throws(
@@ -283,9 +283,8 @@ test('passStyleOf testing remotables', t => {
     'null-proto-tagRecord proto is rejected',
   );
 
-  const tagRecordA2 = makeTagishRecord(
-    'Alleged: null-proto tagRecord grandproto',
-    null,
+  const tagRecordA2 = harden(
+    makeTagishRecord('Alleged: null-proto tagRecord grandproto', null),
   );
   const farObjProtoA2 = harden({ __proto__: tagRecordA2 });
   const farObjA2 = harden({ __proto__: farObjProtoA2 });
@@ -299,7 +298,9 @@ test('passStyleOf testing remotables', t => {
     message: 'cannot serialize Remotables with accessors like "toString" in {}',
   });
 
-  const fauxTagRecordB = makeTagishRecord('Alleged: manually constructed', {});
+  const fauxTagRecordB = harden(
+    makeTagishRecord('Alleged: manually constructed', harden({})),
+  );
   const farObjProtoB = harden({
     __proto__: fauxTagRecordB,
   });
@@ -315,6 +316,7 @@ test('passStyleOf testing remotables', t => {
     'Alleged: manually constructed',
   );
   Object.defineProperty(farObjProtoWithExtra, 'extra', { value: () => {} });
+  harden(farObjProtoWithExtra);
   const badFarObjExtraProtoProp = harden({ __proto__: farObjProtoWithExtra });
   t.throws(() => passStyleOf(badFarObjExtraProtoProp), {
     message: 'Unexpected properties on Remotable Proto ["extra"]',

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -26,6 +26,7 @@ import {
   stringSplit,
   noEvalEvaluate,
   getOwnPropertyNames,
+  getPrototypeOf,
 } from './commons.js';
 import { makeHardener } from './make-hardener.js';
 import { makeIntrinsicsCollector } from './intrinsics.js';
@@ -281,6 +282,14 @@ export const repairIntrinsics = (options = {}) => {
 
   const intrinsics = finalIntrinsics();
 
+  const hostIntrinsics = { __proto__: null };
+
+  // The Node.js Buffer is a derived class of Uint8Array, and as such is often
+  // passed around where a Uint8Array is expected.
+  if (typeof globalThis.Buffer === 'function') {
+    hostIntrinsics.Buffer = globalThis.Buffer;
+  }
+
   /**
    * Wrap console unless suppressed.
    * At the moment, the console is considered a host power in the start
@@ -300,6 +309,19 @@ export const repairIntrinsics = (options = {}) => {
     optGetStackString,
   );
   globalThis.console = /** @type {Console} */ (consoleRecord.console);
+
+  // The untamed Node.js console cannot itself be hardened as it has mutable
+  // internal properties, but some of these properties expose internal versions
+  // of classes from node's "primordials" concept.
+  // eslint-disable-next-line no-underscore-dangle
+  if (typeof (/** @type {any} */ (consoleRecord.console)._times) === 'object') {
+    // SafeMap is a derived Map class used internally by Node
+    // There doesn't seem to be a cleaner way to reach it.
+    hostIntrinsics.SafeMap = getPrototypeOf(
+      // eslint-disable-next-line no-underscore-dangle
+      /** @type {any} */ (consoleRecord.console)._times,
+    );
+  }
 
   // @ts-ignore assert is absent on globalThis type def.
   if (errorTaming === 'unsafe' && globalThis.assert === assert) {
@@ -390,6 +412,7 @@ export const repairIntrinsics = (options = {}) => {
     // must be the operation that modifies the intrinsics.
     const toHarden = {
       intrinsics,
+      hostIntrinsics,
       globals: {
         // Harden evaluators
         Function: globalThis.Function,

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -388,19 +388,26 @@ export const repairIntrinsics = (options = {}) => {
 
     // Finally register and optionally freeze all the intrinsics. This
     // must be the operation that modifies the intrinsics.
-    tamedHarden(intrinsics);
+    const toHarden = {
+      intrinsics,
+      globals: {
+        // Harden evaluators
+        Function: globalThis.Function,
+        eval: globalThis.eval,
+        // @ts-ignore Compartment does exist on globalThis
+        Compartment: globalThis.Compartment,
 
-    // Harden evaluators
-    tamedHarden(globalThis.Function);
-    tamedHarden(globalThis.eval);
-    // @ts-ignore Compartment does exist on globalThis
-    tamedHarden(globalThis.Compartment);
+        // Harden Symbol
+        Symbol: globalThis.Symbol,
+      },
+    };
 
     // Harden Symbol and properties for initialGlobalPropertyNames in the host realm
-    tamedHarden(globalThis.Symbol);
     for (const prop of getOwnPropertyNames(initialGlobalPropertyNames)) {
-      tamedHarden(globalThis[prop]);
+      toHarden.globals[prop] = globalThis[prop];
     }
+
+    tamedHarden(toHarden);
 
     return tamedHarden;
   };

--- a/packages/ses/test/test-make-hardener.js
+++ b/packages/ses/test/test-make-hardener.js
@@ -280,6 +280,9 @@ test('harden a typed array subclass', t => {
   class Ooint8Array extends Uint8Array {
     oo = 'ghosts';
   }
+  h(Ooint8Array);
+  t.truthy(Object.isFrozen(Ooint8Array.prototype));
+  t.truthy(Object.isFrozen(Object.getPrototypeOf(Ooint8Array.prototype)));
 
   const a = new Ooint8Array(1);
   t.is(h(a), a);
@@ -290,8 +293,6 @@ test('harden a typed array subclass', t => {
     configurable: false,
     enumerable: true,
   });
-  t.truthy(Object.isFrozen(Ooint8Array.prototype));
-  t.truthy(Object.isFrozen(Object.getPrototypeOf(Ooint8Array.prototype)));
   t.truthy(Object.isSealed(a));
 });
 

--- a/packages/stream/index.js
+++ b/packages/stream/index.js
@@ -211,6 +211,7 @@ export const mapReader = (reader, transform) => {
     }
     return undefined;
   }
+  harden(transformGenerator);
   return harden(transformGenerator());
 };
 harden(mapReader);


### PR DESCRIPTION
refs: #1914

## Description

While working on #1686, I found out that some shared prototypes are currently hardened as a side effect of an instance being hardened. This PR adds explicit harden for these.

It also contains a small refactor to harden all intrinsics in one shot instead of multiple calls to `harden`, as there are cycles in those, and some intrinsics were effectively hardened in other calls.

### Security Considerations

More explicit hardening brings more security

### Scaling Considerations

None

### Documentation Considerations

In Node.js, the `Buffer` and when the console is untamed, the internal `SafeMap` are now explicitly hardened. These would likely get hardened as side-effect of hardening instances before.

### Testing Considerations

Tested in #1914 and https://github.com/Agoric/agoric-sdk/pull/8700 that these are all prototypes found through instances by existing tests. There may be others lurking, but until we have shallow hardening implemented, we won't find them.

### Upgrade Considerations

This is a non breaking change that should be mostly unobservable to consumers.
