### PR TITLE
refactor(daemon): Id means formula identifier

### DIFF
--- a/packages/daemon/src/context.js
+++ b/packages/daemon/src/context.js
@@ -2,10 +2,7 @@
 
 import { makePromiseKit } from '@endo/promise-kit';
 
-export const makeContextMaker = ({
-  controllerForId,
-  provideControllerForId,
-}) => {
+export const makeContextMaker = ({ controllerForId, provideController }) => {
   /**
    * @param {string} id
    */
@@ -26,7 +23,8 @@ export const makeContextMaker = ({
     const hooks = [];
 
     /**
-     * @param {unknown} reason
+     * @param {Error} reason
+     * @param {string} [prefix]
      */
     const cancel = (reason, prefix = '*') => {
       if (done) return disposed;
@@ -52,7 +50,7 @@ export const makeContextMaker = ({
      */
     const thatDiesIfThisDies = dependentId => {
       assert(!done);
-      const dependentController = provideControllerForId(dependentId);
+      const dependentController = provideController(dependentId);
       dependents.set(dependentId, dependentController.context);
     };
 
@@ -60,7 +58,7 @@ export const makeContextMaker = ({
      * @param {string} dependencyId
      */
     const thisDiesIfThatDies = dependencyId => {
-      const dependencyController = provideControllerForId(dependencyId);
+      const dependencyController = provideController(dependencyId);
       dependencyController.context.thatDiesIfThisDies(id);
     };
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -302,7 +302,7 @@ const makeDaemonCore = async (
       /** @type {import('./types.js').Controller<unknown, import('./worker.js').WorkerBootstrap>} */ (
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
-        provideControllerForId(workerId)
+        provideController(workerId)
       );
     const workerDaemonFacet = workerController.internal;
     assert(
@@ -375,7 +375,7 @@ const makeDaemonCore = async (
       /** @type {import('./types.js').Controller<unknown, import('./worker.js').WorkerBootstrap>} */ (
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
-        provideControllerForId(workerId)
+        provideController(workerId)
       );
     const workerDaemonFacet = workerController.internal;
     assert(
@@ -415,7 +415,7 @@ const makeDaemonCore = async (
       /** @type {import('./types.js').Controller<unknown, import('./worker.js').WorkerBootstrap>} */ (
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
-        provideControllerForId(workerId)
+        provideController(workerId)
       );
     const workerDaemonFacet = workerController.internal;
     assert(
@@ -752,8 +752,8 @@ const makeDaemonCore = async (
     });
   };
 
-  /** @type {import('./types.js').DaemonCore['provideControllerForId']} */
-  const provideControllerForId = id => {
+  /** @type {import('./types.js').DaemonCore['provideController']} */
+  const provideController = id => {
     let controller = controllerForId.get(id);
     if (controller !== undefined) {
       return controller;
@@ -810,7 +810,7 @@ const makeDaemonCore = async (
   /** @type {import('./types.js').DaemonCore['cancelValue']} */
   const cancelValue = async (id, reason) => {
     await formulaGraphJobs.enqueue();
-    const controller = provideControllerForId(id);
+    const controller = provideController(id);
     console.log('Cancelled:');
     return controller.context.cancel(reason);
   };
@@ -818,7 +818,7 @@ const makeDaemonCore = async (
   /** @type {import('./types.js').DaemonCore['provide']} */
   const provide = id => {
     const controller = /** @type {import('./types.js').Controller<>} */ (
-      provideControllerForId(id)
+      provideController(id)
     );
     return controller.external.then(value => {
       // Release the value to the public only after ensuring
@@ -830,12 +830,12 @@ const makeDaemonCore = async (
     });
   };
 
-  /** @type {import('./types.js').DaemonCore['provideControllerForIdAndResolveHandle']} */
-  const provideControllerForIdAndResolveHandle = async id => {
+  /** @type {import('./types.js').DaemonCore['provideControllerAndResolveHandle']} */
+  const provideControllerAndResolveHandle = async id => {
     let currentId = id;
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const controller = provideControllerForId(currentId);
+      const controller = provideController(currentId);
       // eslint-disable-next-line no-await-in-loop
       const internalFacet = await controller.internal;
       if (internalFacet === undefined || internalFacet === null) {
@@ -1477,7 +1477,7 @@ const makeDaemonCore = async (
 
   const makeContext = makeContextMaker({
     controllerForId,
-    provideControllerForId,
+    provideController,
   });
 
   const { makeIdentifiedDirectory, makeDirectoryNode } = makeDirectoryMaker({
@@ -1488,19 +1488,19 @@ const makeDaemonCore = async (
 
   const makeMailbox = makeMailboxMaker({
     provide,
-    provideControllerForIdAndResolveHandle,
+    provideControllerAndResolveHandle,
   });
 
   const makeIdentifiedGuestController = makeGuestMaker({
     provide,
-    provideControllerForIdAndResolveHandle,
+    provideControllerAndResolveHandle,
     makeMailbox,
     makeDirectoryNode,
   });
 
   const makeIdentifiedHost = makeHostMaker({
     provide,
-    provideControllerForId,
+    provideController,
     cancelValue,
     incarnateWorker,
     incarnateHost,
@@ -1627,8 +1627,8 @@ const makeDaemonCore = async (
   /** @type {import('./types.js').DaemonCore} */
   const daemonCore = {
     nodeIdentifier: ownNodeIdentifier,
-    provideControllerForId,
-    provideControllerForIdAndResolveHandle,
+    provideController,
+    provideControllerAndResolveHandle,
     provide,
     formulate,
     getIdForRef,

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -5,13 +5,13 @@ const { quote: q } = assert;
 const idPattern = /^(?<number>[0-9a-f]{128}):(?<node>[0-9a-f]{128})$/;
 
 /**
- * @param {string} formulaIdentifier
+ * @param {string} id
  * @param {string} [petName]
  * @returns {void}
  */
-export const assertValidId = (formulaIdentifier, petName) => {
-  if (!idPattern.test(formulaIdentifier)) {
-    let message = `Invalid formula identifier ${q(formulaIdentifier)}`;
+export const assertValidId = (id, petName) => {
+  if (!idPattern.test(id)) {
+    let message = `Invalid formula identifier ${q(id)}`;
     if (petName !== undefined) {
       message += ` for pet name ${q(petName)}`;
     }
@@ -20,19 +20,19 @@ export const assertValidId = (formulaIdentifier, petName) => {
 };
 
 /**
- * @param {string} formulaIdentifier
- * @returns {import("./types").FormulaIdentifierRecord}
+ * @param {string} id
+ * @returns {import("./types").IdRecord}
  */
-export const parseId = formulaIdentifier => {
-  const match = idPattern.exec(formulaIdentifier);
+export const parseId = id => {
+  const match = idPattern.exec(id);
   if (match === null) {
-    throw assert.error(`Invalid formula identifier ${q(formulaIdentifier)}`);
+    throw assert.error(`Invalid formula identifier ${q(id)}`);
   }
   const { groups } = match;
   if (groups === undefined) {
     throw assert.error(
       `Programmer invariant failure: expected match groups, formula identifier was ${q(
-        formulaIdentifier,
+        id,
       )}`,
     );
   }
@@ -42,7 +42,7 @@ export const parseId = formulaIdentifier => {
 };
 
 /**
- * @param {import("./types").FormulaIdentifierRecord} formulaRecord
+ * @param {import("./types").IdRecord} formulaRecord
  * @returns {string}
  */
 export const formatId = ({ number, node }) => {

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -7,48 +7,44 @@ import { makePetSitter } from './pet-sitter.js';
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
- * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
+ * @param {import('./types.js').DaemonCore['provideControllerForIdAndResolveHandle']} args.provideControllerForIdAndResolveHandle
  * @param {import('./types.js').MakeMailbox} args.makeMailbox
  * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
  */
 export const makeGuestMaker = ({
   provide,
-  provideControllerForFormulaIdentifierAndResolveHandle,
+  provideControllerForIdAndResolveHandle,
   makeMailbox,
   makeDirectoryNode,
 }) => {
   /**
-   * @param {string} guestFormulaIdentifier
-   * @param {string} hostHandleFormulaIdentifier
-   * @param {string} petStoreFormulaIdentifier
-   * @param {string} mainWorkerFormulaIdentifier
+   * @param {string} guestId
+   * @param {string} hostHandleId
+   * @param {string} petStoreId
+   * @param {string} mainWorkerId
    * @param {import('./types.js').Context} context
    */
   const makeIdentifiedGuestController = async (
-    guestFormulaIdentifier,
-    hostHandleFormulaIdentifier,
-    petStoreFormulaIdentifier,
-    mainWorkerFormulaIdentifier,
+    guestId,
+    hostHandleId,
+    petStoreId,
+    mainWorkerId,
     context,
   ) => {
-    context.thisDiesIfThatDies(hostHandleFormulaIdentifier);
-    context.thisDiesIfThatDies(petStoreFormulaIdentifier);
-    context.thisDiesIfThatDies(mainWorkerFormulaIdentifier);
+    context.thisDiesIfThatDies(hostHandleId);
+    context.thisDiesIfThatDies(petStoreId);
+    context.thisDiesIfThatDies(mainWorkerId);
 
     const basePetStore = /** @type {import('./types.js').PetStore} */ (
-      await provide(petStoreFormulaIdentifier)
+      await provide(petStoreId)
     );
     const specialStore = makePetSitter(basePetStore, {
-      SELF: guestFormulaIdentifier,
-      HOST: hostHandleFormulaIdentifier,
+      SELF: guestId,
+      HOST: hostHandleId,
     });
     const hostController =
       /** @type {import('./types.js').EndoHostController} */
-      (
-        await provideControllerForFormulaIdentifierAndResolveHandle(
-          hostHandleFormulaIdentifier,
-        )
-      );
+      (await provideControllerForIdAndResolveHandle(hostHandleId));
     const hostPrivateFacet = await hostController.internal;
     const { respond: deliverToHost } = hostPrivateFacet;
     if (deliverToHost === undefined) {
@@ -59,7 +55,7 @@ export const makeGuestMaker = ({
 
     const mailbox = makeMailbox({
       petStore: specialStore,
-      selfFormulaIdentifier: guestFormulaIdentifier,
+      selfId: guestId,
       context,
     });
     const { petStore } = mailbox;

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -7,13 +7,13 @@ import { makePetSitter } from './pet-sitter.js';
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
- * @param {import('./types.js').DaemonCore['provideControllerForIdAndResolveHandle']} args.provideControllerForIdAndResolveHandle
+ * @param {import('./types.js').DaemonCore['provideControllerAndResolveHandle']} args.provideControllerAndResolveHandle
  * @param {import('./types.js').MakeMailbox} args.makeMailbox
  * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
  */
 export const makeGuestMaker = ({
   provide,
-  provideControllerForIdAndResolveHandle,
+  provideControllerAndResolveHandle,
   makeMailbox,
   makeDirectoryNode,
 }) => {
@@ -44,7 +44,7 @@ export const makeGuestMaker = ({
     });
     const hostController =
       /** @type {import('./types.js').EndoHostController} */
-      (await provideControllerForIdAndResolveHandle(hostHandleId));
+      (await provideControllerAndResolveHandle(hostHandleId));
     const hostPrivateFacet = await hostController.internal;
     const { respond: deliverToHost } = hostPrivateFacet;
     if (deliverToHost === undefined) {

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -16,7 +16,7 @@ const assertPowersName = name => {
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
- * @param {import('./types.js').DaemonCore['provideControllerForId']} args.provideControllerForId
+ * @param {import('./types.js').DaemonCore['provideController']} args.provideController
  * @param {import('./types.js').DaemonCore['cancelValue']} args.cancelValue
  * @param {import('./types.js').DaemonCore['incarnateWorker']} args.incarnateWorker
  * @param {import('./types.js').DaemonCore['incarnateHost']} args.incarnateHost
@@ -32,7 +32,7 @@ const assertPowersName = name => {
  */
 export const makeHostMaker = ({
   provide,
-  provideControllerForId,
+  provideController,
   cancelValue,
   incarnateWorker,
   incarnateHost,
@@ -334,7 +334,7 @@ export const makeHostMaker = ({
      */
     const introduceNamesToAgent = async (id, introducedNames) => {
       /** @type {import('./types.js').Controller<any, any>} */
-      const controller = provideControllerForId(id);
+      const controller = provideController(id);
       const { petStore: newPetStore } = await controller.internal;
       await Promise.all(
         Object.entries(introducedNames).map(async ([parentName, childName]) => {
@@ -356,9 +356,7 @@ export const makeHostMaker = ({
         if (id !== undefined) {
           return {
             id,
-            value: /** @type {Promise<any>} */ (
-              provideControllerForId(id).external
-            ),
+            value: /** @type {Promise<any>} */ (provideController(id).external),
           };
         }
       }

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -9,16 +9,16 @@ const { quote: q } = assert;
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
- * @param {import('./types.js').DaemonCore['provideControllerForFormulaIdentifierAndResolveHandle']} args.provideControllerForFormulaIdentifierAndResolveHandle
+ * @param {import('./types.js').DaemonCore['provideControllerForIdAndResolveHandle']} args.provideControllerForIdAndResolveHandle
  * @returns {import('./types.js').MakeMailbox}
  */
 export const makeMailboxMaker = ({
   provide,
-  provideControllerForFormulaIdentifierAndResolveHandle,
+  provideControllerForIdAndResolveHandle,
 }) => {
   /**
     @type {import('./types.js').MakeMailbox} */
-  const makeMailbox = ({ selfFormulaIdentifier, petStore, context }) => {
+  const makeMailbox = ({ selfId, petStore, context }) => {
     /** @type {Map<string, Promise<unknown>>} */
     const responses = new Map();
     /** @type {Map<number, import('./types.js').InternalMessage>} */
@@ -38,29 +38,17 @@ export const makeMailboxMaker = ({
     const dubMessage = message => {
       const { type } = message;
       if (type === 'request') {
-        const {
-          who: senderFormulaIdentifier,
-          dest: recipientFormulaIdentifier,
-          ...rest
-        } = message;
-        const [senderName] = petStore.reverseIdentify(senderFormulaIdentifier);
-        const [recipientName] = petStore.reverseIdentify(
-          recipientFormulaIdentifier,
-        );
+        const { who: senderId, dest: recipientId, ...rest } = message;
+        const [senderName] = petStore.reverseIdentify(senderId);
+        const [recipientName] = petStore.reverseIdentify(recipientId);
         if (senderName !== undefined) {
           return { who: senderName, dest: recipientName, ...rest };
         }
         return undefined;
       } else if (type === 'package') {
-        const {
-          who: senderFormulaIdentifier,
-          dest: recipientFormulaIdentifier,
-          ...rest
-        } = message;
-        const [senderName] = petStore.reverseIdentify(senderFormulaIdentifier);
-        const [recipientName] = petStore.reverseIdentify(
-          recipientFormulaIdentifier,
-        );
+        const { who: senderId, dest: recipientId, ...rest } = message;
+        const [senderName] = petStore.reverseIdentify(senderId);
+        const [recipientName] = petStore.reverseIdentify(recipientId);
         if (senderName !== undefined) {
           return { who: senderName, dest: recipientName, ...rest };
         }
@@ -137,7 +125,7 @@ export const makeMailboxMaker = ({
      * @param {string} dest
      * @returns {Promise<string>}
      */
-    const requestFormulaIdentifier = async (what, who, dest) => {
+    const requestId = async (what, who, dest) => {
       /** @type {import('@endo/promise-kit/src/types.js').PromiseKit<string>} */
       const { promise, resolve } = makePromiseKit();
       const settled = promise.then(
@@ -159,36 +147,28 @@ export const makeMailboxMaker = ({
     const respond = async (
       what,
       responseName,
-      senderFormulaIdentifier,
+      senderId,
       senderPetStore,
-      recipientFormulaIdentifier = selfFormulaIdentifier,
+      recipientId = selfId,
     ) => {
       if (responseName !== undefined) {
         /** @type {string | undefined} */
-        let formulaIdentifier = senderPetStore.identifyLocal(responseName);
-        if (formulaIdentifier === undefined) {
-          formulaIdentifier = await requestFormulaIdentifier(
-            what,
-            senderFormulaIdentifier,
-            recipientFormulaIdentifier,
-          );
-          await senderPetStore.write(responseName, formulaIdentifier);
+        let id = senderPetStore.identifyLocal(responseName);
+        if (id === undefined) {
+          id = await requestId(what, senderId, recipientId);
+          await senderPetStore.write(responseName, id);
         }
         // Behold, recursion:
         // eslint-disable-next-line no-use-before-define
-        return provide(formulaIdentifier);
+        return provide(id);
       }
       // The reference is not named nor to be named.
-      const formulaIdentifier = await requestFormulaIdentifier(
-        what,
-        senderFormulaIdentifier,
-        recipientFormulaIdentifier,
-      );
+      const id = await requestId(what, senderId, recipientId);
       // TODO:
-      // context.thisDiesIfThatDies(formulaIdentifier);
+      // context.thisDiesIfThatDies(id);
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      return provide(formulaIdentifier);
+      return provide(id);
     };
 
     /** @type {import('./types.js').Mail['resolve']} */
@@ -205,13 +185,13 @@ export const makeMailboxMaker = ({
       if (resolveRequest === undefined) {
         throw new Error(`No pending request for number ${messageNumber}`);
       }
-      const formulaIdentifier = petStore.identifyLocal(resolutionName);
-      if (formulaIdentifier === undefined) {
+      const id = petStore.identifyLocal(resolutionName);
+      if (id === undefined) {
         throw new TypeError(
           `No formula exists for the pet name ${q(resolutionName)}`,
         );
       }
-      resolveRequest(formulaIdentifier);
+      resolveRequest(id);
     };
 
     // TODO test reject
@@ -229,32 +209,31 @@ export const makeMailboxMaker = ({
 
     /** @type {import('./types.js').Mail['receive']} */
     const receive = (
-      senderFormulaIdentifier,
+      senderId,
       strings,
       edgeNames,
-      formulaIdentifiers,
-      receiverFormulaIdentifier = selfFormulaIdentifier,
+      ids,
+      receiverId = selfId,
     ) => {
       deliver({
         type: /** @type {const} */ ('package'),
         strings,
         names: edgeNames,
-        formulas: formulaIdentifiers,
-        who: senderFormulaIdentifier,
-        dest: receiverFormulaIdentifier,
+        formulas: ids,
+        who: senderId,
+        dest: receiverId,
       });
     };
 
     /** @type {import('./types.js').Mail['send']} */
     const send = async (recipientName, strings, edgeNames, petNames) => {
-      const recipientFormulaIdentifier = petStore.identifyLocal(recipientName);
-      if (recipientFormulaIdentifier === undefined) {
+      const recipientId = petStore.identifyLocal(recipientName);
+      if (recipientId === undefined) {
         throw new Error(`Unknown pet name for party: ${recipientName}`);
       }
-      const recipientController =
-        await provideControllerForFormulaIdentifierAndResolveHandle(
-          recipientFormulaIdentifier,
-        );
+      const recipientController = await provideControllerForIdAndResolveHandle(
+        recipientId,
+      );
       const recipientInternal = await recipientController.internal;
       if (recipientInternal === undefined || recipientInternal === null) {
         throw new Error(`Recipient cannot receive messages: ${recipientName}`);
@@ -280,28 +259,23 @@ export const makeMailboxMaker = ({
         );
       }
 
-      const formulaIdentifiers = petNames.map(petName => {
-        const formulaIdentifier = petStore.identifyLocal(petName);
-        if (formulaIdentifier === undefined) {
+      const ids = petNames.map(petName => {
+        const id = petStore.identifyLocal(petName);
+        if (id === undefined) {
           throw new Error(`Unknown pet name ${q(petName)}`);
         }
-        return formulaIdentifier;
+        return id;
       });
       // add to recipient mailbox
-      partyReceive(
-        selfFormulaIdentifier,
-        strings,
-        edgeNames,
-        formulaIdentifiers,
-      );
+      partyReceive(selfId, strings, edgeNames, ids);
       // add to own mailbox
       receive(
-        selfFormulaIdentifier,
+        selfId,
         strings,
         edgeNames,
-        formulaIdentifiers,
+        ids,
         // Sender expects the handle formula identifier.
-        recipientFormulaIdentifier,
+        recipientId,
       );
     };
 
@@ -344,28 +318,27 @@ export const makeMailboxMaker = ({
           `No reference named ${q(edgeName)} in message ${q(messageNumber)}`,
         );
       }
-      const formulaIdentifier = message.formulas[index];
-      if (formulaIdentifier === undefined) {
+      const id = message.formulas[index];
+      if (id === undefined) {
         throw new Error(
           `panic: message must contain a formula for every name, including the name ${q(
             edgeName,
           )} at ${q(index)}`,
         );
       }
-      context.thisDiesIfThatDies(formulaIdentifier);
-      await petStore.write(petName, formulaIdentifier);
+      context.thisDiesIfThatDies(id);
+      await petStore.write(petName, id);
     };
 
     /** @type {import('./types.js').Mail['request']} */
     const request = async (recipientName, what, responseName) => {
-      const recipientFormulaIdentifier = petStore.identifyLocal(recipientName);
-      if (recipientFormulaIdentifier === undefined) {
+      const recipientId = petStore.identifyLocal(recipientName);
+      if (recipientId === undefined) {
         throw new Error(`Unknown pet name for party: ${recipientName}`);
       }
-      const recipientController =
-        await provideControllerForFormulaIdentifierAndResolveHandle(
-          recipientFormulaIdentifier,
-        );
+      const recipientController = await provideControllerForIdAndResolveHandle(
+        recipientId,
+      );
       const recipientInternal = await recipientController.internal;
       if (recipientInternal === undefined || recipientInternal === null) {
         throw new Error(
@@ -394,17 +367,17 @@ export const makeMailboxMaker = ({
       const recipientResponseP = deliverToRecipient(
         what,
         responseName,
-        selfFormulaIdentifier,
+        selfId,
         petStore,
       );
       // Send to own inbox.
       const selfResponseP = respond(
         what,
         responseName,
-        selfFormulaIdentifier,
+        selfId,
         petStore,
         // Sender expects the handle formula identifier.
-        recipientFormulaIdentifier,
+        recipientId,
       );
       const newResponseP = Promise.race([recipientResponseP, selfResponseP]);
 
@@ -418,9 +391,9 @@ export const makeMailboxMaker = ({
     /** @type {import('./types.js').PetStore['rename']} */
     const rename = async (fromName, toName) => {
       await petStore.rename(fromName, toName);
-      const formulaIdentifier = responses.get(fromName);
-      if (formulaIdentifier !== undefined) {
-        responses.set(toName, formulaIdentifier);
+      const id = responses.get(fromName);
+      if (id !== undefined) {
+        responses.set(toName, id);
         responses.delete(fromName);
       }
     };

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -9,12 +9,12 @@ const { quote: q } = assert;
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
- * @param {import('./types.js').DaemonCore['provideControllerForIdAndResolveHandle']} args.provideControllerForIdAndResolveHandle
+ * @param {import('./types.js').DaemonCore['provideControllerAndResolveHandle']} args.provideControllerAndResolveHandle
  * @returns {import('./types.js').MakeMailbox}
  */
 export const makeMailboxMaker = ({
   provide,
-  provideControllerForIdAndResolveHandle,
+  provideControllerAndResolveHandle,
 }) => {
   /**
     @type {import('./types.js').MakeMailbox} */
@@ -231,7 +231,7 @@ export const makeMailboxMaker = ({
       if (recipientId === undefined) {
         throw new Error(`Unknown pet name for party: ${recipientName}`);
       }
-      const recipientController = await provideControllerForIdAndResolveHandle(
+      const recipientController = await provideControllerAndResolveHandle(
         recipientId,
       );
       const recipientInternal = await recipientController.internal;
@@ -336,7 +336,7 @@ export const makeMailboxMaker = ({
       if (recipientId === undefined) {
         throw new Error(`Unknown pet name for party: ${recipientName}`);
       }
-      const recipientController = await provideControllerForIdAndResolveHandle(
+      const recipientController = await provideControllerAndResolveHandle(
         recipientId,
       );
       const recipientInternal = await recipientController.internal;

--- a/packages/daemon/src/pet-sitter.js
+++ b/packages/daemon/src/pet-sitter.js
@@ -25,14 +25,14 @@ export const makePetSitter = (petStore, specialNames) => {
 
   /**
    * @param {string} petName
-   * @returns {import('./types.js').FormulaIdentifierRecord}
+   * @returns {import('./types.js').IdRecord}
    */
-  const formulaIdentifierRecordForName = petName => {
-    const formulaIdentifier = identifyLocal(petName);
-    if (formulaIdentifier === undefined) {
+  const idRecordForName = petName => {
+    const id = identifyLocal(petName);
+    if (id === undefined) {
       throw new Error(`Formula does not exist for pet name ${q(petName)}`);
     }
-    return parseId(formulaIdentifier);
+    return parseId(id);
   };
 
   /** @type {import('./types.js').PetStore['list']} */
@@ -42,22 +42,20 @@ export const makePetSitter = (petStore, specialNames) => {
   /** @type {import('./types.js').PetStore['follow']} */
   const follow = async function* currentAndSubsequentNames() {
     for (const name of Object.keys(specialNames).sort()) {
-      const formulaIdentifierRecord = formulaIdentifierRecordForName(name);
-      yield /** @type {{ add: string, value: import('./types.js').FormulaIdentifierRecord }} */ ({
+      const idRecord = idRecordForName(name);
+      yield /** @type {{ add: string, value: import('./types.js').IdRecord }} */ ({
         add: name,
-        value: formulaIdentifierRecord,
+        value: idRecord,
       });
     }
     yield* petStore.follow();
   };
 
   /** @type {import('./types.js').PetStore['reverseIdentify']} */
-  const reverseIdentify = formulaIdentifier => {
-    const names = Array.from(petStore.reverseIdentify(formulaIdentifier));
-    for (const [specialName, specialFormulaIdentifier] of Object.entries(
-      specialNames,
-    )) {
-      if (specialFormulaIdentifier === formulaIdentifier) {
+  const reverseIdentify = id => {
+    const names = Array.from(petStore.reverseIdentify(id));
+    for (const [specialName, specialId] of Object.entries(specialNames)) {
+      if (specialId === id) {
         names.push(specialName);
       }
     }

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -766,8 +766,8 @@ export interface DaemonCoreInternal {
 export interface DaemonCore {
   nodeIdentifier: string;
   provide: (id: string) => Promise<unknown>;
-  provideControllerForId: (id: string) => Controller;
-  provideControllerForIdAndResolveHandle: (id: string) => Promise<Controller>;
+  provideController: (id: string) => Controller;
+  provideControllerAndResolveHandle: (id: string) => Promise<Controller>;
   formulate: (
     formulaNumber: string,
     formula: Formula,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -51,7 +51,7 @@ export type MignonicPowers = {
   };
 };
 
-type FormulaIdentifierRecord = {
+type IdRecord = {
   number: string;
   node: string;
 };
@@ -73,14 +73,14 @@ type WorkerFormula = {
 };
 
 export type WorkerDeferredTaskParams = {
-  workerFormulaIdentifier: string;
+  workerId: string;
 };
 
 /**
  * Deferred tasks parameters for `host` and `guest` formulas.
  */
 export type AgentDeferredTaskParams = {
-  agentFormulaIdentifier: string;
+  agentId: string;
 };
 
 type HostFormula = {
@@ -113,9 +113,9 @@ type EvalFormula = {
 };
 
 export type EvalDeferredTaskParams = {
-  endowmentFormulaIdentifiers: string[];
-  evalFormulaIdentifier: string;
-  workerFormulaIdentifier: string;
+  endowmentIds: string[];
+  evalId: string;
+  workerId: string;
 };
 
 type ReadableBlobFormula = {
@@ -124,7 +124,7 @@ type ReadableBlobFormula = {
 };
 
 export type ReadableBlobDeferredTaskParams = {
-  readableBlobFormulaIdentifier: string;
+  readableBlobId: string;
 };
 
 type LookupFormula = {
@@ -159,9 +159,9 @@ type MakeBundleFormula = {
 };
 
 export type MakeCapletDeferredTaskParams = {
-  capletFormulaIdentifier: string;
-  powersFormulaIdentifier: string;
-  workerFormulaIdentifier: string;
+  capletId: string;
+  powersId: string;
+  workerId: string;
 };
 
 type PeerFormula = {
@@ -302,16 +302,16 @@ export interface Context {
   disposed: Promise<void>;
 
   /**
-   * @param formulaIdentifier - The formula identifier of the value whose
+   * @param id - The formula identifier of the value whose
    * cancellation should cause this value to be cancelled.
    */
-  thisDiesIfThatDies: (formulaIdentifier: string) => void;
+  thisDiesIfThatDies: (id: string) => void;
 
   /**
-   * @param formulaIdentifier - The formula identifier of the value that should
+   * @param id - The formula identifier of the value that should
    * be cancelled if this value is cancelled.
    */
-  thatDiesIfThisDies: (formulaIdentifier: string) => void;
+  thatDiesIfThisDies: (id: string) => void;
 
   /**
    * @param hook - A hook to run when the value is cancelled.
@@ -357,13 +357,13 @@ export interface ExternalHandle {}
  * handle points to. This should not be exposed outside of the endo daemon.
  */
 export interface InternalHandle {
-  targetFormulaIdentifier: string;
+  targetId: string;
 }
 
 export type MakeSha512 = () => Sha512;
 
 export type PetStoreNameDiff =
-  | { add: string; value: FormulaIdentifierRecord }
+  | { add: string; value: IdRecord }
   | { remove: string };
 
 export interface PetStore {
@@ -371,14 +371,14 @@ export interface PetStore {
   identifyLocal(petName: string): string | undefined;
   list(): Array<string>;
   follow(): AsyncGenerator<PetStoreNameDiff, undefined, undefined>;
-  write(petName: string, formulaIdentifier: string): Promise<void>;
+  write(petName: string, id: string): Promise<void>;
   remove(petName: string): Promise<void>;
   rename(fromPetName: string, toPetName: string): Promise<void>;
   /**
-   * @param formulaIdentifier The formula identifier to look up.
+   * @param id The formula identifier to look up.
    * @returns The formula identifier for the given pet name, or `undefined` if the pet name is not found.
    */
-  reverseIdentify(formulaIdentifier: string): Array<string>;
+  reverseIdentify(id: string): Array<string>;
 }
 
 export interface NameHub {
@@ -391,7 +391,7 @@ export interface NameHub {
   ): AsyncGenerator<PetStoreNameDiff, undefined, undefined>;
   lookup(...petNamePath: string[]): Promise<unknown>;
   reverseLookup(value: unknown): Array<string>;
-  write(petNamePath: string[], formulaIdentifier): Promise<void>;
+  write(petNamePath: string[], id): Promise<void>;
   remove(...petNamePath: string[]): Promise<void>;
   move(fromPetName: string[], toPetName: string[]): Promise<void>;
   copy(fromPetName: string[], toPetName: string[]): Promise<void>;
@@ -431,21 +431,21 @@ export interface Mail {
   respond(
     what: string,
     responseName: string,
-    senderFormulaIdentifier: string,
+    senderId: string,
     senderPetStore: PetStore,
-    recipientFormulaIdentifier?: string,
+    recipientId?: string,
   ): Promise<unknown>;
   receive(
-    senderFormulaIdentifier: string,
+    senderId: string,
     strings: Array<string>,
     edgeNames: Array<string>,
-    formulaIdentifiers: Array<string>,
-    receiverFormulaIdentifier: string,
+    ids: Array<string>,
+    receiverId: string,
   ): void;
 }
 
 export type MakeMailbox = (args: {
-  selfFormulaIdentifier: string;
+  selfId: string;
   petStore: PetStore;
   context: Context;
 }) => Mail;
@@ -453,15 +453,15 @@ export type MakeMailbox = (args: {
 export type RequestFn = (
   what: string,
   responseName: string,
-  guestFormulaIdentifier: string,
+  guestId: string,
   guestPetStore: PetStore,
 ) => Promise<unknown>;
 
 export type ReceiveFn = (
-  senderFormulaIdentifier: string,
+  senderId: string,
   strings: Array<string>,
   edgeNames: Array<string>,
-  formulaIdentifiers: Array<string>,
+  ids: Array<string>,
 ) => void;
 
 export interface EndoReadable {
@@ -482,13 +482,13 @@ export type MakeHostOrGuestOptions = {
 };
 
 export interface EndoPeer {
-  provide: (formulaIdentifier: string) => Promise<unknown>;
+  provide: (id: string) => Promise<unknown>;
 }
 export type EndoPeerControllerPartial = ControllerPartial<EndoPeer, undefined>;
 export type EndoPeerController = Controller<EndoPeer, undefined>;
 
 export interface EndoGateway {
-  provide: (formulaIdentifier: string) => Promise<unknown>;
+  provide: (id: string) => Promise<unknown>;
 }
 
 export interface PeerInfo {
@@ -699,12 +699,12 @@ export type DaemonicPowers = {
 };
 
 type IncarnateResult<T> = Promise<{
-  formulaIdentifier: string;
+  id: string;
   value: T;
 }>;
 
 export type DeferredTask<T extends Record<string, string | string[]>> = (
-  formulaIdentifiers: Readonly<T>,
+  ids: Readonly<T>,
 ) => Promise<void>;
 
 /**
@@ -718,34 +718,34 @@ export type DeferredTasks<T extends Record<string, string | string[]>> = {
 
 type IncarnateNumberedGuestParams = {
   guestFormulaNumber: string;
-  hostHandleFormulaIdentifier: string;
-  storeFormulaIdentifier: string;
-  workerFormulaIdentifier: string;
+  hostHandleId: string;
+  storeId: string;
+  workerId: string;
 };
 
 type IncarnateHostDependenciesParams = {
-  endoFormulaIdentifier: string;
-  networksDirectoryFormulaIdentifier: string;
-  specifiedWorkerFormulaIdentifier?: string;
+  endoId: string;
+  networksDirectoryId: string;
+  specifiedWorkerId?: string;
 };
 
 type IncarnateNumberedHostParams = {
   hostFormulaNumber: string;
-  workerFormulaIdentifier: string;
-  storeFormulaIdentifier: string;
-  inspectorFormulaIdentifier: string;
-  endoFormulaIdentifier: string;
-  networksDirectoryFormulaIdentifier: string;
+  workerId: string;
+  storeId: string;
+  inspectorId: string;
+  endoId: string;
+  networksDirectoryId: string;
 };
 
 export interface DaemonCoreInternal {
   /**
    * Helper for callers of {@link incarnateNumberedGuest}.
-   * @param hostFormulaIdentifier - The formula identifier of the host to incarnate a guest for.
+   * @param hostId - The formula identifier of the host to incarnate a guest for.
    * @returns The formula identifiers for the guest incarnation's dependencies.
    */
   incarnateGuestDependencies: (
-    hostFormulaIdentifier: string,
+    hostId: string,
   ) => Promise<Readonly<IncarnateNumberedGuestParams>>;
   incarnateNumberedGuest: (
     identifiers: IncarnateNumberedGuestParams,
@@ -765,24 +765,18 @@ export interface DaemonCoreInternal {
 
 export interface DaemonCore {
   nodeIdentifier: string;
-  provide: (formulaIdentifier: string) => Promise<unknown>;
-  provideControllerForFormulaIdentifier: (
-    formulaIdentifier: string,
-  ) => Controller;
-  provideControllerForFormulaIdentifierAndResolveHandle: (
-    formulaIdentifier: string,
-  ) => Promise<Controller>;
+  provide: (id: string) => Promise<unknown>;
+  provideControllerForId: (id: string) => Controller;
+  provideControllerForIdAndResolveHandle: (id: string) => Promise<Controller>;
   formulate: (
     formulaNumber: string,
     formula: Formula,
   ) => Promise<{
-    formulaIdentifier: string;
+    id: string;
     value: unknown;
   }>;
-  getFormulaIdentifierForRef: (ref: unknown) => string | undefined;
-  getAllNetworkAddresses: (
-    networksDirectoryFormulaIdentifier: string,
-  ) => Promise<string[]>;
+  getIdForRef: (ref: unknown) => string | undefined;
+  getAllNetworkAddresses: (networksDirectoryId: string) => Promise<string[]>;
   incarnateEndoBootstrap: (
     specifiedFormulaNumber: string,
   ) => IncarnateResult<FarEndoBootstrap>;
@@ -791,13 +785,13 @@ export interface DaemonCore {
   ) => IncarnateResult<EndoWorker>;
   incarnateDirectory: () => IncarnateResult<EndoDirectory>;
   incarnateHost: (
-    endoFormulaIdentifier: string,
-    networksDirectoryFormulaIdentifier: string,
+    endoId: string,
+    networksDirectoryId: string,
     deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
-    specifiedWorkerFormulaIdentifier?: string | undefined,
+    specifiedWorkerId?: string | undefined,
   ) => IncarnateResult<EndoHost>;
   incarnateGuest: (
-    hostFormulaIdentifier: string,
+    hostId: string,
     deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
   ) => IncarnateResult<EndoGuest>;
   incarnateReadableBlob: (
@@ -805,34 +799,34 @@ export interface DaemonCore {
     deferredTasks: DeferredTasks<ReadableBlobDeferredTaskParams>,
   ) => IncarnateResult<FarEndoReadable>;
   incarnateEval: (
-    hostFormulaIdentifier: string,
+    hostId: string,
     source: string,
     codeNames: string[],
-    endowmentFormulaIdsOrPaths: (string | string[])[],
+    endowmentIdsOrPaths: (string | string[])[],
     deferredTasks: DeferredTasks<EvalDeferredTaskParams>,
-    specifiedWorkerFormulaIdentifier?: string,
+    specifiedWorkerId?: string,
   ) => IncarnateResult<unknown>;
   incarnateUnconfined: (
-    hostFormulaIdentifier: string,
+    hostId: string,
     specifier: string,
     deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
-    specifiedWorkerFormulaIdentifier?: string,
-    specifiedPowersFormulaIdentifier?: string,
+    specifiedWorkerId?: string,
+    specifiedPowersId?: string,
   ) => IncarnateResult<unknown>;
   incarnateBundle: (
-    hostFormulaIdentifier: string,
-    bundleFormulaIdentifier: string,
+    hostId: string,
+    bundleId: string,
     deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
-    specifiedWorkerFormulaIdentifier?: string,
-    specifiedPowersFormulaIdentifier?: string,
+    specifiedWorkerId?: string,
+    specifiedPowersId?: string,
   ) => IncarnateResult<unknown>;
   incarnatePeer: (
-    networksFormulaIdentifier: string,
+    networksId: string,
     addresses: Array<string>,
   ) => IncarnateResult<EndoPeer>;
   incarnateNetworksDirectory: () => IncarnateResult<EndoDirectory>;
   incarnateLoopbackNetwork: () => IncarnateResult<EndoNetwork>;
-  cancelValue: (formulaIdentifier: string, reason: Error) => Promise<void>;
+  cancelValue: (id: string, reason: Error) => Promise<void>;
   makeMailbox: MakeMailbox;
   makeDirectoryNode: MakeDirectoryNode;
 }

--- a/packages/daemon/src/weak-multimap.js
+++ b/packages/daemon/src/weak-multimap.js
@@ -5,31 +5,31 @@ export const makeWeakMultimap = () => {
   /** @type {WeakMap<WeakKey, Set<unknown>>} */
   const map = new WeakMap();
   return {
-    add: (ref, formulaIdentifier) => {
-      let set = map.get(ref);
+    add: (key, value) => {
+      let set = map.get(key);
       if (set === undefined) {
         set = new Set();
-        map.set(ref, set);
+        map.set(key, set);
       }
-      set.add(formulaIdentifier);
+      set.add(value);
     },
 
-    delete: (ref, formulaIdentifier) => {
-      const set = map.get(ref);
+    delete: (key, value) => {
+      const set = map.get(key);
       if (set !== undefined) {
-        const result = set.delete(formulaIdentifier);
+        const result = set.delete(value);
         if (set.size === 0) {
-          map.delete(ref);
+          map.delete(key);
         }
         return result;
       }
       return false;
     },
 
-    deleteAll: ref => map.delete(ref),
+    deleteAll: key => map.delete(key),
 
-    get: ref => map.get(ref)?.keys().next().value,
+    get: key => map.get(key)?.keys().next().value,
 
-    getAll: ref => Array.from(map.get(ref) ?? []),
+    getAll: key => Array.from(map.get(key) ?? []),
   };
 };

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -1328,7 +1328,7 @@ test('guest cannot access host methods', async t => {
   await t.throwsAsync(() => E(guestsHost).lookup('SELF'), {
     message: /target has no method "lookup"/u,
   });
-  const revealedTarget = await E.get(guestsHost).targetFormulaIdentifier;
+  const revealedTarget = await E.get(guestsHost).targetId;
   t.is(revealedTarget, undefined);
 });
 
@@ -1352,11 +1352,11 @@ test('read unknown nodeId', async t => {
   // write a bogus value for a bogus nodeId
   const node = await cryptoPowers.randomHex512();
   const number = await cryptoPowers.randomHex512();
-  const formulaIdentifier = formatId({
+  const id = formatId({
     node,
     number,
   });
-  await E(host).write(['abc'], formulaIdentifier);
+  await E(host).write(['abc'], id);
   // observe reification failure
   t.throwsAsync(() => E(host).lookup('abc'), {
     message: /No peer found for node identifier /u,


### PR DESCRIPTION
We have decided that there is one meaning of “identifier”, that it is “formula identifier”, that it is what “identify” returns, and that we can consequently consistently abbreviate it as “Id” or “id”.

While we’re here, abbreviate `provideControllerForFormulaIdentifier` to `provideController`.