### PR TITLE
feat(bundle-source): Zip original sources with --no-transforms

### DIFF
--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -325,12 +325,12 @@ export const makeNodeBundleCache = async (
   nonce,
 ) => {
   const [fs, path, url, crypto, timers, os] = await Promise.all([
-    await loadModule('fs'),
-    await loadModule('path'),
-    await loadModule('url'),
-    await loadModule('crypto'),
-    await loadModule('timers'),
-    await loadModule('os'),
+    loadModule('fs'),
+    loadModule('path'),
+    loadModule('url'),
+    loadModule('crypto'),
+    loadModule('timers'),
+    loadModule('os'),
   ]);
 
   if (nonce === undefined) {

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -39,8 +39,10 @@
   "devDependencies": {
     "@endo/lockdown": "^1.0.7",
     "@endo/ses-ava": "^1.2.2",
+    "@endo/zip": "^1.0.5",
     "ava": "^6.1.3",
     "c8": "^7.14.0",
+    "eslint": "^8.57.0",
     "typescript": "5.5.0-beta"
   },
   "keywords": [],

--- a/packages/bundle-source/src/types.js
+++ b/packages/bundle-source/src/types.js
@@ -64,6 +64,9 @@ export {};
  * @property {T} [format]
  * @property {boolean} [dev] - development mode, for test bundles that need
  * access to devDependencies of the entry package.
+ * @property {boolean} [noTransforms] - when true, generates a bundle with the
+ * original sources instead of SES-shim specific ESM and CJS. This may become
+ * default in a future major version.
  */
 
 /**

--- a/packages/bundle-source/test/no-transforms.test.js
+++ b/packages/bundle-source/test/no-transforms.test.js
@@ -1,0 +1,36 @@
+// @ts-check
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import fs from 'fs';
+import url from 'url';
+import { decodeBase64 } from '@endo/base64';
+import { ZipReader } from '@endo/zip';
+import bundleSource from '../src/index.js';
+
+test('no-transforms applies no transforms', async t => {
+  const entryPath = url.fileURLToPath(
+    new URL(`../demo/circular/a.js`, import.meta.url),
+  );
+  const { endoZipBase64 } = await bundleSource(entryPath, {
+    moduleFormat: 'endoZipBase64',
+    noTransforms: true,
+  });
+  const endoZipBytes = decodeBase64(endoZipBase64);
+  const zipReader = new ZipReader(endoZipBytes);
+  const compartmentMapBytes = zipReader.read('compartment-map.json');
+  const compartmentMapText = new TextDecoder().decode(compartmentMapBytes);
+  const compartmentMap = JSON.parse(compartmentMapText);
+  const { entry, compartments } = compartmentMap;
+  const compartment = compartments[entry.compartment];
+  const module = compartment.modules[entry.module];
+  // Alleged module type is not precompiled (pre-mjs-json)
+  t.is(module.parser, 'mjs');
+
+  const moduleBytes = zipReader.read(
+    `${compartment.location}/${module.location}`,
+  );
+  const moduleText = new TextDecoder().decode(moduleBytes);
+  const originalModuleText = await fs.promises.readFile(entryPath, 'utf-8');
+  // And, just to be sure, the text in the bundle matches the original text.
+  t.is(moduleText, originalModuleText);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,11 +190,13 @@ __metadata:
     "@endo/promise-kit": "npm:^1.1.2"
     "@endo/ses-ava": "npm:^1.2.2"
     "@endo/where": "npm:^1.0.5"
+    "@endo/zip": "npm:^1.0.5"
     "@rollup/plugin-commonjs": "npm:^19.0.0"
     "@rollup/plugin-node-resolve": "npm:^13.0.0"
     acorn: "npm:^8.2.4"
     ava: "npm:^6.1.3"
     c8: "npm:^7.14.0"
+    eslint: "npm:^8.57.0"
     rollup: "npm:^2.79.1"
     typescript: "npm:5.5.0-beta"
   bin:


### PR DESCRIPTION
Closes: #2295 
Refs: #400, #2252

## Description

This change adds a mode to the `bundle-source` command with the initial flag `--no-transforms` that generates “endo zip base64” style bundles without applying the module-to-program transform and SES shim censorship evasion transforms, such that the original files on disk appear in the zip file. This is a preparatory step, necessary for building test artifacts, in advance of full support for this bundle style.

### Security Considerations

`bundle-source` is part of the Endo and Agoric toolkit and it, or its surrogate, participate in the toolchain for generating content that can be confined by Hardened JavaScript, but is not trusted by Hardened JavaScript at runtime. It does however _currently_ run with all the authority of the developer in their development environment and its integrity must be carefully guarded.

### Scaling Considerations

No improvements expected at this time, but in pursuit of #400, it may be possible to move the heavy and performance sensitive JavaScript transform components from `bundle-source` to `import-bundle` and only suffer the performance cost of these transforms on Node.js, where those costs are more readily born by some runtimes. Precompiled bundles may continue to be the preferred medium for deployment to the web, for example.

### Documentation Considerations

We will need to advertise the `--no-transforms` flag eventually, since there will be a period where it is advisable if not necessary to generate contracts and caplets targeting the XS runtime.

### Testing Considerations

I have included a test that verifies the API behavior and manually run the following to verify behavior for the CLI:

```sh
rm -rf bundles
yarn bundle-source --no-transforms --cache-json bundles demo/circular/a.js circular-a
rm -rf circular-a
mkdir -p circular-a
jq -r .endoZipBase64 bundles/bundle-circular-a.json | base64 -d > circular-a/circular-a.zip
(cd circular-a; unzip circular-a.zip)
jq . circular-a/compartment-map.json
# verifying the final module entires have parser: 'mjs'
```

### Compatibility Considerations

This flag is opt-in and breaks no prior behaviors. This introduces a new entry to the build cache meta-data and may cause some bundles to be regenerated one extra time after upgrading.

### Upgrade Considerations

This should not impact upgrade, though it participates in the greater #400 story which will require xsnap upgrades to come to bear.