### PR TITLE
feat(ses): expect more properties to censor

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -384,6 +384,8 @@ const CommonMath = {
   irem: false,
   // See https://github.com/Moddable-OpenSource/moddable/issues/523
   mod: false,
+  // See https://github.com/Moddable-OpenSource/moddable/issues/523#issuecomment-1942904505
+  irandom: false,
 };
 
 export const permitted = {
@@ -445,6 +447,8 @@ export const permitted = {
     values: fn,
     // https://github.com/tc39/proposal-array-grouping
     groupBy: fn,
+    // Seen on QuickJS
+    __getClass: false,
   },
 
   '%ObjectPrototype%': {
@@ -491,6 +495,10 @@ export const permitted = {
     caller: false,
     // proposed but not yet std. To be removed if there
     arguments: false,
+    // Seen on QuickJS. TODO grab getter for use by console
+    fileName: false,
+    // Seen on QuickJS. TODO grab getter for use by console
+    lineNumber: false,
   },
 
   Boolean: {
@@ -530,6 +538,8 @@ export const permitted = {
     useSimple: false,
     // Seen at core-js https://github.com/zloirock/core-js#ecmascript-symbol
     useSetter: false,
+    // Seen on QuickJS
+    operatorSet: false,
   },
 
   '%SymbolPrototype%': {
@@ -640,6 +650,30 @@ export const permitted = {
     bitLength: false,
     // See https://github.com/Moddable-OpenSource/moddable/issues/523
     fromArrayBuffer: false,
+    // Seen on QuickJS
+    tdiv: false,
+    // Seen on QuickJS
+    fdiv: false,
+    // Seen on QuickJS
+    cdiv: false,
+    // Seen on QuickJS
+    ediv: false,
+    // Seen on QuickJS
+    tdivrem: false,
+    // Seen on QuickJS
+    fdivrem: false,
+    // Seen on QuickJS
+    cdivrem: false,
+    // Seen on QuickJS
+    edivrem: false,
+    // Seen on QuickJS
+    sqrt: false,
+    // Seen on QuickJS
+    sqrtrem: false,
+    // Seen on QuickJS
+    floorLog2: false,
+    // Seen on QuickJS
+    ctz: false,
   },
 
   '%BigIntPrototype%': {
@@ -808,6 +842,8 @@ export const permitted = {
     isWellFormed: fn,
     toWellFormed: fn,
     unicodeSets: fn,
+    // Seen on QuickJS
+    __quote: false,
   },
 
   '%StringIteratorPrototype%': {
@@ -1112,6 +1148,8 @@ export const permitted = {
     '[[Proto]]': '%FunctionPrototype%',
     prototype: '%SetPrototype%',
     '@@species': getter,
+    // Seen on QuickJS
+    groupBy: false,
   },
 
   '%SetPrototype%': {
@@ -1294,6 +1332,8 @@ export const permitted = {
     '@@toStringTag': 'string',
     // https://github.com/tc39/proposal-async-iterator-helpers
     toAsync: fn,
+    // See https://github.com/Moddable-OpenSource/moddable/issues/523#issuecomment-1942904505
+    '@@dispose': false,
   },
 
   // https://github.com/tc39/proposal-iterator-helpers
@@ -1336,6 +1376,8 @@ export const permitted = {
     every: fn,
     find: fn,
     '@@toStringTag': 'string',
+    // See https://github.com/Moddable-OpenSource/moddable/issues/523#issuecomment-1942904505
+    '@@asyncDispose': false,
   },
 
   // https://github.com/tc39/proposal-async-iterator-helpers


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Moddable-OpenSource/moddable/issues/523#issuecomment-1942904505

## Description

Initializing SES on XS reports additional non-standard properties to remove, beyond those previously mentioned by https://github.com/Moddable-OpenSource/moddable/issues/523 . Initializing SES on QuickJS reveals a different set of additional non-standard properties to remove. Without this PR, all these extra properties are still safely removed, but with a console warning because they were unexpected. This PR simply adds a `propertyName: false` for each of these to `permits.js` to record that we now expect them and do not need the warning.

### Security Considerations

The purpose of the warning is so that we, the SES developers, are alerted to surprising additions to the platform in case they raise the possibility of a dangerous change in semantics of the parts not removed. From the names of the additional XS properties, we can guess at their purpose and semantics well enough that they don't raise such alarms about the unremoved parts of the platform.

For the QuickJS properties, a few are more mysterious, in particular `__getClass` and `operatorSet`. However, we have not yet qualified the base QuickJS engine as being SES safe. These additional properties are not temporally new for us compared to a QuickJS baseline we've already understood without them. They are in the first version of QuickJS we've seriously examined. Nevertheless, they may indicate some novel semantics that we should worry about. This PR, by listed them as expected and suppressing the warning, also risks allowing us to become complacent rather than worrying.

Attn @raphdev @LuqiPan @ivanlei 

### Scaling Considerations
none
### Documentation Considerations
XS or QuickJS users may expect some of these properties. Indeed, once we understand what they do, we might judge them to be safe and eventually enable them in permits.js. But as of this PR we wish to continue removing all of them. Just silently. XS or QuickJS users should be able to find out about this surprise, and an explanation, from some of our documentation.
### Testing Considerations
none
### Compatibility Considerations
none
### Upgrade Considerations
none

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
