### PR TITLE
feat(ses): tolerate omitted species

### DIFF
--- a/packages/ses/src/tame-regexp-constructor.js
+++ b/packages/ses/src/tame-regexp-constructor.js
@@ -25,6 +25,16 @@ export default function tameRegExpConstructor(regExpTaming = 'safe') {
       return construct(FERAL_REG_EXP, rest, new.target);
     };
 
+    defineProperties(ResultRegExp, {
+      length: { value: 2 },
+      prototype: {
+        value: RegExpPrototype,
+        writable: false,
+        enumerable: false,
+        configurable: false,
+      },
+    });
+    // Hermes does not have `Symbol.species`. We should suppory such platforms.
     if (speciesSymbol) {
       const speciesDesc = getOwnPropertyDescriptor(
         FERAL_REG_EXP,
@@ -33,15 +43,7 @@ export default function tameRegExpConstructor(regExpTaming = 'safe') {
       if (!speciesDesc) {
         throw TypeError('no RegExp[Symbol.species] descriptor');
       }
-
       defineProperties(ResultRegExp, {
-        length: { value: 2 },
-        prototype: {
-          value: RegExpPrototype,
-          writable: false,
-          enumerable: false,
-          configurable: false,
-        },
         [speciesSymbol]: speciesDesc,
       });
     }

--- a/packages/ses/src/tame-regexp-constructor.js
+++ b/packages/ses/src/tame-regexp-constructor.js
@@ -25,21 +25,26 @@ export default function tameRegExpConstructor(regExpTaming = 'safe') {
       return construct(FERAL_REG_EXP, rest, new.target);
     };
 
-    const speciesDesc = getOwnPropertyDescriptor(FERAL_REG_EXP, speciesSymbol);
-    if (!speciesDesc) {
-      throw TypeError('no RegExp[Symbol.species] descriptor');
-    }
+    if (speciesSymbol) {
+      const speciesDesc = getOwnPropertyDescriptor(
+        FERAL_REG_EXP,
+        speciesSymbol,
+      );
+      if (!speciesDesc) {
+        throw TypeError('no RegExp[Symbol.species] descriptor');
+      }
 
-    defineProperties(ResultRegExp, {
-      length: { value: 2 },
-      prototype: {
-        value: RegExpPrototype,
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      },
-      [speciesSymbol]: speciesDesc,
-    });
+      defineProperties(ResultRegExp, {
+        length: { value: 2 },
+        prototype: {
+          value: RegExpPrototype,
+          writable: false,
+          enumerable: false,
+          configurable: false,
+        },
+        [speciesSymbol]: speciesDesc,
+      });
+    }
     return ResultRegExp;
   };
 

--- a/packages/ses/src/tame-regexp-constructor.js
+++ b/packages/ses/src/tame-regexp-constructor.js
@@ -34,7 +34,7 @@ export default function tameRegExpConstructor(regExpTaming = 'safe') {
         configurable: false,
       },
     });
-    // Hermes does not have `Symbol.species`. We should suppory such platforms.
+    // Hermes does not have `Symbol.species`. We should support such platforms.
     if (speciesSymbol) {
       const speciesDesc = getOwnPropertyDescriptor(
         FERAL_REG_EXP,


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

MetaMask is targeting React Native, that run on the Hermes JS engine. Thus, it would be good for the ses-shim to work on Hermes. Once problem we ran into is that Hermes omits `Symbol.species`. (Good riddance!) With this PR, the ses-shim should tolerate this difference from standard JS.

### Security Considerations

***Assuming*** that the semantics of the JS they implement is adjusted from the standard semantics in any of the obvious ways to cope with the absence of `Symbol.species`, this should have little effect on security.

Those "obvious ways" are
- Just act as if the species is always the base constructor itself. IOW, when asking a subclass of Array to `.map`, return an array rather than an instance of this or a related subclass of array.
- Just use `constructor` for what `Symbol.species` would have been used for. IOW, when asking a subclass of Array to `.map`, return an instance of this subclass rather than a somehow related subclass of array.

(FWIW, I further assume they make the first choice. Otherwise, what's the point of the omission? However, this PR should be compat with either.)

I say "little effect on security" above because this absence can in theory mislead correct JS code into silently doing the wrong thing.

### Scaling Considerations

None
### Documentation Considerations

None
### Testing Considerations

I leave that to those set up to test on Hermes, since that is the point. Attn @naugtur @kumavis 

### Compatibility Considerations

It only causes an observable difference on platforms that omit `Symbol.species`, on which the ses shim previously refused to run. So none.

### Upgrade Considerations

None. Nothing Breaking certainly. Nothing newsworthy yet. But when the ses-shim as a whole is know to support Hermes, that will be newsworthy ;) 

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
