### PR TITLE
fix(bundle-source): Export types properly

### DIFF
--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -284,7 +284,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
 
 /**
  * @param {string} dest
- * @param {{ format?: string, cacheOpts?: CacheOpts, cacheSourceMaps: boolean, dev?: boolean, log?: Logger }} options
+ * @param {{ format?: string, cacheOpts?: CacheOpts, cacheSourceMaps?: boolean, dev?: boolean, log?: Logger }} options
  * @param {(id: string) => Promise<any>} loadModule
  * @param {number} [pid]
  * @param {number} [nonce]

--- a/packages/bundle-source/src/bundle-source.js
+++ b/packages/bundle-source/src/bundle-source.js
@@ -2,8 +2,9 @@
 const DEFAULT_MODULE_FORMAT = 'endoZipBase64';
 const SUPPORTED_FORMATS = ['getExport', 'nestedEvaluate', 'endoZipBase64'];
 
-/** @type {import('./types').BundleSource} */
-// @ts-ignore cast
+/**
+ * @type {import('./types').BundleSourceGeneral}
+ */
 const bundleSource = async (
   startFilename,
   options = {},
@@ -13,8 +14,6 @@ const bundleSource = async (
   if (typeof options === 'string') {
     options = { format: options };
   }
-  /** @type {{ format: import('./types').ModuleFormat }} */
-  // @ts-expect-error cast (xxx params)
   const { format: moduleFormat = DEFAULT_MODULE_FORMAT } = options;
 
   switch (moduleFormat) {
@@ -52,4 +51,6 @@ const bundleSource = async (
   }
 };
 
-export default bundleSource;
+export default /** @satisfies {import('./types').BundleSource} */ (
+  bundleSource
+);

--- a/packages/bundle-source/src/nested-evaluate-and-get-exports.js
+++ b/packages/bundle-source/src/nested-evaluate-and-get-exports.js
@@ -30,10 +30,7 @@ function longestCommonPrefix(strings) {
 }
 
 /**
- * @template {'nestedEvaluate' | 'getExport'} T
- * @param {string} startFilename
- * @param {T} moduleFormat
- * @param {any} powers
+ * @type {import('./types').BundleSourceWithFormat}
  */
 export async function bundleNestedEvaluateAndGetExports(
   startFilename,
@@ -47,7 +44,7 @@ export async function bundleNestedEvaluateAndGetExports(
     pathResolve = path.resolve,
     pathToFileURL = url.pathToFileURL,
     externals = [],
-  } = powers || {};
+  } = /** @type {any} */ (powers || {});
   const resolvedPath = pathResolve(startFilename);
   const bundle = await rollup({
     input: resolvedPath,
@@ -160,6 +157,7 @@ ${sourceBundle[entrypoint]}
 return module.exports;
 }
 ${sourceMap}`;
+    // @ts-expect-error generic T not assignable to moduleFormat
     return harden({ moduleFormat, source, sourceMap });
   } else if (moduleFormat === 'nestedEvaluate') {
     sourceMap = `//# sourceURL=${DEFAULT_FILE_PREFIX}-preamble.js\n`;
@@ -284,6 +282,7 @@ function getExportWithNestedEvaluate(filePrefix) {
   return computeExports(entrypoint, { require: systemRequire, systemEval }, {});
 }
 ${sourceMap}`;
+    // @ts-expect-error generic T not assignable to moduleFormat
     return harden({ moduleFormat, source, sourceMap });
   }
 

--- a/packages/bundle-source/src/zip-base64.js
+++ b/packages/bundle-source/src/zip-base64.js
@@ -17,9 +17,12 @@ const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 const readPowers = makeReadPowers({ fs, url, crypto });
 
+/**
+ * @type {import('./types').BundleSourceWithOptions}
+ */
 export async function bundleZipBase64(
   startFilename,
-  options = {},
+  options,
   grantedPowers = {},
 ) {
   const { dev = false, cacheSourceMaps = false, commonDependencies } = options;


### PR DESCRIPTION

## Description

Using dynamic import in bundleSource made it possible to use `bundleSource` for one format and not entrain all the tooling for other formats, like Rollup for `getExport` and Babel for `endoZipBase64`. But, it broke the flow of type information. This change proposed by @michaelfig rectifies the internal and external types.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

This PR does not adequately test the exported type signature.
It would pair well with a change that relies on the exported types.

### Compatibility Considerations

None.

### Upgrade Considerations

None.

- ~~[ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.~~
- ~~[ ] Updates `NEWS.md` for user-facing changes.~~
