### PR TITLE
test(ses): fix 1973, unskip log test

### DIFF
--- a/packages/ses/test/error/test-permit-removal-warnings.js
+++ b/packages/ses/test/error/test-permit-removal-warnings.js
@@ -32,8 +32,16 @@ const logRecordMatches = (logRecord, goldenRecord) =>
   logRecord.length === goldenRecord.length &&
   logRecord.every((logEntry, i) => logEntry === goldenRecord[i]);
 
-// Specialized for the test below.
-// See https://github.com/endojs/endo/issues/1973
+/**
+ * Test that log includes goldenLog in order
+ * that is: test that they match but for possible extra warning lines in log.
+ * Specialized for the test below.
+ * See https://github.com/endojs/endo/issues/1973
+ *
+ * @param {Implementation} t
+ * @param {any[][]} log
+ * @param {any[][]} goldenLog
+ */
 const compareLogs = (t, log, goldenLog) => {
   t.deepEqual(log[0], goldenLog[0]);
   const logLast = log.length - 1;
@@ -76,8 +84,6 @@ test('permit removal warnings', t => {
       ['warn', 'Removing intrinsics.Array.extraRemovableDataProperty'],
       ['groupEnd'],
     ],
-    {
-      compareLogs,
-    },
+    { compareLogs },
   );
 });

--- a/packages/ses/test/error/test-permit-removal-warnings.js
+++ b/packages/ses/test/error/test-permit-removal-warnings.js
@@ -1,7 +1,6 @@
 import test from 'ava';
 import '../../index.js';
 import { assertLogs } from './throws-and-logs.js';
-// import { whitelistIntrinsics } from '../../src/permits-intrinsics.js';
 
 const { defineProperties } = Object;
 const { apply } = Reflect;
@@ -18,10 +17,52 @@ defineProperties(Array, {
       return apply(originalIsArray, this, args);
     },
   },
+  // To ensure that the test below remains tolerant of future engines
+  // adding unexpected properties, causing extra warnings on removal.
+  // See https://github.com/endojs/endo/issues/1973
+  anotherOne: {
+    value: `another removable property`,
+    configurable: true,
+  },
 });
 
-// TODO unskip once https://github.com/endojs/endo/issues/1973 is fixed.
-test.skip('permit removal warnings', t => {
+const logRecordMatches = (logRecord, goldenRecord) =>
+  Array.isArray(logRecord) &&
+  Array.isArray(goldenRecord) &&
+  logRecord.length === goldenRecord.length &&
+  logRecord.every((logEntry, i) => logEntry === goldenRecord[i]);
+
+// Specialized for the test below.
+// See https://github.com/endojs/endo/issues/1973
+const compareLogs = (t, log, goldenLog) => {
+  t.deepEqual(log[0], goldenLog[0]);
+  const logLast = log.length - 1;
+  const goldenLast = goldenLog.length - 1;
+  t.deepEqual(log[logLast], goldenLog[goldenLast]);
+  t.assert(logLast >= goldenLast);
+
+  let g = 1;
+  let skip = 0;
+  for (; g < goldenLast; g += 1) {
+    const logRecord = log[g + skip];
+    const goldenRecord = goldenLog[g];
+    if (logRecordMatches(logRecord, goldenRecord)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    if (g + skip >= logLast) {
+      // no more slack left
+      t.deepEqual(logRecord, goldenRecord, 'log record mismatch');
+      t.fail('log record mismatch');
+    }
+    if (logRecord[0] !== 'warn') {
+      t.fail('can only skip warnings');
+    }
+    skip += 1;
+  }
+};
+
+test('permit removal warnings', t => {
   assertLogs(
     t,
     () => lockdown(),
@@ -35,6 +76,8 @@ test.skip('permit removal warnings', t => {
       ['warn', 'Removing intrinsics.Array.extraRemovableDataProperty'],
       ['groupEnd'],
     ],
-    {},
+    {
+      compareLogs,
+    },
   );
 });

--- a/packages/ses/test/error/throws-and-logs.js
+++ b/packages/ses/test/error/throws-and-logs.js
@@ -10,7 +10,7 @@ import {
 // For our internal debugging purposes
 // const internalDebugConsole = console;
 
-const compareLogs = freeze((t, log, goldenLog) => {
+const defaultCompareLogs = freeze((t, log, goldenLog) => {
   // For our internal debugging purposes
   // internalDebugConsole.log('LOG', log);
 
@@ -71,7 +71,11 @@ const getBogusStackString = error => {
 //            [['error', 'what ', err]]);
 // ```
 export const assertLogs = freeze((t, thunk, goldenLog, options = {}) => {
-  const { checkLogs = true, wrapWithCausal = false } = options;
+  const {
+    checkLogs = true,
+    wrapWithCausal = false,
+    compareLogs = defaultCompareLogs,
+  } = options;
   const { loggingConsole, takeLog } = makeLoggingConsoleKit(
     loggedErrorHandler,
     { shouldResetForDebugging: true },


### PR DESCRIPTION

closes: #1973 
refs: #XXXX

## Description

Previously, `throwsAndLogs` would only support testing against a literal golden. But for testing the initial-removal-log-messages, this was too fragile, since new engines might have added new properties whose removal would general additional initial-removal-log-messages. This PR enable the caller to provide an alternative compare function. That one test then uses this flexibility to tolerate additional warnings interspersed between the golden warnings it looks for.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations

The whole point. This enables us to turn an annoying `test.skip` back into the needed `test`.

### Compatibility Considerations
Enables the test to remain compatible with benign future engine versions.
### Upgrade Considerations
none.

Nothing breaking.
No news updates warranted.
- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
