### PR TITLE
feat(patterns): New `M.tagged` pattern maker

### DIFF
--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in `@endo/patterns`:
 
+# next release
+
+- Add `M.tagged(tagPattern, payloadPattern)` for making patterns that match
+  Passable Tagged objects.
+
 # v0.2.6 (2023-09-11)
 
 - Adds support for CopyMap patterns (e.g., `matches(specimen, makeCopyMap([]))`).

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -871,13 +871,16 @@ const makePatternKit = () => {
 
   /** @type {import('./types.js').MatchHelper} */
   const matchTaggedHelper = Far('match:tagged helper', {
-    checkMatches: (specimen, [tagPatt, payloadPatt], check) =>
-      check(
-        passStyleOf(specimen) === 'tagged',
-        X`Expected tagged object, not ${q(passStyleOf(specimen))}: ${specimen}`,
-      ) &&
-      checkMatches(getTag(specimen), tagPatt, check, 'tag') &&
-      checkMatches(specimen.payload, payloadPatt, check, 'payload'),
+    checkMatches: (specimen, [tagPatt, payloadPatt], check) => {
+      if (passStyleOf(specimen) !== 'tagged') {
+        return check(
+          false,
+          X`Expected tagged object, not ${q(passStyleOf(specimen))}: ${specimen}`,
+        );
+      }
+      return checkMatches(getTag(specimen), tagPatt, check, 'tag') &&
+        checkMatches(specimen.payload, payloadPatt, check, 'payload');
+    },
 
     checkIsWellFormed: (payload, check) =>
       checkMatches(
@@ -887,7 +890,7 @@ const makePatternKit = () => {
         'match:tagged payload',
       ),
 
-    getRankCover: (kind, _encodePassable) => getPassStyleCover('tagged'),
+    getRankCover: (_kind, _encodePassable) => getPassStyleCover('tagged'),
   });
 
   /** @type {import('./types.js').MatchHelper} */

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -870,6 +870,27 @@ const makePatternKit = () => {
   });
 
   /** @type {import('./types.js').MatchHelper} */
+  const matchTaggedHelper = Far('match:tagged helper', {
+    checkMatches: (specimen, [tagPatt, payloadPatt], check) =>
+      check(
+        passStyleOf(specimen) === 'tagged',
+        X`Expected tagged object, not ${q(passStyleOf(specimen))}: ${specimen}`,
+      ) &&
+      checkMatches(getTag(specimen), tagPatt, check, 'tag') &&
+      checkMatches(specimen.payload, payloadPatt, check, 'payload'),
+
+    checkIsWellFormed: (payload, check) =>
+      checkMatches(
+        payload,
+        harden([MM.pattern(), MM.pattern()]),
+        check,
+        'match:tagged payload',
+      ),
+
+    getRankCover: (kind, _encodePassable) => getPassStyleCover('tagged'),
+  });
+
+  /** @type {import('./types.js').MatchHelper} */
   const matchBigintHelper = Far('match:bigint helper', {
     checkMatches: (specimen, [limits = undefined], check) => {
       const { decimalDigitsLimit } = limit(limits);
@@ -1500,6 +1521,7 @@ const makePatternKit = () => {
     'match:key': matchKeyHelper,
     'match:pattern': matchPatternHelper,
     'match:kind': matchKindHelper,
+    'match:tagged': matchTaggedHelper,
     'match:bigint': matchBigintHelper,
     'match:nat': matchNatHelper,
     'match:string': matchStringHelper,
@@ -1604,6 +1626,8 @@ const makePatternKit = () => {
     key: () => KeyShape,
     pattern: () => PatternShape,
     kind: makeKindMatcher,
+    tagged: (tagPatt = M.string(), payloadPatt = M.any()) =>
+      makeMatcher('match:tagged', harden([tagPatt, payloadPatt])),
     boolean: () => BooleanShape,
     number: () => NumberShape,
     bigint: (limits = undefined) =>

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -875,11 +875,15 @@ const makePatternKit = () => {
       if (passStyleOf(specimen) !== 'tagged') {
         return check(
           false,
-          X`Expected tagged object, not ${q(passStyleOf(specimen))}: ${specimen}`,
+          X`Expected tagged object, not ${q(
+            passStyleOf(specimen),
+          )}: ${specimen}`,
         );
       }
-      return checkMatches(getTag(specimen), tagPatt, check, 'tag') &&
-        checkMatches(specimen.payload, payloadPatt, check, 'payload');
+      return (
+        checkMatches(getTag(specimen), tagPatt, check, 'tag') &&
+        checkMatches(specimen.payload, payloadPatt, check, 'payload')
+      );
     },
 
     checkIsWellFormed: (payload, check) =>

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -272,6 +272,12 @@ export {};
  * Otherwise, does not match any value.
  * TODO: Reject attempts to create a kind matcher with unknown `kind`?
  *
+ * @property {(tagPatt?: Pattern, payloadPatt?: Pattern) => Matcher} tagged
+ * For matching an arbitrary Passable Tagged object, whether it has a
+ * recognized kind or not. If `tagPatt` is omitted, it defaults to
+ * `M.string()`. If `payloadPatt` is omitted, it defaults to
+ * `M.any()`.
+ *
  * @property {() => Matcher} boolean
  * Matches `true` or `false`.
  *

--- a/packages/patterns/test/test-patterns.js
+++ b/packages/patterns/test/test-patterns.js
@@ -104,6 +104,7 @@ const runTests = (t, successCase, failCase) => {
     failCase(specimen, M.and(3, 4), '3 - Must be: 4');
     failCase(specimen, M.or(4, 4), '3 - Must match one of [4,4]');
     failCase(specimen, M.or(), '3 - no pattern disjuncts to match: []');
+    failCase(specimen, M.tagged(), 'Expected tagged object, not "number": 3');
   }
   {
     const specimen = 0n;
@@ -672,6 +673,37 @@ const runTests = (t, successCase, failCase) => {
       'match:recordOf payload: [1]: A "promise" cannot be a pattern',
     );
   }
+  const specimen = makeTagged('Vowish', {
+    vowVX: Far('VowVX', {}),
+  });
+  successCase(specimen, M.any());
+  successCase(specimen, M.tagged());
+  successCase(specimen, M.tagged('Vowish'));
+  successCase(
+    specimen,
+    M.tagged(
+      'Vowish',
+      harden({
+        vowVX: M.remotable('VowVX'),
+      }),
+    ),
+  );
+  failCase(
+    specimen,
+    M.record(),
+    'cannot check unrecognized tag "Vowish": "[Vowish]"',
+  );
+  failCase(
+    specimen,
+    M.kind('tagged'),
+    'cannot check unrecognized tag "Vowish": "[Vowish]"',
+  );
+  failCase(specimen, M.tagged('Vowoid'), 'tag: "Vowish" - Must be: "Vowoid"');
+  failCase(
+    specimen,
+    M.tagged(undefined, harden({})),
+    'payload: {"vowVX":"[Alleged: VowVX]"} - Must be: {}',
+  );
 };
 
 /**


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8742 https://github.com/Agoric/agoric-sdk/pull/8958

## Description

@dckc encountered the need to express a Vow pattern. The Vow abstraction is currently only defined by agoric-sdk. But it is encoded into a Tagged object, where that Tagged is not a recognized kind at the @endo/patterns level. This caused us to notice the inability to express patterns over Tagged objects. This PR adds that. Using it, a VowShape should be expressible as

```js
const VowShape = M.tagged(
    'Vow',
    harden({
      vowV0: M.remotable('VowV0'),
    }),
  ),
);
```

We include a test case that is similar in all the relevant ways.

### Security Considerations
none
### Scaling Considerations
none
### Documentation Considerations

We include doccomments in the PatternMatchers type, that should show up next time we regenerate https://endojs.github.io/endo/interfaces/_endo_patterns.PatternMatchers.html

Btw, when does that get regenerated? What causes it to get regenerated?

### Testing Considerations
included tests should be adequate
### Compatibility Considerations

The matcher made by `M.tagged(...)` will not be recognized as a matcher by versions of @endo/patterns that precede this PR.

### Upgrade Considerations

Nothing breaking.

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [x] Updates `NEWS.md` for user-facing changes.
