### PR TITLE
feat(ses): permit stage 3 float16 proposal API

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -53,6 +53,8 @@ export const universalPropertyNames = {
   Boolean: 'Boolean',
   DataView: 'DataView',
   EvalError: 'EvalError',
+  // https://github.com/tc39/proposal-float16array
+  Float16Array: 'Float16Array',
   Float32Array: 'Float32Array',
   Float64Array: 'Float64Array',
   Int8Array: 'Int8Array',
@@ -1045,6 +1047,8 @@ export const permitted = {
 
   BigInt64Array: TypedArray('%BigInt64ArrayPrototype%'),
   BigUint64Array: TypedArray('%BigUint64ArrayPrototype%'),
+  // https://github.com/tc39/proposal-float16array
+  Float16Array: TypedArray('%Float16ArrayPrototype%'),
   Float32Array: TypedArray('%Float32ArrayPrototype%'),
   Float64Array: TypedArray('%Float64ArrayPrototype%'),
   Int16Array: TypedArray('%Int16ArrayPrototype%'),
@@ -1057,6 +1061,8 @@ export const permitted = {
 
   '%BigInt64ArrayPrototype%': TypedArrayPrototype('BigInt64Array'),
   '%BigUint64ArrayPrototype%': TypedArrayPrototype('BigUint64Array'),
+  // https://github.com/tc39/proposal-float16array
+  '%Float16ArrayPrototype%': TypedArrayPrototype('Float16Array'),
   '%Float32ArrayPrototype%': TypedArrayPrototype('Float32Array'),
   '%Float64ArrayPrototype%': TypedArrayPrototype('Float64Array'),
   '%Int16ArrayPrototype%': TypedArrayPrototype('Int16Array'),
@@ -1222,6 +1228,8 @@ export const permitted = {
     constructor: 'DataView',
     getBigInt64: fn,
     getBigUint64: fn,
+    // https://github.com/tc39/proposal-float16array
+    getFloat16: fn,
     getFloat32: fn,
     getFloat64: fn,
     getInt8: fn,
@@ -1232,6 +1240,8 @@ export const permitted = {
     getUint32: fn,
     setBigInt64: fn,
     setBigUint64: fn,
+    // https://github.com/tc39/proposal-float16array
+    setFloat16: fn,
     setFloat32: fn,
     setFloat64: fn,
     setInt8: fn,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #XXXX
refs: https://github.com/tc39/proposal-float16array

## Description

We should continue to permit all safe API elements that have reached stage 3. This one is safe and had not yet been included.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
none
### Compatibility Considerations
keeping up
### Upgrade Considerations
none

Neither breaking, not warrants any mention in NEWS.md. As long as they don't see the warning, no one will care.

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
