### PR TITLE
refactor(daemon): Remove numberless host formula

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -586,7 +586,7 @@ export const makeDaemonicPersistencePowers = (
     ? {
         type: /** @type {'make-unconfined'} */ ('make-unconfined'),
         worker: `worker-id512:${zero512}`,
-        powers: 'host',
+        powers: `host-id512:${zero512}`,
         importPath: fileURLToPath(
           new URL('web-page-bundler.js', import.meta.url).href,
         ),

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -407,20 +407,7 @@ const makeEndoBootstrap = (
   ) => {
     const { type: formulaType, number: formulaNumber } =
       parseFormulaIdentifier(formulaIdentifier);
-    if (formulaIdentifier === 'host') {
-      const storeFormulaIdentifier = `pet-store-id512:${zero512}`;
-      const inspectorFormulaIdentifier = `pet-inspector-id512:${zero512}`;
-      const workerFormulaIdentifier = `worker-id512:${zero512}`;
-      // Behold, recursion:
-      // eslint-disable-next-line no-use-before-define
-      return makeIdentifiedHost(
-        formulaIdentifier,
-        storeFormulaIdentifier,
-        inspectorFormulaIdentifier,
-        workerFormulaIdentifier,
-        terminator,
-      );
-    } else if (formulaIdentifier === 'endo') {
+    if (formulaIdentifier === 'endo') {
       // TODO reframe "cancelled" as termination of the "endo" object and
       // ensure that all values ultimately depend on "endo".
       // Behold, self-referentiality:
@@ -462,6 +449,7 @@ const makeEndoBootstrap = (
       const storeFormulaIdentifier = `pet-store-id512:${formulaNumber}`;
       const inspectorFormulaIdentifier = `pet-inspector-id512:${formulaNumber}`;
       const workerFormulaIdentifier = `worker-id512:${formulaNumber}`;
+
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
       return makeIdentifiedHost(
@@ -768,7 +756,7 @@ const makeEndoBootstrap = (
       cancel(new Error('Termination requested'));
     },
 
-    host: () => provideValueForFormulaIdentifier('host'),
+    host: () => provideValueForFormulaIdentifier(`host-id512:${zero512}`),
 
     leastAuthority: () => leastAuthority,
 

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -2,7 +2,6 @@ const { quote: q } = assert;
 
 const numberlessFormulasIdentifiers = new Set([
   'endo',
-  'host',
   'least-authority',
   'web-page-js',
 ]);

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -9,7 +9,7 @@ const { quote: q } = assert;
 
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:host|(?:readable-blob-sha512|worker-id512|pet-store-id512|pet-inspector-id512|eval-id512|lookup-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
+  /^(?:(?:readable-blob-sha512|worker-id512|pet-store-id512|pet-inspector-id512|eval-id512|lookup-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers


### PR DESCRIPTION
Replaces the numberless `host` formula with the zero `host-id512` formula. Can be replaced with something random in the future.