### PR TITLE
feat(daemon,cli): One handle for every agent

### DIFF
--- a/packages/cli/demo/README.md
+++ b/packages/cli/demo/README.md
@@ -201,14 +201,14 @@ Then, assuming the guise of "alice", we find the message in our inbox
 and adopt the "doubler" object into our own store.
 
 ```
-> endo mkguest alice
+> endo mkguest alice alice-agent
 > endo send alice 'Please enjoy this @doubler.'
-> endo inbox --as alice
+> endo inbox --as alice-agent
 0. "HOST" sent "Please enjoy this @doubler."
-> endo adopt --as alice 0 doubler
-> endo list --as alice
+> endo adopt --as alice-agent 0 doubler
+> endo list --as alice-agent
 doubler
-> endo dismiss --as alice 0
+> endo dismiss --as alice-agent 0
 ```
 
 # Names in transit are no-one's names
@@ -227,12 +227,12 @@ Then, alice adopts "counter", giving it their own name, "redoubler".
 
 ```
 > endo send alice 'Please enjoy this @counter:doubler.'
-> endo inbox --as alice
+> endo inbox --as alice-agent
 1. "HOST" sent "Please enjoy this @counter."
-> endo adopt --as alice 1 counter --name redoubler
-> endo list --as alice
+> endo adopt --as alice-agent 1 counter --name redoubler
+> endo list --as alice-agent
 redoubler
-> endo dismiss --as alice 1
+> endo dismiss --as alice-agent 1
 ```
 
 # Mailboxes are symmetric
@@ -241,7 +241,7 @@ Guests can also send their host messages.
 In this example, "alice" send the doubler back to us, their host.
 
 ```
-> endo send HOST --as alice 'This is the @doubler you sent me.'
+> endo send HOST --as alice-agent 'This is the @doubler you sent me.'
 > endo inbox
 0. "alice" sent "This is the @doubler you sent me."
 > endo adopt 0 doubler doubler-from-alice
@@ -271,7 +271,7 @@ _Familiar Chat_ is an example application that provides a web app for
 interacting with your pet daemon.
 
 ```
-> endo install cat.js --listen 8920 --powers SELF --name familiar-chat
+> endo install cat.js --listen 8920 --powers AGENT --name familiar-chat
 ```
 
 This command creates a web page named familiar-chat and endows it with the
@@ -285,8 +285,8 @@ You can then open that page.
 So, if you were to simulate a request from your cat:
 
 ```
-> endo mkguest cat
-> endo request 'pet me' --as cat
+> endo mkguest cat cat-agent
+> endo request HOST 'pet me' --as cat-agent
 ```
 
 This will appear in your Familiar Chat web page, where you can resolve

--- a/packages/cli/demo/README.md
+++ b/packages/cli/demo/README.md
@@ -136,11 +136,15 @@ through which it obtains all of its authority.
 In this example, the doubler requests another counter from the user.
 
 We make a doubler mostly the same way we made the counter.
-However, we must give a name to the agent running the doubler, which we will
-later use to recognize requests coming from the doubler.
+However, we must create a guest profile for the doubler.
+The guest has two facets: its handle and its agent powers.
+The handle appears in the "to" and "from" fields of messages exchanged with the
+guest and provides no other capabilities.
+The agent is a permission management broker that the doubler
+can use to request other capabilities, like the counter.
 
 ```
-> endo mkguest doubler-agent
+> endo mkguest doubler-handle doubler-agent
 > endo make doubler.js --name doubler --powers doubler-agent
 ```
 
@@ -149,7 +153,7 @@ resolve its request for a counter.
 
 ```
 > endo inbox
