### PR TITLE
refactor(daemon): Contract formulate and provide

### DIFF
--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -416,7 +416,8 @@ export const makeDaemonicPersistencePowers = (
   };
 
   // Persist instructions for revival (this can be collected)
-  const writeFormula = async (formula, formulaType, formulaNumber) => {
+  /** @type {import('./types.js').DaemonicPersistencePowers['writeFormula']} */
+  const writeFormula = async (formulaNumber, formula) => {
     const { directory, file } = makeFormulaPath(formulaNumber);
     // TODO Take care to write atomically with a rename here.
     await filePowers.makePath(directory);

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -136,13 +136,9 @@ const makeDaemonCore = async (
     number: leastAuthorityFormulaNumber,
     node: ownNodeIdentifier,
   });
-  await persistencePowers.writeFormula(
-    {
-      type: 'least-authority',
-    },
-    'least-authority',
-    leastAuthorityFormulaNumber,
-  );
+  await persistencePowers.writeFormula(leastAuthorityFormulaNumber, {
+    type: 'least-authority',
+  });
 
   // Prime main worker formula (without incarnation)
   const mainWorkerFormulaNumber = deriveId(
@@ -154,13 +150,9 @@ const makeDaemonCore = async (
     number: mainWorkerFormulaNumber,
     node: ownNodeIdentifier,
   });
-  await persistencePowers.writeFormula(
-    {
-      type: 'worker',
-    },
-    'worker',
-    mainWorkerFormulaNumber,
-  );
+  await persistencePowers.writeFormula(mainWorkerFormulaNumber, {
+    type: 'worker',
+  });
 
   /** @type {import('./types.js').Builtins} */
   const builtins = {
@@ -182,21 +174,17 @@ const makeDaemonCore = async (
           number: formulaNumber,
           node: ownNodeIdentifier,
         });
-        await persistencePowers.writeFormula(
-          formula,
-          formula.type,
-          formulaNumber,
-        );
+        await persistencePowers.writeFormula(formulaNumber, formula);
         return [specialName, formulaIdentifier];
       }),
     ),
   );
 
   /**
-   * The two functions "provideValueForNumberedFormula" and "provideValueForFormulaIdentifier"
+   * The two functions "formulate" and "provideValueForFormulaIdentifier"
    * share a responsibility for maintaining the memoization tables
    * "controllerForFormulaIdentifier" and "formulaIdentifierForRef".
-   * "provideValueForNumberedFormula" is used for incarnating and persisting
+   * "formulate" is used for incarnating and persisting
    * new formulas, whereas "provideValueForFormulaIdentifier" is used for
    * reincarnating stored formulas.
    */
@@ -738,12 +726,8 @@ const makeDaemonCore = async (
     );
   };
 
