### PR TITLE
feat(cli): Add support for `--as` to `list` command

### DIFF
--- a/packages/cli/src/commands/list.js
+++ b/packages/cli/src/commands/list.js
@@ -2,10 +2,10 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { makeRefIterator } from '@endo/daemon';
-import { withEndoHost } from '../context.js';
+import { withEndoAgent } from '../context.js';
 
-export const list = async ({ directoryPath, follow, json }) =>
-  withEndoHost({ os, process }, async ({ host: agent }) => {
+export const list = async ({ directoryPath, follow, json, agentNames }) =>
+  withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
     if (directoryPath !== undefined) {
       agent = E(agent).lookup(...directoryPath.split('.'));
     }

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -278,12 +278,13 @@ export const main = async rawArgs => {
   program
     .command('list [directory]')
     .description('show names known to the current or specified directory')
+    .option(...commonOptions.as)
     .option('-f,--follow', 'Follow updates')
     .option('-j,--json', 'JSON format output')
     .action(async (directoryPath, cmd) => {
-      const { follow, json } = cmd.opts();
+      const { as: agentNames, follow, json } = cmd.opts();
       const { list } = await import('./commands/list.js');
-      return list({ directoryPath, follow, json });
+      return list({ directoryPath, follow, json, agentNames });
     });
 
   program


### PR DESCRIPTION
Adds support for the `--as` flag to the CLI's `list` command.