### PR TITLE
feat(daemon): Add `locate()` facility

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -210,7 +210,13 @@ const makeDaemonCore = async (
       return formulaType;
     }
 
+    if (parseId(id).node !== ownNodeIdentifier) {
+      typeForId.set(id, 'remote');
+      return 'remote';
+    }
+
     const formula = await persistencePowers.readFormula(parseId(id).number);
+    typeForId.set(id, formula.type);
     return formula.type;
   };
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -17,6 +17,7 @@ import { parseId, formatId } from './formula-identifier.js';
 import { makeSerialJobs } from './serial-jobs.js';
 import { makeWeakMultimap } from './weak-multimap.js';
 import { makeLoopbackNetwork } from './networks/loopback.js';
+import { assertValidFormulaType } from './formula-type.js';
 
 const delay = async (ms, cancelled) => {
   // Do not attempt to set up a timer if already cancelled.
@@ -676,28 +677,7 @@ const makeDaemonCore = async (
     }
     const formula = await persistencePowers.readFormula(formulaNumber);
     console.log(`Making ${formula.type} ${formulaNumber}`);
-    if (
-      ![
-        'endo',
-        'worker',
-        'eval',
-        'readable-blob',
-        'make-unconfined',
-        'make-bundle',
-        'host',
-        'guest',
-        'least-authority',
-        'loopback-network',
-        'peer',
-        'handle',
-        'pet-inspector',
-        'pet-store',
-        'lookup',
-        'directory',
-      ].includes(formula.type)
-    ) {
-      assert.Fail`Invalid formula identifier, unrecognized type ${q(id)}`;
-    }
+    assertValidFormulaType(formula.type);
     // TODO further validation
     return makeControllerForFormula(id, formulaNumber, formula, context);
   };

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -956,7 +956,7 @@ const makeDaemonCore = async (
   };
 
   /**
-   * @type {import('./types.js').DaemonCoreInternal['formulateHostDependencies']}
+   * @type {import('./types.js').DaemonCore['formulateHostDependencies']}
    */
   const formulateHostDependencies = async specifiedIdentifiers => {
     const { specifiedWorkerId, ...remainingSpecifiedIdentifiers } =
@@ -977,7 +977,7 @@ const makeDaemonCore = async (
     });
   };
 
