### PR TITLE
refactor(daemon): Synchronize incarnateReadableBlob()

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -288,7 +288,6 @@ export const makeCryptoPowers = crypto => {
 };
 
 /**
- * @param {(URL) => string} fileURLToPath
  * @param {import('./types.js').FilePowers} filePowers
  * @param {import('./types.js').CryptoPowers} cryptoPowers
  * @param {import('./types.js').Locator} locator
@@ -296,7 +295,6 @@ export const makeCryptoPowers = crypto => {
  * @returns {import('./types.js').DaemonicPersistencePowers}
  */
 export const makeDaemonicPersistencePowers = (
-  fileURLToPath,
   filePowers,
   cryptoPowers,
   locator,
@@ -565,7 +563,6 @@ export const makeDaemonicPowers = ({
 
   const petStorePowers = makePetStoreMaker(filePowers, locator);
   const daemonicPersistencePowers = makeDaemonicPersistencePowers(
-    fileURLToPath,
     filePowers,
     cryptoPowers,
     locator,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -219,28 +219,6 @@ const makeDaemonCore = async (
   const getFormulaIdentifierForRef = ref => formulaIdentifierForRef.get(ref);
 
   /**
-   * @param {string} sha512
-   * @returns {import('./types.js').FarEndoReadable}
-   */
-  const makeReadableBlob = sha512 => {
-    const { text, json, streamBase64 } = contentStore.fetch(sha512);
-    return Far(`Readable file with SHA-512 ${sha512.slice(0, 8)}...`, {
-      sha512: () => sha512,
-      streamBase64,
-      text,
-      json,
-    });
-  };
-
-  /** @type {import('./types.js').DaemonCore['storeReaderRef']} */
-  const storeReaderRef = async readerRef => {
-    const sha512Hex = await contentStore.store(makeRefReader(readerRef));
-    // eslint-disable-next-line no-use-before-define
-    const { formulaIdentifier } = await incarnateReadableBlob(sha512Hex);
-    return formulaIdentifier;
-  };
-
-  /**
    * @param {string} workerId512
    */
   const makeWorkerBootstrap = async workerId512 => {
@@ -294,6 +272,23 @@ const makeDaemonCore = async (
     return {
       external: worker,
       internal: workerDaemonFacet,
+    };
+  };
+
+  /**
+   * @param {string} sha512
+   */
+  const makeControllerForReadableBlob = sha512 => {
+    const { text, json, streamBase64 } = contentStore.fetch(sha512);
+    return {
+      /** @type {import('./types.js').FarEndoReadable} */
+      external: Far(`Readable file with SHA-512 ${sha512.slice(0, 8)}...`, {
+        sha512: () => sha512,
+        streamBase64,
+        text,
+        json,
+      }),
+      internal: undefined,
     };
   };
 
@@ -487,8 +482,7 @@ const makeDaemonCore = async (
         context,
       );
     } else if (formula.type === 'readable-blob') {
-      const external = makeReadableBlob(formula.content);
-      return { external, internal: undefined };
+      return makeControllerForReadableBlob(formula.content);
     } else if (formula.type === 'lookup') {
       return makeControllerForLookup(formula.hub, formula.path, context);
     } else if (formula.type === 'worker') {
@@ -906,13 +900,31 @@ const makeDaemonCore = async (
     };
 
   /** @type {import('./types.js').DaemonCore['incarnateReadableBlob']} */
-  const incarnateReadableBlob = async contentSha512 => {
-    const formulaNumber = await randomHex512();
+  const incarnateReadableBlob = async (readerRef, deferredTasks) => {
+    const { formulaNumber, contentSha512 } = await formulaGraphJobs.enqueue(
+      async () => {
+        const values = {
+          formulaNumber: await randomHex512(),
+          contentSha512: await contentStore.store(makeRefReader(readerRef)),
+        };
+
+        await deferredTasks.execute({
+          readableBlobFormulaIdentifier: formatId({
+            number: values.formulaNumber,
+            node: ownNodeIdentifier,
+          }),
+        });
+
+        return values;
+      },
+    );
+
     /** @type {import('./types.js').ReadableBlobFormula} */
     const formula = {
       type: 'readable-blob',
       content: contentSha512,
     };
+
     return /** @type {import('./types.js').IncarnateResult<import('./types.js').FarEndoReadable>} */ (
       provideValueForNumberedFormula(formula.type, formulaNumber, formula)
     );
@@ -1597,7 +1609,7 @@ const makeDaemonCore = async (
     incarnateEval,
     incarnateUnconfined,
     incarnateBundle,
-    storeReaderRef,
+    incarnateReadableBlob,
     makeMailbox,
     makeDirectoryNode,
     getAllNetworkAddresses,
@@ -1726,7 +1738,6 @@ const makeDaemonCore = async (
     getFormulaIdentifierForRef,
     getAllNetworkAddresses,
     cancelValue,
-    storeReaderRef,
     makeMailbox,
     makeDirectoryNode,
     incarnateEndoBootstrap,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -24,7 +24,7 @@ const assertPowersName = name => {
  * @param {import('./types.js').DaemonCore['incarnateEval']} args.incarnateEval
  * @param {import('./types.js').DaemonCore['incarnateUnconfined']} args.incarnateUnconfined
  * @param {import('./types.js').DaemonCore['incarnateBundle']} args.incarnateBundle
- * @param {import('./types.js').DaemonCore['storeReaderRef']} args.storeReaderRef
+ * @param {import('./types.js').DaemonCore['incarnateReadableBlob']} args.incarnateReadableBlob
  * @param {import('./types.js').DaemonCore['getAllNetworkAddresses']} args.getAllNetworkAddresses
  * @param {import('./types.js').MakeMailbox} args.makeMailbox
  * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
@@ -40,7 +40,7 @@ export const makeHostMaker = ({
   incarnateEval,
   incarnateUnconfined,
   incarnateBundle,
-  storeReaderRef,
+  incarnateReadableBlob,
   getAllNetworkAddresses,
   makeMailbox,
   makeDirectoryNode,
@@ -107,15 +107,18 @@ export const makeHostMaker = ({
      * @param {string} [petName]
      */
     const store = async (readerRef, petName) => {
+      /** @type {import('./types.js').DeferredTasks<import('./types.js').ReadableBlobDeferredTaskParams>} */
+      const tasks = makeDeferredTasks();
+
       if (petName !== undefined) {
         assertPetName(petName);
+        tasks.push(identifiers =>
+          petStore.write(petName, identifiers.readableBlobFormulaIdentifier),
+        );
       }
 
-      const formulaIdentifier = await storeReaderRef(readerRef);
-
-      if (petName !== undefined) {
-        await petStore.write(petName, formulaIdentifier);
-      }
+      const { value } = await incarnateReadableBlob(readerRef, tasks);
+      return value;
     };
 
     /**

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -119,6 +119,10 @@ type ReadableBlobFormula = {
   content: string;
 };
 
+export type ReadableBlobDeferredTaskParams = {
+  readableBlobFormulaIdentifier: string;
+};
+
 type LookupFormula = {
   type: 'lookup';
 
@@ -518,7 +522,7 @@ export interface EndoHost extends EndoDirectory {
   store(
     readerRef: ERef<AsyncIterableIterator<string>>,
     petName: string,
-  ): Promise<void>;
+  ): Promise<FarEndoReadable>;
   provideGuest(
     petName?: string,
     opts?: MakeHostOrGuestOptions,
@@ -798,7 +802,8 @@ export interface DaemonCore {
     deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
   ) => IncarnateResult<EndoGuest>;
   incarnateReadableBlob: (
-    contentSha512: string,
+    readerRef: ERef<AsyncIterableIterator<string>>,
+    deferredTasks: DeferredTasks<ReadableBlobDeferredTaskParams>,
   ) => IncarnateResult<FarEndoReadable>;
   incarnateEval: (
     hostFormulaIdentifier: string,
@@ -829,9 +834,6 @@ export interface DaemonCore {
   incarnateNetworksDirectory: () => IncarnateResult<EndoDirectory>;
   incarnateLoopbackNetwork: () => IncarnateResult<EndoNetwork>;
   cancelValue: (formulaIdentifier: string, reason: Error) => Promise<void>;
-  storeReaderRef: (
-    readerRef: ERef<AsyncIterableIterator<string>>,
-  ) => Promise<string>;
   makeMailbox: MakeMailbox;
   makeDirectoryNode: MakeDirectoryNode;
 }


### PR DESCRIPTION
Progresses: #2086 

Merges the daemon's `storeReaderRef()` into `incarnateReadableBlob()` and synchronizes the implementation. Also converts `makeReadableBlob()` into `makeControllerForReadableBlob()` to align it with the family of functions that already exist for most other formulas.

Contrary to its predecessor, `incarnateReadableBlob()` returns the value for stored value, namely a `FarEndoReadable`. A unit test is added for the case of immediately using a stored value without naming it.
