### PR TITLE
feat(ses): Anticipate set-methods proposal

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1121,6 +1121,20 @@ export const permitted = {
     values: fn,
     '@@iterator': fn,
     '@@toStringTag': 'string',
+    // See https://github.com/tc39/proposal-set-methods
+    intersection: fn,
+    // See https://github.com/tc39/proposal-set-methods
+    union: fn,
+    // See https://github.com/tc39/proposal-set-methods
+    difference: fn,
+    // See https://github.com/tc39/proposal-set-methods
+    symmetricDifference: fn,
+    // See https://github.com/tc39/proposal-set-methods
+    isSubsetOf: fn,
+    // See https://github.com/tc39/proposal-set-methods
+    isSupersetOf: fn,
+    // See https://github.com/tc39/proposal-set-methods
+    isDisjointFrom: fn,
   },
 
   '%SetIteratorPrototype%': {


### PR DESCRIPTION

closes: #XXXX
refs: #1969 https://github.com/tc39/proposal-set-methods

## Description

Anticipates https://github.com/tc39/proposal-set-methods .

While doing #1969, I noticed

![image](https://github.com/endojs/endo/assets/273868/55d7dbf5-a434-4081-8e07-ae68d8db9511)

on the Chrome Canary console, which is SES letting us developers know that it encountered properties that it did not previously know about. No security problem, because they were all successfully removed. But the warning lets us know that we should decide what to do about these properties, including explicitly deciding that they should be deleted.

In this case, the properties are from the set-methods proposal, that we participated in at tc39 and are satisfied is safe. This PR permits them, so that SES no longer removes them.

With this PR on top of #1969, Chrome Canary's console is clean.

### Security Considerations

If we missed or misunderstood something about how these set-methods behave, or of an engine's implementation did, then permitting them could introduce a new security problem. But we have no particular reason to worry about these.

### Scaling Considerations

Having efficient set operations will be nice, and may eventually help us make some things faster.

### Documentation Considerations

none

### Testing Considerations

none

### Upgrade Considerations

none