-  /** @type {import('./types.js').DaemonCoreInternal['formulateNumberedHost']} */
+  /** @type {import('./types.js').DaemonCore['formulateNumberedHost']} */
   const formulateNumberedHost = identifiers => {
     /** @type {import('./types.js').HostFormula} */
     const formula = {
@@ -1021,7 +1021,7 @@ const makeDaemonCore = async (
     );
   };
 
-  /** @type {import('./types.js').DaemonCoreInternal['formulateGuestDependencies']} */
+  /** @type {import('./types.js').DaemonCore['formulateGuestDependencies']} */
   const formulateGuestDependencies = async hostId =>
     harden({
       guestFormulaNumber: await randomHex512(),
@@ -1032,7 +1032,7 @@ const makeDaemonCore = async (
       workerId: (await formulateNumberedWorker(await randomHex512())).id,
     });
 
-  /** @type {import('./types.js').DaemonCoreInternal['formulateNumberedGuest']} */
+  /** @type {import('./types.js').DaemonCore['formulateNumberedGuest']} */
   const formulateNumberedGuest = identifiers => {
     /** @type {import('./types.js').GuestFormula} */
     const formula = {
@@ -1600,32 +1600,12 @@ const makeDaemonCore = async (
     return info;
   };
 
-  /** @type {import('./types.js').DaemonCore} */
-  const daemonCore = {
-    nodeIdentifier: ownNodeIdentifier,
-    provideController,
-    provideControllerAndResolveHandle,
-    provide,
-    formulate,
-    getIdForRef,
-    getAllNetworkAddresses,
-    cancelValue,
-    makeMailbox,
-    makeDirectoryNode,
+  /** @type {import('./types.js').DaemonCoreExternal} */
+  return {
     formulateEndoBootstrap,
-    formulateNetworksDirectory,
-    formulateLoopbackNetwork,
-    formulateDirectory,
-    formulateWorker,
-    formulateHost,
-    formulateGuest,
-    formulatePeer,
-    formulateEval,
-    formulateUnconfined,
-    formulateReadableBlob,
-    formulateBundle,
+    provide,
+    nodeIdentifier: ownNodeIdentifier,
   };
-  return daemonCore;
 };
 
 /**

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -2,6 +2,7 @@
 
 import { E, Far } from '@endo/far';
 import { makeIteratorRef } from './reader-ref.js';
+import { formatLocator } from './locator.js';
 
 const { quote: q } = assert;
 
@@ -9,11 +10,13 @@ const { quote: q } = assert;
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
  * @param {import('./types.js').DaemonCore['getIdForRef']} args.getIdForRef
+ * @param {import('./types.js').DaemonCore['getTypeForId']} args.getTypeForId
  * @param {import('./types.js').DaemonCore['formulateDirectory']} args.formulateDirectory
  */
 export const makeDirectoryMaker = ({
   provide,
   getIdForRef,
+  getTypeForId,
   formulateDirectory,
 }) => {
   /** @type {import('./types.js').MakeDirectoryNode} */
@@ -82,6 +85,17 @@ export const makeDirectoryMaker = ({
       }
       const { hub, name } = await lookupTailNameHub(petNamePath);
       return hub.identify(name);
+    };
+
+    /** @type {import('./types.js').EndoDirectory['locate']} */
+    const locate = async (...petNamePath) => {
+      const id = await identify(...petNamePath);
+      if (id === undefined) {
+        return undefined;
+      }
+
+      const formulaType = await getTypeForId(id);
+      return formatLocator(id, formulaType);
     };
 
     /** @type {import('./types.js').EndoDirectory['list']} */
@@ -192,6 +206,7 @@ export const makeDirectoryMaker = ({
     const directory = {
       has,
       identify,
+      locate,
       list,
       listIdentifiers,
       followChanges,

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -2,8 +2,14 @@
 
 const { quote: q } = assert;
 
-export const nodeOrIdPattern = /^[0-9a-f]{128}$/;
+const numberPattern = /^[0-9a-f]{128}$/;
 const idPattern = /^(?<number>[0-9a-f]{128}):(?<node>[0-9a-f]{128})$/;
+
+/**
+ * @param {string} allegedNumber - The formula number or node identifier to test.
+ */
+export const isValidNumber = allegedNumber =>
+  typeof allegedNumber === 'string' && numberPattern.test(allegedNumber);
 
 /**
  * @param {string} id
@@ -11,7 +17,7 @@ const idPattern = /^(?<number>[0-9a-f]{128}):(?<node>[0-9a-f]{128})$/;
  * @returns {void}
  */
 export const assertValidId = (id, petName) => {
-  if (!idPattern.test(id)) {
+  if (typeof id !== 'string' || !idPattern.test(id)) {
     let message = `Invalid formula identifier ${q(id)}`;
     if (petName !== undefined) {
       message += ` for pet name ${q(petName)}`;

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -2,6 +2,7 @@
 
 const { quote: q } = assert;
 
+export const nodeOrIdPattern = /^[0-9a-f]{128}$/;
 const idPattern = /^(?<number>[0-9a-f]{128}):(?<node>[0-9a-f]{128})$/;
 
 /**

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -1,0 +1,31 @@
+const { quote: q } = assert;
+
+// Note: Alphabetically sorted
+const formulaTypes = new Set([
+  'directory',
+  'endo',
+  'eval',
+  'guest',
+  'handle',
+  'host',
+  'least-authority',
+  'lookup',
+  'loopback-network',
+  'make-bundle',
+  'make-unconfined',
+  'peer',
+  'pet-inspector',
+  'pet-store',
+  'readable-blob',
+  'worker',
+]);
+
+/** @param {string} allegedType */
+export const isValidFormulaType = allegedType => formulaTypes.has(allegedType);
+
+/** @param {string} allegedType */
+export const assertValidFormulaType = allegedType => {
+  if (!isValidFormulaType(allegedType)) {
+    assert.Fail`Unrecognized formula type ${q(allegedType)}`;
+  }
+};

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -64,6 +64,7 @@ export const makeGuestMaker = ({
     const {
       has,
       identify,
+      locate,
       list,
       listIdentifiers,
       followChanges,
@@ -93,6 +94,7 @@ export const makeGuestMaker = ({
       // Directory
       has,
       identify,
+      locate,
       list,
       listIdentifiers,
       followChanges,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -455,6 +455,7 @@ export const makeHostMaker = ({
     const {
       has,
       identify,
+      locate,
       list,
       listIdentifiers,
       followChanges,
@@ -483,6 +484,7 @@ export const makeHostMaker = ({
       // Directory
       has,
       identify,
+      locate,
       list,
       listIdentifiers,
       followChanges,

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -1,4 +1,6 @@
-import { parseId, nodeOrIdPattern } from './formula-identifier.js';
+/// <ref types="ses">
+
+import { parseId, isValidNumber } from './formula-identifier.js';
 import { assertValidFormulaType, isValidFormulaType } from './formula-type.js';
 
 const { quote: q } = assert;
@@ -25,7 +27,7 @@ export const parseLocator = allegedLocator => {
   }
 
   const node = url.host;
-  if (!nodeOrIdPattern.test(node)) {
+  if (!isValidNumber(node)) {
     assert.Fail`${errorPrefix} Invalid node identifier.`;
   }
 
@@ -38,7 +40,7 @@ export const parseLocator = allegedLocator => {
   }
 
   const id = url.searchParams.get('id');
-  if (id === null || !nodeOrIdPattern.test(id)) {
+  if (id === null || !isValidNumber(id)) {
     assert.Fail`${errorPrefix} Invalid id.`;
   }
 

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -15,7 +15,9 @@ const { quote: q } = assert;
 export const parseLocator = allegedLocator => {
   const errorPrefix = `Invalid locator ${q(allegedLocator)}:`;
 
-  if (!URL.canParse(allegedLocator)) assert.Fail`${errorPrefix} Invalid URL.`;
+  if (!URL.canParse(allegedLocator)) {
+    assert.Fail`${errorPrefix} Invalid URL.`;
+  }
   const url = new URL(allegedLocator);
 
   if (!allegedLocator.startsWith('endo://')) {
@@ -35,15 +37,13 @@ export const parseLocator = allegedLocator => {
     assert.Fail`${errorPrefix} Invalid search params.`;
   }
 
-  /** @type {string} */
   const id = url.searchParams.get('id');
-  if (!nodeOrIdPattern.test(id)) {
+  if (id === null || !nodeOrIdPattern.test(id)) {
     assert.Fail`${errorPrefix} Invalid id.`;
   }
 
-  /** @type {string} */
   const formulaType = url.searchParams.get('type');
-  if (!isValidFormulaType(formulaType)) {
+  if (formulaType === null || !isValidFormulaType(formulaType)) {
     assert.Fail`${errorPrefix} Invalid type.`;
   }
 

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -1,0 +1,75 @@
+import { parseId, nodeOrIdPattern } from './formula-identifier.js';
+import { assertValidFormulaType, isValidFormulaType } from './formula-type.js';
+
+const { quote: q } = assert;
+
+/**
+ * The endo locator format:
+ * ```
+ * endo://{nodeIdentifier}/?id={formulaNumber}&type={formulaType}
+ * ```
+ * Note that the `id` query param is just the formula number.
+ */
+
+/** @param {string} allegedLocator */
+export const parseLocator = allegedLocator => {
+  const errorPrefix = `Invalid locator ${q(allegedLocator)}:`;
+
+  if (!URL.canParse(allegedLocator)) assert.Fail`${errorPrefix} Invalid URL.`;
+  const url = new URL(allegedLocator);
+
+  if (!allegedLocator.startsWith('endo://')) {
+    assert.Fail`${errorPrefix} Invalid protocol.`;
+  }
+
+  const node = url.host;
+  if (!nodeOrIdPattern.test(node)) {
+    assert.Fail`${errorPrefix} Invalid node identifier.`;
+  }
+
+  if (
+    url.searchParams.size !== 2 ||
+    !url.searchParams.has('id') ||
+    !url.searchParams.has('type')
+  ) {
+    assert.Fail`${errorPrefix} Invalid search params.`;
+  }
+
+  /** @type {string} */
+  const id = url.searchParams.get('id');
+  if (!nodeOrIdPattern.test(id)) {
+    assert.Fail`${errorPrefix} Invalid id.`;
+  }
+
+  /** @type {string} */
+  const formulaType = url.searchParams.get('type');
+  if (!isValidFormulaType(formulaType)) {
+    assert.Fail`${errorPrefix} Invalid type.`;
+  }
+
+  /** @type {{ formulaType: string, node: string, id: string }} */
+  return { formulaType, node, id };
+};
+
+/** @param {string} allegedLocator */
+export const assertValidLocator = allegedLocator => {
+  parseLocator(allegedLocator);
+};
+
+/**
+ * @param {string} id - The full formula identifier.
+ * @param {string} formulaType - The type of the formula with the given id.
+ */
+export const formatLocator = (id, formulaType) => {
+  const { number, node } = parseId(id);
+  const url = new URL(`endo://${node}`);
+  url.pathname = '/';
+
+  // The id query param is just the number
+  url.searchParams.set('id', number);
+
+  assertValidFormulaType(formulaType);
+  url.searchParams.set('type', formulaType);
+
+  return url.toString();
+};

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { parseId, isValidNumber } from './formula-identifier.js';
-import { assertValidFormulaType, isValidFormulaType } from './formula-type.js';
+import { isValidFormulaType } from './formula-type.js';
 
 const { quote: q } = assert;
 
@@ -12,6 +12,25 @@ const { quote: q } = assert;
  * ```
  * Note that the `id` query param is just the formula number.
  */
+
+/**
+ * In addition to all valid formula types, the locator `type` query parameter
+ * also supports `remote` for remote values, since their actual formula type
+ * cannot be known.
+ *
+ * @param {string} allegedType
+ */
+const isValidLocatorType = allegedType =>
+  isValidFormulaType(allegedType) || allegedType === 'remote';
+
+/**
+ * @param {string} allegedType
+ */
+const assertValidLocatorType = allegedType => {
+  if (!isValidLocatorType(allegedType)) {
+    assert.Fail`Unrecognized locator type ${q(allegedType)}`;
+  }
+};
 
 /** @param {string} allegedLocator */
 export const parseLocator = allegedLocator => {
@@ -45,7 +64,7 @@ export const parseLocator = allegedLocator => {
   }
 
   const formulaType = url.searchParams.get('type');
-  if (formulaType === null || !isValidFormulaType(formulaType)) {
+  if (formulaType === null || !isValidLocatorType(formulaType)) {
     assert.Fail`${errorPrefix} Invalid type.`;
   }
 
@@ -70,7 +89,7 @@ export const formatLocator = (id, formulaType) => {
   // The id query param is just the number
   url.searchParams.set('id', number);
 
-  assertValidFormulaType(formulaType);
+  assertValidLocatorType(formulaType);
   url.searchParams.set('type', formulaType);
 
   return url.toString();

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -1,4 +1,4 @@
-/// <ref types="ses">
+// @ts-check
 
 import { parseId, isValidNumber } from './formula-identifier.js';
 import { assertValidFormulaType, isValidFormulaType } from './formula-type.js';

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -1,11 +1,9 @@
 // @ts-check
 
 import { makeChangeTopic } from './pubsub.js';
-import { parseId, assertValidId } from './formula-identifier.js';
+import { parseId, assertValidId, isValidNumber } from './formula-identifier.js';
 
 const { quote: q } = assert;
-
-const validNumberPattern = /^[0-9a-f]{128}$/;
 
 /**
  * @param {import('./types.js').FilePowers} filePowers
@@ -224,16 +222,18 @@ export const makePetStoreMaker = (filePowers, locator) => {
   };
 
   /**
-   * @param {string} id
+   * @param {string} formulaNumber
    * @param {(name: string) => void} assertValidName
    * @returns {Promise<import('./types.js').PetStore>}
    */
-  const makeIdentifiedPetStore = (id, assertValidName) => {
-    if (!validNumberPattern.test(id)) {
-      throw new Error(`Invalid identifier for pet store ${q(id)}`);
+  const makeIdentifiedPetStore = (formulaNumber, assertValidName) => {
+    if (!isValidNumber(formulaNumber)) {
+      throw new Error(
+        `Invalid formula number for pet store ${q(formulaNumber)}`,
+      );
     }
-    const prefix = id.slice(0, 2);
-    const suffix = id.slice(2);
+    const prefix = formulaNumber.slice(0, 2);
+    const suffix = formulaNumber.slice(2);
     const petNameDirectoryPath = filePowers.joinPath(
       locator.statePath,
       'pet-store',

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -391,7 +391,7 @@ export interface NameHub {
   ): AsyncGenerator<PetStoreNameDiff, undefined, undefined>;
   lookup(...petNamePath: string[]): Promise<unknown>;
   reverseLookup(value: unknown): Array<string>;
-  write(petNamePath: string[], id): Promise<void>;
+  write(petNamePath: string[], id: string): Promise<void>;
   remove(...petNamePath: string[]): Promise<void>;
   move(fromPetName: string[], toPetName: string[]): Promise<void>;
   copy(fromPetName: string[], toPetName: string[]): Promise<void>;
@@ -486,6 +486,12 @@ export interface EndoPeer {
 }
 export type EndoPeerControllerPartial = ControllerPartial<EndoPeer, undefined>;
 export type EndoPeerController = Controller<EndoPeer, undefined>;
+
+export interface EndoKnownPeers {
+  has: (nodeIdentifier: string) => boolean;
+  identify: (nodeIdentifier: string) => string | undefined;
+  write: (nodeIdentifier: string, peerId: string) => Promise<void>;
+}
 
 export interface EndoGateway {
   provide: (id: string) => Promise<unknown>;
@@ -849,6 +855,8 @@ export interface DaemonCore {
   provideController: (id: string) => Controller;
 
   provideControllerAndResolveHandle: (id: string) => Promise<Controller>;
+
+  provideKnownPeers: (peersFormulaId: string) => Promise<EndoKnownPeers>;
 }
 
 export interface DaemonCoreExternal {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -738,36 +738,9 @@ type FormulateNumberedHostParams = {
   networksDirectoryId: string;
 };
 
-export interface DaemonCoreInternal {
-  /**
-   * Helper for callers of {@link formulateNumberedGuest}.
-   * @param hostId - The formula identifier of the host to formulate a guest for.
-   * @returns The formula identifiers for the guest formulation's dependencies.
-   */
-  formulateGuestDependencies: (
-    hostId: string,
-  ) => Promise<Readonly<FormulateNumberedGuestParams>>;
-  formulateNumberedGuest: (
-    identifiers: FormulateNumberedGuestParams,
-  ) => FormulateResult<EndoGuest>;
-  /**
-   * Helper for callers of {@link formulateNumberedHost}.
-   * @param specifiedIdentifiers - The existing formula identifiers specified to the host formulation.
-   * @returns The formula identifiers for all of the host formulation's dependencies.
-   */
-  formulateHostDependencies: (
-    specifiedIdentifiers: FormulateHostDependenciesParams,
-  ) => Promise<Readonly<FormulateNumberedHostParams>>;
-  formulateNumberedHost: (
-    identifiers: FormulateNumberedHostParams,
-  ) => FormulateResult<EndoHost>;
-}
-
 export interface DaemonCore {
-  nodeIdentifier: string;
-  provide: (id: string) => Promise<unknown>;
-  provideController: (id: string) => Controller;
-  provideControllerAndResolveHandle: (id: string) => Promise<Controller>;
+  cancelValue: (id: string, reason: Error) => Promise<void>;
+
   formulate: (
     formulaNumber: string,
     formula: Formula,
@@ -775,29 +748,21 @@ export interface DaemonCore {
     id: string;
     value: unknown;
   }>;
-  getIdForRef: (ref: unknown) => string | undefined;
-  getAllNetworkAddresses: (networksDirectoryId: string) => Promise<string[]>;
+
+  formulateBundle: (
+    hostId: string,
+    bundleId: string,
+    deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
+    specifiedWorkerId?: string,
+    specifiedPowersId?: string,
+  ) => FormulateResult<unknown>;
+
+  formulateDirectory: () => FormulateResult<EndoDirectory>;
+
   formulateEndoBootstrap: (
     specifiedFormulaNumber: string,
   ) => FormulateResult<FarEndoBootstrap>;
-  formulateWorker: (
-    deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
-  ) => FormulateResult<EndoWorker>;
-  formulateDirectory: () => FormulateResult<EndoDirectory>;
-  formulateHost: (
-    endoId: string,
-    networksDirectoryId: string,
-    deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
-    specifiedWorkerId?: string | undefined,
-  ) => FormulateResult<EndoHost>;
-  formulateGuest: (
-    hostId: string,
-    deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
-  ) => FormulateResult<EndoGuest>;
-  formulateReadableBlob: (
-    readerRef: ERef<AsyncIterableIterator<string>>,
-    deferredTasks: DeferredTasks<ReadableBlobDeferredTaskParams>,
-  ) => FormulateResult<FarEndoReadable>;
+
   formulateEval: (
     hostId: string,
     source: string,
@@ -806,6 +771,59 @@ export interface DaemonCore {
     deferredTasks: DeferredTasks<EvalDeferredTaskParams>,
     specifiedWorkerId?: string,
   ) => FormulateResult<unknown>;
+
+  formulateGuest: (
+    hostId: string,
+    deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
+  ) => FormulateResult<EndoGuest>;
+
+  /**
+   * Helper for callers of {@link formulateNumberedGuest}.
+   * @param hostId - The formula identifier of the host to formulate a guest for.
+   * @returns The formula identifiers for the guest formulation's dependencies.
+   */
+  formulateGuestDependencies: (
+    hostId: string,
+  ) => Promise<Readonly<FormulateNumberedGuestParams>>;
+
+  formulateHost: (
+    endoId: string,
+    networksDirectoryId: string,
+    deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
+    specifiedWorkerId?: string | undefined,
+  ) => FormulateResult<EndoHost>;
+
+  /**
+   * Helper for callers of {@link formulateNumberedHost}.
+   * @param specifiedIdentifiers - The existing formula identifiers specified to the host formulation.
+   * @returns The formula identifiers for all of the host formulation's dependencies.
+   */
+  formulateHostDependencies: (
+    specifiedIdentifiers: FormulateHostDependenciesParams,
+  ) => Promise<Readonly<FormulateNumberedHostParams>>;
+
+  formulateLoopbackNetwork: () => FormulateResult<EndoNetwork>;
+
+  formulateNetworksDirectory: () => FormulateResult<EndoDirectory>;
+
+  formulateNumberedGuest: (
+    identifiers: FormulateNumberedGuestParams,
+  ) => FormulateResult<EndoGuest>;
+
+  formulateNumberedHost: (
+    identifiers: FormulateNumberedHostParams,
+  ) => FormulateResult<EndoHost>;
+
+  formulatePeer: (
+    networksId: string,
+    addresses: Array<string>,
+  ) => FormulateResult<EndoPeer>;
+
+  formulateReadableBlob: (
+    readerRef: ERef<AsyncIterableIterator<string>>,
+    deferredTasks: DeferredTasks<ReadableBlobDeferredTaskParams>,
+  ) => FormulateResult<FarEndoReadable>;
+
   formulateUnconfined: (
     hostId: string,
     specifier: string,
@@ -813,22 +831,30 @@ export interface DaemonCore {
     specifiedWorkerId?: string,
     specifiedPowersId?: string,
   ) => FormulateResult<unknown>;
-  formulateBundle: (
-    hostId: string,
-    bundleId: string,
-    deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
-    specifiedWorkerId?: string,
-    specifiedPowersId?: string,
-  ) => FormulateResult<unknown>;
-  formulatePeer: (
-    networksId: string,
-    addresses: Array<string>,
-  ) => FormulateResult<EndoPeer>;
-  formulateNetworksDirectory: () => FormulateResult<EndoDirectory>;
-  formulateLoopbackNetwork: () => FormulateResult<EndoNetwork>;
-  cancelValue: (id: string, reason: Error) => Promise<void>;
-  makeMailbox: MakeMailbox;
+
+  formulateWorker: (
+    deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
+  ) => FormulateResult<EndoWorker>;
+
+  getAllNetworkAddresses: (networksDirectoryId: string) => Promise<string[]>;
+
+  getIdForRef: (ref: unknown) => string | undefined;
+
   makeDirectoryNode: MakeDirectoryNode;
+
+  makeMailbox: MakeMailbox;
+
+  provide: (id: string) => Promise<unknown>;
+
+  provideController: (id: string) => Controller;
+
+  provideControllerAndResolveHandle: (id: string) => Promise<Controller>;
+}
+
+export interface DaemonCoreExternal {
+  formulateEndoBootstrap: DaemonCore['formulateEndoBootstrap'];
+  nodeIdentifier: string;
+  provide: DaemonCore['provide'];
 }
 
 export type SerialJobs = {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -384,6 +384,7 @@ export interface PetStore {
 export interface NameHub {
   has(...petNamePath: string[]): Promise<boolean>;
   identify(...petNamePath: string[]): Promise<string | undefined>;
+  locate(...petNamePath: string[]): Promise<string | undefined>;
   list(...petNamePath: string[]): Promise<Array<string>>;
   listIdentifiers(...petNamePath: string[]): Promise<Array<string>>;
   followChanges(
@@ -845,6 +846,8 @@ export interface DaemonCore {
   getAllNetworkAddresses: (networksDirectoryId: string) => Promise<string[]>;
 
   getIdForRef: (ref: unknown) => string | undefined;
+
+  getTypeForId: (id: string) => Promise<string>;
 
   makeDirectoryNode: MakeDirectoryNode;
 

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -1357,7 +1357,7 @@ test('guest cannot access host methods', async t => {
 test('read unknown nodeId', async t => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();
   t.teardown(() => cancel(Error('teardown')));
-  const locator = makeLocator('tmp', 'read unknown nodeId');
+  const locator = makeLocator('tmp', 'read-unknown-nodeid');
 
   await stop(locator).catch(() => {});
   await purge(locator);
@@ -1390,8 +1390,8 @@ test('read unknown nodeId', async t => {
 test('read remote value', async t => {
   const { promise: cancelled, reject: cancel } = makePromiseKit();
   t.teardown(() => cancel(Error('teardown')));
-  const locatorA = makeLocator('tmp', 'read remote value A');
-  const locatorB = makeLocator('tmp', 'read remote value B');
+  const locatorA = makeLocator('tmp', 'read-remote-value-a');
+  const locatorB = makeLocator('tmp', 'read-remote-value-b');
   let hostA;
   {
     await stop(locatorA).catch(() => {});

--- a/packages/daemon/test/test-formula-type.js
+++ b/packages/daemon/test/test-formula-type.js
@@ -1,0 +1,27 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import {
+  assertValidFormulaType,
+  isValidFormulaType,
+} from '../src/formula-type.js';
+
+test('isValidFormulaType', t => {
+  [
+    ['eval', true],
+    ['make-unconfined', true],
+    ['', false],
+    [null, false],
+    [undefined, false],
+    [{}, false],
+  ].forEach(([value, expected]) => {
+    t.is(isValidFormulaType(value), expected);
+  });
+});
+
+test('assertValidFormulaType - valid', t => {
+  t.notThrows(() => assertValidFormulaType('eval'));
+});
+
+test('assertValidFormulaType - invalid', t => {
+  t.throws(() => assertValidFormulaType('foobar'));
+});

--- a/packages/daemon/test/test-locator.js
+++ b/packages/daemon/test/test-locator.js
@@ -1,0 +1,72 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import {
+  assertValidLocator,
+  formatLocator,
+  parseLocator,
+} from '../src/locator.js';
+import { formatId } from '../src/formula-identifier.js';
+
+const validNode =
+  'd5c98890be3d17ad375517464ec494068267de60bd4b3143ef0214cc895746f2892baca4fec19b6d4dfc1f683b7cf3d2a884dfcae568555dd89665c33dfdc4b3';
+const validId =
+  '5cf3d8b4d6e03fb51d71fbbb6fa6982edbff673cd193707c902b70a26b7b468017fbcfc5c2895f4379459badbe507a4ef00e1d3638f4a67e8a8c14fd1d85d9aa';
+const validType = 'eval';
+
+const makeLocator = (components = {}) => {
+  const {
+    protocol = 'endo://',
+    host = validNode,
+    param1 = `id=${validId}`,
+    param2 = `type=${validType}`,
+  } = components;
+  return `${protocol}${host}/?${param1}&${param2}`;
+};
+
+test('assertValidLocator - valid', t => {
+  t.notThrows(() => assertValidLocator(makeLocator()));
+
+  // Reverse search param order
+  t.notThrows(() =>
+    assertValidLocator(
+      makeLocator({
+        param1: `type=${validType}`,
+        param2: `id=${validId}`,
+      }),
+    ),
+  );
+});
+
+test('assertValidLocator - invalid', t => {
+  [
+    ['foobar', /Invalid URL.$/u],
+    ['', /Invalid URL.$/u],
+    [null, /Invalid URL.$/u],
+    [undefined, /Invalid URL.$/u],
+    [{}, /Invalid URL.$/u],
+    [makeLocator({ protocol: 'foobar://' }), /Invalid protocol.$/u],
+    [makeLocator({ host: 'foobar' }), /Invalid node identifier.$/u],
+    [makeLocator({ param1: 'foo=bar' }), /Invalid search params.$/u],
+    [makeLocator({ param2: 'foo=bar' }), /Invalid search params.$/u],
+    [`${makeLocator()}&foo=bar`, /Invalid search params.$/u],
+    [makeLocator({ param1: 'id=foobar' }), /Invalid id.$/u],
+    [makeLocator({ param2: 'type=foobar' }), /Invalid type.$/u],
+  ].forEach(([locator, reason]) => {
+    t.throws(() => assertValidLocator(locator), { message: reason });
+  });
+});
+
+test('parseLocator', t => {
+  t.deepEqual(parseLocator(makeLocator()), {
+    id: validId,
+    node: validNode,
+    formulaType: validType,
+  });
+});
+
+test('formatLocator', t => {
+  t.is(
+    formatLocator(formatId({ number: validId, node: validNode }), validType),
+    makeLocator(),
+  );
+});


### PR DESCRIPTION
Adds locator strings and a `locate()` method to the daemon's directory abstraction, and thereby hosts and guests. A locator string is a URL of the following form:
```text
endo://{nodeIdentifier}/?id={formulaNumber}&type={formulaType}
```

Formula identifiers are of the form `{formulaNumber}:{nodeIdentifier}`. Therefore, we can say that a locator is the URL form of the formula identifier, annotated with the `formulaType`. If a value is remote, i.e. belonging to a different peer, we set the `type` query param to `remote` to indicate this. `remote` is not a valid formula type in the general case—i.e. there are no formula objects with that type—but perhaps it should be.

Note that the `id` query param is just the `formulaNumber`, not the formula identifier. We may address this internal discrepancy in naming by using locators and formula numbers instead of the `{formulaNumber}:{nodeIdentifier}` construction.