### PR TITLE
feat(daemon): Always stop the daemon on purge

### DIFF
--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -535,7 +535,7 @@ export const main = async rawArgs => {
   program
     .command('purge')
     .option('-f, --force', 'skip the confirmation prompt')
-    .description('erases persistent state and restarts if running')
+    .description('erases persistent state and stops if running')
     .action(async cmd => {
       const { force } = cmd.opts();
       const doPurge =

--- a/packages/daemon/index.js
+++ b/packages/daemon/index.js
@@ -160,12 +160,7 @@ export const restart = async (locator = defaultLocator) => {
 };
 
 export const purge = async (locator = defaultLocator) => {
-  // Attempt to restore to a running state if currently running, based on
-  // whether we manage to terminate it.
-  const needsRestart = await terminate(locator).then(
-    () => true,
-    () => false,
-  );
+  await terminate(locator).catch(() => {});
 
   const cleanedUp = clean(locator);
   const removedState = removePath(locator.statePath).catch(enoentOk);
@@ -179,8 +174,4 @@ export const purge = async (locator = defaultLocator) => {
     removedEphemeralState,
     removedCache,
   ]);
-
-  if (needsRestart) {
-    await start(locator);
-  }
 };

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -184,7 +184,6 @@ const prepareLocator = async t => {
     getLocatorDirectoryName(t.title, t.context.length),
   );
 
-  await stop(locator).catch(() => {});
   await purge(locator);
   await start(locator);
 


### PR DESCRIPTION
Ensures that the daemon is not restarted after being purged, even if it was previously running. Any CLI command will simply restart the daemon anyway.