### PR TITLE
docs: demote some packages from developer API product

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -3,6 +3,19 @@
         "packages/*"
     ],
     "exclude": [
+        "packages/cjs-module-analyzer",
+        "packages/compartment-mapper",
+        "packages/cli",
+        "packages/daemon",
+        "packages/evasive-transform",
+        "packages/lp32",
+        "packages/memoize",
+        "packages/netstring",
+        "packages/syrup",
+        "packages/skel",
+        "packages/static-module-record",
+        "packages/stream-types-test",
+        "packages/where",
         "packages/test262-runner/"
     ],
     "name": "Endo API documentation",


### PR DESCRIPTION
refs: https://github.com/Agoric/documentation/issues/1031

## Description / Documentation Considerations

In https://github.com/Agoric/documentation/issues/1031 , we aim to define "the developer API product" and to supply corresponding reference docs.

This is a proposal to exclude whole packages from consideration, leaving them as implementation details or some such.

@sufyaankhan 

### Security / Scaling / Testing / Upgrade Considerations

n/a

### Compatibility Considerations

This could lower some compatibility burdens.

