### PR TITLE
refactor(daemon): Remove numberless inspector formula

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -407,14 +407,9 @@ const makeEndoBootstrap = (
   ) => {
     const { type: formulaType, number: formulaNumber } =
       parseFormulaIdentifier(formulaIdentifier);
-    if (formulaIdentifier === 'pet-inspector') {
-      // Behold, unavoidable forward-reference:
-      // eslint-disable-next-line no-use-before-define
-      const external = makePetStoreInspector(`pet-store-id512:${zero512}`);
-      return { external, internal: undefined };
-    } else if (formulaIdentifier === 'host') {
+    if (formulaIdentifier === 'host') {
       const storeFormulaIdentifier = `pet-store-id512:${zero512}`;
-      const inspectorFormulaIdentifier = 'pet-inspector';
+      const inspectorFormulaIdentifier = `pet-inspector-id512:${zero512}`;
       const workerFormulaIdentifier = `worker-id512:${zero512}`;
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -4,7 +4,6 @@ const numberlessFormulasIdentifiers = new Set([
   'endo',
   'host',
   'least-authority',
-  'pet-inspector',
   'web-page-js',
 ]);
 

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -9,7 +9,7 @@ const { quote: q } = assert;
 
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:host|pet-inspector|(?:readable-blob-sha512|worker-id512|pet-store-id512|eval-id512|lookup-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
+  /^(?:host|(?:readable-blob-sha512|worker-id512|pet-store-id512|pet-inspector-id512|eval-id512|lookup-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers


### PR DESCRIPTION
Replaces the numberless `pet-inspector` formula with the id512-equivalent. The root inspector has the zero id. This can be replaced with a random number in the future.