### PR TITLE
test(ci): Node.js 22 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         platform: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
refs: #2230

## Description

This change adds `latest` to the CI [node setup action](https://github.com/actions/setup-node) so we can see upcoming breaking changes to our platform. The corresponding test results will not be required for merge.

Testing canary did not pan out. You can get `22-v8-canary` out of `actions/setup-node`, and you can add `yarn install --ignore-engines`, but `yarn` will still die with error if any dependency specifies `engines` since the canary versions do not match other version ranges, even broad ones like `>= 16`. This may be worth revisiting with newer versions of `yarn` or whatever succeeds it.

### Security Considerations

This increases our visibility into breaking changes on the Node.js platform.

### Scaling Considerations

This may prolong CI runs by a multiplicative factor if CI workers are contended.

### Documentation Considerations

None.

### Testing Considerations

Increases visibility into our future.

### Compatibility Considerations

None.

### Upgrade Considerations

None.

- ~[ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.~
- ~[ ] Updates `NEWS.md` for user-facing changes.~
