### PR TITLE
docs(common): include utility modules in api-docs

### DIFF
--- a/packages/common/typedoc.json
+++ b/packages/common/typedoc.json
@@ -1,0 +1,8 @@
+{
+    "extends": [
+        "../../typedoc.base.json"
+    ],
+    "entryPoints": [
+        "*.js",
+    ]
+}


### PR DESCRIPTION
refs: https://github.com/Agoric/documentation/issues/1031

## Description / Documentation Considerations

https://endojs.github.io/endo/modules/_endo_common.html says "Each utility is in its own top-level source file" but there are no links to them.

### Security / Scaling / Testing / Compatibility / Upgrade Considerations

n/a
