### PR TITLE
chore(ses): Reapply hardened typed array configurable properties test

### DIFF
--- a/packages/ses/test/test-make-hardener.js
+++ b/packages/ses/test/test-make-hardener.js
@@ -86,8 +86,12 @@ test('harden typed arrays', t => {
     t.truthy(Object.isSealed(a));
     const descriptor = Object.getOwnPropertyDescriptor(a, '0');
     t.is(descriptor.value, a[0]);
-    // Fails in Node.js 14 and earlier due to an engine bug:
-    // t.is(descriptor.configurable, true, 'hardened typed array indexed property remains configurable');
+    // Failed in Node.js 14 and earlier due to an engine bug:
+    t.is(
+      descriptor.configurable,
+      true,
+      'hardened typed array indexed property remains configurable',
+    );
     // Note that indexes of typed arrays are exceptionally writable for hardened objects.
     t.is(
       descriptor.writable,
@@ -187,8 +191,12 @@ test('harden typed arrays and their expandos', t => {
       { value: 0, writable: true, enumerable: true },
       'hardened typed array index property',
     );
-    // Fails in Node.js 14 and earlier due to an engine bug:
-    // t.is(descriptor.configurable, true, 'typed array indexed property is configurable');
+    // Failed in Node.js 14 and earlier due to an engine bug:
+    t.is(
+      descriptor.configurable,
+      true,
+      'typed array indexed property is configurable',
+    );
     // Note that indexes of typed arrays are exceptionally writable for hardened objects:
   }
 


### PR DESCRIPTION
Closes #1053

## Description

A defect in a version of Node 14 required us to relax a check in the SES tests. With Node.js 14 a distant memory and 18 being LTS, we can reapply the test.

### Security Considerations

This reenables a test of our invariants.

### Scaling Considerations

Not applicable.

### Documentation Considerations

None.

### Testing Considerations

Improves tests.

### Compatibility Considerations

Does not alter compatibility.

### Upgrade Considerations

Will not impact upgrade.
