### PR TITLE
Daemon: add directories

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -122,9 +122,7 @@ const makeDaemonCore = async (
     });
   };
 
-  /**
-   * @param {import('@endo/eventual-send').ERef<AsyncIterableIterator<string>>} readerRef
-   */
+  /** @type {import('./types.js').DaemonCore['storeReaderRef']} */
   const storeReaderRef = async readerRef => {
     const sha512Hex = await contentStore.store(makeRefReader(readerRef));
     // eslint-disable-next-line no-use-before-define
@@ -567,7 +565,7 @@ const makeDaemonCore = async (
     }
   };
 
-  /** @type {import('./types.js').ProvideValueForNumberedFormula} */
+  /** @type {import('./types.js').DaemonCore['provideValueForNumberedFormula']} */
   const provideValueForNumberedFormula = async (
     formulaType,
     formulaNumber,
@@ -622,7 +620,7 @@ const makeDaemonCore = async (
     });
   };
 
-  /** @type {import('./types.js').ProvideControllerForFormulaIdentifier} */
+  /** @type {import('./types.js').DaemonCore['provideControllerForFormulaIdentifier']} */
   const provideControllerForFormulaIdentifier = formulaIdentifier => {
     const { type: formulaType, number: formulaNumber } =
       parseFormulaIdentifier(formulaIdentifier);
@@ -656,7 +654,7 @@ const makeDaemonCore = async (
     return controller;
   };
 
-  /** @type {import('./types.js').CancelValue} */
+  /** @type {import('./types.js').DaemonCore['cancelValue']} */
   const cancelValue = async (formulaIdentifier, reason) => {
     await formulaGraphMutex.enqueue();
     const controller = provideControllerForFormulaIdentifier(formulaIdentifier);
@@ -664,7 +662,7 @@ const makeDaemonCore = async (
     return controller.context.cancel(reason);
   };
 
-  /** @type {import('./types.js').ProvideValueForFormulaIdentifier} */
+  /** @type {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} */
   const provideValueForFormulaIdentifier = formulaIdentifier => {
     const controller = /** @type {import('./types.js').Controller<>} */ (
       provideControllerForFormulaIdentifier(formulaIdentifier)
@@ -679,7 +677,7 @@ const makeDaemonCore = async (
     });
   };
 
-  /** @type {import('./types.js').ProvideControllerForFormulaIdentifierAndResolveHandle} */
+  /** @type {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} */
   const provideControllerForFormulaIdentifierAndResolveHandle =
     async formulaIdentifier => {
       let currentFormulaIdentifier = formulaIdentifier;
@@ -705,7 +703,7 @@ const makeDaemonCore = async (
     };
 
   /**
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').EndoGuest }>}
+   * @type {import('./types.js').DaemonCore['incarnateLeastAuthority']}
    */
   const incarnateLeastAuthority = async () => {
     const formulaNumber = await randomHex512();
@@ -713,14 +711,13 @@ const makeDaemonCore = async (
     const formula = {
       type: 'least-authority',
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').EndoGuest }>} */ (
+    return /** @type {import('./types').IncarnateResult<import('./types').EndoGuest>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
 
   /**
-   * @param {string} targetFormulaIdentifier
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').ExternalHandle }>}
+   * @type {import('./types.js').DaemonCore['incarnateHandle']}
    */
   const incarnateHandle = async targetFormulaIdentifier => {
     const formulaNumber = await randomHex512();
@@ -729,13 +726,13 @@ const makeDaemonCore = async (
       type: 'handle',
       target: targetFormulaIdentifier,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').ExternalHandle }>} */ (
+    return /** @type {import('./types').IncarnateResult<import('./types').ExternalHandle>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
 
   /**
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').PetStore }>}
+   * @type {import('./types.js').DaemonCore['incarnatePetStore']}
    */
   const incarnatePetStore = async () => {
     const formulaNumber = await randomHex512();
@@ -743,13 +740,13 @@ const makeDaemonCore = async (
     const formula = {
       type: 'pet-store',
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').PetStore }>} */ (
+    return /** @type {import('./types').IncarnateResult<import('./types').PetStore>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
 
   /**
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').EndoWorker }>}
+   * @type {import('./types.js').DaemonCore['incarnateWorker']}
    */
   const incarnateWorker = async () => {
     const formulaNumber = await randomHex512();
@@ -757,7 +754,7 @@ const makeDaemonCore = async (
     const formula = {
       type: 'worker',
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').EndoWorker }>} */ (
+    return /** @type {import('./types').IncarnateResult<import('./types').EndoWorker>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
@@ -774,17 +771,12 @@ const makeDaemonCore = async (
       type: 'worker',
     };
 
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').EndoWorker }>} */ (
+    return /** @type {import('./types').IncarnateResult<import('./types').EndoWorker>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
 
-  /**
-   * @param {string} endoFormulaIdentifier
-   * @param {string} leastAuthorityFormulaIdentifier
-   * @param {string} [specifiedWorkerFormulaIdentifier]
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').EndoHost }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateHost']} */
   const incarnateHost = async (
     endoFormulaIdentifier,
     leastAuthorityFormulaIdentifier,
@@ -810,15 +802,12 @@ const makeDaemonCore = async (
       endo: endoFormulaIdentifier,
       leastAuthority: leastAuthorityFormulaIdentifier,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').EndoHost }>} */ (
+    return /** @type {import('./types').IncarnateResult<import('./types').EndoHost>} */ (
       provideValueForNumberedFormula('host', formulaNumber, formula)
     );
   };
 
-  /**
-   * @param {string} hostHandleFormulaIdentifier
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').EndoGuest }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateGuest']} */
   const incarnateGuest = async hostHandleFormulaIdentifier => {
     const formulaNumber = await randomHex512();
     const { formulaIdentifier: storeFormulaIdentifier } =
@@ -832,20 +821,12 @@ const makeDaemonCore = async (
       petStore: storeFormulaIdentifier,
       worker: workerFormulaIdentifier,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').EndoGuest }>} */ (
+    return /** @type {import('./types').IncarnateResult<import('./types').EndoGuest>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
 
-  /**
-   * @param {string} hostFormulaIdentifier
-   * @param {string} source
-   * @param {string[]} codeNames
-   * @param {(string | string[])[]} endowmentFormulaIdsOrPaths
-   * @param {import('./types.js').EvalFormulaHook[]} hooks
-   * @param {string} [specifiedWorkerFormulaIdentifier]
-   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateEval']} */
   const incarnateEval = async (
     hostFormulaIdentifier,
     source,
@@ -901,7 +882,7 @@ const makeDaemonCore = async (
       names: codeNames,
       values: endowmentFormulaIdentifiers,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: unknown }>} */ (
+    return /** @type {import('./types.js').IncarnateResult<unknown>} */ (
       provideValueForNumberedFormula(formula.type, evalFormulaNumber, formula)
     );
   };
@@ -928,17 +909,12 @@ const makeDaemonCore = async (
       path: petNamePath,
     };
 
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types.js').EndoWorker }>} */ (
+    return /** @type {import('./types.js').IncarnateResult<import('./types.js').EndoWorker>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
 
-  /**
-   * @param {string} workerFormulaIdentifier
-   * @param {string} powersFormulaIdentifiers
-   * @param {string} specifier
-   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateUnconfined']} */
   const incarnateUnconfined = async (
     workerFormulaIdentifier,
     powersFormulaIdentifiers,
@@ -952,15 +928,12 @@ const makeDaemonCore = async (
       powers: powersFormulaIdentifiers,
       specifier,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: unknown }>} */ (
+    return /** @type {import('./types.js').IncarnateResult<unknown>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
 
-  /**
-   * @param {string} contentSha512
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types.js').FarEndoReadable }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateReadableBlob']} */
   const incarnateReadableBlob = async contentSha512 => {
     const formulaNumber = await randomHex512();
     /** @type {import('./types.js').ReadableBlobFormula} */
@@ -968,16 +941,12 @@ const makeDaemonCore = async (
       type: 'readable-blob',
       content: contentSha512,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types.js').FarEndoReadable }>} */ (
+    return /** @type {import('./types.js').IncarnateResult<import('./types.js').FarEndoReadable>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
 
-  /**
-   * @param {string} powersFormulaIdentifier
-   * @param {string} workerFormulaIdentifier
-   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateBundler']} */
   const incarnateBundler = async (
     powersFormulaIdentifier,
     workerFormulaIdentifier,
@@ -993,12 +962,7 @@ const makeDaemonCore = async (
     return provideValueForNumberedFormula(formula.type, formulaNumber, formula);
   };
 
-  /**
-   * @param {string} powersFormulaIdentifier
-   * @param {string} workerFormulaIdentifier
-   * @param {string} bundleFormulaIdentifier
-   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateBundle']} */
   const incarnateBundle = async (
     powersFormulaIdentifier,
     workerFormulaIdentifier,
@@ -1015,11 +979,7 @@ const makeDaemonCore = async (
     return provideValueForNumberedFormula(formula.type, formulaNumber, formula);
   };
 
-  /**
-   * @param {string} powersFormulaIdentifier
-   * @param {string} bundleFormulaIdentifier
-   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateWebBundle']} */
   const incarnateWebBundle = async (
     powersFormulaIdentifier,
     bundleFormulaIdentifier,
@@ -1035,10 +995,7 @@ const makeDaemonCore = async (
     return provideValueForNumberedFormula(formula.type, formulaNumber, formula);
   };
 
-  /**
-   * @param {string} petStoreFormulaIdentifier
-   * @returns {Promise<{ formulaIdentifier: string, value: unknown }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnatePetInspector']} */
   const incarnatePetInspector = async petStoreFormulaIdentifier => {
     const formulaNumber = await randomHex512();
     /** @type {import('./types.js').PetInspectorFormula} */
@@ -1046,13 +1003,12 @@ const makeDaemonCore = async (
       type: 'pet-inspector',
       petStore: petStoreFormulaIdentifier,
     };
-    return provideValueForNumberedFormula(formula.type, formulaNumber, formula);
+    return /** @type {import('./types').IncarnateResult<import('./types').EndoInspector>} */ (
+      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+    );
   };
 
-  /**
-   * @param {string} [specifiedFormulaNumber] - The formula number of the endo bootstrap.
-   * @returns {Promise<{ formulaIdentifier: string, value: import('./types').FarEndoBootstrap }>}
-   */
+  /** @type {import('./types.js').DaemonCore['incarnateEndoBootstrap']} */
   const incarnateEndoBootstrap = async specifiedFormulaNumber => {
     const formulaNumber = await (specifiedFormulaNumber ?? randomHex512());
     const endoFormulaIdentifier = `endo:${formulaNumber}`;
@@ -1086,7 +1042,7 @@ const makeDaemonCore = async (
       leastAuthority: leastAuthorityFormulaIdentifier,
       webPageJs: webPageJsFormulaIdentifier,
     };
-    return /** @type {Promise<{ formulaIdentifier: string, value: import('./types').FarEndoBootstrap }>} */ (
+    return /** @type {import('./types').IncarnateResult<import('./types').FarEndoBootstrap>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
   };
@@ -1244,8 +1200,16 @@ const makeDaemonCore = async (
     return info;
   };
 
+  /** @type {import('./types.js').DaemonCore} */
   const daemonCore = {
+    provideControllerForFormulaIdentifier,
+    provideControllerForFormulaIdentifierAndResolveHandle,
     provideValueForFormulaIdentifier,
+    provideValueForNumberedFormula,
+    getFormulaIdentifierForRef,
+    cancelValue,
+    storeReaderRef,
+    makeMailbox,
     incarnateEndoBootstrap,
     incarnateLeastAuthority,
     incarnateHandle,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1056,7 +1056,6 @@ const makeDaemonCore = async (
     getFormulaIdentifierForRef,
     provideValueForFormulaIdentifier,
     provideControllerForFormulaIdentifierAndResolveHandle,
-    cancelValue,
   });
 
   const makeIdentifiedGuestController = makeGuestMaker({
@@ -1068,6 +1067,7 @@ const makeDaemonCore = async (
   const makeIdentifiedHost = makeHostMaker({
     provideValueForFormulaIdentifier,
     provideControllerForFormulaIdentifier,
+    cancelValue,
     incarnateWorker,
     incarnateHost,
     incarnateGuest,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -495,12 +495,35 @@ const makeDaemonCore = async (
         internal: undefined,
       };
     } else if (formula.type === 'least-authority') {
-      /** @type {import('./types.js').EndoGuest} */
-      const leastAuthority = Far('EndoGuest', {
-        async request() {
-          throw new Error('declined');
-        },
-      });
+      const disallowedFn = async () => {
+        throw new Error('not allowed');
+      };
+      const leastAuthority =
+        /** @type {import('@endo/far').FarRef<import('./types.js').EndoGuest>} */ (
+          /** @type {unknown} */ (
+            Far('EndoGuest', {
+              has: disallowedFn,
+              identify: disallowedFn,
+              list: disallowedFn,
+              followChanges: disallowedFn,
+              lookup: disallowedFn,
+              reverseLookup: disallowedFn,
+              write: disallowedFn,
+              remove: disallowedFn,
+              move: disallowedFn,
+              copy: disallowedFn,
+              listMessages: disallowedFn,
+              followMessages: disallowedFn,
+              resolve: disallowedFn,
+              reject: disallowedFn,
+              adopt: disallowedFn,
+              dismiss: disallowedFn,
+              request: disallowedFn,
+              send: disallowedFn,
+              makeDirectory: disallowedFn,
+            })
+          )
+        );
       return { external: leastAuthority, internal: undefined };
     } else if (formula.type === 'pet-store') {
       const external = petStorePowers.makeIdentifiedPetStore(

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -83,6 +83,29 @@ export const makeDirectoryMaker = ({
       return hub.identify(name);
     };
 
+    /** @type {import('./types.js').EndoDirectory['list']} */
+    const list = async (...petNamePath) => {
+      if (petNamePath.length === 0) {
+        return petStore.list();
+      }
+      const hub = /** @type {import('./types.js').NameHub} */ (
+        await lookup(...petNamePath)
+      );
+      return hub.list();
+    };
+
+    /** @type {import('./types.js').EndoDirectory['followChanges']} */
+    const followChanges = async function* followChanges(...petNamePath) {
+      if (petNamePath.length === 0) {
+        yield* petStore.follow();
+        return;
+      }
+      const hub = /** @type {import('./types.js').NameHub} */ (
+        await lookup(...petNamePath)
+      );
+      yield* hub.followChanges();
+    };
+
     /** @type {import('./types.js').EndoDirectory['remove']} */
     const remove = async (...petNamePath) => {
       if (petNamePath.length === 1) {
@@ -154,6 +177,8 @@ export const makeDirectoryMaker = ({
     const directory = {
       has,
       identify,
+      list,
+      followChanges,
       lookup,
       reverseLookup,
       write,

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { E, Far } from '@endo/far';
+import { makeIteratorRef } from './reader-ref.js';
 
 const { quote: q } = assert;
 
@@ -206,7 +207,10 @@ export const makeDirectoryMaker = ({
     );
     const directory = makeDirectoryNode(petStore);
 
-    const external = Far('EndoDirectory', directory);
+    const external = Far('EndoDirectory', {
+      ...directory,
+      followChanges: () => makeIteratorRef(directory.followChanges()),
+    });
     const internal = harden({});
 
     return harden({ external, internal });

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -28,6 +28,7 @@ export const makeDirectoryMaker = ({
       // eslint-disable-next-line no-use-before-define
       const value = provideValueForFormulaIdentifier(formulaIdentifier);
       return tailNames.reduce(
+        // @ts-expect-error We assume its a NameHub
         (directory, petName) => E(directory).lookup(petName),
         value,
       );

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -1,0 +1,190 @@
+// @ts-check
+
+import { E, Far } from '@endo/far';
+
+const { quote: q } = assert;
+
+/**
+ * @param {object} args
+ * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['getFormulaIdentifierForRef']} args.getFormulaIdentifierForRef
+ * @param {import('./types.js').DaemonCore['incarnateDirectory']} args.incarnateDirectory
+ */
+export const makeDirectoryMaker = ({
+  provideValueForFormulaIdentifier,
+  getFormulaIdentifierForRef,
+  incarnateDirectory,
+}) => {
+  /** @type {import('./types.js').MakeDirectoryNode} */
+  const makeDirectoryNode = petStore => {
+    /** @type {import('./types.js').EndoDirectory['lookup']} */
+    const lookup = (...petNamePath) => {
+      const [headName, ...tailNames] = petNamePath;
+      const formulaIdentifier = petStore.identifyLocal(headName);
+      if (formulaIdentifier === undefined) {
+        throw new TypeError(`Unknown pet name: ${q(headName)}`);
+      }
+      // Behold, recursion:
+      // eslint-disable-next-line no-use-before-define
+      const value = provideValueForFormulaIdentifier(formulaIdentifier);
+      return tailNames.reduce(
+        (directory, petName) => E(directory).lookup(petName),
+        value,
+      );
+    };
+
+    /** @type {import('./types.js').EndoDirectory['reverseLookup']} */
+    const reverseLookup = async presence => {
+      const formulaIdentifier = getFormulaIdentifierForRef(await presence);
+      if (formulaIdentifier === undefined) {
+        return harden([]);
+      }
+      return petStore.reverseIdentify(formulaIdentifier);
+    };
+
+    /**
+     * @param {Array<string>} petNamePath
+     * @returns {Promise<{ hub: import('./types.js').NameHub, name: string }>}
+     */
+    const lookupTailNameHub = async petNamePath => {
+      if (petNamePath.length === 0) {
+        throw new TypeError(`Empty pet name path`);
+      }
+      const headPath = petNamePath.slice(0, -1);
+      const tailName = petNamePath[petNamePath.length - 1];
+      if (headPath.length === 0) {
+        // eslint-disable-next-line no-use-before-define
+        return { hub: directory, name: tailName };
+      }
+      const nameHub = /** @type {import('./types.js').NameHub} */ (
+        await lookup(...headPath)
+      );
+      return { hub: nameHub, name: tailName };
+    };
+
+    /** @type {import('./types.js').EndoDirectory['has']} */
+    const has = async (...petNamePath) => {
+      if (petNamePath.length === 1) {
+        const petName = petNamePath[0];
+        return petStore.has(petName);
+      }
+      const { hub, name } = await lookupTailNameHub(petNamePath);
+      return hub.has(name);
+    };
+
+    /** @type {import('./types.js').EndoDirectory['identify']} */
+    const identify = async (...petNamePath) => {
+      if (petNamePath.length === 1) {
+        const petName = petNamePath[0];
+        return petStore.identifyLocal(petName);
+      }
+      const { hub, name } = await lookupTailNameHub(petNamePath);
+      return hub.identify(name);
+    };
+
+    /** @type {import('./types.js').EndoDirectory['remove']} */
+    const remove = async (...petNamePath) => {
+      if (petNamePath.length === 1) {
+        const petName = petNamePath[0];
+        await petStore.remove(petName);
+        return;
+      }
+      const { hub, name } = await lookupTailNameHub(petNamePath);
+      await hub.remove(name);
+    };
+
+    /** @type {import('./types.js').EndoDirectory['move']} */
+    const move = async (fromPath, toPath) => {
+      const { hub: fromHub, name: fromName } = await lookupTailNameHub(
+        fromPath,
+      );
+      const { hub: toHub, name: toName } = await lookupTailNameHub(toPath);
+      if (fromHub === toHub) {
+        // eslint-disable-next-line no-use-before-define
+        if (fromHub === directory) {
+          await petStore.rename(fromName, toName);
+        } else {
+          await fromHub.move([fromName], [toName]);
+        }
+        return;
+      }
+      const formulaIdentifier = await fromHub.identify(fromName);
+      if (formulaIdentifier === undefined) {
+        throw new Error(`Unknown name: ${q(fromPath)}`);
+      }
+      const removeP = fromHub.remove(fromName);
+      const addP = toHub.write([toName], formulaIdentifier);
+      await Promise.all([addP, removeP]);
+    };
+
+    /** @type {import('./types.js').EndoDirectory['copy']} */
+    const copy = async (fromPath, toPath) => {
+      const { hub: fromHub, name: fromName } = await lookupTailNameHub(
+        fromPath,
+      );
+      const { hub: toHub, name: toName } = await lookupTailNameHub(toPath);
+      const formulaIdentifier = await fromHub.identify(fromName);
+      if (formulaIdentifier === undefined) {
+        throw new Error(`Unknown name: ${q(fromPath)}`);
+      }
+      await toHub.write([toName], formulaIdentifier);
+    };
+
+    /** @type {import('./types.js').EndoDirectory['makeDirectory']} */
+    const makeDirectory = async directoryPetName => {
+      const { value: directory, formulaIdentifier } =
+        await incarnateDirectory();
+      await petStore.write(directoryPetName, formulaIdentifier);
+      return directory;
+    };
+
+    /** @type {import('./types.js').EndoDirectory['write']} */
+    const write = async (petNamePath, formulaIdentifier) => {
+      if (petNamePath.length === 1) {
+        const petName = petNamePath[0];
+        await petStore.write(petName, formulaIdentifier);
+        return;
+      }
+      const { hub, name } = await lookupTailNameHub(petNamePath);
+      await hub.write([name], formulaIdentifier);
+    };
+
+    /** @type {import('./types.js').EndoDirectory} */
+    const directory = {
+      has,
+      identify,
+      lookup,
+      reverseLookup,
+      write,
+      move,
+      remove,
+      copy,
+      makeDirectory,
+    };
+    return directory;
+  };
+
+  /**
+   * @param {object} args
+   * @param {string} args.petStoreFormulaIdentifier
+   * @param {import('./types.js').Context} args.context
+   */
+  const makeIdentifiedDirectory = async ({
+    petStoreFormulaIdentifier,
+    context,
+  }) => {
+    // TODO thread context
+
+    const petStore = /** @type {import('./types.js').PetStore} */ (
+      await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
+    );
+    const directory = makeDirectoryNode(petStore);
+
+    const external = Far('EndoDirectory', directory);
+    const internal = harden({});
+
+    return harden({ external, internal });
+  };
+
+  return { makeIdentifiedDirectory, makeDirectoryNode };
+};

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -4,6 +4,12 @@ import { Far } from '@endo/far';
 import { makeIteratorRef } from './reader-ref.js';
 import { makePetSitter } from './pet-sitter.js';
 
+/**
+ * @param {object} args
+ * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
+ * @param {import('./types.js').DaemonCore['makeMailbox']} args.makeMailbox
+ */
 export const makeGuestMaker = ({
   provideValueForFormulaIdentifier,
   provideControllerForFormulaIdentifierAndResolveHandle,
@@ -35,8 +41,11 @@ export const makeGuestMaker = ({
       HOST: hostHandleFormulaIdentifier,
     });
     const hostController =
-      await provideControllerForFormulaIdentifierAndResolveHandle(
-        hostHandleFormulaIdentifier,
+      /** @type {import('./types.js').EndoHostController} */
+      (
+        await provideControllerForFormulaIdentifierAndResolveHandle(
+          hostHandleFormulaIdentifier,
+        )
       );
     const hostPrivateFacet = await hostController.internal;
     const { respond: deliverToHost } = hostPrivateFacet;

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -119,6 +119,7 @@ export const makeGuestMaker = ({
     const external = Far('EndoGuest', {
       ...guest,
       followChanges: () => makeIteratorRef(guest.followChanges()),
+      followMessages: () => makeIteratorRef(guest.followMessages()),
     });
     const internal = harden({
       receive,

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -78,36 +78,39 @@ export const makeGuestMaker = ({
     const { has, remove, rename, list, follow, listEntries, followEntries } =
       petStore;
 
-    const followNames = () => makeIteratorRef(follow());
-
-    /** @type {import('@endo/far').FarRef<import('./types.js').EndoGuest>} */
-    const guest = Far('EndoGuest', {
+    /** @type {import('./types.js').EndoGuest} */
+    const guest = {
       has,
       remove,
       rename,
       list,
-      followNames,
+      followNames: follow,
       listEntries,
       followEntries,
       lookup,
       reverseLookup,
-      request,
-      send,
       listMessages,
       followMessages,
       resolve,
       reject,
-      dismiss,
       adopt,
-    });
+      dismiss,
+      request,
+      send,
+    };
 
+    const external = Far('EndoGuest', {
+      ...guest,
+      followNames: () => makeIteratorRef(guest.followNames()),
+      followEntries: () => makeIteratorRef(guest.followEntries()),
+    });
     const internal = harden({
       receive,
       respond,
       petStore,
     });
 
-    return harden({ external: guest, internal });
+    return harden({ external, internal });
   };
 
   return makeIdentifiedGuestController;

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -2,6 +2,7 @@
 
 import { Far } from '@endo/far';
 import { makeIteratorRef } from './reader-ref.js';
+import { makePetSitter } from './pet-sitter.js';
 
 export const makeGuestMaker = ({
   provideValueForFormulaIdentifier,
@@ -26,9 +27,13 @@ export const makeGuestMaker = ({
     context.thisDiesIfThatDies(petStoreFormulaIdentifier);
     context.thisDiesIfThatDies(mainWorkerFormulaIdentifier);
 
-    const petStore = /** @type {import('./types.js').PetStore} */ (
+    const basePetStore = /** @type {import('./types.js').PetStore} */ (
       await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
     );
+    const petStore = makePetSitter(basePetStore, {
+      SELF: guestFormulaIdentifier,
+      HOST: hostHandleFormulaIdentifier,
+    });
     const hostController =
       await provideControllerForFormulaIdentifierAndResolveHandle(
         hostHandleFormulaIdentifier,
@@ -60,10 +65,6 @@ export const makeGuestMaker = ({
     } = makeMailbox({
       petStore,
       selfFormulaIdentifier: guestFormulaIdentifier,
-      specialNames: {
-        SELF: guestFormulaIdentifier,
-        HOST: hostHandleFormulaIdentifier,
-      },
       context,
     });
 

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -57,23 +57,12 @@ export const makeGuestMaker = ({
       );
     }
 
-    const {
-      petStore,
-      followMessages,
-      listMessages,
-      resolve,
-      reject,
-      dismiss,
-      adopt,
-      send,
-      receive,
-      respond,
-      request,
-    } = makeMailbox({
+    const mailbox = makeMailbox({
       petStore: specialStore,
       selfFormulaIdentifier: guestFormulaIdentifier,
       context,
     });
+    const { petStore } = mailbox;
     const directory = makeDirectoryNode(petStore);
 
     const {
@@ -89,6 +78,18 @@ export const makeGuestMaker = ({
       copy,
       makeDirectory,
     } = directory;
+    const {
+      listMessages,
+      followMessages,
+      resolve,
+      reject,
+      adopt,
+      dismiss,
+      request,
+      send,
+      receive,
+      respond,
+    } = mailbox;
 
     /** @type {import('./types.js').EndoGuest} */
     const guest = {

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -36,7 +36,7 @@ export const makeGuestMaker = ({
     const basePetStore = /** @type {import('./types.js').PetStore} */ (
       await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
     );
-    const petStore = makePetSitter(basePetStore, {
+    const specialStore = makePetSitter(basePetStore, {
       SELF: guestFormulaIdentifier,
       HOST: hostHandleFormulaIdentifier,
     });
@@ -56,6 +56,7 @@ export const makeGuestMaker = ({
     }
 
     const {
+      petStore,
       lookup,
       reverseLookup,
       followMessages,
@@ -68,38 +69,36 @@ export const makeGuestMaker = ({
       receive,
       respond,
       request,
-      rename,
-      remove,
-      list,
     } = makeMailbox({
-      petStore,
+      petStore: specialStore,
       selfFormulaIdentifier: guestFormulaIdentifier,
       context,
     });
 
-    const { has, follow, listEntries, followEntries } = petStore;
+    const { has, remove, rename, list, follow, listEntries, followEntries } =
+      petStore;
 
     const followNames = () => makeIteratorRef(follow());
 
     /** @type {import('@endo/far').FarRef<import('./types.js').EndoGuest>} */
     const guest = Far('EndoGuest', {
       has,
+      remove,
+      rename,
+      list,
+      followNames,
+      listEntries,
+      followEntries,
       lookup,
       reverseLookup,
       request,
       send,
-      list,
-      followNames,
       listMessages,
       followMessages,
-      listEntries,
-      followEntries,
       resolve,
       reject,
       dismiss,
       adopt,
-      remove,
-      rename,
     });
 
     const internal = harden({

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -76,10 +76,12 @@ export const makeGuestMaker = ({
     });
     const directory = makeDirectoryNode(petStore);
 
-    const { list, follow, listEntries, followEntries } = petStore;
+    const { listEntries, followEntries } = petStore;
     const {
       has,
       identify,
+      list,
+      followChanges,
       lookup,
       reverseLookup,
       write,
@@ -92,13 +94,13 @@ export const makeGuestMaker = ({
     /** @type {import('./types.js').EndoGuest} */
     const guest = {
       // PetStore
-      list,
-      followNames: follow,
       listEntries,
       followEntries,
       // Directory
       has,
       identify,
+      list,
+      followChanges,
       lookup,
       reverseLookup,
       write,
@@ -119,8 +121,8 @@ export const makeGuestMaker = ({
 
     const external = Far('EndoGuest', {
       ...guest,
-      followNames: () => makeIteratorRef(guest.followNames()),
       followEntries: () => makeIteratorRef(guest.followEntries()),
+      followChanges: () => makeIteratorRef(guest.followChanges()),
     });
     const internal = harden({
       receive,

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -8,12 +8,14 @@ import { makePetSitter } from './pet-sitter.js';
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
  * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
- * @param {import('./types.js').DaemonCore['makeMailbox']} args.makeMailbox
+ * @param {import('./types.js').MakeMailbox} args.makeMailbox
+ * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
  */
 export const makeGuestMaker = ({
   provideValueForFormulaIdentifier,
   provideControllerForFormulaIdentifierAndResolveHandle,
   makeMailbox,
+  makeDirectoryNode,
 }) => {
   /**
    * @param {string} guestFormulaIdentifier
@@ -57,8 +59,6 @@ export const makeGuestMaker = ({
 
     const {
       petStore,
-      lookup,
-      reverseLookup,
       followMessages,
       listMessages,
       resolve,
@@ -74,21 +74,39 @@ export const makeGuestMaker = ({
       selfFormulaIdentifier: guestFormulaIdentifier,
       context,
     });
+    const directory = makeDirectoryNode(petStore);
 
-    const { has, remove, rename, list, follow, listEntries, followEntries } =
-      petStore;
+    const { list, follow, listEntries, followEntries } = petStore;
+    const {
+      has,
+      identify,
+      lookup,
+      reverseLookup,
+      write,
+      move,
+      remove,
+      copy,
+      makeDirectory,
+    } = directory;
 
     /** @type {import('./types.js').EndoGuest} */
     const guest = {
-      has,
-      remove,
-      rename,
+      // PetStore
       list,
       followNames: follow,
       listEntries,
       followEntries,
+      // Directory
+      has,
+      identify,
       lookup,
       reverseLookup,
+      write,
+      move,
+      remove,
+      copy,
+      makeDirectory,
+      // Mail
       listMessages,
       followMessages,
       resolve,

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -76,7 +76,6 @@ export const makeGuestMaker = ({
     });
     const directory = makeDirectoryNode(petStore);
 
-    const { listEntries, followEntries } = petStore;
     const {
       has,
       identify,
@@ -93,9 +92,6 @@ export const makeGuestMaker = ({
 
     /** @type {import('./types.js').EndoGuest} */
     const guest = {
-      // PetStore
-      listEntries,
-      followEntries,
       // Directory
       has,
       identify,
@@ -121,7 +117,6 @@ export const makeGuestMaker = ({
 
     const external = Far('EndoGuest', {
       ...guest,
-      followEntries: () => makeIteratorRef(guest.followEntries()),
       followChanges: () => makeIteratorRef(guest.followChanges()),
     });
     const internal = harden({

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { Far } from '@endo/far';
+import { makeIteratorRef } from './reader-ref.js';
 
 export const makeGuestMaker = ({
   provideValueForFormulaIdentifier,
@@ -66,9 +67,11 @@ export const makeGuestMaker = ({
       context,
     });
 
-    const { has, follow: followNames, listEntries, followEntries } = petStore;
+    const { has, follow, listEntries, followEntries } = petStore;
 
-    /** @type {import('@endo/eventual-send').ERef<import('./types.js').EndoGuest>} */
+    const followNames = () => makeIteratorRef(follow());
+
+    /** @type {import('@endo/far').FarRef<import('./types.js').EndoGuest>} */
     const guest = Far('EndoGuest', {
       has,
       lookup,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { Far } from '@endo/far';
+import { makeIteratorRef } from './reader-ref.js';
 import { assertPetName, petNamePathFrom } from './pet-name.js';
 
 const { quote: q } = assert;
@@ -493,9 +494,11 @@ export const makeHostMaker = ({
       return value;
     };
 
-    const { has, follow: followNames, listEntries, followEntries } = petStore;
+    const { has, follow, listEntries, followEntries } = petStore;
 
-    /** @type {import('./types.js').EndoHost} */
+    const followNames = () => makeIteratorRef(follow());
+
+    /** @type {import('@endo/far').FarRef<import('./types.js').EndoHost>} */
     const host = Far('EndoHost', {
       has,
       lookup,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -21,7 +21,8 @@ const { quote: q } = assert;
  * @param {import('./types.js').DaemonCore['incarnateWebBundle']} args.incarnateWebBundle
  * @param {import('./types.js').DaemonCore['incarnateHandle']} args.incarnateHandle
  * @param {import('./types.js').DaemonCore['storeReaderRef']} args.storeReaderRef
- * @param {import('./types.js').DaemonCore['makeMailbox']} args.makeMailbox
+ * @param {import('./types.js').MakeMailbox} args.makeMailbox
+ * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
  */
 export const makeHostMaker = ({
   provideValueForFormulaIdentifier,
@@ -37,6 +38,7 @@ export const makeHostMaker = ({
   incarnateHandle,
   storeReaderRef,
   makeMailbox,
+  makeDirectoryNode,
 }) => {
   /**
    * @param {string} hostFormulaIdentifier
@@ -73,8 +75,6 @@ export const makeHostMaker = ({
 
     const {
       petStore,
-      lookup,
-      reverseLookup,
       listMessages,
       followMessages,
       resolve,
@@ -90,6 +90,8 @@ export const makeHostMaker = ({
       selfFormulaIdentifier: hostFormulaIdentifier,
       context,
     });
+
+    const directory = makeDirectoryNode(petStore);
 
     /**
      * @returns {Promise<{ formulaIdentifier: string, value: import('./types').ExternalHandle }>}
@@ -524,20 +526,37 @@ export const makeHostMaker = ({
       return cancelValue(formulaIdentifier, reason);
     };
 
-    const { has, remove, rename, list, follow, listEntries, followEntries } =
-      petStore;
+    const { list, follow, listEntries, followEntries } = petStore;
+    const {
+      lookup,
+      reverseLookup,
+      has,
+      identify,
+      write,
+      remove,
+      move,
+      copy,
+      makeDirectory,
+    } = directory;
 
     /** @type {import('./types.js').EndoHost} */
     const host = {
-      has,
-      remove,
-      rename,
+      // PetStore
       list,
       followNames: follow,
       listEntries,
       followEntries,
+      // Directory
+      has,
+      identify,
       lookup,
       reverseLookup,
+      write,
+      remove,
+      move,
+      copy,
+      makeDirectory,
+      // Mail
       listMessages,
       followMessages,
       resolve,
@@ -546,6 +565,7 @@ export const makeHostMaker = ({
       dismiss,
       request,
       send,
+      // Host
       store,
       provideGuest,
       provideHost,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -579,6 +579,7 @@ export const makeHostMaker = ({
     const external = Far('EndoHost', {
       ...host,
       followChanges: () => makeIteratorRef(host.followChanges()),
+      followMessages: () => makeIteratorRef(host.followMessages()),
     });
     const internal = harden({ receive, respond, petStore });
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -3,6 +3,7 @@
 import { Far } from '@endo/far';
 import { makeIteratorRef } from './reader-ref.js';
 import { assertPetName, petNamePathFrom } from './pet-name.js';
+import { makePetSitter } from './pet-sitter.js';
 
 const { quote: q } = assert;
 
@@ -41,11 +42,17 @@ export const makeHostMaker = ({
     context.thisDiesIfThatDies(storeFormulaIdentifier);
     context.thisDiesIfThatDies(mainWorkerFormulaIdentifier);
 
-    const petStore = /** @type {import('./types.js').PetStore} */ (
+    const basePetStore = /** @type {import('./types.js').PetStore} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
       await provideValueForFormulaIdentifier(storeFormulaIdentifier)
     );
+    const petStore = makePetSitter(basePetStore, {
+      SELF: hostFormulaIdentifier,
+      ENDO: endoFormulaIdentifier,
+      INFO: inspectorFormulaIdentifier,
+      NONE: leastAuthorityFormulaIdentifier,
+    });
 
     const {
       lookup,
@@ -68,12 +75,6 @@ export const makeHostMaker = ({
     } = makeMailbox({
       petStore,
       selfFormulaIdentifier: hostFormulaIdentifier,
-      specialNames: {
-        SELF: hostFormulaIdentifier,
-        ENDO: endoFormulaIdentifier,
-        INFO: inspectorFormulaIdentifier,
-        NONE: leastAuthorityFormulaIdentifier,
-      },
       context,
     });
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -7,6 +7,21 @@ import { makePetSitter } from './pet-sitter.js';
 
 const { quote: q } = assert;
 
+/**
+ * @param {object} args
+ * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifier']} args.provideControllerForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['incarnateWorker']} args.incarnateWorker
+ * @param {import('./types.js').DaemonCore['incarnateHost']} args.incarnateHost
+ * @param {import('./types.js').DaemonCore['incarnateGuest']} args.incarnateGuest
+ * @param {import('./types.js').DaemonCore['incarnateEval']} args.incarnateEval
+ * @param {import('./types.js').DaemonCore['incarnateUnconfined']} args.incarnateUnconfined
+ * @param {import('./types.js').DaemonCore['incarnateBundle']} args.incarnateBundle
+ * @param {import('./types.js').DaemonCore['incarnateWebBundle']} args.incarnateWebBundle
+ * @param {import('./types.js').DaemonCore['incarnateHandle']} args.incarnateHandle
+ * @param {import('./types.js').DaemonCore['storeReaderRef']} args.storeReaderRef
+ * @param {import('./types.js').DaemonCore['makeMailbox']} args.makeMailbox
+ */
 export const makeHostMaker = ({
   provideValueForFormulaIdentifier,
   provideControllerForFormulaIdentifier,
@@ -130,7 +145,10 @@ export const makeHostMaker = ({
           await petStore.write(petName, guestFormulaIdentifier);
         }
 
-        return { value, formulaIdentifier: guestFormulaIdentifier };
+        return {
+          value: Promise.resolve(value),
+          formulaIdentifier: guestFormulaIdentifier,
+        };
       } else if (!formulaIdentifier.startsWith('guest:')) {
         throw new Error(
           `Existing pet name does not designate a guest powers capability: ${q(
@@ -437,7 +455,10 @@ export const makeHostMaker = ({
           assertPetName(petName);
           await petStore.write(petName, newFormulaIdentifier);
         }
-        return { formulaIdentifier: newFormulaIdentifier, value };
+        return {
+          formulaIdentifier: newFormulaIdentifier,
+          value: Promise.resolve(value),
+        };
       } else if (!formulaIdentifier.startsWith('host:')) {
         throw new Error(
           `Existing pet name does not designate a host powers capability: ${q(

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -517,15 +517,13 @@ export const makeHostMaker = ({
     const { has, remove, rename, list, follow, listEntries, followEntries } =
       petStore;
 
-    const followNames = () => makeIteratorRef(follow());
-
-    /** @type {import('@endo/far').FarRef<import('./types.js').EndoHost>} */
-    const host = Far('EndoHost', {
+    /** @type {import('./types.js').EndoHost} */
+    const host = {
       has,
       remove,
       rename,
       list,
-      followNames,
+      followNames: follow,
       listEntries,
       followEntries,
       lookup,
@@ -544,17 +542,22 @@ export const makeHostMaker = ({
       makeWorker,
       provideWorker,
       evaluate,
-      cancel,
       makeUnconfined,
       makeBundle,
       provideWebPage,
-    });
+      cancel,
+    };
 
+    const external = Far('EndoHost', {
+      ...host,
+      followNames: () => makeIteratorRef(host.followNames()),
+      followEntries: () => makeIteratorRef(host.followEntries()),
+    });
     const internal = harden({ receive, respond, petStore });
 
     await provideValueForFormulaIdentifier(mainWorkerFormulaIdentifier);
 
-    return harden({ external: host, internal });
+    return harden({ external, internal });
   };
 
   return makeIdentifiedHost;

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -11,6 +11,7 @@ const { quote: q } = assert;
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
  * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifier']} args.provideControllerForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['cancelValue']} args.cancelValue
  * @param {import('./types.js').DaemonCore['incarnateWorker']} args.incarnateWorker
  * @param {import('./types.js').DaemonCore['incarnateHost']} args.incarnateHost
  * @param {import('./types.js').DaemonCore['incarnateGuest']} args.incarnateGuest
@@ -25,6 +26,7 @@ const { quote: q } = assert;
 export const makeHostMaker = ({
   provideValueForFormulaIdentifier,
   provideControllerForFormulaIdentifier,
+  cancelValue,
   incarnateWorker,
   incarnateHost,
   incarnateGuest,
@@ -83,7 +85,6 @@ export const makeHostMaker = ({
       send,
       dismiss,
       adopt,
-      cancel,
     } = makeMailbox({
       petStore: specialStore,
       selfFormulaIdentifier: hostFormulaIdentifier,
@@ -512,6 +513,15 @@ export const makeHostMaker = ({
       }
 
       return value;
+    };
+
+    /** @type {import('./types.js').EndoHost['cancel']} */
+    const cancel = async (petName, reason = new Error('Cancelled')) => {
+      const formulaIdentifier = petStore.identifyLocal(petName);
+      if (formulaIdentifier === undefined) {
+        throw new TypeError(`Unknown pet name: ${q(petName)}`);
+      }
+      return cancelValue(formulaIdentifier, reason);
     };
 
     const { has, remove, rename, list, follow, listEntries, followEntries } =

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -526,7 +526,6 @@ export const makeHostMaker = ({
       return cancelValue(formulaIdentifier, reason);
     };
 
-    const { listEntries, followEntries } = petStore;
     const {
       has,
       identify,
@@ -543,9 +542,6 @@ export const makeHostMaker = ({
 
     /** @type {import('./types.js').EndoHost} */
     const host = {
-      // PetStore
-      listEntries,
-      followEntries,
       // Directory
       has,
       identify,
@@ -582,7 +578,6 @@ export const makeHostMaker = ({
 
     const external = Far('EndoHost', {
       ...host,
-      followEntries: () => makeIteratorRef(host.followEntries()),
       followChanges: () => makeIteratorRef(host.followChanges()),
     });
     const internal = harden({ receive, respond, petStore });

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -73,24 +73,12 @@ export const makeHostMaker = ({
       NONE: leastAuthorityFormulaIdentifier,
     });
 
-    const {
-      petStore,
-      listMessages,
-      followMessages,
-      resolve,
-      reject,
-      respond,
-      request,
-      receive,
-      send,
-      dismiss,
-      adopt,
-    } = makeMailbox({
+    const mailbox = makeMailbox({
       petStore: specialStore,
       selfFormulaIdentifier: hostFormulaIdentifier,
       context,
     });
-
+    const { petStore } = mailbox;
     const directory = makeDirectoryNode(petStore);
 
     /**
@@ -539,6 +527,18 @@ export const makeHostMaker = ({
       copy,
       makeDirectory,
     } = directory;
+    const {
+      listMessages,
+      followMessages,
+      resolve,
+      reject,
+      adopt,
+      dismiss,
+      request,
+      send,
+      receive,
+      respond,
+    } = mailbox;
 
     /** @type {import('./types.js').EndoHost} */
     const host = {

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -526,12 +526,14 @@ export const makeHostMaker = ({
       return cancelValue(formulaIdentifier, reason);
     };
 
-    const { list, follow, listEntries, followEntries } = petStore;
+    const { listEntries, followEntries } = petStore;
     const {
-      lookup,
-      reverseLookup,
       has,
       identify,
+      list,
+      followChanges,
+      lookup,
+      reverseLookup,
       write,
       remove,
       move,
@@ -542,13 +544,13 @@ export const makeHostMaker = ({
     /** @type {import('./types.js').EndoHost} */
     const host = {
       // PetStore
-      list,
-      followNames: follow,
       listEntries,
       followEntries,
       // Directory
       has,
       identify,
+      list,
+      followChanges,
       lookup,
       reverseLookup,
       write,
@@ -580,8 +582,8 @@ export const makeHostMaker = ({
 
     const external = Far('EndoHost', {
       ...host,
-      followNames: () => makeIteratorRef(host.followNames()),
       followEntries: () => makeIteratorRef(host.followEntries()),
+      followChanges: () => makeIteratorRef(host.followChanges()),
     });
     const internal = harden({ receive, respond, petStore });
 

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -13,14 +13,12 @@ const { quote: q } = assert;
  * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
  * @param {import('./types.js').DaemonCore['getFormulaIdentifierForRef']} args.getFormulaIdentifierForRef
  * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
- * @param {import('./types.js').DaemonCore['cancelValue']} args.cancelValue
  * @returns {import('./types.js').MakeMailbox}
  */
 export const makeMailboxMaker = ({
   getFormulaIdentifierForRef,
   provideValueForFormulaIdentifier,
   provideControllerForFormulaIdentifierAndResolveHandle,
-  cancelValue,
 }) => {
   /**
     @type {import('./types.js').MakeMailbox} */
@@ -50,15 +48,6 @@ export const makeMailboxMaker = ({
         (currentValue, petName) => E(currentValue).lookup(petName),
         provideValueForFormulaIdentifier(formulaIdentifier),
       );
-    };
-
-    /** @type {import('./types.js').Mail['cancel']} */
-    const cancel = async (petName, reason = new Error('Cancelled')) => {
-      const formulaIdentifier = petStore.identifyLocal(petName);
-      if (formulaIdentifier === undefined) {
-        throw new TypeError(`Unknown pet name: ${q(petName)}`);
-      }
-      return cancelValue(formulaIdentifier, reason);
     };
 
     /** @type {import('./types.js').Mail['reverseLookup']} */
@@ -496,8 +485,6 @@ export const makeMailboxMaker = ({
       reject,
       dismiss,
       adopt,
-      // etc
-      cancel,
     });
   };
 

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -90,7 +90,7 @@ export const makeMailboxMaker = ({
 
     /** @type {import('./types.js').Mail['reverseLookupFormulaIdentifier']} */
     const reverseLookupFormulaIdentifier = formulaIdentifier => {
-      const names = Array.from(petStore.reverseLookup(formulaIdentifier));
+      const names = Array.from(petStore.reverseIdentify(formulaIdentifier));
       for (const [specialName, specialFormulaIdentifier] of Object.entries(
         specialNames,
       )) {

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -473,16 +473,15 @@ export const makeMailboxMaker = ({
       responses.delete(petName);
     };
 
-    const { has, list, identifyLocal, reverseIdentify } = petStore;
-
-    return harden({
-      // PetStore
-      has,
+    /** @type {import('./types.js').PetStore} */
+    const mailStore = {
+      ...petStore,
       rename,
       remove,
-      list,
-      identifyLocal,
-      reverseIdentify,
+    };
+
+    return harden({
+      petStore: mailStore,
       // NameHub
       lookup,
       reverseLookup,

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -10,10 +10,11 @@ const { quote: q } = assert;
 
 /**
  * @param {object} args
- * @param {import('./types.js').ProvideValueForFormulaIdentifier} args.provideValueForFormulaIdentifier
- * @param {import('./types.js').GetFormulaIdentifierForRef} args.getFormulaIdentifierForRef
- * @param {import('./types.js').ProvideControllerForFormulaIdentifierAndResolveHandle} args.provideControllerForFormulaIdentifierAndResolveHandle
- * @param {import('./types.js').CancelValue} args.cancelValue
+ * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['getFormulaIdentifierForRef']} args.getFormulaIdentifierForRef
+ * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
+ * @param {import('./types.js').DaemonCore['cancelValue']} args.cancelValue
+ * @returns {import('./types.js').MakeMailbox}
  */
 export const makeMailboxMaker = ({
   getFormulaIdentifierForRef,
@@ -22,12 +23,7 @@ export const makeMailboxMaker = ({
   cancelValue,
 }) => {
   /**
-   * @param {object} args
-   * @param {string} args.selfFormulaIdentifier
-   * @param {import('./types.js').PetStore} args.petStore
-   * @param {import('./types.js').Context} args.context
-   * @returns {import('./types.js').Mail}
-   */
+    @type {import('./types.js').MakeMailbox} */
   const makeMailbox = ({ selfFormulaIdentifier, petStore, context }) => {
     /** @type {Map<string, Promise<unknown>>} */
     const responses = new Map();
@@ -461,7 +457,7 @@ export const makeMailboxMaker = ({
       return newResponseP;
     };
 
-    /** @type {import('./types.js').Mail['rename']} */
+    /** @type {import('./types.js').PetStore['rename']} */
     const rename = async (fromName, toName) => {
       await petStore.rename(fromName, toName);
       const formulaIdentifier = responses.get(fromName);
@@ -471,7 +467,7 @@ export const makeMailboxMaker = ({
       }
     };
 
-    /** @type {import('./types.js').Mail['remove']} */
+    /** @type {import('./types.js').PetStore['remove']} */
     const remove = async petName => {
       await petStore.remove(petName);
       responses.delete(petName);

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import { E } from '@endo/far';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeChangeTopic } from './pubsub.js';
 import { makeIteratorRef } from './reader-ref.js';
@@ -11,12 +10,10 @@ const { quote: q } = assert;
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
- * @param {import('./types.js').DaemonCore['getFormulaIdentifierForRef']} args.getFormulaIdentifierForRef
  * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
  * @returns {import('./types.js').MakeMailbox}
  */
 export const makeMailboxMaker = ({
-  getFormulaIdentifierForRef,
   provideValueForFormulaIdentifier,
   provideControllerForFormulaIdentifierAndResolveHandle,
 }) => {
@@ -34,30 +31,6 @@ export const makeMailboxMaker = ({
     /** @type {import('./types.js').Topic<import('./types.js').InternalMessage>} */
     const messagesTopic = makeChangeTopic();
     let nextMessageNumber = 0;
-
-    /** @type {import('./types.js').Mail['lookup']} */
-    const lookup = async (...petNamePath) => {
-      const [headName, ...tailNames] = petNamePath;
-      const formulaIdentifier = petStore.identifyLocal(headName);
-      if (formulaIdentifier === undefined) {
-        throw new TypeError(`Unknown pet name: ${q(headName)}`);
-      }
-      // Behold, recursion:
-      return tailNames.reduce(
-        // @ts-expect-error calling lookup on an unknown object
-        (currentValue, petName) => E(currentValue).lookup(petName),
-        provideValueForFormulaIdentifier(formulaIdentifier),
-      );
-    };
-
-    /** @type {import('./types.js').Mail['reverseLookup']} */
-    const reverseLookup = async presence => {
-      const formulaIdentifier = getFormulaIdentifierForRef(await presence);
-      if (formulaIdentifier === undefined) {
-        return harden([]);
-      }
-      return petStore.reverseIdentify(formulaIdentifier);
-    };
 
     /**
      * @param {import('./types.js').InternalMessage} message
@@ -471,9 +444,6 @@ export const makeMailboxMaker = ({
 
     return harden({
       petStore: mailStore,
-      // NameHub
-      lookup,
-      reverseLookup,
       // Mail
       listMessages,
       followMessages,

--- a/packages/daemon/src/pet-sitter.js
+++ b/packages/daemon/src/pet-sitter.js
@@ -10,12 +10,12 @@ const { quote: q } = assert;
  * @returns {import('./types.js').PetStore}
  */
 export const makePetSitter = (petStore, specialNames) => {
-  /** @type {import('./types.js').Mail['has']} */
+  /** @type {import('./types.js').PetStore['has']} */
   const has = petName => {
     return Object.hasOwn(specialNames, petName) || petStore.has(petName);
   };
 
-  /** @type {import('./types.js').Mail['identifyLocal']} */
+  /** @type {import('./types.js').PetStore['identifyLocal']} */
   const identifyLocal = petName => {
     if (Object.hasOwn(specialNames, petName)) {
       return specialNames[petName];
@@ -35,7 +35,7 @@ export const makePetSitter = (petStore, specialNames) => {
     return parseFormulaIdentifier(formulaIdentifier);
   };
 
-  /** @type {import('./types.js').Mail['list']} */
+  /** @type {import('./types.js').PetStore['list']} */
   const list = () =>
     harden([...Object.keys(specialNames).sort(), ...petStore.list()]);
 

--- a/packages/daemon/src/pet-sitter.js
+++ b/packages/daemon/src/pet-sitter.js
@@ -51,24 +51,6 @@ export const makePetSitter = (petStore, specialNames) => {
     yield* petStore.follow();
   };
 
-  // Provided as an alias for follow, with naming symmetry to listEntries.
-  /** @type {import('./types.js').PetStore['follow']} */
-  const followEntries = follow;
-
-  // Returns in Object.fromEntries format.
-  /** @type {import('./types.js').PetStore['listEntries']} */
-  const listEntries = () => {
-    const specialEntries = Object.keys(specialNames)
-      .sort()
-      .map(name => {
-        return /** @type {[string, import('./types.js').FormulaIdentifierRecord]} */ ([
-          name,
-          formulaIdentifierRecordForName(name),
-        ]);
-      });
-    return harden([...specialEntries, ...petStore.listEntries()]);
-  };
-
   /** @type {import('./types.js').PetStore['reverseIdentify']} */
   const reverseIdentify = formulaIdentifier => {
     const names = Array.from(petStore.reverseIdentify(formulaIdentifier));
@@ -90,8 +72,6 @@ export const makePetSitter = (petStore, specialNames) => {
     reverseIdentify,
     list,
     follow,
-    listEntries,
-    followEntries,
     write,
     remove,
     rename,

--- a/packages/daemon/src/pet-sitter.js
+++ b/packages/daemon/src/pet-sitter.js
@@ -1,0 +1,101 @@
+// @ts-check
+
+import { parseFormulaIdentifier } from './formula-identifier.js';
+
+const { quote: q } = assert;
+
+/**
+ * @param {import('./types.js').PetStore} petStore
+ * @param {Record<string,string>} specialNames
+ * @returns {import('./types.js').PetStore}
+ */
+export const makePetSitter = (petStore, specialNames) => {
+  /** @type {import('./types.js').Mail['has']} */
+  const has = petName => {
+    return Object.hasOwn(specialNames, petName) || petStore.has(petName);
+  };
+
+  /** @type {import('./types.js').Mail['identifyLocal']} */
+  const identifyLocal = petName => {
+    if (Object.hasOwn(specialNames, petName)) {
+      return specialNames[petName];
+    }
+    return petStore.identifyLocal(petName);
+  };
+
+  /**
+   * @param {string} petName
+   * @returns {import('./types.js').FormulaIdentifierRecord}
+   */
+  const formulaIdentifierRecordForName = petName => {
+    const formulaIdentifier = identifyLocal(petName);
+    if (formulaIdentifier === undefined) {
+      throw new Error(`Formula does not exist for pet name ${q(petName)}`);
+    }
+    return parseFormulaIdentifier(formulaIdentifier);
+  };
+
+  /** @type {import('./types.js').Mail['list']} */
+  const list = () =>
+    harden([...Object.keys(specialNames).sort(), ...petStore.list()]);
+
+  /** @type {import('./types.js').PetStore['follow']} */
+  const follow = async function* currentAndSubsequentNames() {
+    for (const name of Object.keys(specialNames).sort()) {
+      const formulaIdentifierRecord = formulaIdentifierRecordForName(name);
+      yield /** @type {{ add: string, value: import('./types.js').FormulaIdentifierRecord }} */ ({
+        add: name,
+        value: formulaIdentifierRecord,
+      });
+    }
+    yield* petStore.follow();
+  };
+
+  // Provided as an alias for follow, with naming symmetry to listEntries.
+  /** @type {import('./types.js').PetStore['follow']} */
+  const followEntries = follow;
+
+  // Returns in Object.fromEntries format.
+  /** @type {import('./types.js').PetStore['listEntries']} */
+  const listEntries = () => {
+    const specialEntries = Object.keys(specialNames)
+      .sort()
+      .map(name => {
+        return /** @type {[string, import('./types.js').FormulaIdentifierRecord]} */ ([
+          name,
+          formulaIdentifierRecordForName(name),
+        ]);
+      });
+    return harden([...specialEntries, ...petStore.listEntries()]);
+  };
+
+  /** @type {import('./types.js').PetStore['reverseIdentify']} */
+  const reverseIdentify = formulaIdentifier => {
+    const names = Array.from(petStore.reverseIdentify(formulaIdentifier));
+    for (const [specialName, specialFormulaIdentifier] of Object.entries(
+      specialNames,
+    )) {
+      if (specialFormulaIdentifier === formulaIdentifier) {
+        names.push(specialName);
+      }
+    }
+    return harden(names);
+  };
+
+  const { write, remove, rename } = petStore;
+
+  const petSitter = {
+    has,
+    identifyLocal,
+    reverseIdentify,
+    list,
+    follow,
+    listEntries,
+    followEntries,
+    write,
+    remove,
+    rename,
+  };
+
+  return petSitter;
+};

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -1,8 +1,6 @@
 // @ts-check
 
-import { Far } from '@endo/far';
 import { makeChangeTopic } from './pubsub.js';
-import { makeIteratorRef } from './reader-ref.js';
 import { parseFormulaIdentifier } from './formula-identifier.js';
 
 const { quote: q } = assert;
@@ -19,7 +17,7 @@ export const makePetStoreMaker = (filePowers, locator) => {
   /**
    * @param {string} petNameDirectoryPath
    * @param {(name: string) => void} assertValidName
-   * @returns {Promise<import('@endo/far').FarRef<import('./types.js').PetStore>>}
+   * @returns {Promise<import('./types.js').PetStore>}
    */
   const makePetStoreAtPath = async (petNameDirectoryPath, assertValidName) => {
     /** @type {Map<string, string>} */
@@ -125,21 +123,17 @@ export const makePetStoreMaker = (filePowers, locator) => {
     const list = () => harden([...petNames.keys()].sort());
     // Returns in an object operations format ({ add, value } or { remove }).
     /** @type {import('./types.js').PetStore['follow']} */
-    const follow = async () =>
-      makeIteratorRef(
-        (async function* currentAndSubsequentNames() {
-          const changes = changesTopic.subscribe();
-          for (const name of [...petNames.keys()].sort()) {
-            const formulaIdentifierRecord =
-              formulaIdentifierRecordForName(name);
-            yield /** @type {{ add: string, value: import('./types.js').FormulaIdentifierRecord }} */ ({
-              add: name,
-              value: formulaIdentifierRecord,
-            });
-          }
-          yield* changes;
-        })(),
-      );
+    const follow = async function* currentAndSubsequentNames() {
+      const changes = changesTopic.subscribe();
+      for (const name of [...petNames.keys()].sort()) {
+        const formulaIdentifierRecord = formulaIdentifierRecordForName(name);
+        yield /** @type {{ add: string, value: import('./types.js').FormulaIdentifierRecord }} */ ({
+          add: name,
+          value: formulaIdentifierRecord,
+        });
+      }
+      yield* changes;
+    };
 
     // Returns in Object.fromEntries format.
     /** @type {import('./types.js').PetStore['listEntries']} */
@@ -236,8 +230,8 @@ export const makePetStoreMaker = (filePowers, locator) => {
       // TODO consider retaining a backlog of overwritten names for recovery
     };
 
-    /** @type {import('./types.js').PetStore['reverseLookup']} */
-    const reverseLookup = formulaIdentifier => {
+    /** @type {import('./types.js').PetStore['reverseIdentify']} */
+    const reverseIdentify = formulaIdentifier => {
       if (!validFormulaPattern.test(formulaIdentifier)) {
         throw new Error(`Invalid formula identifier ${q(formulaIdentifier)}`);
       }
@@ -251,7 +245,7 @@ export const makePetStoreMaker = (filePowers, locator) => {
     const petStore = {
       has,
       identifyLocal,
-      reverseLookup,
+      reverseIdentify,
       list,
       follow,
       listEntries,
@@ -261,7 +255,7 @@ export const makePetStoreMaker = (filePowers, locator) => {
       rename,
     };
 
-    return Far('PetStore', petStore);
+    return petStore;
   };
 
   /**

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -135,18 +135,6 @@ export const makePetStoreMaker = (filePowers, locator) => {
       yield* changes;
     };
 
-    // Returns in Object.fromEntries format.
-    /** @type {import('./types.js').PetStore['listEntries']} */
-    const listEntries = () =>
-      harden(
-        [...petNames.keys()].sort().map(name => {
-          return [name, formulaIdentifierRecordForName(name)];
-        }),
-      );
-    // Provided as an alias for follow, with naming symmetry to listEntries.
-    /** @type {import('./types.js').PetStore['follow']} */
-    const followEntries = follow;
-
     /** @type {import('./types.js').PetStore['remove']} */
     const remove = async petName => {
       assertValidName(petName);
@@ -248,8 +236,6 @@ export const makePetStoreMaker = (filePowers, locator) => {
       reverseIdentify,
       list,
       follow,
-      listEntries,
-      followEntries,
       write,
       remove,
       rename,

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -261,6 +261,7 @@ export const makePetStoreMaker = (filePowers, locator) => {
   /**
    * @param {string} id
    * @param {(name: string) => void} assertValidName
+   * @returns {Promise<import('./types.js').PetStore>}
    */
   const makeIdentifiedPetStore = (id, assertValidName) => {
     if (!validIdPattern.test(id)) {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -557,7 +557,7 @@ export type PetStorePowers = {
   makeIdentifiedPetStore: (
     id: string,
     assertValidName: AssertValidNameFn,
-  ) => Promise<FarRef<PetStore>>;
+  ) => Promise<PetStore>;
 };
 
 export type SocketPowers = {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -343,7 +343,6 @@ export interface PetStore {
    */
   reverseIdentify(formulaIdentifier: string): Array<string>;
 }
-}
 
 export interface Mail {
   // Partial inheritance from PetStore:
@@ -352,10 +351,10 @@ export interface Mail {
   remove: PetStore['remove'];
   list: PetStore['list'];
   identifyLocal: PetStore['identifyLocal'];
-  reverseLookup(value: unknown): Array<string>;
+  reverseIdentify(formulaIdentifier: string): Array<string>;
   // Extended methods:
   lookup(...petNamePath: string[]): Promise<unknown>;
-  reverseLookupFormulaIdentifier(formulaIdentifier: string): Array<string>;
+  reverseLookup(value: unknown): Array<string>;
   cancel(petName: string, reason: Error): Promise<void>;
   // Mail operations:
   listMessages(): Promise<Array<Message>>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -325,12 +325,7 @@ export interface PetStore {
 
 export interface Mail {
   // Partial inheritance from PetStore:
-  has: PetStore['has'];
-  rename: PetStore['rename'];
-  remove: PetStore['remove'];
-  list: PetStore['list'];
-  identifyLocal: PetStore['identifyLocal'];
-  reverseIdentify(formulaIdentifier: string): Array<string>;
+  petStore: PetStore;
   // Extended methods:
   lookup(...petNamePath: string[]): Promise<unknown>;
   reverseLookup(value: unknown): Array<string>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -332,6 +332,10 @@ export interface PetStore {
 export interface NameHub {
   has(...petNamePath: string[]): Promise<boolean>;
   identify(...petNamePath: string[]): Promise<string | undefined>;
+  list(...petNamePath: string[]): Promise<Array<string>>;
+  followChanges(
+    ...petNamePath: string[]
+  ): AsyncGenerator<PetStoreNameDiff, undefined, undefined>;
   lookup(...petNamePath: string[]): Promise<unknown>;
   reverseLookup(value: unknown): Array<string>;
   write(petNamePath: string[], formulaIdentifier): Promise<void>;
@@ -425,8 +429,6 @@ export type MakeHostOrGuestOptions = {
 };
 
 export interface EndoGuest extends EndoDirectory {
-  list: PetStore['list'];
-  followNames: PetStore['follow'];
   listEntries: PetStore['listEntries'];
   followEntries: PetStore['followEntries'];
   listMessages: Mail['listMessages'];
@@ -440,8 +442,6 @@ export interface EndoGuest extends EndoDirectory {
 }
 
 export interface EndoHost extends EndoDirectory {
-  list: PetStore['list'];
-  followNames: PetStore['follow'];
   listEntries: PetStore['listEntries'];
   followEntries: PetStore['followEntries'];
   listMessages: Mail['listMessages'];

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -354,11 +354,25 @@ export interface Mail {
   // Mail operations:
   listMessages(): Promise<Array<Message>>;
   followMessages(): Promise<FarRef<Reader<Message>>>;
+  resolve(messageNumber: number, resolutionName: string): Promise<void>;
+  reject(messageNumber: number, message?: string): Promise<void>;
+  adopt(
+    messageNumber: number,
+    edgeName: string,
+    petName: string,
+  ): Promise<void>;
+  dismiss(messageNumber: number): Promise<void>;
   request(
     recipientName: string,
     what: string,
     responseName: string,
   ): Promise<unknown>;
+  send(
+    recipientName: string,
+    strings: Array<string>,
+    edgeNames: Array<string>,
+    petNames: Array<string>,
+  ): Promise<void>;
   respond(
     what: string,
     responseName: string,
@@ -373,20 +387,6 @@ export interface Mail {
     formulaIdentifiers: Array<string>,
     receiverFormulaIdentifier: string,
   ): void;
-  send(
-    recipientName: string,
-    strings: Array<string>,
-    edgeNames: Array<string>,
-    petNames: Array<string>,
-  ): Promise<void>;
-  resolve(messageNumber: number, resolutionName: string): Promise<void>;
-  reject(messageNumber: number, message?: string): Promise<void>;
-  dismiss(messageNumber: number): Promise<void>;
-  adopt(
-    messageNumber: number,
-    edgeName: string,
-    petName: string,
-  ): Promise<void>;
 }
 
 export type MakeMailbox = (args: {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -329,7 +329,6 @@ export interface Mail {
   // Extended methods:
   lookup(...petNamePath: string[]): Promise<unknown>;
   reverseLookup(value: unknown): Array<string>;
-  cancel(petName: string, reason: Error): Promise<void>;
   // Mail operations:
   listMessages(): Promise<Array<Message>>;
   followMessages(): Promise<FarRef<Reader<Message>>>;
@@ -481,7 +480,7 @@ export interface EndoHost {
     bundleName: string,
     powersName: string,
   ): Promise<unknown>;
-  cancel: Mail['cancel'];
+  cancel(petName: string, reason: Error): Promise<void>;
 }
 
 export interface InternalEndoHost {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -406,20 +406,43 @@ export type MakeHostOrGuestOptions = {
 };
 
 export interface EndoGuest {
-  request(what: string, responseName: string): Promise<unknown>;
+  has: PetStore['has'];
+  remove: PetStore['remove'];
+  rename: PetStore['rename'];
+  list: PetStore['list'];
+  followNames: PetStore['follow'];
+  listEntries: PetStore['listEntries'];
+  followEntries: PetStore['followEntries'];
+  lookup: Mail['lookup'];
+  reverseLookup: Mail['reverseLookup'];
+  listMessages: Mail['listMessages'];
+  followMessages: Mail['followMessages'];
+  resolve: Mail['resolve'];
+  reject: Mail['reject'];
+  adopt: Mail['adopt'];
+  dismiss: Mail['dismiss'];
+  request: Mail['request'];
+  send: Mail['send'];
 }
 
 export interface EndoHost {
-  listMessages(): Promise<Array<Message>>;
-  followMessages(): ERef<AsyncIterable<Message>>;
-  followNames(): FarRef<Reader<PetStoreNameDiff>>;
-  lookup(...petNamePath: string[]): Promise<unknown>;
-  resolve(requestNumber: number, petName: string);
-  reject(requestNumber: number, message: string);
-  reverseLookup(ref: object): Promise<Array<string>>;
-  remove(petName: string);
-  rename(fromPetName: string, toPetName: string);
-  list(): Array<string>; // pet names
+  has: PetStore['has'];
+  remove: PetStore['remove'];
+  rename: PetStore['rename'];
+  list: PetStore['list'];
+  followNames: PetStore['follow'];
+  listEntries: PetStore['listEntries'];
+  followEntries: PetStore['followEntries'];
+  lookup: Mail['lookup'];
+  reverseLookup: Mail['reverseLookup'];
+  listMessages: Mail['listMessages'];
+  followMessages: Mail['followMessages'];
+  resolve: Mail['resolve'];
+  reject: Mail['reject'];
+  adopt: Mail['adopt'];
+  dismiss: Mail['dismiss'];
+  request: Mail['request'];
+  send: Mail['send'];
   store(
     readerRef: ERef<AsyncIterableIterator<string>>,
     petName: string,
@@ -433,6 +456,7 @@ export interface EndoHost {
     opts?: MakeHostOrGuestOptions,
   ): Promise<EndoHost>;
   makeWorker(petName: string): Promise<EndoWorker>;
+  provideWorker(petName: string): Promise<EndoWorker>;
   evaluate(
     workerPetName: string | undefined,
     source: string,
@@ -452,6 +476,12 @@ export interface EndoHost {
     powersName: string,
     resultName?: string,
   ): Promise<unknown>;
+  provideWebPage(
+    webPageName: string,
+    bundleName: string,
+    powersName: string,
+  ): Promise<unknown>;
+  cancel: Mail['cancel'];
 }
 
 export interface InternalEndoHost {
@@ -461,7 +491,7 @@ export interface InternalEndoHost {
 }
 
 export interface EndoHostController
-  extends Controller<EndoHost, InternalEndoHost> {}
+  extends Controller<FarRef<EndoHost>, InternalEndoHost> {}
 
 export type EndoInspector<Record = string> = {
   lookup: (petName: Record) => Promise<unknown>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -317,8 +317,6 @@ export interface PetStore {
   identifyLocal(petName: string): string | undefined;
   list(): Array<string>;
   follow(): AsyncGenerator<PetStoreNameDiff, undefined, undefined>;
-  listEntries(): Array<[string, FormulaIdentifierRecord]>;
-  followEntries(): AsyncGenerator<PetStoreNameDiff, undefined, undefined>;
   write(petName: string, formulaIdentifier: string): Promise<void>;
   remove(petName: string): Promise<void>;
   rename(fromPetName: string, toPetName: string): Promise<void>;
@@ -429,8 +427,6 @@ export type MakeHostOrGuestOptions = {
 };
 
 export interface EndoGuest extends EndoDirectory {
-  listEntries: PetStore['listEntries'];
-  followEntries: PetStore['followEntries'];
   listMessages: Mail['listMessages'];
   followMessages: Mail['followMessages'];
   resolve: Mail['resolve'];
@@ -442,8 +438,6 @@ export interface EndoGuest extends EndoDirectory {
 }
 
 export interface EndoHost extends EndoDirectory {
-  listEntries: PetStore['listEntries'];
-  followEntries: PetStore['followEntries'];
   listMessages: Mail['listMessages'];
   followMessages: Mail['followMessages'];
   resolve: Mail['resolve'];

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -353,7 +353,7 @@ export interface Mail {
   petStore: PetStore;
   // Mail operations:
   listMessages(): Promise<Array<Message>>;
-  followMessages(): Promise<FarRef<Reader<Message>>>;
+  followMessages(): AsyncGenerator<Message, undefined, undefined>;
   resolve(messageNumber: number, resolutionName: string): Promise<void>;
   reject(messageNumber: number, message?: string): Promise<void>;
   adopt(

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -323,25 +323,17 @@ export type ProvideValueForNumberedFormula = (
   formula: Formula,
 ) => Promise<{ formulaIdentifier: string; value: unknown }>;
 
+export type PetStoreNameDiff =
+  | { add: string; value: FormulaIdentifierRecord }
+  | { remove: string };
+
 export interface PetStore {
   has(petName: string): boolean;
   identifyLocal(petName: string): string | undefined;
   list(): Array<string>;
-  follow(): Promise<
-    FarRef<
-      Reader<
-        { add: string; value: FormulaIdentifierRecord } | { remove: string }
-      >
-    >
-  >;
+  follow(): AsyncGenerator<PetStoreNameDiff, undefined, undefined>;
   listEntries(): Array<[string, FormulaIdentifierRecord]>;
-  followEntries(): Promise<
-    FarRef<
-      Reader<
-        { add: string; value: FormulaIdentifierRecord } | { remove: string }
-      >
-    >
-  >;
+  followEntries(): AsyncGenerator<PetStoreNameDiff, undefined, undefined>;
   write(petName: string, formulaIdentifier: string): Promise<void>;
   remove(petName: string);
   rename(fromPetName: string, toPetName: string);
@@ -349,7 +341,8 @@ export interface PetStore {
    * @param formulaIdentifier The formula identifier to look up.
    * @returns The formula identifier for the given pet name, or `undefined` if the pet name is not found.
    */
-  reverseLookup(formulaIdentifier: string): Array<string>;
+  reverseIdentify(formulaIdentifier: string): Array<string>;
+}
 }
 
 export interface Mail {
@@ -440,6 +433,7 @@ export interface EndoGuest {
 export interface EndoHost {
   listMessages(): Promise<Array<Message>>;
   followMessages(): ERef<AsyncIterable<Message>>;
+  followNames(): FarRef<Reader<PetStoreNameDiff>>;
   lookup(...petNamePath: string[]): Promise<unknown>;
   resolve(requestNumber: number, petName: string);
   reject(requestNumber: number, message: string);


### PR DESCRIPTION
- adds pet-sitter utility for dealing with specialNames
- factors non-mail methods out of mail
- introduces directories and nameHub interface
- removes `listEntries` and `followEntries` from petStore, host, guest
- breaks host and guest API slightly


Updates https://github.com/endojs/endo/pull/1993