### PR TITLE
refactor(errors): support our assert conventions

### DIFF
--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -52,6 +52,7 @@
     "c8": "^7.14.0"
   },
   "dependencies": {
+    "@endo/errors": "^1.0.2",
     "@endo/eventual-send": "^1.1.0",
     "@endo/marshal": "^1.1.0",
     "@endo/nat": "^5.0.2",

--- a/packages/captp/src/atomics.js
+++ b/packages/captp/src/atomics.js
@@ -1,6 +1,6 @@
 /// <reference types="ses"/>
 
-const { details: X, Fail } = assert;
+import { X, Fail } from '@endo/errors';
 
 // This is a pathological minimum, but exercised by the unit test.
 export const MIN_DATA_BUFFER_LENGTH = 1;
@@ -154,7 +154,7 @@ export const makeAtomicsTrapGuest = transferBuffer => {
     //
     // TODO: It would be nice to use an error type, but captp is just too
     // noisy with spurious "Temporary logging of sent error" messages.
-    // it.throw(assert.error(X`Trap host has not finished`));
+    // it.throw(makeError(X`Trap host has not finished`));
     it.throw(null);
 
     // eslint-disable-next-line no-bitwise

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -12,7 +12,7 @@ import { Remotable, Far, makeMarshal, QCLASS } from '@endo/marshal';
 import { E, HandledPromise } from '@endo/eventual-send';
 import { isPromise, makePromiseKit } from '@endo/promise-kit';
 
-import { X, Fail, errorNote } from '@endo/errors';
+import { X, Fail, annotateError } from '@endo/errors';
 import { makeTrap } from './trap.js';
 
 import { makeFinalizingMap } from './finalize.js';
@@ -669,7 +669,7 @@ export const makeCapTP = (
           if (!e) {
             Fail`trapGuest expected trapHost AsyncIterator(${questionID}) to be done, but it wasn't`;
           }
-          errorNote(e, X`trapHost AsyncIterator(${questionID}) threw`);
+          annotateError(e, X`trapHost AsyncIterator(${questionID}) threw`);
           throw e;
         }
       };

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -12,13 +12,12 @@ import { Remotable, Far, makeMarshal, QCLASS } from '@endo/marshal';
 import { E, HandledPromise } from '@endo/eventual-send';
 import { isPromise, makePromiseKit } from '@endo/promise-kit';
 
+import { X, Fail, errorNote } from '@endo/errors';
 import { makeTrap } from './trap.js';
 
 import { makeFinalizingMap } from './finalize.js';
 
 export { E };
-
-const { details: X, Fail } = assert;
 
 const WELL_KNOWN_SLOT_PROPERTIES = harden(['answerID', 'questionID', 'target']);
 
@@ -670,7 +669,7 @@ export const makeCapTP = (
           if (!e) {
             Fail`trapGuest expected trapHost AsyncIterator(${questionID}) to be done, but it wasn't`;
           }
-          assert.note(e, X`trapHost AsyncIterator(${questionID}) threw`);
+          errorNote(e, X`trapHost AsyncIterator(${questionID}) threw`);
           throw e;
         }
       };

--- a/packages/captp/test/traplib.js
+++ b/packages/captp/test/traplib.js
@@ -2,11 +2,10 @@
 /// <reference types="ses"/>
 
 import { Far } from '@endo/marshal';
+import { X, Fail } from '@endo/errors';
 import { E, makeCapTP } from '../src/captp.js';
 
 import { makeAtomicsTrapGuest, makeAtomicsTrapHost } from '../src/atomics.js';
