### PR TITLE
refactor(daemon): Factor out internal facets

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -109,6 +109,8 @@ const makeDaemonCore = async (
   } = powers;
   const { randomHex512 } = cryptoPowers;
   const contentStore = persistencePowers.makeContentSha512Store();
+  /** @type {WeakMap<object, import('@endo/eventual-send').ERef<import('./worker.js').WorkerBootstrap>>} */
+  const workerDaemonFacets = new WeakMap();
   /**
    * Mutations of the formula graph must be serialized through this queue.
    * "Mutations" include:
@@ -313,9 +315,12 @@ const makeDaemonCore = async (
       {},
     );
 
+    // @ts-expect-error Evidently not specific enough.
+    workerDaemonFacets.set(worker, workerDaemonFacet);
+
     return {
       external: worker,
-      internal: workerDaemonFacet,
+      internal: undefined,
     };
   };
 
@@ -355,17 +360,13 @@ const makeDaemonCore = async (
       context.thisDiesIfThatDies(id);
     }
 
-    const workerController =
-      /** @type {import('./types.js').Controller<unknown, import('./worker.js').WorkerBootstrap>} */ (
-        // Behold, recursion:
-        // eslint-disable-next-line no-use-before-define
-        provideController(workerId)
-      );
-    const workerDaemonFacet = workerController.internal;
-    assert(
-      workerDaemonFacet,
-      `panic: No internal bootstrap for worker ${workerId}`,
+    const worker = /** @type {import('./worker.js').WorkerBootstrap} */ (
+      // Behold, recursion:
+      // eslint-disable-next-line no-use-before-define
+      await provide(workerId)
     );
+    const workerDaemonFacet = workerDaemonFacets.get(worker);
+    assert(workerDaemonFacet, `Cannot evaluate using non-worker`);
 
     const endowmentValues = await Promise.all(
       ids.map(id =>
@@ -428,17 +429,13 @@ const makeDaemonCore = async (
     context.thisDiesIfThatDies(workerId);
     context.thisDiesIfThatDies(powersId);
 
-    const workerController =
-      /** @type {import('./types.js').Controller<unknown, import('./worker.js').WorkerBootstrap>} */ (
-        // Behold, recursion:
-        // eslint-disable-next-line no-use-before-define
-        provideController(workerId)
-      );
-    const workerDaemonFacet = workerController.internal;
-    assert(
-      workerDaemonFacet,
-      `panic: No internal bootstrap for worker ${workerId}`,
+    const worker = /** @type {import('./worker.js').WorkerBootstrap} */ (
+      // Behold, recursion:
+      // eslint-disable-next-line no-use-before-define
+      await provide(workerId)
     );
+    const workerDaemonFacet = workerDaemonFacets.get(worker);
+    assert(workerDaemonFacet, 'Cannot make unconfined plugin with non-worker');
     // Behold, recursion:
     // eslint-disable-next-line no-use-before-define
     const powersP = provide(powersId);
@@ -466,17 +463,13 @@ const makeDaemonCore = async (
     context.thisDiesIfThatDies(workerId);
     context.thisDiesIfThatDies(powersId);
 
-    const workerController =
-      /** @type {import('./types.js').Controller<unknown, import('./worker.js').WorkerBootstrap>} */ (
-        // Behold, recursion:
-        // eslint-disable-next-line no-use-before-define
-        provideController(workerId)
-      );
-    const workerDaemonFacet = workerController.internal;
-    assert(
-      workerDaemonFacet,
-      `panic: No internal bootstrap for worker ${workerId}`,
+    const worker = /** @type {import('./worker.js').WorkerBootstrap} */ (
+      // Behold, recursion:
+      // eslint-disable-next-line no-use-before-define
+      await provide(workerId)
     );
+    const workerDaemonFacet = workerDaemonFacets.get(worker);
+    assert(workerDaemonFacet, 'Cannot make caplet with non-worker');
     const readableBundleP =
       /** @type {Promise<import('./types.js').EndoReadable>} */ (
         // Behold, recursion:

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -320,7 +320,6 @@ const makeDaemonCore = async (
 
     return {
       external: worker,
-      internal: undefined,
     };
   };
 
@@ -337,7 +336,6 @@ const makeDaemonCore = async (
         text,
         json,
       }),
-      internal: undefined,
     };
   };
 
@@ -392,7 +390,7 @@ const makeDaemonCore = async (
     // That might mean racing two formulas and terminating the evaluator
     // if it turns out the value can be captured.
 
-    return { external, internal: undefined };
+    return { external };
   };
 
   /**
@@ -411,7 +409,7 @@ const makeDaemonCore = async (
     const hub = provide(hubId);
     // @ts-expect-error calling lookup on an unknown object
     const external = E(hub).lookup(...path);
-    return { external, internal: undefined };
+    return { external };
   };
 
   /**
@@ -445,7 +443,7 @@ const makeDaemonCore = async (
       /** @type {any} */ (powersP),
       /** @type {any} */ (makeFarContext(context)),
     );
-    return { external, internal: undefined };
+    return { external };
   };
 
   /**
@@ -485,7 +483,7 @@ const makeDaemonCore = async (
       /** @type {any} */ (powersP),
       /** @type {any} */ (makeFarContext(context)),
     );
-    return { external, internal: undefined };
+    return { external };
   };
 
   /**
@@ -571,10 +569,7 @@ const makeDaemonCore = async (
       );
       const handle = agent.handle();
       agentIdForHandle.set(handle, formula.agent);
-      return {
-        external: handle,
-        internal: undefined,
-      };
+      return { external: handle };
     } else if (formula.type === 'endo') {
       // Gateway is equivalent to E's "nonce locator". It provides a value for
       // a formula identifier to a remote client.
@@ -649,20 +644,14 @@ const makeDaemonCore = async (
           await knownPeers.write(nodeIdentifier, peerId);
         },
       });
-      return {
-        external: endoBootstrap,
-        internal: undefined,
-      };
+      return { external: endoBootstrap };
     } else if (formula.type === 'loopback-network') {
       // Behold, forward-reference:
       const loopbackNetwork = makeLoopbackNetwork({
         // eslint-disable-next-line no-use-before-define
         provide,
       });
-      return {
-        external: loopbackNetwork,
-        internal: undefined,
-      };
+      return { external: loopbackNetwork };
     } else if (formula.type === 'least-authority') {
       const disallowedFn = async () => {
         throw new Error('not allowed');
@@ -697,14 +686,14 @@ const makeDaemonCore = async (
             )
           )
         );
-      return { external: leastAuthority, internal: undefined };
+      return { external: leastAuthority };
     } else if (formula.type === 'pet-store') {
       const external = petStorePowers.makeIdentifiedPetStore(
         formulaNumber,
         'pet-store',
         assertPetName,
       );
-      return { external, internal: undefined };
+      return { external };
     } else if (formula.type === 'known-peers-store') {
       const external = petStorePowers.makeIdentifiedPetStore(
         formulaNumber,
@@ -713,12 +702,12 @@ const makeDaemonCore = async (
         // (i.e. formula numbers) as "names".
         assertValidNumber,
       );
-      return { external, internal: undefined };
+      return { external };
     } else if (formula.type === 'pet-inspector') {
       // Behold, unavoidable forward-reference:
       // eslint-disable-next-line no-use-before-define
       const external = makePetStoreInspector(formula.petStore);
-      return { external, internal: undefined };
+      return { external };
     } else if (formula.type === 'directory') {
       // Behold, forward-reference:
       // eslint-disable-next-line no-use-before-define
@@ -787,7 +776,6 @@ const makeDaemonCore = async (
         }
         return value;
       }),
-      internal: E.get(partial).internal,
     });
     controllerForId.set(id, controller);
 
@@ -830,7 +818,6 @@ const makeDaemonCore = async (
     controller = harden({
       context,
       external: E.get(partial).external,
-      internal: E.get(partial).internal,
     });
     controllerForId.set(id, controller);
 

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -236,7 +236,7 @@ export const makeDirectoryMaker = ({
     );
     const directory = makeDirectoryNode(petStore);
 
-    const external = makeExo(
+    return makeExo(
       'EndoDirectory',
       M.interface('EndoDirectory', {}, { defaultGuards: 'passable' }),
       {
@@ -244,9 +244,6 @@ export const makeDirectoryMaker = ({
         followChanges: () => makeIteratorRef(directory.followChanges()),
       },
     );
-    const internal = harden({});
-
-    return harden({ external, internal });
   };
 
   return { makeIdentifiedDirectory, makeDirectoryNode };

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -119,11 +119,8 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
         followMessages: () => makeIteratorRef(guest.followMessages()),
       },
     );
-    const internal = harden({
-      petStore,
-    });
 
-    return harden({ external, internal });
+    return harden({ external });
   };
 
   return makeIdentifiedGuestController;

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -21,7 +21,7 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
    * @param {string} mainWorkerId
    * @param {import('./types.js').Context} context
    */
-  const makeIdentifiedGuestController = async (
+  const makeGuest = async (
     guestId,
     handleId,
     hostAgentId,
@@ -110,7 +110,7 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
       deliver,
     };
 
-    const external = makeExo(
+    return makeExo(
       'EndoGuest',
       M.interface('EndoGuest', {}, { defaultGuards: 'passable' }),
       {
@@ -119,9 +119,7 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
         followMessages: () => makeIteratorRef(guest.followMessages()),
       },
     );
-
-    return harden({ external });
   };
 
-  return makeIdentifiedGuestController;
+  return makeGuest;
 };

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -324,21 +324,21 @@ export const makeHostMaker = ({
      * Attempts to introduce the given names to the specified agent. The agent in question
      * must be formulated before this function is called.
      *
-     * @param {string} id - The agent's formula identifier.
+     * @param {string} agentId - The agent's formula identifier.
      * @param {Record<string,string>} introducedNames - The names to introduce.
      * @returns {Promise<void>}
      */
-    const introduceNamesToAgent = async (id, introducedNames) => {
-      /** @type {import('./types.js').Controller<any, any>} */
-      const controller = provideController(id);
-      const { petStore: newPetStore } = await controller.internal;
+    const introduceNamesToAgent = async (agentId, introducedNames) => {
+      const agent = /** @type {import('./types.js').EndoAgent} */ (
+        await provide(agentId)
+      );
       await Promise.all(
         Object.entries(introducedNames).map(async ([parentName, childName]) => {
           const introducedId = petStore.identifyLocal(parentName);
           if (introducedId === undefined) {
             return;
           }
-          await newPetStore.write(childName, introducedId);
+          await agent.write([childName], introducedId);
         }),
       );
     };

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -60,7 +60,7 @@ export const makeHostMaker = ({
    * @param {{[name: string]: string}} platformNames
    * @param {import('./types.js').Context} context
    */
-  const makeIdentifiedHost = async (
+  const makeHost = async (
     hostId,
     handleId,
     storeId,
@@ -384,7 +384,7 @@ export const makeHostMaker = ({
      * @param {import('./types.js').MakeHostOrGuestOptions} [opts]
      * @returns {Promise<{id: string, value: Promise<import('./types.js').EndoHost>}>}
      */
-    const makeHost = async (
+    const makeChildHost = async (
       petName,
       { introducedNames = {}, agentName = undefined } = {},
     ) => {
@@ -408,7 +408,7 @@ export const makeHostMaker = ({
 
     /** @type {import('./types.js').EndoHost['provideHost']} */
     const provideHost = async (petName, opts) => {
-      const { value } = await makeHost(petName, opts);
+      const { value } = await makeChildHost(petName, opts);
       return value;
     };
 
@@ -546,7 +546,7 @@ export const makeHostMaker = ({
       deliver,
     };
 
-    const external = makeExo(
+    const hostExo = makeExo(
       'EndoHost',
       M.interface('EndoHost', {}, { defaultGuards: 'passable' }),
       {
@@ -555,12 +555,11 @@ export const makeHostMaker = ({
         followMessages: () => makeIteratorRef(host.followMessages()),
       },
     );
-    const internal = harden({ petStore });
 
     await provide(mainWorkerId);
 
-    return harden({ external, internal });
+    return hostExo;
   };
 
-  return makeIdentifiedHost;
+  return makeHost;
 };

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -342,16 +342,8 @@ export interface FarContext {
   addDisposalHook: Context['onCancel'];
 }
 
-export interface InternalExternal<External = unknown> {
-  external: External;
-}
-
-export interface ControllerPartial<External = unknown> {
-  external: Promise<External>;
-}
-
-export interface Controller<External = unknown>
-  extends ControllerPartial<External> {
+export interface Controller<Value = unknown> {
+  value: Promise<Value>;
   context: Context;
 }
 
@@ -469,8 +461,6 @@ export type MakeHostOrGuestOptions = {
 export interface EndoPeer {
   provide: (id: string) => Promise<unknown>;
 }
-export type EndoPeerControllerPartial = ControllerPartial<EndoPeer>;
-export type EndoPeerController = Controller<EndoPeer>;
 
 export interface EndoGateway {
   provide: (id: string) => Promise<unknown>;
@@ -650,11 +640,12 @@ export type DaemonicPersistencePowers = {
 export interface DaemonWorkerFacet {}
 
 export interface WorkerDaemonFacet {
-  terminate(): void;
+  terminate(): Promise<void>;
   evaluate(
     source: string,
     names: Array<string>,
     values: Array<unknown>,
+    id: string,
     cancelled: Promise<never>,
   ): Promise<unknown>;
   makeBundle(bundle: ERef<EndoReadable>, powers: ERef<unknown>);

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -342,18 +342,16 @@ export interface FarContext {
   addDisposalHook: Context['onCancel'];
 }
 
-export interface InternalExternal<External = unknown, Internal = unknown> {
+export interface InternalExternal<External = unknown> {
   external: External;
-  internal: Internal;
 }
 
-export interface ControllerPartial<External = unknown, Internal = unknown> {
+export interface ControllerPartial<External = unknown> {
   external: Promise<External>;
-  internal: Promise<Internal>;
 }
 
-export interface Controller<External = unknown, Internal = unknown>
-  extends ControllerPartial<External, Internal> {
+export interface Controller<External = unknown>
+  extends ControllerPartial<External> {
   context: Context;
 }
 
@@ -471,8 +469,8 @@ export type MakeHostOrGuestOptions = {
 export interface EndoPeer {
   provide: (id: string) => Promise<unknown>;
 }
-export type EndoPeerControllerPartial = ControllerPartial<EndoPeer, undefined>;
-export type EndoPeerController = Controller<EndoPeer, undefined>;
+export type EndoPeerControllerPartial = ControllerPartial<EndoPeer>;
+export type EndoPeerController = Controller<EndoPeer>;
 
 export interface EndoGateway {
   provide: (id: string) => Promise<unknown>;
@@ -551,12 +549,7 @@ export interface EndoHost extends EndoAgent {
   addPeerInfo(peerInfo: PeerInfo): Promise<void>;
 }
 
-export interface InternalEndoAgent {
-  petStore: PetStore;
-}
-
-export interface EndoHostController
-  extends Controller<FarRef<EndoHost>, InternalEndoAgent> {}
+export interface EndoHostController extends Controller<FarRef<EndoHost>> {}
 
 export type EndoInspector<Record = string> = {
   lookup: (petName: Record) => Promise<unknown>;

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -1011,7 +1011,7 @@ test('name and reuse inspector', async t => {
 });
 
 // Regression test for https://github.com/endojs/endo/issues/2021
-test.failing('eval-mediated worker name', async t => {
+test('eval-mediated worker name', async t => {
   const { cancelled, locator } = await prepareLocator(t);
   const { host } = await makeHost(locator, cancelled);
 

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -266,8 +266,7 @@ test('spawning a worker does not overwrite existing non-worker name', async t =>
   // with a new worker.
   await E(host).provideWorker('foo');
   await t.throwsAsync(() => E(host).evaluate('foo', '20', [], [], 'bar'), {
-    message:
-      'Cannot deliver "evaluate" to target; typeof target is "undefined"',
+    message: 'Cannot evaluate using non-worker',
   });
 });
 


### PR DESCRIPTION
This is a simplifying refactor that reduces {internal, external} controller facets to just the (external) value. In preparation, removes the last vestiges of internal facets on worker and agent. Then mops up by collapsing the controller logic and structures.