### PR TITLE
docs(ses): more links for stack own accessor problem

### DIFF
--- a/packages/ses/error-codes/SES_UNEXPECTED_ERROR_OWN_STACK_ACCESSOR.md
+++ b/packages/ses/error-codes/SES_UNEXPECTED_ERROR_OWN_STACK_ACCESSOR.md
@@ -26,4 +26,8 @@ v8 issue at https://issues.chromium.org/issues/40279506
 
 Endo issue at https://github.com/endojs/endo/issues/2198
 
+Failed attempt at mitigation https://github.com/Agoric/endojs-vespera/pull/1
+
 Endo workaround at https://github.com/endojs/endo/pull/2232
+
+v8 discussion of a proper fix https://chromium-review.googlesource.com/c/v8/v8/+/4459251/10..15/src/execution/messages.cc#b1131


### PR DESCRIPTION

closes: #XXXX
refs: https://github.com/Agoric/endojs-vespera/pull/1 https://chromium-review.googlesource.com/c/v8/v8/+/4459251/10..15/src/execution/messages.cc#b1131

## Description

Now that https://github.com/Agoric/endojs-vespera is public, just adds links into it, and to a related v8 discussion that it links to.
