### PR TITLE
fix(daemon): Address off-by-nybble formula path error

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -542,7 +542,7 @@ export const makeDaemonicPersistencePowers = (
       );
     }
     const head = formulaId512.slice(0, 2);
-    const tail = formulaId512.slice(3);
+    const tail = formulaId512.slice(2);
     const directory = filePowers.joinPath(
       statePath,
       'formulas',

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -282,7 +282,7 @@ export const makePetStoreMaker = (filePowers, locator) => {
       throw new Error(`Invalid identifier for pet store ${q(id)}`);
     }
     const prefix = id.slice(0, 2);
-    const suffix = id.slice(3);
+    const suffix = id.slice(2);
     const petNameDirectoryPath = filePowers.joinPath(
       locator.statePath,
       'pet-store-id512',


### PR DESCRIPTION
When splitting a hash into a single byte prefix and suffix, I accidentally trimmed four bits from the head of the suffix. Nothing broke because the mistake was consistent over a consistent hash but it is technically incorrect.