### PR TITLE
fix(daemon): Fix provision of new, unnamed workers

### DIFF
--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -128,9 +128,7 @@ export const makeHostMaker = ({
       /** @type {import('./types.js').DeferredTasks<import('./types.js').WorkerDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       // eslint-disable-next-line no-use-before-define
-      const workerId = tryGetWorkerId(workerName);
-      // eslint-disable-next-line no-use-before-define
-      prepareWorkerFormulation(workerName, workerId, tasks.push);
+      const workerId = prepareWorkerFormulation(workerName, tasks.push);
 
       if (workerId !== undefined) {
         return /** @type {Promise<import('./types.js').EndoWorker>} */ (
@@ -145,28 +143,22 @@ export const makeHostMaker = ({
 
     /**
      * @param {string} workerName
-     * @returns {string | undefined}
+     * @param {import('./types.js').DeferredTasks<{ workerId: string }>['push']} deferTask
      */
-    const tryGetWorkerId = workerName => {
+    const prepareWorkerFormulation = (workerName, deferTask) => {
       if (workerName === 'MAIN') {
         return mainWorkerId;
       } else if (workerName === 'NEW') {
         return undefined;
       }
-      return petStore.identifyLocal(workerName);
-    };
 
-    /**
-     * @param {string} workerName
-     * @param {string | undefined} workerId
-     * @param {import('./types.js').DeferredTasks<{ workerId: string }>['push']} deferTask
-     */
-    const prepareWorkerFormulation = (workerName, workerId, deferTask) => {
+      const workerId = petStore.identifyLocal(workerName);
       if (workerId === undefined) {
         deferTask(identifiers =>
           petStore.write(workerName, identifiers.workerId),
         );
       }
+      return workerId;
     };
 
     /**
@@ -193,8 +185,7 @@ export const makeHostMaker = ({
       /** @type {import('./types.js').DeferredTasks<import('./types.js').EvalDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
-      const workerId = tryGetWorkerId(workerName);
-      prepareWorkerFormulation(workerName, workerId, tasks.push);
+      const workerId = prepareWorkerFormulation(workerName, tasks.push);
 
       /** @type {(string | string[])[]} */
       const endowmentFormulaIdsOrPaths = petNamePaths.map(
@@ -245,8 +236,7 @@ export const makeHostMaker = ({
       /** @type {import('./types.js').DeferredTasks<import('./types.js').MakeCapletDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
-      const workerId = tryGetWorkerId(workerName);
-      prepareWorkerFormulation(workerName, workerId, tasks.push);
+      const workerId = prepareWorkerFormulation(workerName, tasks.push);
 
       const powersId = petStore.identifyLocal(powersName);
       if (powersId === undefined) {

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -149,6 +149,28 @@ test('anonymous spawn and evaluate', async t => {
   await stop(locator);
 });
 
+test('anonymous spawn and evaluate with new worker', async t => {
+  const { promise: cancelled, reject: cancel } = makePromiseKit();
+  t.teardown(() => cancel(Error('teardown')));
+  const locator = makeLocator('tmp', 'spawn-eval-anon-new-worker');
+
+  await stop(locator).catch(() => {});
+  await purge(locator);
+  await start(locator);
+
+  const { getBootstrap } = await makeEndoClient(
+    'client',
+    locator.sockPath,
+    cancelled,
+  );
+  const bootstrap = getBootstrap();
+  const host = E(bootstrap).host();
+  const ten = await E(host).evaluate('NEW', '10', [], []);
+  t.is(ten, 10);
+
+  await stop(locator);
+});
+
 // Regression test for https://github.com/endojs/endo/issues/2147
 test('spawning a worker does not overwrite existing non-worker name', async t => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();


### PR DESCRIPTION
Fixes the provision of new (i.e. `NEW`) unnamed workers after #2139 broke it. Adds a regression test for this case.