### PR TITLE
refactor(daemon): Despecify id512/sha512 in formula type

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -565,25 +565,20 @@ export const makeDaemonicPersistencePowers = (
 
   /**
    * @param {string} formulaType
-   * @param {string} formulaId512
+   * @param {string} formulaNumber
    */
-  const makeFormulaPath = (formulaType, formulaId512) => {
+  const makeFormulaPath = (formulaType, formulaNumber) => {
     const { statePath } = locator;
-    if (formulaId512.length < 3) {
+    if (formulaNumber.length < 3) {
       throw new TypeError(
-        `Invalid formula identifier ${q(formulaId512)} for formula of type ${q(
+        `Invalid formula identifier ${q(formulaNumber)} for formula of type ${q(
           formulaType,
         )}`,
       );
     }
-    const head = formulaId512.slice(0, 2);
-    const tail = formulaId512.slice(2);
-    const directory = filePowers.joinPath(
-      statePath,
-      'formulas',
-      formulaType,
-      head,
-    );
+    const head = formulaNumber.slice(0, 2);
+    const tail = formulaNumber.slice(2);
+    const directory = filePowers.joinPath(statePath, 'formulas', head);
     const file = filePowers.joinPath(directory, `${tail}.json`);
     return harden({ directory, file });
   };
@@ -612,8 +607,8 @@ export const makeDaemonicPersistencePowers = (
   };
 
   // Persist instructions for revival (this can be collected)
-  const writeFormula = async (formula, formulaType, formulaId512) => {
-    const { directory, file } = makeFormulaPath(formulaType, formulaId512);
+  const writeFormula = async (formula, formulaType, formulaNumber) => {
+    const { directory, file } = makeFormulaPath(formulaType, formulaNumber);
     // TODO Take care to write atomically with a rename here.
     await filePowers.makePath(directory);
     await filePowers.writeFileText(file, `${q(formula)}\n`);
@@ -657,19 +652,11 @@ export const makeDaemonicControlPowers = (
   const makeWorker = async (workerId, daemonWorkerFacet, cancelled) => {
     const { cachePath, statePath, ephemeralStatePath, sockPath } = locator;
 
-    const workerCachePath = filePowers.joinPath(
-      cachePath,
-      'worker-id512',
-      workerId,
-    );
-    const workerStatePath = filePowers.joinPath(
-      statePath,
-      'worker-id512',
-      workerId,
-    );
+    const workerCachePath = filePowers.joinPath(cachePath, 'worker', workerId);
+    const workerStatePath = filePowers.joinPath(statePath, 'worker', workerId);
     const workerEphemeralStatePath = filePowers.joinPath(
       ephemeralStatePath,
-      'worker-id512',
+      'worker',
       workerId,
     );
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -107,6 +107,7 @@ export const makeHostMaker = ({
       if (petName !== undefined) {
         formulaIdentifier = identifyLocal(petName);
       }
+
       if (formulaIdentifier === undefined) {
         /** @type {import('./types.js').GuestFormula} */
         const formula = {
@@ -116,19 +117,21 @@ export const makeHostMaker = ({
         const { value, formulaIdentifier: guestFormulaIdentifier } =
           // Behold, recursion:
           // eslint-disable-next-line no-use-before-define
-          await provideValueForFormula(formula, 'guest-id512');
+          await provideValueForFormula(formula, 'guest');
         if (petName !== undefined) {
           assertPetName(petName);
           await petStore.write(petName, guestFormulaIdentifier);
         }
+
         return { value, formulaIdentifier: guestFormulaIdentifier };
-      } else if (!formulaIdentifier.startsWith('guest-id512:')) {
+      } else if (!formulaIdentifier.startsWith('guest:')) {
         throw new Error(
           `Existing pet name does not designate a guest powers capability: ${q(
             petName,
           )}`,
         );
       }
+
       const newGuestController =
         /** @type {import('./types.js').Controller<>} */ (
           provideControllerForFormulaIdentifier(formulaIdentifier)
@@ -176,10 +179,10 @@ export const makeHostMaker = ({
       let workerFormulaIdentifier = identifyLocal(workerName);
       if (workerFormulaIdentifier === undefined) {
         const workerId512 = await randomHex512();
-        workerFormulaIdentifier = `worker-id512:${workerId512}`;
+        workerFormulaIdentifier = `worker:${workerId512}`;
         assertPetName(workerName);
         await petStore.write(workerName, workerFormulaIdentifier);
-      } else if (!workerFormulaIdentifier.startsWith('worker-id512:')) {
+      } else if (!workerFormulaIdentifier.startsWith('worker:')) {
         throw new Error(`Not a worker ${q(workerName)}`);
       }
       return /** @type {Promise<import('./types.js').EndoWorker>} */ (
@@ -197,13 +200,13 @@ export const makeHostMaker = ({
         return mainWorkerFormulaIdentifier;
       } else if (workerName === 'NEW') {
         const workerId512 = await randomHex512();
-        return `worker-id512:${workerId512}`;
+        return `worker:${workerId512}`;
       }
       assertPetName(workerName);
       let workerFormulaIdentifier = identifyLocal(workerName);
       if (workerFormulaIdentifier === undefined) {
         const workerId512 = await randomHex512();
-        workerFormulaIdentifier = `worker-id512:${workerId512}`;
+        workerFormulaIdentifier = `worker:${workerId512}`;
         assertPetName(workerName);
         await petStore.write(workerName, workerFormulaIdentifier);
       }
@@ -288,7 +291,7 @@ export const makeHostMaker = ({
       // eslint-disable-next-line no-use-before-define
       const { formulaIdentifier, value } = await provideValueForFormula(
         evalFormula,
-        'eval-id512',
+        'eval',
       );
       if (resultName !== undefined) {
         await petStore.write(resultName, formulaIdentifier);
@@ -323,7 +326,7 @@ export const makeHostMaker = ({
       // eslint-disable-next-line no-use-before-define
       const { formulaIdentifier, value } = await provideValueForFormula(
         formula,
-        'make-unconfined-id512',
+        'make-unconfined',
       );
       if (resultName !== undefined) {
         await petStore.write(resultName, formulaIdentifier);
@@ -368,7 +371,7 @@ export const makeHostMaker = ({
       // eslint-disable-next-line no-use-before-define
       const { value, formulaIdentifier } = await provideValueForFormula(
         formula,
-        'make-bundle-id512',
+        'make-bundle',
       );
 
       if (resultName !== undefined) {
@@ -383,7 +386,7 @@ export const makeHostMaker = ({
      */
     const makeWorker = async petName => {
       const workerId512 = await randomHex512();
-      const formulaIdentifier = `worker-id512:${workerId512}`;
+      const formulaIdentifier = `worker:${workerId512}`;
       if (petName !== undefined) {
         assertPetName(petName);
         await petStore.write(petName, formulaIdentifier);
@@ -408,12 +411,12 @@ export const makeHostMaker = ({
       }
       if (formulaIdentifier === undefined) {
         const id512 = await randomHex512();
-        formulaIdentifier = `host-id512:${id512}`;
+        formulaIdentifier = `host:${id512}`;
         if (petName !== undefined) {
           assertPetName(petName);
           await petStore.write(petName, formulaIdentifier);
         }
-      } else if (!formulaIdentifier.startsWith('host-id512:')) {
+      } else if (!formulaIdentifier.startsWith('host:')) {
         throw new Error(
           `Existing pet name does not designate a host powers capability: ${q(
             petName,

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -136,7 +136,7 @@ export const makeMailboxMaker = ({
       };
 
       return provideValueForNumberedFormula(
-        'lookup-id512',
+        'lookup',
         lookupFormulaNumber,
         lookupFormula,
       );

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -9,7 +9,7 @@ const { quote: q } = assert;
 
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:(?:readable-blob-sha512|worker-id512|pet-store-id512|pet-inspector-id512|eval-id512|lookup-id512|make-unconfined-id512|make-bundle-id512|host-id512|guest-id512):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
+  /^(?:(?:readable-blob|worker|pet-store|pet-inspector|eval|lookup|make-unconfined|make-bundle|host|guest):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers
@@ -287,7 +287,7 @@ export const makePetStoreMaker = (filePowers, locator) => {
     const suffix = id.slice(2);
     const petNameDirectoryPath = filePowers.joinPath(
       locator.statePath,
-      'pet-store-id512',
+      'pet-store',
       prefix,
       suffix,
     );

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -285,10 +285,10 @@ export type EndoInspector<Record = string> = {
 };
 
 export type KnownEndoInspectors = {
-  'eval-id512': EndoInspector<'endowments' | 'source' | 'worker'>;
-  'make-unconfined-id512': EndoInspector<'host'>;
-  'make-bundle-id512': EndoInspector<'bundle' | 'powers' | 'worker'>;
-  'guest-id512': EndoInspector<'bundle' | 'powers'>;
+  eval: EndoInspector<'endowments' | 'source' | 'worker'>;
+  'make-unconfined': EndoInspector<'host'>;
+  'make-bundle': EndoInspector<'bundle' | 'powers' | 'worker'>;
+  guest: EndoInspector<'bundle' | 'powers'>;
   'web-bundle': EndoInspector<'powers' | 'specifier' | 'worker'>;
   // This is an "empty" inspector, in that there is nothing to `lookup()` or `list()`.
   [formulaType: string]: EndoInspector<string>;
@@ -381,7 +381,7 @@ export type DaemonicPersistencePowers = {
   writeFormula: (
     formula: Formula,
     formulaType: string,
-    formulaId512: string,
+    formulaNumber: string,
   ) => Promise<void>;
   getWebPageBundlerFormula?: (
     workerFormulaIdentifier: string,

--- a/packages/daemon/src/web-page-bundler.js
+++ b/packages/daemon/src/web-page-bundler.js
@@ -2,8 +2,8 @@
 
 // This is a built-in unconfined plugin for lazily constructing the web-page.js
 // bundle for booting up web caplets.
-// The hard-coded 'web-page-js-id512' formula is a hard-coded 'make-unconfined' formula
-// that runs this program in worker 0.
+// The 'web-page-js' formula is a hard-coded 'make-unconfined' formula that runs
+// this program in worker 0.
 // It does not accept its endowed powers.
 
 import 'ses';

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -528,17 +528,21 @@ test('guest facet receives a message for host', async t => {
   const guest = E(host).provideGuest('guest');
   await E(host).provideWorker('worker');
   await E(host).evaluate('worker', '10', [], [], 'ten1');
+
   const iteratorRef = E(host).followMessages();
   E.sendOnly(guest).request('HOST', 'a number', 'number');
   const { value: message0 } = await E(iteratorRef).next();
   t.is(message0.number, 0);
   await E(host).resolve(message0.number, 'ten1');
+
   await E(guest).send('HOST', ['Hello, World!'], ['gift'], ['number']);
+
   const { value: message1 } = await E(iteratorRef).next();
   t.is(message1.number, 1);
   await E(host).adopt(message1.number, 'gift', 'ten2');
   const ten = await E(host).lookup('ten2');
   t.is(ten, 10);
+
   // Host should have received messages.
   const hostInbox = await E(host).listMessages();
   t.deepEqual(
@@ -548,6 +552,7 @@ test('guest facet receives a message for host', async t => {
       { type: 'package', who: 'guest', dest: 'SELF' },
     ],
   );
+
   // Guest should have own sent messages.
   const guestInbox = await E(guest).listMessages();
   t.deepEqual(


### PR DESCRIPTION
Removes the `-id512` and `-sha512` suffixes from all formula type strings. These were redundant since all formula numbers are of that format (except `web-bundle`, which we shall fix in the near future).