### PR TITLE
docs(marshal): Update to latest agreed ocapn terminology

### DIFF
--- a/packages/marshal/docs/smallcaps-cheatsheet.md
+++ b/packages/marshal/docs/smallcaps-cheatsheet.md
@@ -16,7 +16,7 @@ An example-based summary of the Smallcaps encoding
 | copyRecord      | Struct        | `{x:a,y:b}`         | `{<x>:<a>,<y>:<b>}`  |
 | error           | Error         | `TypeError(msg)`    | `{"#error":<msg>,"name":"TypeError"}` |
 | tagged          | Tagged        | `makeTagged(t,p)`   | `{"#tag":<t>,"payload":<p>}` |
-| ?               | ByteArray     | ?                   | ? |
+| ?               | ByteArray     | ?                   | ?                    |
 
 * The `-0` encoding is defined as above, but not yet implemented in JS.
 * In JS, only registered and well-known symbols are passable.

--- a/packages/marshal/docs/smallcaps-cheatsheet.md
+++ b/packages/marshal/docs/smallcaps-cheatsheet.md
@@ -4,19 +4,19 @@ An example-based summary of the Smallcaps encoding
 
 | Passable value  | OCapn name    | JS example          | JSON encoding        |
 | ----------------|---------------|---------------------|----------------------|
-| bigint          | SignedInteger | `7n`<br>`-7n`       | `"+7"`<br>`"-7"`     |
+| bigint          | Integer       | `7n`<br>`-7n`       | `"+7"`<br>`"-7"`     |
 | manifest constant | Undefined<br><br>Float64<br><br><br> | `undefined`<br>`Infinity`<br>`-Infinity`<br>`NaN`<br>`-0` | `"#undefined"`<br>`"#Infinity"`<br>`"#-Infinity"`<br>`"#NaN"`<br>`"#-0"` // unimplemented |
 | passable symbol | Symbol        | `Symbol.for('foo')`<br>`Symbol.asyncIterator` | `"%foo"`<br>`"%@@asyncIterator"` |
-| remotable       | Capability    | `Far('foo', {})`    | `"$0.foo"`           |
-| promise         | Capability    | `Promise.resolve()` | `"&1"`               |
+| remotable       | Remotable     | `Far('foo', {})`    | `"$0.foo"`           |
+| promise         | Promise       | `Promise.resolve()` | `"&1"`               |
 | special string  | String        | `'#foo'`            | `"!#foo"`            |
 | other string    | String        | `'foo'`             | `"foo"`              |
 | other JSON scalar | Null<br>Boolean<br><br>Float64 | `null`<br>`true`<br>`false`<br>`7.1` | `null`<br>`true`<br>`false`<br>`7.1` |
-| copyArray       | Sequence      | `[a,b]`             | `[<a>,<b>]`          |
+| copyArray       | List          | `[a,b]`             | `[<a>,<b>]`          |
 | copyRecord      | Struct        | `{x:a,y:b}`         | `{<x>:<a>,<y>:<b>}`  |
 | error           | Error         | `TypeError(msg)`    | `{"#error":<msg>,"name":"TypeError"}` |
 | tagged          | Tagged        | `makeTagged(t,p)`   | `{"#tag":<t>,"payload":<p>}` |
-| ? | ByteString | ? | ? |
+| ?               | ByteArray     | ?                   | ? |
 
 * The `-0` encoding is defined as above, but not yet implemented in JS.
 * In JS, only registered and well-known symbols are passable.

--- a/packages/marshal/docs/smallcaps-cheatsheet.md
+++ b/packages/marshal/docs/smallcaps-cheatsheet.md
@@ -27,6 +27,6 @@ An example-based summary of the Smallcaps encoding
 * Structs [can only have string-named properties](https://github.com/endojs/endo/blob/master/packages/pass-style/doc/copyRecord-guarantees.md).
 * Errors can also carry an optional `errorId` string property.
 * We expect to expand the optional error properties over time.
-* The ByteString encoding is not yet designed or implemented.
+* The ByteArray encoding is not yet designed or implemented.
 
 Every JSON encoding with no special strings anywhere decodes to itself.

--- a/packages/marshal/docs/smallcaps-cheatsheet.md
+++ b/packages/marshal/docs/smallcaps-cheatsheet.md
@@ -30,3 +30,5 @@ An example-based summary of the Smallcaps encoding
 * The ByteArray encoding is not yet designed or implemented.
 
 Every JSON encoding with no special strings anywhere decodes to itself.
+
+See OCapN [Abstract Syntax](https://github.com/ocapn/ocapn/wiki/Abstract-Syntax).


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

Upgrade the smallcaps cheatsheet's "OCapn name" column to use the latest agreed OCapN names.

Attn @cwebber @tsyesika @jar398

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
This PR itself doesn't change the first column "Passable value" of the names we normally use when we're not speaking to OCapN interoperability, so none there.

OCapN connected discussions have largely already moved to the new terminology, so this is mostly catchup.

### Testing Considerations
none
### Upgrade Considerations
none