### PR TITLE
cli: Add a `--verbose` option to the `endo list` command

### DIFF
--- a/packages/cli/src/commands/list.js
+++ b/packages/cli/src/commands/list.js
@@ -1,11 +1,40 @@
 /* global process */
 import os from 'os';
+import { inspect } from 'util';
 import { E } from '@endo/far';
 import { makeRefIterator } from '@endo/daemon';
 import { withEndoHost } from '../context.js';
 import { parsePetNamePath } from '../pet-name.js';
 
-export const list = async ({ directory, follow, json }) =>
+const prettyValue = val => {
+  let result;
+  const type = typeof val;
+  if (type === 'string') {
+    result = `'${val}'`;
+  } else if (type === 'object') {
+    result = `${val}`;
+    const noise = '[object Alleged: ';
+    if (result.startsWith(noise)) {
+      result = result.substring(noise.length);
+      result = result.substring(0, result.length - 1);
+    } else {
+      result = inspect(val);
+    }
+  } else {
+    result = inspect(val);
+  }
+  return result;
+};
+
+const pad = (fieldVal, width, minPad = 2) => {
+  let spaces = width - `${fieldVal}`.length;
+  if (spaces < minPad) {
+    spaces = minPad;
+  }
+  return ' '.repeat(spaces);
+};
+
+export const list = async ({ directory, follow, json, verbose }) =>
   withEndoHost({ os, process }, async ({ host: agent }) => {
     if (directory !== undefined) {
       const directoryPath = parsePetNamePath(directory);
@@ -30,7 +59,12 @@ export const list = async ({ directory, follow, json }) =>
     } else {
       const petNames = await E(agent).list();
       for await (const petName of petNames) {
-        console.log(petName);
+        if (verbose) {
+          const val = await E(agent).lookup(petName);
+          console.log(`${petName}${pad(petName, 20)}${prettyValue(val)}`);
+        } else {
+          console.log(petName);
+        }
       }
     }
   });

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -280,10 +280,11 @@ export const main = async rawArgs => {
     .description('show names known to the current or specified directory')
     .option('-f,--follow', 'Follow updates')
     .option('-j,--json', 'JSON format output')
+    .option('-v,--verbose', 'Provide more detailed output')
     .action(async (directory, cmd) => {
-      const { follow, json } = cmd.opts();
+      const { follow, json, verbose } = cmd.opts();
       const { list } = await import('./commands/list.js');
-      return list({ directory, follow, json });
+      return list({ directory, follow, json, verbose });
     });
 
   program


### PR DESCRIPTION
The `endo list` command now accepts a `--verbose` option that will cause it to print out a prettified version of the value that would be shown by `endo show` for each entry.

I kept finding myself wanting this during my explorations, so I just went ahead and implemented it.
