### PR TITLE
perf(pass-style): Eliminate redundant work to validate passStyle shapes

### DIFF
--- a/packages/pass-style/src/copyArray.js
+++ b/packages/pass-style/src/copyArray.js
@@ -1,7 +1,7 @@
 /// <reference types="ses"/>
 
 import { X } from '@endo/errors';
-import { assertChecker, checkNormalProperty } from './passStyle-helpers.js';
+import { assertChecker, getOwnDataDescriptor } from './passStyle-helpers.js';
 
 const { getPrototypeOf } = Object;
 const { ownKeys } = Reflect;
@@ -30,16 +30,19 @@ export const CopyArrayHelper = harden({
     getPrototypeOf(candidate) === arrayPrototype ||
       assert.fail(X`Malformed array: ${candidate}`, TypeError);
     // Since we're already ensured candidate is an array, it should not be
-    // possible for the following test to fail
-    checkNormalProperty(candidate, 'length', false, assertChecker);
-    const len = /** @type {unknown[]} */ (candidate).length;
+    // possible for the following get to fail.
+    const len = /** @type {number} */ (
+      getOwnDataDescriptor(candidate, 'length', false, assertChecker).value
+    );
+    // Validate that each index property is own/data/enumerable
+    // and its associated value is recursively passable.
     for (let i = 0; i < len; i += 1) {
-      checkNormalProperty(candidate, i, true, assertChecker);
+      passStyleOfRecur(
+        getOwnDataDescriptor(candidate, i, true, assertChecker).value,
+      );
     }
-    // +1 for the 'length' property itself.
+    // Expect one key per index plus one for 'length'.
     ownKeys(candidate).length === len + 1 ||
       assert.fail(X`Arrays must not have non-indexes: ${candidate}`, TypeError);
-    // Recursively validate that each member is passable.
-    candidate.every(v => !!passStyleOfRecur(v));
   },
 });

--- a/packages/pass-style/src/copyRecord.js
+++ b/packages/pass-style/src/copyRecord.js
@@ -5,12 +5,46 @@
 import {
   assertChecker,
   canBeMethod,
-  checkNormalProperty,
+  getOwnDataDescriptor,
   CX,
 } from './passStyle-helpers.js';
 
 const { ownKeys } = Reflect;
-const { getPrototypeOf, values, prototype: objectPrototype } = Object;
+const { getPrototypeOf, prototype: objectPrototype } = Object;
+
+/**
+ * @param {unknown} candidate
+ * @param {Checker} [check]
+ */
+const checkObjectPrototype = (candidate, check = undefined) => {
+  return (
+    getPrototypeOf(candidate) === objectPrototype ||
+    (!!check &&
+      CX(check)`Records must inherit from Object.prototype: ${candidate}`)
+  );
+};
+
+/**
+ * @param {unknown} candidate
+ * @param {PropertyKey} key
+ * @param {unknown} value
+ * @param {Checker} [check]
+ */
+const checkPropertyCanBeValid = (candidate, key, value, check = undefined) => {
+  return (
+    (typeof key === 'string' ||
+      (!!check &&
+        CX(
+          check,
+        )`Records can only have string-named properties: ${candidate}`)) &&
+    (!canBeMethod(value) ||
+      (!!check &&
+        // TODO: Update message now that there is no such thing as "implicit Remotable".
+        CX(
+          check,
+        )`Records cannot contain non-far functions because they may be methods of an implicit Remotable: ${candidate}`))
+  );
+};
 
 /**
  *
@@ -20,34 +54,30 @@ export const CopyRecordHelper = harden({
   styleName: 'copyRecord',
 
   canBeValid: (candidate, check = undefined) => {
-    if (getPrototypeOf(candidate) !== objectPrototype) {
-      return (
-        !!check &&
-        CX(check)`Records must inherit from Object.prototype: ${candidate}`
-      );
-    }
-
-    return ownKeys(candidate).every(key => {
-      return (
-        (typeof key === 'string' ||
-          (!!check &&
-            CX(check)`Records can only have string-named properties: ${candidate}`)) &&
-        (!canBeMethod(candidate[key]) ||
-          (!!check &&
-            // TODO: Update message now that there is no such thing as "implicit Remotable".
-            CX(check)`Records cannot contain non-far functions because they may be methods of an implicit Remotable: ${candidate}`))
-      );
-    });
+    return (
+      checkObjectPrototype(candidate, check) &&
+      // Reject any candidate with a symbol-keyed property or method-like property
+      // (such input is potentially a Remotable).
+      ownKeys(candidate).every(key =>
+        checkPropertyCanBeValid(candidate, key, candidate[key], check),
+      )
+    );
   },
 
   assertValid: (candidate, passStyleOfRecur) => {
-    CopyRecordHelper.canBeValid(candidate, assertChecker);
+    checkObjectPrototype(candidate, assertChecker);
+
+    // Validate that each own property is appropriate, data/enumerable,
+    // and has a recursively passable associated value.
     for (const name of ownKeys(candidate)) {
-      checkNormalProperty(candidate, name, true, assertChecker);
-    }
-    // Recursively validate that each member is passable.
-    for (const val of values(candidate)) {
-      passStyleOfRecur(val);
+      const { value } = getOwnDataDescriptor(
+        candidate,
+        name,
+        true,
+        assertChecker,
+      );
+      checkPropertyCanBeValid(candidate, name, value, assertChecker);
+      passStyleOfRecur(value);
     }
   },
 });

--- a/packages/pass-style/src/copyRecord.js
+++ b/packages/pass-style/src/copyRecord.js
@@ -1,10 +1,12 @@
 /// <reference types="ses"/>
 
-import { X } from '@endo/errors';
+/** @import {Checker} from './types.js' */
+
 import {
   assertChecker,
   canBeMethod,
   checkNormalProperty,
+  CX,
 } from './passStyle-helpers.js';
 
 const { ownKeys } = Reflect;