-
-const { details: X, Fail } = assert;
 
 export const createHostBootstrap = makeTrapHandler => {
   // Create a remotable that has a syncable return value.

--- a/packages/captp/test/worker.js
+++ b/packages/captp/test/worker.js
@@ -4,9 +4,8 @@ import '@endo/init/pre-remoting.js';
 import '@endo/init/debug.js';
 
 import { parentPort } from 'worker_threads';
+import { Fail } from '@endo/errors';
 import { makeGuest, makeHost } from './traplib.js';
-
-const { Fail } = assert;
 
 let dispatch;
 parentPort.addListener('message', obj => {

--- a/packages/check-bundle/lite.js
+++ b/packages/check-bundle/lite.js
@@ -4,7 +4,7 @@
 import { decodeBase64 } from '@endo/base64/decode.js';
 import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
 
-const { Fail, details: d, quote: q } = assert;
+import { Fail, X, q } from '@endo/errors';
 
 /**
  * Verifies that a bundle passes its own integrity checks or rejects the
@@ -25,7 +25,7 @@ export const checkBundle = async (
   assert.typeof(
     bundle,
     'object',
-    d`checkBundle cannot hash non-bundle, must be of type object, got ${q(
+    X`checkBundle cannot hash non-bundle, must be of type object, got ${q(
       bundle,
     )}`,
   );
@@ -56,7 +56,7 @@ export const checkBundle = async (
   assert.typeof(
     moduleFormat,
     'string',
-    d`checkBundle cannot hash non-bundle, moduleFormat must be a string, got ${typeof moduleFormat}`,
+    X`checkBundle cannot hash non-bundle, moduleFormat must be a string, got ${typeof moduleFormat}`,
   );
 
   if (moduleFormat === 'endoZipBase64') {
@@ -64,12 +64,12 @@ export const checkBundle = async (
     assert.typeof(
       endoZipBase64,
       'string',
-      d`checkBundle cannot hash non-bundle, property 'endoZipBase64' must be a string, got ${typeof endoZipBase64}`,
+      X`checkBundle cannot hash non-bundle, property 'endoZipBase64' must be a string, got ${typeof endoZipBase64}`,
     );
     assert.typeof(
       endoZipBase64Sha512,
       'string',
-      d`checkBundle cannot bundle without the property 'endoZipBase64Sha512', which must be a string, got ${typeof endoZipBase64Sha512}`,
+      X`checkBundle cannot bundle without the property 'endoZipBase64Sha512', which must be a string, got ${typeof endoZipBase64Sha512}`,
     );
     const bytes = decodeBase64(endoZipBase64);
     const { sha512: parsedSha512 } = await parseArchive(bytes, bundleName, {

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "@endo/base64": "^1.0.1",
-    "@endo/compartment-mapper": "^1.1.0"
+    "@endo/compartment-mapper": "^1.1.0",
+    "@endo/errors": "^1.0.2"
   },
   "devDependencies": {
     "@endo/bundle-source": "^3.0.2",

--- a/packages/common/from-unique-entries.js
+++ b/packages/common/from-unique-entries.js
@@ -1,7 +1,7 @@
+import { q, Fail } from '@endo/errors';
+
 const { fromEntries } = Object;
 const { ownKeys } = Reflect;
-
-const { quote: q, Fail } = assert;
 
 /**
  * Throws if multiple entries use the same property name. Otherwise acts

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -41,6 +41,7 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
+    "@endo/errors": "^1.0.2",
     "@endo/eventual-send": "^1.1.0",
     "@endo/promise-kit": "^1.0.2"
   },

--- a/packages/common/test/test-apply-labeling-error.js
+++ b/packages/common/test/test-apply-labeling-error.js
@@ -1,7 +1,8 @@
 import { test } from './prepare-test-env-ava.js';
-import { applyLabelingError } from '../apply-labeling-error.js';
 
-const { Fail } = assert;
+// eslint-disable-next-line import/order
+import { Fail } from '@endo/errors';
+import { applyLabelingError } from '../apply-labeling-error.js';
 
 test('test applyLabelingError', async t => {
   t.is(

--- a/packages/common/throw-labeled.js
+++ b/packages/common/throw-labeled.js
@@ -1,4 +1,4 @@
-import { X, makeError, errorNote } from '@endo/errors';
+import { X, makeError, annotateError } from '@endo/errors';
 
 /**
  * Given an error `innerErr` and a `label`, throws a similar
@@ -15,7 +15,7 @@ export const throwLabeled = (innerErr, label, ErrorConstructor = undefined) => {
     label = `[${label}]`;
   }
   const outerErr = makeError(`${label}: ${innerErr.message}`, ErrorConstructor);
-  errorNote(outerErr, X`Caused by ${innerErr}`);
+  annotateError(outerErr, X`Caused by ${innerErr}`);
   throw outerErr;
 };
 harden(throwLabeled);

--- a/packages/common/throw-labeled.js
+++ b/packages/common/throw-labeled.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { X, makeError, errorNote } from '@endo/errors';
 
 /**
  * Given an error `innerErr` and a `label`, throws a similar
@@ -14,11 +14,8 @@ export const throwLabeled = (innerErr, label, ErrorConstructor = undefined) => {
   if (typeof label === 'number') {
     label = `[${label}]`;
   }
-  const outerErr = assert.error(
-    `${label}: ${innerErr.message}`,
-    ErrorConstructor,
-  );
-  assert.note(outerErr, X`Caused by ${innerErr}`);
+  const outerErr = makeError(`${label}: ${innerErr.message}`, ErrorConstructor);
+  errorNote(outerErr, X`Caused by ${innerErr}`);
   throw outerErr;
 };
 harden(throwLabeled);

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@endo/captp": "^4.0.2",
+    "@endo/errors": "^1.0.2",
     "@endo/eventual-send": "^1.1.0",
     "@endo/far": "^1.0.2",
     "@endo/lockdown": "^1.0.2",

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -17,9 +17,8 @@ import url from 'url';
 
 import { E, Far } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
+import { q } from '@endo/errors';
 import { makeNodeNetstringCapTP } from './connection.js';
-
-const { quote: q } = assert;
 
 const { promise: cancelled, reject: cancel } = makePromiseKit();
 

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -76,5 +76,5 @@ export {
   quote as q,
   redacted as X,
   throwRedacted as Fail,
-  note as errorNote,
+  note as annotateError,
 };

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -71,4 +71,10 @@ export {
   quote,
   redacted,
   throwRedacted,
+  // conventional abbreviations and aliases
+  bare as b,
+  quote as q,
+  redacted as X,
+  throwRedacted as Fail,
+  note as errorNote,
 };

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -53,7 +53,7 @@ const makeEProxyHandler = (recipient, HandledPromise) =>
               // Reject the async function call
               return HandledPromise.reject(
                 assert.error(
-                  X`Unexpected receiver for "${propertyKey}" method of E(${q(
+                  X`Unexpected receiver for "${q(propertyKey)}" method of E(${q(
                     recipient,
                   )})`,
                 ),

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@endo/common": "^1.0.2",
+    "@endo/errors": "^1.0.2",
     "@endo/env-options": "^1.1.0",
     "@endo/eventual-send": "^1.1.0",
     "@endo/far": "^1.0.2",

--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -2,9 +2,9 @@
 import { environmentOptionsListHas } from '@endo/env-options';
 import { objectMap } from '@endo/common/object-map.js';
 
+import { Fail, q } from '@endo/errors';
 import { defendPrototype, defendPrototypeKit } from './exo-tools.js';
 
-const { Fail, quote: q } = assert;
 const { create, seal, freeze, defineProperty, values } = Object;
 
 // Turn on to give each exo instance its own toStringTag value.

--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -13,6 +13,7 @@ import {
 } from '@endo/patterns';
 import { listDifference } from '@endo/common/list-difference.js';
 import { objectMap } from '@endo/common/object-map.js';
+import { q, Fail } from '@endo/errors';
 import { GET_INTERFACE_GUARD } from './get-interface.js';
 
 /** @typedef {import('@endo/patterns').Method} Method */
@@ -23,7 +24,6 @@ import { GET_INTERFACE_GUARD } from './get-interface.js';
  * @typedef {import('@endo/patterns').InterfaceGuard<T>} InterfaceGuard
  */
 
-const { quote: q, Fail } = assert;
 const { apply, ownKeys } = Reflect;
 const { defineProperties, fromEntries } = Object;
 

--- a/packages/exo/test/test-exo-wobbly-point.js
+++ b/packages/exo/test/test-exo-wobbly-point.js
@@ -14,10 +14,11 @@ import { test } from './prepare-test-env-ava.js';
 import { getMethodNames } from '@endo/eventual-send/utils.js';
 import { passStyleOf, Far, GET_METHOD_NAMES } from '@endo/pass-style';
 import { M } from '@endo/patterns';
-import { defineExoClass } from '../src/exo-makers.js';
-import { GET_INTERFACE_GUARD } from '../src/get-interface.js';
 
-const { Fail, quote: q } = assert;
+import { Fail, q } from '@endo/errors';
+import { GET_INTERFACE_GUARD } from '../src/get-interface.js';
+import { defineExoClass } from '../src/exo-makers.js';
+
 const { apply } = Reflect;
 
 const ExoEmptyI = M.interface('ExoEmpty', {});

--- a/packages/exo/test/test-label-instances.js
+++ b/packages/exo/test/test-label-instances.js
@@ -4,13 +4,13 @@ import { test } from './prepare-test-env-ava-label-instances.js';
 // eslint-disable-next-line import/order
 import { passStyleOf } from '@endo/far';
 import { M } from '@endo/patterns';
+
+import { q } from '@endo/errors';
 import {
   defineExoClass,
   defineExoClassKit,
   makeExo,
 } from '../src/exo-makers.js';
-
-const { quote: q } = assert;
 
 const UpCounterI = M.interface('UpCounter', {
   incr: M.call().returns(M.number()),

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
+    "@endo/errors": "^1.0.2",
     "@endo/eventual-send": "^1.1.0",
     "@endo/pass-style": "^1.1.0"
   },

--- a/packages/far/test/test-marshal-far-obj.js
+++ b/packages/far/test/test-marshal-far-obj.js
@@ -1,10 +1,11 @@
 // @ts-check
-
 import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { q } from '@endo/errors';
 
 import { Far, passStyleOf, getInterfaceOf } from '../src/index.js';
 
-const { quote: q } = assert;
 const { create, getPrototypeOf } = Object;
 
 // this only includes the tests that do not use liveSlots

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@endo/base64": "^1.0.1",
     "@endo/compartment-mapper": "^1.1.0",
+    "@endo/errors": "^1.0.2",
     "@endo/where": "^1.0.1",
     "ses": "^1.1.0"
   },

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -7,9 +7,8 @@
 
 import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
 import { decodeBase64 } from '@endo/base64';
+import { Fail } from '@endo/errors';
 import { wrapInescapableCompartment } from './compartment-wrapper.js';
-
-const { Fail } = assert;
 
 // importBundle takes the output of bundle-source, and returns a namespace
 // object (with .default, and maybe other properties for named exports)

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -49,6 +49,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@endo/errors": "^1.0.2",
     "@endo/init": "^1.0.2",
     "@endo/stream": "^1.0.2",
     "ses": "^1.1.0"

--- a/packages/lp32/reader.js
+++ b/packages/lp32/reader.js
@@ -4,9 +4,8 @@
 // We use a DataView to give users choice over endianness.
 // But DataView does not default to host-byte-order like other typed arrays.
 
+import { Fail, q } from '@endo/errors';
 import { hostIsLittleEndian } from './src/host-endian.js';
-
-const { Fail, quote: q } = assert;
 
 /**
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} reader

--- a/packages/lp32/writer.js
+++ b/packages/lp32/writer.js
@@ -1,9 +1,8 @@
 // @ts-check
 /// <reference types="ses"/>
 
+import { Fail, q } from '@endo/errors';
 import { hostIsLittleEndian } from './src/host-endian.js';
-
-const { Fail, quote: q } = assert;
 
 /**
  * @param {import('@endo/stream').Writer<Uint8Array, undefined>} output

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
+    "@endo/errors": "^1.0.2",
     "@endo/eventual-send": "^1.1.0",
     "@endo/nat": "^5.0.2",
     "@endo/pass-style": "^1.1.0",

--- a/packages/marshal/src/deeplyFulfilled.js
+++ b/packages/marshal/src/deeplyFulfilled.js
@@ -7,7 +7,8 @@ import { getTag, isObject, makeTagged, passStyleOf } from '@endo/pass-style';
 /** @typedef {import('@endo/pass-style').Passable} Passable */
 /** @template T @typedef {import('@endo/eventual-send').ERef<T>} ERef */
 
-const { details: X, quote: q } = assert;
+import { X, q } from '@endo/errors';
+
 const { ownKeys } = Reflect;
 const { fromEntries } = Object;
 

--- a/packages/marshal/src/dot-membrane.js
+++ b/packages/marshal/src/dot-membrane.js
@@ -3,11 +3,11 @@
 
 import { E } from '@endo/eventual-send';
 import { isObject, getInterfaceOf, Far, passStyleOf } from '@endo/pass-style';
+import { Fail } from '@endo/errors';
 import { makeMarshal } from './marshal.js';
 
 const { fromEntries } = Object;
 const { ownKeys } = Reflect;
-const { Fail } = assert;
 
 // TODO(erights): Add Converter type
 /** @param {any} [mirrorConverter] */

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -18,7 +18,8 @@ import {
  */
 /** @typedef {import('./types.js').RankCover} RankCover */
 
-const { quote: q, Fail } = assert;
+import { q, Fail } from '@endo/errors';
+
 const { fromEntries, is } = Object;
 const { ownKeys } = Reflect;
 

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -17,6 +17,7 @@ import {
   nameForPassableSymbol,
   passableSymbolForName,
 } from '@endo/pass-style';
+import { X, Fail, q } from '@endo/errors';
 
 /** @typedef {import('@endo/pass-style').Passable} Passable */
 /** @typedef {import('./types.js').Encoding} Encoding */
@@ -33,7 +34,6 @@ const {
   fromEntries,
   freeze,
 } = Object;
-const { details: X, Fail, quote: q } = assert;
 
 /**
  * Special property name that indicates an encoding that needs special

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -16,6 +16,7 @@ import {
   nameForPassableSymbol,
   passableSymbolForName,
 } from '@endo/pass-style';
+import { X, Fail, q } from '@endo/errors';
 
 /** @typedef {import('@endo/pass-style').Passable} Passable */
 /** @typedef {import('@endo/pass-style').Remotable} Remotable */
@@ -27,7 +28,6 @@ import {
 const { ownKeys } = Reflect;
 const { isArray } = Array;
 const { is, entries, fromEntries } = Object;
-const { details: X, Fail, quote: q } = assert;
 
 const BANG = '!'.charCodeAt(0);
 const DASH = '-'.charCodeAt(0);

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -6,6 +6,7 @@ import {
   isObject,
   passableSymbolForName,
 } from '@endo/pass-style';
+import { q, X, Fail } from '@endo/errors';
 import { QCLASS } from './encodeToCapData.js';
 
 /** @typedef {import('./types.js').Encoding} Encoding */
@@ -14,7 +15,6 @@ import { QCLASS } from './encodeToCapData.js';
 const { ownKeys } = Reflect;
 const { isArray } = Array;
 const { stringify: quote } = JSON;
-const { quote: q, details: X, Fail } = assert;
 
 /**
  * @typedef {object} Indenter

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -1,10 +1,9 @@
 /// <reference types="ses"/>
 
+import { Fail } from '@endo/errors';
 import { makeMarshal } from './marshal.js';
 
 /** @typedef {import('@endo/pass-style').Passable} Passable */
-
-const { Fail } = assert;
 
 /** @type {import('./types.js').ConvertValToSlot<any>} */
 const doNotConvertValToSlot = val =>

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -8,6 +8,7 @@ import {
   hasOwnPropertyOf,
 } from '@endo/pass-style';
 
+import { X, Fail, q, makeError, errorNote } from '@endo/errors';
 import {
   QCLASS,
   makeEncodeToCapData,
@@ -29,7 +30,6 @@ import {
 /** @typedef {import('@endo/pass-style').RemotableObject} Remotable */
 
 const { isArray } = Array;
-const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
 
 /** @type {ConvertValToSlot<any>} */
@@ -124,7 +124,7 @@ export const makeMarshal = (
         // with the correlation.
         const errorId = encodeRecur(nextErrorId());
         assert.typeof(errorId, 'string');
-        assert.note(err, X`Sent as ${errorId}`);
+        errorNote(err, X`Sent as ${errorId}`);
         marshalSaveError(err);
         return harden({ errorId, message, name });
       } else {
@@ -278,7 +278,7 @@ export const makeMarshal = (
         dErrorId === undefined
           ? `Remote${EC.name}`
           : `Remote${EC.name}(${dErrorId})`;
-      const error = assert.error(dMessage, EC, { errorName });
+      const error = makeError(dMessage, EC, { errorName });
       return harden(error);
     };
 

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -8,7 +8,7 @@ import {
   hasOwnPropertyOf,
 } from '@endo/pass-style';
 
-import { X, Fail, q, makeError, errorNote } from '@endo/errors';
+import { X, Fail, q, makeError, annotateError } from '@endo/errors';
 import {
   QCLASS,
   makeEncodeToCapData,
@@ -124,7 +124,7 @@ export const makeMarshal = (
         // with the correlation.
         const errorId = encodeRecur(nextErrorId());
         assert.typeof(errorId, 'string');
-        errorNote(err, X`Sent as ${errorId}`);
+        annotateError(err, X`Sent as ${errorId}`);
         marshalSaveError(err);
         return harden({ errorId, message, name });
       } else {

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -1,4 +1,5 @@
 import { getTag, passStyleOf, nameForPassableSymbol } from '@endo/pass-style';
+import { Fail, q } from '@endo/errors';
 import {
   passStylePrefixes,
   recordNames,
@@ -12,7 +13,6 @@ import {
 /** @typedef {import('./types.js').RankCompare} RankCompare */
 /** @typedef {import('./types.js').FullCompare} FullCompare */
 
-const { Fail, quote: q } = assert;
 const { entries, fromEntries, setPrototypeOf, is } = Object;
 
 /**

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -116,7 +116,7 @@ export {};
  * identify the sending of errors relative to this marshal instance.
  * @property {(err: Error) => void=} marshalSaveError If `errorTagging` is
  * `'on'`, then errors serialized by this marshal instance are also
- * logged by calling `marshalSaveError` *after* `assert.note` associated
+ * logged by calling `marshalSaveError` *after* `errorNote` associated
  * that error with its errorId. Thus, if `marshalSaveError` in turn logs
  * to the normal console, which is the default, then the console will
  * show that note showing the associated errorId.

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -116,7 +116,7 @@ export {};
  * identify the sending of errors relative to this marshal instance.
  * @property {(err: Error) => void=} marshalSaveError If `errorTagging` is
  * `'on'`, then errors serialized by this marshal instance are also
- * logged by calling `marshalSaveError` *after* `errorNote` associated
+ * logged by calling `marshalSaveError` *after* `annotateError` associated
  * that error with its errorId. Thus, if `marshalSaveError` in turn logs
  * to the normal console, which is the default, then the console will
  * show that note showing the associated errorId.

--- a/packages/marshal/test/test-encodePassable.js
+++ b/packages/marshal/test/test-encodePassable.js
@@ -1,21 +1,21 @@
 // @ts-nocheck
 /* eslint-disable no-bitwise, @endo/restrict-comparison-operands */
-
 // eslint-disable-next-line import/order
 import { test } from './prepare-test-env-ava.js';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line import/order
 import { fc } from '@fast-check/ava';
-
 import { arbPassable } from '@endo/pass-style/tools.js';
+import { Fail, q } from '@endo/errors';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+
 import {
   makeEncodePassable,
   makeDecodePassable,
 } from '../src/encodePassable.js';
 import { compareRank, makeComparatorKit } from '../src/rankOrder.js';
 import { sample } from './test-rankOrder.js';
-
-const { Fail, quote: q } = assert;
 
 const buffers = {
   __proto__: null,

--- a/packages/marshal/test/test-marshal-far-obj.js
+++ b/packages/marshal/test/test-marshal-far-obj.js
@@ -1,11 +1,11 @@
+// eslint-disable-next-line import/order
 import { test } from './prepare-test-env-ava.js';
 
-// eslint-disable-next-line import/order
+import { q } from '@endo/errors';
 import { passStyleOf, Remotable, Far, getInterfaceOf } from '@endo/pass-style';
 
 import { makeMarshal } from '../src/marshal.js';
 
-const { quote: q } = assert;
 const { create, getPrototypeOf, prototype: objectPrototype } = Object;
 
 // this only includes the tests that do not use liveSlots

--- a/packages/marshal/test/test-rankOrder.js
+++ b/packages/marshal/test/test-rankOrder.js
@@ -12,6 +12,7 @@ import {
   arbPassable,
 } from '@endo/pass-style/tools.js';
 
+import { q } from '@endo/errors';
 import {
   FullRankCover,
   compareRank,
@@ -21,8 +22,6 @@ import {
   getIndexCover,
   assertRankSorted,
 } from '../src/rankOrder.js';
-
-const { quote: q } = assert;
 
 test('compareRank is reflexive', async t => {
   await fc.assert(

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -33,6 +33,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@endo/errors": "^1.0.2",
     "@endo/eventual-send": "^1.1.0",
     "@endo/promise-kit": "^1.0.2",
     "@fast-check/ava": "^1.1.5"

--- a/packages/pass-style/src/copyArray.js
+++ b/packages/pass-style/src/copyArray.js
@@ -1,8 +1,8 @@
 /// <reference types="ses"/>
 
+import { X } from '@endo/errors';
 import { assertChecker, checkNormalProperty } from './passStyle-helpers.js';
 
-const { details: X } = assert;
 const { getPrototypeOf } = Object;
 const { ownKeys } = Reflect;
 const { isArray, prototype: arrayPrototype } = Array;

--- a/packages/pass-style/src/copyRecord.js
+++ b/packages/pass-style/src/copyRecord.js
@@ -1,12 +1,12 @@
 /// <reference types="ses"/>
 
+import { X } from '@endo/errors';
 import {
   assertChecker,
   canBeMethod,
   checkNormalProperty,
 } from './passStyle-helpers.js';
 
-const { details: X } = assert;
 const { ownKeys } = Reflect;
 const { getPrototypeOf, values, prototype: objectPrototype } = Object;
 

--- a/packages/pass-style/src/error.js
+++ b/packages/pass-style/src/error.js
@@ -1,6 +1,6 @@
 /// <reference types="ses"/>
 
-import { X, Fail, errorNote } from '@endo/errors';
+import { X, Fail, annotateError } from '@endo/errors';
 import { assertChecker } from './passStyle-helpers.js';
 
 /** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
@@ -116,7 +116,7 @@ export const toPassableError = err => {
   // Even the cleaned up error copy, if sent to the console, should
   // cause hidden diagnostic information of the original error
   // to be logged.
-  errorNote(newError, X`copied from error ${err}`);
+  annotateError(newError, X`copied from error ${err}`);
   return newError;
 };
 harden(toPassableError);

--- a/packages/pass-style/src/error.js
+++ b/packages/pass-style/src/error.js
@@ -1,11 +1,11 @@
 /// <reference types="ses"/>
 
+import { X, Fail, errorNote } from '@endo/errors';
 import { assertChecker } from './passStyle-helpers.js';
 
 /** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
 /** @typedef {import('./types.js').Checker} Checker */
 
-const { details: X, Fail } = assert;
 const { getPrototypeOf, getOwnPropertyDescriptors } = Object;
 const { ownKeys } = Reflect;
 
@@ -116,7 +116,7 @@ export const toPassableError = err => {
   // Even the cleaned up error copy, if sent to the console, should
   // cause hidden diagnostic information of the original error
   // to be logged.
-  assert.note(newError, X`copied from error ${err}`);
+  errorNote(newError, X`copied from error ${err}`);
   return newError;
 };
 harden(toPassableError);

--- a/packages/pass-style/src/make-far.js
+++ b/packages/pass-style/src/make-far.js
@@ -1,13 +1,12 @@
 /// <reference types="ses"/>
 
 import { getMethodNames } from '@endo/eventual-send/utils.js';
+import { q, Fail } from '@endo/errors';
 import { assertChecker, PASS_STYLE } from './passStyle-helpers.js';
 import { assertIface, getInterfaceOf, RemotableHelper } from './remotable.js';
 
 /** @typedef {import('./types.js').InterfaceSpec} InterfaceSpec */
 /** @template L,R @typedef {import('@endo/eventual-send').RemotableBrand<L, R>} RemotableBrand */
-
-const { quote: q, Fail } = assert;
 
 const { prototype: functionPrototype } = Function;
 const {

--- a/packages/pass-style/src/makeTagged.js
+++ b/packages/pass-style/src/makeTagged.js
@@ -1,10 +1,10 @@
 /// <reference types="ses"/>
 
+import { Fail } from '@endo/errors';
 import { PASS_STYLE } from './passStyle-helpers.js';
 import { assertPassable } from './passStyleOf.js';
 
 const { create, prototype: objectPrototype } = Object;
-const { Fail } = assert;
 
 export const makeTagged = (tag, payload) => {
   typeof tag === 'string' ||

--- a/packages/pass-style/src/passStyle-helpers.js
+++ b/packages/pass-style/src/passStyle-helpers.js
@@ -3,7 +3,8 @@
 /** @typedef {import('./types.js').Checker} Checker */
 /** @typedef {import('./types.js').PassStyle} PassStyle */
 
-const { details: X, quote: q } = assert;
+import { X, q } from '@endo/errors';
+
 const { isArray } = Array;
 const { prototype: functionPrototype } = Function;
 const {

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -3,6 +3,7 @@
 /// <reference types="ses"/>
 
 import { isPromise } from '@endo/promise-kit';
+import { X, Fail, q } from '@endo/errors';
 import { isObject, isTypedArray, PASS_STYLE } from './passStyle-helpers.js';
 
 import { CopyArrayHelper } from './copyArray.js';
@@ -22,7 +23,6 @@ import { assertSafePromise } from './safe-promise.js';
 
 /** @typedef {Exclude<PassStyle, PrimitiveStyle | "promise">} HelperPassStyle */
 
-const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
 const { isFrozen } = Object;
 

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -1,5 +1,6 @@
 /// <reference types="ses"/>
 
+import { X, Fail, q } from '@endo/errors';
 import {
   assertChecker,
   canBeMethod,
@@ -17,7 +18,6 @@ import {
 /** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
 /** @typedef {import('./types.js').RemotableObject} Remotable */
 
-const { details: X, Fail, quote: q } = assert;
 const { ownKeys } = Reflect;
 const { isArray } = Array;
 const {

--- a/packages/pass-style/src/safe-promise.js
+++ b/packages/pass-style/src/safe-promise.js
@@ -1,11 +1,11 @@
 /// <reference types="ses"/>
 
 import { isPromise } from '@endo/promise-kit';
+import { X, q } from '@endo/errors';
 import { assertChecker, hasOwnPropertyOf } from './passStyle-helpers.js';
 
 /** @typedef {import('./types.js').Checker} Checker */
 
-const { details: X, quote: q } = assert;
 const { isFrozen, getPrototypeOf, getOwnPropertyDescriptor } = Object;
 const { ownKeys } = Reflect;
 const { toStringTag } = Symbol;

--- a/packages/pass-style/src/symbol.js
+++ b/packages/pass-style/src/symbol.js
@@ -1,4 +1,5 @@
-const { Fail, quote: q } = assert;
+import { Fail, q } from '@endo/errors';
+
 const { ownKeys } = Reflect;
 
 /**

--- a/packages/pass-style/src/tagged.js
+++ b/packages/pass-style/src/tagged.js
@@ -1,5 +1,6 @@
 /// <reference types="ses"/>
 
+import { Fail } from '@endo/errors';
 import {
   assertChecker,
   checkTagRecord,
@@ -8,7 +9,6 @@ import {
   checkPassStyle,
 } from './passStyle-helpers.js';
 
-const { Fail } = assert;
 const { ownKeys } = Reflect;
 const { getOwnPropertyDescriptors } = Object;
 

--- a/packages/pass-style/src/typeGuards.js
+++ b/packages/pass-style/src/typeGuards.js
@@ -1,3 +1,4 @@
+import { Fail, q } from '@endo/errors';
 import { passStyleOf } from './passStyleOf.js';
 
 /** @typedef {import('./types.js').Passable} Passable */
@@ -10,8 +11,6 @@ import { passStyleOf } from './passStyleOf.js';
  * @typedef {import('./types.js').CopyRecord<T>} CopyRecord
  */
 /** @typedef {import('./types.js').RemotableObject} Remotable */
-
-const { Fail, quote: q } = assert;
 
 /**
  * Check whether the argument is a pass-by-copy array, AKA a "copyArray"

--- a/packages/pass-style/test/test-passStyleOf.js
+++ b/packages/pass-style/test/test-passStyleOf.js
@@ -1,12 +1,14 @@
 /* eslint-disable max-classes-per-file */
 import { test } from './prepare-test-env-ava.js';
 
+// eslint-disable-next-line import/order
+import { q } from '@endo/errors';
+
 import { passStyleOf } from '../src/passStyleOf.js';
 import { Far } from '../src/make-far.js';
 import { makeTagged } from '../src/makeTagged.js';
 import { PASS_STYLE } from '../src/passStyle-helpers.js';
 
-const { quote: q } = assert;
 const { getPrototypeOf, defineProperty } = Object;
 const { ownKeys } = Reflect;
 

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@endo/common": "^1.0.2",
+    "@endo/errors": "^1.0.2",
     "@endo/eventual-send": "^1.1.0",
     "@endo/marshal": "^1.1.0",
     "@endo/promise-kit": "^1.0.2"

--- a/packages/patterns/src/keys/checkKey.js
+++ b/packages/patterns/src/keys/checkKey.js
@@ -14,10 +14,10 @@ import {
 } from '@endo/marshal';
 import { identChecker } from '@endo/common/ident-checker.js';
 
+import { X, q, Fail } from '@endo/errors';
 import { checkElements, makeSetOfElements } from './copySet.js';
 import { checkBagEntries, makeBagOfEntries } from './copyBag.js';
 
-const { details: X, quote: q, Fail } = assert;
 const { ownKeys } = Reflect;
 
 /** @typedef {import('@endo/marshal').Checker} Checker */

--- a/packages/patterns/src/keys/compareKeys.js
+++ b/packages/patterns/src/keys/compareKeys.js
@@ -8,6 +8,7 @@ import {
   recordValues,
   trivialComparator,
 } from '@endo/marshal';
+import { q, Fail } from '@endo/errors';
 import {
   assertKey,
   getCopyBagEntries,
@@ -17,8 +18,6 @@ import {
 import { makeCompareCollection } from './keycollection-operators.js';
 
 /** @template {import('../types.js').Key} [K=import('../types.js').Key] @typedef {import('../types').CopySet<K>} CopySet */
-
-const { quote: q, Fail } = assert;
 
 /**
  * CopySet X is smaller than CopySet Y iff all of these conditions hold:

--- a/packages/patterns/src/keys/copyBag.js
+++ b/packages/patterns/src/keys/copyBag.js
@@ -10,7 +10,7 @@ import {
 
 /// <reference types="ses"/>
 
-const { details: X } = assert;
+import { X } from '@endo/errors';
 
 /** @template {Key} [K=Key] @typedef {import('../types').CopyBag<K>} CopyBag */
 /** @typedef {import('../types').Key} Key */

--- a/packages/patterns/src/keys/copySet.js
+++ b/packages/patterns/src/keys/copySet.js
@@ -10,7 +10,7 @@ import {
 
 /// <reference types="ses"/>
 
-const { details: X } = assert;
+import { X } from '@endo/errors';
 
 /** @template {Key} [K=Key] @typedef {import('../types').CopySet<K>} CopySet */
 /** @typedef {import('../types').Key} Key */

--- a/packages/patterns/src/keys/keycollection-operators.js
+++ b/packages/patterns/src/keys/keycollection-operators.js
@@ -14,7 +14,7 @@ import { makeArrayIterator } from '@endo/common/make-array-iterator.js';
 /** @typedef {import('../types').FullCompare} FullCompare */
 /** @typedef {import('../types').KeyCollection} KeyCollection */
 
-const { quote: q, Fail } = assert;
+import { q, Fail } from '@endo/errors';
 
 /**
  * Refines a sequence of entries that is already sorted over its keys by the

--- a/packages/patterns/src/keys/merge-bag-operators.js
+++ b/packages/patterns/src/keys/merge-bag-operators.js
@@ -4,9 +4,8 @@ import {
   makeFullOrderComparatorKit,
   sortByRank,
 } from '@endo/marshal';
+import { q, Fail } from '@endo/errors';
 import { assertNoDuplicateKeys, makeBagOfEntries } from './copyBag.js';
-
-const { quote: q, Fail } = assert;
 
 /** @typedef {import('../types').KeyComparison} KeyComparison */
 /** @typedef {import('../types').FullCompare} FullCompare */

--- a/packages/patterns/src/keys/merge-set-operators.js
+++ b/packages/patterns/src/keys/merge-set-operators.js
@@ -4,9 +4,8 @@ import {
   makeFullOrderComparatorKit,
   sortByRank,
 } from '@endo/marshal';
+import { q, Fail } from '@endo/errors';
 import { assertNoDuplicates, makeSetOfElements } from './copySet.js';
-
-const { quote: q, Fail } = assert;
 
 /** @typedef {import('../types').KeyComparison} KeyComparison */
 /** @typedef {import('../types').FullCompare} FullCompare */

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -18,7 +18,7 @@ import { applyLabelingError } from '@endo/common/apply-labeling-error.js';
 import { fromUniqueEntries } from '@endo/common/from-unique-entries.js';
 import { listDifference } from '@endo/common/list-difference.js';
 
-import { q, b, X, Fail, makeError, errorNote } from '@endo/errors';
+import { q, b, X, Fail, makeError, annotateError } from '@endo/errors';
 import { keyEQ, keyGT, keyGTE, keyLT, keyLTE } from '../keys/compareKeys.js';
 import {
   assertKey,
@@ -590,7 +590,7 @@ const makePatternKit = () => {
       X`internal: ${label}: inconsistent pattern match: ${q(patt)}`,
     );
     if (innerError !== undefined) {
-      errorNote(outerError, X`caused by ${innerError}`);
+      annotateError(outerError, X`caused by ${innerError}`);
     }
     throw outerError;
   };

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -18,6 +18,7 @@ import { applyLabelingError } from '@endo/common/apply-labeling-error.js';
 import { fromUniqueEntries } from '@endo/common/from-unique-entries.js';
 import { listDifference } from '@endo/common/list-difference.js';
 
+import { q, b, X, Fail, makeError, errorNote } from '@endo/errors';
 import { keyEQ, keyGT, keyGTE, keyLT, keyLTE } from '../keys/compareKeys.js';
 import {
   assertKey,
@@ -36,7 +37,6 @@ import { generateCollectionPairEntries } from '../keys/keycollection-operators.j
 
 /// <reference types="ses"/>
 
-const { quote: q, bare: b, details: X, Fail } = assert;
 const { entries, values } = Object;
 const { ownKeys } = Reflect;
 
@@ -586,11 +586,11 @@ const makePatternKit = () => {
     }
     // should only throw
     checkMatches(specimen, patt, assertChecker, label);
-    const outerError = assert.error(
+    const outerError = makeError(
       X`internal: ${label}: inconsistent pattern match: ${q(patt)}`,
     );
     if (innerError !== undefined) {
-      assert.note(outerError, X`caused by ${innerError}`);
+      errorNote(outerError, X`caused by ${innerError}`);
     }
     throw outerError;
   };

--- a/packages/patterns/test/test-copyMap.js
+++ b/packages/patterns/test/test-copyMap.js
@@ -1,5 +1,7 @@
-import { test } from './prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+import { Fail } from '@endo/errors';
 import { makeTagged, getTag, passStyleOf } from '@endo/marshal';
 import {
   isCopyMap,
@@ -11,8 +13,6 @@ import {
 import { matches } from '../src/patterns/patternMatchers.js';
 
 import '../src/types.js';
-
-const { Fail } = assert;
 
 const assertIsCopyMap = (t, m) => {
   t.is(passStyleOf(m), 'tagged');

--- a/packages/patterns/test/test-patterns.js
+++ b/packages/patterns/test/test-patterns.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-continue */
-import { test } from './prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
+import { test } from './prepare-test-env-ava.js';
+
+import { Fail } from '@endo/errors';
 import { makeTagged, Far } from '@endo/marshal';
 import {
   makeCopyBag,
@@ -12,8 +14,6 @@ import { mustMatch, matches, M } from '../src/patterns/patternMatchers.js';
 import '../src/types.js';
 
 /** @typedef {import('ava').ExecutionContext} TestContext */
-
-const { Fail } = assert;
 
 // TODO The desired semantics for CopyMap comparison have not yet been decided.
 // See https://github.com/endojs/endo/pull/1737#pullrequestreview-1596595411

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -40,6 +40,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@endo/errors": "^1.0.2",
     "@endo/init": "^1.0.2",
     "@endo/stream": "^1.0.2",
     "ses": "^1.1.0"

--- a/packages/stream-node/reader.js
+++ b/packages/stream-node/reader.js
@@ -8,7 +8,7 @@
 
 import { mapReader } from '@endo/stream';
 
-const { Fail, quote: q } = assert;
+import { Fail, q } from '@endo/errors';
 
 /**
  * @param {import('stream').Readable} input the source Node.js reader

--- a/packages/stream-node/writer.js
+++ b/packages/stream-node/writer.js
@@ -5,7 +5,7 @@
 // @ts-check
 /// <reference types="ses"/>
 
-const { Fail } = assert;
+import { Fail } from '@endo/errors';
 
 const sink = harden(() => {});
 


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8781#pullrequestreview-1835371445

## Description

At https://github.com/Agoric/agoric-sdk/pull/8781#pullrequestreview-1835371445 @turadg reacts to

```js
import { quote as q, throwRedacted as Fail } from '@endo/errors';
```
with

> This pattern is what I was trying to get away from with making a package at all. There's no export of `Fail` so there's no autocomplete when someone wants to import `Fail`.

IMO quite right. At https://github.com/Agoric/agoric-sdk/pull/8781 I tried following the agreement from which the current @endo/errors API was born, where the exported explanatory names would be renamed to the conventionally used names on import. Even though I did not notice the autocomplete problem myself, I found https://github.com/Agoric/agoric-sdk/pull/8781 unpleasant enough that I consider the current @endo/errors API to be a failed experiment.

This PR in its current state splits the difference. It does not withdraw the explanatory names. It simply exports aliases to their conventional names. ***Reviewers: Should I instead delete the explanatory names, since we don't intend to use them anyway?*** If so, it is ok if that deletion happens in a separate PR?

I needed to make two additional changes to switch things to @endo/errors. Unlike the `assert` global, the `assert` exported by @endo/errors does not include `error` (aka `makeError`) and `note`, instead making them separate exports of the module. This is good. But is requires changing the affected occurrences of `assert.error` to `makeError` and `assert.note` to something. For the latter, I first tried just using the name @endo/errors already exports, `note`, but found it too mysterious by itself. So I added an alias to `errorNote` and universally used that instead.

Finally, I had to omit completely those packages that were too low level to get `assert` by importing it from @endo/assert. I left them continuing to use the `assert` global.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations

We should document the new @endo/assert convention as we use it, to encourage others to adopt the same conventions.

### Testing Considerations
none, I think
### Compatibility Considerations
If this PR continues to not withdraw the explanatory names, then none. Otherwise we'd need to fix existing uses, of which there appears to be none.
### Upgrade Considerations

Without withdrawing the explanatory names, there should be no breaking change. I still need to write a NEWS.md entry and check that box. But I'll wait until I get feedback on this PR before writing that.

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
