### PR TITLE
fix(cli): Improve log behavior when stopped

### DIFF
--- a/packages/cli/src/commands/log.js
+++ b/packages/cli/src/commands/log.js
@@ -46,12 +46,23 @@ export const log = async ({ follow, ping }) =>
       cancelled.catch(cancelFollower);
 
       (async () => {
-        const { getBootstrap } = await makeEndoClient(
+        const client = await makeEndoClient(
           'log-follower-probe',
           sockPath,
           followCancelled,
-        );
-        const bootstrap = await getBootstrap();
+        ).catch(error => {
+          console.error(`Endo offline: ${error.message}`);
+        });
+        if (client === undefined) {
+          return;
+        }
+        const { getBootstrap } = client;
+        const bootstrap = await getBootstrap().catch(error => {
+          console.error(`Endo offline: ${error.message}`);
+        });
+        if (bootstrap === undefined) {
+          return;
+        }
         for (;;) {
           await delay(logCheckIntervalMs, followCancelled);
           await E(bootstrap).ping();


### PR DESCRIPTION
Doing `endo log` when the daemon is stopped would previously provide unhelpful results. Now, the user is notified that the daemon is not running instead. `endo log -f` will not exit but wait for the daemon to start, then operate normally.