### PR TITLE
feat(cli,daemon): Make packages private

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@endo/cli",
   "version": "1.0.2",
+  "private": true,
   "description": "Endo command line interface",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@endo/daemon",
   "version": "1.0.2",
+  "private": true,
   "description": "Endo daemon",
   "keywords": [
     "endo",


### PR DESCRIPTION
Set `package.json['private']` to `true` to prevent accidentally publishing `@endo/daemon` and `@endo/cli`.