### PR TITLE
feat(compartment-mapper): Support dynamic require/importNow

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,12 @@
 User-visible changes to `@endo/compartment-mapper`:
 
+# Next release
+
+- Adds support for dynamic requires in CommonJS modules. This requires specific
+  configuration to be passed in (including new read powers), and is _not_
+  enabled by default. See the signature of `loadFromMap()` in `import-lite.js`
+  for details.
+
 # v1.2.0 (2024-07-30)
 
 - Fixes incompatible behavior with Node.js package conditional exports #2276.

--- a/packages/compartment-mapper/node-powers.js
+++ b/packages/compartment-mapper/node-powers.js
@@ -1,3 +1,7 @@
-export { makeReadPowers, makeWritePowers } from './src/node-powers.js';
+export {
+  makeReadPowers,
+  makeWritePowers,
+  makeReadNowPowers,
+} from './src/node-powers.js';
 // Deprecated:
 export { makeNodeReadPowers, makeNodeWritePowers } from './src/node-powers.js';

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@endo/cjs-module-analyzer": "workspace:^",
     "@endo/module-source": "workspace:^",
+    "@endo/trampoline": "workspace:^",
     "@endo/zip": "workspace:^",
     "ses": "workspace:^"
   },

--- a/packages/compartment-mapper/src/import-lite.js
+++ b/packages/compartment-mapper/src/import-lite.js
@@ -16,11 +16,13 @@
 
 // @ts-check
 /* eslint no-shadow: "off" */
-
 /** @import {CompartmentMapDescriptor} from './types.js' */
+/** @import {SyncImportLocationOptions} from './types.js' */
+/** @import {ImportNowHookMaker} from './types.js' */
+/** @import {ModuleTransforms} from './types.js' */
+/** @import {ReadNowPowers} from './types.js' */
 /** @import {Application} from './types.js' */
 /** @import {ImportLocationOptions} from './types.js' */
-/** @import {LoadLocationOptions} from './types.js' */
 /** @import {ExecuteFn} from './types.js' */
 /** @import {ReadFn} from './types.js' */
 /** @import {ReadPowers} from './types.js' */
@@ -30,19 +32,63 @@ import { link } from './link.js';
 import {
   exitModuleImportHookMaker,
   makeImportHookMaker,
+  makeImportNowHookMaker,
 } from './import-hook.js';
+import { isReadNowPowers } from './powers.js';
 
