### PR TITLE
fix(bundle-source): Accommodate Windows lack of atomic rename

### DIFF
--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -296,12 +296,13 @@ export const makeNodeBundleCache = async (
   pid,
   nonce,
 ) => {
-  const [fs, path, url, crypto, timers] = await Promise.all([
+  const [fs, path, url, crypto, timers, os] = await Promise.all([
     await loadModule('fs'),
     await loadModule('path'),
     await loadModule('url'),
     await loadModule('crypto'),
     await loadModule('timers'),
+    await loadModule('os'),
   ]);
 
   if (nonce === undefined) {
@@ -316,6 +317,6 @@ export const makeNodeBundleCache = async (
 
   const cwd = makeFileReader('', { fs, path });
   await fs.promises.mkdir(dest, { recursive: true });
-  const destWr = makeAtomicFileWriter(dest, { fs, path }, pid, nonce);
+  const destWr = makeAtomicFileWriter(dest, { fs, path, os }, pid, nonce);
   return makeBundleCache(destWr, cwd, readPowers, options);
 };

--- a/packages/bundle-source/src/tool.js
+++ b/packages/bundle-source/src/tool.js
@@ -5,7 +5,7 @@ import { main } from './main.js';
 const { Fail } = assert;
 
 /* global process */
-const allowedModules = ['fs', 'path', 'url', 'crypto', 'timers'];
+const allowedModules = ['fs', 'path', 'url', 'crypto', 'timers', 'os'];
 const loadModule = spec => {
   allowedModules.includes(spec) || Fail`Not allowed to import ${spec}`;
   return import(spec);


### PR DESCRIPTION
Fixes #1955

Windows rename is not atomic and fails if the target exists. Our CI revealed this to us because it cached a bundle.

