### PR TITLE
feat(daemon,cli): Make and store at path

### DIFF
--- a/packages/cli/src/commands/make.js
+++ b/packages/cli/src/commands/make.js
@@ -8,6 +8,7 @@ import bundleSource from '@endo/bundle-source';
 import { makeReaderRef } from '@endo/daemon';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 import { randomHex16 } from '../random.js';
 
 const textEncoder = new TextEncoder();
@@ -37,6 +38,8 @@ export const makeCommand = async ({
     process.exitCode = 1;
     return;
   }
+
+  const resultPath = resultName && parsePetNamePath(resultName);
 
   /** @type {import('@endo/eventual-send').FarRef<import('@endo/stream').Reader<string>> | undefined} */
   let bundleReaderRef;
@@ -68,9 +71,9 @@ export const makeCommand = async ({
             workerName,
             url.pathToFileURL(path.resolve(importPath)).href,
             powersName,
-            resultName,
+            resultPath,
           )
-        : E(agent).makeBundle(workerName, bundleName, powersName, resultName);
+        : E(agent).makeBundle(workerName, bundleName, powersName, resultPath);
     const result = await resultP;
     console.log(result);
 

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -12,6 +12,7 @@ import url from 'url';
 
 import { Command } from 'commander';
 import { prompt } from './prompt.js';
+import { parsePetNamePath } from './pet-name.js';
 
 const packageDescriptorPath = url.fileURLToPath(
   new URL('../package.json', import.meta.url),
@@ -370,7 +371,7 @@ export const main = async rawArgs => {
         storeJson,
         storeJsonStdin,
         storeBigInt,
-        name,
+        name: parsePetNamePath(name),
         agentNames,
       });
     });

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -216,6 +216,9 @@ export const makeDirectoryMaker = ({
 
     /** @type {EndoDirectory['write']} */
     const write = async (petNamePath, id) => {
+      if (typeof petNamePath === 'string') {
+        petNamePath = [petNamePath];
+      }
       if (petNamePath.length === 1) {
         const petName = petNamePath[0];
         await petStore.write(petName, id);

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -244,7 +244,7 @@ export const makeHostMaker = ({
      * Helper function for makeUnconfined and makeBundle.
      * @param {string} powersName
      * @param {string} workerName
-     * @param {string} [resultName]
+     * @param {string | string[]} [resultName]
      */
     const prepareMakeCaplet = (powersName, workerName, resultName) => {
       assertPowersName(powersName);
@@ -263,7 +263,7 @@ export const makeHostMaker = ({
 
       if (resultName !== undefined) {
         tasks.push(identifiers =>
-          petStore.write(resultName, identifiers.capletId),
+          E(directory).write(resultName, identifiers.capletId),
         );
       }
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -108,16 +108,15 @@ export const makeHostMaker = ({
 
     /**
      * @param {ERef<AsyncIterableIterator<string>>} readerRef
-     * @param {string} [petName]
+     * @param {string | string[]} [petName]
      */
     const storeBlob = async (readerRef, petName) => {
       /** @type {DeferredTasks<ReadableBlobDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
       if (petName !== undefined) {
-        assertPetName(petName);
         tasks.push(identifiers =>
-          petStore.write(petName, identifiers.readableBlobId),
+          E(directory).write(petName, identifiers.readableBlobId),
         );
       }
 
@@ -131,9 +130,8 @@ export const makeHostMaker = ({
       const tasks = makeDeferredTasks();
 
       if (petName !== undefined) {
-        assertPetName(petName);
         tasks.push(identifiers =>
-          petStore.write(petName, identifiers.marshalId),
+          E(directory).write(petName, identifiers.marshalId),
         );
       }
 

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -446,7 +446,7 @@ export interface NameHub {
   ): AsyncGenerator<PetStoreNameChange, undefined, undefined>;
   lookup(...petNamePath: string[]): Promise<unknown>;
   reverseLookup(value: unknown): Array<string>;
-  write(petNamePath: string[], id: string): Promise<void>;
+  write(petNamePath: string | string[], id: string): Promise<void>;
   remove(...petNamePath: string[]): Promise<void>;
   move(fromPetName: string[], toPetName: string[]): Promise<void>;
   copy(fromPetName: string[], toPetName: string[]): Promise<void>;

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -568,7 +568,10 @@ export interface EndoHost extends EndoAgent {
     readerRef: ERef<AsyncIterableIterator<string>>,
     petName: string,
   ): Promise<FarRef<EndoReadable>>;
-  storeValue<T extends Passable>(value: T, petName: string): Promise<void>;
+  storeValue<T extends Passable>(
+    value: T,
+    petName: string | string[],
+  ): Promise<void>;
   provideGuest(
     petName?: string,
     opts?: MakeHostOrGuestOptions,


### PR DESCRIPTION
Enables caplets to be made and values to be stored at deeper pet name paths.

```
endo make x.js -n dir.x
endo store --json 42 -n dir.forty-two
endo store --text-stdin --name dir.greeting < <(echo hi)
```