-const { assign, create, freeze } = Object;
+const { assign, create, freeze, entries } = Object;
 
 /**
- * @param {ReadFn | ReadPowers} readPowers
+ * Returns `true` if `value` is a {@link SyncImportLocationOptions}.
+ *
+ * The requirements here are:
+ * - `moduleTransforms` _is not_ present in `value`
+ * - `parserForLanguage` - if set, contains synchronous parsers only
+ *
+ * @param {ImportLocationOptions|SyncImportLocationOptions} value
+ * @returns {value is SyncImportLocationOptions}
+ */
+const isSyncOptions = value => {
+  if (!value || (typeof value === 'object' && !('moduleTransforms' in value))) {
+    if (value.parserForLanguage) {
+      for (const [_language, { synchronous }] of entries(
+        value.parserForLanguage,
+      )) {
+        if (!synchronous) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+  return false;
+};
+
+/**
+ * @overload
+ * @param {ReadNowPowers} readPowers
  * @param {CompartmentMapDescriptor} compartmentMap
- * @param {LoadLocationOptions} [options]
+ * @param {SyncImportLocationOptions} [opts]
  * @returns {Promise<Application>}
  */
+
+/**
+ * @overload
+ * @param {ReadFn | ReadPowers} readPowers
+ * @param {CompartmentMapDescriptor} compartmentMap
+ * @param {ImportLocationOptions} [opts]
+ * @returns {Promise<Application>}
+ */
+
+/**
+ * @param {ReadFn|ReadPowers|ReadNowPowers} readPowers
+ * @param {CompartmentMapDescriptor} compartmentMap
+ * @param {ImportLocationOptions} [options]
+ * @returns {Promise<Application>}
+ */
+
 export const loadFromMap = async (readPowers, compartmentMap, options = {}) => {
   const {
-    moduleTransforms = {},
     searchSuffixes = undefined,
     parserForLanguage: parserForLanguageOption = {},
     languageForExtension: languageForExtensionOption = {},
@@ -54,6 +100,44 @@ export const loadFromMap = async (readPowers, compartmentMap, options = {}) => {
   const languageForExtension = freeze(
     assign(create(null), languageForExtensionOption),
   );
+
+  /**
+   * Object containing options and read powers that fulfills all requirements
+   * for creation of a {@link ImportNowHookMaker}, thus enabling dynamic import.
+   *
+   * @typedef SyncBehavior
+   * @property {ReadNowPowers} readPowers
+   * @property {SyncImportLocationOptions} options
+   * @property {'SYNC'} type
+   */
+
+  /**
+   * Object containing options and read powers which is incompatible with
+   * creation of an {@link ImportNowHookMaker}, thus disabling dynamic import.
+   *
+   * @typedef AsyncBehavior
+   * @property {ReadFn|ReadPowers} readPowers
+   * @property {ImportLocationOptions} options
+   * @property {'ASYNC'} type
+   */
+
+  /**
+   * When we must control flow based on _n_ type guards consdering _n_ discrete
+   * values, grouping the values into an object, then leveraging a discriminated
+   * union (the `type` property) is one way to approach the problem.
+   */
+  const behavior =
+    isReadNowPowers(readPowers) && isSyncOptions(options)
+      ? /** @type {SyncBehavior} */ ({
+          readPowers,
+          options: options || {},
+          type: 'SYNC',
+        })
+      : /** @type {AsyncBehavior} */ ({
+          readPowers,
+          options: options || {},
+          type: 'ASYNC',
+        });
 
   const {
     entry: { compartment: entryCompartmentName, module: entryModuleSpecifier },
@@ -85,16 +169,54 @@ export const loadFromMap = async (readPowers, compartmentMap, options = {}) => {
         exitModuleImportHook: compartmentExitModuleImportHook,
       },
     );
-    const { compartment, pendingJobsPromise } = link(compartmentMap, {
-      makeImportHook,
-      parserForLanguage,
-      languageForExtension,
-      globals,
-      transforms,
-      moduleTransforms,
-      __shimTransforms__,
-      Compartment,
-    });
+
+    /** @type {ImportNowHookMaker | undefined} */
+    let makeImportNowHook;
+
+    /** @type {Compartment} */
+    let compartment;
+    /** @type {Promise<void>} */
+    let pendingJobsPromise;
+
+    if (behavior.type === 'SYNC') {
+      const { importNowHook: exitModuleImportNowHook, syncModuleTransforms } =
+        behavior.options;
+      makeImportNowHook = makeImportNowHookMaker(
+        /** @type {ReadNowPowers} */ (readPowers),
+        entryCompartmentName,
+        {
+          compartmentDescriptors: compartmentMap.compartments,
+          searchSuffixes,
+          exitModuleImportNowHook,
+        },
+      );
+      ({ compartment, pendingJobsPromise } = link(compartmentMap, {
+        makeImportHook,
+        makeImportNowHook,
+        parserForLanguage,
+        languageForExtension,
+        globals,
+        transforms,
+        syncModuleTransforms,
+        __shimTransforms__,
+        Compartment,
+      }));
+    } else {
+      // sync module transforms are allowed, because they are "compatible"
+      // with async module transforms (not vice-versa)
+      const { moduleTransforms, syncModuleTransforms } = behavior.options;
+      ({ compartment, pendingJobsPromise } = link(compartmentMap, {
+        makeImportHook,
+        parserForLanguage,
+        languageForExtension,
+        globals,
+        transforms,
+        moduleTransforms,
+        syncModuleTransforms,
+        __shimTransforms__,
+        Compartment,
+      }));
+    }
 
     await pendingJobsPromise;
 

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -19,8 +19,13 @@ import { loadFromMap } from './import-lite.js';
 const { assign, create, freeze } = Object;
 
 /** @import {Application} from './types.js' */
+/** @import {ImportLocationOptions} from './types.js' */
+/** @import {SyncArchiveOptions} from './types.js' */
+/** @import {LoadLocationOptions} from './types.js' */
+/** @import {SyncImportLocationOptions} from './types.js' */
+/** @import {SomeObject} from './types.js' */
+/** @import {ReadNowPowers} from './types.js' */
 /** @import {ArchiveOptions} from './types.js' */
-/** @import {ExecuteOptions} from './types.js' */
 /** @import {ReadFn} from './types.js' */
 /** @import {ReadPowers} from './types.js' */
 
@@ -38,9 +43,25 @@ const assignParserForLanguage = (options = {}) => {
 };
 
 /**
+ * @overload
+ * @param {ReadNowPowers} readPowers
+ * @param {string} moduleLocation
+ * @param {SyncArchiveOptions} options
+ * @returns {Promise<Application>}
+ */
+
+/**
+ * @overload
  * @param {ReadFn | ReadPowers} readPowers
  * @param {string} moduleLocation
- * @param {ArchiveOptions} [options]
+ * @param {LoadLocationOptions} [options]
+ * @returns {Promise<Application>}
+ */
+
+/**
+ * @param {ReadFn|ReadPowers|ReadNowPowers} readPowers
+ * @param {string} moduleLocation
+ * @param {LoadLocationOptions} [options]
  * @returns {Promise<Application>}
  */
 export const loadLocation = async (
@@ -48,7 +69,10 @@ export const loadLocation = async (
   moduleLocation,
   options = {},
 ) => {
-  const { dev, tags, conditions = tags, commonDependencies, policy } = options;
+  const { dev, tags, commonDependencies, policy } = options;
+  // conditions are not present in SyncArchiveOptions
+  const conditions =
+    'conditions' in options ? options.conditions || tags : tags;
   const compartmentMap = await mapNodeModules(readPowers, moduleLocation, {
     dev,
     conditions,
@@ -63,10 +87,32 @@ export const loadLocation = async (
 };
 
 /**
- * @param {ReadFn | ReadPowers} readPowers
+ * Allows dynamic requires
+ *
+ * @overload
+ * @param {ReadNowPowers} readPowers
  * @param {string} moduleLocation
- * @param {ExecuteOptions & ArchiveOptions} [options]
- * @returns {Promise<import('./types.js').SomeObject>} the object of the imported modules exported
+ * @param {SyncImportLocationOptions} options
+ * @returns {Promise<SomeObject>} the object of the imported modules exported
+ * names.
+ */
+
+/**
+ * Disallows dynamic requires
+ *
+ * @overload
+ * @param {ReadPowers|ReadFn} readPowers
+ * @param {string} moduleLocation
+ * @param {ImportLocationOptions} [options]
+ * @returns {Promise<SomeObject>} the object of the imported modules exported
+ * names.
+ */
+
+/**
+ * @param {ReadPowers|ReadFn|ReadNowPowers} readPowers
+ * @param {string} moduleLocation
+ * @param {ImportLocationOptions} [options]
+ * @returns {Promise<SomeObject>} the object of the imported modules exported
  * names.
  */
 export const importLocation = async (readPowers, moduleLocation, options) => {

--- a/packages/compartment-mapper/src/map-parser.js
+++ b/packages/compartment-mapper/src/map-parser.js
@@ -1,0 +1,339 @@
+/**
+ * Exports {@link makeMapParsers}, which creates a function which matches a
+ * module to a parser based on reasons.
+ *
+ * @module
+ */
+
+// @ts-check
+
+import { syncTrampoline, asyncTrampoline } from '@endo/trampoline';
+import { parseExtension } from './extension.js';
+
+/**
+ * @import {
+ *   LanguageForExtension,
+ *   LanguageForModuleSpecifier,
+ *   MakeMapParsersOptions,
+ *   MapParsersFn,
+ *   ModuleTransform,
+ *   ModuleTransforms,
+ *   ParseFn,
+ *   ParseFnAsync,
+ *   ParseResult,
+ *   ParserForLanguage,
+ *   SyncModuleTransform,
+ *   SyncModuleTransforms
+ * } from './types.js';
+ */
+
+const { entries, fromEntries, keys, hasOwnProperty, values } = Object;
+const { apply } = Reflect;
+// q, as in quote, for strings in error messages.
+const q = JSON.stringify;
+
+/**
+ * @param {Record<string, unknown>} object
+ * @param {string} key
+ * @returns {boolean}
+ */
+const has = (object, key) => apply(hasOwnProperty, object, [key]);
+
+/**
+ * Decide if extension is clearly indicating a parser/language for a file
+ *
+ * @param {string} extension
+ * @returns {boolean}
+ */
+const extensionImpliesLanguage = extension => extension !== 'js';
+
+/**
+ * Produces a `parser` that parses the content of a module according to the
+ * corresponding module language, given the extension of the module specifier
+ * and the configuration of the containing compartment. We do not yet support
+ * import assertions and we do not have a mechanism for validating the MIME type
+ * of the module content against the language implied by the extension or file
+ * name.
+ *
+ * @param {boolean} preferSynchronous
+ * @param {Record<string, string>} languageForExtension - maps a file extension
+ * to the corresponding language.
+ * @param {Record<string, string>} languageForModuleSpecifier - In a rare case,
+ * the type of a module is implied by package.json and should not be inferred
+ * from its extension.
+ * @param {ParserForLanguage} parserForLanguage
+ * @param {ModuleTransforms} moduleTransforms
+ * @param {SyncModuleTransforms} syncModuleTransforms
+ * @returns {ParseFnAsync|ParseFn}
+ */
+const makeExtensionParser = (
+  preferSynchronous,
+  languageForExtension,
+  languageForModuleSpecifier,
+  parserForLanguage,
+  moduleTransforms,
+  syncModuleTransforms,
+) => {
+  /** @type {Record<string, ModuleTransform | SyncModuleTransform>} */
+  let transforms;
+
+  /**
+   * Function returning a generator which executes a parser for a module in either sync or async context.
+   *
+   * @param {Uint8Array} bytes
+   * @param {string} specifier
+   * @param {string} location
+   * @param {string} packageLocation
+   * @param {*} options
+   * @returns {Generator<ReturnType<ModuleTransform>|ReturnType<SyncModuleTransform>, ParseResult, Awaited<ReturnType<ModuleTransform>|ReturnType<SyncModuleTransform>>>}
+   */
+  function* getParserGenerator(
+    bytes,
+    specifier,
+    location,
+    packageLocation,
+    options,
+  ) {
+    /** @type {string} */
+    let language;
+    const extension = parseExtension(location);
+
+    if (
+      !extensionImpliesLanguage(extension) &&
+      has(languageForModuleSpecifier, specifier)
+    ) {
+      language = languageForModuleSpecifier[specifier];
+    } else {
+      language = languageForExtension[extension] || extension;
+    }
+
+    /** @type {string|undefined} */
+    let sourceMap;
+
+    if (has(transforms, language)) {
+      try {
+        ({
+          bytes,
+          parser: language,
+          sourceMap,
+        } = yield transforms[language](
+          bytes,
+          specifier,
+          location,
+          packageLocation,
+          {
+            // At time of writing, sourceMap is always undefined, but keeping
+            // it here is more resilient if the surrounding if block becomes a
+            // loop for multi-step transforms.
+            sourceMap,
+          },
+        ));
+      } catch (err) {
+        throw Error(
+          `Error transforming ${q(language)} source in ${q(location)}: ${err.message}`,
+          { cause: err },
+        );
+      }
+    }
+    if (!has(parserForLanguage, language)) {
+      throw Error(
+        `Cannot parse module ${specifier} at ${location}, no parser configured for the language ${language}`,
+      );
+    }
+    const { parse } = parserForLanguage[language];
+    return parse(bytes, specifier, location, packageLocation, {
+      sourceMap,
+      ...options,
+    });
+  }
+
+  /**
+   * @type {ParseFn}
+   */
+  const syncParser = (bytes, specifier, location, packageLocation, options) => {
+    const result = syncTrampoline(
+      getParserGenerator,
+      bytes,
+      specifier,
+      location,
+      packageLocation,
+      options,
+    );
+    if ('then' in result && typeof result.then === 'function') {
+      throw new TypeError(
+        'Sync parser cannot return a Thenable; ensure parser is actually synchronous',
+      );
+    }
+    return result;
+  };
+  syncParser.isSyncParser = true;
+
+  /**
+   * @type {ParseFnAsync}
+   */
+  const asyncParser = async (
+    bytes,
+    specifier,
+    location,
+    packageLocation,
+    options,
+  ) => {
+    return asyncTrampoline(
+      getParserGenerator,
+      bytes,
+      specifier,
+      location,
+      packageLocation,
+      options,
+    );
+  };
+
+  // Unfortunately, typescript was not smart enough to figure out the return
+  // type depending on a boolean in arguments, so it has to be
+  // ParseFnAsync|ParseFn
+  if (preferSynchronous) {
+    transforms = syncModuleTransforms;
+    return syncParser;
+  } else {
+    // we can fold syncModuleTransforms into moduleTransforms because
+    // async supports sync, but not vice-versa
+    transforms = {
+      ...syncModuleTransforms,
+      ...moduleTransforms,
+    };
+
+    return asyncParser;
+  }
+};
+
+/**
+ * Creates a synchronous parser
+ *
+ * @overload
+ * @param {LanguageForExtension} languageForExtension
+ * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
+ * the type of a module is implied by package.json and should not be inferred
+ * from its extension.
+ * @param {ParserForLanguage} parserForLanguage
+ * @param {ModuleTransforms} [moduleTransforms]
+ * @param {SyncModuleTransforms} [syncModuleTransforms]
+ * @param {true} preferSynchronous If `true`, will create a `ParseFn`
+ * @returns {ParseFn}
+ */
+
+/**
+ * Creates an asynchronous parser
+ *
+ * @overload
+ * @param {LanguageForExtension} languageForExtension
+ * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
+ * the type of a module is implied by package.json and should not be inferred
+ * from its extension.
+ * @param {ParserForLanguage} parserForLanguage
+ * @param {ModuleTransforms} [moduleTransforms]
+ * @param {SyncModuleTransforms} [syncModuleTransforms]
+ * @param {false} [preferSynchronous]
+ * @returns {ParseFnAsync}
+ */
+
+/**
+ * @param {LanguageForExtension} languageForExtension
+ * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
+ * the type of a module is implied by package.json and should not be inferred
+ * from its extension.
+ * @param {ParserForLanguage} parserForLanguage
+ * @param {ModuleTransforms} [moduleTransforms]
+ * @param {SyncModuleTransforms} [syncModuleTransforms]
+ * @param {boolean} [preferSynchronous] If `true`, will create a `ParseFn`
+ * @returns {ParseFnAsync|ParseFn}
+ */
+function mapParsers(
+  languageForExtension,
+  languageForModuleSpecifier,
+  parserForLanguage,
+  moduleTransforms = {},
+  syncModuleTransforms = {},
+  preferSynchronous = false,
+) {
+  const languageForExtensionEntries = [];
+  const problems = [];
+  for (const [extension, language] of entries(languageForExtension)) {
+    if (has(parserForLanguage, language)) {
+      languageForExtensionEntries.push([extension, language]);
+    } else {
+      problems.push(`${q(language)} for extension ${q(extension)}`);
+    }
+  }
+  if (problems.length > 0) {
+    throw Error(`No parser available for language: ${problems.join(', ')}`);
+  }
+  return makeExtensionParser(
+    preferSynchronous,
+    fromEntries(languageForExtensionEntries),
+    languageForModuleSpecifier,
+    parserForLanguage,
+    moduleTransforms,
+    syncModuleTransforms,
+  );
+}
+
+/**
+ * Prepares a function to map parsers after verifying whether synchronous
+ * behavior is preferred. Synchronous behavior is selected if all parsers are
+ * synchronous and no async transforms are provided.
+ *
+ * _Note:_ The type argument for {@link MapParsersFn} _could_ be inferred from
+ * the function arguments _if_ {@link ParserForLanguage} contained only values
+ * of type `ParserImplementation & {synchronous: true}` (and also considering
+ * the emptiness of `moduleTransforms`); may only be worth the effort if it was
+ * causing issues in practice.
+ *
+ * @param {MakeMapParsersOptions} options
+ * @returns {MapParsersFn}
+ */
+export const makeMapParsers = ({
+  parserForLanguage,
+  moduleTransforms,
+  syncModuleTransforms,
+}) => {
+  /**
+   * Async `mapParsers()` function; returned when a non-synchronous parser is
+   * present _or_ when `moduleTransforms` is non-empty.
+   *
+   * @type {MapParsersFn<ParseFnAsync>}
+   */
+  const asyncParseFn = (languageForExtension, languageForModuleSpecifier) =>
+    mapParsers(
+      languageForExtension,
+      languageForModuleSpecifier,
+      parserForLanguage,
+      moduleTransforms,
+      syncModuleTransforms,
+    );
+
+  if (moduleTransforms && keys(moduleTransforms).length > 0) {
+    return asyncParseFn;
+  }
+
+  // all parsers must explicitly be flagged `synchronous` to return a
+  // `MapParsersFn<ParseFn>`
+  if (values(parserForLanguage).some(({ synchronous }) => !synchronous)) {
+    return asyncParseFn;
+  }
+
+  /**
+   * Synchronous `mapParsers()` function; returned when all parsers are
+   * synchronous and `moduleTransforms` is empty.
+   *
+   * @type {MapParsersFn<ParseFn>}
+   */
+  return (languageForExtension, languageForModuleSpecifier) =>
+    mapParsers(
+      languageForExtension,
+      languageForModuleSpecifier,
+      parserForLanguage,
+      moduleTransforms,
+      syncModuleTransforms,
+      true,
+    );
+};

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -12,6 +12,8 @@
 /* eslint no-shadow: 0 */
 
 /** @import {CanonicalFn} from './types.js' */
+/** @import {CompartmentMapForNodeModulesOptions} from './types.js' */
+/** @import {SomePolicy} from './types.js' */
 /** @import {CompartmentDescriptor} from './types.js' */
 /** @import {CompartmentMapDescriptor} from './types.js' */
 /** @import {Language} from './types.js' */
@@ -605,7 +607,7 @@ const graphPackages = async (
  * @param {Graph} graph
  * @param {Set<string>} conditions - build conditions about the target environment
  * for selecting relevant exports, e.g., "browser" or "node".
- * @param {import('./types.js').Policy} [policy]
+ * @param {SomePolicy} [policy]
  * @returns {CompartmentMapDescriptor}
  */
 const translateGraph = (
@@ -642,6 +644,12 @@ const translateGraph = (
     /** @type {Record<string, ScopeDescriptor>} */
     const scopes = Object.create(null);
 
+    /**
+     * List of all the compartments (by name) that this compartment can import from.
+     *
+     * @type {Set<string>}
+     */
+    const compartmentNames = new Set();
     const packagePolicy = getPolicyForPackage(
       {
         isEntry: dependeeLocation === entryPackageLocation,
@@ -699,6 +707,7 @@ const translateGraph = (
     for (const dependencyName of keys(dependencyLocations).sort()) {
       const dependencyLocation = dependencyLocations[dependencyName];
       digestExternalAliases(dependencyName, dependencyLocation);
+      compartmentNames.add(dependencyLocation);
     }
     // digest own internal aliases
     for (const modulePath of keys(internalAliases).sort()) {
@@ -724,6 +733,7 @@ const translateGraph = (
       parsers,
       types,
       policy: /** @type {SomePackagePolicy} */ (packagePolicy),
+      compartments: compartmentNames,
     };
   }
 
@@ -745,10 +755,7 @@ const translateGraph = (
  * @param {Set<string>} conditions
  * @param {object} packageDescriptor
  * @param {string} moduleSpecifier
- * @param {object} [options]
- * @param {boolean} [options.dev]
- * @param {object} [options.commonDependencies]
- * @param {object} [options.policy]
+ * @param {CompartmentMapForNodeModulesOptions} [options]
  * @returns {Promise<CompartmentMapDescriptor>}
  */
 export const compartmentMapForNodeModules = async (

--- a/packages/compartment-mapper/src/parse-archive-cjs.js
+++ b/packages/compartment-mapper/src/parse-archive-cjs.js
@@ -16,7 +16,7 @@ const noopExecute = () => {};
 freeze(noopExecute);
 
 /** @type {import('./types.js').ParseFn} */
-export const parseArchiveCjs = async (
+export const parseArchiveCjs = (
   bytes,
   specifier,
   location,
@@ -66,4 +66,5 @@ export const parseArchiveCjs = async (
 export default {
   parse: parseArchiveCjs,
   heuristicImports: true,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/parse-archive-mjs.js
+++ b/packages/compartment-mapper/src/parse-archive-mjs.js
@@ -9,7 +9,7 @@ const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
 /** @type {import('./types.js').ParseFn} */
-export const parseArchiveMjs = async (
+export const parseArchiveMjs = (
   bytes,
   specifier,
   sourceUrl,
@@ -35,4 +35,5 @@ export const parseArchiveMjs = async (
 export default {
   parse: parseArchiveMjs,
   heuristicImports: false,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/parse-bytes.js
+++ b/packages/compartment-mapper/src/parse-bytes.js
@@ -13,12 +13,7 @@
 const freeze = Object.freeze;
 
 /** @type {import('./types.js').ParseFn} */
-export const parseBytes = async (
-  bytes,
-  _specifier,
-  _location,
-  _packageLocation,
-) => {
+export const parseBytes = (bytes, _specifier, _location, _packageLocation) => {
   // Snapshot ArrayBuffer
   const buffer = new ArrayBuffer(bytes.length);
   const bytesView = new Uint8Array(buffer);
@@ -49,4 +44,5 @@ export const parseBytes = async (
 export default {
   parse: parseBytes,
   heuristicImports: false,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/parse-cjs.js
+++ b/packages/compartment-mapper/src/parse-cjs.js
@@ -12,7 +12,7 @@ const textDecoder = new TextDecoder();
 const { freeze } = Object;
 
 /** @type {import('./types.js').ParseFn} */
-export const parseCjs = async (
+export const parseCjs = (
   bytes,
   _specifier,
   location,
@@ -31,7 +31,7 @@ export const parseCjs = async (
     exports.push('default');
   }
 
-  const { filename, dirname } = await getModulePaths(readPowers, location);
+  const { filename, dirname } = getModulePaths(readPowers, location);
 
   /**
    * @param {object} moduleEnvironmentRecord
@@ -67,4 +67,5 @@ export const parseCjs = async (
 export default {
   parse: parseCjs,
   heuristicImports: true,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/parse-json.js
+++ b/packages/compartment-mapper/src/parse-json.js
@@ -2,25 +2,24 @@
 
 // @ts-check
 
+/** @import {Harden} from 'ses' */
+/** @import {ParseFn} from './types.js' */
+/** @import {ParserImplementation} from './types.js' */
+
 import { parseLocatedJson } from './json.js';
 
 /**
  * TypeScript cannot be relied upon to deal with the nuances of Readonly, so we
  * borrow the pass-through type definition of harden here.
  *
- * @type {import('ses').Harden}
+ * @type {Harden}
  */
 const freeze = Object.freeze;
 
 const textDecoder = new TextDecoder();
 
-/** @type {import('./types.js').ParseFn} */
-export const parseJson = async (
-  bytes,
-  _specifier,
-  location,
-  _packageLocation,
-) => {
+/** @type {ParseFn} */
+export const parseJson = (bytes, _specifier, location, _packageLocation) => {
   const source = textDecoder.decode(bytes);
   const imports = freeze([]);
 
@@ -41,8 +40,9 @@ export const parseJson = async (
   };
 };
 
-/** @type {import('./types.js').ParserImplementation} */
+/** @type {ParserImplementation} */
 export default {
   parse: parseJson,
   heuristicImports: false,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/parse-mjs.js
+++ b/packages/compartment-mapper/src/parse-mjs.js
@@ -7,7 +7,7 @@ import { ModuleSource } from '@endo/module-source';
 const textDecoder = new TextDecoder();
 
 /** @type {import('./types.js').ParseFn} */
-export const parseMjs = async (
+export const parseMjs = (
   bytes,
   _specifier,
   sourceUrl,
@@ -33,4 +33,5 @@ export const parseMjs = async (
 export default {
   parse: parseMjs,
   heuristicImports: false,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/parse-pre-cjs.js
+++ b/packages/compartment-mapper/src/parse-pre-cjs.js
@@ -12,7 +12,7 @@ import { wrap, getModulePaths } from './parse-cjs-shared-export-wrapper.js';
 const textDecoder = new TextDecoder();
 
 /** @type {import('./types.js').ParseFn} */
-export const parsePreCjs = async (
+export const parsePreCjs = (
   bytes,
   _specifier,
   location,
@@ -25,7 +25,7 @@ export const parsePreCjs = async (
     location,
   );
 
-  const { filename, dirname } = await getModulePaths(readPowers, location);
+  const { filename, dirname } = getModulePaths(readPowers, location);
 
   /**
    * @param {object} moduleEnvironmentRecord
@@ -64,4 +64,5 @@ export const parsePreCjs = async (
 export default {
   parse: parsePreCjs,
   heuristicImports: true,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/parse-pre-mjs.js
+++ b/packages/compartment-mapper/src/parse-pre-mjs.js
@@ -11,7 +11,7 @@ import { parseLocatedJson } from './json.js';
 const textDecoder = new TextDecoder();
 
 /** @type {import('./types.js').ParseFn} */
-export const parsePreMjs = async (
+export const parsePreMjs = (
   bytes,
   _specifier,
   location,
@@ -38,4 +38,5 @@ export const parsePreMjs = async (
 export default {
   parse: parsePreMjs,
   heuristicImports: false,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/parse-text.js
+++ b/packages/compartment-mapper/src/parse-text.js
@@ -16,12 +16,7 @@ const freeze = Object.freeze;
 const textDecoder = new TextDecoder();
 
 /** @type {import('./types.js').ParseFn} */
-export const parseText = async (
-  bytes,
-  _specifier,
-  _location,
-  _packageLocation,
-) => {
+export const parseText = (bytes, _specifier, _location, _packageLocation) => {
   const text = textDecoder.decode(bytes);
 
   /** @type {Array<string>} */
@@ -49,4 +44,5 @@ export const parseText = async (
 export default {
   parse: parseText,
   heuristicImports: false,
+  synchronous: true,
 };

--- a/packages/compartment-mapper/src/policy.js
+++ b/packages/compartment-mapper/src/policy.js
@@ -3,6 +3,16 @@
 
 // @ts-check
 
+/** @import {Policy} from './types.js' */
+/** @import {PackagePolicy} from './types.js' */
+/** @import {AttenuationDefinition} from './types.js' */
+/** @import {PackageNamingKit} from './types.js' */
+/** @import {DeferredAttenuatorsProvider} from './types.js' */
+/** @import {CompartmentDescriptor} from './types.js' */
+/** @import {Attenuator} from './types.js' */
+/** @import {SomePolicy} from './types.js' */
+/** @import {SomePackagePolicy} from './types.js' */
+
 import {
   getAttenuatorFromDefinition,
   isAllowingEverything,
@@ -21,26 +31,26 @@ const q = JSON.stringify;
 export const ATTENUATORS_COMPARTMENT = '<ATTENUATORS>';
 
 /**
- * Copies properties (optionally limited to a specific list) from one object
- * to another. By default, copies all enumerable, own, string- and
- * symbol-named properties.
- *
- * @param {object} from
- * @param {object} to
- * @param {Array<string | symbol>} [list]
- * @returns {object}
+ * Copies properties (optionally limited to a specific list) from one object to another.
+ * @template {Record<PropertyKey, any>} T
+ * @template {Record<PropertyKey, any>} U
+ * @template {Array<Partial<keyof T>>} [K=Array<keyof T>]
+ * @param {T} from
+ * @param {U} to
+ * @param {K} [list]
+ * @returns {Omit<U, K[number]> & Pick<T, K[number]>}
  */
 const selectiveCopy = (from, to, list) => {
+  /** @type {Array<Partial<keyof T>>} */
+  let props;
   if (!list) {
     const descs = getOwnPropertyDescriptors(from);
-    list = ownKeys(from).filter(
-      key =>
-        // @ts-expect-error TypeScript still confused about a symbol as index
-        descs[key].enumerable,
-    );
+    props = ownKeys(from).filter(key => descs[key].enumerable);
+  } else {
+    props = list;
   }
-  for (let index = 0; index < list.length; index += 1) {
-    const key = list[index];
+  for (let index = 0; index < props.length; index += 1) {
+    const key = props[index];
     // If an endowment is missing, global value is undefined.
     // This is an expected behavior if globals are used for platform feature detection
     to[key] = from[key];
@@ -53,7 +63,7 @@ const selectiveCopy = (from, to, list) => {
  *
  * Note: this function is recursive
  * @param {string[]} attenuators - List of attenuator names; may be mutated
- * @param {import('./types.js').AttenuationDefinition|import('./types.js').Policy} policyFragment
+ * @param {AttenuationDefinition|Policy} policyFragment
  */
 const collectAttenuators = (attenuators, policyFragment) => {
   if ('attenuate' in policyFragment) {
@@ -72,7 +82,7 @@ const attenuatorsCache = new WeakMap();
  * Goes through policy and lists all attenuator specifiers used.
  * Memoization keyed on policy object reference
  *
- * @param {import('./types.js').Policy} [policy]
+ * @param {Policy} [policy]
  * @returns {Array<string>} attenuators
  */
 export const detectAttenuators = policy => {
@@ -93,7 +103,7 @@ export const detectAttenuators = policy => {
 /**
  * Generates a string identifying a package for policy lookup purposes.
  *
- * @param {import('./types.js').PackageNamingKit} namingKit
+ * @param {PackageNamingKit} namingKit
  * @returns {string}
  */
 const generateCanonicalName = ({ isEntry = false, name, path }) => {
@@ -110,8 +120,8 @@ const generateCanonicalName = ({ isEntry = false, name, path }) => {
  * Verifies if a module identified by `namingKit` can be a dependency of a package per `packagePolicy`.
  * `packagePolicy` is required, when policy is not set, skipping needs to be handled by the caller.
  *
- * @param {import('./types.js').PackageNamingKit} namingKit
- * @param {import('./types.js').PackagePolicy} packagePolicy
+ * @param {PackageNamingKit} namingKit
+ * @param {PackagePolicy} packagePolicy
  * @returns {boolean}
  */
 export const dependencyAllowedByPolicy = (namingKit, packagePolicy) => {
@@ -127,25 +137,25 @@ export const dependencyAllowedByPolicy = (namingKit, packagePolicy) => {
  * Returns the policy applicable to the canonicalName of the package
  *
  * @overload
- * @param {import('./types.js').PackageNamingKit} namingKit - a key in the policy resources spec is derived from these
- * @param {import('./types.js').Policy} policy - user supplied policy
- * @returns {import('./types.js').PackagePolicy} packagePolicy if policy was specified
+ * @param {PackageNamingKit} namingKit - a key in the policy resources spec is derived from these
+ * @param {SomePolicy} policy - user supplied policy
+ * @returns {SomePackagePolicy} packagePolicy if policy was specified
  */
 
 /**
  * Returns `undefined`
  *
  * @overload
- * @param {import('./types.js').PackageNamingKit} namingKit - a key in the policy resources spec is derived from these
- * @param {import('./types.js').Policy} [policy] - user supplied policy
- * @returns {import('./types.js').PackagePolicy|undefined} packagePolicy if policy was specified
+ * @param {PackageNamingKit} namingKit - a key in the policy resources spec is derived from these
+ * @param {SomePolicy} [policy] - user supplied policy
+ * @returns {SomePackagePolicy|undefined} packagePolicy if policy was specified
  */
 
 /**
  * Returns the policy applicable to the canonicalName of the package
  *
- * @param {import('./types.js').PackageNamingKit} namingKit - a key in the policy resources spec is derived from these
- * @param {import('./types.js').Policy} [policy] - user supplied policy
+ * @param {PackageNamingKit} namingKit - a key in the policy resources spec is derived from these
+ * @param {SomePolicy} [policy] - user supplied policy
  */
 export const getPolicyForPackage = (namingKit, policy) => {
   if (!policy) {
@@ -171,7 +181,7 @@ export const getPolicyForPackage = (namingKit, policy) => {
 
 /**
  * Get list of globals from package policy
- * @param {import('./types.js').PackagePolicy} [packagePolicy]
+ * @param {PackagePolicy} [packagePolicy]
  * @returns {Array<string>}
  */
 const getGlobalsList = packagePolicy => {
@@ -188,8 +198,8 @@ const MODULE_ATTENUATOR = 'attenuateModule';
 
 /**
  * Imports attenuator per its definition and provider
- * @param {import('./types.js').AttenuationDefinition} attenuationDefinition
- * @param {import('./types.js').DeferredAttenuatorsProvider} attenuatorsProvider
+ * @param {AttenuationDefinition} attenuationDefinition
+ * @param {DeferredAttenuatorsProvider} attenuatorsProvider
  * @param {string} attenuatorExportName
  * @returns {Promise<Function>}
  */
@@ -218,8 +228,8 @@ const importAttenuatorForDefinition = async (
 /**
  * Makes an async provider for attenuators
  * @param {Record<string, Compartment>} compartments
- * @param {Record<string, import('./types.js').CompartmentDescriptor>} compartmentDescriptors
- * @returns {import('./types.js').DeferredAttenuatorsProvider}
+ * @param {Record<string, CompartmentDescriptor>} compartmentDescriptors
+ * @returns {DeferredAttenuatorsProvider}
  */
 export const makeDeferredAttenuatorsProvider = (
   compartments,
@@ -243,7 +253,7 @@ export const makeDeferredAttenuatorsProvider = (
     /**
      *
      * @param {string} attenuatorSpecifier
-     * @returns {Promise<import('./types.js').Attenuator>}
+     * @returns {Promise<Attenuator>}
      */
     importAttenuator = async attenuatorSpecifier => {
       if (!attenuatorSpecifier) {
@@ -267,8 +277,8 @@ export const makeDeferredAttenuatorsProvider = (
  * Attenuates the `globalThis` object
  *
  * @param {object} options
- * @param {import('./types.js').DeferredAttenuatorsProvider} options.attenuators
- * @param {import('./types.js').AttenuationDefinition} options.attenuationDefinition
+ * @param {DeferredAttenuatorsProvider} options.attenuators
+ * @param {AttenuationDefinition} options.attenuationDefinition
  * @param {object} options.globalThis
  * @param {object} options.globals
  */
@@ -307,8 +317,8 @@ async function attenuateGlobalThis({
  *
  * @param {object} globalThis
  * @param {object} globals
- * @param {import('./types.js').PackagePolicy} packagePolicy
- * @param {import('./types.js').DeferredAttenuatorsProvider} attenuators
+ * @param {PackagePolicy} packagePolicy
+ * @param {DeferredAttenuatorsProvider} attenuators
  * @param {Array<Promise>} pendingJobs
  * @param {string} name
  * @returns {void}
@@ -383,7 +393,7 @@ const diagnoseModulePolicy = errorHint => {
  * Throws if importing of the specifier is not allowed by the policy
  *
  * @param {string} specifier
- * @param {import('./types.js').CompartmentDescriptor} compartmentDescriptor
+ * @param {CompartmentDescriptor} compartmentDescriptor
  * @param {EnforceModulePolicyOptions} [options]
  */
 export const enforceModulePolicy = (
@@ -421,8 +431,8 @@ export const enforceModulePolicy = (
 /**
  * Attenuates a module
  * @param {object} options
- * @param {import('./types.js').DeferredAttenuatorsProvider} options.attenuators
- * @param {import('./types.js').AttenuationDefinition} options.attenuationDefinition
+ * @param {DeferredAttenuatorsProvider} options.attenuators
+ * @param {AttenuationDefinition} options.attenuationDefinition
  * @param {import('ses').ThirdPartyStaticModuleInterface} options.originalModuleRecord
  * @returns {Promise<import('ses').ThirdPartyStaticModuleInterface>}
  */
@@ -460,8 +470,8 @@ async function attenuateModule({
  *
  * @param {string} specifier - exit module name
  * @param {import('ses').ThirdPartyStaticModuleInterface} originalModuleRecord - reference to the exit module
- * @param {import('./types.js').PackagePolicy} policy - local compartment policy
- * @param {import('./types.js').DeferredAttenuatorsProvider} attenuators - a key-value where attenuations can be found
+ * @param {PackagePolicy} policy - local compartment policy
+ * @param {DeferredAttenuatorsProvider} attenuators - a key-value where attenuations can be found
  * @returns {Promise<import('ses').ThirdPartyStaticModuleInterface>} - the attenuated module
  */
 export const attenuateModuleHook = async (

--- a/packages/compartment-mapper/src/powers.js
+++ b/packages/compartment-mapper/src/powers.js
@@ -7,25 +7,35 @@
 
 // @ts-check
 
-/** @type {import('./types.js').CanonicalFn} */
+/** @import {CanonicalFn} from './types.js' */
+/** @import {ReadNowPowers} from './types.js' */
+/** @import {ReadNowPowersProp} from './types.js' */
+/** @import {ReadFn} from './types.js' */
+/** @import {ReadPowers} from './types.js' */
+/** @import {MaybeReadPowers} from './types.js' */
+/** @import {MaybeReadFn} from './types.js' */
+
+const { freeze } = Object;
+
+/** @type {CanonicalFn} */
 const canonicalShim = async path => path;
 
 /**
- * @param {import('./types.js').ReadFn | import('./types.js').ReadPowers | import('./types.js').MaybeReadPowers} powers
- * @returns {import('./types.js').MaybeReadPowers}
+ * @param {ReadFn | ReadPowers | MaybeReadPowers} powers
+ * @returns {MaybeReadPowers}
  */
 export const unpackReadPowers = powers => {
-  /** @type {import('./types.js').ReadFn | undefined} */
+  /** @type {ReadFn | undefined} */
   let read;
-  /** @type {import('./types.js').MaybeReadFn | undefined} */
+  /** @type {MaybeReadFn | undefined} */
   let maybeRead;
-  /** @type {import('./types.js').CanonicalFn | undefined} */
+  /** @type {CanonicalFn | undefined} */
   let canonical;
 
   if (typeof powers === 'function') {
     read = powers;
   } else {
-    ({ read, maybeRead, canonical } = powers);
+    ({ read, maybeRead, canonical } = /** @type {MaybeReadPowers} */ (powers));
   }
 
   if (canonical === undefined) {
@@ -35,9 +45,7 @@ export const unpackReadPowers = powers => {
   if (maybeRead === undefined) {
     /** @param {string} path */
     maybeRead = path =>
-      /** @type {import('./types.js').ReadFn} */ (read)(path).catch(
-        _error => undefined,
-      );
+      /** @type {ReadFn} */ (read)(path).catch(_error => undefined);
   }
 
   return {
@@ -46,4 +54,46 @@ export const unpackReadPowers = powers => {
     maybeRead,
     canonical,
   };
+};
+
+/**
+ * Ordered array of every property in {@link ReadNowPowers} which is _required_.
+ *
+ * @satisfies {Readonly<{[K in ReadNowPowersProp]-?: {} extends Pick<ReadNowPowers, K> ? never : K}[ReadNowPowersProp][]>}
+ */
+const requiredReadNowPowersProps = freeze(
+  /** @type {const} */ (['fileURLToPath', 'isAbsolute', 'maybeReadNow']),
+);
+
+/**
+ * Returns `true` if `value` is a {@link ReadNowPowers}
+ *
+ * @param {ReadPowers|ReadFn|undefined} value
+ * @returns {value is ReadNowPowers}
+ */
+export const isReadNowPowers = value =>
+  Boolean(
+    value &&
+      typeof value === 'object' &&
+      requiredReadNowPowersProps.every(
+        prop => prop in value && typeof value[prop] === 'function',
+      ),
+  );
+
+/**
+ * Returns a list of the properties missing from (or invalid within) `value` that are required for
+ * `value` to be a {@link ReadNowPowers}.
+ *
+ * Used for human-friendly error messages
+ *
+ * @param {ReadPowers | ReadFn} [value] The value to check for missing properties.
+ * @returns {ReadNowPowersProp[]}
+ */
+export const findInvalidReadNowPowersProps = value => {
+  if (!value || typeof value === 'function') {
+    return [...requiredReadNowPowersProps];
+  }
+  return requiredReadNowPowersProps.filter(
+    prop => !(prop in value) || typeof value[prop] !== 'function',
+  );
 };

--- a/packages/compartment-mapper/src/search.js
+++ b/packages/compartment-mapper/src/search.js
@@ -96,10 +96,9 @@ const maybeReadDescriptorDefault = async (
  * }>}
  */
 export const search = async (readPowers, moduleLocation) => {
-  const { maybeRead } = unpackReadPowers(readPowers);
   const { data, directory, location, packageDescriptorLocation } =
     await searchDescriptor(moduleLocation, loc =>
-      maybeReadDescriptorDefault(maybeRead, loc),
+      maybeReadDescriptorDefault(readPowers, loc),
     );
 
   if (!data) {

--- a/packages/compartment-mapper/test/dynamic-require.test.js
+++ b/packages/compartment-mapper/test/dynamic-require.test.js
@@ -1,0 +1,417 @@
+/* eslint-disable no-shadow */
+// @ts-check
+/* eslint-disable import/no-dynamic-require */
+
+/** @import {ExitModuleImportNowHook, Policy} from '../src/types.js' */
+/** @import {SyncModuleTransforms} from '../src/types.js' */
+
+import 'ses';
+import test from 'ava';
+import fs from 'node:fs';
+import { Module } from 'node:module';
+import path from 'node:path';
+import url from 'node:url';
+import { importLocation } from '../src/import.js';
+import { makeReadNowPowers } from '../src/node-powers.js';
+
+const readPowers = makeReadNowPowers({ fs, url, path });
+const { freeze, keys, assign } = Object;
+
+const importNowHook = (specifier, packageLocation) => {
+  const require = Module.createRequire(
+    readPowers.fileURLToPath(packageLocation),
+  );
+  /** @type {object} */
+  const ns = require(specifier);
+  return freeze(
+    /** @type {import('ses').ThirdPartyStaticModuleInterface} */ ({
+      imports: [],
+      exports: keys(ns),
+      execute: moduleExports => {
+        moduleExports.default = ns;
+        assign(moduleExports, ns);
+      },
+    }),
+  );
+};
+
+test('intra-package dynamic require works without invoking the exitModuleImportNowHook', async t => {
+  t.plan(2);
+  const fixture = new URL(
+    'fixtures-dynamic/node_modules/app/index.js',
+    import.meta.url,
+  ).toString();
+  let importNowHookCallCount = 0;
+  const importNowHook = (specifier, packageLocation) => {
+    importNowHookCallCount += 1;
+    const require = Module.createRequire(
+      readPowers.fileURLToPath(packageLocation),
+    );
+    /** @type {object} */
+    const ns = require(specifier);
+    return freeze(
+      /** @type {import('ses').ThirdPartyStaticModuleInterface} */ ({
+        imports: [],
+        exports: keys(ns),
+        execute: moduleExports => {
+          moduleExports.default = ns;
+          assign(moduleExports, ns);
+        },
+      }),
+    );
+  };
+
+  /** @type {Policy} */
+  const policy = {
+    entry: {
+      packages: 'any',
+    },
+    resources: {
+      dynamic: {
+        packages: {
+          'is-ok': true,
+        },
+      },
+    },
+  };
+  const { namespace } = await importLocation(readPowers, fixture, {
+    policy,
+    importNowHook,
+  });
+
+  t.deepEqual(
+    {
+      default: {
+        isOk: 1,
+      },
+      isOk: 1,
+    },
+    { ...namespace },
+  );
+  t.is(importNowHookCallCount, 0);
+});
+
+// this test mimics how node-gyp-require works; you pass it a directory and it
+// figures out what file to require within that directory. there is no
+// reciprocal dependency on wherever that directory lives (usually it's
+// somewhere in the dependent package)
+test('intra-package dynamic require with inter-package absolute path works without invoking the exitModuleImportNowHook', async t => {
+  t.plan(2);
+  const fixture = new URL(
+    'fixtures-dynamic/node_modules/absolute-app/index.js',
+    import.meta.url,
+  ).toString();
+  let importNowHookCallCount = 0;
+  const importNowHook = (specifier, packageLocation) => {
+    importNowHookCallCount += 1;
+    const require = Module.createRequire(
+      readPowers.fileURLToPath(packageLocation),
+    );
+    /** @type {object} */
+    const ns = require(specifier);
+    return freeze(
+      /** @type {import('ses').ThirdPartyStaticModuleInterface} */ ({
+        imports: [],
+        exports: keys(ns),
+        execute: moduleExports => {
+          moduleExports.default = ns;
+          assign(moduleExports, ns);
+        },
+      }),
+    );
+  };
+  /** @type {Policy} */
+  const policy = {
+    entry: {
+      packages: 'any',
+    },
+    resources: {
+      sprunt: {
+        packages: {
+          'node-tammy-build': true,
+        },
+      },
+    },
+  };
+
+  const { namespace } = await importLocation(readPowers, fixture, {
+    policy,
+    importNowHook,
+  });
+
+  t.deepEqual(
+    {
+      default: {
+        isOk: 1,
+      },
+      isOk: 1,
+    },
+    { ...namespace },
+  );
+  t.is(importNowHookCallCount, 0);
+});
+
+test('intra-package dynamic require using known-but-restricted absolute path fails', async t => {
+  const fixture = new URL(
+    'fixtures-dynamic/node_modules/broken-app/index.js',
+    import.meta.url,
+  ).toString();
+  /** @type {ExitModuleImportNowHook} */
+  const importNowHook = (specifier, packageLocation) => {
+    const require = Module.createRequire(
+      readPowers.fileURLToPath(packageLocation),
+    );
+    /** @type {object} */
+    const ns = require(specifier);
+    return freeze(
+      /** @type {import('ses').ThirdPartyStaticModuleInterface} */ ({
+        imports: [],
+        exports: keys(ns),
+        execute: moduleExports => {
+          moduleExports.default = ns;
+          assign(moduleExports, ns);
+        },
+      }),
+    );
+  };
+  /** @type {Policy} */
+  const policy = {
+    entry: {
+      packages: 'any',
+    },
+    resources: {
+      badsprunt: {
+        packages: {
+          'node-tammy-build': true,
+        },
+      },
+      'badsprunt>node-tammy-build': {
+        packages: { sprunt: false },
+      },
+    },
+  };
+
+  await t.throwsAsync(
+    importLocation(readPowers, fixture, {
+      policy,
+      importNowHook,
+    }),
+    {
+      message: /Blocked in import hook/,
+    },
+  );
+});
+
+test('dynamic require fails without maybeReadNow in read powers', async t => {
+  const fixture = new URL(
+    'fixtures-dynamic/node_modules/app/index.js',
+    import.meta.url,
+  ).toString();
+
+  const { maybeReadNow: _, ...lessPower } = readPowers;
+  await t.throwsAsync(
+    // @ts-expect-error bad type
+    importLocation(lessPower, fixture, {
+      importNowHook,
+      policy: {
+        entry: {
+          packages: 'any',
+        },
+        resources: {
+          dynamic: {
+            packages: {
+              'is-ok': true,
+            },
+          },
+        },
+      },
+    }),
+    {
+      message:
+        /Synchronous readPowers required for dynamic import of "is-ok"; missing or invalid prop\(s\): maybeReadNow/,
+    },
+  );
+});
+
+test('dynamic require fails without isAbsolute & fileURLToPath in read powers', async t => {
+  const fixture = new URL(
+    'fixtures-dynamic/node_modules/app/index.js',
+    import.meta.url,
+  ).toString();
+  const { isAbsolute: _, fileURLToPath: ___, ...lessPower } = readPowers;
+  await t.throwsAsync(
+    // @ts-expect-error bad types
+    importLocation(lessPower, fixture, {
+      importNowHook,
+      policy: {
+        entry: {
+          packages: 'any',
+        },
+        resources: {
+          dynamic: {
+            packages: {
+              'is-ok': true,
+            },
+          },
+        },
+      },
+    }),
+    {
+      message:
+        /Synchronous readPowers required for dynamic import of "is-ok"; missing or invalid prop\(s\): fileURLToPath, isAbsolute/,
+    },
+  );
+});
+
+test('inter-package and exit module dynamic require works', async t => {
+  t.plan(3);
+
+  const fixture = new URL(
+    'fixtures-dynamic/node_modules/hooked-app/index.js',
+    import.meta.url,
+  ).toString();
+
+  // number of times the `importNowHook` got called
+  let importNowHookCallCount = 0;
+  /** @type {string[]} */
+  const importNowHookSpecifiers = [];
+
+  /** @type {ExitModuleImportNowHook} */
+  const importNowHook = (specifier, packageLocation) => {
+    importNowHookCallCount += 1;
+    importNowHookSpecifiers.push(specifier);
+    const require = Module.createRequire(
+      readPowers.fileURLToPath(packageLocation),
+    );
+    /** @type {object} */
+    const ns = require(specifier);
+    return freeze(
+      /** @type {import('ses').ThirdPartyStaticModuleInterface} */ ({
+        imports: [],
+        exports: keys(ns),
+        execute: moduleExports => {
+          moduleExports.default = ns;
+          assign(moduleExports, ns);
+        },
+      }),
+    );
+  };
+
+  const { namespace } = await importLocation(readPowers, fixture, {
+    importNowHook,
+    policy: {
+      entry: {
+        packages: 'any',
+      },
+      resources: {
+        hooked: {
+          packages: {
+            dynamic: true,
+          },
+          builtins: {
+            cluster: true,
+          },
+        },
+        'hooked>dynamic': {
+          packages: {
+            'is-ok': true,
+          },
+        },
+      },
+    },
+  });
+
+  t.deepEqual(
+    {
+      default: {
+        isOk: 1,
+      },
+      isOk: 1,
+    },
+    { ...namespace },
+  );
+
+  t.is(importNowHookCallCount, 1);
+  t.deepEqual(importNowHookSpecifiers, ['cluster']);
+});
+
+test('sync module transforms work with dynamic require support', async t => {
+  const fixture = new URL(
+    'fixtures-dynamic/node_modules/app/index.js',
+    import.meta.url,
+  ).toString();
+
+  t.plan(2);
+
+  let transformCount = 0;
+
+  /** @type {SyncModuleTransforms} */
+  const syncModuleTransforms = {
+    cjs: sourceBytes => {
+      transformCount += 1;
+      return {
+        bytes: sourceBytes,
+        parser: 'cjs',
+      };
+    },
+  };
+
+  /** @type {Policy} */
+  const policy = {
+    entry: {
+      packages: 'any',
+    },
+    resources: {
+      dynamic: {
+        packages: {
+          'is-ok': true,
+        },
+      },
+    },
+  };
+
+  const { namespace } = await importLocation(readPowers, fixture, {
+    syncModuleTransforms,
+    importNowHook,
+    policy,
+  });
+
+  t.deepEqual(
+    {
+      default: {
+        isOk: 1,
+      },
+      isOk: 1,
+    },
+    { ...namespace },
+  );
+
+  t.true(transformCount > 0);
+});
+
+test('sync module transforms work without dynamic require support', async t => {
+  const fixture = new URL(
+    'fixtures-cjs-compat/node_modules/app/index.js',
+    import.meta.url,
+  ).toString();
+
+  let transformCount = 0;
+
+  /** @type {SyncModuleTransforms} */
+  const syncModuleTransforms = {
+    cjs: sourceBytes => {
+      transformCount += 1;
+      return {
+        bytes: sourceBytes,
+        parser: 'cjs',
+      };
+    },
+  };
+
+  const { read } = readPowers;
+  await importLocation(read, fixture, {
+    syncModuleTransforms,
+  });
+
+  t.true(transformCount === 29);
+});

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/absolute-app/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/absolute-app/README.md
@@ -1,0 +1,1 @@
+An app requiring a package which dynamically requires using an absolute path as a module specifier.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/absolute-app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/absolute-app/index.js
@@ -1,0 +1,1 @@
+exports.isOk = require('sprunt').isOk;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/absolute-app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/absolute-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "absolute-app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "sprunt": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/app/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/app/README.md
@@ -1,0 +1,1 @@
+App which requires a package which dynamically loads its own module.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/app/index.js
@@ -1,0 +1,1 @@
+exports.isOk = require('dynamic').isOk;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "dynamic": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/badsprunt/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/badsprunt/README.md
@@ -1,0 +1,1 @@
+This package calls the function returned by `node-tammy-build` with an absolute path to a file contained in a compartment which it `node-tammy-build` explicitly cannot access.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/badsprunt/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/badsprunt/index.js
@@ -1,0 +1,5 @@
+const tammy = require('node-tammy-build');
+
+const sprunt = __dirname + '/../sprunt/sprunt.js';
+
+module.exports = tammy(sprunt);

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/badsprunt/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/badsprunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "badsprunt",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  },
+  "dependencies": {
+    "node-tammy-build": "^1.0.0",
+    "sprunt": "^1.0.0"
+  },
+  "main": "index.js"
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/broken-app/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/broken-app/README.md
@@ -1,0 +1,1 @@
+This package loads package `badsprunt`, which is bad. See `badsprunt`'s `README` for the dirt

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/broken-app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/broken-app/index.js
@@ -1,0 +1,1 @@
+exports.isOk = require('badsprunt').isOk;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/broken-app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/broken-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "badsprunt": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/dynamic/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/dynamic/README.md
@@ -1,0 +1,1 @@
+This package dynamically requires another package by name.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/dynamic/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/dynamic/index.js
@@ -1,0 +1,3 @@
+const pkg = 'is-ok';
+
+exports.isOk = require(pkg).isOk;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/dynamic/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/dynamic/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dynamic",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  },
+  "dependencies": {
+    "is-ok": "^1.0.0"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked-app/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked-app/README.md
@@ -1,0 +1,1 @@
+App which requires a package which dynamically requires other packages.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked-app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked-app/index.js
@@ -1,0 +1,5 @@
+exports.isOk = require('hooked').isOk;
+
+const builtin = 'cluster';
+
+require(builtin);

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked-app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "hooked": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked/README.md
@@ -1,0 +1,1 @@
+This package dynamically requires another package and dynamically requires a builtin.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked/index.js
@@ -1,0 +1,3 @@
+const dynamic = require.resolve('dynamic');
+
+exports.isOk = require(dynamic).isOk;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/hooked/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "hooked",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  },
+  "dependencies": {
+    "dynamic": "^1.0.0"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/README.md
@@ -1,0 +1,1 @@
+This package does nothing interesting.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/index.js
@@ -1,0 +1,1 @@
+exports.isOk = 1

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "is-ok",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/node-tammy-build/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/node-tammy-build/README.md
@@ -1,0 +1,1 @@
+This package exports a function which accepts a path and returns the result of `require`-ing aforementioned path. It mimics the behavior of `node-gyp-build`.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/node-tammy-build/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/node-tammy-build/index.js
@@ -1,0 +1,3 @@
+module.exports = (path) => {
+  return require(path);
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/node-tammy-build/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/node-tammy-build/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "node-tammy-build",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/sprunt/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/sprunt/README.md
@@ -1,0 +1,1 @@
+This package mimics a consumer of `node-gyp-build`, where a package is required and a path is provided to that package, which is then dynamically required

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/sprunt/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/sprunt/index.js
@@ -1,0 +1,4 @@
+const dynamo = require('node-tammy-build');
+
+const sprunt = __dirname + '/sprunt.js';
+module.exports = dynamo(sprunt);

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/sprunt/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/sprunt/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sprunt",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  },
+  "dependencies": {
+    "node-tammy-build": "^1.0.0"
+  },
+  "main": "index.js"
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/sprunt/sprunt.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/sprunt/sprunt.js
@@ -1,0 +1,1 @@
+exports.isOk = 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,6 +348,7 @@ __metadata:
   dependencies:
     "@endo/cjs-module-analyzer": "workspace:^"
     "@endo/module-source": "workspace:^"
+    "@endo/trampoline": "workspace:^"
     "@endo/zip": "workspace:^"
     ava: "npm:^6.1.3"
     babel-eslint: "npm:^10.1.0"
@@ -889,7 +890,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/trampoline@workspace:packages/trampoline":
+"@endo/trampoline@workspace:^, @endo/trampoline@workspace:packages/trampoline":
   version: 0.0.0-use.local
   resolution: "@endo/trampoline@workspace:packages/trampoline"
   dependencies:


### PR DESCRIPTION
## Description

- This PR adds support for dynamic requires via `loadFromMap()` and `link()` (in `import-lite.js` and `link.js`, respectively).  `importLocation()`'s signature has also been modified for support.  

    To use this feature in either function, the following must be true:

    1. The `moduleTransforms` option (in the appropriate `options` parameter) must not be present. These are _asynchronous_ module transforms, which cannot be used by dynamic require.
    2. The `ReadPowers` param must be a proper `ReadPowers` object (not just a `ReadFn`) _and_ must contain both the _new_ `maybeReadSync`, _new_ `isAbsolute`, and `fileURLToPath` functions. The new type representing this is `SyncReadPowers`.
    
    If all of the above are true, then a compartment will be allowed to dynamically require something.  If that thing still cannot be found in the compartment map, the sync "fallback" exit hook (see next item) will be executed.  
- The new `importHookNow` property can be provided via options, which is a synchronous exit module import hook.
- About `SyncReadPowers`: 
    - `SyncReadPowers.maybeReadSync()` is necessary to read files synchronously which is necessary to load them synchronously. This fails gracefully if the file is not found; the implementation is platform-dependent.
    - `SyncReadPowers.isAbsolute()` is necessary to determine if the module specifier of a dynamic require is absolute. If it is, it could be just about anything, and must be loaded via the user-provided `importNowHook` (the sync exit module import hook).  
    - `SyncReadPowers.fileURLToPath()` is needed for `__filename` and `__dirname`, which is often used to create absolute paths for requiring dynamically.
- As an alternative to `moduleTransforms`, _synchronous_ module transforms may be provided via the _new_ `syncModuleTransforms` object.  In a non-dynamic-require use-case, if present, `syncModuleTransforms` are combined with the `moduleTransforms` option; all sync module transforms are module transforms, but not all module transforms are sync module transforms.
- **All builtin parsers are now synchronous**.  User-defined parsers _can_ be async, but this will disable dynamic require support.
- `@endo/evasive-transform` now exports `evadeCensorSync()` in addition to `evadeCensor()`. This is possible because I've swapped the async-only [source-map](https://npm.im/source-map) with [source-map-js](https://npm.im/source-map-js), which is a fork of the former before it went async-only.  `source-map-js` claims comparable performance.

### Security Considerations

Dynamically requiring an exit module (e.g., a Node.js builtin) requires a user-defined hook, which has the same security considerations as a user-defined exit module hook.  

Swapping out a dependency (`source-map-js` for `source-map`) incurs risk.

### Scaling Considerations

n/a

### Documentation Considerations

Should be announced as a user-facing feature

### Testing Considerations

I've added some fixtures and tested around the conditionals I've added, but am open to any suggestions for additional coverage.

### Compatibility Considerations

This increases ecosystem compatibility considerably; use of dynamic require in the ecosystem is not rare.  

For example, most packages which ship a native module will be using dynamic require, because the filepath of the build artifact is dependent upon the platform and architecture.

### Upgrade Considerations

Everything else _should_ be backwards-compatible, as long as `source-map-js` does as it says on the tin.

Users of `@endo/evasive-transform` may note that native modules are neither downloaded/compiled (due to the switch from `source-map` to `source-map-js`).

* * *

## UPDATE: Aug 18 2024 

This PR now targets the `boneskull/supertramp` branch, which is PR #2263