### PR TITLE
fix(marshal)!: compare strings by codepoint

### DIFF
--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,5 +1,13 @@
 User-visible changes in `@endo/marshal`:
 
+# Next release
+
+- JavaScript's relational comparison operators like `<` compare strings by lexicographic UTF16 code unit order, which exposes an internal representational detail not relevant to the string's meaning as a Unicode string. Previously, `compareRank` and associated functions compared strings using this JavaScript-native comparison. Now `compareRank` and associated functions compare strings by lexicographic Unicode Code Point order. ***This change only affects strings containing so-called supplementary characters, i.e., those whose Unicode character code does not fit in 16 bits***.
+  - This release does not change the `encodePassable` encoding. But now, when we say it is order preserving, we need to be careful about which order we mean. `encodePassable` is rank-order preserving when the encoded strings are compared using `compareRank`.
+  - The key order of strings defined by the @endo/patterns module is still defined to be the same as the rank ordering of those strings. So this release changes key order among strings to also be lexicographic comparison of Unicode Code Points. To accommodate this change, you may need to adapt applications that relied on key-order being the same as JS native order. This could include the use of any patterns expressing key inequality tests, like `M.gte(string)`.
+  - These string ordering changes brings Endo into conformance with any string ordering components of the OCapN standard.
+  - To accommodate these change, you may need to adapt applications that relied on rank-order or key-order being the same as JS native order. You may need to resort any data that had previously been rank sorted using the prior `compareRank` function. You may need to revisit any use of patterns like `M.gte(string)` expressing inequalities over strings.
+
 # v1.7.0 (2025-06-02)
 
 - `@endo/marshal` now also exports a `qp` function meaning "quote passable"

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -16,6 +16,7 @@ export {
 
 export {
   compareNumerics,
+  compareByCodePoints,
   assertRankSorted,
   compareRank,
   isRankSorted,

--- a/packages/marshal/test/encodePassable-for-testing.js
+++ b/packages/marshal/test/encodePassable-for-testing.js
@@ -1,0 +1,87 @@
+/* eslint-disable no-bitwise, @endo/restrict-comparison-operands */
+import { Fail, q } from '@endo/errors';
+
+import {
+  makeEncodePassable,
+  makeDecodePassable,
+} from '../src/encodePassable.js';
+import { compareRank, makeComparatorKit } from '../src/rankOrder.js';
+
+const buffers = {
+  __proto__: null,
+  r: [],
+  '?': [],
+  '!': [],
+};
+const resetBuffers = () => {
+  buffers.r = [];
+  buffers['?'] = [];
+  buffers['!'] = [];
+};
+const cursors = {
+  __proto__: null,
+  r: 0,
+  '?': 0,
+  '!': 0,
+};
+const resetCursors = () => {
+  cursors.r = 0;
+  cursors['?'] = 0;
+  cursors['!'] = 0;
+};
+
+const encodeThing = (prefix, r) => {
+  buffers[prefix].push(r);
+  // With this encoding, all things with the same prefix have the same rank
+  return prefix;
+};
+
+const decodeThing = (prefix, e) => {
+  prefix === e ||
+    Fail`expected encoding ${q(e)} to simply be the prefix ${q(prefix)}`;
+  (cursors[prefix] >= 0 && cursors[prefix] < buffers[prefix].length) ||
+    Fail`while decoding ${q(e)}, expected cursors[${q(prefix)}], i.e., ${q(
+      cursors[prefix],
+    )} <= ${q(buffers[prefix].length)}`;
+  const thing = buffers[prefix][cursors[prefix]];
+  cursors[prefix] += 1;
+  return thing;
+};
+
+const encodePassableInternal = makeEncodePassable({
+  encodeRemotable: r => encodeThing('r', r),
+  encodePromise: p => encodeThing('?', p),
+  encodeError: er => encodeThing('!', er),
+});
+
+export const encodePassableInternal2 = makeEncodePassable({
+  encodeRemotable: r => encodeThing('r', r),
+  encodePromise: p => encodeThing('?', p),
+  encodeError: er => encodeThing('!', er),
+  format: 'compactOrdered',
+});
+
+export const encodePassable = passable => {
+  resetBuffers();
+  return encodePassableInternal(passable);
+};
+
+export const encodePassable2 = passable => {
+  resetBuffers();
+  return encodePassableInternal2(passable);
+};
+export const decodePassableInternal = makeDecodePassable({
+  decodeRemotable: e => decodeThing('r', e),
+  decodePromise: e => decodeThing('?', e),
+  decodeError: e => decodeThing('!', e),
+});
+
+export const decodePassable = encoded => {
+  resetCursors();
+  return decodePassableInternal(encoded);
+};
+
+const compareRemotables = (x, y) =>
+  compareRank(encodeThing('r', x), encodeThing('r', y));
+
+export const { comparator: compareFull } = makeComparatorKit(compareRemotables);

--- a/packages/marshal/test/test-string-rank-order.js
+++ b/packages/marshal/test/test-string-rank-order.js
@@ -1,0 +1,64 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { compareRank } from '../src/rankOrder.js';
+import { encodePassable } from './encodePassable-for-testing.js';
+
+/**
+ * Essentially a ponyfill for Array.prototype.toSorted, for use before
+ * we can always rely on the platform to provide it.
+ *
+ * @param {string[]} strings
+ * @param {(
+ *   left: string,
+ *   right: string
+ * ) => import('../src/types.js').RankComparison} comp
+ * @returns {string[]}
+ */
+const sorted = (strings, comp) => [...strings].sort(comp);
+
+test('unicode code point order', t => {
+  // Test case from
+  // https://icu-project.org/docs/papers/utf16_code_point_order.html
+  const str0 = '\u{ff61}';
+  const str3 = '\u{d800}\u{dc02}';
+
+  // str1 and str2 become impossible examples once we prohibit
+  // non - well - formed strings.
+  // See https://github.com/endojs/endo/pull/2002
+  const str1 = '\u{d800}X';
+  const str2 = '\u{d800}\u{ff61}';
+
+  // harden to ensure it is not sorted in place, just for sanity
+  const strs = harden([str0, str1, str2, str3]);
+
+  /**
+   * @param {string} left
+   * @param {string} right
+   * @returns {import('../src/types.js').RankComparison}
+   */
+  const nativeComp = (left, right) =>
+    // eslint-disable-next-line no-nested-ternary
+    left < right ? -1 : left > right ? 1 : 0;
+
+  const nativeSorted = sorted(strs, nativeComp);
+
+  t.deepEqual(nativeSorted, [str1, str3, str2, str0]);
+
+  const rankSorted = sorted(strs, compareRank);
+
+  t.deepEqual(rankSorted, [str1, str2, str0, str3]);
+
+  const nativeEncComp = (left, right) =>
+    nativeComp(encodePassable(left), encodePassable(right));
+
+  const nativeEncSorted = sorted(strs, nativeEncComp);
+
+  t.deepEqual(nativeEncSorted, nativeSorted);
+
+  const rankEncComp = (left, right) =>
+    compareRank(encodePassable(left), encodePassable(right));
+
+  const rankEncSorted = sorted(strs, rankEncComp);
+
+  t.deepEqual(rankEncSorted, rankSorted);
+});

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -2,13 +2,14 @@ User-visible changes in `@endo/patterns`:
 
 # Next release
 
+- JavaScript's relational comparison operators like `<` compare strings by lexicographic UTF16 code unit order, which exposes an internal representational detail not relevant to the string's meaning as a Unicode string.  Previously, `compareKeys` and associated functions compared strings using this JavaScript-native comparison. Now `compareKeys` and associated functions compare strings by lexicographic Unicode Code Point order. ***This change only affects strings containing so-called supplementary characters, i.e., those whose Unicode character code does not fit in 16 bits***.
+  - See the NEWS.md of @endo/marshal for more on this change.
 - In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Now this quoting is done with `qp`, which renders these nested patterns into readable [Justin](https://github.com/endojs/Jessie/blob/main/packages/parse/src/quasi-justin.js) source code.
 
 # v1.5.0 (2025-03-11)
 
 - New pattern: `M.containerHas(elementPatt, bound = 1n)` motivated to support want patterns in Zoe, to pull out only `bound` number of elements that match `elementPatt`. `bound` must be a positive bigint.
 - Closely related, `@endo/patterns` now exports `containerHasSplit` to support ERTP's use of `M.containerHas` on non-fungible (`set`, `copySet`) and semifungible (`copyBag`) assets, respectively. See https://github.com/Agoric/agoric-sdk/pull/10952 .
-
 # v1.4.0 (2024-05-06)
 
 - `Passable` is now an accurate type instead of `any`. Downstream type checking may require changes ([example](https://github.com/Agoric/agoric-sdk/pull/8774))

--- a/packages/patterns/test/test-string-key-order.js
+++ b/packages/patterns/test/test-string-key-order.js
@@ -1,0 +1,54 @@
+// modeled on test-string-rank-order.js
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { compareKeys } from '../src/keys/compareKeys.js';
+
+/**
+ * Essentially a ponyfill for Array.prototype.toSorted, for use before
+ * we can always rely on the platform to provide it.
+ *
+ * @param {string[]} strings
+ * @param {(
+ *   left: string,
+ *   right: string
+ * ) => import('@endo/marshal').RankComparison} comp
+ * @returns {string[]}
+ */
+const sorted = (strings, comp) => [...strings].sort(comp);
+
+test('unicode code point order', t => {
+  // Test case from
+  // https://icu-project.org/docs/papers/utf16_code_point_order.html
+  const str0 = '\u{ff61}';
+  const str3 = '\u{d800}\u{dc02}';
+
+  // str1 and str2 become impossible examples once we prohibit
+  // non - well - formed strings.
+  // See https://github.com/endojs/endo/pull/2002
+  const str1 = '\u{d800}X';
+  const str2 = '\u{d800}\u{ff61}';
+
+  // harden to ensure it is not sorted in place, just for sanity
+  const strs = harden([str0, str1, str2, str3]);
+
+  /**
+   * @param {string} left
+   * @param {string} right
+   * @returns {import('@endo/marshal').RankComparison}
+   */
+  const nativeComp = (left, right) =>
+    // eslint-disable-next-line no-nested-ternary
+    left < right ? -1 : left > right ? 1 : 0;
+
+  const nativeSorted = sorted(strs, nativeComp);
+
+  t.deepEqual(nativeSorted, [str1, str3, str2, str0]);
+
+  // @ts-expect-error We know that for strings, `compareKeys` never returns
+  // NaN because it never judges strings to be incomparable. Thus, the
+  // KeyComparison it returns happens to also be a RankComparison we can
+  // sort with.
+  const keySorted = sorted(strs, compareKeys);
+
+  t.deepEqual(keySorted, [str1, str2, str0, str3]);
+});


### PR DESCRIPTION
closes: #2113 
refs: #2002  https://github.com/Agoric/agoric-sdk/pull/10299 https://github.com/Agoric/agoric-sdk/pull/10165/files#diff-b51392c299617fe43392dd0bcf11b9ed89b619cd4e5051fcffc9bfedef1c4d15 https://github.com/endojs/endo/pull/2873

## Description

- JavaScript's relational comparison operations as exposed in methods like `Array.prototype.sort` and operators `<`/`<=`/`>=`/`>` compare strings by lexicographic UTF-16 code unit order, which is exposes an internal representational detail not relevant to the string's meaning as a Unicode string. Previously, `compareRank` and associated functions compared strings using this JavaScript-native comparison. Now `compareRank` and associated functions compare strings by lexicographic Unicode _code point_ order. ***This change only affects comparison of characters in the range U+E000 through U+FFFF vs. supplementary-plane characters starting at U+10000 [i.e., those whose code point does not fit in 16 bits], and therefore only collections of strings including characters from both of those ranges***.
  - This release does not change the `encodePassable` encoding. But now, when we say it is order preserving, we need to be careful about which order we mean. `encodePassable` is rank-order preserving when the encoded strings are compared using `compareRank`.
  - The key order of strings defined by the @endo/patterns module is still defined to be the same as the rank ordering of those strings. So this release changes key order among strings to also be lexicographic comparison of Unicode code points. To accommodate this change, you may need to adapt applications that relied on key-order being the same as JS native order. This could include the use of any patterns expressing key inequality tests, like `M.gte(string)`.

### Security Considerations

The fact that the string ordering is closer to the Unicode semantics of the strings probably minimizes some surprises in ways that help security. OTOH, this difference from JS native string ordering probably causes other surprises that hurt security. Altogether, we do not expect much effect.

### Scaling Considerations

As a comparison written in JS, will be slower that the JS native string comparison. On XS at least, we expect to have a native code point comparison function available eventually. Altogether, we do not expect much effect.

### Documentation Considerations

Most developers will not care. But it needs to be explained somewhere carefully so that developers that do care can easily find out.

### Testing Considerations

@gibson042 , in a later PR, could you expand the property-based-testing to generate test cases sensitive to this change?

### Compatibility Considerations

  - These string ordering changes brings Endo into conformance with any string ordering components of the OCapN standard.
  - To accommodate these change, you may need to adapt applications that relied on rank-order or key-order being the same as JS native order. You may need to resort any data that had previously been rank sorted using the prior `compareRank` function. You may need to revisit any use of patterns like `M.gte(string)` expressing inequalities over strings.


### Upgrade Considerations

If we currently have any persistent data, especially on chain, sorted according to JS native order (by UTF-16 code unit), then we cannot accept this PR until we have a plan to resort that data, or somehow continue to live with mis-sorted. (Historical note: This is how Oracle came to permanently rely on UTF-16 code unit order, because of the impracticality of resorting all that data.)


- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [x] Updates `NEWS.md` for user-facing changes.