-  /** @type {import('./types.js').DaemonCore['provideValueForNumberedFormula']} */
-  const provideValueForNumberedFormula = async (
-    formulaType,
-    formulaNumber,
-    formula,
-  ) => {
+  /** @type {import('./types.js').DaemonCore['formulate']} */
+  const formulate = async (formulaNumber, formula) => {
     const formulaIdentifier = formatId({
       number: formulaNumber,
       node: ownNodeIdentifier,
@@ -782,11 +766,7 @@ const makeDaemonCore = async (
 
     // Ensure that failure to flush the formula to storage
     // causes a rejection for both the controller and the incarnation value.
-    const written = persistencePowers.writeFormula(
-      formula,
-      formulaType,
-      formulaNumber,
-    );
+    const written = persistencePowers.writeFormula(formulaNumber, formula);
     resolvePartial(written.then(() => /** @type {any} */ (controllerValue)));
     await written;
 
@@ -926,7 +906,7 @@ const makeDaemonCore = async (
     };
 
     return /** @type {import('./types.js').IncarnateResult<import('./types.js').FarEndoReadable>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -945,7 +925,7 @@ const makeDaemonCore = async (
       target: targetFormulaIdentifier,
     };
     return /** @type {import('./types').IncarnateResult<import('./types').ExternalHandle>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -962,7 +942,7 @@ const makeDaemonCore = async (
       type: 'pet-store',
     };
     return /** @type {import('./types').IncarnateResult<import('./types').PetStore>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -979,7 +959,7 @@ const makeDaemonCore = async (
       petStore: petStoreFormulaIdentifier,
     };
     return /** @type {import('./types').IncarnateResult<import('./types').EndoDirectory>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -997,7 +977,7 @@ const makeDaemonCore = async (
     };
 
     return /** @type {import('./types').IncarnateResult<import('./types').EndoWorker>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -1065,11 +1045,7 @@ const makeDaemonCore = async (
     };
 
     return /** @type {import('./types').IncarnateResult<import('./types').EndoHost>} */ (
-      provideValueForNumberedFormula(
-        'host',
-        identifiers.hostFormulaNumber,
-        formula,
-      )
+      formulate(identifiers.hostFormulaNumber, formula)
     );
   };
 
@@ -1129,11 +1105,7 @@ const makeDaemonCore = async (
     };
 
     return /** @type {import('./types').IncarnateResult<import('./types').EndoGuest>} */ (
-      provideValueForNumberedFormula(
-        formula.type,
-        identifiers.guestFormulaNumber,
-        formula,
-      )
+      formulate(identifiers.guestFormulaNumber, formula)
     );
   };
 
@@ -1233,7 +1205,7 @@ const makeDaemonCore = async (
       values: endowmentFormulaIdentifiers,
     };
     return /** @type {import('./types.js').IncarnateResult<unknown>} */ (
-      provideValueForNumberedFormula(formula.type, evalFormulaNumber, formula)
+      formulate(evalFormulaNumber, formula)
     );
   };
 
@@ -1260,7 +1232,7 @@ const makeDaemonCore = async (
     };
 
     return /** @type {import('./types.js').IncarnateResult<import('./types.js').EndoWorker>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -1347,11 +1319,7 @@ const makeDaemonCore = async (
       powers: powersFormulaIdentifier,
       specifier,
     };
-    return provideValueForNumberedFormula(
-      formula.type,
-      capletFormulaNumber,
-      formula,
-    );
+    return formulate(capletFormulaNumber, formula);
   };
 
   /** @type {import('./types.js').DaemonCore['incarnateBundle']} */
@@ -1383,11 +1351,7 @@ const makeDaemonCore = async (
       powers: powersFormulaIdentifier,
       bundle: bundleFormulaIdentifier,
     };
-    return provideValueForNumberedFormula(
-      formula.type,
-      capletFormulaNumber,
-      formula,
-    );
+    return formulate(capletFormulaNumber, formula);
   };
 
   /**
@@ -1404,7 +1368,7 @@ const makeDaemonCore = async (
       petStore: petStoreFormulaIdentifier,
     };
     return /** @type {import('./types').IncarnateResult<import('./types').EndoInspector>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -1423,7 +1387,7 @@ const makeDaemonCore = async (
       addresses,
     };
     return /** @type {import('./types').IncarnateResult<import('./types').EndoPeer>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -1435,7 +1399,7 @@ const makeDaemonCore = async (
       type: 'loopback-network',
     };
     return /** @type {import('./types').IncarnateResult<import('./types').EndoNetwork>} */ (
-      provideValueForNumberedFormula(formula.type, formulaNumber, formula)
+      formulate(formulaNumber, formula)
     );
   };
 
@@ -1496,11 +1460,7 @@ const makeDaemonCore = async (
     };
 
     return /** @type {import('./types').IncarnateResult<import('./types').FarEndoBootstrap>} */ (
-      provideValueForNumberedFormula(
-        formula.type,
-        identifiers.formulaNumber,
-        formula,
-      )
+      formulate(identifiers.formulaNumber, formula)
     );
   };
 
