### PR TITLE
fix: Update version scripts

### DIFF
--- a/scripts/get-versions.sh
+++ b/scripts/get-versions.sh
@@ -5,7 +5,7 @@ set -ueo pipefail
 WORKDIR=${1:-.}
 
 cd -- "$WORKDIR"
-yarn workspaces --json info --silent |
-jq -r '.data | fromjson | .[].location | "\(.)/package.json"' |
+npm query .workspace |
+jq -r '.[].location | "\(.)/package.json"' |
 xargs jq '{key: .name, value: "^\(.version)"}' |
 jq --slurp from_entries

--- a/scripts/set-versions.sh
+++ b/scripts/set-versions.sh
@@ -16,14 +16,14 @@ VERSIONSHASH=$(git hash-object -w --stdin)
   jq -r '.data | fromjson | .[].location | "\(.)/package.json"' || true
 ) | while read PACKAGEJSON; do
   PACKAGEJSONHASH=$(
-    jq --argfile versions <(git cat-file blob "$VERSIONSHASH") '
+    jq --slurpfile versions <(git cat-file blob "$VERSIONSHASH") '
       def update(name): if .[name] then {
         (name): [
           .[name] |
           to_entries[] |
           {
             key: .key,
-            value: ($versions[.key] // .value)
+            value: ($versions[0][.key] // .value)
           }
         ] | from_entries
       } else {} end;


### PR DESCRIPTION
Recent upgrades to `yarn` and (older) `jq` require updates to the version management scripts we use to sync Endo with Agoric SDK.