### PR TITLE
fix: Corepack with TypeDoc generation job

### DIFF
--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v4
+      # Without this, setup-node errors on mismatched yarn versions
+      - run: corepack enable
       # Without this the inter-package imports don't resolve
       - run: yarn install
       # Generate the TypeDoc site

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -35,7 +35,7 @@
   "unpkg": "./dist/ses.umd.js",
   "types": "./types.d.ts",
   "exports": {
-    ".": {      
+    ".": {
       "import": {
         "types": "./types.d.ts",
         "default": "./index.js"
@@ -45,7 +45,7 @@
         "default": "./dist/ses.cjs"
       }
     },
-    "./lockdown": {      
+    "./lockdown": {
       "import": {
         "types": "./types.d.ts",
         "default": "./index.js"


### PR DESCRIPTION
The typedoc CI job failed because of a package manager mismatch that can be addressed by enabling corepack.

https://github.com/endojs/endo/actions/runs/8975075410/job/24648857762