### PR TITLE
perf(marshal): Replace more XS-expensive string operations

### DIFF
--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -132,7 +132,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
     // Assert that the #error property decodes to a string.
     const message = encoding['#error'];
     (typeof message === 'string' &&
-      (!startsSpecial(message) || message.startsWith('!'))) ||
+      (!startsSpecial(message) || message.charAt(0) === '!')) ||
       Fail`internal: Error encoding must have string message: ${q(message)}`;
   };
 
@@ -241,7 +241,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
           passable,
           encodeToSmallcapsRecur,
         );
-        if (typeof result === 'string' && result.startsWith('$')) {
+        if (typeof result === 'string' && result.charAt(0) === '$') {
           return result;
         }
         // `throw` is noop since `Fail` throws. But linter confused
@@ -252,7 +252,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
           passable,
           encodeToSmallcapsRecur,
         );
-        if (typeof result === 'string' && result.startsWith('&')) {
+        if (typeof result === 'string' && result.charAt(0) === '&') {
           return result;
         }
         throw Fail`internal: Promise encoding must start with "&": ${result}`;
@@ -446,7 +446,7 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
             Fail`Property name ${q(
               encodedName,
             )} of ${encoding} must be a string`;
-          !encodedName.startsWith('#') ||
+          encodedName.charAt(0) !== '#' ||
             Fail`Unrecognized record type ${q(encodedName)}: ${encoding}`;
           const name = decodeFromSmallcaps(encodedName);
           typeof name === 'string' ||

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -310,7 +310,7 @@ export const makeMarshal = (
        * @returns {Remotable | Promise}
        */
       return (stringEncoding, _decodeRecur) => {
-        assert(stringEncoding.startsWith(prefix));
+        assert(stringEncoding.charAt(0) === prefix);
         // slots: $slotIndex.iface or $slotIndex
         const i = stringEncoding.indexOf('.');
         const index = Number(stringEncoding.slice(1, i < 0 ? undefined : i));
@@ -350,7 +350,7 @@ export const makeMarshal = (
     const { reviveFromCapData, reviveFromSmallcaps } = makeFullRevive(slots);
     let result;
     // JSON cannot begin with a '#', so this is an unambiguous signal.
-    if (body.startsWith('#')) {
+    if (body.charAt(0) === '#') {
       const smallcapsBody = body.slice(1);
       const encoding = harden(JSON.parse(smallcapsBody));
       result = harden(reviveFromSmallcaps(encoding));


### PR DESCRIPTION
Most notably, prefer `charAt(0) === ch` over `startsWith(ch)`.

```console
$ esbench --eshost-option '-h *XS' --init '
const c50 = "I am the *very* model of a modern major general.\n\n";
const c500 = Array(10).fill(c50).join("");
const c5k = Array(100).fill(c50).join("");
const c50k = Array(1000).fill(c50).join("");
' '' '{                                     
  "c50.startsWith(ch)": `result = c50.startsWith("I");`,
  "c500.startsWith(ch)": `result = c500.startsWith("I");`,
  "c5k.startsWith(ch)": `result = c5k.startsWith("I");`,
  "c50k.startsWith(ch)": `result = c50k.startsWith("I");`,
  "c50[0]": `result = c50[0] === "I";`,
  "c500[0]": `result = c500[0] === "I";`,
  "c5k[0]": `result = c5k[0] === "I";`,
  "c50k[0]": `result = c50k[0] === "I";`,
  "c50.charAt(0)": `result = c50.charAt(0) === "I";`,
  "c500.charAt(0)": `result = c500.charAt(0) === "I";`,
  "c5k.charAt(0)": `result = c5k.charAt(0) === "I";`,
  "c50k.charAt(0)": `result = c50k.charAt(0) === "I";`,
}'
#### Moddable XS
c50.startsWith(ch): 9.17 ops/ms
c500.startsWith(ch): 5.03 ops/ms
c5k.startsWith(ch): 1.84 ops/ms
c50k.startsWith(ch): 0.22 ops/ms
c50[0]: 8.20 ops/ms
c500[0]: 6.06 ops/ms
c5k[0]: 1.85 ops/ms
c50k[0]: 0.24 ops/ms
c50.charAt(0): 8.55 ops/ms
c500.charAt(0): 8.06 ops/ms
c5k.charAt(0): 9.09 ops/ms
c50k.charAt(0): 8.70 ops/ms
```

Ref #1982
Ref #2001

### Security Considerations

n/a

### Scaling Considerations

As stated on the tin.

### Documentation Considerations

n/a

### Testing Considerations

n/a

### Compatibility Considerations

n/a

### Upgrade Considerations

Some error messages are affected.