### PR TITLE
fix(pass-style): remove redundant vestigial @returns declaration

### DIFF
--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -164,12 +164,13 @@ const checkRemotable = (val, check) => {
 };
 
 /**
- * Simple semantics, just tell what interface (or undefined) a remotable has.
+ * Simple semantics, just tell what interface spec a Remotable has,
+ * or undefined if not deemed to be a Remotable.
+ *
  * @type {{
  * <T extends string>(val: PassStyled<any, T>): T;
- * (val: any): string | undefined;
+ * (val: any): InterfaceSpec | undefined;
  * }}
- * @returns the interface specification, or undefined if not a deemed to be a Remotable
  */
 export const getInterfaceOf = val => {
   if (


### PR DESCRIPTION
closes: #XXXX
refs: #1933 

## Description

The declaration site had both a correct @type declaration and a redundant vestigial partial @returns declaration. Because the latter also was not properly formed, it caused the warning

```
.../endojs/endo/packages/pass-style/src/remotable.js
  175:1  warning  Missing JSDoc @returns type  jsdoc/require-returns-type

✖ 1 problem (0 errors, 1 warning)
```

This PR removes it, and does a bit of trivial polishing of the remainder.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

more accurate type declarations should eventually help documentation

### Testing Considerations

none

### Upgrade Considerations

none