### PR TITLE
Daemon: List special names

### DIFF
--- a/packages/cli/src/commands/list.js
+++ b/packages/cli/src/commands/list.js
@@ -3,12 +3,16 @@ import os from 'os';
 import { E } from '@endo/far';
 import { withEndoHost } from '../context.js';
 
-export const list = async ({ directoryName }) =>
-  withEndoHost({ os, process }, async ({ party }) => {
+export const list = async ({ directoryName, special, all }) =>
+  withEndoHost({ os, process }, async ({ host: party }) => {
     if (directoryName !== undefined) {
       party = E(party).lookup(directoryName);
     }
-    const petNames = await E(party).list();
+    const petNames = await (() => {
+      if (all) return E(party).listAll();
+      if (special) return E(party).listSpecial();
+      return E(party).list();
+    })();
     for await (const petName of petNames) {
       console.log(petName);
     }

--- a/packages/cli/src/commands/list.js
+++ b/packages/cli/src/commands/list.js
@@ -1,10 +1,13 @@
 /* global process */
 import os from 'os';
 import { E } from '@endo/far';
-import { withEndoParty } from '../context.js';
+import { withEndoHost } from '../context.js';
 
-export const list = async ({ partyNames }) =>
-  withEndoParty(partyNames, { os, process }, async ({ party }) => {
+export const list = async ({ directoryName }) =>
+  withEndoHost({ os, process }, async ({ party }) => {
+    if (directoryName !== undefined) {
+      party = E(party).lookup(directoryName);
+    }
     const petNames = await E(party).list();
     for await (const petName of petNames) {
       console.log(petName);

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -255,10 +255,13 @@ export const main = async rawArgs => {
 
   program
     .command('list [directory]')
-    .description('show names')
-    .action(async directoryName => {
+    .description('show names known to the current or specified directory')
+    .option('-s,--special', 'show special names')
+    .option('--all', 'show all names')
+    .action(async (directoryName, cmd) => {
+      const { special, all } = cmd.opts();
       const { list } = await import('./commands/list.js');
-      return list({ directoryName });
+      return list({ directoryName, special, all });
     });
 
   program

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -254,13 +254,11 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('list')
-    .option(...commonOptions.as)
+    .command('list [directory]')
     .description('show names')
-    .action(async cmd => {
-      const { as: partyNames } = cmd.opts();
+    .action(async directoryName => {
       const { list } = await import('./commands/list.js');
-      return list({ partyNames });
+      return list({ directoryName });
     });
 
   program

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -59,6 +59,9 @@ export const makeGuestMaker = ({
       request,
       rename,
       remove,
+      list,
+      listSpecial,
+      listAll,
     } = makeMailbox({
       petStore,
       selfFormulaIdentifier: guestFormulaIdentifier,
@@ -69,13 +72,7 @@ export const makeGuestMaker = ({
       terminator,
     });
 
-    const {
-      has,
-      list,
-      follow: followNames,
-      listEntries,
-      followEntries,
-    } = petStore;
+    const { has, follow: followNames, listEntries, followEntries } = petStore;
 
     /** @type {import('@endo/eventual-send').ERef<import('./types.js').EndoGuest>} */
     const guest = Far('EndoGuest', {
@@ -85,6 +82,8 @@ export const makeGuestMaker = ({
       request,
       send,
       list,
+      listSpecial,
+      listAll,
       followNames,
       listMessages,
       followMessages,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -57,6 +57,9 @@ export const makeHostMaker = ({
       send,
       dismiss,
       adopt,
+      list,
+      listAll,
+      listSpecial,
       rename,
       remove,
       terminate,
@@ -486,13 +489,7 @@ export const makeHostMaker = ({
       return value;
     };
 
-    const {
-      has,
-      list,
-      follow: followNames,
-      listEntries,
-      followEntries,
-    } = petStore;
+    const { has, follow: followNames, listEntries, followEntries } = petStore;
 
     /** @type {import('./types.js').EndoHost} */
     const host = Far('EndoHost', {
@@ -508,6 +505,8 @@ export const makeHostMaker = ({
       request,
       send,
       list,
+      listSpecial,
+      listAll,
       followNames,
       listEntries,
       followEntries,

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -75,6 +75,13 @@ export const makeMailboxMaker = ({
       return controller.terminator.terminate();
     };
 
+    const list = () => harden(petStore.list());
+
+    const listSpecial = () => harden(Object.keys(specialNames).sort());
+
+    const listAll = () =>
+      harden([...Object.keys(specialNames).sort(), ...petStore.list()]);
+
     /**
      * @param {string} formulaIdentifier
      */
@@ -564,6 +571,9 @@ export const makeMailboxMaker = ({
       send,
       dismiss,
       adopt,
+      list,
+      listSpecial,
+      listAll,
       rename,
       remove,
       terminate,


### PR DESCRIPTION
Replaces https://github.com/endojs/endo/pull/1918

dropped shorthand flag for `--all` bc its already pretty short and didnt want to confuse with `--as`