### PR TITLE
refactor(daemon): Add known-peers-store formula

### DIFF
--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -12,6 +12,15 @@ export const isValidNumber = allegedNumber =>
   typeof allegedNumber === 'string' && numberPattern.test(allegedNumber);
 
 /**
+ * @param {string} allegedNumber - The formula number or node identifier to test.
+ */
+export const assertValidNumber = allegedNumber => {
+  if (!isValidNumber(allegedNumber)) {
+    throw assert.error(`Invalid number ${q(allegedNumber)}`);
+  }
+};
+
+/**
  * @param {string} id
  * @param {string} [petName]
  * @returns {void}

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -10,6 +10,7 @@ const formulaTypes = new Set([
   'guest',
   'handle',
   'host',
+  'known-peers-store',
   'least-authority',
   'lookup',
   'loopback-network',

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -222,11 +222,13 @@ export const makePetStoreMaker = (filePowers, locator) => {
   };
 
   /**
-   * @param {string} formulaNumber
-   * @param {(name: string) => void} assertValidName
-   * @returns {Promise<import('./types.js').PetStore>}
+   * @type {import('./types.js').PetStorePowers['makeIdentifiedPetStore']}
    */
-  const makeIdentifiedPetStore = (formulaNumber, assertValidName) => {
+  const makeIdentifiedPetStore = (
+    formulaNumber,
+    formulaType,
+    assertValidName,
+  ) => {
     if (!isValidNumber(formulaNumber)) {
       throw new Error(
         `Invalid formula number for pet store ${q(formulaNumber)}`,
@@ -236,7 +238,7 @@ export const makePetStoreMaker = (filePowers, locator) => {
     const suffix = formulaNumber.slice(2);
     const petNameDirectoryPath = filePowers.joinPath(
       locator.statePath,
-      'pet-store',
+      formulaType,
       prefix,
       suffix,
     );

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -181,6 +181,10 @@ type HandleFormula = {
   target: string;
 };
 
+type KnownPeersStoreFormula = {
+  type: 'known-peers-store';
+};
+
 type PetStoreFormula = {
   type: 'pet-store';
 };
@@ -210,6 +214,7 @@ export type Formula =
   | WebBundleFormula
   | HandleFormula
   | PetInspectorFormula
+  | KnownPeersStoreFormula
   | PetStoreFormula
   | DirectoryFormula
   | PeerFormula;
@@ -488,12 +493,6 @@ export interface EndoPeer {
 export type EndoPeerControllerPartial = ControllerPartial<EndoPeer, undefined>;
 export type EndoPeerController = Controller<EndoPeer, undefined>;
 
-export interface EndoKnownPeers {
-  has: (nodeIdentifier: string) => boolean;
-  identify: (nodeIdentifier: string) => string | undefined;
-  write: (nodeIdentifier: string, peerId: string) => Promise<void>;
-}
-
 export interface EndoGateway {
   provide: (id: string) => Promise<unknown>;
 }
@@ -626,6 +625,7 @@ export type AssertValidNameFn = (name: string) => void;
 export type PetStorePowers = {
   makeIdentifiedPetStore: (
     id: string,
+    formulaType: 'pet-store' | 'known-peers-store',
     assertValidName: AssertValidNameFn,
   ) => Promise<PetStore>;
 };
@@ -858,8 +858,6 @@ export interface DaemonCore {
   provideController: (id: string) => Controller;
 
   provideControllerAndResolveHandle: (id: string) => Promise<Controller>;
-
-  provideKnownPeers: (peersFormulaId: string) => Promise<EndoKnownPeers>;
 }
 
 export interface DaemonCoreExternal {


### PR DESCRIPTION
Closes #2166 

Replace the known peers store adapter with a dedicated `known-peers-store` formula type, instantiated the same way as other "special" formulas such as `least-authority`. The adapter used a `pet-store` formula under the hood. Giving it a different formula entirely is probably less likely to confuse us in the future.