@@ -18,23 +20,22 @@ export const CopyRecordHelper = harden({
   styleName: 'copyRecord',
 
   canBeValid: (candidate, check = undefined) => {
-    const reject = !!check && ((T, ...subs) => check(false, X(T, ...subs)));
     if (getPrototypeOf(candidate) !== objectPrototype) {
       return (
-        reject &&
-        reject`Records must inherit from Object.prototype: ${candidate}`
+        !!check &&
+        CX(check)`Records must inherit from Object.prototype: ${candidate}`
       );
     }
 
     return ownKeys(candidate).every(key => {
       return (
         (typeof key === 'string' ||
-          (reject &&
-            reject`Records can only have string-named properties: ${candidate}`)) &&
+          (!!check &&
+            CX(check)`Records can only have string-named properties: ${candidate}`)) &&
         (!canBeMethod(candidate[key]) ||
-          (reject &&
+          (!!check &&
             // TODO: Update message now that there is no such thing as "implicit Remotable".
-            reject`Records cannot contain non-far functions because they may be methods of an implicit Remotable: ${candidate}`))
+            CX(check)`Records cannot contain non-far functions because they may be methods of an implicit Remotable: ${candidate}`))
       );
     });
   },

--- a/packages/pass-style/src/tagged.js
+++ b/packages/pass-style/src/tagged.js
@@ -5,7 +5,7 @@ import {
   assertChecker,
   checkTagRecord,
   PASS_STYLE,
-  checkNormalProperty,
+  getOwnDataDescriptor,
   checkPassStyle,
 } from './passStyle-helpers.js';
 
