### PR TITLE
docs(eventual-send): strike ~. (tildot) fwd ref

### DIFF
--- a/packages/eventual-send/README.md
+++ b/packages/eventual-send/README.md
@@ -8,8 +8,6 @@ Create a HandledPromise class to implement the eventual-send API.  This API is u
 
 ## How to use
 
-> Note: If you're writing an application, you probably don't want to use this package directly. You'll want to use the eventual-send `~.` operator (tildot) provided in [SES](https://github.com/Agoric/SES) or other platforms.
-
 To install the `HandledPromise` global property shim, do:
 
 ```js


### PR DESCRIPTION
### Documentation Considerations

tildot is far from ready-for-prime-time

context: increased priority on reference docs

 - [@endo/eventual\-send \- v1\.1\.0 \| Endo API documentation](https://endojs.github.io/endo/modules/_endo_eventual_send.html)