### PR TITLE
fix: Restore Agoric SDK compatibility for sync

### DIFF
--- a/packages/bundle-source/src/bundle-source.js
+++ b/packages/bundle-source/src/bundle-source.js
@@ -2,9 +2,8 @@
 const DEFAULT_MODULE_FORMAT = 'endoZipBase64';
 const SUPPORTED_FORMATS = ['getExport', 'nestedEvaluate', 'endoZipBase64'];
 
-/**
- * @type {import('./types').BundleSourceGeneral}
- */
+/** @type {import('./types').BundleSource} */
+// @ts-ignore cast
 const bundleSource = async (
   startFilename,
   options = {},
@@ -14,6 +13,8 @@ const bundleSource = async (
   if (typeof options === 'string') {
     options = { format: options };
   }
+  /** @type {{ format: import('./types').ModuleFormat }} */
+  // @ts-expect-error cast (xxx params)
   const { format: moduleFormat = DEFAULT_MODULE_FORMAT } = options;
 
   switch (moduleFormat) {
@@ -51,6 +52,4 @@ const bundleSource = async (
   }
 };
 
-export default /** @satisfies {import('./types').BundleSource} */ (
-  bundleSource
-);
+export default bundleSource;

--- a/packages/bundle-source/src/nested-evaluate-and-get-exports.js
+++ b/packages/bundle-source/src/nested-evaluate-and-get-exports.js
@@ -30,7 +30,10 @@ function longestCommonPrefix(strings) {
 }
 
 /**
- * @type {import('./types').BundleSourceWithFormat}
+ * @template {'nestedEvaluate' | 'getExport'} T
+ * @param {string} startFilename
+ * @param {T} moduleFormat
+ * @param {any} powers
  */
 export async function bundleNestedEvaluateAndGetExports(
   startFilename,
@@ -44,7 +47,7 @@ export async function bundleNestedEvaluateAndGetExports(
     pathResolve = path.resolve,
     pathToFileURL = url.pathToFileURL,
     externals = [],
-  } = /** @type {any} */ (powers || {});
+  } = powers || {};
   const resolvedPath = pathResolve(startFilename);
   const bundle = await rollup({
     input: resolvedPath,
@@ -157,7 +160,6 @@ ${sourceBundle[entrypoint]}
 return module.exports;
 }
 ${sourceMap}`;
-    // @ts-expect-error generic T not assignable to moduleFormat
     return harden({ moduleFormat, source, sourceMap });
   } else if (moduleFormat === 'nestedEvaluate') {
     sourceMap = `//# sourceURL=${DEFAULT_FILE_PREFIX}-preamble.js\n`;
@@ -282,7 +284,6 @@ function getExportWithNestedEvaluate(filePrefix) {
   return computeExports(entrypoint, { require: systemRequire, systemEval }, {});
 }
 ${sourceMap}`;
-    // @ts-expect-error generic T not assignable to moduleFormat
     return harden({ moduleFormat, source, sourceMap });
   }
 

--- a/packages/bundle-source/src/zip-base64.js
+++ b/packages/bundle-source/src/zip-base64.js
@@ -17,12 +17,9 @@ const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 const readPowers = makeReadPowers({ fs, url, crypto });
 
-/**
- * @type {import('./types').BundleSourceWithOptions}
- */
 export async function bundleZipBase64(
   startFilename,
-  options,
+  options = {},
   grantedPowers = {},
 ) {
   const { dev = false, cacheSourceMaps = false, commonDependencies } = options;

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -39,8 +39,10 @@
   "dependencies": {
     "@endo/env-options": "^1.1.1",
     "@endo/init": "^1.0.4",
-    "ava": "^6.1.2",
     "ses": "^1.3.0"
+  },
+  "peerDependencies": {
+    "ava": "^5.3.0|^6.1.2"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION

Two changes are necessary to close the gap with Agoric SDK.

1. We need to use `peerDependencies` between `@endo/ses-ava` and `ava`, in order to allow Agoric SDK to run behind on Ava 5 while Endo is on Ava 6. This is consistent with the usage pattern of `wrapTest`, requiring the dependent package to combine their `ava` with `@endo/ses-ava`, with some liberty to use either version.
1. My proposed changes for the `bundleSource` type signature are not currently reconciled and will have to endure another attempt. 