### PR TITLE
feat(ses,pass-style,marshal): permit Promise.any, AggregateError, cause

### DIFF
--- a/packages/common/NEWS.md
+++ b/packages/common/NEWS.md
@@ -1,0 +1,18 @@
+User-visible changes in `@endo/common`:
+
+# next release
+
+- Change to `throwLabeled`
+  - Like the assertion functions/methods that were parameterized by an error
+    constructor (`makeError`, `assert`, `assert.fail`, `assert.equal`),
+    `throwLabeled` now also accepts named options `cause` and `errors` in its
+    immediately succeeding `options` argument.
+  - Like those assertion functions, the error constructor argument to
+    `throwLabeled` can now be an `AggregateError`.
+    If `throwLabeled` makes an error instance, it encapsulates the
+    non-uniformity of the `AggregateError` construction arguments, allowing
+    all the error constructors to be used polymorphically
+    (generic / interchangeable).
+  - The error constructor argument is now typed `GenericErrorConstructor`,
+    effectively the common supertype of `ErrorConstructor` and
+    `AggregateErrorConstructor`.

--- a/packages/common/NEWS.md
+++ b/packages/common/NEWS.md
@@ -1,8 +1,8 @@
 User-visible changes in `@endo/common`:
 
-# next release
+# Next release
 
-- Change to `throwLabeled`
+- `throwLabeled` parameterized error construction
   - Like the assertion functions/methods that were parameterized by an error
     constructor (`makeError`, `assert`, `assert.fail`, `assert.equal`),
     `throwLabeled` now also accepts named options `cause` and `errors` in its

--- a/packages/common/throw-labeled.js
+++ b/packages/common/throw-labeled.js
@@ -7,14 +7,24 @@ import { X, makeError, annotateError } from '@endo/errors';
  *
  * @param {Error} innerErr
  * @param {string|number} label
- * @param {ErrorConstructor=} ErrorConstructor
+ * @param {import('ses').GenericErrorConstructor} [errConstructor]
+ * @param {import('ses').AssertMakeErrorOptions} [options]
  * @returns {never}
  */
