### PR TITLE
docs(pass-style): don't rely on Remotable in Far docs

### DIFF
--- a/packages/pass-style/src/make-far.js
+++ b/packages/pass-style/src/make-far.js
@@ -164,16 +164,24 @@ const getMethodNamesDescriptor = harden({
 });
 
 /**
- * A concise convenience for the most common `Remotable` use.
+ * Mark an object to be exposed for remote interaction
+ * and give it a suggestive interface name for debugging.
  *
- * For far objects (as opposed to far functions), also adds a miranda
- * `GET_METHOD_NAMES` method that returns an array of all the method names,
- * if there is not yet any method named `GET_METHOD_NAMES`. (Hence "miranda")
+ * All properties of the object have to be methods, not data.
  *
+ * The object must not be hardened before it is marked.
+ * It will be hardened after marking.
+ *
+ * For far objects (as opposed to far functions), also adds
+ * `__getMethodNames__` method that returns an array of all the method names,
+ * if there is not yet any method named `__getMethodNames__`.
+ *
+ * @example
+ * Far('Employee', { getManager })
  * @template {{}} T
  * @param {string} farName This name will be prepended with `Alleged: `
  * for now to form the `Remotable` `iface` argument.
- * @param {T} [remotable] The object used as the remotable
+ * @param {T} [remotable] The object to be marked as remotable
  */
 export const Far = (farName, remotable = undefined) => {
   const r = remotable === undefined ? /** @type {T} */ ({}) : remotable;


### PR DESCRIPTION
refs:

 - https://github.com/Agoric/documentation/issues/1031

## Description / Documentation Considerations

The 1st bit of SDK used in the 1st sample app in our docs is `Far`.

https://github.com/Agoric/dapp-offer-up/blob/cbf3836dff05e95220a201f930430a10ce960ce3/contract/src/offer-up.contract.js#L22

likewise the "hello world" contract in [smart contract basics](https://docs.agoric.com/guides/zoe/contract-basics.html).

Far's JSDoc was in terms of Remotable. I don't think folks using `Far` need to know about `Remotable` so much.

There's momentum to skip `Far` and teach exo's from the start (https://github.com/Agoric/documentation/issues/1033) but we're not there yet.

### Security / Scaling / Testing / Compatibility / Upgrade Considerations

n/a