### PR TITLE
refactor(daemon): Make endo formula numbered

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -407,7 +407,11 @@ const makeEndoBootstrap = (
   ) => {
     const { type: formulaType, number: formulaNumber } =
       parseFormulaIdentifier(formulaIdentifier);
-    if (formulaIdentifier === 'endo') {
+    if (formulaType === 'endo-id512') {
+      if (formulaNumber !== zero512) {
+        throw Error('Invalid endo-id512 formula number.');
+      }
+
       // TODO reframe "cancelled" as termination of the "endo" object and
       // ensure that all values ultimately depend on "endo".
       // Behold, self-referentiality:
@@ -449,6 +453,7 @@ const makeEndoBootstrap = (
       );
       return { external, internal: undefined };
     } else if (formulaType === 'host-id512') {
+      const endoFormulaIdentifier = `endo-id512:${zero512}`;
       const storeFormulaIdentifier = `pet-store-id512:${formulaNumber}`;
       const inspectorFormulaIdentifier = `pet-inspector-id512:${formulaNumber}`;
       const workerFormulaIdentifier = `worker-id512:${formulaNumber}`;
@@ -458,6 +463,7 @@ const makeEndoBootstrap = (
       // eslint-disable-next-line no-use-before-define
       return makeIdentifiedHost(
         formulaIdentifier,
+        endoFormulaIdentifier,
         storeFormulaIdentifier,
         inspectorFormulaIdentifier,
         workerFormulaIdentifier,

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -1,7 +1,5 @@
 const { quote: q } = assert;
 
-const numberlessFormulasIdentifiers = new Set(['endo']);
-
 /**
  * @param {string} formulaIdentifier
  * @returns {import("./types").FormulaIdentifierRecord}
@@ -9,14 +7,11 @@ const numberlessFormulasIdentifiers = new Set(['endo']);
 export const parseFormulaIdentifier = formulaIdentifier => {
   const delimiterIndex = formulaIdentifier.indexOf(':');
   if (delimiterIndex < 0) {
-    if (numberlessFormulasIdentifiers.has(formulaIdentifier)) {
-      return { type: formulaIdentifier, number: '' };
-    } else {
-      throw new TypeError(
-        `Formula identifier must have a colon: ${q(formulaIdentifier)}`,
-      );
-    }
+    throw new TypeError(
+      `Formula identifier must have a colon: ${q(formulaIdentifier)}`,
+    );
   }
+
   const type = formulaIdentifier.slice(0, delimiterIndex);
   const number = formulaIdentifier.slice(delimiterIndex + 1);
   return { type, number };

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -17,6 +17,7 @@ export const makeHostMaker = ({
 }) => {
   /**
    * @param {string} hostFormulaIdentifier
+   * @param {string} endoFormulaIdentifier
    * @param {string} storeFormulaIdentifier
    * @param {string} inspectorFormulaIdentifier
    * @param {string} mainWorkerFormulaIdentifier
@@ -25,6 +26,7 @@ export const makeHostMaker = ({
    */
   const makeIdentifiedHost = async (
     hostFormulaIdentifier,
+    endoFormulaIdentifier,
     storeFormulaIdentifier,
     inspectorFormulaIdentifier,
     mainWorkerFormulaIdentifier,
@@ -63,9 +65,9 @@ export const makeHostMaker = ({
       selfFormulaIdentifier: hostFormulaIdentifier,
       specialNames: {
         SELF: hostFormulaIdentifier,
+        ENDO: endoFormulaIdentifier,
         INFO: inspectorFormulaIdentifier,
         NONE: leastAuthorityFormulaIdentifier,
-        ENDO: 'endo',
       },
       terminator,
     });


### PR DESCRIPTION
Converts the `endo` formula to a numbered, id512 equivalent. The formula number used will always be the zero id512, but this can be changed in the future.