### PR TITLE
fix(pass-style,marshal): fix tests consistent with #2200

### DIFF
--- a/packages/marshal/test/marshal-test-data.js
+++ b/packages/marshal/test/marshal-test-data.js
@@ -1,4 +1,4 @@
-import { makeTagged } from '@endo/pass-style';
+import { makeTagged, toPassableError } from '@endo/pass-style';
 import {
   exampleAlice,
   exampleBob,
@@ -80,7 +80,7 @@ export const roundTripPairs = harden([
 
   // errors
   [
-    Error(),
+    toPassableError(Error()),
     {
       '@qclass': 'error',
       message: '',
@@ -88,7 +88,7 @@ export const roundTripPairs = harden([
     },
   ],
   [
-    ReferenceError('msg'),
+    toPassableError(ReferenceError('msg')),
     {
       '@qclass': 'error',
       message: 'msg',
@@ -96,7 +96,7 @@ export const roundTripPairs = harden([
     },
   ],
   [
-    ReferenceError('#msg'),
+    toPassableError(ReferenceError('#msg')),
     {
       '@qclass': 'error',
       message: '#msg',
@@ -265,7 +265,7 @@ export const unsortedSample = harden([
   exampleAlice,
   [],
   Symbol.for('foo'),
-  Error('not erroneous'),
+  toPassableError(Error('not erroneous')),
   Symbol.for('@@foo'),
   [5, { bar: 5 }],
   Symbol.for(''),
@@ -300,7 +300,7 @@ export const unsortedSample = harden([
   [Promise.resolve(null)],
 ]);
 
-const rejectedP = Promise.reject(Error('broken'));
+const rejectedP = Promise.reject(toPassableError(Error('broken')));
 rejectedP.catch(() => {}); // Suppress unhandled rejection warning/error
 
 /**
@@ -308,7 +308,7 @@ rejectedP.catch(() => {}); // Suppress unhandled rejection warning/error
  */
 export const sortedSample = harden([
   // All errors are tied.
-  Error('different'),
+  toPassableError(Error('different')),
 
   {},
 

--- a/packages/marshal/test/test-encodePassable.js
+++ b/packages/marshal/test/test-encodePassable.js
@@ -3,7 +3,7 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { fc } from '@fast-check/ava';
-import { Remotable } from '@endo/pass-style';
+import { Remotable, toPassableError } from '@endo/pass-style';
 import { arbPassable } from '@endo/pass-style/tools.js';
 import { Fail, q } from '@endo/errors';
 
@@ -199,7 +199,11 @@ test('capability encoding', t => {
     encodeError: (_err, encodeRecur) => forceSigil(encodeRecur(allAscii), '!'),
   };
 
-  const data = harden([Remotable(), new Promise(() => {}), Error('Foo')]);
+  const data = harden([
+    Remotable(),
+    new Promise(() => {}),
+    toPassableError(Error('Foo')),
+  ]);
   const decoders = Object.fromEntries(
     Object.keys(encoders).map((encoderName, i) => {
       const decoderName = encoderName.replace('encode', 'decode');

--- a/packages/marshal/test/test-marshal-smallcaps.js
+++ b/packages/marshal/test/test-marshal-smallcaps.js
@@ -11,6 +11,7 @@ const {
   create,
   prototype: objectPrototype,
   getPrototypeOf,
+  defineProperty,
 } = Object;
 
 const harden = /** @type {import('ses').Harden & { isFake?: boolean }} */ (
@@ -425,6 +426,9 @@ test('smallcaps encoding examples', t => {
   const nonPassableErr = Error('foo');
   // @ts-expect-error this type error is what we're testing
   nonPassableErr.extraProperty = 'something bad';
+  // Ensure that `stack` is a data property even on v8, so it does not
+  // first cause a different error than we're trying to test here.
+  defineProperty(nonPassableErr, 'stack', { value: nonPassableErr.stack });
   harden(nonPassableErr);
   t.throws(() => passStyleOf(nonPassableErr), {
     message:

--- a/packages/pass-style/NEWS.md
+++ b/packages/pass-style/NEWS.md
@@ -1,5 +1,11 @@
 User-visible changes in `@endo/pass-style`:
 
+# Next release
+
+- At https://chromium-review.googlesource.com/c/v8/v8/+/4459251 v8 changed their error `stack` property into an own accessor property with per-instance getters and setters. Because these getters and setters are fresh per error instance, on seeing such a property, we have no way to know whether the getter and setter is the platform-provided one, or one provided by an attacker. Thus, raw platform-created errors cannot be judged `Passable` until such problems are sanitized away. Either
+  - use `toPassableError` to coerce the error to a similar one that is passable
+  - use `makeError` from `@endo/errors` to directly make a passable error
+
 # v1.3.0 (2024-03-19)
 
 - Exports `isWellFormedString` and `assertWellFormedString`. Unfortunately the [standard `String.prototype.isWellFormed`](https://tc39.es/proposal-is-usv-string/) first coerces its input to string, leading it to claim that some non-strings are well-formed strings. By contrast, `isWellFormedString` and `assertWellFormedString` will not judge any non-strings to be well-formed strings.

--- a/packages/pass-style/NEWS.md
+++ b/packages/pass-style/NEWS.md
@@ -2,7 +2,7 @@ User-visible changes in `@endo/pass-style`:
 
 # Next release
 
-- At https://chromium-review.googlesource.com/c/v8/v8/+/4459251 v8 changed their error `stack` property into an own accessor property with per-instance getters and setters. Because these getters and setters are fresh per error instance, on seeing such a property, we have no way to know whether the getter and setter is the platform-provided one, or one provided by an attacker. Thus, raw platform-created errors cannot be judged `Passable` until such problems are sanitized away. Either
+- At https://chromium-review.googlesource.com/c/v8/v8/+/4459251 v8 changed their error `stack` property into an own accessor property with per-instance getters and setters. Thus, raw platform-created errors cannot be judged `Passable` until such problems are sanitized away. Either
   - use `toPassableError` to coerce the error to a similar one that is passable
   - use `makeError` from `@endo/errors` to directly make a passable error
 

--- a/packages/pass-style/tools/arb-passable.js
+++ b/packages/pass-style/tools/arb-passable.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { makeError } from '@endo/errors';
 import '../src/types.js';
 import { fc } from '@fast-check/ava';
 import { Far } from '../src/make-far.js';
@@ -31,7 +32,7 @@ export const arbLeaf = fc.oneof(
   fc.constantFrom(-0, NaN, Infinity, -Infinity),
   fc.record({}),
   fc.constantFrom(exampleAlice, exampleBob, exampleCarol),
-  arbString.map(s => Error(s)),
+  arbString.map(s => makeError(s)),
   // unresolved promise
   fc.constant(new Promise(() => {})),
 );


### PR DESCRIPTION
closes: #2198 
refs: #2230 #2200  https://chromium-review.googlesource.com/c/v8/v8/+/4459251 

## Description

At https://chromium-review.googlesource.com/c/v8/v8/+/4459251 v8 changed their error `stack` property into an own accessor property with per-instance getters and setters. Because these getters and setters are fresh per error instance, on seeing such a property, we have no way to know whether the getter and setter is the platform-provided one, or one provided by an attacker.

https://github.com/endojs/endo/issues/2198 was erroneously closed by https://github.com/endojs/endo/pull/2200 because https://github.com/endojs/endo/issues/2198 only manifested on browsers and we manually tested https://github.com/endojs/endo/pull/2200 on those browsers to "verify" that it was fixed.

### Security Considerations

Given the problematic v8 stack accessor behavior, which we're not in a position to fix, we are faced with only bad choices regarding Passable errors:
- platform created errors, or those created by direct calls to the various *Error constructors, are not made Passable merely by freezing them. Rather, the error has to go through some kind of sanitization first to derive from it a Passable error. This is the option we chose in #2200 
- Allow errors with own `stack` accessor properties, with per-instance getters and setters, to be considered Passable. Since we'd have no way to check, on v8, that the getters and setters are the ones introduced by the platform rather that an attacker, this would compromise the desired security properties of Passables.
- Give up on v8 (and therefore Node, Chrome, Brave, etc...) as a target platform.
- (In theory, we could introduce a special case into `harden` to convert an error's own `stack` accessor property into a data property before freezing. But this would be a major abstraction levels violation that we should consider only if the none of the other choices above are viable. I mention it for completeness.)


Since we are not willing to give up either on Passable security, nor on supporting v8-based target platforms, this seems to force us into the first choice.

Note that marshal *will* encode top-level non-passable errors safely, so this does not inhibit the reporting of normal remotely-thrown errors. Thus, even for the first choice, the unpleasantness should be well contained.

### Scaling Considerations

none

### Documentation Considerations

When an error is used in a context where only Passable is accepted, we will need to explain what to do and why.

### Testing Considerations

Because our current CI setup test at nothing more recent than Node 20, which does not have the v8 problem, this PR is not meaningfully verified by our current CI setup. Of course, it should remain green (which it is at the moment). But I'm manually verifying only that I can run `yarn test` locally while using Node 21, whose v8 does have the problematic accessor behavior.

### Compatibility Considerations

This v8 change of the `stack` property into an own accessor property with unverifiable per-instance getters and setters, causes the compat break that initially manifested as #2198, fixed by #2200 + this PR. But that still leaves a compat problem, as demonstrated by the test cases that this PR needed to fix, so they would continue to work. Old code that used error-handling patterns that used to work may break, due to this change in v8 behavior, even after both #2200 and this PR. Such old code will need to be fixed to somehow sanitize errors that need to be Passable, either by
- coercing them through `toPassableError`
- making them initially using `makeError` imported from `@endo/errors`.

### Upgrade Considerations

Neither #2200 nor this PR actually *cause* a breaking change. Rather, v8 causes a breaking change that these two PRs mitigate, but without reducing this to a non-breaking change. So I added a NEWS.md item. Reviewers, since this PR is not *causing* any breakage, where should the breaking change be noted?

- ~[ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.~
- [x] Updates `NEWS.md` for user-facing changes.
