### PR TITLE
feat(ses): group removal cleanup diagnostics

### DIFF
--- a/packages/ses/test/error/test-permit-removal-warnings.js
+++ b/packages/ses/test/error/test-permit-removal-warnings.js
@@ -25,12 +25,14 @@ test('permit removal warnings', t => {
     t,
     () => lockdown(),
     [
+      ['groupCollapsed', 'Removing unpermitted intrinsics'],
       ['warn', 'Removing intrinsics.Array.isArray.prototype'],
       [
         'warn',
         'Tolerating undeletable intrinsics.Array.isArray.prototype === undefined',
       ],
       ['warn', 'Removing intrinsics.Array.extraRemovableDataProperty'],
+      ['groupEnd'],
     ],
     {},
   );


### PR DESCRIPTION
Staged on #1941 

closes: #1345 
refs: #1941 

## Description

Places all intrinsics removal cleanup diagnostics into a collapsed console group.

Attn @Jack-Works 

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

We should mention somewhere what this diagnostic means. Even though it is less visible, because it is now in a collapsed group, it is still purposely visible on the console output and people should be able to find out what it means --- and to know when to bring it to our attention.

### Testing Considerations

none

### Upgrade Considerations

none