### PR TITLE
feat(daemon): Add TCP net layer

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -179,13 +179,9 @@ export const makeHttpPowers = ({ http, ws }) => {
 /**
  * @param {object} modules
  * @param {typeof import('net')} modules.net
- * @param {typeof import('http')} modules.http
- * @param {typeof import('ws')} modules.ws
- * @returns {import('./types.js').NetworkPowers}
+ * @returns {import('./types.js').SocketPowers}
  */
-export const makeNetworkPowers = ({ http, ws, net }) => {
-  const { servePortHttp } = makeHttpPowers({ http, ws });
-
+export const makeSocketPowers = ({ net }) => {
   const serveListener = async (listen, cancelled) => {
     const [
       /** @type {Reader<import('./types.js').Connection>} */ readFrom,
@@ -259,6 +255,20 @@ export const makeNetworkPowers = ({ http, ws, net }) => {
         }),
       );
     }, cancelled);
+
+  return { servePort, servePath };
+};
+
+/**
+ * @param {object} modules
+ * @param {typeof import('net')} modules.net
+ * @param {typeof import('http')} modules.http
+ * @param {typeof import('ws')} modules.ws
+ * @returns {import('./types.js').NetworkPowers}
+ */
+export const makeNetworkPowers = ({ http, ws, net }) => {
+  const { servePortHttp } = makeHttpPowers({ http, ws });
+  const { servePort, servePath } = makeSocketPowers({ net });
 
   const connectionNumbers = (function* generateNumbers() {
     let n = 0;

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -215,7 +215,12 @@ export const makeSocketPowers = ({ net }) => {
       void writeTo.next({ reader, writer, closed });
     });
 
-    return readFrom;
+    const port = await listening;
+
+    return harden({
+      port,
+      connections: readFrom,
+    });
   };
 
   /**
@@ -228,7 +233,7 @@ export const makeSocketPowers = ({ net }) => {
     serveListener(
       server =>
         new Promise(resolve =>
-          server.listen(port, host, () => resolve(undefined)),
+          server.listen(port, host, () => resolve(server.address().port)),
         ),
       cancelled,
     );
@@ -238,8 +243,8 @@ export const makeSocketPowers = ({ net }) => {
    * @param {string} args.path
    * @param {Promise<never>} args.cancelled
    */
-  const servePath = async ({ path, cancelled }) =>
-    serveListener(server => {
+  const servePath = async ({ path, cancelled }) => {
+    const { connections } = await serveListener(server => {
       return new Promise((resolve, reject) =>
         server.listen({ path }, error => {
           if (error) {
@@ -255,6 +260,8 @@ export const makeSocketPowers = ({ net }) => {
         }),
       );
     }, cancelled);
+    return connections;
+  };
 
   return { servePort, servePath };
 };

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -223,12 +223,7 @@ export const makeSocketPowers = ({ net }) => {
     });
   };
 
-  /**
-   * @param {object} args
-   * @param {number} args.port
-   * @param {string} [args.host]
-   * @param {Promise<never>} args.cancelled
-   */
+  /** @type {import('./types.js').SocketPowers['servePort']} */
   const servePort = async ({ port, host = '0.0.0.0', cancelled }) =>
     serveListener(
       server =>
@@ -238,6 +233,7 @@ export const makeSocketPowers = ({ net }) => {
       cancelled,
     );
 
+  /** @type {import('./types.js').SocketPowers['connectPort']} */
   const connectPort = ({ port, host, cancelled }) =>
     new Promise((resolve, reject) => {
       const conn = net.connect(port, host, err => {
@@ -256,11 +252,7 @@ export const makeSocketPowers = ({ net }) => {
       });
     });
 
-  /**
-   * @param {object} args
-   * @param {string} args.path
-   * @param {Promise<never>} args.cancelled
-   */
+  /** @type {import('./types.js').SocketPowers['servePath']} */
   const servePath = async ({ path, cancelled }) => {
     const { connections } = await serveListener(server => {
       return new Promise((resolve, reject) =>

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -322,14 +322,21 @@ export type PetStorePowers = {
 };
 
 export type SocketPowers = {
-  servePath: (args: {
-    path: string;
-    host?: string;
-    cancelled: Promise<never>;
-  }) => Promise<AsyncIterableIterator<Connection>>;
   servePort: (args: {
     port: number;
     host?: string;
+    cancelled: Promise<never>;
+  }) => Promise<{
+    port: number;
+    connections: Reader<Connection>;
+  }>;
+  connectPort: (args: {
+    port: number;
+    host?: string;
+    cancelled: Promise<never>;
+  }) => Promise<Connection>;
+  servePath: (args: {
+    path: string;
     cancelled: Promise<never>;
   }) => Promise<AsyncIterableIterator<Connection>>;
 };

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -321,7 +321,7 @@ export type PetStorePowers = {
   ) => Promise<FarRef<PetStore>>;
 };
 
-export type NetworkPowers = {
+export type SocketPowers = {
   servePath: (args: {
     path: string;
     host?: string;
@@ -332,6 +332,9 @@ export type NetworkPowers = {
     host?: string;
     cancelled: Promise<never>;
   }) => Promise<AsyncIterableIterator<Connection>>;
+};
+
+export type NetworkPowers = SocketPowers & {
   servePortHttp: (args: {
     port: number;
     host?: string;


### PR DESCRIPTION
- breaks out `SocketPowers` from `NetworkPowers`
- adds `connectPort` for tcp net layer to be utilized later

Ref: https://github.com/endojs/endo/pull/1993