### PR TITLE
feat(daemon): Invitations

### DIFF
--- a/packages/cli/src/commands/accept.js
+++ b/packages/cli/src/commands/accept.js
@@ -1,0 +1,20 @@
+/* global process */
+import os from 'os';
+import { E } from '@endo/far';
+import { withEndoAgent } from '../context.js';
+
+const fromAsync = async iterable => {
+  const all = [];
+  for await (const iterand of iterable) {
+    all.push(iterand);
+  }
+  return all;
+};
+
+export const accept = async ({ guestName, agentNames }) => {
+  process.stdin.setEncoding('utf-8');
+  const invitationLocator = (await fromAsync(process.stdin)).join('').trim();
+  return withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
+    await E(agent).accept(invitationLocator.trim(), guestName);
+  });
+};

--- a/packages/cli/src/commands/invite.js
+++ b/packages/cli/src/commands/invite.js
@@ -1,0 +1,11 @@
+/* global process */
+import os from 'os';
+import { E } from '@endo/far';
+import { withEndoAgent } from '../context.js';
+
+export const invite = async ({ guestName, agentNames }) =>
+  withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
+    const invitation = await E(agent).invite(guestName);
+    const locator = await E(invitation).locate();
+    console.log(locator);
+  });

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -447,6 +447,24 @@ export const main = async rawArgs => {
     });
 
   program
+    .command('invite <guest-name>')
+    .option(...commonOptions.as)
+    .action(async (guestName, cmd) => {
+      const { as: agentNames } = cmd.opts();
+      const { invite } = await import('./commands/invite.js');
+      return invite({ agentNames, guestName });
+    });
+
+  program
+    .command('accept <guest-name>')
+    .option(...commonOptions.as)
+    .action(async (guestName, cmd) => {
+      const { as: agentNames } = cmd.opts();
+      const { accept } = await import('./commands/accept.js');
+      return accept({ agentNames, guestName });
+    });
+
+  program
     .command('cancel <name> [reason]')
     .option(...commonOptions.as)
     .description('cancel a value and its deps, recovering resources')

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -10,6 +10,7 @@ const formulaTypes = new Set([
   'guest',
   'handle',
   'host',
+  'invitation',
   'known-peers-store',
   'least-authority',
   'lookup',

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -1481,6 +1481,30 @@ test('locate remote value', async t => {
   t.is(parsedGreetingsLocator.formulaType, 'remote');
 });
 
+test('invite, accept, and send mail', async t => {
+  const hostA = await prepareHostWithTestNetwork(t);
+  const hostB = await prepareHostWithTestNetwork(t);
+
+  const invitation = await E(hostA).invite('bob');
+  const invitationLocator = await E(invitation).locate();
+  await E(hostB).accept(invitationLocator, 'alice');
+
+  // create value to share
+  await E(hostA).evaluate('MAIN', '"hello, world!"', [], [], 'salutations');
+  const expectedSalutationsId = await E(hostA).identify('salutations');
+  await E(hostA).send('bob', ['Hello'], ['salutations'], ['salutations']);
+
+  const messages = await E(hostB).listMessages();
+  const {
+    strings: [hi],
+    names: [salutationsName],
+    ids: [salutationsId],
+  } = messages.find(({ number }) => number === 1);
+  t.is(hi, 'Hello');
+  t.is(salutationsName, 'salutations');
+  t.is(salutationsId, expectedSalutationsId);
+});
+
 test('reverse locate local value', async t => {
   const { host } = await prepareHost(t);
 


### PR DESCRIPTION
This change introduces a user workflow for connecting daemons.

```
alice> endo invite bob > invitation.link
*alice sends bob invitation.link*
bob> endo accept alice < invitation.link
```

The two parties can now exchange mail.

```
alice> endo send bob 'Hi, here is @power'
bob> endo inbox
0. alice sent “Hi, here is @power”
bob> endo adopt 0 power 
```

Here's a transcript for testing this in `packages/cli/demo`:

```
> endo make counter.js --name counter
Object [Alleged: Counter] {}

> endo mkhost other other-agent
Object [Alleged: EndoHost] {}

> endo invite bob > invitation.link

> endo accept alice --as other-agent < invitation.link

> endo send bob 'Hi, here is @counter'

> endo show counter
Object [Alleged: Counter] {}

> endo show counter --as other-agent
CapTP cli exception: (RemoteTypeError(error:captp:Endo#20001)#1)
RemoteTypeError(error:captp:Endo#20001)#1: Unknown pet name: "counter"
...

> endo adopt 0 counter --as other-agent

> endo show counter --as other-agent
Object [Alleged: Counter] {}
```