### PR TITLE
feat(daemon): pet store list entries

### DIFF
--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -1,0 +1,29 @@
+const { quote: q } = assert;
+
+const numberlessFormulasIdentifiers = new Set([
+  'pet-store',
+  'host',
+  'endo',
+  'least-authority',
+  'web-page-js',
+]);
+
+/**
+ * @param {string} formulaIdentifier
+ * @returns {import("./types").FormulaIdentifierRecord}
+ */
+export const parseFormulaIdentifier = formulaIdentifier => {
+  const delimiterIndex = formulaIdentifier.indexOf(':');
+  if (delimiterIndex < 0) {
+    if (numberlessFormulasIdentifiers.has(formulaIdentifier)) {
+      return { type: formulaIdentifier, number: '' };
+    } else {
+      throw new TypeError(
+        `Formula identifier must have a colon: ${q(formulaIdentifier)}`,
+      );
+    }
+  }
+  const type = formulaIdentifier.slice(0, delimiterIndex);
+  const number = formulaIdentifier.slice(delimiterIndex + 1);
+  return { type, number };
+};

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -69,7 +69,13 @@ export const makeGuestMaker = ({
       terminator,
     });
 
-    const { has, list, follow: followNames } = petStore;
+    const {
+      has,
+      list,
+      follow: followNames,
+      listEntries,
+      followEntries,
+    } = petStore;
 
     /** @type {import('@endo/eventual-send').ERef<import('./types.js').EndoGuest>} */
     const guest = Far('EndoGuest', {
@@ -80,8 +86,10 @@ export const makeGuestMaker = ({
       send,
       list,
       followNames,
-      followMessages,
       listMessages,
+      followMessages,
+      listEntries,
+      followEntries,
       resolve,
       reject,
       dismiss,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -417,7 +417,13 @@ export const makeHostMaker = ({
       return value;
     };
 
-    const { has, list, follow: followNames } = petStore;
+    const {
+      has,
+      list,
+      follow: followNames,
+      listEntries,
+      followEntries,
+    } = petStore;
 
     /** @type {import('./types.js').EndoHost} */
     const host = Far('EndoHost', {
@@ -434,6 +440,8 @@ export const makeHostMaker = ({
       send,
       list,
       followNames,
+      listEntries,
+      followEntries,
       remove,
       rename,
       store,

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -3,6 +3,7 @@
 import { Far } from '@endo/far';
 import { makeChangeTopic } from './pubsub.js';
 import { makeIteratorRef } from './reader-ref.js';
+import { parseFormulaIdentifier } from './formula-identifier.js';
 
 const { quote: q } = assert;
 
@@ -104,21 +105,55 @@ export const makePetStoreMaker = (filePowers, locator) => {
       const petNamePath = filePowers.joinPath(petNameDirectoryPath, petName);
       const petNameText = `${formulaIdentifier}\n`;
       await filePowers.writeFileText(petNamePath, petNameText);
-      changesTopic.publisher.next({ add: petName });
+      const formularIdentifierRecord =
+        parseFormulaIdentifier(formulaIdentifier);
+      changesTopic.publisher.next({
+        add: petName,
+        value: formularIdentifierRecord,
+      });
     };
 
-    const list = () => harden([...petNames.keys()].sort());
+    /**
+     * @param {string} petName
+     * @returns {import('./types.js').FormulaIdentifierRecord}
+     */
+    const formulaIdentifierRecordForName = petName => {
+      const formulaIdentifier = petNames.get(petName);
+      if (formulaIdentifier === undefined) {
+        throw new Error(`Formula does not exist for pet name ${q(petName)}`);
+      }
+      return parseFormulaIdentifier(formulaIdentifier);
+    };
 
+    // Returns in an Array format.
+    const list = () => harden([...petNames.keys()].sort());
+    // Returns in an object operations format ({ add, value } or { remove }).
     const follow = async () =>
       makeIteratorRef(
         (async function* currentAndSubsequentNames() {
           const changes = changesTopic.subscribe();
           for (const name of [...petNames.keys()].sort()) {
-            yield { add: name };
+            const formularIdentifierRecord =
+              formulaIdentifierRecordForName(name);
+            yield {
+              add: name,
+              value: formularIdentifierRecord,
+            };
           }
           yield* changes;
         })(),
       );
+
+    // Returns in Object.fromEntries format.
+    /** @returns {Array<[string, import('./types.js').FormulaIdentifierRecord]>} */
+    const listEntries = () =>
+      harden(
+        [...petNames.keys()].sort().map(name => {
+          return [name, formulaIdentifierRecordForName(name)];
+        }),
+      );
+    // Provided as an alias for follow, with naming symmetry to listEntries.
+    const followEntries = follow;
 
     /**
      * @param {string} petName
@@ -225,6 +260,8 @@ export const makePetStoreMaker = (filePowers, locator) => {
       reverseLookup,
       list,
       follow,
+      listEntries,
+      followEntries,
       write,
       remove,
       rename,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -53,6 +53,11 @@ export type MignonicPowers = {
   };
 };
 
+type FormulaIdentifierRecord = {
+  type: string;
+  number: string;
+};
+
 type GuestFormula = {
   type: 'guest';
   host: string;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -163,12 +163,20 @@ export interface Controller<External = unknown, Internal = unknown> {
 export interface PetStore {
   has(petName: string): boolean;
   list(): Array<string>;
+  follow(): Promise<FarRef<String<{ add: string } | { remove: string }>>>;
+  listEntries(): Array<[string, FormulaIdentifierRecord]>;
+  followEntries(): Promise<
+    FarRef<
+      String<
+        { add: string; value: FormulaIdentifierRecord } | { remove: string }
+      >
+    >
+  >;
   write(petName: string, formulaIdentifier: string): Promise<void>;
   remove(petName: string);
   rename(fromPetName: string, toPetName: string);
   lookup(petName: string): string | undefined;
   reverseLookup(formulaIdentifier: string): Array<string>;
-  follow(): Promise<FarRef<String<{ add: string } | { remove: string }>>>;
 }
 
 export type RequestFn = (


### PR DESCRIPTION
- Adds `parseFormulaIdentifier` utility
- Adds  `{type, number}` formula identifier pair as `value` to petstore `follow()` entries
- Adds `listEntries` to petstore in `Object.fromEntries` with `{type, number}` formula identifier pair as value
- Provides `followEntries` as an alias to `follow`
- Exposes `listEntries` and `followEntries` on host and guest

I'm sending the `{type, number}` formula identifier pair instead of the string formula identifier. Alternatively, we could just the formula identifier.