### PR TITLE
Daemon: Change unsafe import formula from path to specifier

### DIFF
--- a/packages/cli/src/commands/make.js
+++ b/packages/cli/src/commands/make.js
@@ -2,6 +2,7 @@
 
 import os from 'os';
 import path from 'path';
+import url from 'url';
 
 import bundleSource from '@endo/bundle-source';
 import { makeReaderRef } from '@endo/daemon';
@@ -65,7 +66,7 @@ export const makeCommand = async ({
       importPath !== undefined
         ? E(party).makeUnconfined(
             workerName,
-            path.resolve(importPath),
+            url.pathToFileURL(path.resolve(importPath)).href,
             powersName,
             resultName,
           )

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -587,9 +587,7 @@ export const makeDaemonicPersistencePowers = (
         type: /** @type {'make-unconfined'} */ ('make-unconfined'),
         worker: `worker-id512:${zero512}`,
         powers: `host-id512:${zero512}`,
-        importPath: fileURLToPath(
-          new URL('web-page-bundler.js', import.meta.url).href,
-        ),
+        specifier: new URL('web-page-bundler.js', import.meta.url).href,
       }
     : undefined;
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -251,13 +251,13 @@ const makeEndoBootstrap = (
   /**
    * @param {string} workerFormulaIdentifier
    * @param {string} guestFormulaIdentifier
-   * @param {string} importPath
+   * @param {string} specifier
    * @param {import('./types.js').Terminator} terminator
    */
   const makeControllerForUnconfinedPlugin = async (
     workerFormulaIdentifier,
     guestFormulaIdentifier,
-    importPath,
+    specifier,
     terminator,
   ) => {
     terminator.thisDiesIfThatDies(workerFormulaIdentifier);
@@ -279,7 +279,7 @@ const makeEndoBootstrap = (
       // eslint-disable-next-line no-use-before-define
       provideValueForFormulaIdentifier(guestFormulaIdentifier)
     );
-    const external = E(workerDaemonFacet).makeUnconfined(importPath, guestP);
+    const external = E(workerDaemonFacet).makeUnconfined(specifier, guestP);
     return { external, internal: undefined };
   };
 
@@ -352,7 +352,7 @@ const makeEndoBootstrap = (
       return makeControllerForUnconfinedPlugin(
         formula.worker,
         formula.powers,
-        formula.importPath,
+        formula.specifier,
         terminator,
       );
     } else if (formula.type === 'make-bundle') {

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -293,15 +293,10 @@ export const makeHostMaker = ({
       return value;
     };
 
-    /**
-     * @param {string | 'NEW' | 'MAIN'} workerName
-     * @param {string} importPath
-     * @param {string | 'NONE' | 'SELF' | 'ENDO'} powersName
-     * @param {string} resultName
-     */
+    /** @type {import('./types.js').EndoHost['makeUnconfined']} */
     const makeUnconfined = async (
       workerName,
-      importPath,
+      specifier,
       powersName,
       resultName,
     ) => {
@@ -318,7 +313,7 @@ export const makeHostMaker = ({
         type: 'make-unconfined',
         worker: workerFormulaIdentifier,
         powers: powersFormulaIdentifier,
-        importPath,
+        specifier,
       };
 
       // Behold, recursion:

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -46,7 +46,6 @@ export type HttpConnect = (
 ) => void;
 
 export type MignonicPowers = {
-  pathToFileURL: (path: string) => string;
   connection: {
     reader: Reader<Uint8Array>;
     writer: Writer<Uint8Array>;
@@ -91,7 +90,7 @@ type MakeUnconfinedFormula = {
   type: 'make-unconfined';
   worker: string;
   powers: string;
-  importPath: string;
+  specifier: string;
   // TODO formula slots
 };
 
@@ -260,9 +259,9 @@ export interface EndoHost {
     resultName?: string,
   );
   makeUnconfined(
-    workerPetName: string | undefined,
-    importPath: string,
-    powersName: string,
+    workerName: string | 'NEW' | 'MAIN',
+    specifier: string,
+    powersName: string | 'NONE' | 'SELF' | 'ENDO',
     resultName?: string,
   ): Promise<unknown>;
   makeBundle(

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -389,7 +389,8 @@ test('persist unconfined services and their requests', async t => {
     await E(host).makeWorker('w1');
     await E(host).provideGuest('o1');
     const servicePath = path.join(dirname, 'test', 'service.js');
-    await E(host).makeUnconfined('w1', servicePath, 'o1', 's1');
+    const serviceLocation = url.pathToFileURL(servicePath).href;
+    await E(host).makeUnconfined('w1', serviceLocation, 'o1', 's1');
 
     await E(host).makeWorker('w2');
     const answer = await E(host).evaluate(
@@ -579,7 +580,8 @@ test('direct termination', async t => {
   await E(host).provideWorker('worker');
 
   const counterPath = path.join(dirname, 'test', 'counter.js');
-  await E(host).makeUnconfined('worker', counterPath, 'NONE', 'counter');
+  const counterLocation = url.pathToFileURL(counterPath).href;
+  await E(host).makeUnconfined('worker', counterLocation, 'NONE', 'counter');
   t.is(
     1,
     await E(host).evaluate(
@@ -659,7 +661,8 @@ test('indirect termination', async t => {
   await E(host).provideWorker('worker');
 
   const counterPath = path.join(dirname, 'test', 'counter.js');
-  await E(host).makeUnconfined('worker', counterPath, 'SELF', 'counter');
+  const counterLocation = url.pathToFileURL(counterPath).href;
+  await E(host).makeUnconfined('worker', counterLocation, 'SELF', 'counter');
   t.is(
     1,
     await E(host).evaluate(
@@ -741,7 +744,8 @@ test('terminate because of requested capability', async t => {
   const messages = E(host).followMessages();
 
   const counterPath = path.join(dirname, 'test', 'counter-party.js');
-  E(host).makeUnconfined('worker', counterPath, 'guest', 'counter');
+  const counterLocation = url.pathToFileURL(counterPath).href;
+  E(host).makeUnconfined('worker', counterLocation, 'guest', 'counter');
 
   await E(host).evaluate('worker', '0', [], [], 'zero');
   await E(messages).next();


### PR DESCRIPTION
if we want to add backwards compat we can attempt to resolve the old path, but the attempt at backwards compat that was in the cherry-picked commit looked broken (didnt re-resolve)

update of https://github.com/endojs/endo/pull/1899