### PR TITLE
refactor(ses): refactor console init and test cleanup

### DIFF
--- a/packages/ses/test/error/test-permit-removal-warnings.js
+++ b/packages/ses/test/error/test-permit-removal-warnings.js
@@ -1,0 +1,37 @@
+import test from 'ava';
+import '../../index.js';
+import { assertLogs } from './throws-and-logs.js';
+// import { whitelistIntrinsics } from '../../src/permits-intrinsics.js';
+
+const { defineProperties } = Object;
+const { apply } = Reflect;
+
+const originalIsArray = Array.isArray;
+
+defineProperties(Array, {
+  extraRemovableDataProperty: {
+    value: 'extra removable data property',
+    configurable: true,
+  },
+  isArray: {
+    value: function isArrayWithCleanablePrototype(...args) {
+      return apply(originalIsArray, this, args);
+    },
+  },
+});
+
+test('permit removal warnings', t => {
+  assertLogs(
+    t,
+    () => lockdown(),
+    [
+      ['warn', 'Removing intrinsics.Array.isArray.prototype'],
+      [
+        'warn',
+        'Tolerating undeletable intrinsics.Array.isArray.prototype === undefined',
+      ],
+      ['warn', 'Removing intrinsics.Array.extraRemovableDataProperty'],
+    ],
+    {},
+  );
+});


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: #1345 #1942 

## Description

<!-- Add a description of the changes that this PR introduces and the files that are the most critical to review.  -->

A flaw in tame-console.js made it hard to use throws-and-logs.js to test the console output that happens during lockdown. The flaw is that tame-console.js read the value of the global `console` variable at initialization, rather than when `tameConsole()` is called. This PR moves that initialization code into `tameConsole`, which is highly unlikely to break any working code.

Using that fix, this PR also tests the current behavior that #1345 complains about. A later PR #1942 will fix that problem, building on this PR so that the difference is itself tested.

### Security Considerations

Prior to this PR, tame-console.js used `console` and `print` as ambient globals without a `/* global ... */` annotation. For `console` this is not surprising, as we generally assume this is ambiently available. But for `print` it is surprising. Do we have a bug in our lint diagnostic framework? Attn @kriskowal 

In any case, this PR changes those specifically to `globalThis.console` and `globalThis.print`, where that `globalThis` is itself obtained from `commons.js`.

Moving the sampling of these globals into `tameConsole()` enables them to be changed before `tameConsole()` samples them, as we now intend. This should have zero security implications as these will still be sampled before `lockdown()` returns.

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

Moving the sampling of `console` this way should enable other uses of `throws-and-logs.js` for testing console output that would not work before this PR.

### Upgrade Considerations

none.