### PR TITLE
fix(daemon): Catch up init dev dependency to adjacent workspace

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@endo/bundle-source": "^3.1.0",
-    "@endo/init": "^1.0.3",
+    "@endo/init": "^1.0.4",
     "@endo/ses-ava": "^1.1.2",
     "ava": "^5.3.0",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
It looks like Lerna didn’t adjust the devDependencies for the daemon to match the latest release. I’ll keep an eye on that, but for now, this addresses the issue and is the mechanical effect of running `./scripts/sync-version.sh .`.