### PR TITLE
perf(syrup): Minimize expensive operations when encoding

### DIFF
--- a/packages/syrup/src/encode.js
+++ b/packages/syrup/src/encode.js
@@ -145,7 +145,8 @@ function encodeRecord(buffer, record, path) {
  * @param {string} path
  */
 function encodeArray(buffer, array, path) {
-  let cursor = grow(buffer, 1);
+  let cursor = grow(buffer, 2 + array.length);
+  buffer.length = cursor + 1;
   buffer.bytes[cursor] = LIST_START;
 
   let index = 0;

--- a/packages/syrup/src/encode.js
+++ b/packages/syrup/src/encode.js
@@ -27,21 +27,22 @@ const textEncoder = new TextEncoder();
 
 /**
  * @param {Buffer} buffer
- * @param {number} length
- * @returns {number} cursor (old length)
+ * @param {number} increaseBy
+ * @returns {number} old length
  */
-function grow(buffer, length) {
+function grow(buffer, increaseBy) {
   const cursor = buffer.length;
-  if (length === 0) {
+  if (increaseBy === 0) {
     return cursor;
   }
-  buffer.length += length;
-  let newLength = buffer.bytes.length;
-  if (buffer.length + length > newLength) {
-    while (buffer.length + length > newLength) {
-      newLength *= 2;
+  buffer.length += increaseBy;
+  let capacity = buffer.bytes.length;
+  // Expand backing storage, leaving headroom for another similar-size increase.
+  if (buffer.length + increaseBy > capacity) {
+    while (buffer.length + increaseBy > capacity) {
+      capacity *= 2;
     }
-    const bytes = new Uint8Array(newLength);
+    const bytes = new Uint8Array(capacity);
     const data = new DataView(bytes.buffer);
     bytes.set(buffer.bytes.subarray(0, buffer.length), 0);
     buffer.bytes = bytes;


### PR DESCRIPTION
refs: #1984

## Description

`encodeString`:
* Avoid redundant encoding.
* Cache `length` to avoid re-reading.
* Anticipate the likely count of prefix bytes to avoid moving data.

`encodeArray`:
* Account for element minimum size in encodeArray buffer expansion

`encodeAny`:
* Pass diagnostic path data as an array rather than a string 
   (In the absence of errors, the associated string concatenation doesn't even take place.)

<details><summary>Effect</summary>

```shell
esbench -n 100 --repetitions 10 --eshost-option '-h V8,*XS' --eshost-option '-m' \
--init-file <(printf '%s\n' '
    import { smuggle } from "data:text/javascript,delete globalThis.harden; if(typeof TextEncoder === `undefined`) Object.defineProperties(globalThis, { TextDecoder: { writable: true, enumerable: false, configurable: true, value: class TextDecoder {} }, TextEncoder: { writable: true, enumerable: false, configurable: true, value: class TextEncoder { encodeInto(str, buf){ const bufLen = buf.length; let read = 0, written = 0; if (bufLen > 0) for(const ch of str){ const cp = ch.codePointAt(0), n = cp >= 0x10000 ? 4 : cp >= 0x800 ? 3 : cp >= 0x80 ? 2 : 1; if(written + n > bufLen) break; read += ch.length; written += n; if(written === bufLen) break; } return { read, written }; } } }, }); globalThis.console ||= Object.fromEntries(`debug log info warn error groupCollapsed groupEnd`.split(` `).map(m => [m, print])); /* abuse console.clear to smuggle values */ let smuggled; export const smuggle = val => { smuggled = val; }; { globalThis.process ||= { env: {} }; process.env.LOCKDOWN_CONSOLE_TAMING = `unsafe`; console.clear = () => smuggled; }";
    import "@endo/init";
    import { encodeSyrup } from "@endo/syrup";
    smuggle({ encodeSyrup });
  ' | \
  npx rollup@4.9.5 -p @rollup/plugin-node-resolve -p ~/lib/rollup-plugin-js-data-url.js -f iife | \
  npx terser@v5.26.0 -cm --toplevel
) \
'
  const { encodeSyrup } = console.clear(), capacity = 1;
  const str = "A".repeat(42), short = Array(5).fill(str), mid = Array(100).fill(str), long = Array(1000).fill(str);
' '{
  encodeShort: `result = encodeSyrup(short, { length: capacity });`,
  encodeMid: `result = encodeSyrup(mid, { length: capacity });`,
  encodeLong: `result = encodeSyrup(long, { length: capacity });`,
}'
```

Before:
```console
#### Moddable XS
encodeShort: 2.08 ops/ms
encodeMid: 0.22 ops/ms
encodeLong: 0.02 ops/ms

#### V8
encodeShort: 8.33 ops/ms
encodeMid: 1.14 ops/ms
encodeLong: 0.12 ops/ms
```

After:
```console
#### Moddable XS
encodeShort: 3.03 ops/ms
encodeMid: 0.23 ops/ms
encodeLong: 0.02 ops/ms

#### V8
encodeShort: 10.00 ops/ms
encodeMid: 1.35 ops/ms
encodeLong: 0.16 ops/ms
```

</details>

### Security Considerations

None known.

### Scaling Considerations

For large strings, performance is still dominated by currently-unavoidable O(n) operations.

### Documentation Considerations

n/a

### Testing Considerations

n/a

### Upgrade Considerations

n/a