### PR TITLE
test: Walk back from Node.js 22 to 21 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 21.x]
         platform: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
## Description

#2231 merged despite a defect: Node.js 22 is not available in CI, through Node.js 21 anticipates the next stable version train.

This change overlaps #2234 and may be closed unmerged if it lands first.