### PR TITLE
Daemon: in host breakout makeHost/makeGuest from provideHost/provideGuest

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -645,7 +645,6 @@ const makeEndoBootstrap = (
     provideValueForFormula,
     provideValueForNumberedFormula,
     provideControllerForFormulaIdentifier,
-    formulaIdentifierForRef,
     storeReaderRef,
     randomHex512,
     makeSha512,


### PR DESCRIPTION
this helps remove an unnecessary dependency on `formulaIdentifierForRef` in host

(we are currently suspicious of the correctness of `formulaIdentifierForRef`)