### PR TITLE
build: .d.ts for nat

### DIFF
--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -10,9 +10,11 @@
   },
   "scripts": {
     "build": "exit 0",
+    "build:types": "tsc --build tsconfig.build.json",
+    "clean:types": "git clean -f '*.d.ts*'",
     "test": "ava test/**/test-*.js",
     "lint-fix": "eslint --fix",
-    "lint-check": "eslint"
+    "lint": "tsc"
   },
   "repository": {
     "type": "git",

--- a/packages/nat/tsconfig.build.json
+++ b/packages/nat/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../tsconfig-build-options.json"
+  ],
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "exclude": [
+    "test/"
+  ]
+}

--- a/packages/nat/tsconfig.json
+++ b/packages/nat/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.eslint-base.json",
+  "include": [
+    "*.js",
+    "*.ts",
+    "src/**/*.js",
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Description

The types weren't being built in the NPM package. Downstream would get them sometimes by node modules search, but only if within sufficient search depth.

This removes the need for searching node_modules

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

no, more like other packages now

### Testing Considerations

CI

### Compatibility Considerations

fully back compat

### Upgrade Considerations

none

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
