### PR TITLE
test(ses-ava): option to use t.log

### DIFF
--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -36,6 +36,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@endo/errors": "^1.1.0",
     "ses": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/ses-ava/src/ses-ava-test.js
+++ b/packages/ses-ava/src/ses-ava-test.js
@@ -7,6 +7,19 @@ import {
   consoleOtherMethods,
 } from 'ses/console-tools.js';
 
+/**
+ * TODO For some reason, the following declaration (with "at-" as "@")
+ * doesn't work well for either TS or typedoc. For TS it seems to type
+ * `VirtualConsole` as `any` in a vscode hover. For typedoc it results in
+ * errors.
+ *
+ * at-typedef {import('ses/console-tools.js').VirtualConsole} VirtualConsole
+ *
+ * so instead, for now, we just declare it as `any`. TODO is to repair this.
+ *
+ * @typedef {any} VirtualConsole
+ */
+
 const { stringify } = JSON;
 const { defineProperty, freeze } = Object;
 const { apply } = Reflect;
@@ -50,7 +63,7 @@ const isPromise = maybePromise =>
  * @param {unknown[]} args
  * @param {string} source
  * @param {Logger} logger
- * @param {import('ses/console-tools.js').VirtualConsole} [optConsole]
+ * @param {VirtualConsole} [optConsole]
  */
 const logErrorFirst = (func, args, source, logger, optConsole = undefined) => {
   const originalConsole = globalThis.console;
@@ -98,7 +111,7 @@ const overrideList = [
  * are output in the right place.
  *
  * @param {Logger} tlogger
- * @returns {import('ses/console-tools.js').VirtualConsole}
+ * @returns {VirtualConsole}
  */
 const makeConsoleFromLogger = tlogger => {
   const baseConsole = {};
@@ -113,7 +126,10 @@ const makeConsoleFromLogger = tlogger => {
     baseConsole[name2] = (...args) => tlogger(name2, ...args);
   }
   harden(baseConsole);
-  return makeCausalConsole(baseConsole, loggedErrorHandler);
+  return makeCausalConsole(
+    /** @type {VirtualConsole} */ (baseConsole),
+    loggedErrorHandler,
+  );
 };
 
 /**

--- a/packages/ses-ava/src/ses-ava-test.js
+++ b/packages/ses-ava/src/ses-ava-test.js
@@ -76,25 +76,35 @@ const overrideList = [
 ];
 
 /**
- * @param {Logger} tlog
- * @param {Logger | 'tlog'} loggerOrOption
+ * @typedef {object} LoggingOptions
+ * @property {boolean} [tlog]
+ */
+
+/**
+ * @param {Logger} tlogger
+ * @param {Logger | LoggingOptions} loggerOrOptions
  * @returns {Logger}
  */
-const getLogger = (tlog, loggerOrOption) => {
-  if (typeof loggerOrOption === 'function') {
-    return loggerOrOption;
-  } else if (loggerOrOption === 'tlog') {
-    // TODO wrap with SES causal console
-    return tlog;
-  } else {
-    throw Error(`Unrecognized loggerOrOption ${loggerOrOption}`);
+const getLogger = (tlogger, loggerOrOptions) => {
+  if (typeof loggerOrOptions === 'function') {
+    return loggerOrOptions;
+  } else if (typeof loggerOrOptions === 'object') {
+    const { tlog } = loggerOrOptions;
+    if (tlog) {
+      // TODO wrap with SES causal console
+      return tlogger;
+    } else {
+      // Without causal console wrapper
+      return tlogger;
+    }
   }
+  throw Error(`Unrecognized loggerOrOption ${loggerOrOptions}`);
 };
 
 /**
  * @template {import('ava').TestFn} T
  * @param {T} testerFunc
- * @param {Logger | 'tlog'} loggerOrOption
+ * @param {Logger | LoggingOptions} loggerOrOption
  * @returns {T} Not yet frozen!
  */
 const augmentLogging = (testerFunc, loggerOrOption) => {
@@ -197,7 +207,7 @@ const augmentLogging = (testerFunc, loggerOrOption) => {
  *
  * @template {import('ava').TestFn} T ava `test`
  * @param {T} avaTest
- * @param {Logger | 'tlog'} [loggerOrOption]
+ * @param {Logger | LoggingOptions} [loggerOrOption]
  * @returns {T}
  */
 const wrapTest = (avaTest, loggerOrOption = defaultLogger) => {

--- a/packages/ses-ava/test/example-problem.js
+++ b/packages/ses-ava/test/example-problem.js
@@ -1,0 +1,15 @@
+import { makeError, X, q } from '@endo/errors';
+
+const { freeze } = Object;
+
+export const exampleProblem = (label, optLogger = undefined) => {
+  const subError = makeError(X`nested ${q(label)} ${'REDACTED'}`);
+
+  const err = makeError(X`${q(label)} ${'NOTICE ME'} nest ${subError}`);
+
+  if (optLogger === undefined) {
+    throw err;
+  }
+  optLogger(label, err);
+};
+freeze(exampleProblem);

--- a/packages/ses-ava/test/prepare-test-env-ava.js
+++ b/packages/ses-ava/test/prepare-test-env-ava.js
@@ -4,4 +4,4 @@ import rawTest from 'ava';
 import { wrapTest } from '../src/ses-ava-test.js';
 
 /** @type {typeof rawTest} */
-export const test = wrapTest(rawTest, 'tlog');
+export const test = wrapTest(rawTest, { tlog: true });

--- a/packages/ses-ava/test/prepare-test-env-ava.js
+++ b/packages/ses-ava/test/prepare-test-env-ava.js
@@ -4,4 +4,4 @@ import rawTest from 'ava';
 import { wrapTest } from '../src/ses-ava-test.js';
 
 /** @type {typeof rawTest} */
-export const test = wrapTest(rawTest, { tlog: true });
+export const test = wrapTest(rawTest, { tlog: true, pushConsole: true });

--- a/packages/ses-ava/test/prepare-test-env-ava.js
+++ b/packages/ses-ava/test/prepare-test-env-ava.js
@@ -4,4 +4,4 @@ import rawTest from 'ava';
 import { wrapTest } from '../src/ses-ava-test.js';
 
 /** @type {typeof rawTest} */
-export const test = wrapTest(rawTest);
+export const test = wrapTest(rawTest, 'tlog');

--- a/packages/ses-ava/test/test-raw-ava-reject.js
+++ b/packages/ses-ava/test/test-raw-ava-reject.js
@@ -6,23 +6,28 @@ lockdown({
   // output shown below. When all the switches are uncommented, you should
   // see that output.
   //
-  stackFiltering: 'verbose', // Exclude `assert` infrastructure
-  consoleTaming: 'unsafe', // Doesn't make a difference here
-  errorTaming: 'unsafe', // Redacts entire `error.stack`
+  // Commenting out all settings for a given switch defaults to using
+  // the current relevant environment variable setting. To get results
+  // independent of that, always uncomment one setting for each switch.
+  //
+  // stackFiltering: 'concise', // Default. Hide infrastructure, shorten paths
+  stackFiltering: 'verbose', // Include `assert` infrastructure
+  // consoleTaming: 'safe', // Default. Console with access to redacted info
+  consoleTaming: 'unsafe', // Console without access to redacted info
+  // errorTaming: 'safe', // Default. Hide redacted info from ava
+  errorTaming: 'unsafe', // Disclose `error.stack` to ava
 });
 
 test('raw ava reject console output', t => {
   t.assert(true);
   // Uncomment this to see something like the text in the extended comment below
 
-  /*
-  return Promise.resolve(null)
-    .then(v => v)
-    .then(v => v)
-    .then(_ => {
-      assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
-    });
-  */
+  // return Promise.resolve(null)
+  //   .then(v => v)
+  //   .then(v => v)
+  //   .then(_ => {
+  //     assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
+  //   });
 });
 
 /*

--- a/packages/ses-ava/test/test-raw-ava-reject.js
+++ b/packages/ses-ava/test/test-raw-ava-reject.js
@@ -1,5 +1,6 @@
 import 'ses';
 import test from 'ava';
+import { exampleProblem } from './example-problem.js';
 
 lockdown({
   // Comment or uncomment each of these switches to see variations of the
@@ -20,43 +21,18 @@ lockdown({
 
 test('raw ava reject console output', t => {
   t.assert(true);
-  // Uncomment this to see something like the text in the extended comment below
 
-  // return Promise.resolve(null)
-  //   .then(v => v)
-  //   .then(v => v)
-  //   .then(_ => {
-  //     assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
-  //   });
+  exampleProblem('t.log1:', t.log);
+  exampleProblem('console.log1:', console.log);
+
+  return Promise.resolve(null)
+    .then(v => v)
+    .then(v => v)
+    .then(_ => {
+      exampleProblem('console.log2:', console.log);
+      exampleProblem('t.log2:', t.log);
+
+      // Uncomment to see something how this test case fails
+      // exampleProblem('throw', undefined);
+    });
 });
-
-/*
-Uncommenting the test code above should produce something like the following.
-This output is all from ava. The stack-like display comes from ava's direct
-use of the `error.stack` property. Ava bypasses the normal `console`.
-For the error message, ava has access only to the `message` string carried
-by the error instance, which would normally be redacted to
-`'msg (a string)'`. But `errorTaming: 'unsafe'` suppresses that redaction along
-with suppressing the redaction of the stack, so the console blabs
-`'msg "NOTICE ME"'` instead.
-```
-  raw ava reject console output
-
-  Rejected promise returned by test. Reason:
-
-  TypeError {
-    message: 'msg "NOTICE ME"',
-  }
-
-  › makeError (file:///Users/markmiller/src/ongithub/agoric/SES-shim/packages/ses/src/error/assert.js:141:17)
-  › fail (file:///Users/markmiller/src/ongithub/agoric/SES-shim/packages/ses/src/error/assert.js:260:20)
-  › baseAssert (file:///Users/markmiller/src/ongithub/agoric/SES-shim/packages/ses/src/error/assert.js:278:13)
-  › equal (file:///Users/markmiller/src/ongithub/agoric/SES-shim/packages/ses/src/error/assert.js:289:5)
-  › Function.assertTypeof [as typeof] (file:///Users/markmiller/src/ongithub/agoric/SES-shim/packages/ses/src/error/assert.js:308:5)
-  › file://test/test-raw-ava-reject.js:22:20
-
-  ─
-
-  1 test failed
-```
-*/

--- a/packages/ses-ava/test/test-raw-ava-throw.js
+++ b/packages/ses-ava/test/test-raw-ava-throw.js
@@ -6,18 +6,23 @@ lockdown({
   // output shown below. When all the switches are uncommented, you should
   // see that output.
   //
-  stackFiltering: 'verbose', // Exclude `assert` infrastructure
-  consoleTaming: 'unsafe', // Doesn't make a difference here
-  errorTaming: 'unsafe', // Redacts entire `error.stack`
+  // Commenting out all settings for a given switch defaults to using
+  // the current relevant environment variable setting. To get results
+  // independent of that, always uncomment one setting for each switch.
+  //
+  // stackFiltering: 'concise', // Default. Hide infrastructure, shorten paths
+  stackFiltering: 'verbose', // Include `assert` infrastructure
+  // consoleTaming: 'safe', // Default. Console with access to redacted info
+  consoleTaming: 'unsafe', // Console without access to redacted info
+  // errorTaming: 'safe', // Default. Hide redacted info from ava
+  errorTaming: 'unsafe', // Disclose `error.stack` to ava
 });
 
 test('raw ava throw console output', t => {
   t.assert(true);
   // Uncomment this to see something like the text in the extended comment below
 
-  /*
-  assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
-  */
+  // assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
 });
 
 /*

--- a/packages/ses-ava/test/test-raw-ava-throw.js
+++ b/packages/ses-ava/test/test-raw-ava-throw.js
@@ -1,5 +1,6 @@
 import 'ses';
 import test from 'ava';
+import { exampleProblem } from './example-problem.js';
 
 lockdown({
   // Comment or uncomment each of these switches to see variations of the
@@ -20,38 +21,10 @@ lockdown({
 
 test('raw ava throw console output', t => {
   t.assert(true);
-  // Uncomment this to see something like the text in the extended comment below
 
-  // assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
+  exampleProblem('t.log:', t.log);
+  exampleProblem('console.log:', console.log);
+
+  // Uncomment to see something how this test case fails
+  // exampleProblem('throw', undefined);
 });
-
-/*
-Uncommenting the test code above should produce something like the following.
-This output is all from ava. The stack-like display comes from ava's direct
-use of the `error.stack` property. Ava bypasses the normal `console`.
-For the error message, ava has access only to the `message` string carried
-by the error instance, which would normally be redacted to
-`'msg (a string)'`. But `errorTaming: 'unsafe'` suppresses that redaction along
-with suppressing the redaction of the stack, so the console blabs
-`'msg "NOTICE ME"'` instead.
-```
-  raw ava throw console output
-
-  Error thrown in test:
-
-  TypeError {
-    message: 'msg "NOTICE ME"',
-  }
-
-  › makeError (file:///Users/alice/agoric/SES-shim/packages/ses/src/error/assert.js:141:17)
-  › fail (file:///Users/alice/agoric/SES-shim/packages/ses/src/error/assert.js:260:20)
-  › baseAssert (file:///Users/alice/agoric/SES-shim/packages/ses/src/error/assert.js:278:13)
-  › equal (file:///Users/alice/agoric/SES-shim/packages/ses/src/error/assert.js:289:5)
-  › Function.assertTypeof [as typeof] (file:///Users/alice/agoric/SES-shim/packages/ses/src/error/assert.js:308:5)
-  › file://test/test-raw-ava-throw.js:17:16
-
-  ─
-
-  1 test failed
-```
-*/

--- a/packages/ses-ava/test/test-ses-ava-reject.js
+++ b/packages/ses-ava/test/test-ses-ava-reject.js
@@ -7,25 +7,30 @@ lockdown({
   // output shown below. When all the switches are commented, you should
   // see that output.
   //
-  // stackFiltering: 'verbose', // Include `assert` infrastructure
-  // consoleTaming: 'unsafe', // console without access to redacted info
-  // errorTaming: 'unsafe', // Disclose `error.stack` to ava
+  // Commenting out all settings for a given switch defaults to using
+  // the current relevant environment variable setting. To get results
+  // independent of that, always uncomment one setting for each switch.
+  //
+  // stackFiltering: 'concise', // Default. Hide infrastructure, shorten paths
+  stackFiltering: 'verbose', // Include `assert` infrastructure
+  consoleTaming: 'safe', // Default. Console with access to redacted info
+  // consoleTaming: 'unsafe', // Console without access to redacted info
+  // errorTaming: 'safe', // Default. Hide redacted info from ava
+  errorTaming: 'unsafe', // Disclose `error.stack` to ava
 });
 
-const test = wrapTest(rawTest);
+const test = wrapTest(rawTest, 'tlog');
 
 test('ses-ava reject console output', t => {
   t.assert(true);
   // Uncomment this to see something like the text in the extended comment below
 
-  /*
-  return Promise.resolve(null)
-    .then(v => v)
-    .then(v => v)
-    .then(_ => {
-      assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
-    });
-  */
+  // return Promise.resolve(null)
+  //   .then(v => v)
+  //   .then(v => v)
+  //   .then(_ => {
+  //     assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
+  //   });
 });
 
 /*

--- a/packages/ses-ava/test/test-ses-ava-reject.js
+++ b/packages/ses-ava/test/test-ses-ava-reject.js
@@ -1,6 +1,7 @@
 import 'ses';
 import rawTest from 'ava';
 import { wrapTest } from '../src/ses-ava-test.js';
+import { exampleProblem } from './example-problem.js';
 
 lockdown({
   // Comment or uncomment each of these switches to see variations of the
@@ -19,44 +20,22 @@ lockdown({
   errorTaming: 'unsafe', // Disclose `error.stack` to ava
 });
 
-const test = wrapTest(rawTest, { tlog: true });
+const test = wrapTest(rawTest, { tlog: true, pushConsole: true });
 
 test('ses-ava reject console output', t => {
   t.assert(true);
-  // Uncomment this to see something like the text in the extended comment below
 
-  // return Promise.resolve(null)
-  //   .then(v => v)
-  //   .then(v => v)
-  //   .then(_ => {
-  //     assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
-  //   });
+  exampleProblem('t.log1:', t.log);
+  exampleProblem('console.log1:', console.log);
+
+  return Promise.resolve(null)
+    .then(v => v)
+    .then(v => v)
+    .then(_ => {
+      exampleProblem('console.log2:', console.log);
+      exampleProblem('t.log2:', t.log);
+
+      // Uncomment to see something how this test case fails
+      // exampleProblem('throw', undefined);
+    });
 });
-
-/*
-Uncommenting the test code above should produce something like the following.
-Some of this output still comes from ava. The stack-like display comes from
-the SES `console`, which shows the detailed error message including the
-redacted `'NOTICE ME'` that ava has no access to.
-
-We will revisit this example in `@agoric/eventual-send` using `E.when` instead
-of `then` to show deep stacks across multiple turns.
-```
-REJECTED from ava test: (TypeError#1)
-TypeError#1: msg NOTICE ME
-
-  at packages/ses-ava/test/test-ses-ava-reject.js:26:20
-
-  ses-ava reject console output
-
-  Rejected promise returned by test. Reason:
-
-  TypeError {
-    message: 'msg (a string)',
-  }
-
-  ─
-
-  1 test failed
-```
-*/

--- a/packages/ses-ava/test/test-ses-ava-reject.js
+++ b/packages/ses-ava/test/test-ses-ava-reject.js
@@ -19,7 +19,7 @@ lockdown({
   errorTaming: 'unsafe', // Disclose `error.stack` to ava
 });
 
-const test = wrapTest(rawTest, 'tlog');
+const test = wrapTest(rawTest, { tlog: true });
 
 test('ses-ava reject console output', t => {
   t.assert(true);

--- a/packages/ses-ava/test/test-ses-ava-throw.js
+++ b/packages/ses-ava/test/test-ses-ava-throw.js
@@ -7,20 +7,25 @@ lockdown({
   // output shown below. When all the switches are commented, you should
   // see that output.
   //
-  // stackFiltering: 'verbose', // Include `assert` infrastructure
-  // consoleTaming: 'unsafe', // console without access to redacted info
-  // errorTaming: 'unsafe', // Disclose `error.stack` to ava
+  // Commenting out all settings for a given switch defaults to using
+  // the current relevant environment variable setting. To get results
+  // independent of that, always uncomment one setting for each switch.
+  //
+  // stackFiltering: 'concise', // Default. Hide infrastructure, shorten paths
+  stackFiltering: 'verbose', // Include `assert` infrastructure
+  consoleTaming: 'safe', // Default. Console with access to redacted info
+  // consoleTaming: 'unsafe', // Console without access to redacted info
+  // errorTaming: 'safe', // Default. Hide redacted info from ava
+  errorTaming: 'unsafe', // Disclose `error.stack` to ava
 });
 
-const test = wrapTest(rawTest);
+const test = wrapTest(rawTest, 'tlog');
 
 test('ses-ava throw console output', t => {
   t.assert(true);
   // Uncomment this to see something like the text in the extended comment below
 
-  /*
-  assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
-  */
+  // assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
 });
 
 /*

--- a/packages/ses-ava/test/test-ses-ava-throw.js
+++ b/packages/ses-ava/test/test-ses-ava-throw.js
@@ -19,7 +19,7 @@ lockdown({
   errorTaming: 'unsafe', // Disclose `error.stack` to ava
 });
 
-const test = wrapTest(rawTest, 'tlog');
+const test = wrapTest(rawTest, { tlog: true });
 
 test('ses-ava throw console output', t => {
   t.assert(true);

--- a/packages/ses-ava/test/test-ses-ava-throw.js
+++ b/packages/ses-ava/test/test-ses-ava-throw.js
@@ -1,6 +1,7 @@
 import 'ses';
 import rawTest from 'ava';
 import { wrapTest } from '../src/ses-ava-test.js';
+import { exampleProblem } from './example-problem.js';
 
 lockdown({
   // Comment or uncomment each of these switches to see variations of the
@@ -19,38 +20,14 @@ lockdown({
   errorTaming: 'unsafe', // Disclose `error.stack` to ava
 });
 
-const test = wrapTest(rawTest, { tlog: true });
+const test = wrapTest(rawTest, { tlog: true, pushConsole: true });
 
 test('ses-ava throw console output', t => {
   t.assert(true);
-  // Uncomment this to see something like the text in the extended comment below
 
-  // assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
+  exampleProblem('t.log:', t.log);
+  exampleProblem('console.log:', console.log);
+
+  // Uncomment to see something how this test case fails
+  // exampleProblem('throw', undefined);
 });
-
-/*
-Uncommenting the test code above should produce something like the following.
-Some of this output still comes from ava. The stack-like display comes from
-the SES `console`, which shows the detailed error message including the
-redacted `'NOTICE ME'` that ava has no access to.
-```
-THROWN from ava test: (TypeError#1)
-TypeError#1: msg NOTICE ME
-
-  at packages/ses-ava/test/test-ses-ava-throw.js:21:16
-  at logErrorFirst (packages/ses-ava/src/ses-ava-test.js:32:14)
-  at testFuncWrapper (packages/ses-ava/src/ses-ava-test.js:73:14)
-
-  ses-ava throw console output
-
-  Error thrown in test:
-
-  TypeError {
-    message: 'msg (a string)',
-  }
-
-  ─
-
-  1 test failed
-```
-*/


### PR DESCRIPTION
Staged on https://github.com/endojs/endo/pull/2107

closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/8965#discussion_r1501192561 https://github.com/endojs/endo/issues/611 https://github.com/endojs/endo/issues/647 https://github.com/endojs/endo/issues/891 https://github.com/endojs/endo/issues/1467 https://github.com/endojs/endo/pull/2107 https://github.com/Agoric/agoric-sdk/issues/8662 https://github.com/endojs/endo/issues/1798


## Description

Alter ses-ava so that it ultimately uses `t.log` to log errors or rejections from the `t => {...}` function.

### Security Considerations

As of this PR, ses-ava will import from `console-tools.js`, as exported by `ses` in https://github.com/endojs/endo/pull/2107 . We must ensure that this arrangement does not accidentally make these powers available to non-privileged code executing in constructed (non-start) compartments. See "Security Considerations" at https://github.com/endojs/endo/pull/2107

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

The whole point. Since *this* PR changes only the logging of errors or rejections from the `t => {...}` function, it will not by itself clean up console output in general. But at least it will cause these error reports to appear at the "right" place in the overall console output.

### Compatibility Considerations

Mostly none.

If there are programs post-processing our voluminous console output, they might need to change. However,
- I am not aware of any such programs
- the console output was never stable anyway, so any such programs should be adaptable enough to tolerate this change as well.

### Upgrade Considerations

Nothing breaking. Nothing newsworthy as of this PR by itself. 

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
