### PR TITLE
chore(monorepo): Make placeholder tests fail by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "format": "yarn prettier --write .github packages",
     "lint": "yarn prettier --check .github packages && lerna run lint",
     "lint-fix": "lerna run --no-bail lint-fix",
-    "test": "lerna run test",
+    "test": "lerna run --ignore @endo/skel test",
     "test262": "lerna run test262",
     "postinstall": "patch-package",
     "patch-package": "patch-package",

--- a/packages/skel/test/test-index.js
+++ b/packages/skel/test/test-index.js
@@ -1,5 +1,5 @@
 import { test } from './prepare-test-env-ava.js';
 
-test('place holder', async t => {
-  t.pass();
+test('placeholder', async t => {
+  t.fail('TODO: add tests');
 });


### PR DESCRIPTION
Makes the placeholder test in the placeholder package (`packages/skel/test/test-index.js`) fail by default.

Closes #1586