### PR TITLE
refactor(daemon): Make web-page-js formula numbered

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -415,12 +415,15 @@ const makeEndoBootstrap = (
       return { external: endoBootstrap, internal: undefined };
     } else if (formulaType === 'least-authority-id512') {
       return { external: leastAuthority, internal: undefined };
-    } else if (formulaIdentifier === 'web-page-js') {
+    } else if (formulaType === 'web-page-js-id512') {
       if (persistencePowers.webPageBundlerFormula === undefined) {
-        throw Error('No web-page-js formula provided.');
+        throw Error('No web-page-js-id512 formula provided.');
+      }
+      if (formulaNumber !== zero512) {
+        throw Error('Invalid web-page-js-id512 formula number.');
       }
       return makeControllerForFormula(
-        'web-page-js',
+        formulaIdentifier,
         zero512,
         persistencePowers.webPageBundlerFormula,
         terminator,
@@ -762,7 +765,8 @@ const makeEndoBootstrap = (
 
     leastAuthority: () => leastAuthority,
 
-    webPageJs: () => provideValueForFormulaIdentifier('web-page-js'),
+    webPageJs: () =>
+      provideValueForFormulaIdentifier(`web-page-js-id512:${zero512}`),
 
     importAndEndowInWebPage: async (webPageP, webPageNumber) => {
       const { bundle: bundleBlob, powers: endowedPowers } =

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -1,6 +1,6 @@
 const { quote: q } = assert;
 
-const numberlessFormulasIdentifiers = new Set(['endo', 'web-page-js']);
+const numberlessFormulasIdentifiers = new Set(['endo']);
 
 /**
  * @param {string} formulaIdentifier

--- a/packages/daemon/src/web-page-bundler.js
+++ b/packages/daemon/src/web-page-bundler.js
@@ -2,7 +2,7 @@
 
 // This is a built-in unconfined plugin for lazily constructing the web-page.js
 // bundle for booting up web caplets.
-// The hard-coded 'web-page-js' formula is a hard-coded 'make-unconfined' formula
+// The hard-coded 'web-page-js-id512' formula is a hard-coded 'make-unconfined' formula
 // that runs this program in worker 0.
 // It does not accept its endowed powers.
 


### PR DESCRIPTION
Converts the `web-page-js` formula to a numbered, id512 equivalent. The formula number used will always be the zero id512, but this can be changed in the future.