### PR TITLE
fix(ses): makeError defaults to making passable errors

### DIFF
--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -296,6 +296,7 @@ export const makeMarshal = (
           : `Remote${errConstructor.name}(${dErrorId})`;
       const options = {
         errorName,
+        sanitize: false,
       };
       if (cause) {
         options.cause = decodeRecur(cause);

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -298,6 +298,7 @@ export const toPassableError = err => {
     cause,
     errors,
   });
+  // Still needed, because `makeError` only does a shallow freeze.
   harden(newError);
   // Even the cleaned up error copy, if sent to the console, should
   // cause hidden diagnostic information of the original error

--- a/packages/pass-style/test/test-errors.js
+++ b/packages/pass-style/test/test-errors.js
@@ -30,9 +30,14 @@ test('style of extended errors', t => {
 });
 
 test('toPassableError rejects unfrozen errors', t => {
-  const e = makeError('test error');
+  const e = makeError('test error', undefined, {
+    sanitize: false,
+  });
   // I include this test because I was recently surprised that the errors
-  // make by `makeError` are not frozen, and therefore not passable.
+  // made by `makeError` are not frozen, and therefore not passable.
+  // Since then, we changed `makeError` to make reasonable effort
+  // to return a passable error by default. But also added the
+  // `sanitize: false` option to suppress that.
   t.false(Object.isFrozen(e));
   t.false(isPassable(e));
 
@@ -40,7 +45,12 @@ test('toPassableError rejects unfrozen errors', t => {
   // is a passable error.
   const e2 = toPassableError(e);
 
+  t.true(Object.isFrozen(e2));
+  t.true(isPassable(e2));
+
+  // May not be true on all platforms, depending on what "extraneous"
+  // properties the host added to the error before `makeError` returned it.
+  // If this fails, please let us know. See the doccomment on the
+  // `sanitizeError` function is the ses-shim's `assert.js`.
   t.is(e, e2);
-  t.true(Object.isFrozen(e));
-  t.true(isPassable(e));
 });

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -27,9 +27,24 @@
 /**
  * @typedef {object} AssertMakeErrorOptions
  * @property {string} [errorName]
+ *   Does not affect the error.name property. That remains determined by
+ *   the constructor. Rather, the `errorName` determines how this error is
+ *   identified in the causal console log's output.
  * @property {Error} [cause]
+ *   Discloses the error that caused this one, typically from a lower
+ *   layer of abstraction. This is represented by a public `cause` data property
+ *   on the error, not a hidden annotation.
  * @property {Error[]} [errors]
- *   Normally only used when the ErrorConstuctor is `AggregateError`
+ *   Normally only used when the ErrorConstuctor is `AggregateError`, to
+ *   represent the set of prior errors aggregated together in this error,
+ *   typically by `Promise.any`. But `makeError` allows it on any error.
+ *   This is represented by a public `errors` data property on the error,
+ *   not a hidden annotation.
+ * @property {boolean} [sanitize]
+ *   Defaults to true. If true, `makeError` will apply `sanitizeError`
+ *   to the error before returning it. See the comments on `sanitizeError`.
+ *   (TODO what is the proper jsdoc manner to link to another function's
+ *   doc-comment?)
  */
 
 /**

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -121,6 +121,7 @@ export interface AssertMakeErrorOptions {
   errorName?: string;
   cause?: Error;
   errors?: Error[];
+  sanitize?: boolean;
 }
 
 type AssertTypeofBigint = (


### PR DESCRIPTION
closes: #2198 
refs: #2156 

## Description

The symptoms of #2156 reveal that some hosts add "extraneous" or harmful own properties to errors
- Chrome, Brave (v8) adds an own `stack` accessor property, whose getter and setter functions can be used for mischief.
- Firefox (SpiderMonkey) adds own `fileName` and `lineNumber` properties that are useful for diagnostics but should be redacted from public view.
- Safari (JSC) adds an own `line` property, that likewise is useful for diagnostics, but should be redacted from public view.

Note that the contents of the stack should also be redacted from public view, but SES already deals with that separately.

Prior to this PR, some code assumed that the error that `makeError` returns would be passable once frozen. But these extra own properties, or own accessor properties, added by the host before `makeError` returns the error, caused it not to be passable, causing #2198 . As of this PR, `makeError` *by default* makes reasonable effort to return a passable error despite such host-added own properties. However, some code took advantage of the mutability of the error that `makeError` was returning, so this PR adds a `sanitize: false` option to suppress this cleaning and freezing of the returned error.

`makeError` does *not* guarantee that the returned error is passable, no matter what `cause` or `errors` options are provided. The purpose of this new sanitization behavior is to protect against host mischief. To test or coerce an error into a passable error, use `toPassable` in @endo/pass-style.


### Security Considerations

Having `makeError`, by default, return errors that are already better behaved and more discreet helps security. However, because the underlying platform makes errors that are not sanitized in this manner, this PR doesn't help security significantly.

### Scaling Considerations

none

### Documentation Considerations

I added doc-comments to the `makeError` options doc-comment. However, the important added doccomment is on the new `sanitizeError` function which is encapsulated with SES's assert.js. I made a `TODO` that I don't know how one doccomment can link to another.

### Testing Considerations

This problem was caught by accident. We should do enough browser-based testing early enough that problems like this would be caught first by purposeful testing.

### Compatibility Considerations

This PR is staged on #2156. Like #2156, it presents a compat problem in theory but likely not in practice. #2156 stops exporting `isPassableError` and `assertPassableError`, which it turns out were never correct but which no one imports or uses. 

This PR changes `makeError` to return a "sanitized" and frozen error, where it used to return a non-sanitized and non-frozen error. I looked through every call to `makeError` in endo and agoric-sdk, and found one site that made use of the non-frozen nature of that error. However, `makeError` is much older, so it is more plausible that there are other such uses outside these two repos. To accommodate that one known use case and mitigate problems at possible others, this PR adds a `sanitize: false` option to `makeError` to recover the old behavior. That one known site uses this option.

I leave it to my reviewers whether this PR as well as #2156 should be marked with a `!` or not. In theory both should be. IMO, we should mark neither with `!`. Please let me know.

### Upgrade Considerations

Since this bug manifested for #2156 on unmarshalling, i.e., unserializing use the `@endo/marshal` mechanisms, that bug raises the possibility of an upgrade hazard -- that an error saved to durable storage before an upgrade might cause another error on the attempt to read it from durable storage after the upgrade. This PR prevents that hazard.

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
