### PR TITLE
refactor(daemon): Move mail delivery to agent public facets

### DIFF
--- a/packages/cli/src/commands/inbox.js
+++ b/packages/cli/src/commands/inbox.js
@@ -1,4 +1,5 @@
 /* global process */
+/* eslint-disable no-continue */
 
 import os from 'os';
 import { E } from '@endo/far';
@@ -6,36 +7,67 @@ import { makeRefIterator } from '@endo/daemon';
 import { withEndoAgent } from '../context.js';
 import { formatMessage } from '../message-format.js';
 
+const { stringify: q } = JSON;
+
 export const inbox = async ({ follow, agentNames }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
+    const selfId = await E(agent).identify('SELF');
     const messages = follow
       ? makeRefIterator(E(agent).followMessages())
       : await E(agent).listMessages();
     for await (const message of messages) {
-      const { number, who, when } = message;
+      const { number, type, from, to, date } = message;
+
+      let verb = '';
+      if (type === 'request') {
+        verb = 'requested';
+      } else if (type === 'package') {
+        verb = 'sent';
+      } else {
+        verb = 'sent an unrecognizable message';
+      }
+
+      let provenance = 'unrecognizable message';
+      if (from === selfId && to === selfId) {
+        provenance = `you ${verb} yourself `;
+      } else if (from === selfId) {
+        const [toName] = await E(agent).reverseIdentify(to);
+        if (toName === undefined) {
+          continue;
+        }
+        provenance = `${verb} ${q(toName)} `;
+      } else if (to === selfId) {
+        const [fromName] = await E(agent).reverseIdentify(from);
+        if (fromName === undefined) {
+          continue;
+        }
+        provenance = `${q(fromName)} ${verb} `;
+      } else {
+        const [toName] = await E(agent).reverseIdentify(to);
+        const [fromName] = await E(agent).reverseIdentify(from);
+        if (fromName === undefined || toName === undefined) {
+          continue;
+        }
+        provenance = `${q(fromName)} ${verb} ${q(toName)} `;
+      }
+
       if (message.type === 'request') {
-        const { what } = message;
+        const { description } = message;
         console.log(
-          `${number}. ${JSON.stringify(who)} requested ${JSON.stringify(
-            what,
-          )} at ${JSON.stringify(when)}`,
+          `${number}. ${provenance}${JSON.stringify(
+            description,
+          )} at ${JSON.stringify(date)}`,
         );
       } else if (message.type === 'package') {
         const { strings, names: edgeNames } = message;
         console.log(
-          `${number}. ${JSON.stringify(who)} sent ${formatMessage(
+          `${number}. ${provenance}${formatMessage(
             strings,
             edgeNames,
-          )} at ${JSON.stringify(when)}`,
+          )} at ${JSON.stringify(date)}`,
         );
       } else {
-        console.log(
-          `${number}. ${JSON.stringify(
-            who,
-          )} sent an unrecognizable message at ${JSON.stringify(
-            when,
-          )}. Consider upgrading.`,
-        );
+        console.log(`${number}. ${provenance}, consider upgrading.`);
       }
     }
   });

--- a/packages/cli/src/commands/show.js
+++ b/packages/cli/src/commands/show.js
@@ -5,6 +5,6 @@ import { withEndoAgent } from '../context.js';
 
 export const show = async ({ name, agentNames }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    const pet = await E(agent).lookup(name);
+    const pet = await E(agent).lookup(...name.split('.'));
     console.log(pet);
   });

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -890,8 +890,8 @@ const makeDaemonCore = async (
     });
   };
 
