### PR TITLE
refactor(pass-style): better non-remotable function error

### DIFF
--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -180,12 +180,13 @@ test('missing interface', t => {
   );
   const greeterMaker = makeExo('greeterMaker', undefined, {
     makeSayHello() {
-      return () => 'hello';
+      const helloFunc = () => 'hello';
+      return harden(helloFunc);
     },
   });
   t.throws(() => greeterMaker.makeSayHello(), {
     message:
-      'In "makeSayHello" method of (greeterMaker): result: Remotables must be explicitly declared: "[Function <anon>]"',
+      'In "makeSayHello" method of (greeterMaker): result: Remotables must be explicitly declared: "[Function helloFunc]"',
   });
   t.is(greeterMaker[GET_INTERFACE_GUARD]?.(), undefined);
 });

--- a/packages/exo/test/test-heap-classes.js
+++ b/packages/exo/test/test-heap-classes.js
@@ -185,7 +185,7 @@ test('missing interface', t => {
   });
   t.throws(() => greeterMaker.makeSayHello(), {
     message:
-      'In "makeSayHello" method of (greeterMaker): result: "[Symbol(passStyle)]" property expected: "[Function <anon>]"',
+      'In "makeSayHello" method of (greeterMaker): result: Remotables must be explicitly declared: "[Function <anon>]"',
   });
   t.is(greeterMaker[GET_INTERFACE_GUARD]?.(), undefined);
 });

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -87,7 +87,11 @@ const checkRemotableProtoOf = (original, check) => {
   //        }}
   //
   const proto = getPrototypeOf(original);
-  if (proto === objectPrototype || proto === null) {
+  if (
+    proto === objectPrototype ||
+    proto === null ||
+    proto === Function.prototype
+  ) {
     return (
       reject && reject`Remotables must be explicitly declared: ${q(original)}`
     );


### PR DESCRIPTION
closes: #XXXX
refs: https://github.com/Agoric/agoric-sdk/pull/9097

## Description

As the changed test case demonstrates, before this PR, testing the `passStyleOf` a normal unmarked function was correctly rejected, but with a terrible error message, such as: 
- `"[Symbol(passStyle)]" property expected: "[Function ...]"`

This change aligns with the error message already used for an unmarked objects-as-closure object. For an unmarked function, the error would be
- `Remotables must be explicitly declared: "[Function ...]"`

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing & Compatibility Considerations

There might be tests with golden text based on the old error message. These tests would need to be revised to the new text. During the transition, golden text error tests should use a regexp to be compat with both the before and after of this PR, with a link to the PR itself so we know when we can clean it up.

I found three such dependencies. One in endo, which this PR fixes. None in agoric-sdk master. Two in https://github.com/Agoric/agoric-sdk/pull/9097 , both of which have now been revised to be compat before and after.


### Upgrade Considerations

none

- ~[ ] Includes `*BREAKING*:` in the commit message with migration instructions for any breaking change.~
- ~[ ] Updates `NEWS.md` for user-facing changes.~
