### PR TITLE
refactor(daemon): Rename "incarnate" to "formulate"

### DIFF
--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -9,12 +9,12 @@ const { quote: q } = assert;
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
  * @param {import('./types.js').DaemonCore['getIdForRef']} args.getIdForRef
- * @param {import('./types.js').DaemonCore['incarnateDirectory']} args.incarnateDirectory
+ * @param {import('./types.js').DaemonCore['formulateDirectory']} args.formulateDirectory
  */
 export const makeDirectoryMaker = ({
   provide,
   getIdForRef,
-  incarnateDirectory,
+  formulateDirectory,
 }) => {
   /** @type {import('./types.js').MakeDirectoryNode} */
   const makeDirectoryNode = petStore => {
@@ -172,7 +172,7 @@ export const makeDirectoryMaker = ({
 
     /** @type {import('./types.js').EndoDirectory['makeDirectory']} */
     const makeDirectory = async directoryPetName => {
-      const { value: directory, id } = await incarnateDirectory();
+      const { value: directory, id } = await formulateDirectory();
       await petStore.write(directoryPetName, id);
       return directory;
     };

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -18,13 +18,13 @@ const assertPowersName = name => {
  * @param {import('./types.js').DaemonCore['provide']} args.provide
  * @param {import('./types.js').DaemonCore['provideController']} args.provideController
  * @param {import('./types.js').DaemonCore['cancelValue']} args.cancelValue
- * @param {import('./types.js').DaemonCore['incarnateWorker']} args.incarnateWorker
- * @param {import('./types.js').DaemonCore['incarnateHost']} args.incarnateHost
- * @param {import('./types.js').DaemonCore['incarnateGuest']} args.incarnateGuest
- * @param {import('./types.js').DaemonCore['incarnateEval']} args.incarnateEval
- * @param {import('./types.js').DaemonCore['incarnateUnconfined']} args.incarnateUnconfined
- * @param {import('./types.js').DaemonCore['incarnateBundle']} args.incarnateBundle
- * @param {import('./types.js').DaemonCore['incarnateReadableBlob']} args.incarnateReadableBlob
+ * @param {import('./types.js').DaemonCore['formulateWorker']} args.formulateWorker
+ * @param {import('./types.js').DaemonCore['formulateHost']} args.formulateHost
+ * @param {import('./types.js').DaemonCore['formulateGuest']} args.formulateGuest
+ * @param {import('./types.js').DaemonCore['formulateEval']} args.formulateEval
+ * @param {import('./types.js').DaemonCore['formulateUnconfined']} args.formulateUnconfined
+ * @param {import('./types.js').DaemonCore['formulateBundle']} args.formulateBundle
+ * @param {import('./types.js').DaemonCore['formulateReadableBlob']} args.formulateReadableBlob
  * @param {import('./types.js').DaemonCore['getAllNetworkAddresses']} args.getAllNetworkAddresses
  * @param {import('./types.js').MakeMailbox} args.makeMailbox
  * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
@@ -34,13 +34,13 @@ export const makeHostMaker = ({
   provide,
   provideController,
   cancelValue,
-  incarnateWorker,
-  incarnateHost,
-  incarnateGuest,
-  incarnateEval,
-  incarnateUnconfined,
-  incarnateBundle,
-  incarnateReadableBlob,
+  formulateWorker,
+  formulateHost,
+  formulateGuest,
+  formulateEval,
+  formulateUnconfined,
+  formulateBundle,
+  formulateReadableBlob,
   getAllNetworkAddresses,
   makeMailbox,
   makeDirectoryNode,
@@ -117,7 +117,7 @@ export const makeHostMaker = ({
         );
       }
 
-      const { value } = await incarnateReadableBlob(readerRef, tasks);
+      const { value } = await formulateReadableBlob(readerRef, tasks);
       return value;
     };
 
@@ -130,7 +130,7 @@ export const makeHostMaker = ({
       // eslint-disable-next-line no-use-before-define
       const workerId = tryGetWorkerId(workerName);
       // eslint-disable-next-line no-use-before-define
-      prepareWorkerIncarnation(workerName, workerId, tasks.push);
+      prepareWorkerFormulation(workerName, workerId, tasks.push);
 
       if (workerId !== undefined) {
         return /** @type {Promise<import('./types.js').EndoWorker>} */ (
@@ -139,7 +139,7 @@ export const makeHostMaker = ({
         );
       }
 
-      const { value } = await incarnateWorker(tasks);
+      const { value } = await formulateWorker(tasks);
       return value;
     };
 
@@ -161,7 +161,7 @@ export const makeHostMaker = ({
      * @param {string | undefined} workerId
      * @param {import('./types.js').DeferredTasks<{ workerId: string }>['push']} deferTask
      */
-    const prepareWorkerIncarnation = (workerName, workerId, deferTask) => {
+    const prepareWorkerFormulation = (workerName, workerId, deferTask) => {
       if (workerId === undefined) {
         deferTask(identifiers =>
           petStore.write(workerName, identifiers.workerId),
@@ -194,7 +194,7 @@ export const makeHostMaker = ({
       const tasks = makeDeferredTasks();
 
       const workerId = tryGetWorkerId(workerName);
-      prepareWorkerIncarnation(workerName, workerId, tasks.push);
+      prepareWorkerFormulation(workerName, workerId, tasks.push);
 
       /** @type {(string | string[])[]} */
       const endowmentFormulaIdsOrPaths = petNamePaths.map(
@@ -222,7 +222,7 @@ export const makeHostMaker = ({
         );
       }
 
-      const { value } = await incarnateEval(
+      const { value } = await formulateEval(
         hostId,
         source,
         codeNames,
@@ -246,7 +246,7 @@ export const makeHostMaker = ({
       const tasks = makeDeferredTasks();
 
       const workerId = tryGetWorkerId(workerName);
-      prepareWorkerIncarnation(workerName, workerId, tasks.push);
+      prepareWorkerFormulation(workerName, workerId, tasks.push);
 
       const powersId = petStore.identifyLocal(powersName);
       if (powersId === undefined) {
@@ -279,7 +279,7 @@ export const makeHostMaker = ({
 
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      const { value } = await incarnateUnconfined(
+      const { value } = await formulateUnconfined(
         hostId,
         specifier,
         tasks,
@@ -314,7 +314,7 @@ export const makeHostMaker = ({
 
       // Behold, recursion:
       // eslint-disable-next-line no-use-before-define
-      const { value } = await incarnateBundle(
+      const { value } = await formulateBundle(
         hostId,
         bundleId,
         tasks,
@@ -326,7 +326,7 @@ export const makeHostMaker = ({
 
     /**
      * Attempts to introduce the given names to the specified agent. The agent in question
-     * must be incarnated before this function is called.
+     * must be formulated before this function is called.
      *
      * @param {string} id - The agent's formula identifier.
      * @param {Record<string,string>} introducedNames - The names to introduce.
@@ -385,7 +385,7 @@ export const makeHostMaker = ({
       if (host === undefined) {
         const { value, id } =
           // Behold, recursion:
-          await incarnateHost(
+          await formulateHost(
             endoId,
             networksDirectoryId,
             getDeferredTasksForAgent(petName),
@@ -415,7 +415,7 @@ export const makeHostMaker = ({
       if (guest === undefined) {
         const { value, id } =
           // Behold, recursion:
-          await incarnateGuest(hostId, getDeferredTasksForAgent(petName));
+          await formulateGuest(hostId, getDeferredTasksForAgent(petName));
         guest = { value: Promise.resolve(value), id };
       }
 

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -698,7 +698,7 @@ export type DaemonicPowers = {
   control: DaemonicControlPowers;
 };
 
-type IncarnateResult<T> = Promise<{
+type FormulateResult<T> = Promise<{
   id: string;
   value: T;
 }>;
@@ -716,20 +716,20 @@ export type DeferredTasks<T extends Record<string, string | string[]>> = {
   push(value: DeferredTask<T>): void;
 };
 
-type IncarnateNumberedGuestParams = {
+type FormulateNumberedGuestParams = {
   guestFormulaNumber: string;
   hostHandleId: string;
   storeId: string;
   workerId: string;
 };
 
-type IncarnateHostDependenciesParams = {
+type FormulateHostDependenciesParams = {
   endoId: string;
   networksDirectoryId: string;
   specifiedWorkerId?: string;
 };
 
-type IncarnateNumberedHostParams = {
+type FormulateNumberedHostParams = {
   hostFormulaNumber: string;
   workerId: string;
   storeId: string;
@@ -740,27 +740,27 @@ type IncarnateNumberedHostParams = {
 
 export interface DaemonCoreInternal {
   /**
-   * Helper for callers of {@link incarnateNumberedGuest}.
-   * @param hostId - The formula identifier of the host to incarnate a guest for.
-   * @returns The formula identifiers for the guest incarnation's dependencies.
+   * Helper for callers of {@link formulateNumberedGuest}.
+   * @param hostId - The formula identifier of the host to formulate a guest for.
+   * @returns The formula identifiers for the guest formulation's dependencies.
    */
-  incarnateGuestDependencies: (
+  formulateGuestDependencies: (
     hostId: string,
-  ) => Promise<Readonly<IncarnateNumberedGuestParams>>;
-  incarnateNumberedGuest: (
-    identifiers: IncarnateNumberedGuestParams,
-  ) => IncarnateResult<EndoGuest>;
+  ) => Promise<Readonly<FormulateNumberedGuestParams>>;
+  formulateNumberedGuest: (
+    identifiers: FormulateNumberedGuestParams,
+  ) => FormulateResult<EndoGuest>;
   /**
-   * Helper for callers of {@link incarnateNumberedHost}.
-   * @param specifiedIdentifiers - The existing formula identifiers specified to the host incarnation.
-   * @returns The formula identifiers for all of the host incarnation's dependencies.
+   * Helper for callers of {@link formulateNumberedHost}.
+   * @param specifiedIdentifiers - The existing formula identifiers specified to the host formulation.
+   * @returns The formula identifiers for all of the host formulation's dependencies.
    */
-  incarnateHostDependencies: (
-    specifiedIdentifiers: IncarnateHostDependenciesParams,
-  ) => Promise<Readonly<IncarnateNumberedHostParams>>;
-  incarnateNumberedHost: (
-    identifiers: IncarnateNumberedHostParams,
-  ) => IncarnateResult<EndoHost>;
+  formulateHostDependencies: (
+    specifiedIdentifiers: FormulateHostDependenciesParams,
+  ) => Promise<Readonly<FormulateNumberedHostParams>>;
+  formulateNumberedHost: (
+    identifiers: FormulateNumberedHostParams,
+  ) => FormulateResult<EndoHost>;
 }
 
 export interface DaemonCore {
@@ -777,55 +777,55 @@ export interface DaemonCore {
   }>;
   getIdForRef: (ref: unknown) => string | undefined;
   getAllNetworkAddresses: (networksDirectoryId: string) => Promise<string[]>;
-  incarnateEndoBootstrap: (
+  formulateEndoBootstrap: (
     specifiedFormulaNumber: string,
-  ) => IncarnateResult<FarEndoBootstrap>;
-  incarnateWorker: (
+  ) => FormulateResult<FarEndoBootstrap>;
+  formulateWorker: (
     deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
-  ) => IncarnateResult<EndoWorker>;
-  incarnateDirectory: () => IncarnateResult<EndoDirectory>;
-  incarnateHost: (
+  ) => FormulateResult<EndoWorker>;
+  formulateDirectory: () => FormulateResult<EndoDirectory>;
+  formulateHost: (
     endoId: string,
     networksDirectoryId: string,
     deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
     specifiedWorkerId?: string | undefined,
-  ) => IncarnateResult<EndoHost>;
-  incarnateGuest: (
+  ) => FormulateResult<EndoHost>;
+  formulateGuest: (
     hostId: string,
     deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
-  ) => IncarnateResult<EndoGuest>;
-  incarnateReadableBlob: (
+  ) => FormulateResult<EndoGuest>;
+  formulateReadableBlob: (
     readerRef: ERef<AsyncIterableIterator<string>>,
     deferredTasks: DeferredTasks<ReadableBlobDeferredTaskParams>,
-  ) => IncarnateResult<FarEndoReadable>;
-  incarnateEval: (
+  ) => FormulateResult<FarEndoReadable>;
+  formulateEval: (
     hostId: string,
     source: string,
     codeNames: string[],
     endowmentIdsOrPaths: (string | string[])[],
     deferredTasks: DeferredTasks<EvalDeferredTaskParams>,
     specifiedWorkerId?: string,
-  ) => IncarnateResult<unknown>;
-  incarnateUnconfined: (
+  ) => FormulateResult<unknown>;
+  formulateUnconfined: (
     hostId: string,
     specifier: string,
     deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
     specifiedWorkerId?: string,
     specifiedPowersId?: string,
-  ) => IncarnateResult<unknown>;
-  incarnateBundle: (
+  ) => FormulateResult<unknown>;
+  formulateBundle: (
     hostId: string,
     bundleId: string,
     deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
     specifiedWorkerId?: string,
     specifiedPowersId?: string,
-  ) => IncarnateResult<unknown>;
-  incarnatePeer: (
+  ) => FormulateResult<unknown>;
+  formulatePeer: (
     networksId: string,
     addresses: Array<string>,
-  ) => IncarnateResult<EndoPeer>;
-  incarnateNetworksDirectory: () => IncarnateResult<EndoDirectory>;
-  incarnateLoopbackNetwork: () => IncarnateResult<EndoNetwork>;
+  ) => FormulateResult<EndoPeer>;
+  formulateNetworksDirectory: () => FormulateResult<EndoDirectory>;
+  formulateLoopbackNetwork: () => FormulateResult<EndoNetwork>;
   cancelValue: (id: string, reason: Error) => Promise<void>;
   makeMailbox: MakeMailbox;
   makeDirectoryNode: MakeDirectoryNode;


### PR DESCRIPTION
Closes: #2146 

Replaces all references to "incarnate"/"incarnation" with "formulate"/"formulation". Incarnations will live on in the phylacteries of our hearts.