### PR TITLE
feat: endo bundle command supports specifying commonDeps

### DIFF
--- a/packages/bundle-source/src/zip-base64.js
+++ b/packages/bundle-source/src/zip-base64.js
@@ -22,7 +22,7 @@ export async function bundleZipBase64(
   options = {},
   grantedPowers = {},
 ) {
-  const { dev = false, cacheSourceMaps = false } = options;
+  const { dev = false, cacheSourceMaps = false, commonDependencies } = options;
   const powers = { ...readPowers, ...grantedPowers };
   const {
     computeSha512,
@@ -174,6 +174,7 @@ export async function bundleZipBase64(
     sourceMapHook(sourceMap, sourceDescriptor) {
       sourceMapJobs.add(writeSourceMap(sourceMap, sourceDescriptor));
     },
+    commonDependencies,
   });
   assert(sha512);
   await Promise.all(sourceMapJobs);

--- a/packages/cli/src/commands/bundle.js
+++ b/packages/cli/src/commands/bundle.js
@@ -12,8 +12,16 @@ export const bundleCommand = async ({
   applicationPath,
   bundleName,
   partyNames,
+  bundleOptions,
 }) => {
-  const bundle = await bundleSource(applicationPath);
+  const bundle =
+    /** @type {{ moduleFormat: 'endoZipBase64', endoZipBase64: string, endoZipBase64Sha512: string }} */
+    (
+      await bundleSource(applicationPath, {
+        ...bundleOptions,
+        format: 'endoZipBase64',
+      })
+    );
   process.stdout.write(`${bundle.endoZipBase64Sha512}\n`);
   const bundleText = JSON.stringify(bundle);
   const bundleBytes = textEncoder.encode(bundleText);

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -21,6 +21,17 @@ const commonOptions = {
   as: ['-a,--as <party>', 'Pose as named party (as named by current party)'],
 };
 
+const parseOptionAsMapping = (optionValueString, obj) => {
+  // arguments can be provided as "a:b" or just "a"
+  // eslint-disable-next-line prefer-const
+  let [from, to] = optionValueString.split(':');
+  if (to === undefined) {
+    to = from;
+  }
+  obj[from] = to;
+  return obj;
+};
+
 export const main = async rawArgs => {
   const program = new Command();
 
@@ -363,13 +374,26 @@ export const main = async rawArgs => {
     .description('stores a program')
     .option(...commonOptions.as)
     .option('-n,--name <name>', 'Store the bundle into Endo')
+    .option(
+      '--common-dep <name>',
+      'Specify common dependency for bundle (eg node builtin package shims)',
+      parseOptionAsMapping,
+      {},
+    )
     .action(async (applicationPath, cmd) => {
-      const { name: bundleName, as: partyNames } = cmd.opts();
+      const {
+        name: bundleName,
+        as: partyNames,
+        commonDep: commonDependencies,
+      } = cmd.opts();
       const { bundleCommand } = await import('./commands/bundle.js');
       return bundleCommand({
         applicationPath,
         bundleName,
         partyNames,
+        bundleOptions: {
+          commonDependencies,
+        },
       });
     });
 


### PR DESCRIPTION
needed `commonDependencies` option exposed to handle node builtin package shims for browser