### PR TITLE
refactor(daemon): Synchronize host `evaluate` method

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -825,8 +825,9 @@ const makeDaemonCore = async (
       evalFormulaNumber,
     } = await formulaGraphMutex.enqueue(async () => {
       const ownFormulaNumber = await randomHex512();
-      const workerFormulaNumber = await (specifiedWorkerFormulaIdentifier ??
-        randomHex512());
+      const workerFormulaNumber = await (specifiedWorkerFormulaIdentifier
+        ? parseFormulaIdentifier(specifiedWorkerFormulaIdentifier).number
+        : randomHex512());
 
       const identifiers = harden({
         workerFormulaIdentifier: (

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -17,7 +17,6 @@ export const makeHostMaker = ({
   incarnateWebBundle,
   incarnateHandle,
   storeReaderRef,
-  randomHex512,
   makeMailbox,
 }) => {
   /**

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -298,7 +298,7 @@ export const makeHostMaker = ({
       );
 
       /** @type {(string | string[])[]} */
-      const endowmentFormulaPointers = petNamePaths.map(
+      const endowmentFormulaIdsOrPaths = petNamePaths.map(
         (petNameOrPath, index) => {
           if (typeof codeNames[index] !== 'string') {
             throw new Error(`Invalid endowment name: ${q(codeNames[index])}`);
@@ -313,8 +313,6 @@ export const makeHostMaker = ({
             return formulaIdentifier;
           }
 
-          // TODO:lookup Check if a formula already exists for the path. May have to be
-          // done in the daemon itself.
           return petNamePath;
         },
       );
@@ -329,7 +327,7 @@ export const makeHostMaker = ({
         hostFormulaIdentifier,
         source,
         codeNames,
-        endowmentFormulaPointers,
+        endowmentFormulaIdsOrPaths,
         hooks,
         workerFormulaIdentifier,
       );

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -10,14 +10,12 @@ const { quote: q } = assert;
 
 /**
  * @param {object} args
- * @param {(hubFormulaIdentifier: string, petNamePath: string[]) => Promise<{ formulaIdentifier: string, value: unknown }>} args.incarnateLookup
  * @param {import('./types.js').ProvideValueForFormulaIdentifier} args.provideValueForFormulaIdentifier
  * @param {import('./types.js').ProvideControllerForFormulaIdentifier} args.provideControllerForFormulaIdentifier
  * @param {import('./types.js').GetFormulaIdentifierForRef} args.getFormulaIdentifierForRef
  * @param {import('./types.js').ProvideControllerForFormulaIdentifierAndResolveHandle} args.provideControllerForFormulaIdentifierAndResolveHandle
  */
 export const makeMailboxMaker = ({
-  incarnateLookup,
   getFormulaIdentifierForRef,
   provideValueForFormulaIdentifier,
   provideControllerForFormulaIdentifier,
@@ -84,10 +82,8 @@ export const makeMailboxMaker = ({
         throw new TypeError(`Unknown pet name: ${q(petName)}`);
       }
       // Behold, recursion:
-      // eslint-disable-next-line no-use-before-define
-      const controller = await provideControllerForFormulaIdentifier(
-        formulaIdentifier,
-      );
+      const controller =
+        provideControllerForFormulaIdentifier(formulaIdentifier);
       console.log('Cancelled:');
       return controller.context.cancel(reason);
     };
@@ -120,12 +116,6 @@ export const makeMailboxMaker = ({
         return harden([]);
       }
       return reverseLookupFormulaIdentifier(formulaIdentifier);
-    };
-
-    /** @type {import('./types.js').Mail['provideLookupFormula']} */
-    const provideLookupFormula = async petNamePath => {
-      // TODO:lookup Check if the lookup formula already exists in the store
-      return incarnateLookup(selfFormulaIdentifier, petNamePath);
     };
 
     /**
@@ -541,7 +531,6 @@ export const makeMailboxMaker = ({
       reverseLookup,
       reverseLookupFormulaIdentifier,
       identifyLocal,
-      provideLookupFormula,
       followMessages,
       listMessages,
       request,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -97,6 +97,14 @@ type EvalFormula = {
   // TODO formula slots
 };
 
+export type EvalFormulaHook = (
+  identifiers: Readonly<{
+    endowmentFormulaIdentifiers: string[];
+    evalFormulaNumber: string;
+    workerFormulaIdentifier: string;
+  }>,
+) => Promise<unknown>;
+
 type ReadableBlobFormula = {
   type: 'readable-blob';
   content: string;
@@ -315,14 +323,6 @@ export interface Mail {
   listAll(): Array<string>;
   reverseLookupFormulaIdentifier(formulaIdentifier: string): Array<string>;
   cancel(petName: string, reason: unknown): Promise<void>;
-  /**
-   * Takes a sequence of pet names and returns a formula identifier and value
-   * for the corresponding lookup formula.
-   *
-   * @param petNamePath A sequence of pet names.
-   * @returns The formula identifier and value of the lookup formula.
-   */
-  provideLookupFormula(petNamePath: string[]): Promise<unknown>;
   // Mail operations:
   listMessages(): Promise<Array<Message>>;
   followMessages(): Promise<FarRef<Reader<Message>>>;

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -881,8 +881,7 @@ test('name and reuse inspector', async t => {
   await stop(locator);
 });
 
-// This tests behavior that previously failed due to a bug.
-// See: https://github.com/endojs/endo/issues/2021
+// Regression test for: https://github.com/endojs/endo/issues/2021
 test('eval-mediated worker name', async t => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();
   t.teardown(() => cancel(Error('teardown')));

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -647,7 +647,8 @@ test('direct termination', async t => {
   t.pass();
 });
 
-test('indirect termination', async t => {
+// See: https://github.com/endojs/endo/issues/2074
+test.failing('indirect termination', async t => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();
   t.teardown(() => cancel(Error('teardown')));
 


### PR DESCRIPTION
Progresses: #2086 
Fixes: #2021

Synchronizes the host's `evaluate()` method by delegating all incarnations to the daemon via `incarnateEval()`. The latter is responsible for incarnating its dependents as necessary, and for the generation of their formula numbers. To facilitate this, the synchronous methods `incarnateLookupSync()` and `incarnateWorkerSync()` have been added. These methods synchronously mutate the formula graph, and return promises that resolve when the formulas have been written to disk. The result is that the formula graph is mutated within a single turn of the event loop.

To achieve this, the implementation introduces new constraints on the daemon and its dependents. https://github.com/endojs/endo/pull/2089 introduced the notion of "incarnating" values. By the current definition, incarnating a value consists of the following steps:
1. Collecting dependencies (async)
    1. Generating requisite formula numbers (async)
        - We use the asynchronous signature of `crypto.randomBytes` to do
        this for performance reasons.
    2. Incarnating any dependent values (recursion!)
2. Updating the in-memory formula graph (sync)
3. Writing the resulting formula to disk (async)
4. Reifiying the resulting value (async)

In order to make formula graph mutations mutually exclusive, we introduce a "formula graph mutex" under which step 1 must be performed. This mutex is currently only used by `incarnateEval()`, and must be expanded to its sibling methods in the future.

`incarnateEval()` also introduces the notion of "incarnation hooks" to the codebase. Originators of incarnations that are exogenous to the daemon may themselves have asynchronous work perform. For example, `petName -> formulaIdentifier` mappings are the responsibility of the host and its pet store, and pet names must be associated with their respective formula identifiers the moment that those identifiers are observable to the consumer. To handle sych asynchronous side effects, the implementation introduces a notion of "hooks" to `incarnateEval()`, with the intention of spreading this to other incarnation methods as necessary. These hooks receive as an argument all formula identifiers created by the incarnation, and are executed under the formula graph mutex. This will surface IO errors to the consumer, and help us uphold the principle of "death before confusion".

Also of note, `provideValueForNumberedFormula` has been modified such that the formula is written to disk _after_ the controller has been constructed. This is critical in order to synchronize formula graph mutations.

Finally, it appears that the implementation incidentally fixed https://github.com/endojs/endo/issues/2021. We may still wish to adopt the more robust solution proposed in that issue.