-0. "doubler-agent" requested "please give me a counter"
+0. "doubler-handle" requested "please give me a counter"
 > endo resolve 0 counter
 ```
 

--- a/packages/cli/src/commands/mkguest.js
+++ b/packages/cli/src/commands/mkguest.js
@@ -3,8 +3,16 @@ import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
 
-export const mkguest = async ({ name, agentNames, introducedNames }) =>
+export const mkguest = async ({
+  handleName,
+  agentName,
+  agentNames,
+  introducedNames,
+}) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    const newGuest = await E(agent).provideGuest(name, { introducedNames });
+    const newGuest = await E(agent).provideGuest(handleName, {
+      introducedNames,
+      agentName,
+    });
     console.log(newGuest);
   });

--- a/packages/cli/src/commands/mkhost.js
+++ b/packages/cli/src/commands/mkhost.js
@@ -3,8 +3,16 @@ import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
 
-export const mkhost = async ({ name, agentNames, introducedNames }) =>
+export const mkhost = async ({
+  handleName,
+  agentName,
+  agentNames,
+  introducedNames,
+}) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    const newHost = await E(agent).provideHost(name, { introducedNames });
+    const newHost = await E(agent).provideHost(handleName, {
+      introducedNames,
+      agentName,
+    });
     console.log(newHost);
   });

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -415,7 +415,7 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('mkhost <name>')
+    .command('mkhost <handle-name> [agent-name]')
     .option(...commonOptions.as)
     .option(
       '--introduce <name>',
@@ -424,14 +424,14 @@ export const main = async rawArgs => {
       {},
     )
     .description('makes a separate mailbox and storage for you')
-    .action(async (name, cmd) => {
+    .action(async (handleName, agentName, cmd) => {
       const { as: agentNames, introduce: introducedNames } = cmd.opts();
       const { mkhost } = await import('./commands/mkhost.js');
-      return mkhost({ name, agentNames, introducedNames });
+      return mkhost({ handleName, agentName, agentNames, introducedNames });
     });
 
   program
-    .command('mkguest <name>')
+    .command('mkguest <handle-name> [agent-name]')
     .option(...commonOptions.as)
     .option(
       '--introduce <name>',
@@ -440,10 +440,10 @@ export const main = async rawArgs => {
       {},
     )
     .description('makes a mailbox and storage for a guest (peer or program)')
-    .action(async (name, cmd) => {
+    .action(async (handleName, agentName, cmd) => {
       const { as: agentNames, introduce: introducedNames } = cmd.opts();
       const { mkguest } = await import('./commands/mkguest.js');
-      return mkguest({ name, agentNames, introducedNames });
+      return mkguest({ agentName, handleName, agentNames, introducedNames });
     });
 
   program

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -558,11 +558,11 @@ const makeDaemonCore = async (
         context,
       );
     } else if (formula.type === 'handle') {
-      context.thisDiesIfThatDies(formula.target);
+      context.thisDiesIfThatDies(formula.agent);
       return {
         external: {},
         internal: {
-          targetId: formula.target,
+          agentId: formula.agent,
         },
       };
     } else if (formula.type === 'endo') {
@@ -885,13 +885,13 @@ const makeDaemonCore = async (
         return controller;
       }
       // @ts-expect-error We can't know the type of the internal facet.
-      if (internalFacet.targetId === undefined) {
+      if (internalFacet.agentId === undefined) {
         return controller;
       }
       const handle = /** @type {import('./types.js').InternalHandle} */ (
         internalFacet
       );
-      currentId = handle.targetId;
+      currentId = handle.agentId;
     }
   };
 
@@ -931,14 +931,14 @@ const makeDaemonCore = async (
    * The returned promise is resolved after the formula is persisted.
    *
    * @param {string} formulaNumber - The formula number of the handle to formulate.
-   * @param {string} targetId - The formula identifier of the handle's target.
+   * @param {string} agentId - The formula identifier of the handle's agent.
    * @returns {import('./types.js').FormulateResult<import('./types.js').ExternalHandle>} The formulated handle.
    */
-  const formulateNumberedHandle = (formulaNumber, targetId) => {
+  const formulateNumberedHandle = (formulaNumber, agentId) => {
     /** @type {import('./types.js').HandleFormula} */
     const formula = {
       type: 'handle',
-      target: targetId,
+      agent: agentId,
     };
     return /** @type {import('./types').FormulateResult<import('./types').ExternalHandle>} */ (
       formulate(formulaNumber, formula)

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -20,6 +20,8 @@ export const makeGuestMaker = ({
 }) => {
   /**
    * @param {string} guestId
+   * @param {string} handleId
+   * @param {string} hostAgentId
    * @param {string} hostHandleId
    * @param {string} petStoreId
    * @param {string} mainWorkerId
@@ -27,12 +29,15 @@ export const makeGuestMaker = ({
    */
   const makeIdentifiedGuestController = async (
     guestId,
+    handleId,
+    hostAgentId,
     hostHandleId,
     petStoreId,
     mainWorkerId,
     context,
   ) => {
     context.thisDiesIfThatDies(hostHandleId);
+    context.thisDiesIfThatDies(hostAgentId);
     context.thisDiesIfThatDies(petStoreId);
     context.thisDiesIfThatDies(mainWorkerId);
 
@@ -40,7 +45,8 @@ export const makeGuestMaker = ({
       await provide(petStoreId)
     );
     const specialStore = makePetSitter(basePetStore, {
-      SELF: guestId,
+      AGENT: guestId,
+      SELF: handleId,
       HOST: hostHandleId,
     });
     const hostController =
@@ -56,7 +62,7 @@ export const makeGuestMaker = ({
 
     const mailbox = makeMailbox({
       petStore: specialStore,
-      selfId: guestId,
+      selfId: handleId,
       context,
     });
     const { petStore } = mailbox;
@@ -90,8 +96,16 @@ export const makeGuestMaker = ({
       respond,
     } = mailbox;
 
+    const handle = makeExo(
+      'EndoGuestHandle',
+      M.interface('EndoGuestHandle', {}),
+      {},
+    );
+
     /** @type {import('./types.js').EndoGuest} */
     const guest = {
+      // Agent
+      handle: () => handle,
       // Directory
       has,
       identify,

--- a/packages/daemon/src/pet-name.js
+++ b/packages/daemon/src/pet-name.js
@@ -7,6 +7,11 @@ const validNamePattern = /^[a-z][a-z0-9-]{0,127}$/;
 /**
  * @param {string} petName
  */
+export const isPetName = petName => validNamePattern.test(petName);
+
+/**
+ * @param {string} petName
+ */
 export const assertPetName = petName => {
   if (typeof petName !== 'string' || !validNamePattern.test(petName)) {
     throw new Error(`Invalid pet name ${q(petName)}`);

--- a/packages/daemon/src/pet-sitter.js
+++ b/packages/daemon/src/pet-sitter.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { isPetName } from './pet-name.js';
 import { parseId } from './formula-identifier.js';
 
 const { quote: q } = assert;
@@ -19,6 +20,13 @@ export const makePetSitter = (petStore, specialNames) => {
   const identifyLocal = petName => {
     if (Object.hasOwn(specialNames, petName)) {
       return specialNames[petName];
+    }
+    if (!isPetName(petName)) {
+      throw new Error(
+        `Invalid pet name ${q(petName)} and not one of ${Object.keys(
+          specialNames,
+        ).join(', ')}`,
+      );
     }
     return petStore.identifyLocal(petName);
   };

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -178,7 +178,7 @@ type WebBundleFormula = {
 
 type HandleFormula = {
   type: 'handle';
-  target: string;
+  agent: string;
 };
 
 type KnownPeersStoreFormula = {
@@ -353,7 +353,7 @@ export interface Controller<External = unknown, Internal = unknown>
  * provide an EndoGuest with a reference to its creator EndoHost. By using a handle
  * that points to the host instead of giving a direct reference to the host, the
  * guest does not get access to the functions of the host. This is the external
- * facet of a handle. It directly exposes nothing. The handle's target is only
+ * facet of a handle. It directly exposes nothing. The handle's agent is only
  * exposed on the internal facet.
  */
 export interface ExternalHandle {}
@@ -362,7 +362,7 @@ export interface ExternalHandle {}
  * handle points to. This should not be exposed outside of the endo daemon.
  */
 export interface InternalHandle {
-  targetId: string;
+  agentId: string;
 }
 
 export type MakeSha512 = () => Sha512;

--- a/packages/daemon/test/service.js
+++ b/packages/daemon/test/service.js
@@ -2,13 +2,13 @@ import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';
 
-export const make = powers => {
+export const make = agent => {
   return makeExo(
     'Service',
     M.interface('Service', {}, { defaultGuards: 'passable' }),
     {
       async ask() {
-        return E(powers).request(
+        return E(agent).request(
           'HOST',
           'the meaning of life, the universe, everything',
           'answer',


### PR DESCRIPTION
Toward sending messages between mailboxes in separate nodes, this change gives every agent (both hosts and guests) a powerless handle that can be used to mention the agent without leaking agency.

This is somewhat tricky because this is the first cycle in the formula graph. The agent _contains_ a handle and the handle identifier and formula are just ways of referring to the facet held by the agent. So, writing an agent formula generates a handle formula as a side-effect and populates the agent id for handle table.

This also means that `mkguest` and `mkhost` need to designate the handle (so that messages from the other agent are visible) and might optionally also designate a pet name for the agent.