### PR TITLE
feat(cli)!: Rename --UNSAFE to --UNCONFINED

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -86,7 +86,10 @@ export const main = async rawArgs => {
       [],
     )
     .option('-b,--bundle <bundle>', 'Bundle name for the caplet program')
-    .option('--UNSAFE <path>', 'Or path of an unsafe plugin to run in Node.js')
+    .option(
+      '--UNCONFINED <path>',
+      'Or path of an unsafe plugin to run in Node.js',
+    )
     .option(
       '-p,--powers <endowment>',
       'Endowment to give the worklet (a name, NONE, HOST, or ENDO)',
@@ -95,7 +98,7 @@ export const main = async rawArgs => {
       const {
         as: partyNames,
         bundle: bundleName,
-        UNSAFE: importPath,
+        UNCONFINED: importPath,
         powers: powersName = 'NONE',
       } = cmd.opts();
       const { run } = await import('./run.js');
@@ -113,7 +116,7 @@ export const main = async rawArgs => {
     .command('make [file]')
     .description('make a plugin or a worker caplet (worklet)')
     .option('-b,--bundle <bundle>', 'Bundle for a web page to open')
-    .option('--UNSAFE <file>', 'Path to a Node.js module')
+    .option('--UNCONFINED <file>', 'Path to a Node.js module')
     .option(
       '-a,--as <party>',
       'Pose as named party (as named by current party)',
@@ -131,7 +134,7 @@ export const main = async rawArgs => {
     )
     .action(async (filePath, cmd) => {
       const {
-        UNSAFE: importPath,
+        UNCONFINED: importPath,
         name: resultName,
         bundle: bundleName,
         worker: workerName = 'NEW',

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -88,7 +88,7 @@ export const main = async rawArgs => {
     .option('-b,--bundle <bundle>', 'Bundle name for the caplet program')
     .option(
       '--UNCONFINED <path>',
-      'Or path of an unsafe plugin to run in Node.js',
+      'Or path of an unconfined plugin to run in Node.js',
     )
     .option(
       '-p,--powers <endowment>',

--- a/packages/cli/src/make.js
+++ b/packages/cli/src/make.js
@@ -66,18 +66,13 @@ export const makeCommand = async ({
 
     const resultP =
       importPath !== undefined
-        ? E(party).importUnsafeAndEndow(
+        ? E(party).makeUnconfined(
             workerName,
             path.resolve(importPath),
             powersName,
             resultName,
           )
-        : E(party).importBundleAndEndow(
-            workerName,
-            bundleName,
-            powersName,
-            resultName,
-          );
+        : E(party).makeBundle(workerName, bundleName, powersName, resultName);
     const result = await resultP;
     console.log(result);
 

--- a/packages/cli/src/make.js
+++ b/packages/cli/src/make.js
@@ -24,7 +24,7 @@ export const makeCommand = async ({
   powersName,
 }) => {
   if (filePath !== undefined && importPath !== undefined) {
-    console.error('Specify only one of [file] or --UNSAFE <file>');
+    console.error('Specify only one of [file] or --UNCONFINED <file>');
     process.exitCode = 1;
     return;
   }
@@ -34,7 +34,7 @@ export const makeCommand = async ({
     bundleName === undefined
   ) {
     console.error(
-      'Specify at least one of [file], --bundle <file>, or --UNSAFE <file>',
+      'Specify at least one of [file], --bundle <file>, or --UNCONFINED <file>',
     );
     process.exitCode = 1;
     return;

--- a/packages/cli/src/run.js
+++ b/packages/cli/src/run.js
@@ -29,7 +29,7 @@ export const run = async ({
     importPath === undefined &&
     bundleName === undefined
   ) {
-    console.error('Specify at least one of --file, --bundle, or --UNSAFE');
+    console.error('Specify at least one of --file, --bundle, or --UNCONFINED');
     process.exitCode = 1;
     return;
   }
@@ -51,7 +51,9 @@ export const run = async ({
 
       if (importPath !== undefined) {
         if (bundleName !== undefined) {
-          console.error('Must specify either --bundle or --UNSAFE, not both');
+          console.error(
+            'Must specify either --bundle or --UNCONFINED, not both',
+          );
           process.exitCode = 1;
           return;
         }
@@ -70,7 +72,9 @@ export const run = async ({
         let bundle;
         if (bundleName !== undefined) {
           if (importPath !== undefined) {
-            console.error('Must specify either --bundle or --UNSAFE, not both');
+            console.error(
+              'Must specify either --bundle or --UNCONFINED, not both',
+            );
             process.exitCode = 1;
             return;
           }

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -586,7 +586,7 @@ export const makeDaemonicPersistencePowers = (
 
   const webPageBundlerFormula = includeWebPageBundler
     ? {
-        type: /** @type {'import-unsafe'} */ ('import-unsafe'),
+        type: /** @type {'make-unconfined'} */ ('make-unconfined'),
         worker: `worker-id512:${zero512}`,
         powers: 'host',
         importPath: fileURLToPath(

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -239,10 +239,7 @@ const makeEndoBootstrap = (
       // eslint-disable-next-line no-use-before-define
       provideValueForFormulaIdentifier(guestFormulaIdentifier)
     );
-    const external = E(workerDaemonFacet).importUnsafeAndEndow(
-      importPath,
-      guestP,
-    );
+    const external = E(workerDaemonFacet).makeUnconfined(importPath, guestP);
     return { external, internal: undefined };
   };
 
@@ -285,10 +282,7 @@ const makeEndoBootstrap = (
       // eslint-disable-next-line no-use-before-define
       provideValueForFormulaIdentifier(guestFormulaIdentifier)
     );
-    const external = E(workerDaemonFacet).importBundleAndEndow(
-      readableBundleP,
-      guestP,
-    );
+    const external = E(workerDaemonFacet).makeBundle(readableBundleP, guestP);
     return { external, internal: undefined };
   };
 
@@ -312,14 +306,14 @@ const makeEndoBootstrap = (
         formula.values,
         terminator,
       );
-    } else if (formula.type === 'import-unsafe') {
+    } else if (formula.type === 'make-unconfined') {
       return makeControllerForUnsafePlugin(
         formula.worker,
         formula.powers,
         formula.importPath,
         terminator,
       );
-    } else if (formula.type === 'import-bundle') {
+    } else if (formula.type === 'make-bundle') {
       return makeControllerForSafeBundle(
         formula.worker,
         formula.powers,
@@ -433,8 +427,8 @@ const makeEndoBootstrap = (
     } else if (
       [
         'eval-id512',
-        'import-unsafe-id512',
-        'import-bundle-id512',
+        'make-unconfined-id512',
+        'make-bundle-id512',
         'guest-id512',
         'web-bundle',
       ].includes(formulaType)
@@ -614,7 +608,7 @@ const makeEndoBootstrap = (
           })
         );
       const bundle = await E(bundleBlob).json();
-      await E(webPageP).importBundleAndEndow(bundle, endowedPowers);
+      await E(webPageP).makeBundle(bundle, endowedPowers);
     },
   });
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -214,7 +214,7 @@ const makeEndoBootstrap = (
    * @param {string} importPath
    * @param {import('./types.js').Terminator} terminator
    */
-  const makeControllerForUnsafePlugin = async (
+  const makeControllerForUnconfinedPlugin = async (
     workerFormulaIdentifier,
     guestFormulaIdentifier,
     importPath,
@@ -307,7 +307,7 @@ const makeEndoBootstrap = (
         terminator,
       );
     } else if (formula.type === 'make-unconfined') {
-      return makeControllerForUnsafePlugin(
+      return makeControllerForUnconfinedPlugin(
         formula.worker,
         formula.powers,
         formula.importPath,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -244,7 +244,7 @@ export const makeHostMaker = ({
      * @param {string | 'NONE' | 'HOST' | 'ENDO'} powersName
      * @param {string} resultName
      */
-    const importUnsafeAndEndow = async (
+    const makeUnconfined = async (
       workerName,
       importPath,
       powersName,
@@ -259,8 +259,8 @@ export const makeHostMaker = ({
       );
 
       const formula = {
-        /** @type {'import-unsafe'} */
-        type: 'import-unsafe',
+        /** @type {'make-unconfined'} */
+        type: 'make-unconfined',
         worker: workerFormulaIdentifier,
         powers: powersFormulaIdentifier,
         importPath,
@@ -270,7 +270,7 @@ export const makeHostMaker = ({
       // eslint-disable-next-line no-use-before-define
       const { formulaIdentifier, value } = await provideValueForFormula(
         formula,
-        'import-unsafe-id512',
+        'make-unconfined-id512',
       );
       if (resultName !== undefined) {
         await petStore.write(resultName, formulaIdentifier);
@@ -284,7 +284,7 @@ export const makeHostMaker = ({
      * @param {string | 'NONE' | 'HOST' | 'ENDO'} powersName
      * @param {string} resultName
      */
-    const importBundleAndEndow = async (
+    const makeBundle = async (
       workerName,
       bundleName,
       powersName,
@@ -305,8 +305,8 @@ export const makeHostMaker = ({
       );
 
       const formula = {
-        /** @type {'import-bundle'} */
-        type: 'import-bundle',
+        /** @type {'make-bundle'} */
+        type: 'make-bundle',
         worker: workerFormulaIdentifier,
         powers: powersFormulaIdentifier,
         bundle: bundleFormulaIdentifier,
@@ -316,7 +316,7 @@ export const makeHostMaker = ({
       // eslint-disable-next-line no-use-before-define
       const { value, formulaIdentifier } = await provideValueForFormula(
         formula,
-        'import-bundle-id512',
+        'make-bundle-id512',
       );
 
       if (resultName !== undefined) {
@@ -451,8 +451,8 @@ export const makeHostMaker = ({
       provideWorker,
       evaluate,
       terminate,
-      importUnsafeAndEndow,
-      importBundleAndEndow,
+      makeUnconfined,
+      makeBundle,
       provideWebPage,
     });
 

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -9,7 +9,7 @@ const { quote: q } = assert;
 
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:host|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|import-unsafe-id512|import-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
+  /^(?:host|pet-store|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -73,7 +73,7 @@ type EvalFormula = {
 };
 
 type ImportUnsafeFormula = {
-  type: 'import-unsafe';
+  type: 'make-unconfined';
   worker: string;
   powers: string;
   importPath: string;
@@ -81,7 +81,7 @@ type ImportUnsafeFormula = {
 };
 
 type ImportBundleFormula = {
-  type: 'import-bundle';
+  type: 'make-bundle';
   worker: string;
   powers: string;
   bundle: string;
@@ -233,13 +233,13 @@ export interface EndoHost {
     petNames: Array<string>,
     resultName?: string,
   );
-  importUnsafeAndEndow(
+  makeUnconfined(
     workerPetName: string | undefined,
     importPath: string,
     powersName: string,
     resultName?: string,
   ): Promise<unknown>;
-  importBundleAndEndow(
+  makeBundle(
     workerPetName: string | undefined,
     bundleName: string,
     powersName: string,
@@ -342,8 +342,8 @@ export interface WorkerDaemonFacet {
     values: Array<unknown>,
     cancelled: Promise<never>,
   ): Promise<unknown>;
-  importBundleAndEndow(bundle: ERef<EndoReadable>, powers: ERef<unknown>);
-  importUnsafeAndEndow(path: string, powers: ERef<unknown>);
+  makeBundle(bundle: ERef<EndoReadable>, powers: ERef<unknown>);
+  makeUnconfined(path: string, powers: ERef<unknown>);
 }
 
 export type DaemonicControlPowers = {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -72,7 +72,7 @@ type EvalFormula = {
   // TODO formula slots
 };
 
-type ImportUnsafeFormula = {
+type MakeUnconfinedFormula = {
   type: 'make-unconfined';
   worker: string;
   powers: string;
@@ -80,7 +80,7 @@ type ImportUnsafeFormula = {
   // TODO formula slots
 };
 
-type ImportBundleFormula = {
+type MakeBundleFormula = {
   type: 'make-bundle';
   worker: string;
   powers: string;
@@ -97,8 +97,8 @@ type WebBundleFormula = {
 export type Formula =
   | GuestFormula
   | EvalFormula
-  | ImportUnsafeFormula
-  | ImportBundleFormula
+  | MakeUnconfinedFormula
+  | MakeBundleFormula
   | WebBundleFormula;
 
 export type Label = {

--- a/packages/daemon/src/web-page-bundler.js
+++ b/packages/daemon/src/web-page-bundler.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-// This is a built-in unsafe plugin for lazily constructing the web-page.js
+// This is a built-in unconfined plugin for lazily constructing the web-page.js
 // bundle for booting up web caplets.
 // The hard-coded 'web-page-js' formula is a hard-coded 'make-unconfined' formula
 // that runs this program in worker 0.

--- a/packages/daemon/src/web-page-bundler.js
+++ b/packages/daemon/src/web-page-bundler.js
@@ -2,7 +2,7 @@
 
 // This is a built-in unsafe plugin for lazily constructing the web-page.js
 // bundle for booting up web caplets.
-// The hard-coded 'web-page-js' formula is a hard-coded 'import-unsafe' formula
+// The hard-coded 'web-page-js' formula is a hard-coded 'make-unconfined' formula
 // that runs this program in worker 0.
 // It does not accept its endowed powers.
 

--- a/packages/daemon/src/web-page.js
+++ b/packages/daemon/src/web-page.js
@@ -82,7 +82,7 @@ const bootstrap = Far('WebFacet', {
     console.log('received ping');
     return 'pong';
   },
-  async importBundleAndEndow(bundle, powers) {
+  async makeBundle(bundle, powers) {
     const namespace = await importBundle(bundle, {
       endowments,
     });

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -53,7 +53,7 @@ export const makeWorkerFacet = ({ pathToFileURL, cancel }) => {
      * @param {string} path
      * @param {unknown} powersP
      */
-    importUnsafeAndEndow: async (path, powersP) => {
+    makeUnconfined: async (path, powersP) => {
       const url = pathToFileURL(path);
       const namespace = await import(url);
       return namespace.make(powersP);
@@ -63,7 +63,7 @@ export const makeWorkerFacet = ({ pathToFileURL, cancel }) => {
      * @param {import('@endo/eventual-send').ERef<import('./types.js').EndoReadable>} readableP
      * @param {unknown} powersP
      */
-    importBundleAndEndow: async (readableP, powersP) => {
+    makeBundle: async (readableP, powersP) => {
       const bundleText = await E(readableP).text();
       const bundle = JSON.parse(bundleText);
 

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -311,7 +311,7 @@ test('closure state lost by restart', async t => {
 test('persist unsafe services and their requests', async t => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();
   t.teardown(() => cancel(Error('teardown')));
-  const locator = makeLocator('tmp', 'import-unsafe');
+  const locator = makeLocator('tmp', 'make-unconfined');
 
   await stop(locator).catch(() => {});
   await reset(locator);
@@ -358,7 +358,7 @@ test('persist unsafe services and their requests', async t => {
     await E(host).makeWorker('w1');
     await E(host).provideGuest('o1');
     const servicePath = path.join(dirname, 'test', 'service.js');
-    await E(host).importUnsafeAndEndow('w1', servicePath, 'o1', 's1');
+    await E(host).makeUnconfined('w1', servicePath, 'o1', 's1');
 
     await E(host).makeWorker('w2');
     const answer = await E(host).evaluate(
@@ -444,7 +444,7 @@ test('direct termination', async t => {
   await E(host).provideWorker('worker');
 
   const counterPath = path.join(dirname, 'test', 'counter.js');
-  await E(host).importUnsafeAndEndow('worker', counterPath, 'NONE', 'counter');
+  await E(host).makeUnconfined('worker', counterPath, 'NONE', 'counter');
   t.is(
     1,
     await E(host).evaluate(
@@ -524,7 +524,7 @@ test('indirect termination', async t => {
   await E(host).provideWorker('worker');
 
   const counterPath = path.join(dirname, 'test', 'counter.js');
-  await E(host).importUnsafeAndEndow('worker', counterPath, 'SELF', 'counter');
+  await E(host).makeUnconfined('worker', counterPath, 'SELF', 'counter');
   t.is(
     1,
     await E(host).evaluate(
@@ -606,7 +606,7 @@ test('terminate because of requested capability', async t => {
   const messages = E(host).followMessages();
 
   const counterPath = path.join(dirname, 'test', 'counter-party.js');
-  E(host).importUnsafeAndEndow('worker', counterPath, 'guest', 'counter');
+  E(host).makeUnconfined('worker', counterPath, 'guest', 'counter');
 
   await E(host).evaluate('worker', '0', [], [], 'zero');
   await E(messages).next();

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -308,7 +308,7 @@ test('closure state lost by restart', async t => {
   await stop(locator);
 });
 
-test('persist unsafe services and their requests', async t => {
+test('persist unconfined services and their requests', async t => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();
   t.teardown(() => cancel(Error('teardown')));
   const locator = makeLocator('tmp', 'make-unconfined');


### PR DESCRIPTION
Renames the `UNSAFE` flag to `UNCONFINED`, which is more specific. Also renames internals using "unsafe" (like `import-unsafe`) to use "unconfined" instead.

Will require an `endo purge -f`.