@@ -20,7 +20,7 @@ export const TaggedHelper = harden({
   styleName: 'tagged',
 
   canBeValid: (candidate, check = undefined) =>
-    checkPassStyle(candidate, 'tagged', check),
+    checkPassStyle(candidate, candidate[PASS_STYLE], 'tagged', check),
 
   assertValid: (candidate, passStyleOfRecur) => {
     checkTagRecord(candidate, 'tagged', assertChecker);
@@ -38,9 +38,10 @@ export const TaggedHelper = harden({
     ownKeys(restDescs).length === 0 ||
       Fail`Unexpected properties on tagged record ${ownKeys(restDescs)}`;
 
-    checkNormalProperty(candidate, 'payload', true, assertChecker);
-
-    // Recursively validate that each member is passable.
-    passStyleOfRecur(candidate.payload);
+    // Validate that the 'payload' property is own/data/enumerable
+    // and its associated value is recursively passable.
+    passStyleOfRecur(
+      getOwnDataDescriptor(candidate, 'payload', true, assertChecker).value,
+    );
   },
 });


### PR DESCRIPTION
## Description

* Make a rejector only when needed
* Use the value from an already-fetched property descriptor rather than fetching the property again.
* Minimize the number of all-property loops.

### Security Considerations

None.

### Scaling Considerations

The total effect is an improvement of 10% to 20% on both V8 and XS for `passStyleOf(harden(largeArrayOrPlainObject))` as observed by
```sh
scripts/esbench.mjs -b3 -h'V8,*XS' \
  -M @endo/init \
  -i 'import { passStyleOf } from "@endo/pass-style"; globalThis.passStyleOf = passStyleOf;' \
  --arg len:0,1,10,100 \
  --setup 'const arr = Array(+len).fill(""), obj = Object.fromEntries(arr.map((val, i) => [`key${i}`, val]));' \
  'passStyleOf(harden(arr.slice()))' \
  'passStyleOf(harden({ ...obj }))' \
  | grep -v '^Removing '
```

<details>

#### Before
```
#### Moddable XS

passStyleOf(harden(arr.slice())) ("0",0) 102.95928500496524 ops/ms after 81 3840-count samples
passStyleOf(harden({ ...obj })) ("0",0) 99.11317008603574 ops/ms after 78 3840-count samples
passStyleOf(harden(arr.slice())) ("1",0) 77.82059800664452 ops/ms after 61 3840-count samples
passStyleOf(harden({ ...obj })) ("1",0) 66.47137150466045 ops/ms after 52 3840-count samples
passStyleOf(harden(arr.slice())) ("10",0) 27.87037037037037 ops/ms after 98 860-count samples
passStyleOf(harden({ ...obj })) ("10",0) 20.98110705999337 ops/ms after 100 633-count samples
passStyleOf(harden(arr.slice())) ("100",0) 3.8361581920903953 ops/ms after 97 119-count samples
passStyleOf(harden({ ...obj })) ("100",0) 2.2479338842975207 ops/ms after 100 68-count samples

#### V8
passStyleOf(harden(arr.slice())) ("0",0) 312.007992007992 ops/ms after 122 7680-count samples
passStyleOf(harden({ ...obj })) ("0",0) 415.27200791295746 ops/ms after 82 15360-count samples
passStyleOf(harden(arr.slice())) ("1",0) 242.5531914893617 ops/ms after 95 7680-count samples
passStyleOf(harden({ ...obj })) ("1",0) 260.4147877984085 ops/ms after 121 6491-count samples
passStyleOf(harden(arr.slice())) ("10",0) 107.24760330578512 ops/ms after 107 3032-count samples
passStyleOf(harden({ ...obj })) ("10",0) 112.47321428571429 ops/ms after 117 2907-count samples
passStyleOf(harden(arr.slice())) ("100",0) 16.280052840158522 ops/ms after 104 474-count samples
passStyleOf(harden({ ...obj })) ("100",0) 10.569347898047004 ops/ms after 103 310-count samples
```

#### After
```
#### Moddable XS

passStyleOf(harden(arr.slice())) ("0",0) 113.61702127659575 ops/ms after 89 3840-count samples
passStyleOf(harden({ ...obj })) ("0",0) 124.67703507610854 ops/ms after 103 3658-count samples
passStyleOf(harden(arr.slice())) ("1",0) 84.938923737207 ops/ms after 67 3840-count samples
passStyleOf(harden({ ...obj })) ("1",0) 77.62334217506631 ops/ms after 64 3658-count samples
passStyleOf(harden(arr.slice())) ("10",0) 32.43941411451398 ops/ms after 104 937-count samples
passStyleOf(harden({ ...obj })) ("10",0) 23.11864406779661 ops/ms after 102 682-count samples
passStyleOf(harden(arr.slice())) ("100",0) 4.580838323353293 ops/ms after 102 135-count samples
passStyleOf(harden({ ...obj })) ("100",0) 2.484707446808511 ops/ms after 101 74-count samples

#### V8
passStyleOf(harden(arr.slice())) ("0",0) 332.46753246753246 ops/ms after 130 7680-count samples
passStyleOf(harden({ ...obj })) ("0",0) 526.6577896138482 ops/ms after 206 7680-count samples
passStyleOf(harden(arr.slice())) ("1",0) 265.7085828343313 ops/ms after 104 7680-count samples
passStyleOf(harden({ ...obj })) ("1",0) 331.9148936170213 ops/ms after 130 7680-count samples
passStyleOf(harden(arr.slice())) ("10",0) 120.50582362728785 ops/ms after 110 3292-count samples
passStyleOf(harden({ ...obj })) ("10",0) 136.24742268041237 ops/ms after 112 3658-count samples
passStyleOf(harden(arr.slice())) ("100",0) 17.79128137384412 ops/ms after 104 518-count samples
passStyleOf(harden({ ...obj })) ("100",0) 12.364597093791282 ops/ms after 104 360-count samples
```

</details>

### Documentation Considerations

None.

### Testing Considerations

All existing tests still pass.

### Compatibility Considerations

n/a

### Upgrade Considerations

None in particular.