### PR TITLE
fix(cli): handle undefined messages as returned by dubMessage

### DIFF
--- a/packages/cli/src/commands/inbox.js
+++ b/packages/cli/src/commands/inbox.js
@@ -18,6 +18,9 @@ export const inbox = async ({
       ? makeRefIterator(E(party).followMessages())
       : await E(party).listMessages();
     for await (const message of messages) {
+      if (message === undefined) {
+        continue;
+      }
       const { number, who, when } = message;
       if (message.type === 'request') {
         const { what } = message;


### PR DESCRIPTION
actually this should prolly be fixed a different way -- does not seem reasonable