### PR TITLE
fix(compartment-mapper): fix ReadPowers-related types

### DIFF
--- a/packages/compartment-mapper/src/node-powers.js
+++ b/packages/compartment-mapper/src/node-powers.js
@@ -30,9 +30,10 @@ const fakePathToFileURL = path => {
  * but `makeReadPowers` presents a type that requires `url`.
  *
  * @param {object} args
- * @param {typeof import('fs')} args.fs
- * @param {typeof import('url')} [args.url]
- * @param {typeof import('crypto')} [args.crypto]
+ * @param {import('./types.js').FsAPI} args.fs
+ * @param {import('./types.js').UrlAPI} [args.url]
+ * @param {import('./types.js').CryptoAPI} [args.crypto]
+ * @returns {import('./types.js').MaybeReadPowers}
  */
 const makeReadPowersSloppy = ({ fs, url = undefined, crypto = undefined }) => {
   const fileURLToPath =

--- a/packages/compartment-mapper/src/powers.js
+++ b/packages/compartment-mapper/src/powers.js
@@ -18,7 +18,8 @@ export const unpackReadPowers = powers => {
   if (typeof powers === 'function') {
     read = powers;
   } else {
-    ({ read, maybeRead, canonical } = powers);
+    ({ read, maybeRead, canonical } =
+      /** @type {import('./types.js').MaybeReadPowers} */ (powers));
   }
 
   if (canonical === undefined) {

--- a/packages/compartment-mapper/src/types.js
+++ b/packages/compartment-mapper/src/types.js
@@ -165,8 +165,7 @@ export {};
  */
 
 /**
- * @typedef {ReadPowers | object} MaybeReadPowers
- * @property {MaybeReadFn} maybeRead
+ * @typedef {ReadPowers & {maybeRead: MaybeReadFn}} MaybeReadPowers
  */
 
 /**
@@ -503,4 +502,26 @@ export {};
 /**
  * Any object. All objects. Not `null`, though.
  * @typedef {Record<PropertyKey, any>} SomeObject
+ */
+
+/**
+ * @typedef FsPromisesApi
+ * @property {(filepath: string) => Promise<string>} realpath
+ * @property {ReadFn} readFile
+ */
+
+/**
+ * @typedef FsAPI
+ * @property {FsPromisesApi} promises
+ */
+
+/**
+ * @typedef UrlAPI
+ * @property {(location: string | URL) => string} fileURLToPath
+ * @property {(path: string) => URL} pathToFileURL
+ */
+
+/**
+ * @typedef CryptoAPI
+ * @property {typeof import('crypto').createHash} createHash
  */


### PR DESCRIPTION
## Description

This change:

1. Creates a minimal interface for the `fs`, `url`, and `crypto` objects as passed into `makeReadPowers()`. This makes it easier to duck-type the objects.
2. Fixes the invalid type of `MaybeReadPowers`; properties (defined thru `@property`) are ignored in a `@typedef` of that `@typedef` does not extend `object`/`Object`.
3. Added necessary type assertion in `powers.js`
4. Adds return type to `makeReadPowersSloppy()`

### Upgrade Considerations

This is a type-only change.
