### PR TITLE
refactor(daemon,cli): Rename capitalized names and arguments

### DIFF
--- a/packages/cli/demo/cat.js
+++ b/packages/cli/demo/cat.js
@@ -4,7 +4,7 @@
 // This command will set up the cat page, create a URL,
 // and open it.
 //
-// > endo open familiar-chat cat.js --powers HOST
+// > endo open familiar-chat cat.js --powers host
 //
 // Thereafter,
 //

--- a/packages/cli/demo/doubler.js
+++ b/packages/cli/demo/doubler.js
@@ -2,7 +2,7 @@ import { E, Far } from '@endo/far';
 
 export const make = powers => {
   const counter = E(powers).request(
-    'HOST',
+    'host',
     'a counter, suitable for doubling',
     'my-counter',
   );

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -41,12 +41,12 @@ export const main = async rawArgs => {
     .option('-b,--bundle <bundle>', 'Bundle for a web page (weblet)')
     .option(
       '-p,--powers <endowment>',
-      'Endowment to give the weblet (a name, NONE, HOST, or ENDO)',
+      'Endowment to give the weblet (a name, none, host, or endo)',
     )
     .action(async (webPageName, programPath, cmd) => {
       const {
         bundle: bundleName,
-        powers: powersName = 'NONE',
+        powers: powersName = 'none',
         as: partyNames,
       } = cmd.opts();
       const { install } = await import('./install.js');
@@ -86,17 +86,20 @@ export const main = async rawArgs => {
       [],
     )
     .option('-b,--bundle <bundle>', 'Bundle name for the caplet program')
-    .option('--UNSAFE <path>', 'Or path of an unsafe plugin to run in Node.js')
+    .option(
+      '--UNCONFINED <path>',
+      'Or path of an unsafe plugin to run in Node.js',
+    )
     .option(
       '-p,--powers <endowment>',
-      'Endowment to give the worklet (a name, NONE, HOST, or ENDO)',
+      'Endowment to give the worklet (a name, none, host, or endo)',
     )
     .action(async (filePath, args, cmd) => {
       const {
         as: partyNames,
         bundle: bundleName,
-        UNSAFE: importPath,
-        powers: powersName = 'NONE',
+        UNCONFINED: importPath,
+        powers: powersName = 'none',
       } = cmd.opts();
       const { run } = await import('./run.js');
       return run({
@@ -113,14 +116,14 @@ export const main = async rawArgs => {
     .command('make [file]')
     .description('make a plugin or a worker caplet (worklet)')
     .option('-b,--bundle <bundle>', 'Bundle for a web page to open')
-    .option('--UNSAFE <file>', 'Path to a Node.js module')
+    .option('--UNCONFINED <file>', 'Path to a Node.js module')
     .option(
       '-a,--as <party>',
       'Pose as named party (as named by current party)',
       collect,
       [],
     )
-    .option('-p,--powers <name>', 'Name of powers to grant or NONE, HOST, ENDO')
+    .option('-p,--powers <name>', 'Name of powers to grant or none, host, endo')
     .option(
       '-n,--name <name>',
       'Assigns a name to the result for future reference, persisted between restarts',
@@ -131,12 +134,12 @@ export const main = async rawArgs => {
     )
     .action(async (filePath, cmd) => {
       const {
-        UNSAFE: importPath,
+        UNCONFINED: importPath,
         name: resultName,
         bundle: bundleName,
-        worker: workerName = 'NEW',
+        worker: workerName = 'new',
         as: partyNames,
-        powers: powersName = 'NONE',
+        powers: powersName = 'none',
       } = cmd.opts();
       const { makeCommand } = await import('./make.js');
       return makeCommand({
@@ -171,7 +174,7 @@ export const main = async rawArgs => {
     .description('ask someone for something')
     .option(
       '-t,--to <party>',
-      'Send the request to another party (default: HOST)',
+      'Send the request to another party (default: host)',
     )
     .option(
       '-a,--as <party>',
@@ -187,7 +190,7 @@ export const main = async rawArgs => {
       const {
         name: resultName,
         as: partyNames,
-        to: toName = 'HOST',
+        to: toName = 'host',
       } = cmd.opts();
       const { request } = await import('./request.js');
       return request({ toName, description, resultName, partyNames });
@@ -421,7 +424,7 @@ export const main = async rawArgs => {
     .action(async (source, names, cmd) => {
       const {
         name: resultName,
-        worker: workerName = 'MAIN',
+        worker: workerName = 'main',
         as: partyNames,
       } = cmd.opts();
       const { evalCommand } = await import('./eval.js');

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -41,7 +41,7 @@ export const main = async rawArgs => {
     .option('-b,--bundle <bundle>', 'Bundle for a web page (weblet)')
     .option(
       '-p,--powers <endowment>',
-      'Endowment to give the weblet (a name, none, host, or endo)',
+      'Endowment to give the weblet (a name, "none", "host", or "endo")',
     )
     .action(async (webPageName, programPath, cmd) => {
       const {
@@ -92,7 +92,7 @@ export const main = async rawArgs => {
     )
     .option(
       '-p,--powers <endowment>',
-      'Endowment to give the worklet (a name, none, host, or endo)',
+      'Endowment to give the worklet (a name, "none", "host", or "endo")',
     )
     .action(async (filePath, args, cmd) => {
       const {

--- a/packages/cli/src/make.js
+++ b/packages/cli/src/make.js
@@ -24,7 +24,7 @@ export const makeCommand = async ({
   powersName,
 }) => {
   if (filePath !== undefined && importPath !== undefined) {
-    console.error('Specify only one of [file] or --UNSAFE <file>');
+    console.error('Specify only one of [file] or --UNCONFINED <file>');
     process.exitCode = 1;
     return;
   }
@@ -34,7 +34,7 @@ export const makeCommand = async ({
     bundleName === undefined
   ) {
     console.error(
-      'Specify at least one of [file], --bundle <file>, or --UNSAFE <file>',
+      'Specify at least one of [file], --bundle <file>, or --UNCONFINED <file>',
     );
     process.exitCode = 1;
     return;

--- a/packages/cli/src/run.js
+++ b/packages/cli/src/run.js
@@ -29,7 +29,7 @@ export const run = async ({
     importPath === undefined &&
     bundleName === undefined
   ) {
-    console.error('Specify at least one of --file, --bundle, or --UNSAFE');
+    console.error('Specify at least one of --file, --bundle, or --UNCONFINED');
     process.exitCode = 1;
     return;
   }
@@ -39,11 +39,11 @@ export const run = async ({
     { os, process },
     async ({ bootstrap, party }) => {
       let powersP;
-      if (powersName === 'NONE') {
+      if (powersName === 'none') {
         powersP = E(bootstrap).leastAuthority();
-      } else if (powersName === 'HOST') {
+      } else if (powersName === 'host') {
         powersP = party;
-      } else if (powersName === 'ENDO') {
+      } else if (powersName === 'endo') {
         powersP = bootstrap;
       } else {
         powersP = E(party).provideGuest(powersName);
@@ -51,7 +51,9 @@ export const run = async ({
 
       if (importPath !== undefined) {
         if (bundleName !== undefined) {
-          console.error('Must specify either --bundle or --UNSAFE, not both');
+          console.error(
+            'Must specify either --bundle or --UNCONFINED, not both',
+          );
           process.exitCode = 1;
           return;
         }
@@ -70,7 +72,9 @@ export const run = async ({
         let bundle;
         if (bundleName !== undefined) {
           if (importPath !== undefined) {
-            console.error('Must specify either --bundle or --UNSAFE, not both');
+            console.error(
+              'Must specify either --bundle or --UNCONFINED, not both',
+            );
             process.exitCode = 1;
             return;
           }

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -63,8 +63,8 @@ export const makeGuestMaker = ({
       petStore,
       selfFormulaIdentifier: guestFormulaIdentifier,
       specialNames: {
-        SELF: guestFormulaIdentifier,
-        HOST: hostFormulaIdentifier,
+        self: guestFormulaIdentifier,
+        host: hostFormulaIdentifier,
       },
       terminator,
     });

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -57,9 +57,9 @@ export const makeHostMaker = ({
       petStore,
       selfFormulaIdentifier: hostFormulaIdentifier,
       specialNames: {
-        SELF: hostFormulaIdentifier,
-        NONE: 'least-authority',
-        ENDO: 'endo',
+        self: hostFormulaIdentifier,
+        none: 'least-authority',
+        endo: 'endo',
       },
       terminator,
     });
@@ -142,12 +142,12 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {string | 'MAIN' | 'NEW'} workerName
+     * @param {string | 'main' | 'new'} workerName
      */
     const provideWorkerFormulaIdentifier = async workerName => {
-      if (workerName === 'MAIN') {
+      if (workerName === 'main') {
         return mainWorkerFormulaIdentifier;
-      } else if (workerName === 'NEW') {
+      } else if (workerName === 'new') {
         const workerId512 = await randomHex512();
         return `worker-id512:${workerId512}`;
       }
@@ -163,7 +163,7 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {string | 'NONE' | 'HOST' | 'ENDO'} partyName
+     * @param {string | 'none' | 'host' | 'endo'} partyName
      */
     const providePowersFormulaIdentifier = async partyName => {
       let guestFormulaIdentifier = lookupFormulaIdentifierForName(partyName);
@@ -180,7 +180,7 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {string | 'MAIN' | 'NEW'} workerName
+     * @param {string | 'main' | 'new'} workerName
      * @param {string} source
      * @param {Array<string>} codeNames
      * @param {Array<string>} petNames
@@ -239,9 +239,9 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {string | 'NEW' | 'MAIN'} workerName
+     * @param {string | 'new' | 'main'} workerName
      * @param {string} importPath
-     * @param {string | 'NONE' | 'HOST' | 'ENDO'} powersName
+     * @param {string | 'none' | 'host' | 'endo'} powersName
      * @param {string} resultName
      */
     const importUnsafeAndEndow = async (
@@ -279,9 +279,9 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {string | 'MAIN' | 'NEW'} workerName
+     * @param {string | 'main' | 'new'} workerName
      * @param {string} bundleName
-     * @param {string | 'NONE' | 'HOST' | 'ENDO'} powersName
+     * @param {string | 'none' | 'host' | 'endo'} powersName
      * @param {string} resultName
      */
     const importBundleAndEndow = async (
@@ -376,7 +376,7 @@ export const makeHostMaker = ({
     /**
      * @param {string} webPageName
      * @param {string} bundleName
-     * @param {string | 'NONE' | 'HOST' | 'ENDO'} powersName
+     * @param {string | 'none' | 'host' | 'endo'} powersName
      */
     const provideWebPage = async (webPageName, bundleName, powersName) => {
       const bundleFormulaIdentifier =

--- a/packages/daemon/test/counter-party.js
+++ b/packages/daemon/test/counter-party.js
@@ -1,7 +1,7 @@
 import { E, Far } from '@endo/far';
 
 export const make = async powers => {
-  let counter = await E(powers).request('HOST', 'starting number', 'start');
+  let counter = await E(powers).request('host', 'starting number', 'start');
   return Far('Counter', {
     incr() {
       counter += 1;

--- a/packages/daemon/test/service.js
+++ b/packages/daemon/test/service.js
@@ -4,7 +4,7 @@ export const make = powers => {
   return Far('Service', {
     async ask() {
       return E(powers).request(
-        'HOST',
+        'host',
         'the meaning of life, the universe, everything',
         'answer',
       );

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -108,7 +108,7 @@ test('anonymous spawn and evaluate', async t => {
   );
   const bootstrap = getBootstrap();
   const host = E(bootstrap).host();
-  const ten = await E(host).evaluate('MAIN', '10', [], []);
+  const ten = await E(host).evaluate('main', '10', [], []);
   t.is(10, ten);
 
   await stop(locator);
@@ -411,11 +411,11 @@ test('guest facet receives a message for host', async t => {
   await E(host).provideWorker('worker');
   await E(host).evaluate('worker', '10', [], [], 'ten1');
   const iteratorRef = E(host).followMessages();
-  E.sendOnly(guest).request('HOST', 'a number', 'number');
+  E.sendOnly(guest).request('host', 'a number', 'number');
   const { value: message0 } = await E(iteratorRef).next();
   t.is(message0.number, 0);
   await E(host).resolve(message0.number, 'ten1');
-  await E(guest).send('HOST', ['Hello, World!'], ['gift'], ['number']);
+  await E(guest).send('host', ['Hello, World!'], ['gift'], ['number']);
   const { value: message1 } = await E(iteratorRef).next();
   t.is(message1.number, 1);
   await E(host).adopt(message1.number, 'gift', 'ten2');
@@ -444,7 +444,7 @@ test('direct termination', async t => {
   await E(host).provideWorker('worker');
 
   const counterPath = path.join(dirname, 'test', 'counter.js');
-  await E(host).importUnsafeAndEndow('worker', counterPath, 'NONE', 'counter');
+  await E(host).importUnsafeAndEndow('worker', counterPath, 'none', 'counter');
   t.is(
     1,
     await E(host).evaluate(
@@ -524,7 +524,7 @@ test('indirect termination', async t => {
   await E(host).provideWorker('worker');
 
   const counterPath = path.join(dirname, 'test', 'counter.js');
-  await E(host).importUnsafeAndEndow('worker', counterPath, 'SELF', 'counter');
+  await E(host).importUnsafeAndEndow('worker', counterPath, 'self', 'counter');
   t.is(
     1,
     await E(host).evaluate(


### PR DESCRIPTION
- Uncapitalizes all "special names" in the daemon, since we have determined we no longer need this.
- Renames the `--UNSAFE` CLI flag to `--UNCONFINED`, which is more specific. We maintain capitalization here to draw attention to it.