### PR TITLE
feat(cli,daemon): Add `mkdir` command

### DIFF
--- a/packages/cli/src/commands/mkdir.js
+++ b/packages/cli/src/commands/mkdir.js
@@ -6,5 +6,5 @@ import { parsePetNamePath } from '../pet-name.js';
 
 export const mkdir = async ({ agentNames, directoryPath }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    await E(agent).makeDirectory(parsePetNamePath(directoryPath));
+    await E(agent).makeDirectory(...parsePetNamePath(directoryPath));
   });

--- a/packages/cli/src/commands/mkdir.js
+++ b/packages/cli/src/commands/mkdir.js
@@ -1,0 +1,10 @@
+/* global process */
+import os from 'os';
+import { E } from '@endo/far';
+import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
+
+export const mkdir = async ({ agentNames, directoryPath }) =>
+  withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
+    await E(agent).makeDirectory(parsePetNamePath(directoryPath));
+  });

--- a/packages/cli/src/commands/store.js
+++ b/packages/cli/src/commands/store.js
@@ -7,6 +7,7 @@ import { makeReaderRef } from '@endo/daemon';
 import { E } from '@endo/far';
 
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
 /**
  * @param {Array<Uint8Array>} arrays
@@ -72,32 +73,34 @@ export const store = async ({
     )})`;
   }
 
+  const parsedName = parsePetNamePath(name);
+
   await withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
     if (storeText !== undefined) {
-      await E(agent).storeValue(storeText, name);
+      await E(agent).storeValue(storeText, parsedName);
     } else if (storeJson !== undefined) {
-      await E(agent).storeValue(JSON.parse(storeJson), name);
+      await E(agent).storeValue(JSON.parse(storeJson), parsedName);
     } else if (storeBigInt !== undefined) {
-      await E(agent).storeValue(BigInt(storeBigInt), name);
+      await E(agent).storeValue(BigInt(storeBigInt), parsedName);
     } else if (storeTextStdin !== undefined) {
       const reader = makeNodeReader(process.stdin);
       const bytes = await asyncConcat(reader);
       const text = new TextDecoder().decode(bytes);
-      await E(agent).storeValue(text, name);
+      await E(agent).storeValue(text, parsedName);
     } else if (storeJsonStdin !== undefined) {
       const reader = makeNodeReader(process.stdin);
       const bytes = await asyncConcat(reader);
       const text = new TextDecoder().decode(bytes);
-      await E(agent).storeValue(JSON.parse(text), name);
+      await E(agent).storeValue(JSON.parse(text), parsedName);
     } else if (storeStdin !== undefined) {
       const reader = makeNodeReader(process.stdin);
       const readerRef = makeReaderRef(reader);
-      await E(agent).storeBlob(readerRef, name);
+      await E(agent).storeBlob(readerRef, parsedName);
     } else if (storePath !== undefined) {
       const nodeReadStream = fs.createReadStream(storePath);
       const reader = makeNodeReader(nodeReadStream);
       const readerRef = makeReaderRef(reader);
-      await E(agent).storeBlob(readerRef, name);
+      await E(agent).storeBlob(readerRef, parsedName);
     }
   });
 };

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -472,6 +472,16 @@ export const main = async rawArgs => {
     });
 
   program
+    .command('mkdir <path>')
+    .option(...commonOptions.as)
+    .description('makes a directory (pet store, name hub)')
+    .action(async (directoryPath, cmd) => {
+      const { as: agentNames } = cmd.opts();
+      const { mkdir } = await import('./commands/mkdir.js');
+      return mkdir({ agentNames, directoryPath });
+    });
+
+  program
     .command('invite <guest-name>')
     .option(...commonOptions.as)
     .action(async (guestName, cmd) => {

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -12,7 +12,6 @@ import url from 'url';
 
 import { Command } from 'commander';
 import { prompt } from './prompt.js';
-import { parsePetNamePath } from './pet-name.js';
 
 const packageDescriptorPath = url.fileURLToPath(
   new URL('../package.json', import.meta.url),
@@ -371,7 +370,7 @@ export const main = async rawArgs => {
         storeJson,
         storeJsonStdin,
         storeBigInt,
-        name: parsePetNamePath(name),
+        name,
         agentNames,
       });
     });

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -207,13 +207,6 @@ export const makeDirectoryMaker = ({
       await toHub.write([toName], id);
     };
 
-    /** @type {EndoDirectory['makeDirectory']} */
-    const makeDirectory = async directoryPetName => {
-      const { value: directory, id } = await formulateDirectory();
-      await petStore.write(directoryPetName, id);
-      return directory;
-    };
-
     /** @type {EndoDirectory['write']} */
     const write = async (petNamePath, id) => {
       if (typeof petNamePath === 'string') {
@@ -226,6 +219,13 @@ export const makeDirectoryMaker = ({
       }
       const { hub, name } = await lookupTailNameHub(petNamePath);
       await hub.write([name], id);
+    };
+
+    /** @type {EndoDirectory['makeDirectory']} */
+    const makeDirectory = async (...directoryPetNamePath) => {
+      const { value: directory, id } = await formulateDirectory();
+      await write(directoryPetNamePath, id);
+      return directory;
     };
 
     /** @type {EndoDirectory} */

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -453,7 +453,7 @@ export interface NameHub {
 }
 
 export interface EndoDirectory extends NameHub {
-  makeDirectory(petName: string): Promise<EndoDirectory>;
+  makeDirectory(...petNamePath: string[]): Promise<EndoDirectory>;
 }
 
 export type MakeDirectoryNode = (petStore: PetStore) => EndoDirectory;


### PR DESCRIPTION
Adds `mkdir` command to the CLI. Updates the daemon's directory abstraction to accept pet name paths at `makeDirectory()`.

```
> endo mkdir dir
> endo make counter.js -n dir.counter
> endo eval 'E(counter).incr()' counter:dir.counter
1
```