### PR TITLE
chore(daemon): Add test:clean script

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -38,7 +38,8 @@
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",
     "lint:types": "tsc",
-    "test": "ava"
+    "test": "ava",
+    "test:clean": "rm -rf tmp && yarn test"
   },
   "dependencies": {
     "@endo/base64": "^1.0.1",


### PR DESCRIPTION
Adds a `test:clean` package script to `@endo/daemon`, which we should never, but nevertheless may, need.