### PR TITLE
refactor(daemon): Parameterize provide type assertion

### DIFF
--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -30,11 +30,8 @@ export const makeDirectoryMaker = ({
       if (id === undefined) {
         throw new TypeError(`Unknown pet name: ${q(headName)}`);
       }
-      // Behold, recursion:
-      // eslint-disable-next-line no-use-before-define
-      const value = provide(id);
+      const value = provide(id, 'hub');
       return tailNames.reduce(
-        // @ts-expect-error We assume its a NameHub
         (directory, petName) => E(directory).lookup(petName),
         value,
       );
@@ -231,9 +228,7 @@ export const makeDirectoryMaker = ({
   const makeIdentifiedDirectory = async ({ petStoreId, context }) => {
     // TODO thread context
 
-    const petStore = /** @type {import('./types.js').PetStore} */ (
-      await provide(petStoreId)
-    );
+    const petStore = await provide(petStoreId, 'pet-store');
     const directory = makeDirectoryNode(petStore);
 
     return makeExo(

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -35,9 +35,7 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
     context.thisDiesIfThatDies(petStoreId);
     context.thisDiesIfThatDies(mainWorkerId);
 
-    const basePetStore = /** @type {import('./types.js').PetStore} */ (
-      await provide(petStoreId)
-    );
+    const basePetStore = await provide(petStoreId, 'pet-store');
     const specialStore = makePetSitter(basePetStore, {
       AGENT: guestId,
       SELF: handleId,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -452,10 +452,7 @@ export interface EndoReadable {
 }
 export type FarEndoReadable = FarRef<EndoReadable>;
 
-export interface EndoWorker {
-  terminate(): void;
-  whenTerminated(): Promise<void>;
-}
+export interface EndoWorker {}
 
 export type MakeHostOrGuestOptions = {
   agentName?: string;
@@ -559,7 +556,7 @@ export type KnownEndoInspectors = {
   [formulaType: string]: EndoInspector<string>;
 };
 
-export type FarEndoBootstrap = FarRef<{
+export type EndoBootstrap = {
   ping: () => Promise<string>;
   terminate: () => Promise<void>;
   host: () => Promise<EndoHost>;
@@ -567,7 +564,9 @@ export type FarEndoBootstrap = FarRef<{
   gateway: () => Promise<EndoGateway>;
   reviveNetworks: () => Promise<void>;
   addPeerInfo: (peerInfo: PeerInfo) => Promise<void>;
-}>;
+};
+
+export type FarEndoBootstrap = FarRef<EndoBootstrap>;
 
 export type CryptoPowers = {
   makeSha512: () => Sha512;
@@ -718,6 +717,30 @@ type FormulateNumberedHostParams = {
   networksDirectoryId: string;
 };
 
+export type FormulaValueTypes = {
+  directory: EndoDirectory;
+  network: EndoNetwork;
+  peer: EndoGateway;
+  'pet-store': PetStore;
+  'readable-blob': EndoReadable;
+  endo: EndoBootstrap;
+  guest: EndoGuest;
+  handle: Handle;
+  host: EndoHost;
+  invitation: Invitation;
+  worker: EndoWorker;
+};
+
+export type ProvideTypes = FormulaValueTypes & {
+  agent: EndoAgent;
+  hub: NameHub;
+};
+
+export type Provide = <T extends keyof ProvideTypes, U extends ProvideTypes[T]>(
+  id: string,
+  expectedType?: T,
+) => Promise<U>;
+
 export interface DaemonCore {
   cancelValue: (id: string, reason: Error) => Promise<void>;
 
@@ -830,7 +853,7 @@ export interface DaemonCore {
 
   makeMailbox: MakeMailbox;
 
-  provide: (id: string) => Promise<unknown>;
+  provide: Provide;
 
   provideController: (id: string) => Controller;
 


### PR DESCRIPTION
This change adds a vestigial second argument to `provide` that just hints to TypeScript the expected return type, resulting is much less verbose type narrowing. I’ve also advanced `provide` higher in the flow so it can eat all the forward-reference lint comments.