### PR TITLE
refactor!(daemon): Remove host `makeWorker()`

### DIFF
--- a/packages/cli/src/commands/spawn.js
+++ b/packages/cli/src/commands/spawn.js
@@ -6,5 +6,5 @@ import { withEndoParty } from '../context.js';
 
 export const spawn = async ({ petNames, partyNames }) =>
   withEndoParty(partyNames, { os, process }, async ({ party }) =>
-    Promise.all(petNames.map(petName => E(party).makeWorker(petName))),
+    Promise.all(petNames.map(petName => E(party).provideWorker(petName))),
   );

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -5,6 +5,7 @@ import { makeIteratorRef } from './reader-ref.js';
 import { assertPetName, petNamePathFrom } from './pet-name.js';
 import { makePetSitter } from './pet-sitter.js';
 import { makeDeferredTasks } from './deferred-tasks.js';
+import { parseFormulaIdentifier } from './formula-identifier.js';
 
 const { quote: q } = assert;
 
@@ -130,7 +131,7 @@ export const makeHostMaker = ({
       if (petName !== undefined) {
         const formulaIdentifier = petStore.identifyLocal(petName);
         if (formulaIdentifier !== undefined) {
-          if (formulaIdentifier.startsWith('guest:')) {
+          if (parseFormulaIdentifier(formulaIdentifier).type !== 'guest') {
             throw new Error(
               `Existing pet name does not designate a guest powers capability: ${q(
                 petName,
@@ -418,20 +419,6 @@ export const makeHostMaker = ({
 
     /**
      * @param {string} [petName]
-     * @returns {Promise<import('./types.js').EndoWorker>}
-     */
-    const makeWorker = async petName => {
-      // Behold, recursion:
-      const { formulaIdentifier, value } = await incarnateWorker();
-      if (petName !== undefined) {
-        assertPetName(petName);
-        await petStore.write(petName, formulaIdentifier);
-      }
-      return /** @type {import('./types.js').EndoWorker} */ (value);
-    };
-
-    /**
-     * @param {string} [petName]
      * @param {import('./types.js').MakeHostOrGuestOptions} [opts]
      * @returns {Promise<{formulaIdentifier: string, value: Promise<import('./types.js').EndoHost>}>}
      */
@@ -599,7 +586,6 @@ export const makeHostMaker = ({
       store,
       provideGuest,
       provideHost,
-      makeWorker,
       provideWorker,
       evaluate,
       makeUnconfined,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -509,7 +509,6 @@ export interface EndoHost extends EndoDirectory {
     opts?: MakeHostOrGuestOptions,
   ): Promise<EndoHost>;
   makeDirectory(petName: string): Promise<EndoDirectory>;
-  makeWorker(petName: string): Promise<EndoWorker>;
   provideWorker(petName: string): Promise<EndoWorker>;
   evaluate(
     workerPetName: string | undefined,


### PR DESCRIPTION
Progresses: #2086 

Removes the host's `makeWorker()` and replaces its use everywhere with the equivalent `provideWorker()`. The latter is essentially like the former but with more validation.