### PR TITLE
chore(compartment-mapper): fix type of internal function

### DIFF
--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -208,9 +208,13 @@ const makeArchiveImportHookMaker = (
   return makeImportHook;
 };
 
-const makeFeauxModuleExportsNamespace = Compartment => {
-  // @ts-ignore Unclear at time of writing why Compartment type is not
-  // constructible.
+/**
+ * Creates a fake module namespace object that passes a brand check.
+ *
+ * @param {typeof Compartment} Compartment
+ * @returns {import('ses').ModuleExportsNamespace}
+ */
+const makeFauxModuleExportsNamespace = Compartment => {
   const compartment = new Compartment(
     {},
     {},
@@ -218,10 +222,11 @@ const makeFeauxModuleExportsNamespace = Compartment => {
       resolveHook() {
         return '.';
       },
-      importHook() {
+      async importHook() {
         return {
           imports: [],
           execute() {},
+          exports: [],
         };
       },
     },
@@ -336,7 +341,7 @@ export const parseArchive = async (
       parserForLanguage,
       modules: Object.fromEntries(
         Object.keys(modules || {}).map(specifier => {
-          return [specifier, makeFeauxModuleExportsNamespace(Compartment)];
+          return [specifier, makeFauxModuleExportsNamespace(Compartment)];
         }),
       ),
       Compartment,


### PR DESCRIPTION
This addresses the `@ts-ignore` found in `makeFauxModuleExportsNamespace()`, which was renamed from `makeFeauxModuleExportsNamespace()`, because "féaux" translates to "loyal supporters" and not "fake" or "false" like was presumably intended.

I am not so bold to rename it `makeErsatzModuleExportsNamespace()`, despite "ersatz" being a wholly superior word to either of the above alternatives.

_Anyway_, this adds a proper type signature and fixes the return type; the `importHook` prop of the returned value did not adhere to the [definition of `ImportHook`](https://github.com/endojs/endo/blob/master/packages/ses/types.d.ts#L97). Likewise, `StaticModuleType` demands an `exports` array.

Given this apparently _worked just fine_ before I changed it, one could argue the types ought to be loosened somewhat.

* * *

- No, I didn't make an issue
- I happened upon the code in question, so I fixed it due to my personal compulsions
- No security concerns
- No scaling concerns
- Modifies a private API
- I have low confidence that @kriskowal did not name this function intentionally. If he did, it went over my head.
