### PR TITLE
refactor: use @endo/errors when acyclic

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "@endo/bundle-source": "^3.2.3",
     "@endo/compartment-mapper": "^1.1.5",
     "@endo/daemon": "^2.3.0",
+    "@endo/errors": "^1.2.2",
     "@endo/eventual-send": "^1.2.2",
     "@endo/exo": "^1.5.0",
     "@endo/far": "^1.1.2",

--- a/packages/cli/src/pet-name.js
+++ b/packages/cli/src/pet-name.js
@@ -1,4 +1,4 @@
-const { quote: q } = assert;
+import { q } from '@endo/errors';
 
 /**
  * Splits a dot-delimited pet name path into an array of pet names.

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -4,6 +4,7 @@
 import { makePromiseKit } from '@endo/promise-kit';
 import { makePipe } from '@endo/stream';
 import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
+import { q } from '@endo/errors';
 import { makeNetstringCapTP } from './connection.js';
 import { makeReaderRef } from './reader-ref.js';
 import { makePetStoreMaker } from './pet-store.js';
@@ -13,8 +14,6 @@ import { makeSerialJobs } from './serial-jobs.js';
 /** @import { Reader, Writer } from '@endo/stream' */
 /** @import { ERef, FarRef } from '@endo/eventual-send' */
 /** @import { Config, CryptoPowers, DaemonWorkerFacet, DaemonicPersistencePowers, DaemonicPowers, EndoReadable, FilePowers, Formula, NetworkPowers, SocketPowers, WorkerDaemonFacet } from './types.js' */
