### PR TITLE
refactor!(daemon): Synchronize `makeHost()`

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1087,7 +1087,7 @@ const makeDaemonCore = async (
         });
 
         await deferredTasks.execute({
-          partyFormulaIdentifier: formatId({
+          agentFormulaIdentifier: formatId({
             type: 'host',
             number: identifiers.hostFormulaNumber,
             node: ownNodeIdentifier,
@@ -1145,7 +1145,7 @@ const makeDaemonCore = async (
         );
 
         await deferredTasks.execute({
-          partyFormulaIdentifier: formatId({
+          agentFormulaIdentifier: formatId({
             type: 'guest',
             number: identifiers.guestFormulaNumber,
             node: ownNodeIdentifier,
@@ -1679,7 +1679,7 @@ const makeDaemonCore = async (
   });
 
   /**
-   * Creates an inspector for the current party's pet store, used to create
+   * Creates an inspector for the current agent's pet store, used to create
    * inspectors for values therein. Notably, can provide references to otherwise
    * un-nameable values such as the `MAIN` worker. See `KnownEndoInspectors` for
    * more details.

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1087,7 +1087,7 @@ const makeDaemonCore = async (
         });
 
         await deferredTasks.execute({
-          hostFormulaIdentifier: serializeFormulaIdentifier({
+          hostFormulaIdentifier: formatId({
             type: 'host',
             number: identifiers.hostFormulaNumber,
             node: ownNodeIdentifier,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -686,7 +686,7 @@ const makeDaemonCore = async (
       );
       // Behold, forward reference:
       // eslint-disable-next-line no-use-before-define
-      return provideRemoteValue(peerIdentifier, formulaIdentifier, context);
+      return provideRemoteValue(peerIdentifier, formulaIdentifier);
     }
     const formula = await persistencePowers.readFormula(formulaNumber);
     if (
@@ -1048,22 +1048,22 @@ const makeDaemonCore = async (
   };
 
   /** @type {import('./types.js').PrivateDaemonCore['incarnateNumberedHost']} */
-  const incarnateNumberedHost = identfiers => {
+  const incarnateNumberedHost = identifiers => {
     /** @type {import('./types.js').HostFormula} */
     const formula = {
       type: 'host',
-      petStore: identfiers.storeFormulaIdentifier,
-      inspector: identfiers.inspectorFormulaIdentifier,
-      worker: identfiers.workerFormulaIdentifier,
-      endo: identfiers.endoFormulaIdentifier,
-      networks: identfiers.networksDirectoryFormulaIdentifier,
-      leastAuthority: identfiers.leastAuthorityFormulaIdentifier,
+      petStore: identifiers.storeFormulaIdentifier,
+      inspector: identifiers.inspectorFormulaIdentifier,
+      worker: identifiers.workerFormulaIdentifier,
+      endo: identifiers.endoFormulaIdentifier,
+      networks: identifiers.networksDirectoryFormulaIdentifier,
+      leastAuthority: identifiers.leastAuthorityFormulaIdentifier,
     };
 
     return /** @type {import('./types').IncarnateResult<import('./types').EndoHost>} */ (
       provideValueForNumberedFormula(
         'host',
-        identfiers.hostFormulaNumber,
+        identifiers.hostFormulaNumber,
         formula,
       )
     );
@@ -1087,7 +1087,7 @@ const makeDaemonCore = async (
         });
 
         await deferredTasks.execute({
-          hostFormulaIdentifier: formatId({
+          partyFormulaIdentifier: formatId({
             type: 'host',
             number: identifiers.hostFormulaNumber,
             node: ownNodeIdentifier,
@@ -1145,7 +1145,7 @@ const makeDaemonCore = async (
         );
 
         await deferredTasks.execute({
-          guestFormulaIdentifier: formatId({
+          partyFormulaIdentifier: formatId({
             type: 'guest',
             number: identifiers.guestFormulaNumber,
             node: ownNodeIdentifier,
@@ -1622,13 +1622,11 @@ const makeDaemonCore = async (
    * originate from the specified peer.
    * @param {string} peerFormulaIdentifier
    * @param {string} remoteValueFormulaIdentifier
-   * @param {import('./types.js').Context} context
    * @returns {Promise<import('./types.js').ControllerPartial<unknown, undefined>>}
    */
   const provideRemoteValue = async (
     peerFormulaIdentifier,
     remoteValueFormulaIdentifier,
-    context,
   ) => {
     const peer = /** @type {import('./types.js').EndoPeer} */ (
       await provideValueForFormulaIdentifier(peerFormulaIdentifier)

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -75,6 +75,13 @@ type WorkerFormula = {
   type: 'worker';
 };
 
+/**
+ * Deferred tasks parameters for `host` and `guest` formulas.
+ */
+export type PartyDeferredTaskParams = {
+  partyFormulaIdentifier: string;
+};
+
 type HostFormula = {
   type: 'host';
   worker: string;
@@ -85,19 +92,11 @@ type HostFormula = {
   leastAuthority: string;
 };
 
-export type HostDeferredTaskParams = {
-  hostFormulaIdentifier: string;
-};
-
 type GuestFormula = {
   type: 'guest';
   host: string;
   petStore: string;
   worker: string;
-};
-
-export type GuestDeferredTaskParams = {
-  guestFormulaIdentifier: string;
 };
 
 type LeastAuthorityFormula = {
@@ -817,12 +816,12 @@ export interface DaemonCore {
     endoFormulaIdentifier: string,
     networksDirectoryFormulaIdentifier: string,
     leastAuthorityFormulaIdentifier: string,
-    deferredTasks: DeferredTasks<HostDeferredTaskParams>,
+    deferredTasks: DeferredTasks<PartyDeferredTaskParams>,
     specifiedWorkerFormulaIdentifier?: string | undefined,
   ) => IncarnateResult<EndoHost>;
   incarnateGuest: (
     hostFormulaIdentifier: string,
-    deferredTasks: DeferredTasks<GuestDeferredTaskParams>,
+    deferredTasks: DeferredTasks<PartyDeferredTaskParams>,
   ) => IncarnateResult<EndoGuest>;
   incarnateReadableBlob: (
     contentSha512: string,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -78,8 +78,8 @@ type WorkerFormula = {
 /**
  * Deferred tasks parameters for `host` and `guest` formulas.
  */
-export type PartyDeferredTaskParams = {
-  partyFormulaIdentifier: string;
+export type AgentDeferredTaskParams = {
+  agentFormulaIdentifier: string;
 };
 
 type HostFormula = {
@@ -549,14 +549,14 @@ export interface EndoHost extends EndoDirectory {
   addPeerInfo(peerInfo: PeerInfo): Promise<void>;
 }
 
-export interface InternalEndoParty {
+export interface InternalEndoAgent {
   receive: Mail['receive'];
   respond: Mail['respond'];
   petStore: PetStore;
 }
 
 export interface EndoHostController
-  extends Controller<FarRef<EndoHost>, InternalEndoParty> {}
+  extends Controller<FarRef<EndoHost>, InternalEndoAgent> {}
 
 export type EndoInspector<Record = string> = {
   lookup: (petName: Record) => Promise<unknown>;
@@ -816,12 +816,12 @@ export interface DaemonCore {
     endoFormulaIdentifier: string,
     networksDirectoryFormulaIdentifier: string,
     leastAuthorityFormulaIdentifier: string,
-    deferredTasks: DeferredTasks<PartyDeferredTaskParams>,
+    deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
     specifiedWorkerFormulaIdentifier?: string | undefined,
   ) => IncarnateResult<EndoHost>;
   incarnateGuest: (
     hostFormulaIdentifier: string,
-    deferredTasks: DeferredTasks<PartyDeferredTaskParams>,
+    deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
   ) => IncarnateResult<EndoGuest>;
   incarnateReadableBlob: (
     contentSha512: string,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -85,6 +85,10 @@ type HostFormula = {
   leastAuthority: string;
 };
 
+export type HostDeferredTaskParams = {
+  hostFormulaIdentifier: string;
+};
+
 type GuestFormula = {
   type: 'guest';
   host: string;
@@ -731,6 +735,55 @@ export type DeferredTasks<T extends Record<string, string | string[]>> = {
   push(value: DeferredTask<T>): void;
 };
 
+type IncarnateNumberedGuestParams = {
+  guestFormulaNumber: string;
+  hostHandleFormulaIdentifier: string;
+  storeFormulaIdentifier: string;
+  workerFormulaIdentifier: string;
+};
+
+type IncarnateHostDependenciesParams = {
+  endoFormulaIdentifier: string;
+  leastAuthorityFormulaIdentifier: string;
+  networksDirectoryFormulaIdentifier: string;
+  specifiedWorkerFormulaIdentifier?: string;
+};
+
+type IncarnateNumberedHostParams = {
+  hostFormulaNumber: string;
+  workerFormulaIdentifier: string;
+  storeFormulaIdentifier: string;
+  inspectorFormulaIdentifier: string;
+  endoFormulaIdentifier: string;
+  networksDirectoryFormulaIdentifier: string;
+  leastAuthorityFormulaIdentifier: string;
+};
+
+export interface PrivateDaemonCore {
+  /**
+   * Helper for callers of {@link incarnateNumberedGuest}.
+   * @param hostFormulaIdentifier - The formula identifier of the host to incarnate a guest for.
+   * @returns The formula identifiers for the guest incarnation's dependencies.
+   */
+  incarnateGuestDependencies: (
+    hostFormulaIdentifier: string,
+  ) => Promise<Readonly<IncarnateNumberedGuestParams>>;
+  incarnateNumberedGuest: (
+    identifiers: IncarnateNumberedGuestParams,
+  ) => IncarnateResult<EndoGuest>;
+  /**
+   * Helper for callers of {@link incarnateNumberedHost}.
+   * @param specifiedIdentifiers - The existing formula identifiers specified to the host incarnation.
+   * @returns The formula identifiers for all of the host incarnation's dependencies.
+   */
+  incarnateHostDependencies: (
+    specifiedIdentifiers: IncarnateHostDependenciesParams,
+  ) => Promise<Readonly<IncarnateNumberedHostParams>>;
+  incarnateNumberedHost: (
+    identifiers: IncarnateNumberedHostParams,
+  ) => IncarnateResult<EndoHost>;
+}
+
 export interface DaemonCore {
   nodeIdentifier: string;
   provideValueForFormulaIdentifier: (
@@ -760,13 +813,11 @@ export interface DaemonCore {
   ) => IncarnateResult<FarEndoBootstrap>;
   incarnateWorker: () => IncarnateResult<EndoWorker>;
   incarnateDirectory: () => IncarnateResult<EndoDirectory>;
-  incarnatePetInspector: (
-    petStoreFormulaIdentifier: string,
-  ) => IncarnateResult<EndoInspector>;
   incarnateHost: (
     endoFormulaIdentifier: string,
     networksDirectoryFormulaIdentifier: string,
     leastAuthorityFormulaIdentifier: string,
+    deferredTasks: DeferredTasks<HostDeferredTaskParams>,
     specifiedWorkerFormulaIdentifier?: string | undefined,
   ) => IncarnateResult<EndoHost>;
   incarnateGuest: (


### PR DESCRIPTION
Progresses: #2086 
Fixes: #2121 

Synchronizes `makeHost()` and its dependent functions. Also refactors the same and `makeGuest()` to extract their commonalities and restore the more succinct form they possessed before the synchronization effort began. As part of the refactor, #2121 was fixed.

_Note to reviewers:_ I recommend going commit-by-commit.