### PR TITLE
feat(ses): expose console tools support

### DIFF
--- a/packages/ses/console-tools.js
+++ b/packages/ses/console-tools.js
@@ -1,0 +1,8 @@
+export { loggedErrorHandler } from './src/error/assert.js';
+export {
+  makeCausalConsole,
+  consoleWhitelist,
+  makeLoggingConsoleKit,
+  filterConsole,
+} from './src/error/console.js';
+export { assertLogs, throwsAndLogs } from './src/error/throws-and-logs.js';

--- a/packages/ses/console-tools.js
+++ b/packages/ses/console-tools.js
@@ -1,8 +1,10 @@
 export { loggedErrorHandler } from './src/error/assert.js';
 export {
   makeCausalConsole,
-  consoleWhitelist,
+  consoleLevelMethods,
+  consoleOtherMethods,
   makeLoggingConsoleKit,
   filterConsole,
+  pumpLogToConsole,
 } from './src/error/console.js';
 export { assertLogs, throwsAndLogs } from './src/error/throws-and-logs.js';

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -46,6 +46,7 @@
       "require": "./dist/ses.cjs"
     },
     "./tools.js": "./tools.js",
+    "./console-tools.js": "./console-tools.js",
     "./assert-shim.js": "./assert-shim.js",
     "./lockdown-shim.js": "./lockdown-shim.js",
     "./compartment-shim.js": "./compartment-shim.js",

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -46,8 +46,17 @@ import './internal-types.js';
 
 /** @typedef {keyof VirtualConsole | 'profile' | 'profileEnd'} ConsoleProps */
 