-  /** @type {import('./types.js').DaemonCore['provideControllerAndResolveHandle']} */
-  const provideControllerAndResolveHandle = async id => {
+  /** @type {import('./types.js').DaemonCore['provideAgentControllerForHandleId']} */
+  const provideAgentControllerForHandleId = async id => {
     const handle = /** @type {{}} */ (await provide(id));
     const agentId = agentIdForHandle.get(handle);
     if (agentId === undefined) {
@@ -1580,12 +1580,12 @@ const makeDaemonCore = async (
 
   const makeMailbox = makeMailboxMaker({
     provide,
-    provideControllerAndResolveHandle,
+    provideAgentControllerForHandleId,
   });
 
   const makeIdentifiedGuestController = makeGuestMaker({
     provide,
-    provideControllerAndResolveHandle,
+    provideAgentControllerForHandleId,
     makeMailbox,
     makeDirectoryNode,
   });

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -890,18 +890,6 @@ const makeDaemonCore = async (
     });
   };
 
-  /** @type {import('./types.js').DaemonCore['provideAgentForHandle']} */
-  const provideAgentForHandle = async id => {
-    const handle = /** @type {{}} */ (await provide(id));
-    const agentId = agentIdForHandle.get(handle);
-    if (agentId === undefined) {
-      throw assert.error(assert.details`No agent for handle ${id}`);
-    }
-    return /** @type {Promise<import('./types.js').EndoAgent>} */ (
-      provide(agentId)
-    );
-  };
-
   /** @type {import('./types.js').DaemonCore['formulateReadableBlob']} */
   const formulateReadableBlob = async (readerRef, deferredTasks) => {
     const { formulaNumber, contentSha512 } = await formulaGraphJobs.enqueue(
@@ -1580,10 +1568,7 @@ const makeDaemonCore = async (
     formulateDirectory,
   });
 
-  const makeMailbox = makeMailboxMaker({
-    provide,
-    provideAgentForHandle,
-  });
+  const makeMailbox = makeMailboxMaker({ provide });
 
   const makeIdentifiedGuestController = makeGuestMaker({
     provide,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -890,14 +890,16 @@ const makeDaemonCore = async (
     });
   };
 
-  /** @type {import('./types.js').DaemonCore['provideAgentControllerForHandleId']} */
-  const provideAgentControllerForHandleId = async id => {
+  /** @type {import('./types.js').DaemonCore['provideAgentForHandle']} */
+  const provideAgentForHandle = async id => {
     const handle = /** @type {{}} */ (await provide(id));
     const agentId = agentIdForHandle.get(handle);
     if (agentId === undefined) {
       throw assert.error(assert.details`No agent for handle ${id}`);
     }
-    return provideController(agentId);
+    return /** @type {Promise<import('./types.js').EndoAgent>} */ (
+      provide(agentId)
+    );
   };
 
   /** @type {import('./types.js').DaemonCore['formulateReadableBlob']} */
@@ -1580,7 +1582,7 @@ const makeDaemonCore = async (
 
   const makeMailbox = makeMailboxMaker({
     provide,
-    provideAgentControllerForHandleId,
+    provideAgentForHandle,
   });
 
   const makeIdentifiedGuestController = makeGuestMaker({

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1585,7 +1585,6 @@ const makeDaemonCore = async (
 
   const makeIdentifiedGuestController = makeGuestMaker({
     provide,
-    provideAgentControllerForHandleId,
     makeMailbox,
     makeDirectoryNode,
   });

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -8,13 +8,13 @@ import { makePetSitter } from './pet-sitter.js';
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
- * @param {import('./types.js').DaemonCore['provideControllerAndResolveHandle']} args.provideControllerAndResolveHandle
+ * @param {import('./types.js').DaemonCore['provideAgentControllerForHandleId']} args.provideAgentControllerForHandleId
  * @param {import('./types.js').MakeMailbox} args.makeMailbox
  * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
  */
 export const makeGuestMaker = ({
   provide,
-  provideControllerAndResolveHandle,
+  provideAgentControllerForHandleId,
   makeMailbox,
   makeDirectoryNode,
 }) => {
@@ -51,7 +51,7 @@ export const makeGuestMaker = ({
     });
     const hostController =
       /** @type {import('./types.js').EndoHostController} */
-      (await provideControllerAndResolveHandle(hostHandleId));
+      (await provideAgentControllerForHandleId(hostHandleId));
     const hostPrivateFacet = await hostController.internal;
     const { respond: deliverToHost } = hostPrivateFacet;
     if (deliverToHost === undefined) {

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -68,6 +68,7 @@ export const makeGuestMaker = ({
     const { petStore } = mailbox;
     const directory = makeDirectoryNode(petStore);
 
+    const { reverseIdentify } = specialStore;
     const {
       has,
       identify,
@@ -109,6 +110,7 @@ export const makeGuestMaker = ({
       // Directory
       has,
       identify,
+      reverseIdentify,
       locate,
       list,
       listIdentifiers,

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -49,7 +49,7 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
       selfId: handleId,
       context,
     });
-    const { petStore } = mailbox;
+    const { petStore, handle } = mailbox;
     const directory = makeDirectoryNode(petStore);
 
     const { reverseIdentify } = specialStore;
@@ -80,16 +80,8 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
       deliver,
     } = mailbox;
 
-    const handle = makeExo(
-      'EndoGuestHandle',
-      M.interface('EndoGuestHandle', {}),
-      {},
-    );
-
     /** @type {import('./types.js').EndoGuest} */
     const guest = {
-      // Agent
-      handle: () => handle,
       // Directory
       has,
       identify,
@@ -106,6 +98,7 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
       copy,
       makeDirectory,
       // Mail
+      handle,
       listMessages,
       followMessages,
       resolve,

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -8,16 +8,10 @@ import { makePetSitter } from './pet-sitter.js';
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
- * @param {import('./types.js').DaemonCore['provideAgentControllerForHandleId']} args.provideAgentControllerForHandleId
  * @param {import('./types.js').MakeMailbox} args.makeMailbox
  * @param {import('./types.js').MakeDirectoryNode} args.makeDirectoryNode
  */
-export const makeGuestMaker = ({
-  provide,
-  provideAgentControllerForHandleId,
-  makeMailbox,
-  makeDirectoryNode,
-}) => {
+export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
   /**
    * @param {string} guestId
    * @param {string} handleId
@@ -49,16 +43,6 @@ export const makeGuestMaker = ({
       SELF: handleId,
       HOST: hostHandleId,
     });
-    const hostController =
-      /** @type {import('./types.js').EndoHostController} */
-      (await provideAgentControllerForHandleId(hostHandleId));
-    const hostPrivateFacet = await hostController.internal;
-    const { respond: deliverToHost } = hostPrivateFacet;
-    if (deliverToHost === undefined) {
-      throw new Error(
-        `panic: a host request function must exist for every host`,
-      );
-    }
 
     const mailbox = makeMailbox({
       petStore: specialStore,

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -77,8 +77,7 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
       dismiss,
       request,
       send,
-      receive,
-      respond,
+      deliver,
     } = mailbox;
 
     const handle = makeExo(
@@ -115,6 +114,7 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
       dismiss,
       request,
       send,
+      deliver,
     };
 
     const external = makeExo(
@@ -127,8 +127,6 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
       },
     );
     const internal = harden({
-      receive,
-      respond,
       petStore,
     });
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -95,7 +95,7 @@ export const makeHostMaker = ({
       selfId: handleId,
       context,
     });
-    const { petStore } = mailbox;
+    const { petStore, handle } = mailbox;
     const directory = makeDirectoryNode(petStore);
 
     const getEndoBootstrap = async () => {
@@ -504,16 +504,8 @@ export const makeHostMaker = ({
       deliver,
     } = mailbox;
 
-    const handle = makeExo(
-      'EndoHostHandle',
-      M.interface('EndoHostHandle', {}),
-      {},
-    );
-
     /** @type {import('./types.js').EndoHost} */
     const host = {
-      // Agent
-      handle: () => handle,
       // Directory
       has,
       identify,
@@ -530,6 +522,7 @@ export const makeHostMaker = ({
       copy,
       makeDirectory,
       // Mail
+      handle,
       listMessages,
       followMessages,
       resolve,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -97,7 +97,6 @@ export const makeHostMaker = ({
     });
     const { petStore } = mailbox;
     const directory = makeDirectoryNode(petStore);
-    const { lookup } = directory;
 
     const getEndoBootstrap = async () => {
       const endoBootstrap =
@@ -477,9 +476,11 @@ export const makeHostMaker = ({
       return peerInfo;
     };
 
+    const { reverseIdentify } = specialStore;
     const {
       has,
       identify,
+      lookup,
       locate,
       list,
       listIdentifiers,
@@ -517,6 +518,7 @@ export const makeHostMaker = ({
       // Directory
       has,
       identify,
+      reverseIdentify,
       locate,
       list,
       listIdentifiers,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -501,8 +501,7 @@ export const makeHostMaker = ({
       dismiss,
       request,
       send,
-      receive,
-      respond,
+      deliver,
     } = mailbox;
 
     const handle = makeExo(
@@ -551,6 +550,7 @@ export const makeHostMaker = ({
       gateway,
       getPeerInfo,
       addPeerInfo,
+      deliver,
     };
 
     const external = makeExo(
@@ -562,7 +562,7 @@ export const makeHostMaker = ({
         followMessages: () => makeIteratorRef(host.followMessages()),
       },
     );
-    const internal = harden({ receive, respond, petStore });
+    const internal = harden({ petStore });
 
     await provide(mainWorkerId);
 

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -9,12 +9,12 @@ const { quote: q } = assert;
 /**
  * @param {object} args
  * @param {import('./types.js').DaemonCore['provide']} args.provide
- * @param {import('./types.js').DaemonCore['provideControllerAndResolveHandle']} args.provideControllerAndResolveHandle
+ * @param {import('./types.js').DaemonCore['provideAgentControllerForHandleId']} args.provideAgentControllerForHandleId
  * @returns {import('./types.js').MakeMailbox}
  */
 export const makeMailboxMaker = ({
   provide,
-  provideControllerAndResolveHandle,
+  provideAgentControllerForHandleId,
 }) => {
   /**
     @type {import('./types.js').MakeMailbox} */
@@ -175,7 +175,7 @@ export const makeMailboxMaker = ({
       if (toId === undefined) {
         throw new Error(`Unknown pet name for agent: ${toName}`);
       }
-      const recipientController = await provideControllerAndResolveHandle(toId);
+      const recipientController = await provideAgentControllerForHandleId(toId);
       const recipientInternal = await recipientController.internal;
       if (recipientInternal === undefined || recipientInternal === null) {
         throw new Error(`Recipient cannot receive messages: ${toName}`);
@@ -278,7 +278,7 @@ export const makeMailboxMaker = ({
       if (toId === undefined) {
         throw new Error(`Unknown pet name for agent: ${toName}`);
       }
-      const recipientController = await provideControllerAndResolveHandle(toId);
+      const recipientController = await provideAgentControllerForHandleId(toId);
       const recipientInternal = await recipientController.internal;
       if (recipientInternal === undefined || recipientInternal === null) {
         throw new Error(

--- a/packages/daemon/src/pet-name.js
+++ b/packages/daemon/src/pet-name.js
@@ -13,7 +13,7 @@ export const isPetName = petName => validNamePattern.test(petName);
  * @param {string} petName
  */
 export const assertPetName = petName => {
-  if (typeof petName !== 'string' || !validNamePattern.test(petName)) {
+  if (typeof petName !== 'string' || !isPetName(petName)) {
     throw new Error(`Invalid pet name ${q(petName)}`);
   }
 };

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -232,16 +232,8 @@ export type Specials = {
   [specialName: string]: (builtins: Builtins) => Formula;
 };
 
-export type Label = {
-  number: number;
-  from: string;
-  to: string;
-  date: string;
-  dismissed: Promise<void>;
-};
-
 export interface Responder {
-  respondId(id: string): void;
+  respondId(id: string | Promise<string>): void;
 }
 
 export type Request = {
@@ -258,9 +250,18 @@ export type Package = {
   ids: Array<string>; // formula identifiers
 };
 
-export type Payload = Request | Package;
+export type Message = Request | Package;
 
-export type Message = Label & Payload;
+export type EnvelopedMessage = Message & {
+  to: string;
+  from: string;
+};
+
+export type StampedMessage = EnvelopedMessage & {
+  number: number;
+  date: string;
+  dismissed: Promise<void>;
+}
 
 export type Invitation = {
   powers: string;
@@ -417,8 +418,8 @@ export interface Mail {
   // Partial inheritance from PetStore:
   petStore: PetStore;
   // Mail operations:
-  listMessages(): Promise<Array<Message>>;
-  followMessages(): AsyncGenerator<Message, undefined, undefined>;
+  listMessages(): Promise<Array<StampedMessage>>;
+  followMessages(): AsyncGenerator<StampedMessage, undefined, undefined>;
   resolve(messageNumber: number, resolutionName: string): Promise<void>;
   reject(messageNumber: number, message?: string): Promise<void>;
   adopt(

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -257,11 +257,16 @@ export type EnvelopedMessage = Message & {
   from: string;
 };
 
+export interface Dismisser {
+  dismiss(): void;
+}
+
 export type StampedMessage = EnvelopedMessage & {
   number: number;
   date: string;
   dismissed: Promise<void>;
-}
+  dismisser: ERef<Dismisser>;
+};
 
 export type Invitation = {
   powers: string;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -357,22 +357,11 @@ export interface Controller<External = unknown, Internal = unknown>
   context: Context;
 }
 
-/**
- * A handle is used to create a pointer to a formula without exposing it directly.
- * This is the external facet of the handle and is safe to expose. This is used to
- * provide an EndoGuest with a reference to its creator EndoHost. By using a handle
- * that points to the host instead of giving a direct reference to the host, the
- * guest does not get access to the functions of the host. This is the external
- * facet of a handle. It directly exposes nothing. The handle's agent is only
- * exposed on the internal facet.
- */
-export interface ExternalHandle {}
-/**
- * This is the internal facet of a handle. It exposes the formula id that the
- * handle points to. This should not be exposed outside of the endo daemon.
- */
-export interface InternalHandle {
-  agentId: string;
+export interface Envelope {}
+
+export interface Handle {
+  receive(envelope: Envelope, allegedFromId: string): void;
+  open(envelope: Envelope): EnvelopedMessage;
 }
 
 export type MakeSha512 = () => Sha512;
@@ -420,6 +409,7 @@ export interface EndoDirectory extends NameHub {
 export type MakeDirectoryNode = (petStore: PetStore) => EndoDirectory;
 
 export interface Mail {
+  handle: () => Handle;
   // Partial inheritance from PetStore:
   petStore: PetStore;
   // Mail operations:

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -523,6 +523,11 @@ export interface EndoAgent extends EndoDirectory {
   dismiss: Mail['dismiss'];
   request: Mail['request'];
   send: Mail['send'];
+  /**
+   * @param id The formula identifier to look up.
+   * @returns The formula identifier for the given pet name, or `undefined` if the pet name is not found.
+   */
+  reverseIdentify(id: string): Array<string>;
 }
 
 export interface EndoGuest extends EndoAgent {}
@@ -530,11 +535,6 @@ export interface EndoGuest extends EndoAgent {}
 export type FarEndoGuest = FarRef<EndoGuest>;
 
 export interface EndoHost extends EndoAgent {
-  /**
-   * @param id The formula identifier to look up.
-   * @returns The formula identifier for the given pet name, or `undefined` if the pet name is not found.
-   */
-  reverseIdentify(id: string): Array<string>;
   store(
     readerRef: ERef<AsyncIterableIterator<string>>,
     petName: string,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -872,7 +872,7 @@ export interface DaemonCore {
 
   provideController: (id: string) => Controller;
 
-  provideControllerAndResolveHandle: (id: string) => Promise<Controller>;
+  provideAgentControllerForHandleId: (id: string) => Promise<Controller>;
 }
 
 export interface DaemonCoreExternal {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -234,33 +234,33 @@ export type Specials = {
 
 export type Label = {
   number: number;
-  who: string;
-  dest: string;
-  when: string;
+  from: string;
+  to: string;
+  date: string;
   dismissed: Promise<void>;
 };
-export type InternalLabel = Label;
+
+export interface Responder {
+  respondId(id: string): void;
+}
 
 export type Request = {
   type: 'request';
-  what: string;
+  description: string;
+  responder: ERef<Responder>;
   settled: Promise<'fulfilled' | 'rejected'>;
 };
-export type InternalRequest = Request;
 
 export type Package = {
   type: 'package';
   strings: Array<string>; // text that appears before, between, and after named formulas.
   names: Array<string>; // edge names
-  formulas: Array<string>; // formula identifiers
+  ids: Array<string>; // formula identifiers
 };
-export type InternalPackage = Package;
 
 export type Payload = Request | Package;
-export type InternalPayload = InternalRequest | InternalPackage;
 
 export type Message = Label & Payload;
-export type InternalMessage = InternalLabel & InternalPayload;
 
 export type Invitation = {
   powers: string;
@@ -530,6 +530,11 @@ export interface EndoGuest extends EndoAgent {}
 export type FarEndoGuest = FarRef<EndoGuest>;
 
 export interface EndoHost extends EndoAgent {
+  /**
+   * @param id The formula identifier to look up.
+   * @returns The formula identifier for the given pet name, or `undefined` if the pet name is not found.
+   */
+  reverseIdentify(id: string): Array<string>;
   store(
     readerRef: ERef<AsyncIterableIterator<string>>,
     petName: string,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -444,20 +444,7 @@ export interface Mail {
     edgeNames: Array<string>,
     petNames: Array<string>,
   ): Promise<void>;
-  respond(
-    what: string,
-    responseName: string,
-    senderId: string,
-    senderPetStore: PetStore,
-    recipientId?: string,
-  ): Promise<unknown>;
-  receive(
-    senderId: string,
-    strings: Array<string>,
-    edgeNames: Array<string>,
-    ids: Array<string>,
-    receiverId: string,
-  ): void;
+  deliver(message: EnvelopedMessage): void;
 }
 
 export type MakeMailbox = (args: {
@@ -472,13 +459,6 @@ export type RequestFn = (
   guestId: string,
   guestPetStore: PetStore,
 ) => Promise<unknown>;
-
-export type ReceiveFn = (
-  senderId: string,
-  strings: Array<string>,
-  edgeNames: Array<string>,
-  ids: Array<string>,
-) => void;
 
 export interface EndoReadable {
   sha512(): string;
@@ -529,6 +509,7 @@ export interface EndoAgent extends EndoDirectory {
   dismiss: Mail['dismiss'];
   request: Mail['request'];
   send: Mail['send'];
+  deliver: Mail['deliver'];
   /**
    * @param id The formula identifier to look up.
    * @returns The formula identifier for the given pet name, or `undefined` if the pet name is not found.
@@ -581,8 +562,6 @@ export interface EndoHost extends EndoAgent {
 }
 
 export interface InternalEndoAgent {
-  receive: Mail['receive'];
-  respond: Mail['respond'];
   petStore: PetStore;
 }
 
@@ -878,7 +857,7 @@ export interface DaemonCore {
 
   provideController: (id: string) => Controller;
 
-  provideAgentControllerForHandleId: (id: string) => Promise<Controller>;
+  provideAgentForHandle: (id: string) => Promise<ERef<EndoAgent>>;
 }
 
 export interface DaemonCoreExternal {

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -447,8 +447,9 @@ test('persist unconfined services and their requests', async t => {
     );
     const iteratorRef = E(host).followMessages();
     const { value: message } = await E(iteratorRef).next();
-    const { number, who } = E.get(message);
-    t.is(await who, 'h1');
+    const { number, from: fromId } = E.get(message);
+    const [fromName] = await E(host).reverseIdentify(await fromId);
+    t.is(await fromName, 'h1');
     await E(host).resolve(await number, 'grant');
   })();
 
@@ -510,8 +511,9 @@ test('persist confined services and their requests', async t => {
     );
     const iteratorRef = E(host).followMessages();
     const { value: message } = await E(iteratorRef).next();
-    const { number, who } = E.get(message);
-    t.is(await who, 'h1');
+    const { number, from: fromId } = E.get(message);
+    const [fromName] = await E(host).reverseIdentify(await fromId);
+    t.is(await fromName, 'h1');
     await E(host).resolve(await number, 'grant');
   })();
 
@@ -571,23 +573,30 @@ test('guest facet receives a message for host', async t => {
   const ten = await E(host).lookup('ten2');
   t.is(ten, 10);
 
+  const guestId = await E(host).identify('guest');
+  const hostId = await E(host).identify('SELF');
+
   // Host should have received messages.
   const hostInbox = await E(host).listMessages();
   t.deepEqual(
-    hostInbox.map(({ type, who, dest }) => ({ type, who, dest })),
+    hostInbox.map(({ type, from, to }) => ({
+      type,
+      from,
+      to,
+    })),
     [
-      { type: 'request', who: 'guest', dest: 'SELF' },
-      { type: 'package', who: 'guest', dest: 'SELF' },
+      { type: 'request', from: guestId, to: hostId },
+      { type: 'package', from: guestId, to: hostId },
     ],
   );
 
   // Guest should have own sent messages.
   const guestInbox = await E(guest).listMessages();
   t.deepEqual(
-    guestInbox.map(({ type, who, dest }) => ({ type, who, dest })),
+    guestInbox.map(({ type, from, to }) => ({ type, from, to })),
     [
-      { type: 'request', who: 'SELF', dest: 'HOST' },
-      { type: 'package', who: 'SELF', dest: 'HOST' },
+      { type: 'request', from: guestId, to: hostId },
+      { type: 'package', from: guestId, to: hostId },
     ],
   );
 });

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -1159,7 +1159,7 @@ test('guest cannot access host methods', async t => {
 
   const guest = E(host).provideGuest('guest');
   const guestsHost = E(guest).lookup('HOST');
-  await t.throwsAsync(() => E(guestsHost).lookup('ANY'), {
+  await t.throwsAsync(() => E(guestsHost).lookup(), {
     message: /target has no method "lookup"/u,
   });
   const revealedTarget = await E.get(guestsHost).targetId;


### PR DESCRIPTION
Toward delivering mail over the network, this change introduces a `deliver` method on guest and host agents that accepts arbitrary messages into the agent’s inbox. Any other agent can send mail to any other local agent for whom they have a handle and cannot spoof their sender handle.

This is a net simplification, since it reduces our dependence on the internal facet of agents and requires less machinery because it treats messages as capabilities on the wire, freely exposing and carrying identifiers. We no longer have separate internal and external representations of messages and pet name “dubbing” is deferred to the UI. This in turn enables us to defer to the UI the question of whether to query the name for each identifier once or watch for changes.

Stacked on #2184 