### PR TITLE
feat(ses): enablements needed by (old?) mobx

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -1,4 +1,4 @@
-import { toStringTagSymbol } from './commons.js';
+import { toStringTagSymbol, iteratorSymbol } from './commons.js';
 
 /**
  * @file Exports {@code enablements}, a recursively defined
@@ -97,6 +97,8 @@ export const moderateEnablements = {
   '%ArrayPrototype%': {
     toString: true,
     push: true, // set by "Google Analytics"
+    concat: true, // set by mobx generated code (old TS compiler?)
+    [iteratorSymbol]: true, // set by mobx generated code (old TS compiler?)
   },
 
   // Function.prototype has no 'prototype' property to enable.

--- a/packages/ses/test/test-enable-property-overrides-default.js
+++ b/packages/ses/test/test-enable-property-overrides-default.js
@@ -8,7 +8,7 @@ test('enablePropertyOverrides - on', t => {
   overrideTester(t, 'Object', {}, ['toString', 'valueOf']);
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
-  overrideTester(t, 'Array', [], ['toString', 'length', 'push']);
+  overrideTester(t, 'Array', [], ['toString', 'length', 'push', 'concat']);
   // eslint-disable-next-line func-names, prefer-arrow-callback
   overrideTester(t, 'Function', function () {}, [
     'constructor',

--- a/packages/ses/test/test-enable-property-overrides-severe-debug.js
+++ b/packages/ses/test/test-enable-property-overrides-severe-debug.js
@@ -16,7 +16,7 @@ test('enablePropertyOverrides - on, with debug', t => {
 
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
-  overrideTester(t, 'Array', [], ['toString', 'length', 'push']);
+  overrideTester(t, 'Array', [], ['toString', 'length', 'push', 'concat']);
 
   const TypedArray = getPrototypeOf(Uint8Array);
   overrideTester(

--- a/packages/ses/test/test-enable-property-overrides-severe.js
+++ b/packages/ses/test/test-enable-property-overrides-severe.js
@@ -12,7 +12,7 @@ test('enablePropertyOverrides - on', t => {
 
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
-  overrideTester(t, 'Array', [], ['toString', 'length', 'push']);
+  overrideTester(t, 'Array', [], ['toString', 'length', 'push', 'concat']);
 
   const TypedArray = getPrototypeOf(Uint8Array);
   overrideTester(


### PR DESCRIPTION

closes: #XXXX
refs: #2029 

## Description

This does not close #2029 , but it does close the first hurdle, the 

```
TypeError: Cannot assign to read only property 'concat' of object '[object Object]'
```

problem. I have yet to diagnose or fix the 

```
TypeError#2: Cannot perform 'ownKeys' on a proxy that has been revoked
```

The problem fixed by this PR is interesting. The override mistake is in mobx generated code, where the corresponding mobx source code is a TypeScript class definition. The generated code is not a JS class definition, but rather, seems to target pre-class JS. The surprising mistake is that the generated code is initializing the methods on the "class" .prototype using assignment rather than `defineProperty` in blatant violation of the JS class semantics. Presumably, this is also a blatant violation of the current TS class semantics, but I don't know. Is some ancient TS compiler at play here? Or some non-standard TS or TS-like compiler? I don't know.

### Security Considerations

The errant TS class compilation is itself worrisome, both from general correctness and from security. But that issue is only revealed by this bug and PR, not affected by it. Nevertheless, we should try to understand what's going on, and to send upstream a mobx fix that repairs their class semantics. Since mobx is only a very indirect dependency of ours to which we do not impute any particular security properties, this is likely low urgency.

In the absence of this PR, as explained at #2029, much more violent inhibitions of SES's security were attempted (`unsafe-fast.js`) and might have been used in practice, resulting is a great loss of hardening and integrity protection. This PR makes that unnecessary, at least as far as this first #2029 problem which raised that possibility.

### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
none
### Compatibility Considerations
none
### Upgrade Considerations
none. Nothing breaking. Nothing that warrants a NEWS.md update.

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
