### PR TITLE
chore: Drop Node.js 16 from CI entirely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - '16.1' # last version before some significant promise hooks changes
-          - '16.5' # last version before unconditional promise fast-path
-          - '16.6' # first version after unconditional promise fast-path
+          # - '16.1' # last version before some significant promise hooks changes
+          # - '16.5' # last version before unconditional promise fast-path
+          # - '16.6' # first version after unconditional promise fast-path
           - '18' # Active LTS
           # '20.6' not viable due to https://github.com/nodejs/node/issues/49497
           # '20.3' to '20.6' not viable due to https://github.com/nodejs/node/pull/49211

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['18.x']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -11,16 +11,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ['18.x']
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
       - name: Install graphviz
         run: sudo apt install -y graphviz
 


### PR DESCRIPTION
closes: #1046

## Description

This removes the last two vestiges of testing on Node.js 16. Depcheck was on 16 by omission. The remaining CI matrix tests were for preventing regressions in `async_hooks` handling, which are leaving firmly behind us. We may at this point remove the promise-kit accommodations for these earlier versions, but that is not in scope for this change.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

We may need to document somewhere that we no longer test Node.js. We have elected not to use the `engines` field in `package.json` since that would be brittle.

### Testing Considerations

fewer

### Compatibility Considerations

none

### Upgrade Considerations

none to my knowledge