### PR TITLE
feat(cli): Add install --open flag

### DIFF
--- a/packages/cli/demo/README.md
+++ b/packages/cli/demo/README.md
@@ -258,11 +258,16 @@ _Familiar Chat_ is an example application that provides a web app for
 interacting with your pet daemon.
 
 ```
-> endo open familiar-chat cat.js --powers HOST
+> endo install familiar-chat cat.js --powers SELF
 ```
 
 This command creates a web page named familiar-chat and endows it with the
 authority to maintain your petstore and mailbox.
+You can then open that page.
+
+```
+> endo open familiar-chat
+```
 
 So, if you were to simulate a request from your cat:
 

--- a/packages/cli/demo/cat.js
+++ b/packages/cli/demo/cat.js
@@ -4,11 +4,11 @@
 // This command will set up the cat page, create a URL,
 // and open it.
 //
-// > endo open familiar-chat cat.js --powers HOST
+// > endo install familiar-chat cat.js --powers SELF
 //
 // Thereafter,
 //
-// > endo open fami ar-chat
+// > endo open familiar-chat
 //
 // To interact with the permission manager, you can mock requests from a fake
 // guest.

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -44,14 +44,17 @@ export const main = async rawArgs => {
       '-p,--powers <endowment>',
       'Endowment to give the weblet (a name, NONE, HOST, or ENDO)',
     )
+    .option('-o,--open', 'Open the new web page immediately (weblet)')
     .action(async (webPageName, programPath, cmd) => {
       const {
         bundle: bundleName,
         powers: powersName = 'NONE',
         as: partyNames,
+        open: doOpen,
       } = cmd.opts();
       const { install } = await import('./install.js');
       return install({
+        doOpen,
         webPageName,
         programPath,
         bundleName,

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -42,7 +42,7 @@ export const main = async rawArgs => {
     .option('-b,--bundle <bundle>', 'Bundle for a web page (weblet)')
     .option(
       '-p,--powers <endowment>',
-      'Endowment to give the weblet (a name, NONE, HOST, or ENDO)',
+      'Endowment to give the weblet (a name, NONE, SELF, or ENDO)',
     )
     .option('-o,--open', 'Open the new web page immediately (weblet)')
     .action(async (webPageName, programPath, cmd) => {
@@ -127,7 +127,7 @@ export const main = async rawArgs => {
       collect,
       [],
     )
-    .option('-p,--powers <name>', 'Name of powers to grant or NONE, HOST, ENDO')
+    .option('-p,--powers <name>', 'Name of powers to grant or NONE, SELF, ENDO')
     .option(
       '-n,--name <name>',
       'Assigns a name to the result for future reference, persisted between restarts',

--- a/packages/cli/src/install.js
+++ b/packages/cli/src/install.js
@@ -2,6 +2,7 @@
 
 import os from 'os';
 
+import openWebPage from 'open';
 import { E } from '@endo/far';
 import { makeReaderRef } from '@endo/daemon';
 import bundleSource from '@endo/bundle-source';
@@ -17,6 +18,7 @@ export const install = async ({
   powersName,
   webPageName,
   programPath,
+  doOpen,
 }) => {
   /** @type {import('@endo/eventual-send').FarRef<import('@endo/stream').Reader<string>> | undefined} */
   let bundleReaderRef;
@@ -54,7 +56,11 @@ export const install = async ({
       } else {
         ({ url: webPageUrl } = await E(party).lookup(webPageName));
       }
+      assert(webPageUrl !== undefined);
       process.stdout.write(`${webPageUrl}\n`);
+      if (doOpen) {
+        openWebPage(webPageUrl);
+      }
     } finally {
       if (temporaryBundleName) {
         await E(party).remove(temporaryBundleName);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -163,7 +163,7 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {string | 'NONE' | 'HOST' | 'ENDO'} partyName
+     * @param {string | 'NONE' | 'SELF' | 'ENDO'} partyName
      */
     const providePowersFormulaIdentifier = async partyName => {
       let guestFormulaIdentifier = lookupFormulaIdentifierForName(partyName);
@@ -241,7 +241,7 @@ export const makeHostMaker = ({
     /**
      * @param {string | 'NEW' | 'MAIN'} workerName
      * @param {string} importPath
-     * @param {string | 'NONE' | 'HOST' | 'ENDO'} powersName
+     * @param {string | 'NONE' | 'SELF' | 'ENDO'} powersName
      * @param {string} resultName
      */
     const makeUnconfined = async (
@@ -281,7 +281,7 @@ export const makeHostMaker = ({
     /**
      * @param {string | 'MAIN' | 'NEW'} workerName
      * @param {string} bundleName
-     * @param {string | 'NONE' | 'HOST' | 'ENDO'} powersName
+     * @param {string | 'NONE' | 'SELF' | 'ENDO'} powersName
      * @param {string} resultName
      */
     const makeBundle = async (
@@ -376,7 +376,7 @@ export const makeHostMaker = ({
     /**
      * @param {string} webPageName
      * @param {string} bundleName
-     * @param {string | 'NONE' | 'HOST' | 'ENDO'} powersName
+     * @param {string | 'NONE' | 'SELF' | 'ENDO'} powersName
      */
     const provideWebPage = async (webPageName, bundleName, powersName) => {
       const bundleFormulaIdentifier =


### PR DESCRIPTION
Buzz a sharp corner off of the `install` and `open` workflow by allowing them to be combined into a single command.