### PR TITLE
fix(daemon): Ensure guest store and worker formula numbers are unique

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -372,8 +372,10 @@ const makeEndoBootstrap = async (
         context,
       );
     } else if (formula.type === 'guest') {
-      const storeFormulaIdentifier = `pet-store:${formulaNumber}`;
-      const workerFormulaIdentifier = `worker:${formulaNumber}`;
+      const storeFormulaNumber = derive(formulaNumber, 'pet-store');
+      const storeFormulaIdentifier = `pet-store:${storeFormulaNumber}`;
+      const workerFormulaNumber = derive(formulaNumber, 'worker');
+      const workerFormulaIdentifier = `worker:${workerFormulaNumber}`;
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
       return makeIdentifiedGuestController(


### PR DESCRIPTION
When formula numbers were made unique, it appears we missed doing so for the guest pet store and worker. This PR ensures that they are derived in a manner similar to that of the host.