### PR TITLE
fix(pass-style): toPassableError fixed. (is/assert)PassableError removed.

### DIFF
--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -28,8 +28,6 @@ export {
   passStyleOf,
   isPassable,
   assertPassable,
-  isPassableError,
-  assertPassableError,
   toPassableError,
 } from './src/passStyleOf.js';
 

--- a/packages/pass-style/test/test-errors.js
+++ b/packages/pass-style/test/test-errors.js
@@ -1,7 +1,12 @@
 /* eslint-disable max-classes-per-file */
 import test from '@endo/ses-ava/prepare-endo.js';
 
-import { passStyleOf } from '../src/passStyleOf.js';
+import { makeError } from '@endo/errors';
+import {
+  passStyleOf,
+  isPassable,
+  toPassableError,
+} from '../src/passStyleOf.js';
 
 test('style of extended errors', t => {
   const e1 = Error('e1');
@@ -22,4 +27,20 @@ test('style of extended errors', t => {
     const a4 = harden(AggregateError([e2, u3], 'a4', { cause: e1 }));
     t.is(passStyleOf(a4), 'error');
   }
+});
+
+test('toPassableError rejects unfrozen errors', t => {
+  const e = makeError('test error');
+  // I include this test because I was recently surprised that the errors
+  // make by `makeError` are not frozen, and therefore not passable.
+  t.false(Object.isFrozen(e));
+  t.false(isPassable(e));
+
+  // toPassableError hardens, and then checks whether the hardened argument
+  // is a passable error.
+  const e2 = toPassableError(e);
+
+  t.is(e, e2);
+  t.true(Object.isFrozen(e));
+  t.true(isPassable(e));
 });


### PR DESCRIPTION
closes: #2173 
refs: #XXXX

## Description

As of the last endo release, @endo/passStyle exports two broken tester functions: `isPassableError` and `assertPassableError`, neither of which correctly do what their names promise. In particular, they will judge some non-frozen errors to be passable even though `passStyleOf(e)` will correctly throw, `isPassable(e)` will correctly say `false`, and `matches(e, M.error())` will correctly throw. (`matches` throws if the specimen is not passable).

Their one use was by `toPassableError` which was therefore incorrect, which is how I noticed the problem. This PR fixes `toPassable`.

Fortunately, these two functions do not appear to be used ***anywhere*** else. They are also unneeded, as the other correct tests suffice. Therefore I would like to withdraw them rather than fix them, even though it would be trivial to fix them. This PR currently deletes them. 

Reviewers, deleting released exports is *technically* a compat break, so I have currently marked marked this PR `feat(...)!:` rather than `feat(...):`. If it is ok with you, I would like to remove the `!`. Please let me know in a comment. 

### Security Considerations

exporting test functions that incorrectly judge non-frozen errors to be passable, and exporting a `toPassableError` that incorrectly would return such non-frozen errors, is a potential local security hazard, though there are no known vulnerabilities due to this hazard. I'll hazard a guess that it is unlikely there are currently any such undiscovered vulnerabilities. But as we make more use of mutually suspicious tenants coexisting in the same vat, if we don't fix this hazard, it may well lead to future vulnerabilities.

### Scaling Considerations

none

### Documentation Considerations

Current typedoc may have automatically generated docs for `isPassableError` and `assertPassableError`. But they will disappear on the first run of typedoc following this PR, so no problem.

### Testing Considerations

Added a test that I checked does fail before this PR.

The bad news is that this bug was not caught before this PR by any tests. The bug was only caught by a surprise during new development.

### Compatibility Considerations

See the top PR comment for the compat issues in withdrawing an export that was present in a previous release. 

Reviewers, with your approval, I would like to delete the `!` because this is only a compat issue in theory, but probably not in practice.

### Upgrade Considerations

None.

Though a withdrawal is technically breaking, I don't think it warrants a BREAKING note nor a mention in NEWS.md. Reviewers, please let me know if you think otherwise.

- ~[ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.~
- ~[ ] Updates `NEWS.md` for user-facing changes.~
