### PR TITLE
feat(cli,daemon): Support pet name paths in `kill` command

### DIFF
--- a/packages/cli/src/commands/kill.js
+++ b/packages/cli/src/commands/kill.js
@@ -2,8 +2,9 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoParty } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
 export const killCommand = async ({ name, partyNames }) =>
   withEndoParty(partyNames, { os, process }, async ({ party }) => {
-    await E(party).terminate(name);
+    await E(party).terminate(parsePetNamePath(name));
   });

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -246,8 +246,18 @@ const makeEndoBootstrap = (
     // eslint-disable-next-line no-use-before-define
     const hub = provideValueForFormulaIdentifier(hubFormulaIdentifier);
 
-    const external = E(hub).lookup(...path);
-    return { external, internal: undefined };
+    const value = E(hub).lookup(...path);
+
+    // If there is already a formula identifier for the resolved value, then
+    // create a circular dependency between the two formulas. Otherwise, we
+    // would disconnect the garbage collection graph.
+    const valueFormulaIdentifier = formulaIdentifierForRef.get(await value);
+    if (valueFormulaIdentifier !== undefined) {
+      terminator.thisDiesIfThatDies(valueFormulaIdentifier);
+      terminator.thatDiesIfThisDies(valueFormulaIdentifier);
+    }
+
+    return { external: value, internal: undefined };
   };
 
   /**

--- a/packages/daemon/test/lookup-proxy.js
+++ b/packages/daemon/test/lookup-proxy.js
@@ -1,0 +1,12 @@
+import { E, Far } from '@endo/far';
+
+// A caplet that proxies the lookup method of its powers object.
+// Useful for testing the behavior of pet name paths.
+
+export const make = target => {
+  return Far('Lookup proxy', {
+    lookup(petName) {
+      return E(target).lookup(petName);
+    },
+  });
+};


### PR DESCRIPTION
Ref: #2023 

Adds support for dot-delimited pet name paths to the `kill` command. Makes requisite changes to handle paths and lookup formulas in the mailbox `terminate()` method.