### PR TITLE
feat(daemon): store endo bootstrap and default host formulas

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -504,6 +504,12 @@ export const makeDaemonicPersistencePowers = (
     await Promise.all([statePathP, cachePathP, ephemeralStatePathP]);
   };
 
+  const isRootInitialized = async () => {
+    const noncePath = filePowers.joinPath(locator.statePath, 'nonce');
+    const nonce = await filePowers.maybeReadFileText(noncePath);
+    return nonce !== undefined;
+  };
+
   const provideRootNonce = async () => {
     const noncePath = filePowers.joinPath(locator.statePath, 'nonce');
     let nonce = await filePowers.maybeReadFileText(noncePath);
@@ -636,6 +642,7 @@ export const makeDaemonicPersistencePowers = (
   return harden({
     initializePersistence,
     provideRootNonce,
+    isRootInitialized,
     makeContentSha512Store,
     readFormula,
     writeFormula,

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -512,8 +512,7 @@ export const makeDaemonicPersistencePowers = (
       nonce = await cryptoPowers.randomHex512();
       await filePowers.writeFileText(noncePath, `${nonce}\n`);
     }
-    const rootNonce = nonce.trim();
-    return { value: rootNonce, isNewlyCreated };
+    return { rootNonce: nonce.trim(), isNewlyCreated };
   };
 
   const makeContentSha512Store = () => {

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -504,20 +504,16 @@ export const makeDaemonicPersistencePowers = (
     await Promise.all([statePathP, cachePathP, ephemeralStatePathP]);
   };
 
-  const isRootInitialized = async () => {
-    const noncePath = filePowers.joinPath(locator.statePath, 'nonce');
-    const nonce = await filePowers.maybeReadFileText(noncePath);
-    return nonce !== undefined;
-  };
-
   const provideRootNonce = async () => {
     const noncePath = filePowers.joinPath(locator.statePath, 'nonce');
     let nonce = await filePowers.maybeReadFileText(noncePath);
+    const isNewlyCreated = nonce === undefined;
     if (nonce === undefined) {
       nonce = await cryptoPowers.randomHex512();
       await filePowers.writeFileText(noncePath, `${nonce}\n`);
     }
-    return nonce.trim();
+    const rootNonce = nonce.trim();
+    return { value: rootNonce, isNewlyCreated };
   };
 
   const makeContentSha512Store = () => {
@@ -642,7 +638,6 @@ export const makeDaemonicPersistencePowers = (
   return harden({
     initializePersistence,
     provideRootNonce,
-    isRootInitialized,
     makeContentSha512Store,
     readFormula,
     writeFormula,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -763,6 +763,33 @@ const makeDaemonCore = async (
   };
 
   /**
+   * @param {string} workerFormulaIdentifier
+   * @param {string} source
+   * @param {string[]} codeNames
+   * @param {string[]} endowmentFormulaIdentifiers
+   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
+   */
+  const incarnateEval = async (
+    workerFormulaIdentifier,
+    source,
+    codeNames,
+    endowmentFormulaIdentifiers,
+  ) => {
+    const formulaNumber = await randomHex512();
+    /** @type {import('./types.js').EvalFormula} */
+    const formula = {
+      type: 'eval',
+      worker: workerFormulaIdentifier,
+      source,
+      names: codeNames,
+      values: endowmentFormulaIdentifiers,
+    };
+    return /** @type {Promise<{ formulaIdentifier: string, value: unknown }>} */ (
+      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+    );
+  };
+
+  /**
    * @param {string} powersFormulaIdentifier
    * @param {string} workerFormulaIdentifier
    * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
@@ -830,6 +857,7 @@ const makeDaemonCore = async (
     provideControllerForFormulaIdentifier,
     incarnateHost,
     incarnateGuest,
+    incarnateEval,
     incarnateHandle,
     storeReaderRef,
     randomHex512,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -68,11 +68,26 @@ const makeDaemonCore = async (
   const { randomHex512 } = cryptoPowers;
   const contentStore = persistencePowers.makeContentSha512Store();
 
-  /** @type {Map<string, import('./types.js').Controller<>>} */
+  /**
+   * The two functions "provideValueForNumberedFormula" and "provideValueForFormulaIdentifier"
+   * share a responsibility for maintaining the memoization tables
+   * "controllerForFormulaIdentifier" and "formulaIdentifierForRef".
+   * "provideValueForNumberedFormula" is used for incarnating and persisting
+   * new formulas, whereas "provideValueForFormulaIdentifier" is used for
+   * reincarnating stored formulas.
+   */
+
+  /**
+   * Reverse look-up, for answering "what is my name for this near or far
+   * reference", and not for "what is my name for this promise".
+   * @type {Map<string, import('./types.js').Controller>}
+   */
   const controllerForFormulaIdentifier = new Map();
-  // Reverse look-up, for answering "what is my name for this near or far
-  // reference", and not for "what is my name for this promise".
-  /** @type {WeakMap<object, string>} */
+  /**
+   * Reverse look-up, for answering "what is my name for this near or far
+   * reference", and not for "what is my name for this promise".
+   * @type {WeakMap<object, string>}
+   */
   const formulaIdentifierForRef = new WeakMap();
   const getFormulaIdentifierForRef = ref => formulaIdentifierForRef.get(ref);
 
@@ -525,10 +540,6 @@ const makeDaemonCore = async (
     }
   };
 
-  // The two functions provideValueForFormula and provideValueForFormulaIdentifier
-  // share a responsibility for maintaining the memoization tables
-  // controllerForFormulaIdentifier and formulaIdentifierForRef, since the
-  // former bypasses the latter in order to avoid a round trip with disk.
   /** @type {import('./types.js').ProvideValueForNumberedFormula} */
   const provideValueForNumberedFormula = async (
     formulaType,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -674,7 +674,7 @@ const makeDaemonCore = async (
 
   /**
    * @param {string} targetFormulaIdentifier
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').Handle }>}
+   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').ExternalHandle }>}
    */
   const incarnateHandle = async targetFormulaIdentifier => {
     const formulaNumber = await randomHex512();
@@ -683,7 +683,7 @@ const makeDaemonCore = async (
       type: 'handle',
       target: targetFormulaIdentifier,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').Handle }>} */ (
+    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').ExternalHandle }>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
@@ -1178,8 +1178,7 @@ const provideEndoBootstrap = async (
     gracePeriodElapsed,
   });
 
-  // Reading root nonce before isRootInitialized will cause isRootInitialized to be true.
-  const { value: endoFormulaNumber, isNewlyCreated } =
+  const { rootNonce: endoFormulaNumber, isNewlyCreated } =
     await persistencePowers.provideRootNonce();
   const isInitialized = !isNewlyCreated;
   if (isInitialized) {

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -852,6 +852,28 @@ const makeDaemonCore = async (
   };
 
   /**
+   * @param {string} powersFormulaIdentifier
+   * @param {string} workerFormulaIdentifier
+   * @param {string} bundleFormulaIdentifier
+   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
+   */
+  const incarnateBundle = async (
+    powersFormulaIdentifier,
+    workerFormulaIdentifier,
+    bundleFormulaIdentifier,
+  ) => {
+    const formulaNumber = await randomHex512();
+    /** @type {import('./types.js').MakeBundleFormula} */
+    const formula = {
+      type: 'make-bundle',
+      worker: workerFormulaIdentifier,
+      powers: powersFormulaIdentifier,
+      bundle: bundleFormulaIdentifier,
+    };
+    return provideValueForNumberedFormula(formula.type, formulaNumber, formula);
+  };
+
+  /**
    * @param {string} [specifiedFormulaNumber]
    * @returns {Promise<{ formulaIdentifier: string, value: import('./types').EndoBootstrap }>}
    */
@@ -901,6 +923,7 @@ const makeDaemonCore = async (
     incarnateGuest,
     incarnateEval,
     incarnateUnconfined,
+    incarnateBundle,
     incarnateHandle,
     storeReaderRef,
     randomHex512,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -727,6 +727,22 @@ const makeDaemonCore = async (
   };
 
   /**
+   * @param {string} hostHandleFormulaIdentifier
+   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').EndoGuest }>}
+   */
+  const incarnateGuest = async hostHandleFormulaIdentifier => {
+    const formulaNumber = await randomHex512();
+    /** @type {import('./types.js').GuestFormula} */
+    const formula = {
+      type: 'guest',
+      host: hostHandleFormulaIdentifier,
+    };
+    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').EndoGuest }>} */ (
+      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+    );
+  };
+
+  /**
    * @param {string} powersFormulaIdentifier
    * @param {string} workerFormulaIdentifier
    * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
@@ -792,6 +808,7 @@ const makeDaemonCore = async (
     provideValueForNumberedFormula,
     provideControllerForFormulaIdentifier,
     incarnateHost,
+    incarnateGuest,
     incarnateHandle,
     storeReaderRef,
     randomHex512,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -864,8 +864,8 @@ const makeDaemonCore = async (
     }
     const formulaNumber = await randomHex512();
     const formula = persistencePowers.getWebPageBundlerFormula(
-      powersFormulaIdentifier,
       workerFormulaIdentifier,
+      powersFormulaIdentifier,
     );
     return provideValueForNumberedFormula(formula.type, formulaNumber, formula);
   };

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -405,7 +405,7 @@ const makeDaemonCore = async (
         },
       };
     } else if (formula.type === 'endo') {
-      /** @type {import('./types.js').EndoBootstrap} */
+      /** @type {import('./types.js').FarEndoBootstrap} */
       const endoBootstrap = Far('Endo private facet', {
         // TODO for user named
         ping: async () => 'pong',
@@ -927,7 +927,7 @@ const makeDaemonCore = async (
 
   /**
    * @param {string} [specifiedFormulaNumber]
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').EndoBootstrap }>}
+   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').FarEndoBootstrap }>}
    */
   const incarnateEndoBootstrap = async specifiedFormulaNumber => {
     const formulaNumber = specifiedFormulaNumber || (await randomHex512());
@@ -962,7 +962,7 @@ const makeDaemonCore = async (
       leastAuthority: leastAuthorityFormulaIdentifier,
       webPageJs: webPageJsFormulaIdentifier,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').EndoBootstrap }>} */ (
+    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').FarEndoBootstrap }>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
@@ -1151,7 +1151,7 @@ const makeDaemonCore = async (
  * @param {(error: Error) => void} args.cancel
  * @param {number} args.gracePeriodMs
  * @param {Promise<never>} args.gracePeriodElapsed
- * @returns {Promise<import('./types.js').EndoBootstrap>}
+ * @returns {Promise<import('./types.js').FarEndoBootstrap>}
  */
 const provideEndoBootstrap = async (
   powers,
@@ -1173,7 +1173,7 @@ const provideEndoBootstrap = async (
   const isInitialized = !isNewlyCreated;
   if (isInitialized) {
     const endoFormulaIdentifier = `endo:${endoFormulaNumber}`;
-    return /** @type {Promise<import('./types.js').EndoBootstrap>} */ (
+    return /** @type {Promise<import('./types.js').FarEndoBootstrap>} */ (
       daemonCore.provideValueForFormulaIdentifier(endoFormulaIdentifier)
     );
   } else {

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1167,9 +1167,10 @@ const provideEndoBootstrap = async (
     gracePeriodElapsed,
   });
 
-  const isInitialized = await persistencePowers.isRootInitialized();
   // Reading root nonce before isRootInitialized will cause isRootInitialized to be true.
-  const endoFormulaNumber = await persistencePowers.provideRootNonce();
+  const { value: endoFormulaNumber, isNewlyCreated } =
+    await persistencePowers.provideRootNonce();
+  const isInitialized = !isNewlyCreated;
   if (isInitialized) {
     const endoFormulaIdentifier = `endo:${endoFormulaNumber}`;
     return /** @type {Promise<import('./types.js').EndoBootstrap>} */ (

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -584,15 +584,6 @@ const makeDaemonCore = async (
     });
   };
 
-  /**
-   * @param {import('./types.js').Formula} formula
-   * @param {string} formulaType
-   */
-  const provideValueForFormula = async (formula, formulaType) => {
-    const formulaNumber = await randomHex512();
-    return provideValueForNumberedFormula(formulaType, formulaNumber, formula);
-  };
-
   /** @type {import('./types.js').ProvideControllerForFormulaIdentifier} */
   const provideControllerForFormulaIdentifier = formulaIdentifier => {
     const { type: formulaType, number: formulaNumber } =
@@ -874,6 +865,25 @@ const makeDaemonCore = async (
   };
 
   /**
+   * @param {string} powersFormulaIdentifier
+   * @param {string} bundleFormulaIdentifier
+   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
+   */
+  const incarnateWebBundle = async (
+    powersFormulaIdentifier,
+    bundleFormulaIdentifier,
+  ) => {
+    const formulaNumber = await randomHex512();
+    /** @type {import('./types.js').WebBundleFormula} */
+    const formula = {
+      type: 'web-bundle',
+      powers: powersFormulaIdentifier,
+      bundle: bundleFormulaIdentifier,
+    };
+    return provideValueForNumberedFormula(formula.type, formulaNumber, formula);
+  };
+
+  /**
    * @param {string} [specifiedFormulaNumber]
    * @returns {Promise<{ formulaIdentifier: string, value: import('./types').EndoBootstrap }>}
    */
@@ -916,18 +926,16 @@ const makeDaemonCore = async (
 
   const makeIdentifiedHost = makeHostMaker({
     provideValueForFormulaIdentifier,
-    provideValueForFormula,
-    provideValueForNumberedFormula,
     provideControllerForFormulaIdentifier,
     incarnateHost,
     incarnateGuest,
     incarnateEval,
     incarnateUnconfined,
     incarnateBundle,
+    incarnateWebBundle,
     incarnateHandle,
     storeReaderRef,
     randomHex512,
-    makeSha512,
     makeMailbox,
   });
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -912,7 +912,8 @@ const makeDaemonCore = async (
     powersFormulaIdentifier,
     bundleFormulaIdentifier,
   ) => {
-    const formulaNumber = await randomHex512();
+    // TODO use regular-length (512-bit) formula numbers for web bundles
+    const formulaNumber = (await randomHex512()).slice(32, 64);
     /** @type {import('./types.js').WebBundleFormula} */
     const formula = {
       type: 'web-bundle',

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -792,6 +792,30 @@ const makeDaemonCore = async (
   };
 
   /**
+   * @param {string} workerFormulaIdentifier
+   * @param {string} powersFormulaIdentifiers
+   * @param {string} specifier
+   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
+   */
+  const incarnateUnconfined = async (
+    workerFormulaIdentifier,
+    powersFormulaIdentifiers,
+    specifier,
+  ) => {
+    const formulaNumber = await randomHex512();
+    /** @type {import('./types.js').MakeUnconfinedFormula} */
+    const formula = {
+      type: 'make-unconfined',
+      worker: workerFormulaIdentifier,
+      powers: powersFormulaIdentifiers,
+      specifier,
+    };
+    return /** @type {Promise<{ formulaIdentifier: string, value: unknown }>} */ (
+      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+    );
+  };
+
+  /**
    * @param {string} contentSha512
    * @returns {Promise<{ formulaIdentifier: string, value: import('./types.js').FarEndoReadable }>}
    */
@@ -876,6 +900,7 @@ const makeDaemonCore = async (
     incarnateHost,
     incarnateGuest,
     incarnateEval,
+    incarnateUnconfined,
     incarnateHandle,
     storeReaderRef,
     randomHex512,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1125,8 +1125,20 @@ const makeDaemonCore = async (
   const daemonCore = {
     provideValueForFormulaIdentifier,
     incarnateEndoBootstrap,
+    incarnateLeastAuthority,
+    incarnateHandle,
+    incarnatePetStore,
+    incarnateWorker,
     incarnateHost,
+    incarnateGuest,
+    incarnateEval,
+    incarnateLookup,
+    incarnateUnconfined,
+    incarnateReadableBlob,
     incarnateBundler,
+    incarnateBundle,
+    incarnateWebBundle,
+    incarnatePetInspector,
   };
   return daemonCore;
 };

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -4,40 +4,36 @@ import { Far } from '@endo/far';
 
 export const makeGuestMaker = ({
   provideValueForFormulaIdentifier,
-  provideControllerForFormulaIdentifier,
+  provideControllerForFormulaIdentifierAndResolveHandle,
   makeMailbox,
 }) => {
   /**
    * @param {string} guestFormulaIdentifier
-   * @param {string} hostFormulaIdentifier
+   * @param {string} hostHandleFormulaIdentifier
    * @param {string} petStoreFormulaIdentifier
    * @param {string} mainWorkerFormulaIdentifier
    * @param {import('./types.js').Context} context
    */
   const makeIdentifiedGuestController = async (
     guestFormulaIdentifier,
-    hostFormulaIdentifier,
+    hostHandleFormulaIdentifier,
     petStoreFormulaIdentifier,
     mainWorkerFormulaIdentifier,
     context,
   ) => {
-    context.thisDiesIfThatDies(hostFormulaIdentifier);
+    context.thisDiesIfThatDies(hostHandleFormulaIdentifier);
     context.thisDiesIfThatDies(petStoreFormulaIdentifier);
     context.thisDiesIfThatDies(mainWorkerFormulaIdentifier);
 
     const petStore = /** @type {import('./types.js').PetStore} */ (
       await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
     );
-    const hostController = /** @type {import('./types.js').Controller<>} */ (
-      await provideControllerForFormulaIdentifier(hostFormulaIdentifier)
-    );
-    const hostPrivateFacet = await hostController.internal;
-    if (hostPrivateFacet === undefined) {
-      throw new Error(
-        `panic: a host request function must exist for every host`,
+    const hostController =
+      await provideControllerForFormulaIdentifierAndResolveHandle(
+        hostHandleFormulaIdentifier,
       );
-    }
-    const { respond: deliverToHost } = hostPrivateFacet;
+    const hostPrivateFacet = await hostController.internal;
+    const { respond: deliverToHost } = /** @type {any} */ (hostPrivateFacet);
     if (deliverToHost === undefined) {
       throw new Error(
         `panic: a host request function must exist for every host`,
@@ -67,7 +63,7 @@ export const makeGuestMaker = ({
       selfFormulaIdentifier: guestFormulaIdentifier,
       specialNames: {
         SELF: guestFormulaIdentifier,
-        HOST: hostFormulaIdentifier,
+        HOST: hostHandleFormulaIdentifier,
       },
       context,
     });

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -33,7 +33,7 @@ export const makeGuestMaker = ({
         hostHandleFormulaIdentifier,
       );
     const hostPrivateFacet = await hostController.internal;
-    const { respond: deliverToHost } = /** @type {any} */ (hostPrivateFacet);
+    const { respond: deliverToHost } = hostPrivateFacet;
     if (deliverToHost === undefined) {
       throw new Error(
         `panic: a host request function must exist for every host`,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -81,7 +81,7 @@ export const makeHostMaker = ({
     });
 
     /**
-     * @returns {Promise<{ formulaIdentifier: string, value: import('./types').Handle }>}
+     * @returns {Promise<{ formulaIdentifier: string, value: import('./types').ExternalHandle }>}
      */
     const makeNewHandleForSelf = () => {
       return incarnateHandle(hostFormulaIdentifier);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -13,6 +13,7 @@ export const makeHostMaker = ({
   incarnateHost,
   incarnateGuest,
   incarnateEval,
+  incarnateUnconfined,
   incarnateHandle,
   storeReaderRef,
   makeSha512,
@@ -315,19 +316,12 @@ export const makeHostMaker = ({
         powersName,
       );
 
-      const formula = {
-        /** @type {'make-unconfined'} */
-        type: 'make-unconfined',
-        worker: workerFormulaIdentifier,
-        powers: powersFormulaIdentifier,
-        specifier,
-      };
-
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      const { formulaIdentifier, value } = await provideValueForFormula(
-        formula,
-        'make-unconfined',
+      const { formulaIdentifier, value } = await incarnateUnconfined(
+        workerFormulaIdentifier,
+        powersFormulaIdentifier,
+        specifier,
       );
       if (resultName !== undefined) {
         await petStore.write(resultName, formulaIdentifier);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -7,17 +7,15 @@ const { quote: q } = assert;
 
 export const makeHostMaker = ({
   provideValueForFormulaIdentifier,
-  provideValueForFormula,
-  provideValueForNumberedFormula,
   provideControllerForFormulaIdentifier,
   incarnateHost,
   incarnateGuest,
   incarnateEval,
   incarnateUnconfined,
   incarnateBundle,
+  incarnateWebBundle,
   incarnateHandle,
   storeReaderRef,
-  makeSha512,
   randomHex512,
   makeMailbox,
 }) => {
@@ -452,24 +450,10 @@ export const makeHostMaker = ({
         powersName,
       );
 
-      const digester = makeSha512();
-      digester.updateText(
-        `${bundleFormulaIdentifier},${powersFormulaIdentifier}`,
-      );
-      const formulaNumber = digester.digestHex().slice(32, 64);
-
-      const formula = {
-        type: 'web-bundle',
-        bundle: bundleFormulaIdentifier,
-        powers: powersFormulaIdentifier,
-      };
-
       // Behold, recursion:
-      // eslint-disable-next-line no-use-before-define
-      const { value, formulaIdentifier } = await provideValueForNumberedFormula(
-        'web-bundle',
-        formulaNumber,
-        formula,
+      const { value, formulaIdentifier } = await incarnateWebBundle(
+        powersFormulaIdentifier,
+        bundleFormulaIdentifier,
       );
 
       if (webPageName !== undefined) {

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -11,6 +11,7 @@ export const makeHostMaker = ({
   provideValueForNumberedFormula,
   provideControllerForFormulaIdentifier,
   incarnateHost,
+  incarnateHandle,
   storeReaderRef,
   makeSha512,
   randomHex512,
@@ -77,6 +78,13 @@ export const makeHostMaker = ({
     });
 
     /**
+     * @returns {Promise<{ formulaIdentifier: string, value: import('./types').Handle }>}
+     */
+    const makeNewHandleForSelf = () => {
+      return incarnateHandle(hostFormulaIdentifier);
+    };
+
+    /**
      * @param {import('./types.js').Controller} newController
      * @param {Record<string,string>} introducedNames
      * @returns {Promise<void>}
@@ -110,10 +118,12 @@ export const makeHostMaker = ({
       }
 
       if (formulaIdentifier === undefined) {
+        const { formulaIdentifier: hostHandleFormulaIdentifier } =
+          await makeNewHandleForSelf();
         /** @type {import('./types.js').GuestFormula} */
         const formula = {
-          type: /* @type {'guest'} */ 'guest',
-          host: hostFormulaIdentifier,
+          type: 'guest',
+          host: hostHandleFormulaIdentifier,
         };
         const { value, formulaIdentifier: guestFormulaIdentifier } =
           // Behold, recursion:

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -14,6 +14,7 @@ export const makeHostMaker = ({
   incarnateGuest,
   incarnateEval,
   incarnateUnconfined,
+  incarnateBundle,
   incarnateHandle,
   storeReaderRef,
   makeSha512,
@@ -354,19 +355,12 @@ export const makeHostMaker = ({
         powersName,
       );
 
-      const formula = {
-        /** @type {'make-bundle'} */
-        type: 'make-bundle',
-        worker: workerFormulaIdentifier,
-        powers: powersFormulaIdentifier,
-        bundle: bundleFormulaIdentifier,
-      };
-
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      const { value, formulaIdentifier } = await provideValueForFormula(
-        formula,
-        'make-bundle',
+      const { value, formulaIdentifier } = await incarnateBundle(
+        powersFormulaIdentifier,
+        workerFormulaIdentifier,
+        bundleFormulaIdentifier,
       );
 
       if (resultName !== undefined) {

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -12,6 +12,7 @@ export const makeHostMaker = ({
   provideControllerForFormulaIdentifier,
   incarnateHost,
   incarnateGuest,
+  incarnateEval,
   incarnateHandle,
   storeReaderRef,
   makeSha512,
@@ -264,7 +265,7 @@ export const makeHostMaker = ({
         throw new Error('Evaluator requires one pet name for each code name');
       }
 
-      const formulaIdentifiers = await Promise.all(
+      const endowmentFormulaIdentifiers = await Promise.all(
         petNamePaths.map(async (petNameOrPath, index) => {
           if (typeof codeNames[index] !== 'string') {
             throw new Error(`Invalid endowment name: ${q(codeNames[index])}`);
@@ -285,20 +286,13 @@ export const makeHostMaker = ({
         }),
       );
 
-      const evalFormula = {
-        /** @type {'eval'} */
-        type: 'eval',
-        worker: workerFormulaIdentifier,
-        source,
-        names: codeNames,
-        values: formulaIdentifiers,
-      };
-
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      const { formulaIdentifier, value } = await provideValueForFormula(
-        evalFormula,
-        'eval',
+      const { formulaIdentifier, value } = await incarnateEval(
+        workerFormulaIdentifier,
+        source,
+        codeNames,
+        endowmentFormulaIdentifiers,
       );
       if (resultName !== undefined) {
         await petStore.write(resultName, formulaIdentifier);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -11,6 +11,7 @@ export const makeHostMaker = ({
   provideValueForNumberedFormula,
   provideControllerForFormulaIdentifier,
   incarnateHost,
+  incarnateGuest,
   incarnateHandle,
   storeReaderRef,
   makeSha512,
@@ -120,15 +121,10 @@ export const makeHostMaker = ({
       if (formulaIdentifier === undefined) {
         const { formulaIdentifier: hostHandleFormulaIdentifier } =
           await makeNewHandleForSelf();
-        /** @type {import('./types.js').GuestFormula} */
-        const formula = {
-          type: 'guest',
-          host: hostHandleFormulaIdentifier,
-        };
         const { value, formulaIdentifier: guestFormulaIdentifier } =
           // Behold, recursion:
           // eslint-disable-next-line no-use-before-define
-          await provideValueForFormula(formula, 'guest');
+          await incarnateGuest(hostHandleFormulaIdentifier);
         if (petName !== undefined) {
           assertPetName(petName);
           await petStore.write(petName, guestFormulaIdentifier);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -10,6 +10,7 @@ export const makeHostMaker = ({
   provideValueForFormula,
   provideValueForNumberedFormula,
   provideControllerForFormulaIdentifier,
+  incarnateHost,
   storeReaderRef,
   makeSha512,
   randomHex512,
@@ -410,12 +411,16 @@ export const makeHostMaker = ({
         formulaIdentifier = identifyLocal(petName);
       }
       if (formulaIdentifier === undefined) {
-        const id512 = await randomHex512();
-        formulaIdentifier = `host:${id512}`;
+        const { formulaIdentifier: newFormulaIdentifier, value } =
+          await incarnateHost(
+            endoFormulaIdentifier,
+            leastAuthorityFormulaIdentifier,
+          );
         if (petName !== undefined) {
           assertPetName(petName);
-          await petStore.write(petName, formulaIdentifier);
+          await petStore.write(petName, newFormulaIdentifier);
         }
+        return { formulaIdentifier: newFormulaIdentifier, value };
       } else if (!formulaIdentifier.startsWith('host:')) {
         throw new Error(
           `Existing pet name does not designate a host powers capability: ${q(

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -10,19 +10,17 @@ const { quote: q } = assert;
 
 /**
  * @param {object} args
+ * @param {(hubFormulaIdentifier: string, petNamePath: string[]) => Promise<{ formulaIdentifier: string, value: unknown }>} args.incarnateLookup
  * @param {import('./types.js').ProvideValueForFormulaIdentifier} args.provideValueForFormulaIdentifier
  * @param {import('./types.js').ProvideControllerForFormulaIdentifier} args.provideControllerForFormulaIdentifier
  * @param {import('./types.js').GetFormulaIdentifierForRef} args.getFormulaIdentifierForRef
- * @param {import('./types.js').MakeSha512} args.makeSha512
- * @param {import('./types.js').ProvideValueForNumberedFormula} args.provideValueForNumberedFormula
  * @param {import('./types.js').ProvideControllerForFormulaIdentifierAndResolveHandle} args.provideControllerForFormulaIdentifierAndResolveHandle
  */
 export const makeMailboxMaker = ({
+  incarnateLookup,
+  getFormulaIdentifierForRef,
   provideValueForFormulaIdentifier,
   provideControllerForFormulaIdentifier,
-  getFormulaIdentifierForRef,
-  makeSha512,
-  provideValueForNumberedFormula,
   provideControllerForFormulaIdentifierAndResolveHandle,
 }) => {
   /**
@@ -126,28 +124,8 @@ export const makeMailboxMaker = ({
 
     /** @type {import('./types.js').Mail['provideLookupFormula']} */
     const provideLookupFormula = async petNamePath => {
-      // The lookup formula identifier consists of the hash of the associated
-      // naming hub's formula identifier and the pet name path.
-      // A "naming hub" is an objected with a variadic lookup method. It includes
-      // objects such as guests and hosts.
-      const digester = makeSha512();
-      digester.updateText(`${selfFormulaIdentifier},${petNamePath.join(',')}`);
-      const lookupFormulaNumber = digester.digestHex();
-
       // TODO:lookup Check if the lookup formula already exists in the store
-      /** @type {import('./types.js').LookupFormula} */
-      const lookupFormula = {
-        /** @type {'lookup'} */
-        type: 'lookup',
-        hub: selfFormulaIdentifier,
-        path: petNamePath,
-      };
-
-      return provideValueForNumberedFormula(
-        'lookup',
-        lookupFormulaNumber,
-        lookupFormula,
-      );
+      return incarnateLookup(selfFormulaIdentifier, petNamePath);
     };
 
     /**

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -9,7 +9,7 @@ const { quote: q } = assert;
 
 const validIdPattern = /^[0-9a-f]{128}$/;
 const validFormulaPattern =
-  /^(?:(?:readable-blob|worker|pet-store|pet-inspector|eval|lookup|make-unconfined|make-bundle|host|guest):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
+  /^(?:(?:readable-blob|worker|pet-store|pet-inspector|eval|lookup|make-unconfined|make-bundle|host|guest|handle):[0-9a-f]{128}|web-bundle:[0-9a-f]{32})$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -418,6 +418,15 @@ export type EndoWebBundle = {
   powers: ERef<unknown>;
 };
 
+export type EndoBootstrap = FarRef<{
+  ping: () => Promise<string>;
+  terminate: () => Promise<void>;
+  host: () => Promise<EndoHost>;
+  leastAuthority: () => Promise<EndoGuest>;
+  webPageJs: () => Promise<unknown>;
+  importAndEndowInWebPage: () => Promise<void>;
+}>;
+
 export type CryptoPowers = {
   makeSha512: () => Sha512;
   randomHex512: () => Promise<string>;
@@ -474,13 +483,13 @@ export type NetworkPowers = SocketPowers & {
     cancelled: Promise<never>;
   }) => Promise<number>;
   makePrivatePathService: (
-    endoBootstrap: FarRef<unknown>,
+    endoBootstrap: EndoBootstrap,
     sockPath: string,
     cancelled: Promise<never>,
     exitWithError: (error: Error) => void,
   ) => { started: Promise<void>; stopped: Promise<void> };
   makePrivateHttpService: (
-    endoBootstrap: FarRef<unknown>,
+    endoBootstrap: EndoBootstrap,
     port: number,
     assignWebletPort: (portP: Promise<number>) => void,
     cancelled: Promise<never>,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -64,6 +64,15 @@ type EndoFormula = {
   webPageJs: string;
 };
 
+type HostFormula = {
+  type: 'host';
+  worker: string;
+  inspector: string;
+  petStore: string;
+  endo: string;
+  leastAuthority: string;
+};
+
 type GuestFormula = {
   type: 'guest';
   host: string;
@@ -117,6 +126,7 @@ type WebBundleFormula = {
 
 export type Formula =
   | EndoFormula
+  | HostFormula
   | GuestFormula
   | EvalFormula
   | LookupFormula

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -124,6 +124,11 @@ type WebBundleFormula = {
   powers: string;
 };
 
+type HandleFormula = {
+  type: 'handle';
+  target: string;
+};
+
 export type Formula =
   | EndoFormula
   | HostFormula
@@ -132,7 +137,8 @@ export type Formula =
   | LookupFormula
   | MakeUnconfinedFormula
   | MakeBundleFormula
-  | WebBundleFormula;
+  | WebBundleFormula
+  | HandleFormula;
 
 export type Label = {
   number: number;
@@ -206,6 +212,15 @@ export type ProvideValueForFormulaIdentifier = (
 export type ProvideControllerForFormulaIdentifier = (
   formulaIdentifier: string,
 ) => Controller;
+export type ProvideControllerForFormulaIdentifierAndResolveHandle = (
+  formulaIdentifier: string,
+) => Promise<Controller>;
+
+export interface Handle {}
+export interface InternalHandle {
+  targetFormulaIdentifier: string;
+}
+
 export type GetFormulaIdentifierForRef = (ref: unknown) => string | undefined;
 export type MakeSha512 = () => Sha512;
 

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -448,7 +448,7 @@ export type EndoWebBundle = {
   powers: ERef<unknown>;
 };
 
-export type EndoBootstrap = FarRef<{
+export type FarEndoBootstrap = FarRef<{
   ping: () => Promise<string>;
   terminate: () => Promise<void>;
   host: () => Promise<EndoHost>;
@@ -513,13 +513,13 @@ export type NetworkPowers = SocketPowers & {
     cancelled: Promise<never>;
   }) => Promise<number>;
   makePrivatePathService: (
-    endoBootstrap: EndoBootstrap,
+    endoBootstrap: FarEndoBootstrap,
     sockPath: string,
     cancelled: Promise<never>,
     exitWithError: (error: Error) => void,
   ) => { started: Promise<void>; stopped: Promise<void> };
   makePrivateHttpService: (
-    endoBootstrap: EndoBootstrap,
+    endoBootstrap: FarEndoBootstrap,
     port: number,
     assignWebletPort: (portP: Promise<number>) => void,
     cancelled: Promise<never>,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -247,14 +247,14 @@ export type ProvideControllerForFormulaIdentifierAndResolveHandle = (
 
 /**
  * A handle is used to create a pointer to a formula without exposing it directly.
- * This is the external facet of the Handle and is safe to expose. This is used to
+ * This is the external facet of the handle and is safe to expose. This is used to
  * provide an EndoGuest with a reference to its creator EndoHost. By using a handle
  * that points to the host instead of giving a direct reference to the host, the
  * guest does not get access to the functions of the host. This is the external
  * facet of a handle. It directly exposes nothing. The handle's target is only
  * exposed on the internal facet.
  */
-export interface Handle {}
+export interface ExternalHandle {}
 /**
  * This is the internal facet of a handle. It exposes the formula id that the
  * handle points to. This should not be exposed outside of the endo daemon.
@@ -542,7 +542,10 @@ export type NetworkPowers = SocketPowers & {
 
 export type DaemonicPersistencePowers = {
   initializePersistence: () => Promise<void>;
-  provideRootNonce: () => Promise<{ value: string; isNewlyCreated: boolean }>;
+  provideRootNonce: () => Promise<{
+    rootNonce: string;
+    isNewlyCreated: boolean;
+  }>;
   makeContentSha512Store: () => {
     store: (readable: AsyncIterable<Uint8Array>) => Promise<string>;
     fetch: (sha512: string) => EndoReadable;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -57,6 +57,13 @@ type FormulaIdentifierRecord = {
   number: string;
 };
 
+type EndoFormula = {
+  type: 'endo';
+  host: string;
+  leastAuthority: string;
+  webPageJs: string;
+};
+
 type GuestFormula = {
   type: 'guest';
   host: string;
@@ -109,6 +116,7 @@ type WebBundleFormula = {
 };
 
 export type Formula =
+  | EndoFormula
   | GuestFormula
   | EvalFormula
   | LookupFormula
@@ -457,6 +465,7 @@ export type NetworkPowers = SocketPowers & {
 
 export type DaemonicPersistencePowers = {
   initializePersistence: () => Promise<void>;
+  isRootInitialized: () => Promise<boolean>;
   provideRootNonce: () => Promise<string>;
   makeContentSha512Store: () => {
     store: (readable: AsyncIterable<Uint8Array>) => Promise<string>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -91,6 +91,11 @@ type EvalFormula = {
   // TODO formula slots
 };
 
+type ReadableBlobFormula = {
+  type: 'readable-blob';
+  content: string;
+};
+
 type LookupFormula = {
   type: 'lookup';
 
@@ -139,6 +144,7 @@ export type Formula =
   | GuestFormula
   | LeastAuthorityFormula
   | EvalFormula
+  | ReadableBlobFormula
   | LookupFormula
   | MakeUnconfinedFormula
   | MakeBundleFormula
@@ -344,6 +350,7 @@ export interface EndoReadable {
   text(): Promise<string>;
   json(): Promise<unknown>;
 }
+export type FarEndoReadable = FarRef<EndoReadable>;
 
 export interface EndoWorker {
   terminate(): void;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -61,7 +61,7 @@ type EndoFormula = {
   type: 'endo';
   host: string;
   leastAuthority: string;
-  webPageJs: string;
+  webPageJs?: string;
 };
 
 type HostFormula = {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -144,6 +144,10 @@ type HandleFormula = {
   target: string;
 };
 
+type PetStoreFormula = {
+  type: 'pet-store';
+};
+
 type PetInspectorFormula = {
   type: 'pet-inspector';
   petStore: string;
@@ -162,7 +166,8 @@ export type Formula =
   | MakeBundleFormula
   | WebBundleFormula
   | HandleFormula
-  | PetInspectorFormula;
+  | PetInspectorFormula
+  | PetStoreFormula;
 
 export type Label = {
   number: number;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -78,6 +78,10 @@ type GuestFormula = {
   host: string;
 };
 
+type LeastAuthorityFormula = {
+  type: 'least-authority';
+};
+
 type EvalFormula = {
   type: 'eval';
   worker: string;
@@ -133,6 +137,7 @@ export type Formula =
   | EndoFormula
   | HostFormula
   | GuestFormula
+  | LeastAuthorityFormula
   | EvalFormula
   | LookupFormula
   | MakeUnconfinedFormula

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -529,8 +529,7 @@ export type NetworkPowers = SocketPowers & {
 
 export type DaemonicPersistencePowers = {
   initializePersistence: () => Promise<void>;
-  isRootInitialized: () => Promise<boolean>;
-  provideRootNonce: () => Promise<string>;
+  provideRootNonce: () => Promise<{ value: string; isNewlyCreated: boolean }>;
   makeContentSha512Store: () => {
     store: (readable: AsyncIterable<Uint8Array>) => Promise<string>;
     fetch: (sha512: string) => EndoReadable;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -245,7 +245,20 @@ export type ProvideControllerForFormulaIdentifierAndResolveHandle = (
   formulaIdentifier: string,
 ) => Promise<Controller>;
 
+/**
+ * A handle is used to create a pointer to a formula without exposing it directly.
+ * This is the external facet of the Handle and is safe to expose. This is used to
+ * provide an EndoGuest with a reference to its creator EndoHost. By using a handle
+ * that points to the host instead of giving a direct reference to the host, the
+ * guest does not get access to the functions of the host. This is the external
+ * facet of a handle. It directly exposes nothing. The handle's target is only
+ * exposed on the internal facet.
+ */
 export interface Handle {}
+/**
+ * This is the internal facet of a handle. It exposes the formula id that the
+ * handle points to. This should not be exposed outside of the endo daemon.
+ */
 export interface InternalHandle {
   targetFormulaIdentifier: string;
 }

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -490,7 +490,7 @@ export type DaemonicPersistencePowers = {
   getWebPageBundlerFormula?: (
     workerFormulaIdentifier: string,
     powersFormulaIdentifier: string,
-  ) => Formula;
+  ) => MakeUnconfinedFormula;
 };
 
 export interface DaemonWorkerFacet {}

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -144,6 +144,11 @@ type HandleFormula = {
   target: string;
 };
 
+type PetInspectorFormula = {
+  type: 'pet-inspector';
+  petStore: string;
+};
+
 export type Formula =
   | EndoFormula
   | WorkerFormula
@@ -156,7 +161,8 @@ export type Formula =
   | MakeUnconfinedFormula
   | MakeBundleFormula
   | WebBundleFormula
-  | HandleFormula;
+  | HandleFormula
+  | PetInspectorFormula;
 
 export type Label = {
   number: number;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -64,6 +64,10 @@ type EndoFormula = {
   webPageJs?: string;
 };
 
+type WorkerFormula = {
+  type: 'worker';
+};
+
 type HostFormula = {
   type: 'host';
   worker: string;
@@ -76,6 +80,8 @@ type HostFormula = {
 type GuestFormula = {
   type: 'guest';
   host: string;
+  petStore: string;
+  worker: string;
 };
 
 type LeastAuthorityFormula = {
@@ -140,6 +146,7 @@ type HandleFormula = {
 
 export type Formula =
   | EndoFormula
+  | WorkerFormula
   | HostFormula
   | GuestFormula
   | LeastAuthorityFormula


### PR DESCRIPTION
- Factors out endo configuration ( eg default host formulaIdentifier ) from newly named `daemonCore`.
- Introduces `incarnateXyz` methods to be used when creating a new thing for the first time.
- Persists all formulas and requires them to be incarnated before they can be reified via `provideValueForFormulaId`
- Adds Handles as a generic pointer to another formula, where the pointer is exposed on the internal facet only. This is currently used to give a guest a reference to the host without exposing host endowments. mail uses `provideControllerForFormulaIdentifierAndResolveHandle` to resolve the handle.

Updates: #1993 
Closes: #2087 