### PR TITLE
fix(ses): handle properties that are already override protected

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,4 +1,20 @@
 User-visible changes in SES:
+# next
+
+- The [iterators-helpers](https://github.com/tc39/proposal-iterator-helpers)
+  proposal includes two accessor properties whose purpose is to emulate
+  a data property, but without the override mistake problem. The ses-shim
+  creates many such properties, but was unprepared for them to already be
+  present in the JS platform it starts with. A Chrome Canary and Node 22
+  both implement the iterators-helper proposal, triggering this bug, preventing
+  the ses-shim from initializing. The ses-shim
+  [now copes safely](https://github.com/endojs/endo/pull/1969) with an
+  enumerated set of such properties, starting with these two properties from
+  the iterators-helpers proposal.
+- The ses-shim now permits the new methods from the
+  [set-methods](https://github.com/tc39/proposal-set-methods) proposal,
+  enabling these methods to be used on platforms where they are implemented,
+  which are currently a Chrome Canary and a Node 22.
 
 # v0.18.8 (2023-09-11)
 
@@ -27,7 +43,7 @@ User-visible changes in SES:
 
 # v0.18.6 (2023-08-07)
 
-- Censors the pattern `{...import(specifier)`}.
+- Censors the pattern `{...import(specifier)}`.
   We previously censored `import(specifier)` and expressly allowed
   `object.import(specifier)`.
   The relaxation for the latter form in version 0.13.0 inadvertently allowed

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -11,7 +11,6 @@ import {
   defineProperty,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
-  getOwnPropertyNames,
   isObject,
   objectHasOwnProperty,
   ownKeys,
@@ -156,12 +155,11 @@ export default function enablePropertyOverrides(
     }
     // TypeScript does not allow symbols to be used as indexes because it
     // cannot recokon types of symbolized properties.
-    // @ts-ignore
     arrayForEach(ownKeys(descs), prop => enable(path, obj, prop, descs[prop]));
   }
 
   function enableProperties(path, obj, plan) {
-    for (const prop of getOwnPropertyNames(plan)) {
+    for (const prop of ownKeys(plan)) {
       const desc = getOwnPropertyDescriptor(obj, prop);
       if (!desc || desc.get || desc.set) {
         // No not a value property, nothing to do.
@@ -169,10 +167,8 @@ export default function enablePropertyOverrides(
         continue;
       }
 
-      // Plan has no symbol keys and we use getOwnPropertyNames()
-      // so `prop` cannot only be a string, not a symbol. We coerce it in place
-      // with `String(..)` anyway just as good hygiene, since these paths are just
-      // for diagnostic purposes.
+      // In case `prop` is a symbol, we first coerce it with `String`,
+      // purely for diagnostic purposes.
       const subPath = `${path}.${String(prop)}`;
       const subPlan = plan[prop];
 

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -1,3 +1,5 @@
+import { toStringTagSymbol } from './commons.js';
+
 /**
  * @file Exports {@code enablements}, a recursively defined
  * JSON record defining the optimum set of intrinsics properties
@@ -73,6 +75,13 @@ export const minEnablements = {
 
   '%ErrorPrototype%': {
     name: true, // set by "precond", "ava", "node-fetch"
+  },
+  '%IteratorPrototype%': {
+    toString: true,
+    // https://github.com/tc39/proposal-iterator-helpers
+    constructor: true,
+    // https://github.com/tc39/proposal-iterator-helpers
+    [toStringTagSymbol]: true,
   },
 };
 
@@ -152,6 +161,10 @@ export const moderateEnablements = {
 
   '%IteratorPrototype%': {
     toString: true,
+    // https://github.com/tc39/proposal-iterator-helpers
+    constructor: true,
+    // https://github.com/tc39/proposal-iterator-helpers
+    [toStringTagSymbol]: true,
   },
 };
 

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -54,6 +54,7 @@ import { getAnonymousIntrinsics } from './get-anonymous-intrinsics.js';
 import { makeCompartmentConstructor } from './compartment.js';
 import { tameHarden } from './tame-harden.js';
 import { tameSymbolConstructor } from './tame-symbol-constructor.js';
+import { tameFauxDataProperties } from './tame-faux-data-properties.js';
 
 /** @typedef {import('../types.js').LockdownOptions} LockdownOptions */
 
@@ -334,6 +335,8 @@ export const repairIntrinsics = (options = {}) => {
 
   // Replace *Locale* methods with their non-locale equivalents
   tameLocaleMethods(intrinsics, localeTaming);
+
+  tameFauxDataProperties(intrinsics);
 
   /**
    * 2. WHITELIST to standardize the environment.

--- a/packages/ses/src/tame-faux-data-properties.js
+++ b/packages/ses/src/tame-faux-data-properties.js
@@ -1,0 +1,131 @@
+import {
+  getOwnPropertyDescriptor,
+  apply,
+  defineProperty,
+  toStringTagSymbol,
+} from './commons.js';
+
+const throws = thunk => {
+  try {
+    thunk();
+  } catch (er) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Exported for convenience of unit testing. Harmless, but not expected
+ * to be useful by itself.
+ *
+ * @param {any} obj
+ * @param {string|symbol} prop
+ * @param {any} expectedValue
+ * @returns {boolean}
+ */
+export const tameFauxDataProperty = (obj, prop, expectedValue) => {
+  if (obj === undefined) {
+    return false;
+  }
+  const desc = getOwnPropertyDescriptor(obj, prop);
+  if (!desc || 'value' in desc) {
+    return false;
+  }
+  const { get, set } = desc;
+  if (typeof get !== 'function') {
+    return false;
+  }
+  if (typeof set !== 'function') {
+    return false;
+  }
+  const observedValue = get();
+  if (observedValue !== expectedValue) {
+    return false;
+  }
+  if (apply(get, obj, []) !== expectedValue) {
+    return false;
+  }
+  const testValue = 'Seems to be a setter';
+  const subject1 = { __proto__: null };
+  apply(set, subject1, [testValue]);
+  if (subject1[prop] !== testValue) {
+    return false;
+  }
+  const subject2 = { __proto__: obj };
+  apply(set, subject2, [testValue]);
+  if (subject2[prop] !== testValue) {
+    return false;
+  }
+  if (!throws(() => apply(set, obj, [testValue]))) {
+    return false;
+  }
+  if ('originalValue' in get) {
+    return false;
+  }
+
+  // We assume that this code runs before any untrusted code runs, so
+  // we do not need to worry about the above conditions passing because of
+  // malicious intent. In fact, it runs even before vetted shims are supposed
+  // to run, between repair and hardening. Given that, after all these tests
+  // pass, we have adequately validated that the property in question is
+  // an accessor function whose purpose is suppressing the override mistake,
+  // i.e., enabling a non-writable property to be overridden by assignment.
+  // In that case, here we *temporarily* turn it into the data property
+  // it seems to emulate, but writable so that it does not trigger the
+  // override mistake while in this temporary state.
+
+  // For those properties that are also listed in `enablements.js`,
+  // that phase will re-enable override for these properties, but
+  // via accessor functions that ses controls, so we know what they are
+  // doing. In addition, the getter functions installed by
+  // `enable-property-overrides.js` have an `originalValue` field
+  // enabling meta-traversal code like harden to visit the original value
+  // without calling the getter.
+
+  if (desc.configurable === false) {
+    // Even though it seems to be an accessor, we're unable to fix it.
+    return false;
+  }
+
+  // Many of the `return false;` cases above plausibly should be turned into
+  // errors, or an least generate warnings. However, for those, the checks
+  // following this phase are likely to signal an error anyway.
+
+  defineProperty(obj, prop, {
+    value: expectedValue,
+    writable: true,
+    enumerable: desc.enumerable,
+    configurable: true,
+  });
+
+  return true;
+};
+
+/**
+ * For each, see it the property is an accessor property that
+ * seems to emulate a data property with this expectedValue,
+ * and seems to be an accessor whose purpose is to protect against
+ * the override mistake, i.e., enable these properties to be overridden
+ * by assignment. If all these expected conditions are met, then
+ * *temporarily* turn it into the data property it emulated.
+ *
+ * Coordinate with `enablements.js` so the appropriate ones are
+ * turned back to accessor that protect against override mistake,
+ * but accessors we know.
+ *
+ * @param {Record<any,any>} intrinsics
+ */
+export const tameFauxDataProperties = intrinsics => {
+  // https://github.com/tc39/proposal-iterator-helpers
+  tameFauxDataProperty(
+    intrinsics['%IteratorPrototype%'],
+    'constructor',
+    intrinsics.Iterator,
+  );
+  // https://github.com/tc39/proposal-iterator-helpers
+  tameFauxDataProperty(
+    intrinsics['%IteratorPrototype%'],
+    toStringTagSymbol,
+    'Iterator',
+  );
+};

--- a/packages/ses/test/test-tame-faux-data-properties.js
+++ b/packages/ses/test/test-tame-faux-data-properties.js
@@ -6,9 +6,9 @@ import { tameFauxDataProperty as tfdp } from '../src/tame-faux-data-properties.j
 const { freeze, defineProperty, getOwnPropertyDescriptor } = Object;
 
 test('unit test tameFauxDataProperty', t => {
-  t.is(tfdp(undefined, 'foo', 'bar'), false);
-  t.is(tfdp({}, 'foo', 'bar'), false);
-  t.is(tfdp({ foo: 'bar' }, 'foo', 'bar'), false);
+  t.is(tfdp(undefined, 'foo', 'bar'), false, 'the object does not exist');
+  t.is(tfdp({}, 'foo', 'bar'), false, 'the property does not exist');
+  t.is(tfdp({ foo: 'bar' }, 'foo', 'bar'), false, 'an actual data property');
 
   t.is(
     tfdp(
@@ -21,6 +21,7 @@ test('unit test tameFauxDataProperty', t => {
       'bar',
     ),
     false,
+    'a getter without a setter',
   );
 
   t.is(
@@ -33,6 +34,7 @@ test('unit test tameFauxDataProperty', t => {
       },
     }),
     false,
+    'setter should not always throw',
   );
 
   t.is(
@@ -45,6 +47,7 @@ test('unit test tameFauxDataProperty', t => {
       },
     }),
     false,
+    'setter should throw when "this === obj"',
   );
 
   const subject1 = {
@@ -57,7 +60,7 @@ test('unit test tameFauxDataProperty', t => {
       }
     },
   };
-  t.is(tfdp(subject1, 'foo', 'bar'), false);
+  t.is(tfdp(subject1, 'foo', 'bar'), false, 'does not assign when it should');
 
   const subject2 = {
     get foo() {
@@ -67,7 +70,11 @@ test('unit test tameFauxDataProperty', t => {
       defineProperty(this, 'foo', { value: newValue });
     },
   };
-  t.is(tfdp(subject2, 'foo', 'bar'), false);
+  t.is(
+    tfdp(subject2, 'foo', 'bar'),
+    false,
+    'setter must fail when "this === obj"',
+  );
 
   const subject3 = {
     get foo() {
@@ -80,7 +87,11 @@ test('unit test tameFauxDataProperty', t => {
       defineProperty(this, 'foo', { value: newValue });
     },
   };
-  t.is(tfdp(freeze(subject3), 'foo', 'bar'), false);
+  t.is(
+    tfdp(freeze(subject3), 'foo', 'bar'),
+    false,
+    'genuine faux data property, but non-configurable so we cannot change it anyway',
+  );
 
   const subject4 = {
     get foo() {
@@ -93,20 +104,32 @@ test('unit test tameFauxDataProperty', t => {
       defineProperty(this, 'foo', { value: newValue });
     },
   };
-  t.is(tfdp(subject4, 'foo', 'bar'), false);
+  t.is(
+    tfdp(subject4, 'foo', 'bar'),
+    false,
+    'genuine faux data property, but not the expected value',
+  );
 
   const desc4 = getOwnPropertyDescriptor(subject4, 'foo');
-  t.deepEqual(desc4, {
-    get: desc4.get,
-    set: desc4.set,
-    enumerable: true,
-    configurable: true,
-  });
-  t.is(tfdp(subject4, 'foo', 'zip'), true);
-  t.deepEqual(getOwnPropertyDescriptor(subject4, 'foo'), {
-    value: 'zip',
-    writable: true,
-    enumerable: true,
-    configurable: true,
-  });
+  t.deepEqual(
+    desc4,
+    {
+      get: desc4.get,
+      set: desc4.set,
+      enumerable: true,
+      configurable: true,
+    },
+    'what the faux data property looks like',
+  );
+  t.is(tfdp(subject4, 'foo', 'zip'), true, 'changed into actual data prop');
+  t.deepEqual(
+    getOwnPropertyDescriptor(subject4, 'foo'),
+    {
+      value: 'zip',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    },
+    'what the resulting actual data property looks like',
+  );
 });

--- a/packages/ses/test/test-tame-faux-data-properties.js
+++ b/packages/ses/test/test-tame-faux-data-properties.js
@@ -1,0 +1,112 @@
+import test from 'ava';
+import '../index.js';
+
+import { tameFauxDataProperty as tfdp } from '../src/tame-faux-data-properties.js';
+
+const { freeze, defineProperty, getOwnPropertyDescriptor } = Object;
+
+test('unit test tameFauxDataProperty', t => {
+  t.is(tfdp(undefined, 'foo', 'bar'), false);
+  t.is(tfdp({}, 'foo', 'bar'), false);
+  t.is(tfdp({ foo: 'bar' }, 'foo', 'bar'), false);
+
+  t.is(
+    tfdp(
+      {
+        get foo() {
+          return 'bar';
+        },
+      },
+      'foo',
+      'bar',
+    ),
+    false,
+  );
+
+  t.is(
+    tfdp({
+      get foo() {
+        return 'bar';
+      },
+      set foo(_newValue) {
+        throw TypeError('always throws');
+      },
+    }),
+    false,
+  );
+
+  t.is(
+    tfdp({
+      get foo() {
+        return 'bar';
+      },
+      set foo(_newValue) {
+        // never throws
+      },
+    }),
+    false,
+  );
+
+  const subject1 = {
+    get foo() {
+      return 'bar';
+    },
+    set foo(_newValue) {
+      if (this === subject1) {
+        throw TypeError('throws only when it should');
+      }
+    },
+  };
+  t.is(tfdp(subject1, 'foo', 'bar'), false);
+
+  const subject2 = {
+    get foo() {
+      return 'bar';
+    },
+    set foo(newValue) {
+      defineProperty(this, 'foo', { value: newValue });
+    },
+  };
+  t.is(tfdp(subject2, 'foo', 'bar'), false);
+
+  const subject3 = {
+    get foo() {
+      return 'bar';
+    },
+    set foo(newValue) {
+      if (this === subject3) {
+        throw TypeError('throws only when it should');
+      }
+      defineProperty(this, 'foo', { value: newValue });
+    },
+  };
+  t.is(tfdp(freeze(subject3), 'foo', 'bar'), false);
+
+  const subject4 = {
+    get foo() {
+      return 'zip';
+    },
+    set foo(newValue) {
+      if (this === subject4) {
+        throw TypeError('throws only when it should');
+      }
+      defineProperty(this, 'foo', { value: newValue });
+    },
+  };
+  t.is(tfdp(subject4, 'foo', 'bar'), false);
+
+  const desc4 = getOwnPropertyDescriptor(subject4, 'foo');
+  t.deepEqual(desc4, {
+    get: desc4.get,
+    set: desc4.set,
+    enumerable: true,
+    configurable: true,
+  });
+  t.is(tfdp(subject4, 'foo', 'zip'), true);
+  t.deepEqual(getOwnPropertyDescriptor(subject4, 'foo'), {
+    value: 'zip',
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+});


### PR DESCRIPTION
Fixes a bug initially reported by @FrederikBolding.
![image](https://github.com/endojs/endo/assets/273868/b4296f35-dd84-416f-812c-7aa0b200f57a)



Staged on #1974 

closes: #1971 
refs: #1655 #1968 https://github.com/tc39/proposal-iterator-helpers https://github.com/endojs/endo/issues/1973

## Description

The iterators-helpers proposal https://github.com/tc39/proposal-iterator-helpers is now shipping in Chrome Canary. As per spec, it makes two properties into accessors that act like data properties that protect against the override mistake, i.e., that enable the property to be overridden by assignment. However, our permits for these properties were written when we knew them to be data properties, are they currently are on the other engines we've tested on to date. Because of this discrepancy, SES failed to initialize on Chrome Canary.

The purpose of this PR is to provide a mechanism to tolerate such methods, so that SES initializes when it encounters an accessor method of this form.

During the `repairIntrinsics` phase of lockdown, before even vetted shims are supposed to run, for each property we said may be of this form, validate as best we can whether it indeed seems to be an accessor that protects from the override mistake, but otherwise emulates a data property. For those, *temporarily* turn it into the plain data property it seems to emulate. But writable, so it won't trigger the override mistake in that form. Note that this JS is not a conformant initial JS state, and is observable by vetted shims.

Then, during the `enable-property-override` portion of the `hardenIntrinsics` phase, after all vetted shims ran, those properties listed in `enablements.js` will turn them (back) into accessors, but ones that we control. This PR also adds these two properties to all phases of enablements.

It turned out that the `enablements` language could not use symbols as property names. This PR fixed that because it needed that feature.

As a drive-by, the accessor functions installed by `enable-property-overrides.js` were `function` functions. This PR changes them to concise methods, so they'll still have the `this` sensitivity they need, but omit the `prototype` property and the `[[Construct]]` behavior.

### Security Considerations

ses did exactly the right thing here. When the initial pre-ses state deviates from what the ses authors knew about as of that version of ses, we divide those changes into two categories:
- Simple addition of stuff we did not know about. JS additions are usually additive, so we assume it is safe enough to delete these that ses init still results in a secure state. But even for these, we issue a warning (now made a bit less noisy https://github.com/endojs/endo/pull/1942 ) so that we become aware that there are changes to the initial state beyond what ses authors knew about as of that version of ses.
- Any change to stuff we already knew about, where the change is something we did not know about. For these, that version of ses must fail to initialize with a decent diagnostic (unless overridden by an explicitly “unsafe” configuration setting). Such changes should not be assumed to simply be additive. Ses must fail to initialize because the initial state changed in ways we don’t know if we can still secure. Ses init should NOT blindly do an intervention to restore the initial state to something it expects, because this surprising change may be symptomatic of coordinated semantic changes to other things that we cannot detect. The only way to get back to secure is exactly what we’ll do today: the ses authors must manually ensure they understand the actual meaning of the surprise, and only then, alter ses to arrive at a secure state starting from this now-understood initial state.

So,
- SES did exactly what it should do in refusing to initialize with a good enough diagnostic for us to pinpoint the problem quickly.
- Chrome did exactly what it should do, in releasing an agreed change to the JS spec first in Canary, so others (like us) get an early warning if JS changes in a way we need to adjust to.
- @FrederikBolding did what we SHOULD periodically do ourselves, which is run SES on the latest canaries of all the platforms we care about. @ivan we need such a process. In fact, we still need to try it against the canaries of the other browsers.
- We did in tc39 exactly what we should have done, which is lobby, successfully in this case, that a change that was going to happen somehow happened in the way least damaging to us.
- Having gotten the change in at tc39, I should have better anticipated it and adjusted ses init to expect this change without breakage.

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

None of the existing tests broke, and I manually verified that things work as expected both on Chrome Canary, and on an earlier Chrome browser that has not implemented the iterators-helpers proposal.

I also exported the core logic as a function that I unit test.

### Upgrade Considerations

This JS change was just encountered in Chrome Canary for now, but it is accepted into the language and will shortly ship on all platforms. Before then, all users of SES should upgrade to a SES incorporating this PR.