### PR TITLE
chore(nat): Fix typo in Nat error message

### DIFF
--- a/packages/nat/src/index.js
+++ b/packages/nat/src/index.js
@@ -63,7 +63,7 @@ function Nat(allegedNum) {
 
   if (typeof allegedNum === 'number') {
     if (!Number.isSafeInteger(allegedNum)) {
-      throw RangeError(`${allegedNum} not a safe integer`);
+      throw RangeError(`${allegedNum} is not a safe integer`);
     }
     if (allegedNum < 0) {
       throw RangeError(`${allegedNum} is negative`);


### PR DESCRIPTION
## Description

Adds a missing "is" to an error message from `Nat`.

### Security Considerations

None.

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

None.

### Compatibility Considerations

n/a

### Upgrade Considerations

We expect error messages to change over time and require code to be tolerant of this.