### PR TITLE
feat(daemon): Add petname path lookup

### DIFF
--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeChangeTopic } from './pubsub.js';
 import { makeIteratorRef } from './reader-ref.js';
@@ -41,16 +42,20 @@ export const makeMailboxMaker = ({
     };
 
     /**
-     * @param {string} petName
+     * @param {...string} petNamePath - A sequence of pet names.
+     * @returns {Promise<unknown>} The value resolved by the pet name path.
      */
-    const lookup = async petName => {
-      const formulaIdentifier = lookupFormulaIdentifierForName(petName);
+    const lookup = async (...petNamePath) => {
+      const [headName, ...tailNames] = petNamePath;
+      const formulaIdentifier = lookupFormulaIdentifierForName(headName);
       if (formulaIdentifier === undefined) {
-        throw new TypeError(`Unknown pet name: ${q(petName)}`);
+        throw new TypeError(`Unknown pet name: ${q(headName)}`);
       }
       // Behold, recursion:
-      // eslint-disable-next-line no-use-before-define
-      return provideValueForFormulaIdentifier(formulaIdentifier);
+      return tailNames.reduce(
+        (currentValue, petName) => E(currentValue).lookup(petName),
+        provideValueForFormulaIdentifier(formulaIdentifier),
+      );
     };
 
     const terminate = async petName => {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -212,7 +212,7 @@ export interface EndoGuest {
 export interface EndoHost {
   listMessages(): Promise<Array<Message>>;
   followMessages(): ERef<AsyncIterable<Message>>;
-  lookup(petName: string): Promise<unknown>;
+  lookup(...petNamePath: string[]): Promise<unknown>;
   resolve(requestNumber: number, petName: string);
   reject(requestNumber: number, message: string);
   reverseLookup(ref: object): Promise<Array<string>>;

--- a/packages/daemon/test/lookup.js
+++ b/packages/daemon/test/lookup.js
@@ -1,0 +1,9 @@
+import { Far } from '@endo/far';
+
+export const make = () => {
+  return Far('Lookup', {
+    lookup(petName) {
+      return `Looked up: ${petName}`;
+    },
+  });
+};


### PR DESCRIPTION
Supersedes: #1915 

## Description

Implements mailbox petname path lookup by making the mailbox `lookup()` method variadic. Adds tests to verify how this composes with the inspector and caplets with their own `lookup()` method.

This enables us to later add dot-separated paths for petnames in the CLI.

## Note to reviewers

Did I overlook any places that should accept `string | string[]` where currently only a single `petName` is expected?