-export const throwLabeled = (innerErr, label, ErrorConstructor = undefined) => {
+export const throwLabeled = (
+  innerErr,
+  label,
+  errConstructor = undefined,
+  options = undefined,
+) => {
   if (typeof label === 'number') {
     label = `[${label}]`;
   }
-  const outerErr = makeError(`${label}: ${innerErr.message}`, ErrorConstructor);
+  const outerErr = makeError(
+    `${label}: ${innerErr.message}`,
+    errConstructor,
+    options,
+  );
   annotateError(outerErr, X`Caused by ${innerErr}`);
   throw outerErr;
 };

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "../../tsconfig.eslint-base.json",
+  "compilerOptions": {
+    "checkJs": true,
+    "maxNodeModuleJsDepth": 1,
+  },
   "include": [
     "*.js",
     "*.ts",

--- a/packages/errors/NEWS.md
+++ b/packages/errors/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/errors`:
 
-# next release
+# Next release
 
 - `AggegateError` support
   - Assertion functions/methods that were parameterized by an error constructor

--- a/packages/errors/NEWS.md
+++ b/packages/errors/NEWS.md
@@ -1,0 +1,20 @@
+User-visible changes in `@endo/errors`:
+
+# next release
+
+- `AggegateError` support
+  - Assertion functions/methods that were parameterized by an error constructor
+    (`makeError`, `assert`, `assert.fail`, `assert.equal`) now also accept named
+    options `cause` and `errors` in their immediately succeeding
+    `options` argument.
+  - For all those, the error constructor can now be an `AggregateError`.
+    If they do make an error instance, they encapsulate the
+    non-uniformity of the `AggregateError` construction arguments, allowing
+    all the error constructors to be used polymorphically
+    (generic / interchangeable).
+  - Adds a `GenericErrorConstructor` type to be effectively the common supertype
+    of `ErrorConstructor` and `AggregateErrorConstructor`, for typing these
+    error constructor parameters that handle the error constructor
+    polymorphically.
+  - The SES `console` now includes `error.cause` and `error.errors` in
+    its diagnostic output for errors.

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -60,8 +60,8 @@ const {
 } = globalAssert;
 /** @type {import("ses").AssertionFunctions } */
 // @ts-expect-error missing properties assigned next
-const assert = (value, optDetails, optErrorContructor) =>
-  globalAssert(value, optDetails, optErrorContructor);
+const assert = (value, optDetails, errContructor, options) =>
+  globalAssert(value, optDetails, errContructor, options);
 Object.assign(assert, assertions);
 
 // As of 2024-02, the Agoric chain's bootstrap vat runs with a version of SES

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -61,6 +61,8 @@ module.exports = {
     lockdown: 'readonly',
     harden: 'readonly',
     HandledPromise: 'readonly',
+    // https://github.com/endojs/endo/issues/550
+    AggregateError: 'readonly',
   },
   rules: {
     '@endo/assert-fail-as-throw': 'error',

--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,5 +1,31 @@
 User-visible changes in `@endo/marshal`:
 
+# next release
+
+- Sending and receiving extended errors.
+  - As of the previous release, `@endo/marshal` tolerates extra error
+    properties with `Passable` values. However, all those extra properties
+    were only recorded in annotations, since they are not recognized as
+    legitimate on `Passable` errors.
+  - This release will use these extra properties to construct an error object
+    with all those extra properties, and then call `toPassableError` to make
+    the locally `Passable` error that it returns. Thus, if the extra properties
+    received are not recognized as a legitimate part of a locally `Passable`
+    error, the error with those extra properties itself becomes the annotation
+    on the returned `Passable` error.
+  - An `error.cause` property whose value is a `Passable` error with therefore
+    show up on the returned `Passable` error. If it is any other `Passable`
+    value, it will show up on the internal error used to annotate the
+    returned error.
+  - An `error.errors` property whose value is a `CopyArray` of `Passable`
+    errors will likewise show up on the returned `Passable` error. Otherwise,
+    only on the internal error annotation of the returned error.
+  - Although this release does otherwise support the error properties
+    `error.cause` and `error.errors` on `Passable` errors, it still does not
+    send these properties because releases prior to the previous release
+    do not tolerate receiving them. Once we no longer need to support
+    releases prior to the previous release, then we can start sending these.
+
 # v1.2.0 (2024-02-14)
 
 - Tolerates receiving extra error properties (https://github.com/endojs/endo/pull/2052). Once pervasive, this tolerance will eventually enable additional error properties to be sent. The motivating examples are the JavaScript standard properties `cause` and `errors`. This change also enables smoother interoperation with other languages with their own theories about diagnostic information to be included in errors.

--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/marshal`:
 
-# next release
+# Next release
 
 - Sending and receiving extended errors.
   - As of the previous release, `@endo/marshal` tolerates extra error

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -217,8 +217,9 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
         }
         case 'error': {
           const { name, message } = rawTree;
-          typeof name === 'string' ||
-            Fail`invalid error name typeof ${q(typeof name)}`;
+          if (typeof name !== 'string') {
+            throw Fail`invalid error name typeof ${q(typeof name)}`;
+          }
           getErrorConstructor(name) !== undefined ||
             Fail`Must be the name of an Error constructor ${name}`;
           typeof message === 'string' ||
@@ -389,11 +390,18 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
         }
 
         case 'error': {
-          const { name, message } = rawTree;
-          // TODO cause, errors, AggregateError
-          // See https://github.com/endojs/endo/pull/2052
+          const {
+            name,
+            message,
+            cause = undefined,
+            errors = undefined,
+          } = rawTree;
+          cause === undefined ||
+            Fail`error cause not yet implemented in marshal-justin`;
           name !== `AggregateError` ||
             Fail`AggregateError not yet implemented in marshal-justin`;
+          errors === undefined ||
+            Fail`error errors not yet implemented in marshal-justin`;
           return out.next(`${name}(${quote(message)})`);
         }
 

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -31,7 +31,9 @@ export {};
  *           EncodingClass<'symbol'> & { name: string } |
  *           EncodingClass<'error'> & { name: string,
  *                                      message: string,
- *                                      errorId?: string
+ *                                      errorId?: string,
+ *                                      cause?: Encoding,
+ *                                      errors?: Encoding[],
  *           } |
  *           EncodingClass<'slot'> & { index: number,
  *                                     iface?: string

--- a/packages/marshal/test/test-marshal-capdata.js
+++ b/packages/marshal/test/test-marshal-capdata.js
@@ -154,11 +154,12 @@ test('unserialize errors', t => {
 });
 
 test('unserialize extended errors', t => {
+  if (typeof AggregateError === 'undefined') {
+    t.pass('skip test on platforms prior to AggregateError');
+    return;
+  }
   const { unserialize } = makeTestMarshal();
   const uns = body => unserialize({ body, slots: [] });
-
-  // TODO cause, errors, and AggregateError will eventually be recognized.
-  // See https://github.com/endojs/endo/pull/2042
 
   const refErr = uns(
     '{"@qclass":"error","message":"msg","name":"ReferenceError","extraProp":"foo","cause":"bar","errors":["zip","zap"]}',
@@ -167,7 +168,6 @@ test('unserialize extended errors', t => {
   t.false('extraProp' in refErr);
   t.false('cause' in refErr);
   t.false('errors' in refErr);
-  console.log('error with extra prop', refErr);
 
   const aggErr = uns(
     '{"@qclass":"error","message":"msg","name":"AggregateError","extraProp":"foo","cause":"bar","errors":["zip","zap"]}',
@@ -176,7 +176,6 @@ test('unserialize extended errors', t => {
   t.false('extraProp' in aggErr);
   t.false('cause' in aggErr);
   t.is(aggErr.errors.length, 0);
-  console.log('error with extra prop', aggErr);
 
   const unkErr = uns(
     '{"@qclass":"error","message":"msg","name":"UnknownError","extraProp":"foo","cause":"bar","errors":["zip","zap"]}',
@@ -185,10 +184,12 @@ test('unserialize extended errors', t => {
   t.false('extraProp' in unkErr);
   t.false('cause' in unkErr);
   t.false('errors' in unkErr);
-  console.log('error with extra prop', unkErr);
 });
 
-test('unserialize errors w recognized extensions', t => {
+const testIfAggregateError =
+  typeof AggregateError !== 'undefined' ? test : test.skip;
+
+testIfAggregateError('unserialize errors w recognized extensions', t => {
   const { unserialize } = makeTestMarshal();
   const uns = body => unserialize({ body, slots: [] });
 
@@ -201,7 +202,6 @@ test('unserialize errors w recognized extensions', t => {
   t.false('extraProp' in refErr);
   t.is(getPrototypeOf(refErr.cause), URIError.prototype);
   t.is(getPrototypeOf(refErr.errors[0]), URIError.prototype);
-  console.log('error with extra prop', refErr);
 
   const aggErr = uns(
     `{"@qclass":"error","message":"msg","name":"AggregateError","extraProp":"foo","cause":${errEnc},"errors":[${errEnc}]}`,
@@ -210,7 +210,6 @@ test('unserialize errors w recognized extensions', t => {
   t.false('extraProp' in aggErr);
   t.is(getPrototypeOf(aggErr.cause), URIError.prototype);
   t.is(getPrototypeOf(aggErr.errors[0]), URIError.prototype);
-  console.log('error with extra prop', aggErr);
 
   const unkErr = uns(
     `{"@qclass":"error","message":"msg","name":"UnknownError","extraProp":"foo","cause":${errEnc},"errors":[${errEnc}]}`,
@@ -219,8 +218,6 @@ test('unserialize errors w recognized extensions', t => {
   t.false('extraProp' in unkErr);
   t.is(getPrototypeOf(unkErr.cause), URIError.prototype);
   t.is(getPrototypeOf(unkErr.errors[0]), URIError.prototype);
-
-  console.log('error with extra prop', unkErr);
 });
 
 test('passStyleOf null is "null"', t => {

--- a/packages/marshal/test/test-marshal-smallcaps.js
+++ b/packages/marshal/test/test-marshal-smallcaps.js
@@ -160,6 +160,10 @@ test('smallcaps unserialize errors', t => {
 });
 
 test('smallcaps unserialize extended errors', t => {
+  if (typeof AggregateError === 'undefined') {
+    t.pass('skip test on platforms prior to AggregateError');
+    return;
+  }
   const { unserialize } = makeTestMarshal();
   const uns = body => unserialize({ body, slots: [] });
 
@@ -170,7 +174,6 @@ test('smallcaps unserialize extended errors', t => {
   t.false('extraProp' in refErr);
   t.false('cause' in refErr);
   t.false('errors' in refErr);
-  console.log('error with extra prop', refErr);
 
   const aggErr = uns(
     '#{"#error":"msg","name":"AggregateError","extraProp":"foo","cause":"bar","errors":["zip","zap"]}',
@@ -179,7 +182,6 @@ test('smallcaps unserialize extended errors', t => {
   t.false('extraProp' in aggErr);
   t.false('cause' in aggErr);
   t.is(aggErr.errors.length, 0);
-  console.log('error with extra prop', aggErr);
 
   const unkErr = uns(
     '#{"#error":"msg","name":"UnknownError","extraProp":"foo","cause":"bar","errors":["zip","zap"]}',
@@ -188,10 +190,13 @@ test('smallcaps unserialize extended errors', t => {
   t.false('extraProp' in unkErr);
   t.false('cause' in unkErr);
   t.false('errors' in unkErr);
-  console.log('error with extra prop', unkErr);
 });
 
 test('smallcaps unserialize errors w recognized extensions', t => {
+  if (typeof AggregateError === 'undefined') {
+    t.pass('skip test on platforms prior to AggregateError');
+    return;
+  }
   const { unserialize } = makeTestMarshal();
   const uns = body => unserialize({ body, slots: [] });
 
@@ -204,7 +209,6 @@ test('smallcaps unserialize errors w recognized extensions', t => {
   t.false('extraProp' in refErr);
   t.is(getPrototypeOf(refErr.cause), URIError.prototype);
   t.is(getPrototypeOf(refErr.errors[0]), URIError.prototype);
-  console.log('error with extra prop', refErr);
 
   const aggErr = uns(
     `#{"#error":"msg","name":"AggregateError","extraProp":"foo","cause":${errEnc},"errors":[${errEnc}]}`,
@@ -213,7 +217,6 @@ test('smallcaps unserialize errors w recognized extensions', t => {
   t.false('extraProp' in aggErr);
   t.is(getPrototypeOf(refErr.cause), URIError.prototype);
   t.is(getPrototypeOf(refErr.errors[0]), URIError.prototype);
-  console.log('error with extra prop', aggErr);
 
   const unkErr = uns(
     `#{"#error":"msg","name":"UnknownError","extraProp":"foo","cause":${errEnc},"errors":[${errEnc}]}`,
@@ -222,7 +225,6 @@ test('smallcaps unserialize errors w recognized extensions', t => {
   t.false('extraProp' in unkErr);
   t.is(getPrototypeOf(refErr.cause), URIError.prototype);
   t.is(getPrototypeOf(refErr.errors[0]), URIError.prototype);
-  console.log('error with extra prop', unkErr);
 });
 
 test('smallcaps mal-formed @qclass', t => {

--- a/packages/pass-style/NEWS.md
+++ b/packages/pass-style/NEWS.md
@@ -1,0 +1,17 @@
+User-visible changes in `@endo/pass-style`:
+
+# next release
+
+- Now supports `AggegateError`, `error.errors`, `error.cause`.
+  - A `Passable` error can now include an `error.cause` property whose
+    value is a `Passable` error.
+  - An `AggregateError` can be a `Passable` error.
+  - A `Passable` error can now include an `error.errors` property whose
+    value is a `CopyArray` of `Passable` errors.
+  - The previously internal `toPassableError` is more general and exported
+    for general use. If its error agument is already `Passable`,
+    `toPassableError` will return it. Otherwise, it will extract from it
+    info for making a `Passable` error, and use `annotateError` to attach
+    the original error to the returned `Passable` error as a note. This
+    node will show up on the SES `console` as additional diagnostic info
+    associated with the returned `Passable` error.

--- a/packages/pass-style/NEWS.md
+++ b/packages/pass-style/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/pass-style`:
 
-# next release
+# Next release
 
 - Now supports `AggegateError`, `error.errors`, `error.cause`.
   - A `Passable` error can now include an `error.cause` property whose

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -7,11 +7,8 @@ export {
   hasOwnPropertyOf,
 } from './src/passStyle-helpers.js';
 
-export {
-  getErrorConstructor,
-  toPassableError,
-  isErrorLike,
-} from './src/error.js';
+export { getErrorConstructor, isErrorLike } from './src/error.js';
+
 export { getInterfaceOf } from './src/remotable.js';
 
 export {
@@ -21,7 +18,14 @@ export {
   passableSymbolForName,
 } from './src/symbol.js';
 
-export { passStyleOf, assertPassable } from './src/passStyleOf.js';
+export {
+  passStyleOf,
+  isPassable,
+  assertPassable,
+  isPassableError,
+  assertPassableError,
+  toPassableError,
+} from './src/passStyleOf.js';
 
 export { makeTagged } from './src/makeTagged.js';
 export {

--- a/packages/pass-style/src/error.js
+++ b/packages/pass-style/src/error.js
@@ -24,9 +24,16 @@ const errorConstructors = new Map(
     ['URIError', URIError],
 
     // https://github.com/endojs/endo/issues/550
-    ['AggregateError', AggregateError],
+    // To accommodate platforms prior to AggregateError, we comment out the
+    // following line and instead conditionally add it to the map below.
+    // ['AggregateError', AggregateError],
   ]),
 );
+
+if (typeof AggregateError !== 'undefined') {
+  // Conditional, to accommodate platforms prior to AggregateError
+  errorConstructors.set('AggregateError', AggregateError);
+}
 
 /**
  * Because the error constructor returned by this function might be

--- a/packages/pass-style/src/error.js
+++ b/packages/pass-style/src/error.js
@@ -1,27 +1,43 @@
 /// <reference types="ses"/>
 
-import { X, Fail, annotateError } from '@endo/errors';
+import { X, q } from '@endo/errors';
 import { assertChecker } from './passStyle-helpers.js';
 
 /** @typedef {import('./internal-types.js').PassStyleHelper} PassStyleHelper */
 /** @typedef {import('./types.js').Checker} Checker */
 
-const { getPrototypeOf, getOwnPropertyDescriptors } = Object;
-const { ownKeys } = Reflect;
+const { getPrototypeOf, getOwnPropertyDescriptors, hasOwn, entries } = Object;
 
 // TODO: Maintenance hazard: Coordinate with the list of errors in the SES
-// whilelist. Currently, both omit AggregateError, which is now standard. Both
-// must eventually include it.
-const errorConstructors = new Map([
-  ['Error', Error],
-  ['EvalError', EvalError],
-  ['RangeError', RangeError],
-  ['ReferenceError', ReferenceError],
-  ['SyntaxError', SyntaxError],
-  ['TypeError', TypeError],
-  ['URIError', URIError],
-]);
+// whilelist.
+const errorConstructors = new Map(
+  // Cast because otherwise TS is confused by AggregateError
+  // See https://github.com/endojs/endo/pull/2042#discussion_r1484933028
+  /** @type {Array<[string, import('ses').GenericErrorConstructor]>} */
+  ([
+    ['Error', Error],
+    ['EvalError', EvalError],
+    ['RangeError', RangeError],
+    ['ReferenceError', ReferenceError],
+    ['SyntaxError', SyntaxError],
+    ['TypeError', TypeError],
+    ['URIError', URIError],
 
+    // https://github.com/endojs/endo/issues/550
+    ['AggregateError', AggregateError],
+  ]),
+);
+
+/**
+ * Because the error constructor returned by this function might be
+ * `AggregateError`, which has different construction parameters
+ * from the other error constructors, do not use it directly to try
+ * to make an error instance. Rather, use `makeError` which encapsulates
+ * this non-uniformity.
+ *
+ * @param {string} name
+ * @returns {import('ses').GenericErrorConstructor | undefined}
+ */
 export const getErrorConstructor = name => errorConstructors.get(name);
 harden(getErrorConstructor);
 
@@ -39,6 +55,7 @@ const checkErrorLike = (candidate, check = undefined) => {
   );
 };
 harden(checkErrorLike);
+/// <reference types="ses"/>
 
 /**
  * Validating error objects are passable raises a tension between security
@@ -62,6 +79,132 @@ export const isErrorLike = candidate => checkErrorLike(candidate);
 harden(isErrorLike);
 
 /**
+ * @param {string} propName
+ * @param {PropertyDescriptor} desc
+ * @param {import('./internal-types.js').PassStyleOf} passStyleOfRecur
+ * @param {Checker} [check]
+ * @returns {boolean}
+ */
+export const checkRecursivelyPassableErrorPropertyDesc = (
+  propName,
+  desc,
+  passStyleOfRecur,
+  check = undefined,
+) => {
+  const reject = !!check && (details => check(false, details));
+  if (desc.enumerable) {
+    return (
+      reject &&
+      reject(
+        X`Passable Error ${q(
+          propName,
+        )} own property must not be enumerable: ${desc}`,
+      )
+    );
+  }
+  if (!hasOwn(desc, 'value')) {
+    return (
+      reject &&
+      reject(
+        X`Passable Error ${q(
+          propName,
+        )} own property must be a data property: ${desc}`,
+      )
+    );
+  }
+  const { value } = desc;
+  switch (propName) {
+    case 'message':
+    case 'stack': {
+      return (
+        typeof value === 'string' ||
+        (reject &&
+          reject(
+            X`Passable Error ${q(
+              propName,
+            )} own property must be a string: ${value}`,
+          ))
+      );
+    }
+    case 'cause': {
+      // eslint-disable-next-line no-use-before-define
+      return checkRecursivelyPassableError(value, passStyleOfRecur, check);
+    }
+    case 'errors': {
+      if (!Array.isArray(value) || passStyleOfRecur(value) !== 'copyArray') {
+        return (
+          reject &&
+          reject(
+            X`Passable Error ${q(
+              propName,
+            )} own property must be a copyArray: ${value}`,
+          )
+        );
+      }
+      return value.every(err =>
+        // eslint-disable-next-line no-use-before-define
+        checkRecursivelyPassableError(err, passStyleOfRecur, check),
+      );
+    }
+    default: {
+      break;
+    }
+  }
+  return (
+    reject &&
+    reject(X`Passable Error has extra unpassed property ${q(propName)}`)
+  );
+};
+harden(checkRecursivelyPassableErrorPropertyDesc);
+
+/**
+ * @param {unknown} candidate
+ * @param {import('./internal-types.js').PassStyleOf} passStyleOfRecur
+ * @param {Checker} [check]
+ * @returns {boolean}
+ */
+export const checkRecursivelyPassableError = (
+  candidate,
+  passStyleOfRecur,
+  check = undefined,
+) => {
+  const reject = !!check && (details => check(false, details));
+  if (!checkErrorLike(candidate, check)) {
+    return false;
+  }
+  const proto = getPrototypeOf(candidate);
+  const { name } = proto;
+  const errConstructor = getErrorConstructor(name);
+  if (errConstructor === undefined || errConstructor.prototype !== proto) {
+    return (
+      reject &&
+      reject(
+        X`Passable Error must inherit from an error class .prototype: ${candidate}`,
+      )
+    );
+  }
+  const descs = getOwnPropertyDescriptors(candidate);
+  if (!('message' in descs)) {
+    return (
+      reject &&
+      reject(
+        X`Passable Error must have an own "message" string property: ${candidate}`,
+      )
+    );
+  }
+
+  return entries(descs).every(([propName, desc]) =>
+    checkRecursivelyPassableErrorPropertyDesc(
+      propName,
+      desc,
+      passStyleOfRecur,
+      check,
+    ),
+  );
+};
+harden(checkRecursivelyPassableError);
+
+/**
  * @type {PassStyleHelper}
  */
 export const ErrorHelper = harden({
@@ -69,54 +212,6 @@ export const ErrorHelper = harden({
 
   canBeValid: checkErrorLike,
 
-  assertValid: candidate => {
-    ErrorHelper.canBeValid(candidate, assertChecker);
-    const proto = getPrototypeOf(candidate);
-    const { name } = proto;
-    const EC = getErrorConstructor(name);
-    (EC && EC.prototype === proto) ||
-      Fail`Errors must inherit from an error class .prototype ${candidate}`;
-
-    const {
-      // TODO Must allow `cause`, `errors`
-      message: mDesc,
-      stack: stackDesc,
-      ...restDescs
-    } = getOwnPropertyDescriptors(candidate);
-    ownKeys(restDescs).length < 1 ||
-      Fail`Passed Error has extra unpassed properties ${restDescs}`;
-    if (mDesc) {
-      typeof mDesc.value === 'string' ||
-        Fail`Passed Error "message" ${mDesc} must be a string-valued data property.`;
-      !mDesc.enumerable ||
-        Fail`Passed Error "message" ${mDesc} must not be enumerable`;
-    }
-    if (stackDesc) {
-      typeof stackDesc.value === 'string' ||
-        Fail`Passed Error "stack" ${stackDesc} must be a string-valued data property.`;
-      !stackDesc.enumerable ||
-        Fail`Passed Error "stack" ${stackDesc} must not be enumerable`;
-    }
-    return true;
-  },
+  assertValid: (candidate, passStyleOfRecur) =>
+    checkRecursivelyPassableError(candidate, passStyleOfRecur, assertChecker),
 });
-
-/**
- * Return a new passable error that propagates the diagnostic info of the
- * original, and is linked to the original as a note.
- *
- * @param {Error} err
- * @returns {Error}
- */
-export const toPassableError = err => {
-  const { name, message } = err;
-
-  const EC = getErrorConstructor(`${name}`) || Error;
-  const newError = harden(new EC(`${message}`));
-  // Even the cleaned up error copy, if sent to the console, should
-  // cause hidden diagnostic information of the original error
-  // to be logged.
-  annotateError(newError, X`copied from error ${err}`);
-  return newError;
-};
-harden(toPassableError);

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -239,9 +239,11 @@ harden(assertPassable);
  *
  * TODO Deprecate and ultimately delete @agoric/base-zone's `isPassable' in
  * favor of this one.
+ * See https://github.com/endojs/endo/issues/2096
  *
  * TODO implement an isPassable that does not rely on try/catch.
- * This implementation is just a standin until then
+ * This implementation is just a standin until then.
+ * See https://github.com/endojs/endo/issues/2096
  *
  * @param {any} specimen
  * @returns {specimen is Passable}
@@ -299,7 +301,7 @@ export const assertPassableError = err => {
  * Return a new passable error that propagates the diagnostic info of the
  * original, and is linked to the original as a note.
  *
- * @param {Error | AggregateError} err
+ * @param {Error} err
  * @returns {Error}
  */
 export const toPassableError = err => {

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -3,13 +3,23 @@
 /// <reference types="ses"/>
 
 import { isPromise } from '@endo/promise-kit';
-import { X, Fail, q } from '@endo/errors';
-import { isObject, isTypedArray, PASS_STYLE } from './passStyle-helpers.js';
+import { X, Fail, q, annotateError, makeError } from '@endo/errors';
+import {
+  assertChecker,
+  isObject,
+  isTypedArray,
+  PASS_STYLE,
+} from './passStyle-helpers.js';
 
 import { CopyArrayHelper } from './copyArray.js';
 import { CopyRecordHelper } from './copyRecord.js';
 import { TaggedHelper } from './tagged.js';
-import { ErrorHelper } from './error.js';
+import {
+  ErrorHelper,
+  checkRecursivelyPassableErrorPropertyDesc,
+  checkRecursivelyPassableError,
+  getErrorConstructor,
+} from './error.js';
 import { RemotableHelper } from './remotable.js';
 
 import { assertPassableSymbol } from './symbol.js';
@@ -24,7 +34,7 @@ import { assertSafePromise } from './safe-promise.js';
 /** @typedef {Exclude<PassStyle, PrimitiveStyle | "promise">} HelperPassStyle */
 
 const { ownKeys } = Reflect;
-const { isFrozen } = Object;
+const { isFrozen, getOwnPropertyDescriptors } = Object;
 
 /**
  * @param {PassStyleHelper[]} passStyleHelpers
@@ -221,3 +231,107 @@ export const assertPassable = val => {
   passStyleOf(val); // throws if val is not a passable
 };
 harden(assertPassable);
+
+/**
+ * Is `specimen` Passable? This returns true iff `passStyleOf(specimen)`
+ * returns a string. This returns `false` iff `passStyleOf(specimen)` throws.
+ * Under no normal circumstance should `isPassable(specimen)` throw.
+ *
+ * TODO Deprecate and ultimately delete @agoric/base-zone's `isPassable' in
+ * favor of this one.
+ *
+ * TODO implement an isPassable that does not rely on try/catch.
+ * This implementation is just a standin until then
+ *
+ * @param {any} specimen
+ * @returns {specimen is Passable}
+ */
+export const isPassable = specimen => {
+  try {
+    // In fact, it never returns undefined. It either returns a
+    // string or throws.
+    return passStyleOf(specimen) !== undefined;
+  } catch (_) {
+    return false;
+  }
+};
+harden(isPassable);
+
+/**
+ * @param {string} name
+ * @param {PropertyDescriptor} desc
+ * @returns {boolean}
+ */
+const isPassableErrorPropertyDesc = (name, desc) =>
+  checkRecursivelyPassableErrorPropertyDesc(name, desc, passStyleOf);
+harden(isPassableErrorPropertyDesc);
+
+/**
+ * @param {string} name
+ * @param {PropertyDescriptor} desc
+ */
+const assertPassableErrorPropertyDesc = (name, desc) => {
+  checkRecursivelyPassableErrorPropertyDesc(
+    name,
+    desc,
+    passStyleOf,
+    assertChecker,
+  );
+};
+harden(assertPassableErrorPropertyDesc);
+
+/**
+ * @param {unknown} err
+ * @returns {err is Error}
+ */
+export const isPassableError = err =>
+  checkRecursivelyPassableError(err, passStyleOf);
+
+/**
+ * @param {unknown} err
+ * @returns {asserts err is Error}
+ */
+export const assertPassableError = err => {
+  checkRecursivelyPassableError(err, passStyleOf, assertChecker);
+};
+
+/**
+ * Return a new passable error that propagates the diagnostic info of the
+ * original, and is linked to the original as a note.
+ *
+ * @param {Error | AggregateError} err
+ * @returns {Error}
+ */
+export const toPassableError = err => {
+  if (isPassableError(err)) {
+    return err;
+  }
+  const { name, message } = err;
+  const { cause: causeDesc, errors: errorsDesc } =
+    getOwnPropertyDescriptors(err);
+  let cause;
+  let errors;
+  if (causeDesc && isPassableErrorPropertyDesc('cause', causeDesc)) {
+    // @ts-expect-error data descriptors have "value" property
+    cause = causeDesc.value;
+  }
+  if (errorsDesc && isPassableErrorPropertyDesc('errors', errorsDesc)) {
+    // @ts-expect-error data descriptors have "value" property
+    errors = errorsDesc.value;
+  }
+
+  const errConstructor = getErrorConstructor(`${name}`) || Error;
+  const newError = makeError(`${message}`, errConstructor, {
+    // @ts-ignore Assuming cause is Error | undefined
+    cause,
+    errors,
+  });
+  harden(newError);
+  // Even the cleaned up error copy, if sent to the console, should
+  // cause hidden diagnostic information of the original error
+  // to be logged.
+  annotateError(newError, X`copied from error ${err}`);
+  assertPassableError(newError);
+  return newError;
+};
+harden(toPassableError);

--- a/packages/pass-style/test/test-extended-errors.js
+++ b/packages/pass-style/test/test-extended-errors.js
@@ -18,6 +18,9 @@ test('style of extended errors', t => {
   const u3 = harden(URIError('u3', { cause: e1 }));
   t.is(passStyleOf(u3), 'error');
 
-  const a4 = harden(AggregateError([e2, u3], 'a4', { cause: e1 }));
-  t.is(passStyleOf(a4), 'error');
+  if (typeof AggregateError !== 'undefined') {
+    // Conditional, to accommodate platforms prior to AggregateError
+    const a4 = harden(AggregateError([e2, u3], 'a4', { cause: e1 }));
+    t.is(passStyleOf(a4), 'error');
+  }
 });

--- a/packages/pass-style/test/test-extended-errors.js
+++ b/packages/pass-style/test/test-extended-errors.js
@@ -1,0 +1,23 @@
+/* eslint-disable max-classes-per-file */
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { passStyleOf } from '../src/passStyleOf.js';
+
+test('style of extended errors', t => {
+  const e1 = Error('e1');
+  t.throws(() => passStyleOf(e1), {
+    message: 'Cannot pass non-frozen objects like "[Error: e1]". Use harden()',
+  });
+  harden(e1);
+  t.is(passStyleOf(e1), 'error');
+
+  const e2 = harden(Error('e2', { cause: e1 }));
+  t.is(passStyleOf(e2), 'error');
+
+  const u3 = harden(URIError('u3', { cause: e1 }));
+  t.is(passStyleOf(u3), 'error');
+
+  const a4 = harden(AggregateError([e2, u3], 'a4', { cause: e1 }));
+  t.is(passStyleOf(a4), 'error');
+});

--- a/packages/pass-style/test/test-passStyleOf.js
+++ b/packages/pass-style/test/test-passStyleOf.js
@@ -30,15 +30,18 @@ test('passStyleOf basic success cases', t => {
   t.is(passStyleOf(harden({})), 'copyRecord', 'empty plain object');
   t.is(passStyleOf(makeTagged('unknown', undefined)), 'tagged');
   t.is(passStyleOf(harden(Error('ok'))), 'error');
+});
 
+test('some passStyleOf rejections', t => {
   const hairlessError = Error('hairless');
   for (const k of ownKeys(hairlessError)) {
     delete hairlessError[k];
   }
-  t.is(passStyleOf(harden(hairlessError)), 'error');
-});
+  t.throws(() => passStyleOf(harden(hairlessError)), {
+    message:
+      'Passable Error must have an own "message" string property: "[Error: ]"',
+  });
 
-test('some passStyleOf rejections', t => {
   t.throws(() => passStyleOf(Symbol('unique')), {
     message:
       /Only registered symbols or well-known symbols are passable: "\[Symbol\(unique\)\]"/,
@@ -391,7 +394,7 @@ test('remotables - safety from the gibson042 attack', t => {
   // console.log(passStyleOf(input1)); // => "remotable"
   t.throws(() => passStyleOf(input1), {
     message:
-      'Errors must inherit from an error class .prototype "[undefined: undefined]"',
+      'Passable Error must inherit from an error class .prototype: "[undefined: undefined]"',
   });
 
   // different because of changes in the prototype
@@ -400,7 +403,7 @@ test('remotables - safety from the gibson042 attack', t => {
   // console.log(passStyleOf(input2)); // => Error (Errors must inherit from an error class .prototype)
   t.throws(() => passStyleOf(input2), {
     message:
-      'Errors must inherit from an error class .prototype "[undefined: undefined]"',
+      'Passable Error must inherit from an error class .prototype: "[undefined: undefined]"',
   });
 });
 
@@ -417,8 +420,7 @@ test('Unexpected stack on errors', t => {
   Object.freeze(err);
 
   t.throws(() => passStyleOf(err), {
-    message:
-      'Passed Error "stack" {"configurable":false,"enumerable":false,"value":{},"writable":false} must be a string-valued data property.',
+    message: 'Passable Error "stack" own property must be a string: {}',
   });
   err.stack.foo = 42;
 });

--- a/packages/pass-style/tsconfig.json
+++ b/packages/pass-style/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "../../tsconfig.eslint-base.json",
+  "compilerOptions": {
+    "checkJs": true,
+    "maxNodeModuleJsDepth": 1,
+  },
   "include": [
     "*.js",
     "*.ts",

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/patterns`:
 
-# next release
+# Next release
 
 - Add `M.tagged(tagPattern, payloadPattern)` for making patterns that match
   Passable Tagged objects.

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in SES:
 
-# next release
+# Next release
 
 - Now supports `Promise.any`, `AggegateError`, `error.errors`,
   and `error.cause`.

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,25 @@
 User-visible changes in SES:
 
+# next release
+
+- Now supports `Promise.any`, `AggegateError`, `error.errors`,
+  and `error.cause`.
+  - Assertion functions/methods that were parameterized by an error constructor
+    (`makeError`, `assert`, `assert.fail`, `assert.equal`) now also accept named
+    options `cause` and `errors` in their immediately succeeding
+    `options` argument.
+  - For all those, the error constructor can now be an `AggregateError`.
+    If they do make an error instance, they encapsulate the
+    non-uniformity of the `AggregateError` construction arguments, allowing
+    all the error constructors to be used polymorphically
+    (generic / interchangeable).
+  - Adds a `GenericErrorConstructor` type to be effectively the common supertype
+    of `ErrorConstructor` and `AggregateErrorConstructor`, for typing these
+    error constructor parameters that handle the error constructor
+    polymorphically.
+  - The SES `console` now includes `error.cause` and `error.errors` in
+    its diagnostic output for errors.
+
 # v1.2.0 (2024-02-14)
 
 - Exports `ses/lockdown-shim.js`, `ses/compartment-shim.js`, and

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -161,7 +161,8 @@
         "isNaN",
         "parseFloat",
         "parseInt",
-        "unescape"
+        "unescape",
+        "AggregateError"
       ],
       "@endo/no-polymorphic-call": "error"
     },

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -47,6 +47,7 @@ export const {
   ReferenceError,
   SyntaxError,
   TypeError,
+  AggregateError,
 } = globalThis;
 
 export const {

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -149,6 +149,12 @@ export const moderateEnablements = {
     name: true, // set by "node 14"
   },
 
+  // https://github.com/endojs/endo/issues/550
+  '%AggregateErrorPrototype%': {
+    message: true, // to match TypeErrorPrototype.message
+    name: true, // set by "node 14"?
+  },
+
   '%PromisePrototype%': {
     constructor: true, // set by "core-js"
   },

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -274,7 +274,10 @@ const makeError = (
   const messageString = getMessageString(hiddenDetails);
   const opts = cause && { cause };
   let error;
-  if (errConstructor === AggregateError) {
+  if (
+    typeof AggregateError !== 'undefined' &&
+    errConstructor === AggregateError
+  ) {
     error = AggregateError(errors || [], messageString, opts);
   } else {
     error = /** @type {ErrorConstructor} */ (errConstructor)(

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -169,6 +169,8 @@ export { makeLoggingConsoleKit };
 const ErrorInfo = {
   NOTE: 'ERROR_NOTE:',
   MESSAGE: 'ERROR_MESSAGE:',
+  CAUSE: 'cause:',
+  ERRORS: 'errors:',
 };
 freeze(ErrorInfo);
 
@@ -308,6 +310,14 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     // eslint-disable-next-line @endo/no-polymorphic-call
     baseConsole[severity](stackString);
     // Show the other annotations on error
+    if (error.cause) {
+      logErrorInfo(severity, error, ErrorInfo.CAUSE, [error.cause], subErrors);
+    }
+    // @ts-expect-error AggregateError has an `errors` property.
+    if (error.errors) {
+      // @ts-expect-error AggregateError has an `errors` property.
+      logErrorInfo(severity, error, ErrorInfo.ERRORS, error.errors, subErrors);
+    }
     for (const noteLogArgs of noteLogArgsArray) {
       logErrorInfo(severity, error, ErrorInfo.NOTE, noteLogArgs, subErrors);
     }

--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -69,7 +69,12 @@
  */
 
 /**
- * @typedef {{ NOTE: 'ERROR_NOTE:', MESSAGE: 'ERROR_MESSAGE:' }} ErrorInfo
+ * @typedef {{
+ *   NOTE: 'ERROR_NOTE:',
+ *   MESSAGE: 'ERROR_MESSAGE:',
+ *   CAUSE: 'cause:',
+ *   ERRORS: 'errors:',
+ * }} ErrorInfo
  */
 
 /**

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -1,19 +1,35 @@
 // @ts-check
 
 /**
+ * TypeScript does not treat `AggregateErrorConstructor` as a subtype of
+ * `ErrorConstructor`, which makes sense because their constructors
+ * have incompatible signatures. However, we want to parameterize some
+ * operations by any error constructor, including possible `AggregateError`.
+ * So we introduce `GenericErrorConstructor` as a common supertype. Any call
+ * to it to make an instance must therefore first case split on whether the
+ * constructor is an AggregateErrorConstructor or a normal ErrorConstructor.
+ *
+ * @typedef {ErrorConstructor | AggregateErrorConstructor} GenericErrorConstructor
+ */
+
+/**
  * @callback BaseAssert
  * The `assert` function itself.
  *
  * @param {any} flag The truthy/falsy value
- * @param {Details=} optDetails The details to throw
- * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
- * constructor to use.
+ * @param {Details} [optDetails] The details to throw
+ * @param {GenericErrorConstructor} [errConstructor]
+ * An optional alternate error constructor to use.
+ * @param {AssertMakeErrorOptions} [options]
  * @returns {asserts flag}
  */
 
 /**
  * @typedef {object} AssertMakeErrorOptions
- * @property {string=} errorName
+ * @property {string} [errorName]
+ * @property {Error} [cause]
+ * @property {Error[]} [errors]
+ *   Normally only used when the ErrorConstuctor is `AggregateError`
  */
 
 /**
@@ -22,10 +38,10 @@
  * The `assert.error` method, recording details for the console.
  *
  * The optional `optDetails` can be a string.
- * @param {Details=} optDetails The details of what was asserted
- * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
- * constructor to use.
- * @param {AssertMakeErrorOptions=} options
+ * @param {Details} [optDetails] The details of what was asserted
+ * @param {GenericErrorConstructor} [errConstructor]
+ * An optional alternate error constructor to use.
+ * @param {AssertMakeErrorOptions} [options]
  * @returns {Error}
  */
 
@@ -40,9 +56,10 @@
  *
  * The optional `optDetails` can be a string for backwards compatibility
  * with the nodejs assertion library.
- * @param {Details=} optDetails The details of what was asserted
- * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
- * constructor to use.
+ * @param {Details} [optDetails] The details of what was asserted
+ * @param {GenericErrorConstructor} [errConstructor]
+ * An optional alternate error constructor to use.
+ * @param {AssertMakeErrorOptions} [options]
  * @returns {never}
  */
 
@@ -53,9 +70,10 @@
  * Assert that two values must be `Object.is`.
  * @param {any} actual The value we received
  * @param {any} expected What we wanted
- * @param {Details=} optDetails The details to throw
- * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
- * constructor to use.
+ * @param {Details} [optDetails] The details to throw
+ * @param {GenericErrorConstructor} [errConstructor]
+ * An optional alternate error constructor to use.
+ * @param {AssertMakeErrorOptions} [options]
  * @returns {void}
  */
 
@@ -66,7 +84,7 @@
  * @callback AssertTypeofBigint
  * @param {any} specimen
  * @param {'bigint'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is bigint}
  */
 
@@ -74,7 +92,7 @@
  * @callback AssertTypeofBoolean
  * @param {any} specimen
  * @param {'boolean'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is boolean}
  */
 
@@ -82,7 +100,7 @@
  * @callback AssertTypeofFunction
  * @param {any} specimen
  * @param {'function'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is Function}
  */
 
@@ -90,7 +108,7 @@
  * @callback AssertTypeofNumber
  * @param {any} specimen
  * @param {'number'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is number}
  */
 
@@ -98,7 +116,7 @@
  * @callback AssertTypeofObject
  * @param {any} specimen
  * @param {'object'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is Record<any, any> | null}
  */
 
@@ -106,7 +124,7 @@
  * @callback AssertTypeofString
  * @param {any} specimen
  * @param {'string'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is string}
  */
 
@@ -114,7 +132,7 @@
  * @callback AssertTypeofSymbol
  * @param {any} specimen
  * @param {'symbol'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is symbol}
  */
 
@@ -122,7 +140,7 @@
  * @callback AssertTypeofUndefined
  * @param {any} specimen
  * @param {'undefined'} typename
- * @param {Details=} optDetails
+ * @param {Details} [optDetails]
  * @returns {asserts specimen is undefined}
  */
 
@@ -141,7 +159,7 @@
  *
  * Assert an expected typeof result.
  * @param {any} specimen The value to get the typeof
- * @param {Details=} optDetails The details to throw
+ * @param {Details} [optDetails] The details to throw
  * @returns {asserts specimen is string}
  */
 
@@ -202,7 +220,7 @@
  *
  * @callback AssertQuote
  * @param {any} payload What to declassify
- * @param {(string|number)=} spaces
+ * @param {(string|number)} [spaces]
  * @returns {StringablePayload} The declassified payload
  */
 
@@ -235,8 +253,8 @@
  * `optRaise` returns normally, which would be unusual, the throw following
  * `optRaise(reason)` would still happen.
  *
- * @param {Raise=} optRaise
- * @param {boolean=} unredacted
+ * @param {Raise} [optRaise]
+ * @param {boolean} [unredacted]
  * @returns {Assert}
  */
 
@@ -400,6 +418,6 @@
  * @callback FilterConsole
  * @param {VirtualConsole} baseConsole
  * @param {ConsoleFilter} filter
- * @param {string=} topic
+ * @param {string} [topic]
  * @returns {VirtualConsole}
  */

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1,4 +1,8 @@
 /* eslint-disable no-restricted-globals */
+/* eslint max-lines: 0 */
+
+import { arrayPush } from './commons.js';
+
 /**
  * @file Exports {@code whitelist}, a recursively defined
  * JSON record enumerating all intrinsics and their properties
@@ -7,8 +11,6 @@
  * @author JF Paradis
  * @author Mark S. Miller
  */
-
-/* eslint max-lines: 0 */
 
 /**
  * constantProperties
@@ -187,7 +189,8 @@ export const uniqueGlobalPropertyNames = {
 
 // All the "subclasses" of Error. These are collectively represented in the
 // ECMAScript spec by the meta variable NativeError.
-export const NativeErrors = [
+/** @type {GenericErrorConstructor[]} */
+const NativeErrors = [
   EvalError,
   RangeError,
   ReferenceError,
@@ -195,8 +198,17 @@ export const NativeErrors = [
   TypeError,
   URIError,
   // https://github.com/endojs/endo/issues/550
-  AggregateError,
+  // Commented out to accommodate platforms prior to AggregateError.
+  // Instead, conditional push below.
+  // AggregateError,
 ];
+
+if (typeof AggregateError !== 'undefined') {
+  // Conditional, to accommodate platforms prior to AggregateError
+  arrayPush(NativeErrors, AggregateError);
+}
+
+export { NativeErrors };
 
 /**
  * <p>Each JSON record enumerates the disposition of the properties on

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -82,6 +82,8 @@ export const universalPropertyNames = {
   Iterator: 'Iterator',
   // https://github.com/tc39/proposal-async-iterator-helpers
   AsyncIterator: 'AsyncIterator',
+  // https://github.com/endojs/endo/issues/550
+  AggregateError: 'AggregateError',
 
   // *** Other Properties of the Global Object
 
@@ -185,7 +187,6 @@ export const uniqueGlobalPropertyNames = {
 
 // All the "subclasses" of Error. These are collectively represented in the
 // ECMAScript spec by the meta variable NativeError.
-// TODO Add AggregateError https://github.com/Agoric/SES-shim/issues/550
 export const NativeErrors = [
   EvalError,
   RangeError,
@@ -193,6 +194,8 @@ export const NativeErrors = [
   SyntaxError,
   TypeError,
   URIError,
+  // https://github.com/endojs/endo/issues/550
+  AggregateError,
 ];
 
 /**
@@ -599,6 +602,8 @@ export const permitted = {
   SyntaxError: NativeError('%SyntaxErrorPrototype%'),
   TypeError: NativeError('%TypeErrorPrototype%'),
   URIError: NativeError('%URIErrorPrototype%'),
+  // https://github.com/endojs/endo/issues/550
+  AggregateError: NativeError('%AggregateErrorPrototype%'),
 
   '%EvalErrorPrototype%': NativeErrorPrototype('EvalError'),
   '%RangeErrorPrototype%': NativeErrorPrototype('RangeError'),
@@ -606,6 +611,8 @@ export const permitted = {
   '%SyntaxErrorPrototype%': NativeErrorPrototype('SyntaxError'),
   '%TypeErrorPrototype%': NativeErrorPrototype('TypeError'),
   '%URIErrorPrototype%': NativeErrorPrototype('URIError'),
+  // https://github.com/endojs/endo/issues/550
+  '%AggregateErrorPrototype%': NativeErrorPrototype('AggregateError'),
 
   // *** Numbers and Dates
 
@@ -1473,9 +1480,8 @@ export const permitted = {
     '[[Proto]]': '%FunctionPrototype%',
     all: fn,
     allSettled: fn,
-    // To transition from `false` to `fn` once we also have `AggregateError`
-    // TODO https://github.com/Agoric/SES-shim/issues/550
-    any: false, // ES2021
+    // https://github.com/Agoric/SES-shim/issues/550
+    any: fn,
     prototype: '%PromisePrototype%',
     race: fn,
     reject: fn,

--- a/packages/ses/test/error/test-aggregate-error-console-demo.js
+++ b/packages/ses/test/error/test-aggregate-error-console-demo.js
@@ -10,6 +10,10 @@ import '../../index.js';
 lockdown();
 
 test('aggregate error console demo', t => {
+  if (typeof AggregateError === 'undefined') {
+    t.pass('skip test on platforms prior to AggregateError');
+    return;
+  }
   const e3 = Error('e3');
   const e2 = Error('e2', { cause: e3 });
   const u4 = URIError('u4', { cause: e2 });

--- a/packages/ses/test/error/test-aggregate-error-console-demo.js
+++ b/packages/ses/test/error/test-aggregate-error-console-demo.js
@@ -1,0 +1,20 @@
+import test from 'ava';
+import '../../index.js';
+
+// This is the demo version of test-aggregate-error-console.js that
+// just outputs to the actual console, rather than using the logging console
+// to test. Its purpose is to eyeball rather than automated testing.
+// It also serves as a demo form of test-error-cause-console.js, since
+// it also shows console output for those cases.
+
+lockdown();
+
+test('aggregate error console demo', t => {
+  const e3 = Error('e3');
+  const e2 = Error('e2', { cause: e3 });
+  const u4 = URIError('u4', { cause: e2 });
+
+  const a1 = AggregateError([e3, u4], 'a1', { cause: e2 });
+  console.log('log1', a1);
+  t.is(a1.cause, e2);
+});

--- a/packages/ses/test/error/test-aggregate-error-console.js
+++ b/packages/ses/test/error/test-aggregate-error-console.js
@@ -1,0 +1,44 @@
+import test from 'ava';
+import '../../index.js';
+import { throwsAndLogs } from './throws-and-logs.js';
+
+lockdown();
+
+test('aggregate error console', t => {
+  const e3 = Error('e3');
+  const e2 = Error('e2', { cause: e3 });
+  const u4 = URIError('u4', { cause: e2 });
+
+  const a1 = AggregateError([e3, u4], 'a1', { cause: e2 });
+  throwsAndLogs(
+    t,
+    () => {
+      console.log('log1', a1);
+      throw a1;
+    },
+    /a1/,
+    [
+      ['log', 'log1', '(AggregateError#1)'],
+      ['log', 'AggregateError#1:', 'a1'],
+      ['log', 'stack of AggregateError\n'],
+      ['log', 'AggregateError#1 cause:', '(Error#2)'],
+      ['log', 'AggregateError#1 errors:', '(Error#3)', '(URIError#4)'],
+      ['group', 'Nested 3 errors under AggregateError#1'],
+      ['log', 'Error#2:', 'e2'],
+      ['log', 'stack of Error\n'],
+      ['log', 'Error#2 cause:', '(Error#3)'],
+      ['group', 'Nested error under Error#2'],
+      ['log', 'Error#3:', 'e3'],
+      ['log', 'stack of Error\n'],
+      ['groupEnd'],
+      ['log', 'URIError#4:', 'u4'],
+      ['log', 'stack of URIError\n'],
+      ['log', 'URIError#4 cause:', '(Error#2)'],
+      ['group', 'Nested error under URIError#4'],
+      ['groupEnd'],
+      ['groupEnd'],
+      ['log', 'Caught', '(AggregateError#1)'],
+    ],
+    { wrapWithCausal: true },
+  );
+});

--- a/packages/ses/test/error/test-aggregate-error-console.js
+++ b/packages/ses/test/error/test-aggregate-error-console.js
@@ -5,6 +5,10 @@ import { throwsAndLogs } from './throws-and-logs.js';
 lockdown();
 
 test('aggregate error console', t => {
+  if (typeof AggregateError === 'undefined') {
+    t.pass('skip test on platforms prior to AggregateError');
+    return;
+  }
   const e3 = Error('e3');
   const e2 = Error('e2', { cause: e3 });
   const u4 = URIError('u4', { cause: e2 });

--- a/packages/ses/test/error/test-aggregate-error.js
+++ b/packages/ses/test/error/test-aggregate-error.js
@@ -1,0 +1,46 @@
+import test from 'ava';
+import '../../index.js';
+
+const { getOwnPropertyDescriptor } = Object;
+
+lockdown();
+
+test('aggregate error', t => {
+  const e1 = Error('e1');
+  const e2 = Error('e2', { cause: e1 });
+  const u3 = URIError('u3', { cause: e1 });
+
+  const a4 = AggregateError([e2, u3], 'a4', { cause: e1 });
+  t.is(a4.message, 'a4');
+  t.is(a4.cause, e1);
+  t.deepEqual(getOwnPropertyDescriptor(a4, 'cause'), {
+    value: e1,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+  t.deepEqual(getOwnPropertyDescriptor(a4, 'errors'), {
+    value: [e2, u3],
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+});
+
+test('Promise.any aggregate error', async t => {
+  const e1 = Error('e1');
+  const e2 = Error('e2', { cause: e1 });
+  const u3 = URIError('u3', { cause: e1 });
+
+  try {
+    await Promise.any([Promise.reject(e2), Promise.reject(u3)]);
+  } catch (a4) {
+    t.false('cause' in a4);
+    t.deepEqual(getOwnPropertyDescriptor(a4, 'errors'), {
+      value: [e2, u3],
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+});

--- a/packages/ses/test/error/test-aggregate-error.js
+++ b/packages/ses/test/error/test-aggregate-error.js
@@ -6,6 +6,10 @@ const { getOwnPropertyDescriptor } = Object;
 lockdown();
 
 test('aggregate error', t => {
+  if (typeof AggregateError === 'undefined') {
+    t.pass('skip test on platforms prior to AggregateError');
+    return;
+  }
   const e1 = Error('e1');
   const e2 = Error('e2', { cause: e1 });
   const u3 = URIError('u3', { cause: e1 });
@@ -28,6 +32,10 @@ test('aggregate error', t => {
 });
 
 test('Promise.any aggregate error', async t => {
+  if (typeof AggregateError === 'undefined') {
+    t.pass('skip test on platforms prior to AggregateError');
+    return;
+  }
   const e1 = Error('e1');
   const e2 = Error('e2', { cause: e1 });
   const u3 = URIError('u3', { cause: e1 });

--- a/packages/ses/test/error/test-error-cause-console.js
+++ b/packages/ses/test/error/test-error-cause-console.js
@@ -1,0 +1,80 @@
+import test from 'ava';
+import '../../index.js';
+import { throwsAndLogs } from './throws-and-logs.js';
+
+lockdown();
+
+test('error cause console control', t => {
+  const e1 = Error('e1');
+  throwsAndLogs(
+    t,
+    () => {
+      console.log('log1', e1);
+      throw e1;
+    },
+    /e1/,
+    [
+      ['log', 'log1', '(Error#1)'],
+      ['log', 'Error#1:', 'e1'],
+      ['log', 'stack of Error\n'],
+      ['log', 'Caught', '(Error#1)'],
+    ],
+    { wrapWithCausal: true },
+  );
+});
+
+test('error cause console one level', t => {
+  const e2 = Error('e2');
+  const e1 = Error('e1', { cause: e2 });
+  throwsAndLogs(
+    t,
+    () => {
+      console.log('log1', e1);
+      throw e1;
+    },
+    /e1/,
+    [
+      ['log', 'log1', '(Error#1)'],
+      ['log', 'Error#1:', 'e1'],
+      ['log', 'stack of Error\n'],
+      ['log', 'Error#1 cause:', '(Error#2)'],
+      ['group', 'Nested error under Error#1'],
+      ['log', 'Error#2:', 'e2'],
+      ['log', 'stack of Error\n'],
+      ['groupEnd'],
+      ['log', 'Caught', '(Error#1)'],
+    ],
+    { wrapWithCausal: true },
+  );
+});
+
+test('error cause console nested', t => {
+  const e3 = Error('e3');
+  const e2 = Error('e2', { cause: e3 });
+  const u1 = URIError('u1', { cause: e2 });
+  throwsAndLogs(
+    t,
+    () => {
+      console.log('log1', u1);
+      throw u1;
+    },
+    /u1/,
+    [
+      ['log', 'log1', '(URIError#1)'],
+      ['log', 'URIError#1:', 'u1'],
+      ['log', 'stack of URIError\n'],
+      ['log', 'URIError#1 cause:', '(Error#2)'],
+      ['group', 'Nested error under URIError#1'],
+      ['log', 'Error#2:', 'e2'],
+      ['log', 'stack of Error\n'],
+      ['log', 'Error#2 cause:', '(Error#3)'],
+      ['group', 'Nested error under Error#2'],
+      ['log', 'Error#3:', 'e3'],
+      ['log', 'stack of Error\n'],
+      ['groupEnd'],
+      ['groupEnd'],
+      ['log', 'Caught', '(URIError#1)'],
+    ],
+    { wrapWithCausal: true },
+  );
+});

--- a/packages/ses/test/error/test-error-cause.js
+++ b/packages/ses/test/error/test-error-cause.js
@@ -27,6 +27,10 @@ test('error cause', t => {
     enumerable: false,
     configurable: true,
   });
+  if (typeof AggregateError === 'undefined') {
+    t.pass('skip rest of test on platforms prior to AggregateError');
+    return;
+  }
   const a4 = AggregateError([e2, u3], 'a4', { cause: e1 });
   t.is(a4.message, 'a4');
   t.is(a4.cause, e1);

--- a/packages/ses/test/error/test-error-cause.js
+++ b/packages/ses/test/error/test-error-cause.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import '../../index.js';
+
+const { getOwnPropertyDescriptor } = Object;
+
+lockdown();
+
+test('error cause', t => {
+  const e1 = Error('e1');
+  t.is(e1.message, 'e1');
+  t.false('cause' in e1);
+  const e2 = Error('e2', { cause: e1 });
+  t.is(e2.message, 'e2');
+  t.is(e2.cause, e1);
+  t.deepEqual(getOwnPropertyDescriptor(e2, 'cause'), {
+    value: e1,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+  const u3 = URIError('u3', { cause: e1 });
+  t.is(u3.message, 'u3');
+  t.is(u3.cause, e1);
+  t.deepEqual(getOwnPropertyDescriptor(u3, 'cause'), {
+    value: e1,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+  const a4 = AggregateError([e2, u3], 'a4', { cause: e1 });
+  t.is(a4.message, 'a4');
+  t.is(a4.cause, e1);
+  t.deepEqual(getOwnPropertyDescriptor(a4, 'cause'), {
+    value: e1,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+});

--- a/packages/ses/test/test-get-global-intrinsics.js
+++ b/packages/ses/test/test-get-global-intrinsics.js
@@ -60,6 +60,8 @@ test.skip('getGlobalIntrinsics', () => {
     'URIError',
     'WeakMap',
     'WeakSet',
+    // https://github.com/endojs/endo/issues/550
+    'AggregateError',
 
     // *** 18.4 Other Properties of the Global Object
 

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -119,6 +119,8 @@ export type Details = string | DetailsToken;
 
 export interface AssertMakeErrorOptions {
   errorName?: string;
+  cause?: Error;
+  errors?: Error[];
 }
 
 type AssertTypeofBigint = (
@@ -175,6 +177,10 @@ interface ToStringable {
   toString(): string;
 }
 
+export type GenericErrorConstructor =
+  | ErrorConstructor
+  | AggregateErrorConstructor;
+
 export type Raise = (reason: Error) => void;
 // Behold: recursion.
 // eslint-disable-next-line no-use-before-define
@@ -184,23 +190,29 @@ export interface AssertionFunctions {
   (
     value: any,
     details?: Details,
-    errorConstructor?: ErrorConstructor,
+    errConstructor?: GenericErrorConstructor,
+    options?: AssertMakeErrorOptions,
   ): asserts value;
   typeof: AssertTypeof;
   equal(
     left: any,
     right: any,
     details?: Details,
-    errorConstructor?: ErrorConstructor,
+    errConstructor?: GenericErrorConstructor,
+    options?: AssertMakeErrorOptions,
   ): void;
   string(specimen: any, details?: Details): asserts specimen is string;
-  fail(details?: Details, errorConstructor?: ErrorConstructor): never;
+  fail(
+    details?: Details,
+    errConstructor?: GenericErrorConstructor,
+    options?: AssertMakeErrorOptions,
+  ): never;
 }
 
 export interface AssertionUtilities {
   error(
     details?: Details,
-    errorConstructor?: ErrorConstructor,
+    errConstructor?: GenericErrorConstructor,
     options?: AssertMakeErrorOptions,
   ): Error;
   note(error: Error, details: Details): void;


### PR DESCRIPTION
closes: #550 
refs: https://github.com/endojs/endo/issues/550#issuecomment-1935013037 https://github.com/cosmology-tech/cosmos-kit/blob/b95e2f92585fd12d7532e846b98cd3b757c1acb8/packages/core/src/utils/endpoint.ts#L28 https://github.com/Agoric/agoric-sdk/pull/7937

## Description

We had previously omitted `AggregateError` from `permits.js`, effectively not permitting it as part of SES, because of concern with it not following the `NativeError` patterns we assume for the other errors. On further examination just now, the only non-uniformity I see are the addition of the own property `errors`. As an own property, it is irrelevant to the job of `permits.js`.

Likewise we have postponed dealing with Error `cause`. But it is an own property as well, and so besides the point of `permits.js`.

Having omitted `AggregateError`, we also declined to permit `Promise.any` since it returns an `AggregateError` instance. Thus, this PR simultaneously permits `Promise.any`.

- [x] Still need to adapt the ses console
- [x] Still need to adapt pass-style
- [x] Still need to adapt marshal
- [x] Still need to test

I am pleasantly surprised that it does not look like I need to adapt the taming of the `Error` constructor itself to add a `cause` argument to the replacement safe constructors. The replacement constructors already take and pass through `...rest` arguments. But

- [x] Still need to test `cause` argument for the faux `Error` constructors, as well as a representative set of the permitted error constructors.

### Security Considerations

Unlikely. But anything that permits more of the engine's surface area does in theory increase vulnerability.

### Scaling Considerations

None

### Documentation Considerations

If we currently document this weird exception to normal JS expectations, we can delete that explanation.

Otherwise, no docs needed since this PR just removes a surprising difference from normal JS developer expectations.

### Testing Considerations

Currently, to test the handling of `*Error` subclasses of `Error`, we just test with a representative subclass such as `UriError`. This PR duplicates some of these tests for `AggregateError`.

### Compatibility Considerations

We need to examine what happens if a ses that permits `AggregateError` talks to a ses that does not. This is mostly a `marshal` issue.

Some agoric-sdk compat concerns noted at https://github.com/endojs/endo/issues/550#issuecomment-1935013037

The previous release of Endo seems to have some [dependence on Node 12 which did not have `AggregateError`](https://github.com/endojs/endo/pull/2042#issuecomment-1935066531). This PR accommodates such early platforms reluctantly, so as not to break tests on those early platforms.

### Upgrade Considerations

Nothing Breaking.

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [x] Updates `NEWS.md` for user-facing changes.
