### PR TITLE
bump TypeScript to 5.5 beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "type-coverage": "^2.26.3",
     "typedoc": "^0.25.12",
     "typedoc-plugin-markdown": "^3.17.1",
-    "typescript": "~5.5.0-dev.20240327",
+    "typescript": "5.5.0-beta",
     "typescript-eslint": "^7.3.1"
   },
   "scripts": {

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -140,6 +140,10 @@ export const makeCapTP = (
     const seen = new Set();
 
     return harden({
+      /**
+       * @param {T} specimen
+       * @returns {T}
+       */
       add(specimen) {
         if (predicate(specimen)) {
           seen.add(specimen);

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "*.js",

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/common/from-unique-entries.js
+++ b/packages/common/from-unique-entries.js
@@ -8,9 +8,9 @@ const { ownKeys } = Reflect;
  * like `Object.fromEntries` but hardens the result.
  * Use it to protect from property names computed from user-provided data.
  *
- * @template K,V
- * @param {Iterable<[K,V]>} allEntries
- * @returns {{[k: K]: V}}
+ * @template [T=any]
+ * @param {Iterable<readonly [PropertyKey, T]>} allEntries
+ * @returns {{ [k: string]: T; }}
  */
 export const fromUniqueEntries = allEntries => {
   const entriesArray = [...allEntries];

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "*.js",

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -69,6 +69,9 @@ Object.assign(assert, assertions);
 // quote behavior for that environment.
 const bareOrQuote = bare || quote;
 
+// XXX module exports fail if these aren't in scope
+/** @import {AssertMakeErrorOptions, Details, GenericErrorConstructor} from 'ses' */
+
 export {
   // assertions
   assert,

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -20,7 +20,7 @@
     "requireindex": "~1.1.0",
     "ts-api-utils": "~1.0.1",
     "tsutils": "~3.21.0",
-    "typescript": "~5.5.0-dev.20240327",
+    "typescript": "5.5.0-beta",
     "typescript-eslint": "^7.3.1"
   },
   "devDependencies": {

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -50,7 +50,7 @@
     "eslint": "^8.57.0",
     "rollup": "^2.79.1",
     "tsd": "^0.30.7",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "*.js",

--- a/packages/eventual-send/src/no-shim.js
+++ b/packages/eventual-send/src/no-shim.js
@@ -1,5 +1,8 @@
 import makeE from './E.js';
 
+// XXX module exports for HandledPromise fail if these aren't in scope
+/** @import {Handler, HandledExecutor} from './handled-promise.js' */
+
 const hp = HandledPromise;
 export const E = makeE(hp);
 export { hp as HandledPromise };

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "*.js",

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -234,12 +234,12 @@ export const makeMarshal = (
   };
 
   const makeFullRevive = slots => {
-    /** @type {Map<number>} */
+    /** @type {Map<number, RemotableObject | Promise>} */
     const valMap = new Map();
 
     /**
      * @param {{iface?: string, index: number}} slotData
-     * @returns {PassableCap}
+     * @returns {RemotableObject | Promise}
      */
     const decodeSlotCommon = slotData => {
       const { iface = undefined, index, ...rest } = slotData;
@@ -346,7 +346,7 @@ export const makeMarshal = (
     const makeDecodeSlotFromSmallcaps = prefix => {
       /**
        * @param {string} stringEncoding
-       * @param {(e: unknown) => PassableCap} _decodeRecur
+       * @param {(e: unknown) => Passable} _decodeRecur
        * @returns {RemotableObject | Promise}
        */
       return (stringEncoding, _decodeRecur) => {

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "*.js",

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "*.js",

--- a/packages/pass-style/src/string.js
+++ b/packages/pass-style/src/string.js
@@ -1,7 +1,6 @@
 import { getEnvironmentOption } from '@endo/env-options';
 import { Fail } from '@endo/errors';
 
-// @ts-expect-error TS builtin `String` type does not yet
 // know about`isWellFormed`
 const hasWellFormedStringMethod = !!String.prototype.isWellFormed;
 
@@ -22,8 +21,7 @@ const hasWellFormedStringMethod = !!String.prototype.isWellFormed;
  * @returns {str is string}
  */
 export const isWellFormedString = hasWellFormedStringMethod
-  ? // @ts-expect-error TS does not yet know about `isWellFormed`
-    str => typeof str === 'string' && str.isWellFormed()
+  ? str => typeof str === 'string' && str.isWellFormed()
   : str => {
       if (typeof str !== 'string') {
         return false;

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "*.js",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -41,7 +41,6 @@
     "ses": "^1.5.0"
   },
   "devDependencies": {
-    "@types/node": "^16.6.0",
     "ava": "^6.1.2",
     "babel-eslint": "^10.0.3",
     "c8": "^7.14.0",

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -95,7 +95,7 @@
     "sinon": "^15.1.0",
     "terser": "^5.16.6",
     "tsd": "^0.30.7",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/static-module-record/package.json
+++ b/packages/static-module-record/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
     "ts-api-utils": "~1.0.1",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [],
   "publishConfig": {

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
     "ts-api-utils": "~1.0.1",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.27.5",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "^3.2.5",
-    "typescript": "~5.5.0-dev.20240327"
+    "typescript": "5.5.0-beta"
   },
   "files": [
     "LICENSE*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,7 +174,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -236,7 +236,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -253,7 +253,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -285,7 +285,7 @@ __metadata:
     open: "npm:^9.1.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   bin:
     endo: ./bin/endo
   languageName: unknown
@@ -323,7 +323,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -360,7 +360,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
     ws: "npm:^8.13.0"
   languageName: unknown
   linkType: soft
@@ -377,7 +377,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -403,7 +403,7 @@ __metadata:
     requireindex: "npm:~1.1.0"
     ts-api-utils: "npm:~1.0.1"
     tsutils: "npm:~3.21.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
     typescript-eslint: "npm:^7.3.1"
   languageName: unknown
   linkType: soft
@@ -427,7 +427,7 @@ __metadata:
     rollup: "npm:^2.79.1"
     source-map: "npm:0.7.4"
     tsd: "npm:^0.30.7"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -464,7 +464,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -538,7 +538,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -576,7 +576,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -612,7 +612,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -635,7 +635,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -658,7 +658,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -677,7 +677,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -697,7 +697,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   peerDependencies:
     ava: ^5.3.0 || ^6.1.2
   languageName: unknown
@@ -734,7 +734,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -757,7 +757,7 @@ __metadata:
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
     ts-api-utils: "npm:~1.0.1"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -774,7 +774,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -797,7 +797,7 @@ __metadata:
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
     ts-api-utils: "npm:~1.0.1"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -814,7 +814,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -832,7 +832,7 @@ __metadata:
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
     test262-harness: "npm:^10.0.0"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -849,7 +849,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -866,7 +866,7 @@ __metadata:
     eslint-plugin-eslint-comments: "npm:^3.1.2"
     eslint-plugin-import: "npm:^2.29.0"
     prettier: "npm:^3.2.5"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -10123,7 +10123,7 @@ __metadata:
     type-coverage: "npm:^2.26.3"
     typedoc: "npm:^0.25.12"
     typedoc-plugin-markdown: "npm:^3.17.1"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
     typescript-eslint: "npm:^7.3.1"
   languageName: unknown
   linkType: soft
@@ -10330,7 +10330,7 @@ __metadata:
     sinon: "npm:^15.1.0"
     terser: "npm:^5.16.6"
     tsd: "npm:^0.30.7"
-    typescript: "npm:~5.5.0-dev.20240327"
+    typescript: "npm:5.5.0-beta"
   languageName: unknown
   linkType: soft
 
@@ -11572,6 +11572,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.5.0-beta":
+  version: 5.5.0-beta
+  resolution: "typescript@npm:5.5.0-beta"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/e4b029678d6e77514355a79bb2b30e80784712b58cdb1391e07d2282aefceaff7850edf16814f6b4b9d4f23c84372afdfc6165cb628adc5303274fff8a795ce5
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^3 || ^4":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
@@ -11582,13 +11592,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.5.0-dev.20240327":
-  version: 5.5.0-dev.20240329
-  resolution: "typescript@npm:5.5.0-dev.20240329"
+"typescript@patch:typescript@npm%3A5.5.0-beta#optional!builtin<compat/typescript>":
+  version: 5.5.0-beta
+  resolution: "typescript@patch:typescript@npm%3A5.5.0-beta#optional!builtin<compat/typescript>::version=5.5.0-beta&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/e21a2971d4154882aeda6df8d3cc21433a52fc052a2b8cca696a4132d8576578cb2314d0003add033db8f799ed29a583120d24ba9e475bce8079447d3db3dafa
+  checksum: 10c0/acf3385e77938238a216dfd8eb39c583253c6184ffba66ffd6232cc3c931bbc7023e522bf09c5389e327ce5c9a6335fca5be082dd3365ed95c35b89ea21aa388
   languageName: node
   linkType: hard
 
@@ -11599,16 +11609,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/e3333f887c6829dfe0ab6c1dbe0dd1e3e2aeb56c66460cb85c5440c566f900c833d370ca34eb47558c0c69e78ced4bfe09b8f4f98b6de7afed9b84b8d1dd06a1
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.5.0-dev.20240327#optional!builtin<compat/typescript>":
-  version: 5.5.0-dev.20240329
-  resolution: "typescript@patch:typescript@npm%3A5.5.0-dev.20240329#optional!builtin<compat/typescript>::version=5.5.0-dev.20240329&hash=5adc0c"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/0261861013b74677c7fd3ac47ed96f15179131a18d97a58baa404f281d6d14ddf7637747adc670823b7536b8e77407babfbcfa6ac0e8a37f225b1c0694fe55f6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,7 +666,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/promise-kit@workspace:packages/promise-kit"
   dependencies:
-    "@types/node": "npm:^16.6.0"
     ava: "npm:^6.1.2"
     babel-eslint: "npm:^10.0.3"
     c8: "npm:^7.14.0"
@@ -2670,10 +2669,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^16.6.0":
-  version: 16.18.34
-  resolution: "@types/node@npm:16.18.34"
-  checksum: 10c0/d6572e12b2200a813b2e0944add0abb8ac59d51a0cf28651dd1dde9de4d43e9d4c2c41fd7cf910d0c3bd8e13d10047f58211a53e76780279fc6d284137d3b001
+"@types/node@npm:*":
+  version: 20.12.7
+  resolution: "@types/node@npm:20.12.7"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10c0/dce80d63a3b91892b321af823d624995c61e39c6a223cc0ac481a44d337640cc46931d33efb3beeed75f5c85c3bda1d97cef4c5cd4ec333caf5dee59cff6eca0
   languageName: node
   linkType: hard
 
@@ -11637,6 +11638,13 @@ __metadata:
     has-symbols: "npm:^1.0.3"
     which-boxed-primitive: "npm:^1.0.2"
   checksum: 10c0/81ca2e81134167cc8f75fa79fbcc8a94379d6c61de67090986a2273850989dd3bae8440c163121b77434b68263e34787a675cbdcb34bb2f764c6b9c843a11b66
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
_no issue_

## Description

https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/

That required cleaning up `@types/node` that was stuck on v16.

I tried bumping typescript-eslint but that introduced some perf warnings about our tsconfig.


### Security Considerations

n/a, types

### Scaling Considerations

n/a, types

### Documentation Considerations

no

### Testing Considerations

CI

### Compatibility Considerations

n/a, types

### Upgrade Considerations

none