@@ -1760,7 +1720,7 @@ const makeDaemonCore = async (
     provideControllerForFormulaIdentifier,
     provideControllerForFormulaIdentifierAndResolveHandle,
     provideValueForFormulaIdentifier,
-    provideValueForNumberedFormula,
+    formulate,
     getFormulaIdentifierForRef,
     getAllNetworkAddresses,
     cancelValue,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -181,12 +181,11 @@ const makeDaemonCore = async (
   );
 
   /**
-   * The two functions "formulate" and "provideValueForFormulaIdentifier"
-   * share a responsibility for maintaining the memoization tables
-   * "controllerForFormulaIdentifier" and "formulaIdentifierForRef".
-   * "formulate" is used for incarnating and persisting
-   * new formulas, whereas "provideValueForFormulaIdentifier" is used for
-   * reincarnating stored formulas.
+   * The two functions "formulate" and "provide" share a responsibility for
+   * maintaining the memoization tables "controllerForFormulaIdentifier" and
+   * "formulaIdentifierForRef".
+   * "formulate" is used for incarnating and persisting new formulas, whereas
+   * "provide" is used for reincarnating stored formulas.
    */
 
   /**
@@ -315,7 +314,7 @@ const makeDaemonCore = async (
       formulaIdentifiers.map(formulaIdentifier =>
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
-        provideValueForFormulaIdentifier(formulaIdentifier),
+        provide(formulaIdentifier),
       ),
     );
 
@@ -355,7 +354,7 @@ const makeDaemonCore = async (
 
     // Behold, recursion:
     // eslint-disable-next-line no-use-before-define
-    const hub = provideValueForFormulaIdentifier(hubFormulaIdentifier);
+    const hub = provide(hubFormulaIdentifier);
     // @ts-expect-error calling lookup on an unknown object
     const external = E(hub).lookup(...path);
     return { external, internal: undefined };
@@ -390,7 +389,7 @@ const makeDaemonCore = async (
     const guestP = /** @type {Promise<import('./types.js').EndoGuest>} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      provideValueForFormulaIdentifier(guestFormulaIdentifier)
+      provide(guestFormulaIdentifier)
     );
     const external = E(workerDaemonFacet).makeUnconfined(
       specifier,
@@ -433,12 +432,12 @@ const makeDaemonCore = async (
       /** @type {Promise<import('./types.js').EndoReadable>} */ (
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
-        provideValueForFormulaIdentifier(bundleFormulaIdentifier)
+        provide(bundleFormulaIdentifier)
       );
     const guestP = /** @type {Promise<import('./types.js').EndoGuest>} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      provideValueForFormulaIdentifier(guestFormulaIdentifier)
+      provide(guestFormulaIdentifier)
     );
     const external = E(workerDaemonFacet).makeBundle(
       readableBundleP,
@@ -535,7 +534,7 @@ const makeDaemonCore = async (
             );
           }
           // eslint-disable-next-line no-use-before-define
-          return provideValueForFormulaIdentifier(requestedFormulaIdentifier);
+          return provide(requestedFormulaIdentifier);
         },
       });
       /** @type {import('./types.js').FarEndoBootstrap} */
@@ -549,14 +548,14 @@ const makeDaemonCore = async (
           // Behold, recursion:
           return /** @type {Promise<import('./types.js').EndoHost>} */ (
             // eslint-disable-next-line no-use-before-define
-            provideValueForFormulaIdentifier(formula.host)
+            provide(formula.host)
           );
         },
         leastAuthority: () => {
           // Behold, recursion:
           return /** @type {Promise<import('./types.js').EndoGuest>} */ (
             // eslint-disable-next-line no-use-before-define
-            provideValueForFormulaIdentifier(leastAuthorityFormulaIdentifier)
+            provide(leastAuthorityFormulaIdentifier)
           );
         },
         gateway: async () => {
@@ -567,7 +566,7 @@ const makeDaemonCore = async (
             /** @type {import('./types.js').EndoDirectory} */ (
               // Behold, recursion:
               // eslint-disable-next-line no-use-before-define
-              await provideValueForFormulaIdentifier(formula.networks)
+              await provide(formula.networks)
             );
           const networkFormulaIdentifiers =
             await networksDirectory.listIdentifiers();
@@ -575,7 +574,7 @@ const makeDaemonCore = async (
             networkFormulaIdentifiers.map(
               // Behold, recursion:
               // eslint-disable-next-line no-use-before-define
-              provideValueForFormulaIdentifier,
+              provide,
             ),
           );
         },
@@ -584,7 +583,7 @@ const makeDaemonCore = async (
             /** @type {import('./types.js').PetStore} */
             // Behold, recursion:
             // eslint-disable-next-line no-use-before-define
-            (await provideValueForFormulaIdentifier(formula.peers));
+            (await provide(formula.peers));
           const { node, addresses } = peerInfo;
           // eslint-disable-next-line no-use-before-define
           const nodeName = petStoreNameForNodeIdentifier(node);
@@ -607,7 +606,7 @@ const makeDaemonCore = async (
       // Behold, forward-reference:
       const loopbackNetwork = makeLoopbackNetwork({
         // eslint-disable-next-line no-use-before-define
-        provideValueForFormulaIdentifier,
+        provide,
       });
       return {
         external: loopbackNetwork,
@@ -819,7 +818,7 @@ const makeDaemonCore = async (
     }
     const peerStore = /** @type {import('./types.js').PetStore} */ (
       // eslint-disable-next-line no-use-before-define
-      await provideValueForFormulaIdentifier(peersFormulaIdentifier)
+      await provide(peersFormulaIdentifier)
     );
     const nodeName = petStoreNameForNodeIdentifier(nodeIdentifier);
     const peerFormulaIdentifier = peerStore.identifyLocal(nodeName);
@@ -839,8 +838,8 @@ const makeDaemonCore = async (
     return controller.context.cancel(reason);
   };
 
-  /** @type {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} */
-  const provideValueForFormulaIdentifier = formulaIdentifier => {
+  /** @type {import('./types.js').DaemonCore['provide']} */
+  const provide = formulaIdentifier => {
     const controller = /** @type {import('./types.js').Controller<>} */ (
       provideControllerForFormulaIdentifier(formulaIdentifier)
     );
@@ -1471,13 +1470,11 @@ const makeDaemonCore = async (
   const getAllNetworks = async networksDirectoryFormulaIdentifier => {
     const networksDirectory = /** @type {import('./types').EndoDirectory} */ (
       // eslint-disable-next-line no-use-before-define
-      await provideValueForFormulaIdentifier(networksDirectoryFormulaIdentifier)
+      await provide(networksDirectoryFormulaIdentifier)
     );
     const networkFormulaIdentifiers = await networksDirectory.listIdentifiers();
     const networks = /** @type {import('./types').EndoNetwork[]} */ (
-      await Promise.all(
-        networkFormulaIdentifiers.map(provideValueForFormulaIdentifier),
-      )
+      await Promise.all(networkFormulaIdentifiers.map(provide))
     );
     return networks;
   };
@@ -1554,7 +1551,7 @@ const makeDaemonCore = async (
     remoteValueFormulaIdentifier,
   ) => {
     const peer = /** @type {import('./types.js').EndoPeer} */ (
-      await provideValueForFormulaIdentifier(peerFormulaIdentifier)
+      await provide(peerFormulaIdentifier)
     );
     const remoteValueP = peer.provide(remoteValueFormulaIdentifier);
     const external = remoteValueP;
@@ -1568,25 +1565,25 @@ const makeDaemonCore = async (
   });
 
   const { makeIdentifiedDirectory, makeDirectoryNode } = makeDirectoryMaker({
-    provideValueForFormulaIdentifier,
+    provide,
     getFormulaIdentifierForRef,
     incarnateDirectory,
   });
 
   const makeMailbox = makeMailboxMaker({
-    provideValueForFormulaIdentifier,
+    provide,
     provideControllerForFormulaIdentifierAndResolveHandle,
   });
 
   const makeIdentifiedGuestController = makeGuestMaker({
-    provideValueForFormulaIdentifier,
+    provide,
     provideControllerForFormulaIdentifierAndResolveHandle,
     makeMailbox,
     makeDirectoryNode,
   });
 
   const makeIdentifiedHost = makeHostMaker({
-    provideValueForFormulaIdentifier,
+    provide,
     provideControllerForFormulaIdentifier,
     cancelValue,
     incarnateWorker,
@@ -1613,7 +1610,7 @@ const makeDaemonCore = async (
    */
   const makePetStoreInspector = async petStoreFormulaIdentifier => {
     const petStore = /** @type {import('./types').PetStore} */ (
-      await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
+      await provide(petStoreFormulaIdentifier)
     );
 
     /**
@@ -1644,14 +1641,11 @@ const makeDaemonCore = async (
           harden({
             endowments: Object.fromEntries(
               formula.names.map((name, index) => {
-                return [
-                  name,
-                  provideValueForFormulaIdentifier(formula.values[index]),
-                ];
+                return [name, provide(formula.values[index])];
               }),
             ),
             source: formula.source,
-            worker: provideValueForFormulaIdentifier(formula.worker),
+            worker: provide(formula.worker),
           }),
         );
       } else if (formula.type === 'lookup') {
@@ -1659,7 +1653,7 @@ const makeDaemonCore = async (
           formula.type,
           formulaNumber,
           harden({
-            hub: provideValueForFormulaIdentifier(formula.hub),
+            hub: provide(formula.hub),
             path: formula.path,
           }),
         );
@@ -1668,7 +1662,7 @@ const makeDaemonCore = async (
           formula.type,
           formulaNumber,
           harden({
-            host: provideValueForFormulaIdentifier(formula.host),
+            host: provide(formula.host),
           }),
         );
       } else if (formula.type === 'make-bundle') {
@@ -1676,9 +1670,9 @@ const makeDaemonCore = async (
           formula.type,
           formulaNumber,
           harden({
-            bundle: provideValueForFormulaIdentifier(formula.bundle),
-            powers: provideValueForFormulaIdentifier(formula.powers),
-            worker: provideValueForFormulaIdentifier(formula.worker),
+            bundle: provide(formula.bundle),
+            powers: provide(formula.powers),
+            worker: provide(formula.worker),
           }),
         );
       } else if (formula.type === 'make-unconfined') {
@@ -1686,9 +1680,9 @@ const makeDaemonCore = async (
           formula.type,
           formulaNumber,
           harden({
-            powers: provideValueForFormulaIdentifier(formula.powers),
+            powers: provide(formula.powers),
             specifier: formula.type,
-            worker: provideValueForFormulaIdentifier(formula.worker),
+            worker: provide(formula.worker),
           }),
         );
       } else if (formula.type === 'peer') {
@@ -1719,7 +1713,7 @@ const makeDaemonCore = async (
     nodeIdentifier: ownNodeIdentifier,
     provideControllerForFormulaIdentifier,
     provideControllerForFormulaIdentifierAndResolveHandle,
-    provideValueForFormulaIdentifier,
+    provide,
     formulate,
     getFormulaIdentifierForRef,
     getAllNetworkAddresses,
@@ -1771,7 +1765,7 @@ const provideEndoBootstrap = async (
       node: daemonCore.nodeIdentifier,
     });
     return /** @type {Promise<import('./types.js').FarEndoBootstrap>} */ (
-      daemonCore.provideValueForFormulaIdentifier(endoFormulaIdentifier)
+      daemonCore.provide(endoFormulaIdentifier)
     );
   } else {
     const { value: endoBootstrap } = await daemonCore.incarnateEndoBootstrap(

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -7,12 +7,12 @@ const { quote: q } = assert;
 
 /**
  * @param {object} args
- * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['provide']} args.provide
  * @param {import('./types.js').DaemonCore['getFormulaIdentifierForRef']} args.getFormulaIdentifierForRef
  * @param {import('./types.js').DaemonCore['incarnateDirectory']} args.incarnateDirectory
  */
 export const makeDirectoryMaker = ({
-  provideValueForFormulaIdentifier,
+  provide,
   getFormulaIdentifierForRef,
   incarnateDirectory,
 }) => {
@@ -27,7 +27,7 @@ export const makeDirectoryMaker = ({
       }
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      const value = provideValueForFormulaIdentifier(formulaIdentifier);
+      const value = provide(formulaIdentifier);
       return tailNames.reduce(
         // @ts-expect-error We assume its a NameHub
         (directory, petName) => E(directory).lookup(petName),
@@ -219,7 +219,7 @@ export const makeDirectoryMaker = ({
     // TODO thread context
 
     const petStore = /** @type {import('./types.js').PetStore} */ (
-      await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
+      await provide(petStoreFormulaIdentifier)
     );
     const directory = makeDirectoryNode(petStore);
 

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -6,13 +6,13 @@ import { makePetSitter } from './pet-sitter.js';
 
 /**
  * @param {object} args
- * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['provide']} args.provide
  * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
  * @param {import('./types.js').MakeMailbox} args.makeMailbox
  * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
  */
 export const makeGuestMaker = ({
-  provideValueForFormulaIdentifier,
+  provide,
   provideControllerForFormulaIdentifierAndResolveHandle,
   makeMailbox,
   makeDirectoryNode,
@@ -36,7 +36,7 @@ export const makeGuestMaker = ({
     context.thisDiesIfThatDies(mainWorkerFormulaIdentifier);
 
     const basePetStore = /** @type {import('./types.js').PetStore} */ (
-      await provideValueForFormulaIdentifier(petStoreFormulaIdentifier)
+      await provide(petStoreFormulaIdentifier)
     );
     const specialStore = makePetSitter(basePetStore, {
       SELF: guestFormulaIdentifier,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -15,7 +15,7 @@ const assertPowersName = name => {
 
 /**
  * @param {object} args
- * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['provide']} args.provide
  * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifier']} args.provideControllerForFormulaIdentifier
  * @param {import('./types.js').DaemonCore['cancelValue']} args.cancelValue
  * @param {import('./types.js').DaemonCore['incarnateWorker']} args.incarnateWorker
@@ -31,7 +31,7 @@ const assertPowersName = name => {
  * @param {string} args.ownNodeIdentifier
  */
 export const makeHostMaker = ({
-  provideValueForFormulaIdentifier,
+  provide,
   provideControllerForFormulaIdentifier,
   cancelValue,
   incarnateWorker,
@@ -74,7 +74,7 @@ export const makeHostMaker = ({
     const basePetStore = /** @type {import('./types.js').PetStore} */ (
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      await provideValueForFormulaIdentifier(storeFormulaIdentifier)
+      await provide(storeFormulaIdentifier)
     );
     const specialStore = makePetSitter(basePetStore, {
       ...platformNames,
@@ -97,7 +97,7 @@ export const makeHostMaker = ({
     const getEndoBootstrap = async () => {
       const endoBootstrap =
         /** @type {import('./types.js').FarEndoBootstrap} */ (
-          await provideValueForFormulaIdentifier(endoFormulaIdentifier)
+          await provide(endoFormulaIdentifier)
         );
       return endoBootstrap;
     };
@@ -135,7 +135,7 @@ export const makeHostMaker = ({
       if (workerFormulaIdentifier !== undefined) {
         return /** @type {Promise<import('./types.js').EndoWorker>} */ (
           // Behold, recursion:
-          provideValueForFormulaIdentifier(workerFormulaIdentifier)
+          provide(workerFormulaIdentifier)
         );
       }
 
@@ -545,7 +545,7 @@ export const makeHostMaker = ({
     });
     const internal = harden({ receive, respond, petStore });
 
-    await provideValueForFormulaIdentifier(mainWorkerFormulaIdentifier);
+    await provide(mainWorkerFormulaIdentifier);
 
     return harden({ external, internal });
   };

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -8,12 +8,12 @@ const { quote: q } = assert;
 
 /**
  * @param {object} args
- * @param {import('./types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('./types.js').DaemonCore['provide']} args.provide
  * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
  * @returns {import('./types.js').MakeMailbox}
  */
 export const makeMailboxMaker = ({
-  provideValueForFormulaIdentifier,
+  provide,
   provideControllerForFormulaIdentifierAndResolveHandle,
 }) => {
   /**
@@ -176,7 +176,7 @@ export const makeMailboxMaker = ({
         }
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
-        return provideValueForFormulaIdentifier(formulaIdentifier);
+        return provide(formulaIdentifier);
       }
       // The reference is not named nor to be named.
       const formulaIdentifier = await requestFormulaIdentifier(
@@ -188,7 +188,7 @@ export const makeMailboxMaker = ({
       // context.thisDiesIfThatDies(formulaIdentifier);
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      return provideValueForFormulaIdentifier(formulaIdentifier);
+      return provide(formulaIdentifier);
     };
 
     /** @type {import('./types.js').Mail['resolve']} */

--- a/packages/daemon/src/networks/loopback.js
+++ b/packages/daemon/src/networks/loopback.js
@@ -3,10 +3,10 @@ import { Far } from '@endo/far';
 
 /**
  * @param {object} args
- * @param {import('../types.js').DaemonCore['provideValueForFormulaIdentifier']} args.provideValueForFormulaIdentifier
+ * @param {import('../types.js').DaemonCore['provide']} args.provide
  * @returns {import('@endo/far').FarRef<import('../types.js').EndoNetwork>}
  */
-export const makeLoopbackNetwork = ({ provideValueForFormulaIdentifier }) => {
+export const makeLoopbackNetwork = ({ provide }) => {
   return Far(
     'Loopback Network',
     /** @type {import('../types.js').EndoNetwork} */ ({
@@ -18,7 +18,7 @@ export const makeLoopbackNetwork = ({ provideValueForFormulaIdentifier }) => {
             'Failed invariant: loopback only supports "loop:" address',
           );
         }
-        return { provide: provideValueForFormulaIdentifier };
+        return { provide };
       },
     }),
   );

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -765,9 +765,7 @@ export interface DaemonCoreInternal {
 
 export interface DaemonCore {
   nodeIdentifier: string;
-  provideValueForFormulaIdentifier: (
-    formulaIdentifier: string,
-  ) => Promise<unknown>;
+  provide: (formulaIdentifier: string) => Promise<unknown>;
   provideControllerForFormulaIdentifier: (
     formulaIdentifier: string,
   ) => Controller;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -663,11 +663,7 @@ export type DaemonicPersistencePowers = {
     fetch: (sha512: string) => EndoReadable;
   };
   readFormula: (formulaNumber: string) => Promise<Formula>;
-  writeFormula: (
-    formula: Formula,
-    formulaType: string,
-    formulaNumber: string,
-  ) => Promise<void>;
+  writeFormula: (formulaNumber: string, formula: Formula) => Promise<void>;
 };
 
 export interface DaemonWorkerFacet {}
@@ -778,8 +774,7 @@ export interface DaemonCore {
   provideControllerForFormulaIdentifierAndResolveHandle: (
     formulaIdentifier: string,
   ) => Promise<Controller>;
-  provideValueForNumberedFormula: (
-    formulaType: string,
+  formulate: (
     formulaNumber: string,
     formula: Formula,
   ) => Promise<{


### PR DESCRIPTION
This change blesses `formulate` and `provide` with short names to convey their significance and reduce noise.