### PR TITLE
fix: "x" parameter in many tests is optional

### DIFF
--- a/packages/exo/test/test-amplify-heap-class-kits.js
+++ b/packages/exo/test/test-amplify-heap-class-kits.js
@@ -21,7 +21,7 @@ test('test amplify defineExoClass fails', t => {
       defineExoClass(
         'UpCounter',
         UpCounterI,
-        /** @param {number} x */
+        /** @param {number} [x] */
         (x = 0) => ({ x }),
         {
           incr(y = 1) {
@@ -46,7 +46,7 @@ test('test amplify defineExoClassKit', t => {
   const makeCounterKit = defineExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       up: {

--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -58,7 +58,7 @@ test('test defineExoClass', t => {
   const makeUpCounter = defineExoClass(
     'UpCounter',
     UpCounterI,
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       incr(y = 1) {
@@ -105,7 +105,7 @@ test('test defineExoClassKit', t => {
   const makeCounterKit = defineExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       up: {

--- a/packages/exo/test/test-label-instances.js
+++ b/packages/exo/test/test-label-instances.js
@@ -24,7 +24,7 @@ test('test defineExoClass', t => {
   const makeUpCounter = defineExoClass(
     'UpCounter',
     UpCounterI,
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       incr() {
@@ -49,7 +49,7 @@ test('test defineExoClassKit', t => {
   const makeCounterKit = defineExoClassKit(
     'Counter',
     { up: UpCounterI, down: DownCounterI },
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     {
       up: {

--- a/packages/exo/test/test-non-enumerable-methods.js
+++ b/packages/exo/test/test-non-enumerable-methods.js
@@ -81,7 +81,7 @@ test('test defineExoClass', t => {
   const makeUpCounter = defineExoClass(
     'UpCounter',
     UpCounterI,
-    /** @param {number} x */
+    /** @param {number} [x] */
     (x = 0) => ({ x }),
     denumerate({
       incr(y = 1) {


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8745

## Description

At https://github.com/Agoric/agoric-sdk/pull/8745#discussion_r1451052306 @dckc noticed that an optional `x` parameter should have been declared optional but was not. Turns out that I had copy-paste-modify that mistaken declaration to other tests. 

This PR fixes the ones in endo. https://github.com/Agoric/agoric-sdk/pull/8750 the ones in agoric-sdk

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

more accurate static types should help us generate more accurate docs

### Testing Considerations

none

### Upgrade Considerations

none