### PR TITLE
perf(base64): Replace random access with iteration

### DIFF
--- a/packages/base64/src/encode.js
+++ b/packages/base64/src/encode.js
@@ -27,8 +27,7 @@ export const jsEncodeBase64 = data => {
   let register = 0;
   let quantum = 0;
 
-  for (let i = 0; i < data.length; i += 1) {
-    const b = data[i];
+  for (const b of data) {
     register = (register << 8) | b;
     quantum += 8;
     if (quantum === 24) {

--- a/packages/base64/test/test-main.js
+++ b/packages/base64/test/test-main.js
@@ -57,3 +57,40 @@ test('bytes conversions', t => {
     t.is(atob(btoa(str)), str, `${str} round trips with atob(btoa)`);
   }
 });
+
+test('invalid encodings', t => {
+  const badInputs = [
+    ['%', /Invalid base64 character %/],
+    ['=', undefined], // this input is bad in multiple ways
+
+    ['Z%', /Invalid base64 character %/],
+    ['Z', /Missing padding at offset 1/],
+    ['Z=', /Missing padding at offset 2/],
+    ['Z=%', /Missing padding at offset 2/],
+    ['Z==%', /Missing padding at offset 3/],
+    ['Z==m', /Missing padding at offset 3/],
+
+    ['Zg%', /Invalid base64 character %/],
+    ['Zg', /Missing padding at offset 2/],
+    ['Zg=', /Missing padding at offset 3/],
+    ['Zg=%', /Missing padding at offset 3/],
+    ['Zg==%', /trailing garbage %/],
+    ['Zg==m', /trailing garbage m/],
+
+    ['Zm8%', /Invalid base64 character %/],
+    ['Zm8', /Missing padding at offset 3/],
+    // not invalid: 'Zm8='
+    ['Zm8=%', /trailing garbage %/],
+    ['Zm8==%', /trailing garbage =%/],
+    ['Zm8==m', /trailing garbage =m/],
+
+    // non-zero padding bits (MAY reject): ['Qf==', ...],
+  ];
+  for (const [badInput, message] of badInputs) {
+    t.throws(
+      () => decodeBase64(badInput),
+      message && { message },
+      `${badInput} is rejected`,
+    );
+  }
+});


### PR DESCRIPTION
## Description

We recently discovered that in XS, random access to string characters is O(n). This PR updates the JS base64 implementation to instead use iterators. It improves the performance in XS as expected, but irrelevantly so because XS provides a native implementation which is _much_ faster still. There's a slight penalty in Node.js, which may or may not be tolerable (_but note that apples-to-apples comparison across implementations is necessary because the JS input is substantially shorter_). I'm comfortable with rejection of this PR (or at least everything after the first commit), but felt that opening it was important for transparency.

### Security Considerations

n/a

### Scaling Considerations

As noted above. Here are the measured effects:
```diff
 Node.js
-encodes 10775.74909090909 characters per millisecond
+encodes 9801.535832414553 characters per millisecond
-JS encodes 23130.176470588234 characters per millisecond
+JS encodes 18329.573806881242 characters per millisecond
-decodes 48752.36084452975 bytes per millisecond
+decodes 45848.339350180504 bytes per millisecond
-JS decodes 43007.671875 bytes per millisecond
+JS decodes 45448.94117647059 bytes per millisecond
 XS
-encodes 577272.2727272727 characters per millisecond
+encodes 578303.1160714285 characters per millisecond
-JS encodes 1335.143596377749 characters per millisecond
+JS encodes 1700.2734761120264 characters per millisecond
-decodes 396777.0553505535 bytes per millisecond
+decodes 393870.26373626373 bytes per millisecond
-JS decodes 1093.7360890302066 bytes per millisecond
+JS decodes 1946.3762376237623 bytes per millisecond
```

### Documentation Considerations

n/a

### Testing Considerations

n/a

### Upgrade Considerations

n/a