### PR TITLE
fix(daemon): use naming convention "identifyLocal"

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -671,7 +671,7 @@ const makeEndoBootstrap = (
      * inspector for the value of the given pet name.
      */
     const lookup = async petName => {
-      const formulaIdentifier = petStore.lookup(petName);
+      const formulaIdentifier = petStore.identifyLocal(petName);
       if (formulaIdentifier === undefined) {
         throw new Error(`Unknown pet name ${petName}`);
       }

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -41,7 +41,7 @@ export const makeHostMaker = ({
     const {
       lookup,
       reverseLookup,
-      lookupFormulaIdentifierForName,
+      identifyLocal,
       listMessages,
       provideLookupFormula,
       followMessages,
@@ -75,7 +75,7 @@ export const makeHostMaker = ({
       /** @type {string | undefined} */
       let formulaIdentifier;
       if (petName !== undefined) {
-        formulaIdentifier = lookupFormulaIdentifierForName(petName);
+        formulaIdentifier = identifyLocal(petName);
       }
       if (formulaIdentifier === undefined) {
         /** @type {import('./types.js').GuestFormula} */
@@ -129,7 +129,7 @@ export const makeHostMaker = ({
       if (typeof workerName !== 'string') {
         throw new Error('worker name must be string');
       }
-      let workerFormulaIdentifier = lookupFormulaIdentifierForName(workerName);
+      let workerFormulaIdentifier = identifyLocal(workerName);
       if (workerFormulaIdentifier === undefined) {
         const workerId512 = await randomHex512();
         workerFormulaIdentifier = `worker-id512:${workerId512}`;
@@ -156,7 +156,7 @@ export const makeHostMaker = ({
         return `worker-id512:${workerId512}`;
       }
       assertPetName(workerName);
-      let workerFormulaIdentifier = lookupFormulaIdentifierForName(workerName);
+      let workerFormulaIdentifier = identifyLocal(workerName);
       if (workerFormulaIdentifier === undefined) {
         const workerId512 = await randomHex512();
         workerFormulaIdentifier = `worker-id512:${workerId512}`;
@@ -170,7 +170,7 @@ export const makeHostMaker = ({
      * @param {string | 'NONE' | 'SELF' | 'ENDO'} partyName
      */
     const providePowersFormulaIdentifier = async partyName => {
-      let guestFormulaIdentifier = lookupFormulaIdentifierForName(partyName);
+      let guestFormulaIdentifier = identifyLocal(partyName);
       if (guestFormulaIdentifier === undefined) {
         const guest = await provideGuest(partyName);
         guestFormulaIdentifier = formulaIdentifierForRef.get(guest);
@@ -216,9 +216,7 @@ export const makeHostMaker = ({
 
           const petNamePath = petNamePathFrom(petNameOrPath);
           if (petNamePath.length === 1) {
-            const formulaIdentifier = lookupFormulaIdentifierForName(
-              petNamePath[0],
-            );
+            const formulaIdentifier = identifyLocal(petNamePath[0]);
             if (formulaIdentifier === undefined) {
               throw new Error(`Unknown pet name ${q(petNamePath[0])}`);
             }
@@ -308,8 +306,7 @@ export const makeHostMaker = ({
         workerName,
       );
 
-      const bundleFormulaIdentifier =
-        lookupFormulaIdentifierForName(bundleName);
+      const bundleFormulaIdentifier = identifyLocal(bundleName);
       if (bundleFormulaIdentifier === undefined) {
         throw new TypeError(`Unknown pet name for bundle: ${bundleName}`);
       }
@@ -364,7 +361,7 @@ export const makeHostMaker = ({
       /** @type {string | undefined} */
       let formulaIdentifier;
       if (petName !== undefined) {
-        formulaIdentifier = lookupFormulaIdentifierForName(petName);
+        formulaIdentifier = identifyLocal(petName);
       }
       if (formulaIdentifier === undefined) {
         const id512 = await randomHex512();
@@ -393,8 +390,7 @@ export const makeHostMaker = ({
      * @param {string | 'NONE' | 'SELF' | 'ENDO'} powersName
      */
     const provideWebPage = async (webPageName, bundleName, powersName) => {
-      const bundleFormulaIdentifier =
-        lookupFormulaIdentifierForName(bundleName);
+      const bundleFormulaIdentifier = identifyLocal(bundleName);
       if (bundleFormulaIdentifier === undefined) {
         throw new Error(`Unknown pet name: ${q(bundleName)}`);
       }

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -35,8 +35,9 @@ export const makeMailboxMaker = ({
 
     /**
      * @param {string} petName
+     * @returns {string | undefined}
      */
-    const lookupFormulaIdentifierForName = petName => {
+    const identifyLocal = petName => {
       if (Object.hasOwn(specialNames, petName)) {
         return specialNames[petName];
       }
@@ -49,7 +50,7 @@ export const makeMailboxMaker = ({
      */
     const lookup = async (...petNamePath) => {
       const [headName, ...tailNames] = petNamePath;
-      const formulaIdentifier = lookupFormulaIdentifierForName(headName);
+      const formulaIdentifier = identifyLocal(headName);
       if (formulaIdentifier === undefined) {
         throw new TypeError(`Unknown pet name: ${q(headName)}`);
       }
@@ -61,7 +62,7 @@ export const makeMailboxMaker = ({
     };
 
     const terminate = async petName => {
-      const formulaIdentifier = lookupFormulaIdentifierForName(petName);
+      const formulaIdentifier = identifyLocal(petName);
       if (formulaIdentifier === undefined) {
         throw new TypeError(`Unknown pet name: ${q(petName)}`);
       }
@@ -113,7 +114,7 @@ export const makeMailboxMaker = ({
       // naming hub's formula identifier and the pet name path.
       // A "naming hub" is an objected with a variadic lookup method. At present,
       // the only such objects are guests and hosts.
-      const hubFormulaIdentifier = lookupFormulaIdentifierForName('SELF');
+      const hubFormulaIdentifier = identifyLocal('SELF');
       const digester = makeSha512();
       digester.updateText(`${hubFormulaIdentifier},${petNamePath.join(',')}`);
       const lookupFormulaNumber = digester.digestHex();
@@ -302,7 +303,7 @@ export const makeMailboxMaker = ({
       if (resolveRequest === undefined) {
         throw new Error(`No pending request for number ${messageNumber}`);
       }
-      const formulaIdentifier = lookupFormulaIdentifierForName(resolutionName);
+      const formulaIdentifier = identifyLocal(resolutionName);
       if (formulaIdentifier === undefined) {
         throw new TypeError(
           `No formula exists for the pet name ${q(resolutionName)}`,
@@ -357,8 +358,7 @@ export const makeMailboxMaker = ({
      * @param {Array<string>} petNames
      */
     const send = async (recipientName, strings, edgeNames, petNames) => {
-      const recipientFormulaIdentifier =
-        lookupFormulaIdentifierForName(recipientName);
+      const recipientFormulaIdentifier = identifyLocal(recipientName);
       if (recipientFormulaIdentifier === undefined) {
         throw new Error(`Unknown pet name for party: ${recipientName}`);
       }
@@ -390,7 +390,7 @@ export const makeMailboxMaker = ({
       }
 
       const formulaIdentifiers = petNames.map(petName => {
-        const formulaIdentifier = lookupFormulaIdentifierForName(petName);
+        const formulaIdentifier = identifyLocal(petName);
         if (formulaIdentifier === undefined) {
           throw new Error(`Unknown pet name ${q(petName)}`);
         }
@@ -469,8 +469,7 @@ export const makeMailboxMaker = ({
      * @param {string} responseName
      */
     const request = async (recipientName, what, responseName) => {
-      const recipientFormulaIdentifier =
-        lookupFormulaIdentifierForName(recipientName);
+      const recipientFormulaIdentifier = identifyLocal(recipientName);
       if (recipientFormulaIdentifier === undefined) {
         throw new Error(`Unknown pet name for party: ${recipientName}`);
       }
@@ -553,7 +552,7 @@ export const makeMailboxMaker = ({
       lookup,
       reverseLookup,
       reverseLookupFormulaIdentifier,
-      lookupFormulaIdentifierForName,
+      identifyLocal,
       provideLookupFormula,
       followMessages,
       listMessages,

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -40,7 +40,7 @@ export const makeMailboxMaker = ({
       if (Object.hasOwn(specialNames, petName)) {
         return specialNames[petName];
       }
-      return petStore.lookup(petName);
+      return petStore.identifyLocal(petName);
     };
 
     /**
@@ -263,7 +263,7 @@ export const makeMailboxMaker = ({
     ) => {
       if (responseName !== undefined) {
         /** @type {string | undefined} */
-        let formulaIdentifier = senderPetStore.lookup(responseName);
+        let formulaIdentifier = senderPetStore.identifyLocal(responseName);
         if (formulaIdentifier === undefined) {
           formulaIdentifier = await requestFormulaIdentifier(
             what,

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -67,11 +67,13 @@ export const makePetStoreMaker = (filePowers, locator) => {
       return petNames.has(petName);
     };
 
-    /** @param {string} petName */
-    const lookup = petName => {
+    /**
+     * @param {string} petName
+     * @returns {string | undefined}
+     */
+    const identifyLocal = petName => {
       assertValidName(petName);
-      const formulaIdentifier = petNames.get(petName);
-      return formulaIdentifier;
+      return petNames.get(petName);
     };
 
     /**
@@ -259,7 +261,7 @@ export const makePetStoreMaker = (filePowers, locator) => {
     /** @type {import('./types.js').PetStore} */
     const petStore = {
       has,
-      lookup,
+      identifyLocal,
       reverseLookup,
       list,
       follow,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -178,6 +178,7 @@ export interface Controller<External = unknown, Internal = unknown> {
 
 export interface PetStore {
   has(petName: string): boolean;
+  identifyLocal(petName: string): string | undefined;
   list(): Array<string>;
   follow(): Promise<FarRef<Reader<{ add: string } | { remove: string }>>>;
   listEntries(): Array<[string, FormulaIdentifierRecord]>;
@@ -191,7 +192,6 @@ export interface PetStore {
   write(petName: string, formulaIdentifier: string): Promise<void>;
   remove(petName: string);
   rename(fromPetName: string, toPetName: string);
-  lookup(petName: string): string | undefined;
   reverseLookup(formulaIdentifier: string): Array<string>;
 }
 


### PR DESCRIPTION
unify naming of methods in `petStore` and `mail` that synchronously return a `formulaIdentifier` for a non-path petname