### PR TITLE
feat(graph): also generate the transitive reduction

### DIFF
--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Generates visualizations of the internal package dependency graph.
+# Also generates vistualizations of the transitive reduction (tred) of
+# that graph, which is the minimal graph with the same *transitive*
+# dependcies. Much more legible by itelf. Seeing the two side by side
+# often helps to understand the full picture.
 set -ueo pipefail
 DIR=$(dirname -- "${BASH_SOURCE[0]}")
 {
@@ -24,6 +28,10 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
 dot -Tpng <packages-graph.dot >"$DIR"/../packages-graph.png
 
 dot -Tsvg <packages-graph.dot >"$DIR"/../packages-graph.svg
+
+tred <packages-graph.dot >packages-graph-tred.dot
+dot -Tpng <packages-graph-tred.dot >"$DIR"/../packages-graph-tred.png
+dot -Tsvg <packages-graph-tred.dot >"$DIR"/../packages-graph-tred.svg
 
 if acyclic packages-graph.dot | dot -Tcanon >packages-graph-sans-cycles.dot; then
     echo "No cycles in 'dependencies' of packages."

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -2,7 +2,7 @@
 # Generates visualizations of the internal package dependency graph.
 # Also generates visualizations of the transitive reduction (tred) of
 # that graph, which is the minimal graph with the same *transitive*
-# dependcies. Much more legible by itelf. Seeing the two side by side
+# dependencies. Much more legible by itelf. Seeing the two side by side
 # often helps to understand the full picture.
 set -ueo pipefail
 DIR=$(dirname -- "${BASH_SOURCE[0]}")

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Generates visualizations of the internal package dependency graph.
-# Also generates vistualizations of the transitive reduction (tred) of
+# Also generates visualizations of the transitive reduction (tred) of
 # that graph, which is the minimal graph with the same *transitive*
 # dependcies. Much more legible by itelf. Seeing the two side by side
 # often helps to understand the full picture.

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -24,16 +24,16 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
     '
     echo '}'
     # normalize
-} | dot -Tcanon >packages-graph.dot
-dot -Tpng <packages-graph.dot >"$DIR"/../packages-graph.png
+} | dot -Tcanon > packages-graph.dot
+dot -Tpng <packages-graph.dot > "$DIR"/../packages-graph.png
 
-dot -Tsvg <packages-graph.dot >"$DIR"/../packages-graph.svg
+dot -Tsvg <packages-graph.dot > "$DIR"/../packages-graph.svg
 
-tred <packages-graph.dot >packages-graph-tred.dot
-dot -Tpng <packages-graph-tred.dot >"$DIR"/../packages-graph-tred.png
-dot -Tsvg <packages-graph-tred.dot >"$DIR"/../packages-graph-tred.svg
+tred <packages-graph.dot > packages-graph-tred.dot
+dot -Tpng <packages-graph-tred.dot > "$DIR"/../packages-graph-tred.png
+dot -Tsvg <packages-graph-tred.dot > "$DIR"/../packages-graph-tred.svg
 
-if acyclic packages-graph.dot | dot -Tcanon >packages-graph-sans-cycles.dot; then
+if acyclic packages-graph.dot | dot -Tcanon > packages-graph-sans-cycles.dot; then
     echo "No cycles in 'dependencies' of packages."
 else
     echo "Cycles detected. These lines appear only in the original graph and not the acyclic variant:"


### PR DESCRIPTION
Closes: #XXXX
Refs: https://github.com/Agoric/agoric-sdk/pull/9359

## Description

Use the "tred" executable that seems to already be bundled with graphviz to

```
# Also generates visualizations of the transitive reduction (tred) of
# that graph, which is the minimal graph with the same *transitive*
# dependencies. Much more legible by itelf. Seeing the two side by side
# often helps to understand the full picture.
```

At the time of writing, the current graph of endo dependencies is

![packages-graph](https://github.com/endojs/endo/assets/273868/248cc216-2cf4-42cb-a7d8-a1d3e1724b46)

and the transitive reduction of those is

![packages-graph-tred](https://github.com/endojs/endo/assets/273868/4957d03b-50f1-4ee9-bc14-6eb2667be68c)

Notice how the columns *mostly* align. Unfortunately, the columns don't fully align, and the vertical order of elements within each column is not the same. For viewing them side by side for better understanding, it would be better if both of these annoyances were fixed. But I have no idea how to do that, so this PR does not try.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

potentially helps someone who wants to understand how our system is internally layered, which is the point. Otherwise, none
### Testing Considerations

none
### Compatibility Considerations

none
### Upgrade Considerations

none