### PR TITLE
feat(ses): fix conflicting definitions of %InertAsyncFunction% on Hermes

### DIFF
--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -111,8 +111,8 @@ export const getAnonymousIntrinsics = () => {
 
   // 25.7.1 The AsyncFunction Constructor
 
-  // eslint-disable-next-line no-empty-function
-  async function AsyncFunctionInstance() {}
+  // eslint-disable-next-line no-empty-function, no-restricted-globals, no-eval
+  const AsyncFunctionInstance = (0, eval)('(async function () { })');
   const AsyncFunction = getConstructorOf(AsyncFunctionInstance);
 
   const intrinsics = {


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/endojs/endo/issues/1891

## Description

Context: Running SES on React Native on Android (Hermes)

Follow-up to
- https://github.com/endojs/endo/pull/2220

When calling `addIntrinsics(getAnonymousIntrinsics())`

The way we define AsyncFunctionInstance
`async function AsyncFunctionInstance() {}`

is throwing `TypeError: Conflicting definitions of %InertAsyncFunction%`
at https://github.com/endojs/endo/blob/master/packages/ses/src/intrinsics.js#L46

which doesn't match what's returned from `(0,eval)('(async function () { })');` which is ok in repro
https://github.com/leotm/RN07117SES/commit/cb44efd88ebbc9cea5450cf114ef1e93ee2996ff

### Security Considerations

Likely since calling eval

### Scaling Considerations

<!-- Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated? -->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?  -->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?  -->

### Compatibility Considerations

<!-- Does this change break any prior usage patterns? Does this change allow usage patterns to evolve? -->

### Upgrade Considerations

<!-- What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed? -->

- [ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.
- [ ] Updates `NEWS.md` for user-facing changes.
