### PR TITLE
refactor!(daemon): Rename mutex to serial-jobs

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -9,7 +9,7 @@ import { makeReaderRef } from './reader-ref.js';
 import { makePetStoreMaker } from './pet-store.js';
 import { servePrivatePortHttp } from './serve-private-port-http.js';
 import { servePrivatePath } from './serve-private-path.js';
-import { makeMutex } from './mutex.js';
+import { makeSerialJobs } from './serial-jobs.js';
 
 const { quote: q } = assert;
 
@@ -355,7 +355,7 @@ export const makeNetworkPowers = ({ http, ws, net }) => {
 };
 
 export const makeFilePowers = ({ fs, path: fspath }) => {
-  const writeLock = makeMutex();
+  const writeJobs = makeSerialJobs();
 
   /**
    * @param {string} path
@@ -379,7 +379,7 @@ export const makeFilePowers = ({ fs, path: fspath }) => {
    * @param {string} text
    */
   const writeFileText = async (path, text) => {
-    await writeLock.enqueue(async () => {
+    await writeJobs.enqueue(async () => {
       await fs.promises.writeFile(path, text);
     });
   };
@@ -423,13 +423,13 @@ export const makeFilePowers = ({ fs, path: fspath }) => {
    * @param {string} path
    */
   const removePath = async path => {
-    await writeLock.enqueue(async () => {
+    await writeJobs.enqueue(async () => {
       return fs.promises.rm(path);
     });
   };
 
   const renamePath = async (source, target) => {
-    await writeLock.enqueue(async () => {
+    await writeJobs.enqueue(async () => {
       return fs.promises.rename(source, target);
     });
   };

--- a/packages/daemon/src/serial-jobs.js
+++ b/packages/daemon/src/serial-jobs.js
@@ -1,9 +1,9 @@
 import { makeQueue } from '@endo/stream';
 
 /**
- * @returns {import('./types.js').Mutex}
+ * @returns {import('./types.js').SerialJobs}
  */
-export const makeMutex = () => {
+export const makeSerialJobs = () => {
   /** @type {import('@endo/stream').AsyncQueue<void>} */
   const queue = makeQueue();
   const lock = () => {
@@ -15,8 +15,6 @@ export const makeMutex = () => {
   unlock();
 
   return {
-    lock,
-    unlock,
     enqueue: async (asyncFn = /** @type {any} */ (async () => {})) => {
       await lock();
       try {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -813,9 +813,7 @@ export interface DaemonCore {
   makeDirectoryNode: MakeDirectoryNode;
 }
 
-export type Mutex = {
-  lock: () => Promise<void>;
-  unlock: () => void;
+export type SerialJobs = {
   enqueue: <T>(asyncFn?: () => Promise<T>) => Promise<T>;
 };
 

--- a/packages/daemon/test/test-serial-jobs.js
+++ b/packages/daemon/test/test-serial-jobs.js
@@ -4,24 +4,24 @@ import '@endo/init/debug.js';
 import rawTest from 'ava';
 import { wrapTest } from '@endo/ses-ava';
 
-import { makeMutex } from '../src/mutex.js';
+import { makeSerialJobs } from '../src/serial-jobs.js';
 
 const test = wrapTest(rawTest);
 
 const delay = () => new Promise(resolve => setTimeout(resolve, 1));
 
-test('releases lock in expected order (sync functions)', async t => {
-  const mutex = makeMutex();
+test('performs operations in expected order (sync functions)', async t => {
+  const serialJobs = makeSerialJobs();
   const results = [];
 
   await Promise.all([
-    mutex.enqueue(() => {
+    serialJobs.enqueue(() => {
       results.push(1);
     }),
-    mutex.enqueue(() => {
+    serialJobs.enqueue(() => {
       results.push(2);
     }),
-    mutex.enqueue(() => {
+    serialJobs.enqueue(() => {
       results.push(3);
     }),
   ]);
@@ -29,18 +29,18 @@ test('releases lock in expected order (sync functions)', async t => {
   t.deepEqual(results, [1, 2, 3]);
 });
 
-test('releases lock in expected order (async functions)', async t => {
-  const mutex = makeMutex();
+test('performs operations in expected order (async functions)', async t => {
+  const serialJobs = makeSerialJobs();
   const results = [];
 
   await Promise.all([
-    mutex.enqueue(async () => {
+    serialJobs.enqueue(async () => {
       results.push(1);
     }),
-    mutex.enqueue(async () => {
+    serialJobs.enqueue(async () => {
       results.push(2);
     }),
-    mutex.enqueue(async () => {
+    serialJobs.enqueue(async () => {
       results.push(3);
     }),
   ]);
@@ -48,20 +48,20 @@ test('releases lock in expected order (async functions)', async t => {
   t.deepEqual(results, [1, 2, 3]);
 });
 
-test('releases lock in expected order (async functions with await)', async t => {
-  const mutex = makeMutex();
+test('performs operations in expected order (async functions with await)', async t => {
+  const serialJobs = makeSerialJobs();
   const results = [];
 
   await Promise.all([
-    mutex.enqueue(async () => {
+    serialJobs.enqueue(async () => {
       await delay();
       results.push(1);
     }),
-    mutex.enqueue(async () => {
+    serialJobs.enqueue(async () => {
       await delay();
       results.push(2);
     }),
-    mutex.enqueue(async () => {
+    serialJobs.enqueue(async () => {
       await delay();
       results.push(3);
     }),
@@ -71,20 +71,20 @@ test('releases lock in expected order (async functions with await)', async t => 
 });
 
 test('immediately releases the lock to the awaiter', async t => {
-  const mutex = makeMutex();
+  const serialJobs = makeSerialJobs();
   const results = [];
 
   await Promise.all([
-    mutex.enqueue(async () => {
+    serialJobs.enqueue(async () => {
       await delay();
       results.push(2);
     }),
     (async () => {
       results.push(1);
-      await mutex.enqueue(() => delay());
+      await serialJobs.enqueue(() => delay());
       results.push(3);
     })(),
-    mutex.enqueue(async () => {
+    serialJobs.enqueue(async () => {
       results.push(4);
     }),
   ]);


### PR DESCRIPTION
Renames the daemon's `Mutex` to `SerialJobs`, which better reflects its purpose. Also removes `lock()` and `unlock()` from its interface.