-/** @type {readonly [ConsoleProps, LogSeverity | undefined][]} */
-const consoleLevelMethods = freeze([
+/**
+ * Those console methods whose actual parameters are `(fmt?, ...args)`
+ * even if their TypeScript types claim otherwise.
+ *
+ * Each is paired with what we consider to be their log severity level.
+ * This is the same as the log severity of these on other
+ * platform console implementations when they all agree.
+ *
+ * @type {readonly [ConsoleProps, LogSeverity | undefined][]}
+ */
+export const consoleLevelMethods = freeze([
   ['debug', 'debug'], // (fmt?, ...args) verbose level on Chrome
   ['log', 'log'], // (fmt?, ...args) info level on Chrome
   ['info', 'info'], // (fmt?, ...args)
@@ -55,13 +64,22 @@ const consoleLevelMethods = freeze([
   ['error', 'error'], // (fmt?, ...args)
 
   ['trace', 'log'], // (fmt?, ...args)
-  ['dirxml', 'log'], // (fmt?, ...args)
-  ['group', 'log'], // (fmt?, ...args)
-  ['groupCollapsed', 'log'], // (fmt?, ...args)
+  ['dirxml', 'log'], // (fmt?, ...args)          but TS typed (...data)
+  ['group', 'log'], // (fmt?, ...args)           but TS typed (...label)
+  ['groupCollapsed', 'log'], // (fmt?, ...args)  but TS typed (...label)
 ]);
 
-/** @type {readonly [ConsoleProps, LogSeverity | undefined][]} */
-const consoleOtherMethods = freeze([
+/**
+ * Those console methods other than those already enumerated by
+ * `consoleLevelMethods`.
+ *
+ * Each is paired with what we consider to be their log severity level.
+ * This is the same as the log severity of these on other
+ * platform console implementations when they all agree.
+ *
+ * @type {readonly [ConsoleProps, LogSeverity | undefined][]}
+ */
+export const consoleOtherMethods = freeze([
   ['assert', 'error'], // (value, fmt?, ...args)
   ['timeLog', 'log'], // (label?, ...args) no fmt string
 
@@ -85,7 +103,7 @@ const consoleOtherMethods = freeze([
 ]);
 
 /** @type {readonly [ConsoleProps, LogSeverity | undefined][]} */
-export const consoleWhitelist = freeze([
+const consoleWhitelist = freeze([
   ...consoleLevelMethods,
   ...consoleOtherMethods,
 ]);
@@ -117,10 +135,10 @@ export const consoleWhitelist = freeze([
  * ]);
  */
 
-// /////////////////////////////////////////////////////////////////////////////
+// //////////////////////////// Logging Console ////////////////////////////////
 
 /** @type {MakeLoggingConsoleKit} */
-const makeLoggingConsoleKit = (
+export const makeLoggingConsoleKit = (
   loggedErrorHandler,
   { shouldResetForDebugging = false } = {},
 ) => {
@@ -161,9 +179,23 @@ const makeLoggingConsoleKit = (
   return freeze({ loggingConsole: typedLoggingConsole, takeLog });
 };
 freeze(makeLoggingConsoleKit);
-export { makeLoggingConsoleKit };
 
-// /////////////////////////////////////////////////////////////////////////////
+/**
+ * Makes the same calls on a `baseConsole` that were made on a
+ * `loggingConsole` to produce this `log`. It this way, a logging console
+ * can be used as a buffer to delay the application of these calls to a
+ * `baseConsole`.
+ *
+ * @param {LogRecord[]} log
+ * @param {VirtualConsole} baseConsole
+ */
+export const pumpLogToConsole = (log, baseConsole) => {
+  for (const [name, ...args] of log) {
+    // eslint-disable-next-line @endo/no-polymorphic-call
+    baseConsole[name](...args);
+  }
+};
+// //////////////////////////// Causal Console /////////////////////////////////
 
 /** @type {ErrorInfo} */
 const ErrorInfo = {
@@ -175,7 +207,7 @@ const ErrorInfo = {
 freeze(ErrorInfo);
 
 /** @type {MakeCausalConsole} */
-const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
+export const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
   if (!baseConsole) {
     return undefined;
   }
@@ -362,12 +394,11 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
   return /** @type {VirtualConsole} */ (freeze(causalConsole));
 };
 freeze(makeCausalConsole);
-export { makeCausalConsole };
 
-// /////////////////////////////////////////////////////////////////////////////
+// ///////////////////////// Filter Console ////////////////////////////////////
 
 /** @type {FilterConsole} */
-const filterConsole = (baseConsole, filter, _topic = undefined) => {
+export const filterConsole = (baseConsole, filter, _topic = undefined) => {
   // TODO do something with optional topic string
   const whitelist = arrayFilter(
     consoleWhitelist,
@@ -391,4 +422,3 @@ const filterConsole = (baseConsole, filter, _topic = undefined) => {
   return /** @type {VirtualConsole} */ (freeze(filteringConsole));
 };
 freeze(filterConsole);
-export { filterConsole };

--- a/packages/ses/src/error/throws-and-logs.js
+++ b/packages/ses/src/error/throws-and-logs.js
@@ -1,11 +1,12 @@
+// This module supports testing/debugging, and should be exported from the
+// 'ses' package only by console-tools.js
+/* eslint-disable no-restricted-globals */
+/* eslint-disable @endo/no-polymorphic-call */
 /* global globalThis */
 
-import { freeze, getPrototypeOf } from '../../src/commons.js';
-import { loggedErrorHandler } from '../../src/error/assert.js';
-import {
-  makeLoggingConsoleKit,
-  makeCausalConsole,
-} from '../../src/error/console.js';
+import { freeze, getPrototypeOf } from '../commons.js';
+import { loggedErrorHandler } from './assert.js';
+import { makeLoggingConsoleKit, makeCausalConsole } from './console.js';
 
 // For our internal debugging purposes
 // const internalDebugConsole = console;
@@ -80,20 +81,27 @@ export const assertLogs = freeze((t, thunk, goldenLog, options = {}) => {
     loggedErrorHandler,
     { shouldResetForDebugging: true },
   );
+  /** @type {VirtualConsole} */
   let useConsole = console;
   if (checkLogs) {
     useConsole = loggingConsole;
     if (wrapWithCausal) {
+      // @ts-ignore Console vs VirtualConsole vs undefined.
+      // Not interesting for the testing/debugging nature of this module
       useConsole = makeCausalConsole(useConsole, {
         ...loggedErrorHandler,
         getStackString: getBogusStackString,
       });
     }
   } else if (wrapWithCausal) {
+    // @ts-ignore Console vs VirtualConsole vs undefined.
+    // Not interesting for the testing/debugging nature of this module
     useConsole = nonLoggingConsole;
   }
 
   const priorConsole = console;
+  // @ts-ignore Console vs VirtualConsole vs undefined.
+  // Not interesting for the testing/debugging nature of this module
   globalThis.console = useConsole;
   try {
     // If thunk() throws, we restore the console and the logging array.

--- a/packages/ses/test/error/test-aggregate-error-console.js
+++ b/packages/ses/test/error/test-aggregate-error-console.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import '../../index.js';
-import { throwsAndLogs } from './throws-and-logs.js';
+import { throwsAndLogs } from '../../src/error/throws-and-logs.js';
 
 lockdown();
 

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { assertLogs, throwsAndLogs } from './throws-and-logs.js';
+import { assertLogs, throwsAndLogs } from '../../src/error/throws-and-logs.js';
 import { assert } from '../../src/error/assert.js';
 
 const { details: d, quote: q, bare: b } = assert;

--- a/packages/ses/test/error/test-error-cause-console.js
+++ b/packages/ses/test/error/test-error-cause-console.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import '../../index.js';
-import { throwsAndLogs } from './throws-and-logs.js';
+import { throwsAndLogs } from '../../src/error/throws-and-logs.js';
 
 lockdown();
 

--- a/packages/ses/test/error/test-filtering-console.js
+++ b/packages/ses/test/error/test-filtering-console.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import '../../index.js';
 import { filterConsole } from '../../src/error/console.js';
-import { assertLogs } from './throws-and-logs.js';
+import { assertLogs } from '../../src/error/throws-and-logs.js';
 
 lockdown();
 

--- a/packages/ses/test/error/test-permit-removal-warnings.js
+++ b/packages/ses/test/error/test-permit-removal-warnings.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import '../../index.js';
-import { assertLogs } from './throws-and-logs.js';
+import { assertLogs } from '../../src/error/throws-and-logs.js';
 
 const { defineProperties } = Object;
 const { apply } = Reflect;


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/endojs/endo/pull/2101

## Description

Exports `console-tools.js` from `ses`, so PRs like https://github.com/endojs/endo/pull/2101 can use these to manipulate consoles ***ONLY*** for testing and debugging purposes. Some of our other packages export testing support API with an export named "tools.js". But ses already exports a "tools.js" with a different meaning.

Other than arranging this new availability, this PR itself should have no observable change whatsoever. In that sense, we can consider it a pure refactoring.

### Security Considerations

The powers exported from `ses` as `console-tools.js` should only be available to privileged code, such as ses-ava and instrumentation that runs in the start compartment. But as an export from the "ses" package, can we prevent others from importing it within the way we're currently using our tooling? @kriskowal , I think this is a question mostly for you.

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

The whole point is to enable testing tools like ses-ava to manipulate the console for better testing and debugging.

### Compatibility Considerations

none

### Upgrade Considerations

none. Nothing breaking. Nothing newsworthy.

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
