### PR TITLE
refactor(daemon): Synchronize host `makeBundle()`

### DIFF
--- a/packages/cli/src/pet-name.js
+++ b/packages/cli/src/pet-name.js
@@ -1,3 +1,5 @@
+const { quote: q } = assert;
+
 /**
  * Splits a dot-delimited pet name path into an array of pet names.
  * Throws if any of the path segments are empty.
@@ -10,7 +12,7 @@ export const parsePetNamePath = petNamePath => {
   for (const petName of petNames) {
     if (petName === '') {
       throw new Error(
-        `Pet name path "${petNamePath}" contains an empty segment.`,
+        `Pet name path ${q(petNamePath)} contains an empty segment.`,
       );
     }
   }

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1224,7 +1224,7 @@ const makeDaemonCore = async (
   ) => {
     const {
       powersFormulaIdentifier,
-      unconfinedFormulaNumber: formulaNumber,
+      capletFormulaNumber,
       workerFormulaIdentifier,
     } = await formulaGraphMutex.enqueue(async () => {
       const ownFormulaNumber = await randomHex512();
@@ -1233,12 +1233,12 @@ const makeDaemonCore = async (
           hostFormulaIdentifier,
           specifiedPowersFormulaIdentifier,
         ),
-        unconfinedFormulaIdentifier: serializeFormulaIdentifier({
+        capletFormulaIdentifier: serializeFormulaIdentifier({
           type: 'make-unconfined',
           number: ownFormulaNumber,
           node: ownNodeIdentifier,
         }),
-        unconfinedFormulaNumber: ownFormulaNumber,
+        capletFormulaNumber: ownFormulaNumber,
         workerFormulaIdentifier: await provideWorkerFormulaIdentifier(
           specifiedWorkerFormulaIdentifier,
         ),
@@ -1254,8 +1254,10 @@ const makeDaemonCore = async (
       powers: powersFormulaIdentifier,
       specifier,
     };
-    return /** @type {import('./types.js').IncarnateResult<unknown>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+    return provideValueForNumberedFormula(
+      formula.type,
+      capletFormulaNumber,
+      formula,
     );
   };
 
@@ -1269,7 +1271,7 @@ const makeDaemonCore = async (
   ) => {
     const {
       powersFormulaIdentifier,
-      bundleFormulaNumber: formulaNumber,
+      capletFormulaNumber,
       workerFormulaIdentifier,
     } = await formulaGraphMutex.enqueue(async () => {
       const ownFormulaNumber = await randomHex512();
@@ -1278,12 +1280,12 @@ const makeDaemonCore = async (
           hostFormulaIdentifier,
           specifiedPowersFormulaIdentifier,
         ),
-        bundleFormulaIdentifier: serializeFormulaIdentifier({
+        capletFormulaIdentifier: serializeFormulaIdentifier({
           type: 'make-bundle',
           number: ownFormulaNumber,
           node: ownNodeIdentifier,
         }),
-        bundleFormulaNumber: ownFormulaNumber,
+        capletFormulaNumber: ownFormulaNumber,
         workerFormulaIdentifier: await provideWorkerFormulaIdentifier(
           specifiedWorkerFormulaIdentifier,
         ),
@@ -1299,7 +1301,11 @@ const makeDaemonCore = async (
       powers: powersFormulaIdentifier,
       bundle: bundleFormulaIdentifier,
     };
-    return provideValueForNumberedFormula(formula.type, formulaNumber, formula);
+    return provideValueForNumberedFormula(
+      formula.type,
+      capletFormulaNumber,
+      formula,
+    );
   };
 
   /** @type {import('./types.js').DaemonCore['incarnateBundler']} */

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -412,7 +412,7 @@ export const makeHostMaker = ({
     ) => {
       const bundleFormulaIdentifier = petStore.identifyLocal(bundleName);
       if (bundleFormulaIdentifier === undefined) {
-        throw new TypeError(`Unknown pet name for bundle: ${bundleName}`);
+        throw new TypeError(`Unknown pet name for bundle: ${q(bundleName)}`);
       }
 
       const { tasks, workerFormulaIdentifier, powersFormulaIdentifier } =

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -143,12 +143,6 @@ type MakeUnconfinedFormula = {
   // TODO formula slots
 };
 
-export type MakeUnconfinedDeferredTaskParams = {
-  powersFormulaIdentifier: string;
-  unconfinedFormulaIdentifier: string;
-  workerFormulaIdentifier: string;
-};
-
 type MakeBundleFormula = {
   type: 'make-bundle';
   worker: string;
@@ -157,9 +151,9 @@ type MakeBundleFormula = {
   // TODO formula slots
 };
 
-export type MakeBundleDeferredTaskParams = {
+export type MakeCapletDeferredTaskParams = {
+  capletFormulaIdentifier: string;
   powersFormulaIdentifier: string;
-  bundleFormulaIdentifier: string;
   workerFormulaIdentifier: string;
 };
 
@@ -785,14 +779,14 @@ export interface DaemonCore {
   incarnateUnconfined: (
     hostFormulaIdentifier: string,
     specifier: string,
-    deferredTasks: DeferredTasks<MakeUnconfinedDeferredTaskParams>,
+    deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
     specifiedWorkerFormulaIdentifier?: string,
     specifiedPowersFormulaIdentifier?: string,
   ) => IncarnateResult<unknown>;
   incarnateBundle: (
     hostFormulaIdentifier: string,
     bundleFormulaIdentifier: string,
-    deferredTasks: DeferredTasks<MakeBundleDeferredTaskParams>,
+    deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
     specifiedWorkerFormulaIdentifier?: string,
     specifiedPowersFormulaIdentifier?: string,
   ) => IncarnateResult<unknown>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -157,6 +157,12 @@ type MakeBundleFormula = {
   // TODO formula slots
 };
 
+export type MakeBundleDeferredTaskParams = {
+  powersFormulaIdentifier: string;
+  bundleFormulaIdentifier: string;
+  workerFormulaIdentifier: string;
+};
+
 type PeerFormula = {
   type: 'peer';
   networks: string;
@@ -783,14 +789,16 @@ export interface DaemonCore {
     specifiedWorkerFormulaIdentifier?: string,
     specifiedPowersFormulaIdentifier?: string,
   ) => IncarnateResult<unknown>;
+  incarnateBundle: (
+    hostFormulaIdentifier: string,
+    bundleFormulaIdentifier: string,
+    deferredTasks: DeferredTasks<MakeBundleDeferredTaskParams>,
+    specifiedWorkerFormulaIdentifier?: string,
+    specifiedPowersFormulaIdentifier?: string,
+  ) => IncarnateResult<unknown>;
   incarnateBundler: (
     powersFormulaIdentifier: string,
     workerFormulaIdentifier: string,
-  ) => IncarnateResult<unknown>;
-  incarnateBundle: (
-    powersFormulaIdentifier: string,
-    workerFormulaIdentifier: string,
-    bundleFormulaIdentifier: string,
   ) => IncarnateResult<unknown>;
   incarnateWebBundle: (
     powersFormulaIdentifier: string,


### PR DESCRIPTION
Progresses: #2086 

Synchronizes the host's `makeBundle()` following the pattern established by `makeUnconfined()`. Eliminates the host's
`provideWorkerFormulaIdentifier()`, which is everywhere replaced with the synchronous `prepareWorkerFormulaIdentifier()`. Performs some opportunistic refactors of `makeX` and `incarnateX` where `X === 'Bundle' | 'Unconfined'`.