-
-const { quote: q } = assert;
 
 const textEncoder = new TextEncoder();
 

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -7,7 +7,7 @@ import { makeExo } from '@endo/exo';
 import { E, Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
-import { makeError, q } from '@endo/errors';
+import { makeError, q, X } from '@endo/errors';
 import { makeRefReader } from './ref-reader.js';
 import { makeDirectoryMaker } from './directory.js';
 import { makeMailboxMaker } from './mail.js';
@@ -491,7 +491,7 @@ const makeDaemonCore = async (
   const mustGetIdForRef = ref => {
     const id = idForRef.get(ref);
     if (id === undefined) {
-      throw makeError(assert.details`No corresponding formula for ${ref}`);
+      throw makeError(X`No corresponding formula for ${ref}`);
     }
     return id;
   };
@@ -501,9 +501,9 @@ const makeDaemonCore = async (
     const ref = refForId.get(id);
     if (ref === undefined) {
       if (formulaForId.get(id) !== undefined) {
-        throw makeError(assert.details`Formula has not produced a ref ${id}`);
+        throw makeError(X`Formula has not produced a ref ${id}`);
       }
-      throw makeError(assert.details`Unknown identifier ${id}`);
+      throw makeError(X`Unknown identifier ${id}`);
     }
     return ref;
   };

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -7,7 +7,7 @@ import { makeExo } from '@endo/exo';
 import { E, Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
-import { q } from '@endo/errors';
+import { makeError, q } from '@endo/errors';
 import { makeRefReader } from './ref-reader.js';
 import { makeDirectoryMaker } from './directory.js';
 import { makeMailboxMaker } from './mail.js';
@@ -491,7 +491,7 @@ const makeDaemonCore = async (
   const mustGetIdForRef = ref => {
     const id = idForRef.get(ref);
     if (id === undefined) {
-      throw assert.error(assert.details`No corresponding formula for ${ref}`);
+      throw makeError(assert.details`No corresponding formula for ${ref}`);
     }
     return id;
   };
@@ -501,11 +501,9 @@ const makeDaemonCore = async (
     const ref = refForId.get(id);
     if (ref === undefined) {
       if (formulaForId.get(id) !== undefined) {
-        throw assert.error(
-          assert.details`Formula has not produced a ref ${id}`,
-        );
+        throw makeError(assert.details`Formula has not produced a ref ${id}`);
       }
-      throw assert.error(assert.details`Unknown identifier ${id}`);
+      throw makeError(assert.details`Unknown identifier ${id}`);
     }
     return ref;
   };
@@ -1576,7 +1574,7 @@ const makeDaemonCore = async (
       const guestNodeNumber = url.hostname;
 
       if (!guestHandleNumber) {
-        throw assert.error('Handle locator must have an "id" parameter');
+        throw makeError('Handle locator must have an "id" parameter');
       }
 
       const guestHandleId = formatId({

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -2,12 +2,11 @@
 
 import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
+import { q } from '@endo/errors';
 import { makeIteratorRef } from './reader-ref.js';
 import { formatLocator, idFromLocator } from './locator.js';
 
 import { DirectoryInterface } from './interfaces.js';
-
-const { quote: q } = assert;
 
 /** @import { DaemonCore, MakeDirectoryNode, EndoDirectory, NameHub, LocatorNameChange, Context } from './types.js' */
 

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -3,7 +3,7 @@
 
 /** @import { IdRecord } from './types.js' */
 
-const { quote: q } = assert;
+import { makeError, q } from '@endo/errors';
 
 const numberPattern = /^[0-9a-f]{128}$/;
 const idPattern = /^(?<number>[0-9a-f]{128}):(?<node>[0-9a-f]{128})$/;
@@ -19,7 +19,7 @@ export const isValidNumber = allegedNumber =>
  */
 export const assertValidNumber = allegedNumber => {
   if (!isValidNumber(allegedNumber)) {
-    throw assert.error(`Invalid number ${q(allegedNumber)}`);
+    throw makeError(`Invalid number ${q(allegedNumber)}`);
   }
 };
 
@@ -45,11 +45,11 @@ export const assertValidId = (id, petName) => {
 export const parseId = id => {
   const match = idPattern.exec(id);
   if (match === null) {
-    throw assert.error(`Invalid formula identifier ${q(id)}`);
+    throw makeError(`Invalid formula identifier ${q(id)}`);
   }
   const { groups } = match;
   if (groups === undefined) {
-    throw assert.error(
+    throw makeError(
       `Programmer invariant failure: expected match groups, formula identifier was ${q(
         id,
       )}`,

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { quote: q } = assert;
+import { q } from '@endo/errors';
 
 // Note: Alphabetically sorted
 const formulaTypes = new Set([

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -6,6 +6,7 @@
 
 import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
+import { makeError, q } from '@endo/errors';
 import { makeIteratorRef } from './reader-ref.js';
 import { assertPetName, petNamePathFrom } from './pet-name.js';
 import { parseId, formatId } from './formula-identifier.js';
@@ -13,8 +14,6 @@ import { makePetSitter } from './pet-sitter.js';
 import { makeDeferredTasks } from './deferred-tasks.js';
 
 import { HostInterface } from './interfaces.js';
-
-const { quote: q } = assert;
 
 /** @param {string} name */
 const assertPowersName = name => {
@@ -494,10 +493,10 @@ export const makeHostMaker = ({
 
       nodeNumber || assert.Fail`Invitation must have a hostname`;
       if (!remoteHandleNumber) {
-        throw assert.error(`Invitation must have a "from" parameter`);
+        throw makeError(`Invitation must have a "from" parameter`);
       }
       if (invitationNumber === null) {
-        throw assert.error(`Invitation must have an "id" parameter`);
+        throw makeError(`Invitation must have an "id" parameter`);
       }
 
       /** @type {PeerInfo} */

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -1,9 +1,8 @@
 // @ts-check
 
+import { makeError, q } from '@endo/errors';
 import { formatId, isValidNumber, parseId } from './formula-identifier.js';
 import { isValidFormulaType } from './formula-type.js';
-
-const { quote: q } = assert;
 
 /**
  * The endo locator format:
@@ -28,7 +27,7 @@ const isValidLocatorType = allegedType =>
  */
 const assertValidLocatorType = allegedType => {
   if (!isValidLocatorType(allegedType)) {
-    throw assert.error(`Unrecognized locator type ${q(allegedType)}`);
+    throw makeError(`Unrecognized locator type ${q(allegedType)}`);
   }
 };
 
@@ -40,17 +39,17 @@ export const parseLocator = allegedLocator => {
   const errorPrefix = `Invalid locator ${q(allegedLocator)}:`;
 
   if (!URL.canParse(allegedLocator)) {
-    throw assert.error(`${errorPrefix} Invalid URL.`);
+    throw makeError(`${errorPrefix} Invalid URL.`);
   }
   const url = new URL(allegedLocator);
 
   if (!allegedLocator.startsWith('endo://')) {
-    throw assert.error(`${errorPrefix} Invalid protocol.`);
+    throw makeError(`${errorPrefix} Invalid protocol.`);
   }
 
   const node = url.host;
   if (!isValidNumber(node)) {
-    throw assert.error(`${errorPrefix} Invalid node identifier.`);
+    throw makeError(`${errorPrefix} Invalid node identifier.`);
   }
 
   if (
@@ -58,17 +57,17 @@ export const parseLocator = allegedLocator => {
     !url.searchParams.has('id') ||
     !url.searchParams.has('type')
   ) {
-    throw assert.error(`${errorPrefix} Invalid search params.`);
+    throw makeError(`${errorPrefix} Invalid search params.`);
   }
 
   const number = url.searchParams.get('id');
   if (number === null || !isValidNumber(number)) {
-    throw assert.error(`${errorPrefix} Invalid id.`);
+    throw makeError(`${errorPrefix} Invalid id.`);
   }
 
   const formulaType = url.searchParams.get('type');
   if (formulaType === null || !isValidLocatorType(formulaType)) {
-    throw assert.error(`${errorPrefix} Invalid type.`);
+    throw makeError(`${errorPrefix} Invalid type.`);
   }
 
   return { formulaType, node, number };

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -3,6 +3,7 @@
 import { E } from '@endo/eventual-send';
 import { makeExo } from '@endo/exo';
 import { makePromiseKit } from '@endo/promise-kit';
+import { q } from '@endo/errors';
 import { makeChangeTopic } from './pubsub.js';
 import { assertPetName } from './pet-name.js';
 
@@ -16,8 +17,6 @@ import {
 /** @import { ERef } from '@endo/eventual-send' */
 /** @import { PromiseKit } from '@endo/promise-kit' */
 /** @import { Envelope, EnvelopedMessage, Handle, Mail, MakeMailbox, Provide, Request, StampedMessage, Topic } from './types.js' */
-
-const { quote: q } = assert;
 
 /**
  * @param {string} description

--- a/packages/daemon/src/multimap.js
+++ b/packages/daemon/src/multimap.js
@@ -2,7 +2,7 @@
 
 /** @import { Multimap, WeakMultimap, BidirectionalMultimap } from './types.js' */
 
-const { quote: q } = assert;
+import { q } from '@endo/errors';
 
 /**
  * @param {new () => (Map | WeakMap)} mapConstructor

--- a/packages/daemon/src/pet-name.js
+++ b/packages/daemon/src/pet-name.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { quote: q } = assert;
+import { q } from '@endo/errors';
 
 const validNamePattern = /^[a-z][a-z0-9-]{0,127}$/;
 

--- a/packages/daemon/src/pet-sitter.js
+++ b/packages/daemon/src/pet-sitter.js
@@ -1,11 +1,10 @@
 // @ts-check
 
+import { q } from '@endo/errors';
 import { isPetName } from './pet-name.js';
 import { parseId } from './formula-identifier.js';
 
 /** @import { PetStore, IdRecord, PetStoreIdNameChange } from './types.js' */
-
-const { quote: q } = assert;
 
 /**
  * @param {PetStore} petStore

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -1,12 +1,11 @@
 // @ts-check
 
+import { q } from '@endo/errors';
 import { makeChangeTopic } from './pubsub.js';
 import { parseId, assertValidId, isValidNumber } from './formula-identifier.js';
 import { makeBidirectionalMultimap } from './multimap.js';
 
 /** @import { BidirectionalMultimap, Config, FilePowers, IdChangesTopic, NameChangesTopic, PetStore, PetStoreIdNameChange, PetStoreNameChange, PetStorePowers } from './types.js' */
-
-const { quote: q } = assert;
 
 /**
  * @param {FilePowers} filePowers

--- a/packages/daemon/src/serve-private-path.js
+++ b/packages/daemon/src/serve-private-path.js
@@ -1,8 +1,7 @@
 // @ts-check
 
+import { q } from '@endo/errors';
 import { makeNetstringCapTP } from './connection.js';
-
-const { quote: q } = assert;
 
 export const servePrivatePath = (
   sockPath,

--- a/packages/daemon/src/serve-private-port-http.js
+++ b/packages/daemon/src/serve-private-port-http.js
@@ -2,13 +2,12 @@
 
 import { E } from '@endo/far';
 import { mapReader, mapWriter } from '@endo/stream';
+import { q } from '@endo/errors';
 import {
   makeMessageCapTP,
   messageToBytes,
   bytesToMessage,
 } from './connection.js';
-
-const { quote: q } = assert;
 
 export const servePrivatePortHttp = (
   requestedWebletPort,

--- a/packages/daemon/src/web-server-node.js
+++ b/packages/daemon/src/web-server-node.js
@@ -12,6 +12,7 @@ import { mapWriter, mapReader } from '@endo/stream';
 import { E, Far } from '@endo/far';
 import { makeBundle } from '@endo/compartment-mapper/bundle.js';
 
+import { q } from '@endo/errors';
 import { makeHttpPowers } from './web-server-node-powers.js';
 
 import {
@@ -19,8 +20,6 @@ import {
   messageToBytes,
   bytesToMessage,
 } from './connection.js';
-
-const { quote: q } = assert;
 
 const { servePortHttp } = makeHttpPowers({ ws, http });
 

--- a/packages/daemon/test/move-hub.js
+++ b/packages/daemon/test/move-hub.js
@@ -3,7 +3,7 @@
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';
 
-const { quote: q } = assert;
+import { q } from '@endo/errors';
 
 /** @import {NameHub} from '../src/types.js' */
 

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -1,7 +1,7 @@
 import { trackTurns } from './track-turns.js';
 import { makeMessageBreakpointTester } from './message-breakpoints.js';
 
-const { details: X, quote: q, Fail } = assert;
+const { details: X, quote: q, Fail, error: makeError } = assert;
 const { assign, create } = Object;
 
 const onSend = makeMessageBreakpointTester('ENDO_SEND_BREAKPOINTS');
@@ -52,7 +52,7 @@ const makeEProxyHandler = (recipient, HandledPromise) =>
             if (this !== receiver) {
               // Reject the async function call
               return HandledPromise.reject(
-                assert.error(
+                makeError(
                   X`Unexpected receiver for "${q(propertyKey)}" method of E(${q(
                     recipient,
                   )})`,

--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -9,7 +9,7 @@ import {
 } from './local.js';
 import { makePostponedHandler } from './postponed.js';
 
-const { Fail, details: X, quote: q } = assert;
+const { Fail, details: X, quote: q, note: annotateError } = assert;
 
 const {
   create,
@@ -337,7 +337,7 @@ export const makeHandledPromise = () => {
         handledResolve(resolvedTarget);
         return resolvedTarget;
       } catch (e) {
-        assert.note(e, X`during resolveWithPresence`);
+        annotateError(e, X`during resolveWithPresence`);
         handledReject(e);
         throw e;
       }

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -392,7 +392,7 @@ User-visible changes in SES:
   for an example of performing a scopeProxy leak workaround.
 - Under the default `{errorTaming: 'safe'}` setting, the SES shim already redacts stack traces from error instances when it can (currently: v8, spiderMonkey, XS). The setting `{errorTaming: 'unsafe'}` suppresses that redaction, instead blabbing these stack traces on error instances via the expected `errorInstance.stack`.
 
-  The purpose of the `details` template literal tag (often spelled `X` or `d`) together with the `quote` function (often spelled `q`) is to redact data from the error messages carried by error instances. With this release, the same `{errorTaming: 'unsafe'}` would suppress that redaction as well, so that all substitution values would act like they've been quoted. IOW, with this setting
+  The purpose of the `details` template literal tag (often spelled `X`) together with the `quote` function (often spelled `q`) is to redact data from the error messages carried by error instances. With this release, the same `{errorTaming: 'unsafe'}` would suppress that redaction as well, so that all substitution values would act like they've been quoted. IOW, with this setting
 
   ```js
   assert(false, X`literal part ${secretData} with ${q(publicData)}.`);

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -339,7 +339,7 @@ can find it there. When the information leak is tolerable, the `'unsafe'`
 setting will preserve the filtered stack information on the `err.stack`.
 
 Like hiding the stack, the purpose of the `details` template literal tag (often
-spelled `X` or `d`) together with the `quote` function (often spelled `q`) is
+spelled `X`) together with the `quote` function (often spelled `q`) is
 to redact data from the error messages carried by error instances. The same
 `{errorTaming: 'unsafe'}` suppresses that redaction as well, so that all
 substitution values would act like they've been quoted. With this setting

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -150,8 +150,8 @@ freeze(DetailsTokenProto.toString);
 
 /**
  * Normally this is the function exported as `assert.details` and often
- * spelled `d`. However, if the `{errorTaming: 'unsafe'}` option is given to
- * `lockdown`, then `unredactedDetails` is used instead.
+ * spelled `X`. However, if the `{errorTaming: 'unsafe'}` option is
+ * given to `lockdown`, then `unredactedDetails` is used instead.
  *
  * There are some unconditional uses of `redactedDetails` in this module. All
  * of them should be uses where the template literal has no redacted

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -58,7 +58,7 @@ import { tameFauxDataProperties } from './tame-faux-data-properties.js';
 
 /** @import {LockdownOptions} from '../types.js' */
 
-const { Fail, details: d, quote: q } = assert;
+const { Fail, details: X, quote: q } = assert;
 
 /** @type {Error=} */
 let priorRepairIntrinsics;
@@ -200,7 +200,7 @@ export const repairIntrinsics = (options = {}) => {
   priorRepairIntrinsics === undefined ||
     // eslint-disable-next-line @endo/no-polymorphic-call
     assert.fail(
-      d`Already locked down at ${priorRepairIntrinsics} (SES_ALREADY_LOCKED_DOWN)`,
+      X`Already locked down at ${priorRepairIntrinsics} (SES_ALREADY_LOCKED_DOWN)`,
       TypeError,
     );
   // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_ALREADY_LOCKED_DOWN.md
@@ -391,7 +391,7 @@ export const repairIntrinsics = (options = {}) => {
     priorHardenIntrinsics === undefined ||
       // eslint-disable-next-line @endo/no-polymorphic-call
       assert.fail(
-        d`Already locked down at ${priorHardenIntrinsics} (SES_ALREADY_LOCKED_DOWN)`,
+        X`Already locked down at ${priorHardenIntrinsics} (SES_ALREADY_LOCKED_DOWN)`,
         TypeError,
       );
     // See https://github.com/endojs/endo/blob/master/packages/ses/error-codes/SES_ALREADY_LOCKED_DOWN.md

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -29,7 +29,7 @@ import {
 } from './commons.js';
 import { assert } from './error/assert.js';
 
-const { Fail, details: d, quote: q } = assert;
+const { Fail, details: X, quote: q, note: annotateError } = assert;
 
 const noop = () => {};
 
@@ -153,7 +153,7 @@ function* loadWithoutErrorAnnotation(
   if (typeof aliasNamespace === 'string') {
     // eslint-disable-next-line @endo/no-polymorphic-call
     assert.fail(
-      d`Cannot map module ${q(moduleSpecifier)} to ${q(
+      X`Cannot map module ${q(moduleSpecifier)} to ${q(
         aliasNamespace,
       )} in parent compartment, not yet implemented`,
       TypeError,
@@ -163,7 +163,7 @@ function* loadWithoutErrorAnnotation(
     if (alias === undefined) {
       // eslint-disable-next-line @endo/no-polymorphic-call
       assert.fail(
-        d`Cannot map module ${q(
+        X`Cannot map module ${q(
           moduleSpecifier,
         )} because the value is not a module exports namespace, or is from another realm`,
         ReferenceError,
@@ -307,9 +307,9 @@ const memoizedLoadWithErrorAnnotation = (
     ],
     error => {
       // eslint-disable-next-line @endo/no-polymorphic-call
-      assert.note(
+      annotateError(
         error,
-        d`${error.message}, loading ${q(moduleSpecifier)} in compartment ${q(
+        X`${error.message}, loading ${q(moduleSpecifier)} in compartment ${q(
           compartmentName,
         )}`,
       );

--- a/packages/ses/test/error/assert-log.test.js
+++ b/packages/ses/test/error/assert-log.test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import { assertLogs, throwsAndLogs } from './throws-and-logs.js';
 import { assert } from '../../src/error/assert.js';
 
-const { details: d, quote: q, bare: b } = assert;
+const { details: X, quote: q, bare: b, error: makeError } = assert;
 
 // Self-test of the example from the throwsAndLogs comment.
 test('throwsAndLogs with data', t => {
@@ -86,11 +86,11 @@ test('causal tree', t => {
       const fooErr = SyntaxError('foo');
       let err1;
       try {
-        assert.fail(d`synful ${fooErr}`);
+        assert.fail(X`synful ${fooErr}`);
       } catch (e1) {
         err1 = e1;
       }
-      assert.fail(d`because ${err1}`);
+      assert.fail(X`because ${err1}`);
     },
     /because/,
     [['log', 'Caught', Error]],
@@ -101,11 +101,11 @@ test('causal tree', t => {
       const fooErr = SyntaxError('foo');
       let err1;
       try {
-        assert.fail(d`synful ${fooErr}`);
+        assert.fail(X`synful ${fooErr}`);
       } catch (e1) {
         err1 = e1;
       }
-      assert.fail(d`because ${err1}`);
+      assert.fail(X`because ${err1}`);
     },
     /because/,
     [
@@ -155,12 +155,12 @@ test('a causal tree falls silently', t => {
       const fooErr = SyntaxError('foo');
       let err1;
       try {
-        assert.fail(d`synful ${fooErr}`);
+        assert.fail(X`synful ${fooErr}`);
       } catch (e1) {
         err1 = e1;
       }
       try {
-        assert.fail(d`because ${err1}`);
+        assert.fail(X`because ${err1}`);
       } catch (e2) {
         t.assert(e2 instanceof Error);
       }
@@ -173,12 +173,12 @@ test('a causal tree falls silently', t => {
       const fooErr = SyntaxError('foo');
       let err1;
       try {
-        assert.fail(d`synful ${fooErr}`);
+        assert.fail(X`synful ${fooErr}`);
       } catch (e1) {
         err1 = e1;
       }
       try {
-        assert.fail(d`because ${err1}`);
+        assert.fail(X`because ${err1}`);
       } catch (e2) {
         t.assert(e2 instanceof Error);
       }
@@ -223,13 +223,13 @@ test('assert.equal', t => {
   );
   throwsAndLogs(
     t,
-    () => assert.equal(5, 6, d`${5} !== ${6}`),
+    () => assert.equal(5, 6, X`${5} !== ${6}`),
     /\(a number\) !== \(a number\)/,
     [['log', 'Caught', Error]],
   );
   throwsAndLogs(
     t,
-    () => assert.equal(5, 6, d`${5} !== ${q(6)}`),
+    () => assert.equal(5, 6, X`${5} !== ${q(6)}`),
     /\(a number\) !== 6/,
     [['log', 'Caught', Error]],
   );
@@ -260,8 +260,8 @@ test('assert.typeof', t => {
   ]);
 });
 
-test('assert.error default type', t => {
-  const err = assert.error(d`<${'bar'},${q('baz')}>`);
+test('makeError default type', t => {
+  const err = makeError(X`<${'bar'},${q('baz')}>`);
   t.is(err.message, '<(a string),"baz">');
   t.is(err.name, 'Error');
   throwsAndLogs(
@@ -287,8 +287,8 @@ test('assert.error default type', t => {
   );
 });
 
-test('assert.error explicit type', t => {
-  const err = assert.error(d`<${'bar'},${q('baz')}>`, URIError);
+test('makeError explicit type', t => {
+  const err = makeError(X`<${'bar'},${q('baz')}>`, URIError);
   t.is(err.message, '<(a string),"baz">');
   t.is(err.name, 'URIError');
   throwsAndLogs(
@@ -314,8 +314,8 @@ test('assert.error explicit type', t => {
   );
 });
 
-test('assert.error named', t => {
-  const err = assert.error(d`<${'bar'},${q('baz')}>`, URIError, {
+test('makeError named', t => {
+  const err = makeError(X`<${'bar'},${q('baz')}>`, URIError, {
     errorName: 'Foo-Err',
   });
   t.is(err.message, '<(a string),"baz">');
@@ -346,13 +346,13 @@ test('assert.error named', t => {
 test('assert.quote', t => {
   throwsAndLogs(
     t,
-    () => assert.fail(d`<${'bar'},${q('baz')}>`),
+    () => assert.fail(X`<${'bar'},${q('baz')}>`),
     /<\(a string\),"baz">/,
     [['log', 'Caught', Error]],
   );
   throwsAndLogs(
     t,
-    () => assert.fail(d`<${'bar'},${q('baz')}>`),
+    () => assert.fail(X`<${'bar'},${q('baz')}>`),
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
@@ -362,47 +362,47 @@ test('assert.quote', t => {
     { wrapWithCausal: true },
   );
   const list = ['a', 'b', 'c'];
-  throwsAndLogs(t, () => assert.fail(d`${q(list)}`), /\["a","b","c"\]/, [
+  throwsAndLogs(t, () => assert.fail(X`${q(list)}`), /\["a","b","c"\]/, [
     ['log', 'Caught', Error],
   ]);
   const repeat = { x: list, y: list };
   throwsAndLogs(
     t,
-    () => assert.fail(d`${q(repeat)}`),
+    () => assert.fail(X`${q(repeat)}`),
     /{"x":\["a","b","c"\],"y":"\[Seen\]"}/,
     [['log', 'Caught', Error]],
   );
   // Make it into a cycle
   list[1] = list;
-  throwsAndLogs(t, () => assert.fail(d`${q(list)}`), /\["a","\[Seen\]","c"\]/, [
+  throwsAndLogs(t, () => assert.fail(X`${q(list)}`), /\["a","\[Seen\]","c"\]/, [
     ['log', 'Caught', Error],
   ]);
   throwsAndLogs(
     t,
-    () => assert.fail(d`${q(repeat)}`),
+    () => assert.fail(X`${q(repeat)}`),
     /{"x":\["a","\[Seen\]","c"\],"y":"\[Seen\]"}/,
     [['log', 'Caught', Error]],
   );
 });
 
 test('assert.bare', t => {
-  throwsAndLogs(t, () => assert.fail(d`${b('foo')}`), 'foo', [
+  throwsAndLogs(t, () => assert.fail(X`${b('foo')}`), 'foo', [
     ['log', 'Caught', Error],
   ]);
   // Spaces are allowed in bare values.
-  throwsAndLogs(t, () => assert.fail(d`${b('foo bar')}`), 'foo bar', [
+  throwsAndLogs(t, () => assert.fail(X`${b('foo bar')}`), 'foo bar', [
     ['log', 'Caught', Error],
   ]);
   // Multiple consecutive spaces are disallowed and fall back to quote.
-  throwsAndLogs(t, () => assert.fail(d`${b('foo  bar')}`), '"foo  bar"', [
+  throwsAndLogs(t, () => assert.fail(X`${b('foo  bar')}`), '"foo  bar"', [
     ['log', 'Caught', Error],
   ]);
   // Strings with non-word punctuation also fall back.
-  throwsAndLogs(t, () => assert.fail(d`${b('foo%bar')}`), '"foo%bar"', [
+  throwsAndLogs(t, () => assert.fail(X`${b('foo%bar')}`), '"foo%bar"', [
     ['log', 'Caught', Error],
   ]);
   // Non-strings also fall back.
-  throwsAndLogs(t, () => assert.fail(d`${b(undefined)}`), '"[undefined]"', [
+  throwsAndLogs(t, () => assert.fail(X`${b(undefined)}`), '"[undefined]"', [
     ['log', 'Caught', Error],
   ]);
 });
@@ -488,7 +488,7 @@ test('assert.quote as best efforts stringify', t => {
 
 // See https://github.com/endojs/endo/issues/729
 test('printing detailsToken', t => {
-  t.throws(() => assert.error({ __proto__: null }), {
+  t.throws(() => makeError({ __proto__: null }), {
     message: 'unrecognized details {}',
   });
 });

--- a/packages/ses/test/error/tame-console-unfilteredError.test.js
+++ b/packages/ses/test/error/tame-console-unfilteredError.test.js
@@ -6,10 +6,10 @@ const originalConsole = console;
 
 lockdown({ errorTaming: 'safe', stackFiltering: 'verbose' });
 
-const { details: d, quote: q } = assert;
+const { details: X, quote: q, note: annotateError } = assert;
 
 test('ava message disclosure quiet', t => {
-  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
     message: /a secret \(a number\) and a public 777/,
   });
 });
@@ -44,7 +44,7 @@ test('assert - safe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -55,7 +55,7 @@ test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   });
 });
 
@@ -63,7 +63,7 @@ test('tameConsole - safe', t => {
   const obj = {};
   const fooErr = SyntaxError('foo');
   const barErr = URIError('bar');
-  assert.note(barErr, d`caused by ${fooErr},${obj}`);
+  annotateError(barErr, X`caused by ${fooErr},${obj}`);
   console.log('bar happens', barErr);
   t.pass();
 });
@@ -72,6 +72,6 @@ test('tameConsole - unlogged safe', t => {
   const obj = {};
   const ufooErr = SyntaxError('ufoo');
   const ubarErr = URIError('ubar');
-  assert.note(ubarErr, d`caused by ${ufooErr},${obj}`);
+  annotateError(ubarErr, X`caused by ${ufooErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/tame-console-unsafe-unfilteredError.test.js
+++ b/packages/ses/test/error/tame-console-unsafe-unfilteredError.test.js
@@ -10,10 +10,10 @@ lockdown({
   stackFiltering: 'verbose',
 });
 
-const { details: d, quote: q } = assert;
+const { details: X, quote: q, note: annotateError } = assert;
 
 test('ava message disclosure quiet', t => {
-  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
     message: /a secret \(a number\) and a public 777/,
   });
 });
@@ -51,7 +51,7 @@ test('assert - unsafe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -62,7 +62,7 @@ test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   });
 });
 
@@ -70,7 +70,7 @@ test('tameConsole - unsafe', t => {
   const obj = {};
   const faaErr = TypeError('faa');
   const borErr = ReferenceError('bor');
-  assert.note(borErr, d`caused by ${faaErr},${obj}`);
+  annotateError(borErr, X`caused by ${faaErr},${obj}`);
   console.log('bor happens', borErr);
   t.pass();
 });
@@ -79,6 +79,6 @@ test('tameConsole - unlogged unsafe', t => {
   const obj = {};
   const ufaaErr = TypeError('ufaa');
   const uborErr = ReferenceError('ubor');
-  assert.note(uborErr, d`caused by ${ufaaErr},${obj}`);
+  annotateError(uborErr, X`caused by ${ufaaErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/tame-console-unsafe-unsafeError-unfilteredError.test.js
+++ b/packages/ses/test/error/tame-console-unsafe-unsafeError-unfilteredError.test.js
@@ -12,10 +12,10 @@ lockdown({
 });
 
 // Grab `details` only after lockdown
-const { details: d, quote: q } = assert;
+const { details: X, quote: q, note: annotateError } = assert;
 
 test('ava message disclosure blabs', t => {
-  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
     message: /a secret 666 and a public 777/,
   });
 });
@@ -53,7 +53,7 @@ test('assert - unsafe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -64,7 +64,7 @@ test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   });
 });
 
@@ -72,7 +72,7 @@ test('tameConsole - unsafe', t => {
   const obj = {};
   const faaErr = TypeError('faa');
   const borErr = ReferenceError('bor');
-  assert.note(borErr, d`caused by ${faaErr},${obj}`);
+  annotateError(borErr, X`caused by ${faaErr},${obj}`);
   console.log('bor happens', borErr);
   t.pass();
 });
@@ -81,6 +81,6 @@ test('tameConsole - unlogged unsafe', t => {
   const obj = {};
   const ufaaErr = TypeError('ufaa');
   const uborErr = ReferenceError('ubor');
-  assert.note(uborErr, d`caused by ${ufaaErr},${obj}`);
+  annotateError(uborErr, X`caused by ${ufaaErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/tame-console-unsafe-unsafeError.test.js
+++ b/packages/ses/test/error/tame-console-unsafe-unsafeError.test.js
@@ -11,10 +11,10 @@ lockdown({
 });
 
 // Grab `details` only after lockdown
-const { details: d, quote: q } = assert;
+const { details: X, quote: q, note: annotateError } = assert;
 
 test('ava message disclosure blabs', t => {
-  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
     message: /a secret 666 and a public 777/,
   });
 });
@@ -52,7 +52,7 @@ test('assert - unsafe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -63,7 +63,7 @@ test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   });
 });
 
@@ -71,7 +71,7 @@ test('tameConsole - unsafe', t => {
   const obj = {};
   const faaErr = TypeError('faa');
   const borErr = ReferenceError('bor');
-  assert.note(borErr, d`caused by ${faaErr},${obj}`);
+  annotateError(borErr, X`caused by ${faaErr},${obj}`);
   console.log('bor happens', borErr);
   t.pass();
 });
@@ -80,6 +80,6 @@ test('tameConsole - unlogged unsafe', t => {
   const obj = {};
   const ufaaErr = TypeError('ufaa');
   const uborErr = ReferenceError('ubor');
-  assert.note(uborErr, d`caused by ${ufaaErr},${obj}`);
+  annotateError(uborErr, X`caused by ${ufaaErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/tame-console-unsafe.test.js
+++ b/packages/ses/test/error/tame-console-unsafe.test.js
@@ -6,10 +6,10 @@ const originalConsole = console;
 
 lockdown({ errorTaming: 'safe', consoleTaming: 'unsafe' });
 
-const { details: d, quote: q } = assert;
+const { details: X, quote: q, note: annotateError } = assert;
 
 test('ava message disclosure quiet', t => {
-  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
     message: /a secret \(a number\) and a public 777/,
   });
 });
@@ -48,7 +48,7 @@ test('assert - unsafe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -59,7 +59,7 @@ test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   });
 });
 
@@ -67,7 +67,7 @@ test('tameConsole - unsafe', t => {
   const obj = {};
   const faaErr = TypeError('faa');
   const borErr = ReferenceError('bor');
-  assert.note(borErr, d`caused by ${faaErr},${obj}`);
+  annotateError(borErr, X`caused by ${faaErr},${obj}`);
   console.log('bor happens', borErr);
   t.pass();
 });
@@ -76,6 +76,6 @@ test('tameConsole - unlogged unsafe', t => {
   const obj = {};
   const ufaaErr = TypeError('ufaa');
   const uborErr = ReferenceError('ubor');
-  assert.note(uborErr, d`caused by ${ufaaErr},${obj}`);
+  annotateError(uborErr, X`caused by ${ufaaErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/tame-console-unsafeError.test.js
+++ b/packages/ses/test/error/tame-console-unsafeError.test.js
@@ -7,10 +7,10 @@ const originalConsole = console;
 lockdown({ errorTaming: 'unsafe' });
 
 // Grab `details` only after lockdown
-const { details: d, quote: q } = assert;
+const { details: X, quote: q, note: annotateError } = assert;
 
 test('ava message disclosure blabs', t => {
-  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
     message: /a secret 666 and a public 777/,
   });
 });
@@ -45,7 +45,7 @@ test('assert - safe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -56,7 +56,7 @@ test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   });
 });
 
@@ -64,7 +64,7 @@ test('tameConsole - safe', t => {
   const obj = {};
   const fooErr = SyntaxError('foo');
   const barErr = URIError('bar');
-  assert.note(barErr, d`caused by ${fooErr},${obj}`);
+  annotateError(barErr, X`caused by ${fooErr},${obj}`);
   console.log('bar happens', barErr);
   t.pass();
 });
@@ -73,6 +73,6 @@ test('tameConsole - unlogged safe', t => {
   const obj = {};
   const ufooErr = SyntaxError('ufoo');
   const ubarErr = URIError('ubar');
-  assert.note(ubarErr, d`caused by ${ufooErr},${obj}`);
+  annotateError(ubarErr, X`caused by ${ufooErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/test/error/tame-console.test.js
+++ b/packages/ses/test/error/tame-console.test.js
@@ -6,10 +6,10 @@ const originalConsole = console;
 
 lockdown({ errorTaming: 'safe' });
 
-const { details: d, quote: q } = assert;
+const { details: X, quote: q, note: annotateError } = assert;
 
 test('ava message disclosure default', t => {
-  t.throws(() => assert.fail(d`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
     message: /a secret \(a number\) and a public 777/,
   });
 });
@@ -52,7 +52,7 @@ test('assert - safe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -67,7 +67,7 @@ test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(d`caused by ${fooErr},${obj}`);
+    assert.fail(X`caused by ${fooErr},${obj}`);
   });
 });
 
@@ -82,7 +82,7 @@ test('tameConsole - safe', t => {
   const obj = {};
   const fooErr = SyntaxError('foo');
   const barErr = URIError('bar');
-  assert.note(barErr, d`caused by ${fooErr},${obj}`);
+  annotateError(barErr, X`caused by ${fooErr},${obj}`);
   console.log('bar happens', barErr);
   t.pass();
 });
@@ -93,6 +93,6 @@ test('tameConsole - unlogged safe', t => {
   const obj = {};
   const ufooErr = SyntaxError('ufoo');
   const ubarErr = URIError('ubar');
-  assert.note(ubarErr, d`caused by ${ufooErr},${obj}`);
+  annotateError(ubarErr, X`caused by ${ufooErr},${obj}`);
   t.pass();
 });

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -346,12 +346,10 @@ export interface AssertionUtilities {
    * ```js
    * assert(sky.isBlue(), details`${sky.color} should be "blue"`);
    * ```
-   * // TODO Update SES-shim to new convention, where `details` is
-   * // renamed to `X` rather than `d`.
-   * or following the normal convention to locally rename `details` to `d`
-   * and `quote` to `q` like `const { details: d, quote: q } = assert;`:
+   * or following the normal convention to locally rename `details` to `X`
+   * and `quote` to `q` like `const { details: X, quote: q } = assert;`:
    * ```js
-   * assert(sky.isBlue(), d`${sky.color} should be "blue"`);
+   * assert(sky.isBlue(), X`${sky.color} should be "blue"`);
    * ```
    * However, note that in most cases it is preferable to instead use the `Fail`
    * template literal tag (which has the same input signature as `details`
@@ -427,10 +425,8 @@ export interface AssertionUtilities {
    * sky.color === expectedColor || Fail`${sky.color} should be ${quote(expectedColor)}`;
    * ```
    *
-   * // TODO Update SES-shim to new convention, where `details` is
-   * // renamed to `X` rather than `d`.
-   * The normal convention is to locally rename `details` to `d` and `quote` to `q`
-   * like `const { details: d, quote: q } = assert;`, so the above example would then be
+   * The normal convention is to locally rename `details` to `X` and `quote` to `q`
+   * like `const { details: X, quote: q } = assert;`, so the above example would then be
    * ```js
    * sky.color === expectedColor || Fail`${sky.color} should be ${q(expectedColor)}`;
    * ```

--- a/packages/ses/types.test-d.ts
+++ b/packages/ses/types.test-d.ts
@@ -82,7 +82,13 @@ d.module('z');
 
 // Assertions
 
-const { Fail, quote: q, details: X } = assert;
+const {
+  Fail,
+  quote: q,
+  details: X,
+  error: makeError,
+  note: annotateError,
+} = assert;
 
 assert.equal('a', 'b');
 assert.equal('a', 'b', 'equality error');
@@ -197,18 +203,18 @@ expectType<void>(assume(false, 'definitely'));
 
 // ////////////////////////////////////////////////////////////////////////
 
-assert.note(Error('nothing to see here'), X`except this ${q('detail')}`);
+annotateError(Error('nothing to see here'), X`except this ${q('detail')}`);
 
 X`canst thou string?`.toString();
 
 const stringable = q(null);
 
-expectType<Error>(assert.error(X`details are ${q(stringable)}`));
+expectType<Error>(makeError(X`details are ${q(stringable)}`));
 
-expectType<Error>(assert.error(X`details are ${stringable}`, TypeError));
+expectType<Error>(makeError(X`details are ${stringable}`, TypeError));
 
 expectType<Error>(
-  assert.error(X`details are ${stringable}`, TypeError, {
+  makeError(X`details are ${stringable}`, TypeError, {
     errorName: 'Nom de plum',
   }),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,6 +268,7 @@ __metadata:
     "@endo/bundle-source": "npm:^3.2.3"
     "@endo/compartment-mapper": "npm:^1.1.5"
     "@endo/daemon": "npm:^2.3.0"
+    "@endo/errors": "npm:^1.2.2"
     "@endo/eventual-send": "npm:^1.2.2"
     "@endo/exo": "npm:^1.5.0"
     "@endo/far": "npm:^1.1.2"


### PR DESCRIPTION
Staged on #2323 

Closes: #XXXX
Refs: https://github.com/Agoric/agoric-sdk/issues/5672 https://github.com/Agoric/agoric-sdk/pull/9513

## Description

Does for endo what https://github.com/Agoric/agoric-sdk/pull/9513 does for agoric-sdk --- importing `assert` from @endo/errors --- when it can do so without causing dependency cycles. For the remaining packages that would cause dependency cycles, just move them towards more modern assert conventions while still using the unstructured global `assert`

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

We should document `assert` only as imported from @endo/errors, since our users will not generally contribute code within endo's internal dependency cycles.

### Testing Considerations

The CI run on this PR also serves to test #2323, since that one, by itself, does not cause a behavioral change. It's purpose is to enable this PR not to hit the problem described at https://github.com/Agoric/agoric-sdk/issues/9515

### Compatibility Considerations

none
### Upgrade Considerations

none