### PR TITLE
feat(cli,daemon): Add `move` CLI command

### DIFF
--- a/packages/cli/src/commands/move.js
+++ b/packages/cli/src/commands/move.js
@@ -2,8 +2,9 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
-export const rename = async ({ fromName, toName, agentNames }) =>
+export const move = async ({ fromPath, toPath, agentNames }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    await E(agent).rename(fromName, toName);
+    await E(agent).move(parsePetNamePath(fromPath), parsePetNamePath(toPath));
   });

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -297,13 +297,14 @@ export const main = async rawArgs => {
     });
 
   program
-    .command('rename <from> <to>')
+    .command('move <from> <to>')
+    .alias('mv')
     .description('change the name for a value')
     .option(...commonOptions.as)
-    .action(async (fromName, toName, cmd) => {
+    .action(async (fromPath, toPath, cmd) => {
       const { as: agentNames } = cmd.opts();
-      const { rename } = await import('./commands/rename.js');
-      return rename({ fromName, toName, agentNames });
+      const { move } = await import('./commands/move.js');
+      return move({ fromPath, toPath, agentNames });
     });
 
   program

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -174,6 +174,7 @@ export const makeDirectoryMaker = ({
       const { hub: fromHub, name: fromName } =
         await lookupTailNameHub(fromPath);
       const { hub: toHub, name: toName } = await lookupTailNameHub(toPath);
+
       if (fromHub === toHub) {
         // eslint-disable-next-line no-use-before-define
         if (fromHub === directory) {
@@ -183,13 +184,14 @@ export const makeDirectoryMaker = ({
         }
         return;
       }
+
       const id = await fromHub.identify(fromName);
       if (id === undefined) {
         throw new Error(`Unknown name: ${q(fromPath)}`);
       }
-      const removeP = fromHub.remove(fromName);
-      const addP = toHub.write([toName], id);
-      await Promise.all([addP, removeP]);
+      // First write to the "to" hub so that the original name is preserved on the
+      // "from" hub in case of failure.
+      await toHub.write([toName], id).then(() => fromHub.remove(fromName));
     };
 
     /** @type {EndoDirectory['copy']} */

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -180,18 +180,19 @@ export const makeDirectoryMaker = ({
         if (fromHub === directory) {
           await petStore.rename(fromName, toName);
         } else {
-          await fromHub.move([fromName], [toName]);
+          await E(fromHub).move([fromName], [toName]);
         }
         return;
       }
 
-      const id = await fromHub.identify(fromName);
+      const id = await E(fromHub).identify(fromName);
       if (id === undefined) {
         throw new Error(`Unknown name: ${q(fromPath)}`);
       }
       // First write to the "to" hub so that the original name is preserved on the
       // "from" hub in case of failure.
-      await toHub.write([toName], id).then(() => fromHub.remove(fromName));
+      await E(toHub).write([toName], id);
+      await E(fromHub).remove(fromName);
     };
 
     /** @type {EndoDirectory['copy']} */

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -195,6 +195,7 @@ export const makePetStoreMaker = (filePowers, config) => {
       }
       assertValidId(formulaIdentifier, fromName);
 
+      // Updated persisted name mapping
       const fromPath = filePowers.joinPath(petNameDirectoryPath, fromName);
       const toPath = filePowers.joinPath(petNameDirectoryPath, toName);
       await filePowers.renamePath(fromPath, toPath);
@@ -206,6 +207,7 @@ export const makePetStoreMaker = (filePowers, config) => {
       }
 
       // Update the mapping for the pet name.
+      idsToPetNames.delete(formulaIdentifier, fromName);
       idsToPetNames.add(formulaIdentifier, toName);
 
       publishNameRemoval(formulaIdentifier, fromName);

--- a/packages/daemon/test/failed-hub.js
+++ b/packages/daemon/test/failed-hub.js
@@ -1,0 +1,14 @@
+import { makeExo } from '@endo/exo';
+import { M } from '@endo/patterns';
+
+export const make = () => {
+  return makeExo(
+    'FailedHub',
+    M.interface('FailedHub', {}, { defaultGuards: 'passable' }),
+    {
+      write() {
+        throw new Error('I had one job.');
+      },
+    },
+  );
+};

--- a/packages/daemon/test/move-hub.js
+++ b/packages/daemon/test/move-hub.js
@@ -1,0 +1,96 @@
+// @ts-check
+
+import { makeExo } from '@endo/exo';
+import { M } from '@endo/patterns';
+
+const { quote: q } = assert;
+
+/** @import {NameHub} from '../src/types.js' */
+
+// This caplet is a mock name hub for testing NameHub.move().
+export const make = () => {
+  /** @type {Map<string, string>} */
+  const idToName = new Map();
+  /** @type {Map<string, string>} */
+  const nameToId = new Map();
+
+  /**
+   * We only support paths of length 1.
+   * @param {Array<string>} petNamePath
+   */
+  const parsePetNamePath = petNamePath => {
+    if (!Array.isArray(petNamePath) || petNamePath.length !== 1) {
+      throw new Error(`Unexpected pet name path ${q(petNamePath)}`);
+    }
+    return petNamePath[0];
+  };
+
+  /**
+   * @param {string} petName
+   */
+  const expectGetId = petName => {
+    const id = nameToId.get(petName);
+    if (id === undefined) {
+      throw new Error(`Unknown pet name ${q(petName)}`);
+    }
+    return id;
+  };
+
+  /**
+   * @type {NameHub['write']}
+   */
+  const write = async (petNamePath, id) => {
+    const petName = parsePetNamePath(petNamePath);
+    idToName.set(id, petName);
+    nameToId.set(petName, id);
+  };
+
+  /**
+   * @type {NameHub['remove']}
+   */
+  const remove = async (...petNamePath) => {
+    const petName = parsePetNamePath(petNamePath);
+    const id = expectGetId(petName);
+
+    nameToId.delete(petName);
+    idToName.delete(id);
+  };
+
+  return makeExo(
+    'MoveHub',
+    M.interface('MoveHub', {}, { defaultGuards: 'passable' }),
+    {
+      write,
+      remove,
+
+      /**
+       * @type {NameHub['identify']}
+       */
+      async identify(...petNamePath) {
+        const petName = parsePetNamePath(petNamePath);
+        return nameToId.get(petName);
+      },
+
+      /**
+       * @type {NameHub['move']}
+       */
+      async move(fromPath, toPath) {
+        const fromName = parsePetNamePath(fromPath);
+        const id = expectGetId(fromName);
+
+        const toName = parsePetNamePath(toPath);
+
+        await remove(fromName);
+        await write([toName], id);
+      },
+
+      /**
+       * @type {NameHub['has']}
+       */
+      async has(...petNamePath) {
+        const petName = parsePetNamePath(petNamePath);
+        return nameToId.has(petName);
+      },
+    },
+  );
+};

--- a/packages/daemon/test/test-endo.js
+++ b/packages/daemon/test/test-endo.js
@@ -439,6 +439,21 @@ test('store with name', async t => {
   }
 });
 
+test('move renames value', async t => {
+  const { host } = await prepareHost(t);
+
+  await E(host).evaluate('MAIN', '10', [], [], 'ten');
+
+  const originalNames = await E(host).list();
+  t.assert(originalNames.includes('ten'));
+
+  await E(host).move(['ten'], ['zehn']);
+
+  const newNames = await E(host).list();
+  t.assert(!newNames.includes('ten'));
+  t.assert(newNames.includes('zehn'));
+});
+
 test('closure state lost by restart', async t => {
   const { cancelled, config } = await prepareConfig(t);
 


### PR DESCRIPTION
Adds a command `move` corresponding to the daemon directory's `move()`, with pet name path support. Replaces the existing `rename` command, which had been broken for some time.

Also ensures that the directory's `move()` method immediately deletes the "from" name mapping. Adds a test for the same. This mapping was already removed from disk and would not persist after restarts.