### PR TITLE
refactor(cli): Rename `reset` command to `purge`

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -599,7 +599,9 @@ export const main = async rawArgs => {
       const doPurge =
         force ||
         /^y(es)?$/u.test(
-          await prompt('Are you sure you want to erase all state? (y/n)'),
+          await prompt(
+            'Are you sure you want to erase all state? This irreversible action will permanently sever all peer connections. Continue? (y/n)',
+          ),
         );
       if (doPurge) {
         const { reset } = await import('@endo/daemon');

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -10,6 +10,7 @@ import fs from 'fs';
 import url from 'url';
 
 import { Command } from 'commander';
+import { prompt } from './prompt.js';
 
 const collect = (value, values) => values.concat([value]);
 
@@ -590,11 +591,20 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('reset')
+    .command('purge')
+    .option('-f, --force', 'skip the confirmation prompt')
     .description('erases persistent state and restarts if running')
-    .action(async _cmd => {
-      const { reset } = await import('@endo/daemon');
-      await reset();
+    .action(async cmd => {
+      const { force } = cmd.opts();
+      const doPurge =
+        force ||
+        /^y(es)?$/u.test(
+          await prompt('Are you sure you want to erase all state? (y/n)'),
+        );
+      if (doPurge) {
+        const { reset } = await import('@endo/daemon');
+        await reset();
+      }
     });
 
   program

--- a/packages/cli/src/prompt.js
+++ b/packages/cli/src/prompt.js
@@ -1,0 +1,23 @@
+import { stdin, stdout } from 'process';
+import readline from 'readline';
+
+/**
+ * Prompts the user for input. The answer is trimmed and converted to
+ * lowercase.
+ *
+ * @param {string} question - The question to ask the user.
+ * @returns {Promise<string>} The user's answer.
+ */
+export async function prompt(question) {
+  const rl = readline.createInterface({
+    input: stdin,
+    output: stdout,
+  });
+
+  return new Promise(resolve => {
+    rl.question(`${question}\n`, answer => {
+      rl.close();
+      resolve(answer.trim().toLowerCase());
+    });
+  });
+}


### PR DESCRIPTION
Closes: #1987 

## Description

Renames the CLI `reset` command to `purge` in order to better distinguish it from `restart`. Also adds a confirmation prompt to the command, which can be overridden with the `-f`/`--force` flag.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations

Would it be helpful to start adding unit tests for anything where that's straightforward? cc: @kriskowal 

### Upgrade Considerations

This is breaking for `@endo/cli`, but I'm not sure what we're doing about breaking changes at this stage, if anything.
