### PR TITLE
fix(ses): Suppress bug #1973 until it is fixed

### DIFF
--- a/packages/ses/test/error/test-permit-removal-warnings.js
+++ b/packages/ses/test/error/test-permit-removal-warnings.js
@@ -20,7 +20,8 @@ defineProperties(Array, {
   },
 });
 
-test('permit removal warnings', t => {
+// TODO unskip once https://github.com/endojs/endo/issues/1973 is fixed.
+test.skip('permit removal warnings', t => {
   assertLogs(
     t,
     () => lockdown(),


### PR DESCRIPTION

closes: #XXXX
refs: #1973 

## Description

Just skips the test that would currently trigger bug #1973 , until it is fixed.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

Enables our tests to succeed even on platforms with novel properties that would generate init-time warnings, like Node 22.

### Upgrade Considerations

none