### PR TITLE
refactor(daemon): Coordinate host `provideX` implementations

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1011,7 +1011,6 @@ const makeDaemonCore = async (
 
         await deferredTasks.execute({
           workerFormulaIdentifier: formatId({
-            type: 'worker',
             number: formulaNumber,
             node: ownNodeIdentifier,
           }),

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1004,9 +1004,22 @@ const makeDaemonCore = async (
   /**
    * @type {import('./types.js').DaemonCore['incarnateWorker']}
    */
-  const incarnateWorker = async () => {
-    const formulaNumber = await formulaGraphJobs.enqueue(randomHex512);
-    return incarnateNumberedWorker(formulaNumber);
+  const incarnateWorker = async deferredTasks => {
+    return incarnateNumberedWorker(
+      await formulaGraphJobs.enqueue(async () => {
+        const formulaNumber = await randomHex512();
+
+        await deferredTasks.execute({
+          workerFormulaIdentifier: formatId({
+            type: 'worker',
+            number: formulaNumber,
+            node: ownNodeIdentifier,
+          }),
+        });
+
+        return formulaNumber;
+      }),
+    );
   };
 
   /**

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -128,10 +128,9 @@ export const makeHostMaker = ({
       /** @type {import('./types.js').DeferredTasks<import('./types.js').WorkerDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       // eslint-disable-next-line no-use-before-define
-      const workerFormulaIdentifier = prepareWorkerFormulaIdentifier(
-        workerName,
-        tasks.push,
-      );
+      const workerFormulaIdentifier = tryGetWorkerFormulaIdentifier(workerName);
+      // eslint-disable-next-line no-use-before-define
+      prepareWorkerIncarnation(workerName, workerFormulaIdentifier, tasks.push);
 
       if (workerFormulaIdentifier !== undefined) {
         return /** @type {Promise<import('./types.js').EndoWorker>} */ (
@@ -146,39 +145,32 @@ export const makeHostMaker = ({
 
     /**
      * @param {string} workerName
-     * @param {import('./types.js').DeferredTasks<{ workerFormulaIdentifier: string }>['push']} deferTask
      * @returns {string | undefined}
      */
-    const prepareWorkerFormulaIdentifier = (workerName, deferTask) => {
+    const tryGetWorkerFormulaIdentifier = workerName => {
       if (workerName === 'MAIN') {
         return mainWorkerFormulaIdentifier;
       } else if (workerName === 'NEW') {
         return undefined;
       }
+      return petStore.identifyLocal(workerName);
+    };
 
-      assertPetName(workerName);
-      const workerFormulaIdentifier = petStore.identifyLocal(workerName);
+    /**
+     * @param {string} workerName
+     * @param {string | undefined} workerFormulaIdentifier
+     * @param {import('./types.js').DeferredTasks<{ workerFormulaIdentifier: string }>['push']} deferTask
+     */
+    const prepareWorkerIncarnation = (
+      workerName,
+      workerFormulaIdentifier,
+      deferTask,
+    ) => {
       if (workerFormulaIdentifier === undefined) {
         deferTask(identifiers =>
           petStore.write(workerName, identifiers.workerFormulaIdentifier),
         );
       }
-      return workerFormulaIdentifier;
-    };
-
-    /**
-     * @param {string | 'NONE' | 'SELF' | 'ENDO'} agentName
-     * @param {import('./types.js').DeferredTasks<{ powersFormulaIdentifier: string }>['push']} deferTask
-     * @returns {string | undefined}
-     */
-    const preparePowersFormulaIdentifier = (agentName, deferTask) => {
-      const powersFormulaIdentifier = petStore.identifyLocal(agentName);
-      if (powersFormulaIdentifier === undefined) {
-        deferTask(identifiers =>
-          petStore.write(agentName, identifiers.powersFormulaIdentifier),
-        );
-      }
-      return powersFormulaIdentifier;
     };
 
     /**
@@ -205,10 +197,8 @@ export const makeHostMaker = ({
       /** @type {import('./types.js').DeferredTasks<import('./types.js').EvalDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
-      const workerFormulaIdentifier = prepareWorkerFormulaIdentifier(
-        workerName,
-        tasks.push,
-      );
+      const workerFormulaIdentifier = tryGetWorkerFormulaIdentifier(workerName);
+      prepareWorkerIncarnation(workerName, workerFormulaIdentifier, tasks.push);
 
       /** @type {(string | string[])[]} */
       const endowmentFormulaIdsOrPaths = petNamePaths.map(
@@ -259,15 +249,15 @@ export const makeHostMaker = ({
       /** @type {import('./types.js').DeferredTasks<import('./types.js').MakeCapletDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
-      const workerFormulaIdentifier = prepareWorkerFormulaIdentifier(
-        workerName,
-        tasks.push,
-      );
+      const workerFormulaIdentifier = tryGetWorkerFormulaIdentifier(workerName);
+      prepareWorkerIncarnation(workerName, workerFormulaIdentifier, tasks.push);
 
-      const powersFormulaIdentifier = preparePowersFormulaIdentifier(
-        powersName,
-        tasks.push,
-      );
+      const powersFormulaIdentifier = petStore.identifyLocal(powersName);
+      if (powersFormulaIdentifier === undefined) {
+        tasks.push(identifiers =>
+          petStore.write(powersName, identifiers.powersFormulaIdentifier),
+        );
+      }
 
       if (resultName !== undefined) {
         tasks.push(identifiers =>
@@ -398,7 +388,7 @@ export const makeHostMaker = ({
      * @returns {Promise<{formulaIdentifier: string, value: Promise<import('./types.js').EndoHost>}>}
      */
     const makeHost = async (petName, { introducedNames = {} } = {}) => {
-      let host = await getNamedAgent(petName);
+      let host = getNamedAgent(petName);
       if (host === undefined) {
         const { value, formulaIdentifier } =
           // Behold, recursion:
@@ -428,7 +418,7 @@ export const makeHostMaker = ({
      * @returns {Promise<{formulaIdentifier: string, value: Promise<import('./types.js').EndoGuest>}>}
      */
     const makeGuest = async (petName, { introducedNames = {} } = {}) => {
-      let guest = await getNamedAgent(petName);
+      let guest = getNamedAgent(petName);
       if (guest === undefined) {
         const { value, formulaIdentifier } =
           // Behold, recursion:

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -72,6 +72,10 @@ type WorkerFormula = {
   type: 'worker';
 };
 
+export type WorkerDeferredTaskParams = {
+  workerFormulaIdentifier: string;
+};
+
 /**
  * Deferred tasks parameters for `host` and `guest` formulas.
  */
@@ -789,7 +793,9 @@ export interface DaemonCore {
   incarnateEndoBootstrap: (
     specifiedFormulaNumber: string,
   ) => IncarnateResult<FarEndoBootstrap>;
-  incarnateWorker: () => IncarnateResult<EndoWorker>;
+  incarnateWorker: (
+    deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
+  ) => IncarnateResult<EndoWorker>;
   incarnateDirectory: () => IncarnateResult<EndoDirectory>;
   incarnateHost: (
     endoFormulaIdentifier: string,


### PR DESCRIPTION
Progresses: #2086 

> coordinate, verb, "to combine in harmonious relation or action."

Synchronizes the host's `provideWorker()`. In addition, coordinates the implementations of the host's `provideX` methods such that they all:
1. Attempt to get the existing formula id for the provided name, if any.
2. If there is no existing formula id, incarnate and return a new value.

All type checks during step 1 have been removed. In other words, if you attempt to provide something under an existing name that resolves to a different value type, you're on your own. We may revisit this decision in the future.