### PR TITLE
refactor(daemon): Synchronize host `makeUnconfined()`

### DIFF
--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -143,6 +143,12 @@ type MakeUnconfinedFormula = {
   // TODO formula slots
 };
 
+export type MakeUnconfinedDeferredTaskParams = {
+  powersFormulaIdentifier: string;
+  unconfinedFormulaIdentifier: string;
+  workerFormulaIdentifier: string;
+};
+
 type MakeBundleFormula = {
   type: 'make-bundle';
   worker: string;
@@ -771,9 +777,11 @@ export interface DaemonCore {
     specifiedWorkerFormulaIdentifier?: string,
   ) => IncarnateResult<unknown>;
   incarnateUnconfined: (
-    workerFormulaIdentifier: string,
-    powersFormulaIdentifier: string,
+    hostFormulaIdentifier: string,
     specifier: string,
+    deferredTasks: DeferredTasks<MakeUnconfinedDeferredTaskParams>,
+    specifiedWorkerFormulaIdentifier?: string,
+    specifiedPowersFormulaIdentifier?: string,
   ) => IncarnateResult<unknown>;
   incarnateBundler: (
     powersFormulaIdentifier: string,

--- a/packages/daemon/test/doubler.js
+++ b/packages/daemon/test/doubler.js
@@ -1,0 +1,15 @@
+import { E, Far } from '@endo/far';
+
+export const make = powers => {
+  const counter = E(powers).request(
+    'HOST',
+    'a counter, suitable for doubling',
+    'my-counter',
+  );
+  return Far('Doubler', {
+    async incr() {
+      const n = await E(counter).incr();
+      return n * 2;
+    },
+  });
+};


### PR DESCRIPTION
Progresses: #2086

Synchronizes the host's `makeUnconfined()` per #2086. Refactoring `daemon.js` in support of this goal fixed one bug while revealing another.

In particular, #2074 is progressed by enabling indirect cancellation of caplets via their workers. The issue is not resolved since indirect cancellation of caplets via their caplet dependencies still does not work as intended. A new, failing regression test has been added for this specific case.

The revealed bug is #2021, which we believed to be fixed by #2092. Rather than fixing the bug, that PR concealed it by always creating a new incarnation of `eval` formula workers, even if they already existed. The regression test for #2021 has been marked as failing, and we will have to find a different solution for it.