### PR TITLE
feat(cli,daemon): Support dot-delimited petname paths for CLI `eval` command

### DIFF
--- a/packages/cli/src/commands/eval.js
+++ b/packages/cli/src/commands/eval.js
@@ -2,6 +2,7 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoParty } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
 export const evalCommand = async ({
   source,
@@ -27,13 +28,13 @@ export const evalCommand = async ({
       return pair;
     });
     const codeNames = pairs.map(pair => pair[0]);
-    const endowmentNames = pairs.map(pair => pair[1]);
+    const petNames = pairs.map(pair => parsePetNamePath(pair[1]));
 
     const result = await E(party).evaluate(
       workerName,
       source,
       codeNames,
-      endowmentNames,
+      petNames,
       resultName,
     );
     console.log(result);

--- a/packages/cli/src/pet-name.js
+++ b/packages/cli/src/pet-name.js
@@ -1,0 +1,18 @@
+/**
+ * Splits a dot-delimited pet name path into an array of pet names.
+ * Throws if any of the path segments are empty.
+ *
+ * @param {string} petNamePath - A dot-delimited pet name path.
+ * @returns {string[]} - The pet name path, as an array of pet names.
+ */
+export const parsePetNamePath = petNamePath => {
+  const petNames = petNamePath.split('.');
+  for (const petName of petNames) {
+    if (petName === '') {
+      throw new Error(
+        `Pet name path "${petNamePath}" contains an empty segment.`,
+      );
+    }
+  }
+  return petNames;
+};

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -680,7 +680,7 @@ const makeEndoBootstrap = (
       if (
         ![
           'eval-id512',
-          'lookup',
+          'lookup-id512',
           'make-unconfined-id512',
           'make-bundle-id512',
           'guest-id512',

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -231,22 +231,22 @@ const makeEndoBootstrap = (
    * Creates a controller for a `lookup` formula. The external facet is the
    * resolved value of the lookup.
    *
-   * @param {string} agentFormulaIdentifier
+   * @param {string} hubFormulaIdentifier
    * @param {string[]} path
    * @param {import('./types.js').Terminator} terminator
    */
   const makeControllerForLookup = async (
-    agentFormulaIdentifier,
+    hubFormulaIdentifier,
     path,
     terminator,
   ) => {
-    terminator.thisDiesIfThatDies(agentFormulaIdentifier);
+    terminator.thisDiesIfThatDies(hubFormulaIdentifier);
 
     // Behold, recursion:
     // eslint-disable-next-line no-use-before-define
-    const agent = provideValueForFormulaIdentifier(agentFormulaIdentifier);
+    const hub = provideValueForFormulaIdentifier(hubFormulaIdentifier);
 
-    const external = E(agent).lookup(...path);
+    const external = E(hub).lookup(...path);
     return { external, internal: undefined };
   };
 
@@ -349,7 +349,7 @@ const makeEndoBootstrap = (
         terminator,
       );
     } else if (formula.type === 'lookup') {
-      return makeControllerForLookup(formula.agent, formula.path, terminator);
+      return makeControllerForLookup(formula.hub, formula.path, terminator);
     } else if (formula.type === 'make-unconfined') {
       return makeControllerForUnconfinedPlugin(
         formula.worker,
@@ -715,7 +715,7 @@ const makeEndoBootstrap = (
           formula.type,
           formulaNumber,
           harden({
-            agent: provideValueForFormulaIdentifier(formula.agent),
+            hub: provideValueForFormulaIdentifier(formula.hub),
             path: formula.path,
           }),
         );

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -228,6 +228,9 @@ const makeEndoBootstrap = (
   };
 
   /**
+   * Creates a controller for a `lookup` formula. The external facet is the
+   * resolved value of the lookup.
+   *
    * @param {string} agentFormulaIdentifier
    * @param {string[]} path
    * @param {import('./types.js').Terminator} terminator
@@ -517,7 +520,7 @@ const makeEndoBootstrap = (
    * @param {string} formulaType - The type of the formula.
    * @param {string} formulaNumber - The number of the formula.
    * @param {import('./types').Formula} formula - The formula.
-   * @returns {Promise<unknown>} The value of the formula.
+   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>} The value of the formula.
    */
   const provideValueForNumberedFormula = async (
     formulaType,
@@ -627,6 +630,8 @@ const makeEndoBootstrap = (
     formulaIdentifierForRef,
     provideValueForFormulaIdentifier,
     provideControllerForFormulaIdentifier,
+    makeSha512,
+    provideValueForNumberedFormula,
   });
 
   const makeIdentifiedGuestController = makeGuestMaker({

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -43,6 +43,7 @@ export const makeHostMaker = ({
       reverseLookup,
       lookupFormulaIdentifierForName,
       listMessages,
+      provideLookupFormula,
       followMessages,
       resolve,
       reject,
@@ -224,26 +225,8 @@ export const makeHostMaker = ({
             return formulaIdentifier;
           }
 
-          const lookupAgent = lookupFormulaIdentifierForName('SELF');
-          const digester = makeSha512();
-          digester.updateText(`${lookupAgent},${petNamePath.join(',')}`);
-          const lookupFormulaNumber = digester.digestHex().slice(32, 64);
-
-          // TODO:lookup Check if the lookup formula already exists in the store
-
-          const lookupFormula = {
-            /** @type {'lookup'} */
-            type: 'lookup',
-            agent: lookupAgent,
-            path: petNamePath,
-          };
-
           const { formulaIdentifier: lookupFormulaIdentifier } =
-            await provideValueForNumberedFormula(
-              'lookup',
-              lookupFormulaNumber,
-              lookupFormula,
-            );
+            await provideLookupFormula(petNamePath);
           return lookupFormulaIdentifier;
         }),
       );

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -112,7 +112,7 @@ export const makeMailboxMaker = ({
       const agentFormulaIdentifier = lookupFormulaIdentifierForName('SELF');
       const digester = makeSha512();
       digester.updateText(`${agentFormulaIdentifier},${petNamePath.join(',')}`);
-      const lookupFormulaNumber = digester.digestHex().slice(32, 64);
+      const lookupFormulaNumber = digester.digestHex();
 
       // TODO:lookup Check if the lookup formula already exists in the store
 
@@ -124,7 +124,7 @@ export const makeMailboxMaker = ({
       };
 
       return provideValueForNumberedFormula(
-        'lookup',
+        'lookup-id512',
         lookupFormulaNumber,
         lookupFormula,
       );

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -109,9 +109,13 @@ export const makeMailboxMaker = ({
      * identifier and value of the lookup formula.
      */
     const provideLookupFormula = async petNamePath => {
-      const agentFormulaIdentifier = lookupFormulaIdentifierForName('SELF');
+      // The lookup formula identifier consists of the hash of the associated
+      // naming hub's formula identifier and the pet name path.
+      // A "naming hub" is an objected with a variadic lookup method. At present,
+      // the only such objects are guests and hosts.
+      const hubFormulaIdentifier = lookupFormulaIdentifierForName('SELF');
       const digester = makeSha512();
-      digester.updateText(`${agentFormulaIdentifier},${petNamePath.join(',')}`);
+      digester.updateText(`${hubFormulaIdentifier},${petNamePath.join(',')}`);
       const lookupFormulaNumber = digester.digestHex();
 
       // TODO:lookup Check if the lookup formula already exists in the store
@@ -119,7 +123,7 @@ export const makeMailboxMaker = ({
       const lookupFormula = {
         /** @type {'lookup'} */
         type: 'lookup',
-        agent: agentFormulaIdentifier,
+        hub: hubFormulaIdentifier,
         path: petNamePath,
       };
 

--- a/packages/daemon/src/pet-name.js
+++ b/packages/daemon/src/pet-name.js
@@ -12,3 +12,11 @@ export const assertPetName = petName => {
     throw new Error(`Invalid pet name ${q(petName)}`);
   }
 };
+
+/**
+ * @param {string | string[]} petNameOrPetNamePath
+ */
+export const petNamePathFrom = petNameOrPetNamePath =>
+  typeof petNameOrPetNamePath === 'string'
+    ? [petNameOrPetNamePath]
+    : petNameOrPetNamePath;

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -9,7 +9,7 @@ const { quote: q } = assert;
 
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:host|pet-store|pet-inspector|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
+  /^(?:host|pet-store|pet-inspector|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|(?:lookup|web-bundle):[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -9,7 +9,7 @@ const { quote: q } = assert;
 
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:host|pet-store|pet-inspector|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|(?:lookup|web-bundle):[0-9a-f]{32})$/;
+  /^(?:host|pet-store|pet-inspector|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|lookup-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -76,9 +76,10 @@ type LookupFormula = {
   type: 'lookup';
 
   /**
-   * The formula identifier of the guest or host to call lookup on.
+   * The formula identifier of the naming hub to call lookup on.
+   * A "naming hub" is an object with a variadic `lookup()` method.
    */
-  agent: string;
+  hub: string;
 
   /**
    * The pet name path.

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -72,6 +72,20 @@ type EvalFormula = {
   // TODO formula slots
 };
 
+type LookupFormula = {
+  type: 'lookup';
+
+  /**
+   * The formula identifier of the guest or host to call lookup on.
+   */
+  agent: string;
+
+  /**
+   * The pet name path.
+   */
+  path: Array<string>;
+};
+
 type MakeUnconfinedFormula = {
   type: 'make-unconfined';
   worker: string;
@@ -97,6 +111,7 @@ type WebBundleFormula = {
 export type Formula =
   | GuestFormula
   | EvalFormula
+  | LookupFormula
   | MakeUnconfinedFormula
   | MakeBundleFormula
   | WebBundleFormula;


### PR DESCRIPTION
Ref: #2023 

## Description

Adds support for dot-delimited petname paths to the CLI `eval` command. This required modifications to the `evaluate` method of the daemon's `host.js`, and the introduction of a new formula type, `lookup`.

The `lookup` formula type is necessary because the names in a lookup path may have neither petnames nor formula identifiers associated with them. Consider:

```text
> endo eval '10' --name ten
10
> endo eval 'foo' foo:INFO.ten.source
10
```

The only way retrieve the value for `source` is to call `E(HOST).lookup('INFO', 'ten', 'source')`, and since the `eval` formula expects its values to be mediated by formula identifiers, the lookup of `INFO.ten.source` must itself be stored as a formula.

The `lookup` formula is an `-id512` formula with the following interface:
```typescript
type LookupFormula = {
  type: 'lookup';

  /**
   * The formula identifier of the naming hub to call lookup on.
   * A "naming hub" is an object with a variadic `lookup()` method.
   */
  hub: string;

  /**
   * The pet name path.
   */
  path: Array<string>;
};
```

The `lookup` formula introduces the language of "naming hubs" into the daemon codebase. At present the only such objects are guests and hosts, which are also agents, but the category of naming hubs is expected to grow to include non-agent objects.