### PR TITLE
refactor(ses): Retool for module descriptors

### DIFF
--- a/packages/ses/src/compartment.js
+++ b/packages/ses/src/compartment.js
@@ -10,6 +10,7 @@ import {
   assign,
   defineProperties,
   entries,
+  isObject,
   promiseThen,
   toStringTagSymbol,
   weakmapGet,
@@ -207,21 +208,36 @@ export const makeCompartmentConstructor = (
     // moduleMap can be invalid in ways that cannot be detected in the
     // constructor, but these checks allow us to throw early for a better
     // developer experience.
-    for (const [specifier, aliasNamespace] of entries(moduleMap || {})) {
-      if (typeof aliasNamespace === 'string') {
+    for (const [specifier, moduleDescriptor] of entries(moduleMap || {})) {
+      if (typeof moduleDescriptor === 'string') {
         // TODO implement parent module record retrieval.
         throw TypeError(
           `Cannot map module ${q(specifier)} to ${q(
-            aliasNamespace,
+            moduleDescriptor,
           )} in parent compartment`,
         );
-      } else if (weakmapGet(moduleAliases, aliasNamespace) === undefined) {
-        // TODO create and link a synthetic module instance from the given
-        // namespace object.
-        throw ReferenceError(
-          `Cannot map module ${q(
-            specifier,
-          )} because it has no known compartment in this realm`,
+      } else if (isObject(moduleDescriptor)) {
+        if (weakmapGet(moduleAliases, moduleDescriptor) !== undefined) {
+          // No further validation for module namespace objects.
+          // They do bear inspection before evaluation gracefully.
+        } else if (moduleDescriptor.specifier !== undefined) {
+          // TODO validate specifier module descriptors
+        } else if (moduleDescriptor.record !== undefined) {
+          // TODO validate record module descriptors
+        } else if (moduleDescriptor.__syncModuleProgram__ !== undefined) {
+          // TODO validate virtual module source descriptors
+        } else if (moduleDescriptor.execute !== undefined) {
+          // TODO validate module source descriptors
+        } else if (weakmapGet(moduleAliases, moduleDescriptor) === undefined) {
+          throw ReferenceError(
+            `Cannot map module ${q(
+              specifier,
+            )} because it has no known compartment in this realm`,
+          );
+        }
+      } else {
+        throw TypeError(
+          `Value for key ${q(specifier)} in module map must be a string, module descriptor object, module source object, or virtual module namespace`,
         );
       }
     }

--- a/packages/ses/src/compartment.js
+++ b/packages/ses/src/compartment.js
@@ -42,19 +42,6 @@ const moduleAliases = new WeakMap();
 // privateFields captures the private state for each compartment.
 const privateFields = new WeakMap();
 
-// Compartments do not need an importHook or resolveHook to be useful
-// as a vessel for evaluating programs.
-// However, any method that operates the module system will throw an exception
-// if these hooks are not available.
-const assertModuleHooks = compartment => {
-  const { importHook, resolveHook } = weakmapGet(privateFields, compartment);
-  if (typeof importHook !== 'function' || typeof resolveHook !== 'function') {
-    throw TypeError(
-      'Compartment must be constructed with an importHook and a resolveHook for it to be able to load modules',
-    );
-  }
-};
-
 export const InertCompartment = function Compartment(
   _endowments = {},
   _modules = {},
@@ -111,8 +98,6 @@ export const CompartmentPrototype = {
       throw TypeError('first argument of module() must be a string');
     }
 
-    assertModuleHooks(this);
-
     const { exportsProxy } = getDeferredExports(
       this,
       weakmapGet(privateFields, this),
@@ -127,8 +112,6 @@ export const CompartmentPrototype = {
     if (typeof specifier !== 'string') {
       throw TypeError('first argument of import() must be a string');
     }
-
-    assertModuleHooks(this);
 
     return promiseThen(
       load(privateFields, moduleAliases, this, specifier),
@@ -149,8 +132,6 @@ export const CompartmentPrototype = {
       throw TypeError('first argument of load() must be a string');
     }
 
-    assertModuleHooks(this);
-
     return load(privateFields, moduleAliases, this, specifier);
   },
 
@@ -159,7 +140,6 @@ export const CompartmentPrototype = {
       throw TypeError('first argument of importNow() must be a string');
     }
 
-    assertModuleHooks(this);
     loadNow(privateFields, moduleAliases, this, specifier);
     return compartmentImportNow(/** @type {Compartment} */ (this), specifier);
   },

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -564,3 +564,7 @@ export { makeAssert };
 /** @type {Assert} */
 const assert = makeAssert();
 export { assert };
+
+// Internal, to obviate polymorphic dispatch, but may become rigorously
+// consistent with @endo/error.
+export { makeError, note as annotateError, redactedDetails as X, quote as q };

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -26,7 +26,7 @@ const { quote: q } = assert;
 
 export const makeThirdPartyModuleInstance = (
   compartmentPrivateFields,
-  staticModuleRecord,
+  moduleSource,
   compartment,
   moduleAliases,
   moduleSpecifier,
@@ -41,16 +41,16 @@ export const makeThirdPartyModuleInstance = (
 
   const notifiers = create(null);
 
-  if (staticModuleRecord.exports) {
+  if (moduleSource.exports) {
     if (
-      !isArray(staticModuleRecord.exports) ||
-      arraySome(staticModuleRecord.exports, name => typeof name !== 'string')
+      !isArray(moduleSource.exports) ||
+      arraySome(moduleSource.exports, name => typeof name !== 'string')
     ) {
       throw TypeError(
         `SES third-party static module record "exports" property must be an array of strings for module ${moduleSpecifier}`,
       );
     }
-    arrayForEach(staticModuleRecord.exports, name => {
+    arrayForEach(moduleSource.exports, name => {
       let value = exportsTarget[name];
       const updaters = [];
 
@@ -96,11 +96,7 @@ export const makeThirdPartyModuleInstance = (
         localState.activated = true;
         try {
           // eslint-disable-next-line @endo/no-polymorphic-call
-          staticModuleRecord.execute(
-            exportsTarget,
-            compartment,
-            resolvedImports,
-          );
+          moduleSource.execute(exportsTarget, compartment, resolvedImports);
         } catch (err) {
           localState.errorFromExecute = err;
           throw err;
@@ -126,7 +122,7 @@ export const makeModuleInstance = (
   const {
     compartment,
     moduleSpecifier,
-    staticModuleRecord,
+    moduleSource,
     importMeta: moduleRecordMeta,
   } = moduleRecord;
   const {
@@ -137,7 +133,7 @@ export const makeModuleInstance = (
     __reexportMap__: reexportMap = {},
     __needsImportMeta__: needsImportMeta = false,
     __syncModuleFunctor__,
-  } = staticModuleRecord;
+  } = moduleSource;
 
   const compartmentFields = weakmapGet(privateFields, compartment);
 

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -24,7 +24,7 @@ import { compartmentEvaluate } from './compartment-evaluate.js';
 
 const { quote: q } = assert;
 
-export const makeThirdPartyModuleInstance = (
+export const makeVirtualModuleInstance = (
   compartmentPrivateFields,
   moduleSource,
   compartment,
@@ -47,7 +47,7 @@ export const makeThirdPartyModuleInstance = (
       arraySome(moduleSource.exports, name => typeof name !== 'string')
     ) {
       throw TypeError(
-        `SES third-party static module record "exports" property must be an array of strings for module ${moduleSpecifier}`,
+        `SES virtual module source "exports" property must be an array of strings for module ${moduleSpecifier}`,
       );
     }
     arrayForEach(moduleSource.exports, name => {

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -1,11 +1,3 @@
-// For brevity, in this file, as in module-link.js, the term "moduleRecord"
-// without qualification means "module compartment record".
-// This is a super-set of the "static module record", that is reusable between
-// compartments with different hooks.
-// The "module compartment record" captures the compartment and overlays the
-// module's "imports" with the more specific "resolvedImports" as inferred from
-// the particular compartment's "resolveHook".
-
 import { getEnvironmentOption as getenv } from '@endo/env-options';
 import {
   Map,
@@ -388,7 +380,7 @@ const preferSync = (_asyncImpl, syncImpl) => syncImpl;
 const preferAsync = (asyncImpl, _syncImpl) => asyncImpl;
 
 /*
- * `load` asynchronously gathers the `StaticModuleRecord`s for a module and its
+ * `load` asynchronously gathers the module records for a module and its
  * transitive dependencies.
  * The module records refer to each other by a reference to the dependency's
  * compartment and the specifier of the module within its own compartment.
@@ -432,8 +424,8 @@ export const load = async (
 };
 
 /*
- * `loadNow` synchronously gathers the `StaticModuleRecord`s for a module and its
- * transitive dependencies.
+ * `loadNow` synchronously gathers the module records for a specified module
+ * and its transitive dependencies.
  * The module records refer to each other by a reference to the dependency's
  * compartment and the specifier of the module within its own compartment.
  * This graph is then ready to be synchronously linked and executed.

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -8,32 +8,31 @@
 
 import { getEnvironmentOption as getenv } from '@endo/env-options';
 import {
-  ReferenceError,
-  TypeError,
   Map,
   Set,
+  TypeError,
   arrayJoin,
   arrayMap,
   arrayPush,
   create,
   freeze,
+  generatorNext,
+  generatorThrow,
+  isObject,
   mapGet,
   mapHas,
   mapSet,
-  setAdd,
   promiseThen,
+  setAdd,
   values,
   weakmapGet,
-  generatorNext,
-  generatorThrow,
+  weakmapHas,
 } from './commons.js';
-import { assert } from './error/assert.js';
-
-const { Fail, details: X, quote: q, note: annotateError } = assert;
+import { makeError, annotateError, q, X } from './error/assert.js';
 
 const noop = () => {};
 
-async function asyncTrampoline(generatorFunc, args, errorWrapper) {
+const asyncTrampoline = async (generatorFunc, args, errorWrapper) => {
   await null;
   const iterator = generatorFunc(...args);
   let result = generatorNext(iterator);
@@ -47,9 +46,9 @@ async function asyncTrampoline(generatorFunc, args, errorWrapper) {
     }
   }
   return result.value;
-}
+};
 
-function syncTrampoline(generatorFunc, args) {
+const syncTrampoline = (generatorFunc, args) => {
   const iterator = generatorFunc(...args);
   let result = generatorNext(iterator);
   while (!result.done) {
@@ -60,7 +59,8 @@ function syncTrampoline(generatorFunc, args) {
     }
   }
   return result.value;
-}
+};
+
 // `makeAlias` constructs compartment specifier tuples for the `aliases`
 // private field of compartments.
 // These aliases allow a compartment to alias an internal module specifier to a
@@ -84,12 +84,12 @@ const resolveAll = (imports, resolveHook, fullReferrerSpecifier) => {
   return freeze(resolvedImports);
 };
 
-const loadRecord = (
+const loadModuleSource = (
   compartmentPrivateFields,
   moduleAliases,
   compartment,
   moduleSpecifier,
-  staticModuleRecord,
+  moduleSource,
   enqueueJob,
   selectImplementation,
   moduleLoads,
@@ -102,13 +102,13 @@ const loadRecord = (
 
   // resolve all imports relative to this referrer module.
   const resolvedImports = resolveAll(
-    staticModuleRecord.imports,
+    moduleSource.imports,
     resolveHook,
     moduleSpecifier,
   );
   const moduleRecord = freeze({
     compartment,
-    staticModuleRecord,
+    moduleSource,
     moduleSpecifier,
     resolvedImports,
     importMeta,
@@ -146,83 +146,74 @@ function* loadWithoutErrorAnnotation(
   const { importHook, importNowHook, moduleMap, moduleMapHook, moduleRecords } =
     weakmapGet(compartmentPrivateFields, compartment);
 
-  // Follow moduleMap, or moduleMapHook if present.
-  let aliasNamespace = moduleMap[moduleSpecifier];
-  if (aliasNamespace === undefined && moduleMapHook !== undefined) {
-    aliasNamespace = moduleMapHook(moduleSpecifier);
-  }
-  if (typeof aliasNamespace === 'string') {
-    // eslint-disable-next-line @endo/no-polymorphic-call
-    assert.fail(
-      X`Cannot map module ${q(moduleSpecifier)} to ${q(
-        aliasNamespace,
-      )} in parent compartment, not yet implemented`,
-      TypeError,
-    );
-  } else if (aliasNamespace !== undefined) {
-    const alias = weakmapGet(moduleAliases, aliasNamespace);
-    if (alias === undefined) {
-      // eslint-disable-next-line @endo/no-polymorphic-call
-      assert.fail(
-        X`Cannot map module ${q(
-          moduleSpecifier,
-        )} because the value is not a module exports namespace, or is from another realm`,
-        ReferenceError,
-      );
-    }
-    // Behold: recursion.
-    // eslint-disable-next-line no-use-before-define
-    const aliasRecord = yield memoizedLoadWithErrorAnnotation(
-      compartmentPrivateFields,
-      moduleAliases,
-      alias.compartment,
-      alias.specifier,
-      enqueueJob,
-      selectImplementation,
-      moduleLoads,
-    );
-    mapSet(moduleRecords, moduleSpecifier, aliasRecord);
-    return aliasRecord;
-  }
-
   if (mapHas(moduleRecords, moduleSpecifier)) {
     return mapGet(moduleRecords, moduleSpecifier);
   }
 
-  const staticModuleRecord = yield selectImplementation(
-    importHook,
-    importNowHook,
-  )(moduleSpecifier);
-
-  if (staticModuleRecord === null || typeof staticModuleRecord !== 'object') {
-    Fail`importHook must return a promise for an object, for module ${q(
-      moduleSpecifier,
-    )} in compartment ${q(compartment.name)}`;
+  // Follow moduleMap, or moduleMapHook if present.
+  let moduleDescriptor = moduleMap[moduleSpecifier];
+  if (moduleDescriptor === undefined && moduleMapHook !== undefined) {
+    moduleDescriptor = moduleMapHook(moduleSpecifier);
+  }
+  if (moduleDescriptor === undefined) {
+    const moduleHook = selectImplementation(importHook, importNowHook);
+    if (moduleHook === undefined) {
+      const moduleHookName = selectImplementation(
+        'importHook',
+        'importNowHook',
+      );
+      throw makeError(
+        X`${moduleHookName} needed to load module ${q(
+          moduleSpecifier,
+        )} in compartment ${q(compartment.name)}`,
+      );
+    }
+    moduleDescriptor = moduleHook(moduleSpecifier);
+    // Uninitialized module namespaces throw if we attempt to coerce them into
+    // promises.
+    if (!weakmapHas(moduleAliases, moduleDescriptor)) {
+      moduleDescriptor = yield moduleDescriptor;
+    }
   }
 
-  // check if record is a RedirectStaticModuleInterface
-  if (staticModuleRecord.specifier !== undefined) {
-    // check if this redirect with an explicit record
-    if (staticModuleRecord.record !== undefined) {
-      // ensure expected record shape
-      if (staticModuleRecord.compartment !== undefined) {
-        throw TypeError(
-          'Cannot redirect to an explicit record with a specified compartment',
-        );
-      }
+  if (typeof moduleDescriptor === 'string') {
+    // eslint-disable-next-line @endo/no-polymorphic-call
+    throw makeError(
+      X`Cannot map module ${q(moduleSpecifier)} to ${q(
+        moduleDescriptor,
+      )} in parent compartment, not yet implemented`,
+      TypeError,
+    );
+  } else if (isObject(moduleDescriptor)) {
+    // In this shim (and not in XS, and not in the standard we imagine), we
+    // allow a module namespace object to stand in for a module descriptor that
+    // describes its original {compartment, specifier} so that it can be used
+    // to create a link.
+    const aliasDescriptor = weakmapGet(moduleAliases, moduleDescriptor);
+    if (aliasDescriptor !== undefined) {
+      moduleDescriptor = aliasDescriptor;
+    }
+
+    // A (legacy) module descriptor for when we find the module source (record)
+    // but at a different specifier than requested.
+    // Providing this {specifier, record} descriptor serves as an ergonomic
+    // short-hand for stashing the record, returning a {compartment, specifier}
+    // reference, bouncing the module hook, then producing the source (record)
+    // when module hook receives the response specifier.
+    if (moduleDescriptor.record !== undefined) {
       const {
         compartment: aliasCompartment = compartment,
         specifier: aliasSpecifier = moduleSpecifier,
-        record: aliasModuleRecord,
+        record: moduleSource,
         importMeta,
-      } = staticModuleRecord;
+      } = moduleDescriptor;
 
-      const aliasRecord = loadRecord(
+      const aliasRecord = loadModuleSource(
         compartmentPrivateFields,
         moduleAliases,
         aliasCompartment,
         aliasSpecifier,
-        aliasModuleRecord,
+        moduleSource,
         enqueueJob,
         selectImplementation,
         moduleLoads,
@@ -232,12 +223,19 @@ function* loadWithoutErrorAnnotation(
       return aliasRecord;
     }
 
-    // check if this redirect with an explicit compartment
-    if (staticModuleRecord.compartment !== undefined) {
-      // ensure expected record shape
-      if (staticModuleRecord.importMeta !== undefined) {
-        throw TypeError(
-          'Cannot redirect to an implicit record with a specified importMeta',
+    // A (legacy) module descriptor that describes a link to a module instance
+    // in a specified compartment.
+    if (
+      moduleDescriptor.compartment !== undefined &&
+      moduleDescriptor.specifier !== undefined
+    ) {
+      if (
+        !isObject(moduleDescriptor.compartment) ||
+        !weakmapHas(compartmentPrivateFields, moduleDescriptor.compartment) ||
+        typeof moduleDescriptor.specifier !== 'string'
+      ) {
+        throw makeError(
+          X`Invalid compartment in module descriptor for specifier ${q(moduleSpecifier)} in compartment ${q(compartment.name)}`,
         );
       }
       // Behold: recursion.
@@ -245,8 +243,8 @@ function* loadWithoutErrorAnnotation(
       const aliasRecord = yield memoizedLoadWithErrorAnnotation(
         compartmentPrivateFields,
         moduleAliases,
-        staticModuleRecord.compartment,
-        staticModuleRecord.specifier,
+        moduleDescriptor.compartment,
+        moduleDescriptor.specifier,
         enqueueJob,
         selectImplementation,
         moduleLoads,
@@ -255,19 +253,26 @@ function* loadWithoutErrorAnnotation(
       return aliasRecord;
     }
 
-    throw TypeError('Unnexpected RedirectStaticModuleInterface record shape');
+    // A (legacy) behavior: If we do not recognize the module descriptor as a
+    // module descriptor, we assume that it is a module source (record):
+    const moduleSource = moduleDescriptor;
+    return loadModuleSource(
+      compartmentPrivateFields,
+      moduleAliases,
+      compartment,
+      moduleSpecifier,
+      moduleSource,
+      enqueueJob,
+      selectImplementation,
+      moduleLoads,
+    );
+  } else {
+    throw makeError(
+      X`module descriptor must be a string or object for specifier ${q(
+        moduleSpecifier,
+      )} in compartment ${q(compartment.name)}`,
+    );
   }
-
-  return loadRecord(
-    compartmentPrivateFields,
-    moduleAliases,
-    compartment,
-    moduleSpecifier,
-    staticModuleRecord,
-    enqueueJob,
-    selectImplementation,
-    moduleLoads,
-  );
 }
 
 const memoizedLoadWithErrorAnnotation = (
@@ -323,7 +328,7 @@ const memoizedLoadWithErrorAnnotation = (
   return moduleLoading;
 };
 
-function asyncJobQueue() {
+const asyncJobQueue = () => {
   /** @type {Set<Promise<undefined>>} */
   const pendingJobs = new Set();
   /** @type {Array<Error>} */
@@ -358,14 +363,14 @@ function asyncJobQueue() {
     return errors;
   };
   return { enqueueJob, drainQueue };
-}
+};
 
 /**
  * @param {object} options
  * @param {Array<Error>} options.errors
  * @param {string} options.errorPrefix
  */
-function throwAggregateError({ errors, errorPrefix }) {
+const throwAggregateError = ({ errors, errorPrefix }) => {
   // Throw an aggregate error if there were any errors.
   if (errors.length > 0) {
     const verbose =
@@ -377,7 +382,7 @@ function throwAggregateError({ errors, errorPrefix }) {
       )}`,
     );
   }
-}
+};
 
 const preferSync = (_asyncImpl, syncImpl) => syncImpl;
 const preferAsync = (asyncImpl, _syncImpl) => asyncImpl;

--- a/packages/ses/test/import.test.js
+++ b/packages/ses/test/import.test.js
@@ -9,7 +9,7 @@ import '../index.js';
 import { resolveNode, makeNodeImporter } from './node.js';
 import { makeImporter, makeStaticRetriever } from './import-commons.js';
 
-test.failing('module map primed with module source', async t => {
+test('module map primed with module source', async t => {
   const compartment = new Compartment(
     // endowments:
     {},
@@ -26,7 +26,7 @@ test.failing('module map primed with module source', async t => {
   t.is(index.default, 42);
 });
 
-test.failing('module map primed with virtual module source', async t => {
+test('module map primed with virtual module source', async t => {
   const compartment = new Compartment(
     // endowments:
     {},
@@ -49,7 +49,7 @@ test.failing('module map primed with virtual module source', async t => {
   t.is(index.default, 42);
 });
 
-test.failing('module map hook returns module source', async t => {
+test('module map hook returns module source', async t => {
   const compartment = new Compartment(
     // endowments:
     {},
@@ -115,7 +115,7 @@ test('importHook returns module namespace', async t => {
   t.is(index.default, 42);
 });
 
-test.failing('importNowHook returns namespace', t => {
+test('importNowHook returns namespace', t => {
   const compartment = new Compartment(
     // endowments:
     {},
@@ -827,6 +827,7 @@ test('importMetaHook', async t => {
   } = await compartment.import('./index.js');
   t.is(metaurl, 'https://example.com/index.js');
 });
+
 test('importMetaHook and meta from record', async t => {
   t.plan(1);
 

--- a/packages/ses/test/import.test.js
+++ b/packages/ses/test/import.test.js
@@ -4,9 +4,219 @@
 /* eslint max-lines: 0 */
 
 import test from 'ava';
+import { StaticModuleRecord } from '@endo/static-module-record';
 import '../index.js';
 import { resolveNode, makeNodeImporter } from './node.js';
 import { makeImporter, makeStaticRetriever } from './import-commons.js';
+
+test.failing('module map primed with module source', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {
+      './index.js': new StaticModuleRecord('export default 42'),
+    },
+    // options:
+    {
+      resolveHook: specifier => specifier,
+    },
+  );
+  const { namespace: index } = await compartment.import('./index.js');
+  t.is(index.default, 42);
+});
+
+test.failing('module map primed with virtual module source', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {
+      './index.js': {
+        imports: [],
+        exports: ['default'],
+        execute(env) {
+          env.default = 42;
+        },
+      },
+    },
+    // options:
+    {
+      resolveHook: specifier => specifier,
+    },
+  );
+  const { namespace: index } = await compartment.import('./index.js');
+  t.is(index.default, 42);
+});
+
+test.failing('module map hook returns module source', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {},
+    // options:
+    {
+      resolveHook: specifier => specifier,
+      moduleMapHook(specifier) {
+        if (specifier === './index.js') {
+          return new StaticModuleRecord('export default 42');
+        }
+      },
+    },
+  );
+  const { namespace: index } = await compartment.import('./index.js');
+  t.is(index.default, 42);
+});
+
+test('importHook returns module source', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {},
+    // options:
+    {
+      resolveHook: specifier => specifier,
+      importHook(specifier) {
+        if (specifier === './index.js') {
+          return new StaticModuleRecord('export default 42');
+        }
+      },
+    },
+  );
+  const { namespace: index } = await compartment.import('./index.js');
+  t.is(index.default, 42);
+});
+
+// This case requires the module loader to take care not to attempt to
+// coerce the module namespace object to a promise.
+test('importHook returns module namespace', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {},
+    // options:
+    {
+      resolveHook: specifier => specifier,
+      importHook(specifier) {
+        if (specifier === '.') {
+          return compartment.module('./index.js');
+        }
+        if (specifier === './index.js') {
+          return new StaticModuleRecord('export default 42');
+        }
+      },
+    },
+  );
+  // Unlike import, importNow does not box the namespace.
+  const { namespace: index } = await compartment.import('.');
+  t.is(index.default, 42);
+});
+
+test.failing('importNowHook returns namespace', t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {},
+    // options:
+    {
+      resolveHook: specifier => specifier,
+      importNowHook(specifier) {
+        if (specifier === '.') {
+          return compartment.module('./index.js');
+        }
+        if (specifier === './index.js') {
+          return new StaticModuleRecord('export default 42');
+        }
+      },
+    },
+  );
+  // Unlike import, importNow does not box the namespace.
+  const index = compartment.importNow('.');
+  t.is(index.default, 42);
+});
+
+test('importHook returns compartment and specifier module descriptor', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {},
+    // options:
+    {
+      resolveHook: specifier => specifier,
+      importHook(specifier) {
+        if (specifier === '.') {
+          return { compartment, specifier: './index.js' };
+        }
+        if (specifier === './index.js') {
+          return new StaticModuleRecord('export default 42');
+        }
+      },
+    },
+  );
+  const { namespace: index } = await compartment.import('.');
+  t.is(index.default, 42);
+});
+
+test('importHook returns record and specifier module descriptor', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {},
+    // options:
+    {
+      resolveHook: specifier => specifier,
+      importHook(specifier) {
+        if (specifier === '.') {
+          return {
+            record: new StaticModuleRecord('export default 42'),
+            specifier: './index.js',
+          };
+        }
+      },
+    },
+  );
+  const { namespace: index } = await compartment.import('.');
+  t.is(index.default, 42);
+});
+
+test('importHook returns record and specifier module descriptor and import specifiers resolve from response specifier', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {
+      './src/peer.js': new StaticModuleRecord('export const number = 42'),
+    },
+    // options:
+    {
+      resolveHook(importSpecifier, moduleSpecifier) {
+        if (
+          moduleSpecifier === './src/index.js' &&
+          importSpecifier === './peer.js'
+        ) {
+          return './src/peer.js';
+        }
+        return importSpecifier;
+      },
+      importHook(specifier) {
+        if (specifier === '.') {
+          return {
+            record: new StaticModuleRecord('export * from "./peer.js"'),
+            specifier: './src/index.js',
+          };
+        }
+      },
+    },
+  );
+  const { namespace: index } = await compartment.import('.');
+  t.is(index.number, 42);
+});
 
 // This test demonstrates a system of modules in a single Compartment
 // that uses fully qualified URLs as module specifiers and module locations,
@@ -421,7 +631,7 @@ test('mutual dependency between compartments', async t => {
   await compartment.import('./main.js');
 });
 
-test('module alias', async t => {
+test('import redirect shorthand', async t => {
   // The following use of Math.random() is informative but does not
   // affect the outcome of the test, just makes the nature of the error
   // obvious in test output.

--- a/packages/ses/test/import.test.js
+++ b/packages/ses/test/import.test.js
@@ -26,6 +26,25 @@ test('module map primed with module source', async t => {
   t.is(index.default, 42);
 });
 
+test('module map primed with module record descriptor', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {
+      './index.js': {
+        record: new StaticModuleRecord('export default 42'),
+      },
+    },
+    // options:
+    {
+      resolveHook: specifier => specifier,
+    },
+  );
+  const { namespace: index } = await compartment.import('./index.js');
+  t.is(index.default, 42);
+});
+
 test('module map primed with virtual module source', async t => {
   const compartment = new Compartment(
     // endowments:
@@ -37,6 +56,31 @@ test('module map primed with virtual module source', async t => {
         exports: ['default'],
         execute(env) {
           env.default = 42;
+        },
+      },
+    },
+    // options:
+    {
+      resolveHook: specifier => specifier,
+    },
+  );
+  const { namespace: index } = await compartment.import('./index.js');
+  t.is(index.default, 42);
+});
+
+test('module map primed with virtual module record descriptor', async t => {
+  const compartment = new Compartment(
+    // endowments:
+    {},
+    // modules:
+    {
+      './index.js': {
+        record: {
+          imports: [],
+          exports: ['default'],
+          execute(env) {
+            env.default = 42;
+          },
         },
       },
     },
@@ -62,6 +106,7 @@ test('module map hook returns module source', async t => {
         if (specifier === './index.js') {
           return new StaticModuleRecord('export default 42');
         }
+        return undefined;
       },
     },
   );
@@ -82,6 +127,7 @@ test('importHook returns module source', async t => {
         if (specifier === './index.js') {
           return new StaticModuleRecord('export default 42');
         }
+        return undefined;
       },
     },
   );
@@ -107,6 +153,7 @@ test('importHook returns module namespace', async t => {
         if (specifier === './index.js') {
           return new StaticModuleRecord('export default 42');
         }
+        return undefined;
       },
     },
   );
@@ -131,6 +178,7 @@ test('importNowHook returns namespace', t => {
         if (specifier === './index.js') {
           return new StaticModuleRecord('export default 42');
         }
+        return undefined;
       },
     },
   );
@@ -155,6 +203,7 @@ test('importHook returns compartment and specifier module descriptor', async t =
         if (specifier === './index.js') {
           return new StaticModuleRecord('export default 42');
         }
+        return undefined;
       },
     },
   );
@@ -178,6 +227,7 @@ test('importHook returns record and specifier module descriptor', async t => {
             specifier: './index.js',
           };
         }
+        return undefined;
       },
     },
   );
@@ -211,6 +261,7 @@ test('importHook returns record and specifier module descriptor and import speci
             specifier: './src/index.js',
           };
         }
+        return undefined;
       },
     },
   );

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -43,10 +43,12 @@ export type RepairIntrinsics = (options?: LockdownOptions) => void;
 export type HardenIntrinsics = () => void;
 export type Lockdown = (options?: LockdownOptions) => void;
 
+export type ModuleExportsNamespace = Record<string, any>;
+
 export type __LiveExportMap__ = Record<string, [string, boolean]>;
 export type __FixedExportMap__ = Record<string, [string]>;
 
-export interface PrecompiledStaticModuleInterface {
+export interface PrecompiledModuleSource {
   imports: Array<string>;
   exports: Array<string>;
   reexports: Array<string>;
@@ -55,7 +57,7 @@ export interface PrecompiledStaticModuleInterface {
   __fixedExportMap__: __FixedExportMap__;
 }
 
-export interface ThirdPartyStaticModuleInterface {
+export interface VirtualModuleSource {
   imports: Array<string>;
   exports: Array<string>;
   /**
@@ -68,34 +70,51 @@ export interface ThirdPartyStaticModuleInterface {
   ): void;
 }
 
-export type FinalStaticModuleType =
-  | PrecompiledStaticModuleInterface
-  | ThirdPartyStaticModuleInterface;
+export type ModuleSource = PrecompiledModuleSource | VirtualModuleSource;
 
-export interface RedirectStaticModuleInterface {
+export interface RedirectModuleDescriptor {
   specifier: string;
-  record?: FinalStaticModuleType;
+  record?: ModuleSource;
   importMeta?: any;
   compartment?: Compartment;
 }
 
-export type StaticModuleType =
-  | RedirectStaticModuleInterface
-  | FinalStaticModuleType;
+export interface ReferenceModuleDescriptor {
+  specifier: string;
+  record?: ModuleSource;
+  importMeta?: any;
+  compartment?: Compartment;
+}
 
-export type ModuleExportsNamespace = Record<string, any>;
+export type ModuleDescriptor =
+  // These descriptor shapes are needed for XS parity:
+  // | SourceModuleDescriptor
+  // | NamespaceModuleDescriptor
+  // To be deprecated:
+  | RedirectModuleDescriptor
+  | ReferenceModuleDescriptor
+  | ModuleExportsNamespace
+  | VirtualModuleSource
+  | PrecompiledModuleSource;
+
+// Deprecated type aliases:
+export type PrecompiledStaticModuleInterface = PrecompiledModuleSource;
+export type ThirdPartyStaticModuleInterface = VirtualModuleSource;
+export type RedirectStaticModuleInterface = RedirectModuleDescriptor;
+export type FinalStaticModuleType = ModuleSource;
+export type StaticModuleType = RedirectStaticModuleInterface | ModuleSource;
 
 export type Transform = (source: string) => string;
 export type ResolveHook = (
   importSpecifier: string,
   referrerSpecifier: string,
 ) => string;
-export type ModuleMap = Record<string, string | ModuleExportsNamespace>;
+export type ModuleMap = Record<string, string | ModuleDescriptor>;
 export type ModuleMapHook = (
   moduleSpecifier: string,
-) => string | ModuleExportsNamespace | void;
-export type ImportHook = (moduleSpecifier: string) => Promise<StaticModuleType>;
-export type ImportNowHook = (moduleSpecifier: string) => StaticModuleType;
+) => ModuleDescriptor | undefined;
+export type ImportHook = (moduleSpecifier: string) => Promise<ModuleDescriptor>;
+export type ImportNowHook = (moduleSpecifier: string) => ModuleDescriptor;
 
 export interface CompartmentOptions {
   name?: string;


### PR DESCRIPTION
Refs: #400 #2251 

## Description

Pursuant to arriving at parity with XS, this change internally reörients the SES module loader around the concept of a “module descriptor”. This creates some clarity and removes some existing duplication of work for “alias” module descriptors, and prepares the material for a richer module descriptor schema to match those implemented by XS.

### Security Considerations

No changes.

### Scaling Considerations

No changes.

### Documentation Considerations

No changes.

### Testing Considerations

No changes.

### Compatibility Considerations

No changes.

### Upgrade Considerations

No changes.