### PR TITLE
feat(compartment-mapper): extract some useful functions [DRAFT]

### DIFF
--- a/packages/compartment-mapper/index.js
+++ b/packages/compartment-mapper/index.js
@@ -6,6 +6,8 @@ export {
   writeArchive,
   mapLocation,
   hashLocation,
+  loadCompartmentForArchive,
+  makeArchiveCompartmentMap,
 } from './src/archive.js';
 export {
   parseArchive,

--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -250,7 +250,7 @@ const captureSourceLocations = async (sources, captureSourceLocation) => {
 /**
  * @param {CompartmentMapDescriptor} compartmentMap
  * @param {Sources} sources
- * @returns {{archiveCompartmentMap: CompartmentMapDescriptor, archiveSources: Sources}}
+ * @returns {import('./types.js').MakeArchiveCompartmentMapResult}
  */
 export const makeArchiveCompartmentMap = (compartmentMap, sources) => {
   const {
@@ -282,29 +282,27 @@ export const makeArchiveCompartmentMap = (compartmentMap, sources) => {
   // accept all valid compartment maps.
   assertCompartmentMap(archiveCompartmentMap);
 
-  return { archiveCompartmentMap, archiveSources };
+  return { archiveCompartmentMap, archiveSources, compartmentRenames };
 };
 
 /**
- * @param {ReadFn | ReadPowers} powers
- * @param {string} moduleLocation
- * @param {ArchiveOptions} [options]
- * @returns {Promise<{sources: Sources, compartmentMapBytes: Uint8Array, sha512?: string}>}
+ * @param {import('./types.js').LoadCompartmentForArchiveOptions & ArchiveOptions} options
+ * @returns {Promise<import('./types.js').LoadCompartmentForArchiveResult>}
  */
-const digestLocation = async (powers, moduleLocation, options) => {
-  const {
-    moduleTransforms,
-    modules: exitModules = {},
-    dev = false,
-    tags = new Set(),
-    captureSourceLocation = undefined,
-    searchSuffixes = undefined,
-    commonDependencies = undefined,
-    importHook: exitModuleImportHook = undefined,
-    policy = undefined,
-    sourceMapHook = undefined,
-  } = options || {};
-  const { read, computeSha512 } = unpackReadPowers(powers);
+export const loadCompartmentForArchive = async ({
+  readPowers,
+  moduleLocation,
+  moduleTransforms,
+  modules: exitModules = {},
+  dev = false,
+  tags = new Set(),
+  searchSuffixes = undefined,
+  commonDependencies = undefined,
+  importHook: exitModuleImportHook = undefined,
+  policy = undefined,
+  sourceMapHook = undefined,
+}) => {
+  const { read, computeSha512 } = unpackReadPowers(readPowers);
   const {
     packageLocation,
     packageDescriptorText,
@@ -321,7 +319,7 @@ const digestLocation = async (powers, moduleLocation, options) => {
     packageDescriptorLocation,
   );
   const compartmentMap = await compartmentMapForNodeModules(
-    powers,
+    readPowers,
     packageLocation,
     tags,
     packageDescriptor,
@@ -362,6 +360,15 @@ const digestLocation = async (powers, moduleLocation, options) => {
     archiveOnly: true,
   });
   await compartment.load(entryModuleSpecifier);
+
+  /** @type {string|undefined} */
+  let compartmentMapSha512;
+  if (computeSha512 !== undefined) {
+    const compartmentMapText = JSON.stringify(compartmentMap, null, 2);
+    const compartmentMapBytes = textEncoder.encode(compartmentMapText);
+    compartmentMapSha512 = computeSha512(compartmentMapBytes);
+  }
+
   if (policy) {
     // retain all attenuators.
     await Promise.all(
@@ -371,10 +378,33 @@ const digestLocation = async (powers, moduleLocation, options) => {
     );
   }
 
-  const { archiveCompartmentMap, archiveSources } = makeArchiveCompartmentMap(
-    compartmentMap,
-    sources,
-  );
+  const { archiveCompartmentMap, archiveSources, compartmentRenames } =
+    makeArchiveCompartmentMap(compartmentMap, sources);
+
+  return {
+    archiveCompartmentMap,
+    archiveSources,
+    compartmentMapSha512,
+    compartmentRenames,
+    computeSha512,
+  };
+};
+
+/**
+ * @param {ReadFn | ReadPowers} powers
+ * @param {string} moduleLocation
+ * @param {ArchiveOptions} [options]
+ * @returns {Promise<{sources: Sources, compartmentMapBytes: Uint8Array, sha512?: string}>}
+ */
+const digestLocation = async (powers, moduleLocation, options = {}) => {
+  const { captureSourceLocation = undefined } = options;
+
+  const { archiveCompartmentMap, archiveSources, computeSha512 } =
+    await loadCompartmentForArchive({
+      readPowers: powers,
+      moduleLocation,
+      ...options,
+    });
 
   const archiveCompartmentMapText = JSON.stringify(
     archiveCompartmentMap,

--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -301,6 +301,7 @@ export const loadCompartmentForArchive = async ({
   importHook: exitModuleImportHook = undefined,
   policy = undefined,
   sourceMapHook = undefined,
+  extraParsers = {},
 }) => {
   const { read, computeSha512 } = unpackReadPowers(readPowers);
   const {
@@ -357,6 +358,7 @@ export const loadCompartmentForArchive = async ({
     makeImportHook,
     moduleTransforms,
     parserForLanguage,
+    extraParsers,
     archiveOnly: true,
   });
   await compartment.load(entryModuleSpecifier);

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -168,6 +168,7 @@ function getBundlerKitForModule(module) {
  * @param {object} [options.commonDependencies]
  * @param {Array<string>} [options.searchSuffixes]
  * @param {import('./types.js').SourceMapHook} [options.sourceMapHook]
+ * @param {Record<string, import('./types.js').Language>} [options.extraParsers]
  * @returns {Promise<string>}
  */
 export const makeBundle = async (read, moduleLocation, options) => {
@@ -178,6 +179,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
     searchSuffixes,
     commonDependencies,
     sourceMapHook = undefined,
+    extraParsers = {},
   } = options || {};
   const tags = new Set(tagsOption);
 
@@ -223,6 +225,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
     makeImportHook,
     moduleTransforms,
     parserForLanguage,
+    extraParsers,
   });
   await compartment.load(entryModuleSpecifier);
 

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -250,6 +250,7 @@ const makeFauxModuleExportsNamespace = Compartment => {
  * @param {CompartmentConstructor} [options.Compartment]
  * @param {import('./types.js').ComputeSourceLocationHook} [options.computeSourceLocation]
  * @param {import('./types.js').ComputeSourceMapLocationHook} [options.computeSourceMapLocation]
+ * @param {Record<string, import('./types.js').Language>} [options.extraParsers]
  * @returns {Promise<import('./types.js').Application>}
  */
 export const parseArchive = async (
@@ -265,6 +266,7 @@ export const parseArchive = async (
     Compartment = DefaultCompartment,
     modules = undefined,
     importHook: exitModuleImportHook = undefined,
+    extraParsers = {},
   } = options;
 
   const compartmentExitModuleImportHook = exitModuleImportHookMaker({
@@ -345,6 +347,7 @@ export const parseArchive = async (
         }),
       ),
       Compartment,
+      extraParsers,
     });
 
     await pendingJobsPromise;
@@ -365,6 +368,7 @@ export const parseArchive = async (
       __shimTransforms__,
       Compartment,
       importHook: exitModuleImportHook,
+      extraParsers = {},
     } = options || {};
 
     const compartmentExitModuleImportHook = exitModuleImportHookMaker({
@@ -388,6 +392,7 @@ export const parseArchive = async (
       transforms,
       __shimTransforms__,
       Compartment,
+      extraParsers,
     });
 
     await pendingJobsPromise;

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -80,6 +80,7 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
       __shimTransforms__,
       Compartment,
       importHook: exitModuleImportHook,
+      extraParsers = {},
     } = options;
     const compartmentExitModuleImportHook = exitModuleImportHookMaker({
       modules,
@@ -101,6 +102,7 @@ export const loadLocation = async (readPowers, moduleLocation, options) => {
       moduleTransforms,
       __shimTransforms__,
       Compartment,
+      extraParsers,
     });
 
     await pendingJobsPromise;

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -147,6 +147,7 @@ export const mapParsers = (
   parserForLanguage,
   moduleTransforms = {},
 ) => {
+  /** @type {[string, string][]} */
   const languageForExtensionEntries = [];
   const problems = [];
   for (const [extension, language] of entries(languageForExtension)) {
@@ -340,6 +341,7 @@ export const link = (
     __shimTransforms__ = [],
     archiveOnly = false,
     Compartment = defaultCompartment,
+    extraParsers = {},
   },
 ) => {
   const { compartment: entryCompartmentName } = entry;
@@ -374,7 +376,7 @@ export const link = (
     compartmentDescriptor.modules = modules;
 
     const parse = mapParsers(
-      languageForExtension,
+      { ...languageForExtension, ...extraParsers },
       languageForModuleSpecifier,
       parserForLanguage,
       moduleTransforms,

--- a/packages/compartment-mapper/src/node-powers.js
+++ b/packages/compartment-mapper/src/node-powers.js
@@ -30,9 +30,10 @@ const fakePathToFileURL = path => {
  * but `makeReadPowers` presents a type that requires `url`.
  *
  * @param {object} args
- * @param {typeof import('fs')} args.fs
- * @param {typeof import('url')} [args.url]
- * @param {typeof import('crypto')} [args.crypto]
+ * @param {import('./types.js').FsAPI} args.fs
+ * @param {import('./types.js').UrlAPI} [args.url]
+ * @param {import('./types.js').CryptoAPI} [args.crypto]
+ * @returns {import('./types.js').MaybeReadPowers}
  */
 const makeReadPowersSloppy = ({ fs, url = undefined, crypto = undefined }) => {
   const fileURLToPath =

--- a/packages/compartment-mapper/src/powers.js
+++ b/packages/compartment-mapper/src/powers.js
@@ -18,7 +18,8 @@ export const unpackReadPowers = powers => {
   if (typeof powers === 'function') {
     read = powers;
   } else {
-    ({ read, maybeRead, canonical } = powers);
+    ({ read, maybeRead, canonical } =
+      /** @type {import('./types.js').MaybeReadPowers} */ (powers));
   }
 
   if (canonical === undefined) {

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -301,6 +301,7 @@ export {};
  * @property {ExitModuleImportHook} [importHook]
  * @property {Record<string, object>} [attenuations]
  * @property {typeof Compartment} [Compartment]
+ * @property {Record<string, Language>} [extraParsers]
  */
 
 /**
@@ -385,6 +386,7 @@ export {};
  * @property {Array<string>} [searchSuffixes]
  * @property {Record<string, string>} [commonDependencies]
  * @property {SourceMapHook} [sourceMapHook]
+ * @property {Record<string, Language>} [extraParsers] Additional mapping of file extension to parser
  */
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -165,8 +165,7 @@ export {};
  */
 
 /**
- * @typedef {ReadPowers | object} MaybeReadPowers
- * @property {MaybeReadFn} maybeRead
+ * @typedef {ReadPowers & {maybeRead: MaybeReadFn}} MaybeReadPowers
  */
 
 /**
@@ -531,4 +530,26 @@ export {};
  * @property {CompartmentMapDescriptor} archiveCompartmentMap
  * @property {Sources} archiveSources
  * @property {Record<string, string>} compartmentRenames
+ */
+
+/**
+ * @typedef FsPromisesApi
+ * @property {(filepath: string) => Promise<string>} realpath
+ * @property {ReadFn} readFile
+ */
+
+/**
+ * @typedef FsAPI
+ * @property {FsPromisesApi} promises
+ */
+
+/**
+ * @typedef UrlAPI
+ * @property {(location: string | URL) => string} fileURLToPath
+ * @property {(path: string) => URL} pathToFileURL
+ */
+
+/**
+ * @typedef CryptoAPI
+ * @property {typeof import('crypto').createHash} createHash
  */

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -504,3 +504,29 @@ export {};
  * Any object. All objects. Not `null`, though.
  * @typedef {Record<PropertyKey, any>} SomeObject
  */
+
+/**
+ * @typedef LoadCompartmentForArchiveOptions
+ * @property {ReadFn | ReadPowers} readPowers
+ * @property {string} moduleLocation
+ */
+
+/**
+ * Return value of `loadCompartmentForArchive`.
+ *
+ * @typedef LoadCompartmentForArchiveResult
+ * @property {CompartmentMapDescriptor} archiveCompartmentMap
+ * @property {Sources} archiveSources
+ * @property {Record<string, string>} compartmentRenames
+ * @property {string} [compartmentMapSha512]
+ * @property {HashFn} [computeSha512]
+ */
+
+/**
+ * Return value of `makeArchiveCompartmentMap`
+ *
+ * @typedef MakeArchiveCompartmentMapResult
+ * @property {CompartmentMapDescriptor} archiveCompartmentMap
+ * @property {Sources} archiveSources
+ * @property {Record<string, string>} compartmentRenames
+ */

--- a/packages/compartment-mapper/types.d.ts
+++ b/packages/compartment-mapper/types.d.ts
@@ -5,6 +5,7 @@ export {
   writeArchive,
   mapLocation,
   hashLocation,
+  loadCompartmentForArchive,
 } from './src/archive.js';
 export {
   parseArchive,


### PR DESCRIPTION
This is supposed to enable LavaMoat to piggyback on `@endo/compartment-mapper` for its own policy generation.  

WIP. Do not even look