### PR TITLE
fix(ses-ava): Fix peer dependency on ava semver range syntax

### DIFF
--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -42,7 +42,7 @@
     "ses": "^1.4.0"
   },
   "peerDependencies": {
-    "ava": "^5.3.0|^6.1.2"
+    "ava": "^5.3.0 || ^6.1.2"
   },
   "devDependencies": {
     "ava": "^6.1.2",


### PR DESCRIPTION

## Description

The last release of ses-ava included an invalid peer dependency range. With yarn and legacy npm behavior, this produces a warning. This change will make the package install properly on modern npm and hopefully eliminates the peer dependency warning in yarn.
