### PR TITLE
refactor(daemon): Make least-authority formula numbered

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -413,7 +413,7 @@ const makeEndoBootstrap = (
       // Behold, self-referentiality:
       // eslint-disable-next-line no-use-before-define
       return { external: endoBootstrap, internal: undefined };
-    } else if (formulaIdentifier === 'least-authority') {
+    } else if (formulaType === 'least-authority-id512') {
       return { external: leastAuthority, internal: undefined };
     } else if (formulaIdentifier === 'web-page-js') {
       if (persistencePowers.webPageBundlerFormula === undefined) {
@@ -449,6 +449,7 @@ const makeEndoBootstrap = (
       const storeFormulaIdentifier = `pet-store-id512:${formulaNumber}`;
       const inspectorFormulaIdentifier = `pet-inspector-id512:${formulaNumber}`;
       const workerFormulaIdentifier = `worker-id512:${formulaNumber}`;
+      const leastAuthorityFormulaIdentifier = `least-authority-id512:${zero512}`;
 
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
@@ -457,6 +458,7 @@ const makeEndoBootstrap = (
         storeFormulaIdentifier,
         inspectorFormulaIdentifier,
         workerFormulaIdentifier,
+        leastAuthorityFormulaIdentifier,
         terminator,
       );
     } else if (

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -1,10 +1,6 @@
 const { quote: q } = assert;
 
-const numberlessFormulasIdentifiers = new Set([
-  'endo',
-  'least-authority',
-  'web-page-js',
-]);
+const numberlessFormulasIdentifiers = new Set(['endo', 'web-page-js']);
 
 /**
  * @param {string} formulaIdentifier

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -20,6 +20,7 @@ export const makeHostMaker = ({
    * @param {string} storeFormulaIdentifier
    * @param {string} inspectorFormulaIdentifier
    * @param {string} mainWorkerFormulaIdentifier
+   * @param {string} leastAuthorityFormulaIdentifier
    * @param {import('./types.js').Terminator} terminator
    */
   const makeIdentifiedHost = async (
@@ -27,6 +28,7 @@ export const makeHostMaker = ({
     storeFormulaIdentifier,
     inspectorFormulaIdentifier,
     mainWorkerFormulaIdentifier,
+    leastAuthorityFormulaIdentifier,
     terminator,
   ) => {
     terminator.thisDiesIfThatDies(storeFormulaIdentifier);
@@ -62,7 +64,7 @@ export const makeHostMaker = ({
       specialNames: {
         SELF: hostFormulaIdentifier,
         INFO: inspectorFormulaIdentifier,
-        NONE: 'least-authority',
+        NONE: leastAuthorityFormulaIdentifier,
         ENDO: 'endo',
       },
       terminator,


### PR DESCRIPTION
Converts the `least-authority` formula to a numbered, id512 equivalent. The formula number used will always be the zero id512, but this can be changed in the future.