### PR TITLE
feat(marshal): tolerate extra error props

### DIFF
--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `@endo/marshal`:
 
+# next
+
+- Tolerates receiving extra error properties (https://github.com/endojs/endo/pull/2052). Once pervasive, this tolerance will eventually enable additional error properties to be sent. The motivating examples are the JavaScript standard properties `cause` and `errors`. This change also enables smoother interoperation with other languages with their own theories about diagnostic information to be included in errors.
+
 # v0.8.1 (2022-12-23)
 
 - Remote objects now reflect methods present on their prototype chain.

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
+    "@endo/common": "^1.0.2",
     "@endo/errors": "^1.0.2",
     "@endo/eventual-send": "^1.1.0",
     "@endo/nat": "^5.0.2",

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -390,6 +390,10 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
 
         case 'error': {
           const { name, message } = rawTree;
+          // TODO cause, errors, AggregateError
+          // See https://github.com/endojs/endo/pull/2052
+          name !== `AggregateError` ||
+            Fail`AggregateError not yet implemented in marshal-justin`;
           return out.next(`${name}(${quote(message)})`);
         }
 

--- a/packages/marshal/test/test-marshal-smallcaps.js
+++ b/packages/marshal/test/test-marshal-smallcaps.js
@@ -6,7 +6,13 @@ import { makeMarshal } from '../src/marshal.js';
 
 import { roundTripPairs } from './marshal-test-data.js';
 
-const { freeze, isFrozen, create, prototype: objectPrototype } = Object;
+const {
+  freeze,
+  isFrozen,
+  create,
+  prototype: objectPrototype,
+  getPrototypeOf,
+} = Object;
 
 const harden = /** @type {import('ses').Harden & { isFake?: boolean }} */ (
   // eslint-disable-next-line no-undef
@@ -151,6 +157,41 @@ test('smallcaps unserialize errors', t => {
   const em3 = uns('#{"#error":"msg3","name":"Unknown"}');
   t.truthy(em3 instanceof Error);
   t.is(em3.message, 'msg3');
+});
+
+test('smallcaps unserialize extended errors', t => {
+  const { unserialize } = makeTestMarshal();
+  const uns = body => unserialize({ body, slots: [] });
+
+  // TODO cause, errors, and AggregateError will eventually be recognized.
+  // See https://github.com/endojs/endo/pull/2042
+
+  const refErr = uns(
+    '#{"#error":"msg","name":"ReferenceError","extraProp":"foo","cause":"bar","errors":["zip","zap"]}',
+  );
+  t.is(getPrototypeOf(refErr), ReferenceError.prototype); // direct instance of
+  t.false('extraProp' in refErr);
+  t.false('cause' in refErr);
+  t.false('errors' in refErr);
+  console.log('error with extra prop', refErr);
+
+  const aggErr = uns(
+    '#{"#error":"msg","name":"AggregateError","extraProp":"foo","cause":"bar","errors":["zip","zap"]}',
+  );
+  t.is(getPrototypeOf(aggErr), Error.prototype); // direct instance of
+  t.false('extraProp' in aggErr);
+  t.false('cause' in aggErr);
+  t.false('errors' in aggErr);
+  console.log('error with extra prop', aggErr);
+
+  const unkErr = uns(
+    '#{"#error":"msg","name":"UnknownError","extraProp":"foo","cause":"bar","errors":["zip","zap"]}',
+  );
+  t.is(getPrototypeOf(unkErr), Error.prototype); // direct instance of
+  t.false('extraProp' in unkErr);
+  t.false('cause' in unkErr);
+  t.false('errors' in unkErr);
+  console.log('error with extra prop', unkErr);
 });
 
 test('smallcaps mal-formed @qclass', t => {


### PR DESCRIPTION

closes: #XXXX
refs: #2042 #550 

## Description

To enable future versions of marshal to send extra error properties, like `cause` and `error`, marshal must tolerate receiving them.

Sets the stage for #2024 

### Security Considerations
by tolerating the reception of extra error props, we no longer inhibit senders from sending them, including misspelled or otherwise mistaken ones. This weaken the degree to which unmarshaling validates. This is the necessary price of accommodating expected future growth.

### Scaling Considerations
none
### Documentation Considerations
none
### Testing Considerations
tests included also serve as a baseline for #2042, which needs to change them in order to pass again. This provides a record of the difference between this PR and #2042.
### Compatibility Considerations
The whole point, is to accommodate an expected future in which some extra properties are sent, such as `cause` and `errors`.
### Upgrade Considerations

This change, to tolerate receiving extra properties, needs to roll out everywhere, before we can roll out a future change sending extra properties such as `cause` or `errors`. (#2042, though it is a future change that builds on this one, is not that future change because it still does not send any extra properties.)

This PR is not breaking. Nor is it combined with #2042. The future change where extra error properties are sent will not be a breaking change compared to code incorporating this PR (or this PR + #2042). However, that future change will be breaking compared to code prior to this PR.

No news update needed.

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
