### PR TITLE
fix: endow with original unstructured `assert`

### DIFF
--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -1,4 +1,4 @@
-/* global process */
+/* global globalThis, process */
 import url from 'url';
 import os from 'os';
 import { E, Far } from '@endo/far';
@@ -10,7 +10,8 @@ import { withEndoAgent } from '../context.js';
 import { parsePetNamePath } from '../pet-name.js';
 
 const endowments = harden({
-  assert,
+  // See https://github.com/Agoric/agoric-sdk/issues/9515
+  assert: globalThis.assert,
   E,
   Far,
   makeExo,

--- a/packages/compartment-mapper/test/main.test.js
+++ b/packages/compartment-mapper/test/main.test.js
@@ -1,3 +1,5 @@
+/* global globalThis */
+
 import 'ses';
 import test from 'ava';
 import { loadLocation, importArchive, makeBundle } from '../index.js';
@@ -96,7 +98,8 @@ test('makeBundle / importArchive', async t => {
     TextEncoder,
     TextDecoder,
     URL,
-    assert,
+    // See https://github.com/Agoric/agoric-sdk/issues/9515
+    assert: globalThis.assert,
   });
   const evasiveArchiverBundle = archiverBundle
     .replace(/(?<!\.)\bimport\b(?![:"'])/g, 'IMPORT')

--- a/packages/daemon/src/web-page.js
+++ b/packages/daemon/src/web-page.js
@@ -1,5 +1,5 @@
 // @ts-check
-/* global window, document */
+/* global globalThis, window, document */
 
 import '@endo/init/debug.js';
 import { makeCapTP } from '@endo/captp';
@@ -56,7 +56,8 @@ const collectPropsAndBind = target => {
 };
 
 const hardenedEndowments = harden({
-  assert,
+  // See https://github.com/Agoric/agoric-sdk/issues/9515
+  assert: globalThis.assert,
   E,
   Far,
   makeExo,

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 // @ts-check
 /// <reference types="ses"/>
 
@@ -12,7 +13,8 @@ import { WorkerFacetForDaemonInterface } from './interfaces.js';
 /** @import { EndoReadable, MignonicPowers } from './types.js' */
 
 const endowments = harden({
-  assert,
+  // See https://github.com/Agoric/agoric-sdk/issues/9515
+  assert: globalThis.assert,
   console,
   E,
   Far,

--- a/packages/ses/demos/challenge/main.js
+++ b/packages/ses/demos/challenge/main.js
@@ -1,4 +1,4 @@
-/* global window, document */
+/* global globalThis, window, document */
 /* eslint-disable no-plusplus */
 
 // two approaches:
@@ -152,7 +152,8 @@ lockdown();
   harden(guess);
   const compartment = new Compartment({
     console,
-    assert,
+    // See https://github.com/Agoric/agoric-sdk/issues/9515
+    assert: globalThis.assert,
     guess,
     ...dateEndowment,
   });

--- a/packages/ses/demos/console/main.js
+++ b/packages/ses/demos/console/main.js
@@ -1,4 +1,4 @@
-/* globals document */
+/* globals globalThis, document */
 
 lockdown();
 {
@@ -13,7 +13,11 @@ lockdown();
 
   // Under the default `lockdown` settings, it is safe enough
   // to endow with the safe `console`.
-  const compartment = new Compartment({ console, assert });
+  const compartment = new Compartment({
+    console,
+    // See https://github.com/Agoric/agoric-sdk/issues/9515
+    assert: globalThis.assert,
+  });
 
   execute.addEventListener('click', () => {
     const sourceText = input.value;


### PR DESCRIPTION
Closes: #XXXX
Refs: https://github.com/Agoric/agoric-sdk/issues/9515 https://github.com/Agoric/agoric-sdk/pull/9514

## Description

Addresses https://github.com/Agoric/agoric-sdk/issues/9515 as applied to endo, by doing for endo what https://github.com/Agoric/agoric-sdk/pull/9514 does for agoric-sdk

To address https://github.com/Agoric/agoric-sdk/issues/5672 for endo , we should change all applicable uses of `assert` to obtain `assert` by importing it from the `@endo/errors` package. However, attempts to do so ran into the symptoms reported at https://github.com/Agoric/agoric-sdk/issues/9515 for the reasons reported there -- accidentally using the imported `assert` as the endowment for the global `assert` of new Compartments.

This PR prepares the ground for these fixes to https://github.com/Agoric/agoric-sdk/issues/5672 for endo by unambiguously endowing with the original unstructured `globalThis.assert`, which will remain the correct endowment even when other uses of `assert` have migrated to the one imported from `@endo/errors`. By itself, this PR, preceding those fixes to https://github.com/Agoric/agoric-sdk/issues/5672 for endo , is not actually fixing a bug in the sense of a behavioral change. Reviewers, let me know if you think this PR should be labeled a "refactor" because of this.


### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

anyone gathering endowments for a new compartment should be aware of this issue, and be sure to use `globalThis.assert` as the `assert` endowment. Fortunately, this will only be of concern to advanced developers.

### Testing Considerations

Since this PR doesn't actually cause any behavioral change, it cannot be tested in place. Rather, its test will be whether #2324  still passes CI once rebased on this PR.

***Update***: #2324 is now passing CI well enough to consider this PR (#2323) to be adequately tested.


### Compatibility Considerations

The point. This PR itself only prepares the ground for the equivalent of https://github.com/Agoric/agoric-sdk/pull/9513 for endo. By itself it has no other effect, and so no other compat issues.

### Upgrade Considerations

none
