### PR TITLE
Further endo daemon CLI support for dot-delimited paths

### DIFF
--- a/packages/cli/src/commands/adopt.js
+++ b/packages/cli/src/commands/adopt.js
@@ -2,6 +2,7 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
 export const adoptCommand = async ({
   messageNumberText,
@@ -12,5 +13,5 @@ export const adoptCommand = async ({
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
     // TODO less bad number parsing.
     const messageNumber = Number(messageNumberText);
-    await E(agent).adopt(messageNumber, edgeName, name);
+    await E(agent).adopt(messageNumber, edgeName, parsePetNamePath(name));
   });

--- a/packages/cli/src/commands/eval.js
+++ b/packages/cli/src/commands/eval.js
@@ -35,7 +35,7 @@ export const evalCommand = async ({
       source,
       codeNames,
       petNames,
-      resultName,
+      parsePetNamePath(resultName),
     );
     console.log(result);
   });

--- a/packages/cli/src/commands/install.js
+++ b/packages/cli/src/commands/install.js
@@ -8,6 +8,7 @@ import { makeReaderRef } from '@endo/daemon';
 import bundleSource from '@endo/bundle-source';
 
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 import { randomHex16 } from '../random.js';
 
 const textEncoder = new TextEncoder();
@@ -25,6 +26,7 @@ export const install = async ({
   let bundleReaderRef;
   /** @type {string | undefined} */
   let temporaryBundleName;
+  await null;
   if (programPath !== undefined) {
     if (bundleName === undefined) {
       // TODO alternately, make a temporary session-scoped GC pet store
@@ -41,6 +43,7 @@ export const install = async ({
 
   await withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
     // Prepare a bundle, with the given name.
+    await null;
     if (bundleReaderRef !== undefined) {
       await E(agent).storeBlob(bundleReaderRef, bundleName);
     }
@@ -53,7 +56,7 @@ export const install = async ({
         )}, $id, $cancelled)`,
         ['apps', 'bundle', 'powers'],
         ['APPS', bundleName, powersName],
-        webletName,
+        parsePetNamePath(webletName),
       );
       const webletLocation = await E(weblet).getLocation();
       process.stdout.write(`${webletLocation}\n`);

--- a/packages/cli/src/commands/mkdir.js
+++ b/packages/cli/src/commands/mkdir.js
@@ -6,5 +6,5 @@ import { parsePetNamePath } from '../pet-name.js';
 
 export const mkdir = async ({ agentNames, directoryPath }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    await E(agent).makeDirectory(...parsePetNamePath(directoryPath));
+    await E(agent).makeDirectory(parsePetNamePath(directoryPath));
   });

--- a/packages/cli/src/commands/remove.js
+++ b/packages/cli/src/commands/remove.js
@@ -2,8 +2,13 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
-export const remove = async ({ petNames, agentNames }) =>
+export const remove = async ({ petNamePaths, agentNames }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) =>
-    Promise.all(petNames.map(petName => E(agent).remove(petName))),
+    Promise.all(
+      petNamePaths.map(petNamePath =>
+        E(agent).remove(...parsePetNamePath(petNamePath)),
+      ),
+    ),
   );

--- a/packages/cli/src/commands/request.js
+++ b/packages/cli/src/commands/request.js
@@ -2,6 +2,7 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
 export const request = async ({
   description,
@@ -10,7 +11,11 @@ export const request = async ({
   agentNames,
 }) => {
   await withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
-    const result = await E(agent).request(toName, description, resultName);
+    const result = await E(agent).request(
+      toName,
+      description,
+      parsePetNamePath(resultName),
+    );
     console.log(result);
   });
 };

--- a/packages/cli/src/commands/spawn.js
+++ b/packages/cli/src/commands/spawn.js
@@ -3,8 +3,13 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
 
-export const spawn = async ({ petNames, agentNames }) =>
+export const spawn = async ({ petNamePaths, agentNames }) =>
   withEndoAgent(agentNames, { os, process }, async ({ agent }) =>
-    Promise.all(petNames.map(petName => E(agent).provideWorker(petName))),
+    Promise.all(
+      petNamePaths.map(petNamePath =>
+        E(agent).provideWorker(parsePetNamePath(petNamePath)),
+      ),
+    ),
   );

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -162,7 +162,7 @@ export const main = async rawArgs => {
         UNCONFINED: importPath,
         name: resultName,
         bundle: bundleName,
-        worker: workerName = 'NEW',
+        worker: workerName = undefined,
         as: agentNames,
         powers: powersName = 'NONE',
       } = cmd.opts();
@@ -291,10 +291,10 @@ export const main = async rawArgs => {
     .command('remove [names...]')
     .description('forget a named value')
     .option(...commonOptions.as)
-    .action(async (petNames, cmd) => {
+    .action(async (petNamePaths, cmd) => {
       const { as: agentNames } = cmd.opts();
       const { remove } = await import('./commands/remove.js');
-      return remove({ petNames, agentNames });
+      return remove({ petNamePaths, agentNames });
     });
 
   program
@@ -405,10 +405,10 @@ export const main = async rawArgs => {
     .command('spawn [names...]')
     .description('creates a worker')
     .option(...commonOptions.as)
-    .action(async (petNames, cmd) => {
+    .action(async (petNamePaths, cmd) => {
       const { as: agentNames } = cmd.opts();
       const { spawn } = await import('./commands/spawn.js');
-      return spawn({ petNames, agentNames });
+      return spawn({ petNamePaths, agentNames });
     });
 
   program
@@ -591,6 +591,7 @@ export const main = async rawArgs => {
     .description('erases persistent state and stops if running')
     .action(async cmd => {
       const { force } = cmd.opts();
+      await null;
       const doPurge =
         force ||
         /^y(es)?$/u.test(

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -439,7 +439,7 @@ const makeDaemonCore = async (
     context.thisDiesIfThatDies(hubId);
 
     const hub = provide(hubId, 'hub');
-    return E(hub).lookup(...path);
+    return E(hub).lookup(path);
   };
 
   /**
@@ -708,6 +708,7 @@ const makeDaemonCore = async (
    * @param {Context} context
    */
   const evaluateFormula = async (id, formulaNumber, formula, context) => {
+    await null;
     if (Object.hasOwn(makers, formula.type)) {
       const make = makers[formula.type];
       const value = await /** @type {unknown} */ (
@@ -839,6 +840,7 @@ const makeDaemonCore = async (
   const formulateReadableBlob = async (readerRef, deferredTasks) => {
     const { formulaNumber, contentSha512 } = await formulaGraphJobs.enqueue(
       async () => {
+        await null;
         const values = {
           formulaNumber: await randomHex512(),
           contentSha512: await contentStore.store(makeRefReader(readerRef)),
@@ -988,6 +990,7 @@ const makeDaemonCore = async (
    * @type {DaemonCore['formulateWorker']}
    */
   const formulateWorker = async deferredTasks => {
+    await null;
     return formulateNumberedWorker(
       await formulaGraphJobs.enqueue(async () => {
         const formulaNumber = await randomHex512();
@@ -1011,6 +1014,7 @@ const makeDaemonCore = async (
     const { specifiedWorkerId, ...remainingSpecifiedIdentifiers } =
       specifiedIdentifiers;
 
+    await null;
     const storeId = (await formulateNumberedPetStore(await randomHex512())).id;
 
     const hostFormulaNumber = await randomHex512();
@@ -1064,6 +1068,7 @@ const makeDaemonCore = async (
     deferredTasks,
     specifiedWorkerId,
   ) => {
+    await null;
     return formulateNumberedHost(
       await formulaGraphJobs.enqueue(async () => {
         const identifiers = await formulateHostDependencies({
@@ -1123,6 +1128,7 @@ const makeDaemonCore = async (
 
   /** @type {DaemonCore['formulateGuest']} */
   const formulateGuest = async (hostAgentId, hostHandleId, deferredTasks) => {
+    await null;
     return formulateNumberedGuest(
       await formulaGraphJobs.enqueue(async () => {
         const identifiers = await formulateGuestDependencies(
@@ -1212,6 +1218,7 @@ const makeDaemonCore = async (
               if (typeof formulaIdOrPath === 'string') {
                 return formulaIdOrPath;
               }
+              await null;
               return (
                 /* eslint-disable no-use-before-define */
                 (
@@ -1657,11 +1664,19 @@ const makeDaemonCore = async (
     const petStore = await provide(petStoreId, 'pet-store');
 
     /**
-     * @param {string} petName - The pet name to inspect.
+     * @param {string|string[]} petName - The pet name to inspect.
      * @returns {Promise<KnownEndoInspectors[string]>} An
      * inspector for the value of the given pet name.
      */
     const lookup = async petName => {
+      if (Array.isArray(petName)) {
+        if (petName.length !== 1) {
+          throw Error(
+            'PetStoreInspector.lookup(path) requires path length of 1',
+          );
+        }
+        petName = petName[0];
+      }
       const id = petStore.identifyLocal(petName);
       if (id === undefined) {
         throw new Error(`Unknown pet name ${petName}`);

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -26,8 +26,12 @@ export const makeDirectoryMaker = ({
   /** @type {MakeDirectoryNode} */
   const makeDirectoryNode = petStore => {
     /** @type {EndoDirectory['lookup']} */
-    const lookup = (...petNamePath) => {
+    const lookup = petNamePath => {
+      if (typeof petNamePath === 'string') {
+        petNamePath = [petNamePath];
+      }
       const [headName, ...tailNames] = petNamePath;
+
       const id = petStore.identifyLocal(headName);
       if (id === undefined) {
         throw new TypeError(`Unknown pet name: ${q(headName)}`);
@@ -41,6 +45,7 @@ export const makeDirectoryMaker = ({
 
     /** @type {EndoDirectory['reverseLookup']} */
     const reverseLookup = async presence => {
+      await null;
       const id = getIdForRef(await presence);
       if (id === undefined) {
         return harden([]);
@@ -62,7 +67,7 @@ export const makeDirectoryMaker = ({
         // eslint-disable-next-line no-use-before-define
         return { hub: directory, name: tailName };
       }
-      const nameHub = /** @type {NameHub} */ (await lookup(...headPath));
+      const nameHub = /** @type {NameHub} */ (await lookup(headPath));
       return { hub: nameHub, name: tailName };
     };
 
@@ -126,12 +131,13 @@ export const makeDirectoryMaker = ({
       if (petNamePath.length === 0) {
         return petStore.list();
       }
-      const hub = /** @type {NameHub} */ (await lookup(...petNamePath));
+      const hub = /** @type {NameHub} */ (await lookup(petNamePath));
       return hub.list();
     };
 
     /** @type {EndoDirectory['listIdentifiers']} */
     const listIdentifiers = async (...petNamePath) => {
+      petNamePath = petNamePath || [];
       const names = await list(...petNamePath);
       const identities = new Set();
       await Promise.all(
@@ -153,12 +159,13 @@ export const makeDirectoryMaker = ({
         yield* petStore.followNameChanges();
         return;
       }
-      const hub = /** @type {NameHub} */ (await lookup(...petNamePath));
+      const hub = /** @type {NameHub} */ (await lookup(petNamePath));
       yield* hub.followNameChanges();
     };
 
     /** @type {EndoDirectory['remove']} */
     const remove = async (...petNamePath) => {
+      await null;
       if (petNamePath.length === 1) {
         const petName = petNamePath[0];
         await petStore.remove(petName);
@@ -211,6 +218,7 @@ export const makeDirectoryMaker = ({
       if (typeof petNamePath === 'string') {
         petNamePath = [petNamePath];
       }
+      await null;
       if (petNamePath.length === 1) {
         const petName = petNamePath[0];
         await petStore.write(petName, id);
@@ -221,7 +229,7 @@ export const makeDirectoryMaker = ({
     };
 
     /** @type {EndoDirectory['makeDirectory']} */
-    const makeDirectory = async (...directoryPetNamePath) => {
+    const makeDirectory = async directoryPetNamePath => {
       const { value: directory, id } = await formulateDirectory();
       await write(directoryPetNamePath, id);
       return directory;

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -44,13 +44,14 @@ export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
       HOST: hostHandleId,
     });
 
+    const directory = makeDirectoryNode(specialStore);
     const mailbox = makeMailbox({
       petStore: specialStore,
+      directory,
       selfId: handleId,
       context,
     });
-    const { petStore, handle } = mailbox;
-    const directory = makeDirectoryNode(petStore);
+    const { handle } = mailbox;
 
     const { reverseIdentify } = specialStore;
     const {

--- a/packages/daemon/src/pet-name.js
+++ b/packages/daemon/src/pet-name.js
@@ -19,6 +19,18 @@ export const assertPetName = petName => {
 };
 
 /**
+ * @param {string[]} petNamePath
+ */
+export const assertPetNamePath = petNamePath => {
+  if (!Array.isArray(petNamePath) || petNamePath.length < 1) {
+    throw new Error(`Invalid pet name path`);
+  }
+  for (const petName of petNamePath) {
+    assertPetName(petName);
+  }
+};
+
+/**
  * @param {string | string[]} petNameOrPetNamePath
  */
 export const petNamePathFrom = petNameOrPetNamePath =>

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -444,7 +444,7 @@ export interface NameHub {
   followNameChanges(
     ...petNamePath: string[]
   ): AsyncGenerator<PetStoreNameChange, undefined, undefined>;
-  lookup(...petNamePath: string[]): Promise<unknown>;
+  lookup(petNamePath: string | string[]): Promise<unknown>;
   reverseLookup(value: unknown): Array<string>;
   write(petNamePath: string | string[], id: string): Promise<void>;
   remove(...petNamePath: string[]): Promise<void>;
@@ -453,7 +453,7 @@ export interface NameHub {
 }
 
 export interface EndoDirectory extends NameHub {
-  makeDirectory(...petNamePath: string[]): Promise<EndoDirectory>;
+  makeDirectory(petNamePath: string[]): Promise<EndoDirectory>;
 }
 
 export type MakeDirectoryNode = (petStore: PetStore) => EndoDirectory;
@@ -470,7 +470,7 @@ export interface Mail {
   adopt(
     messageNumber: number,
     edgeName: string,
-    petName: string,
+    petName: string[],
   ): Promise<void>;
   dismiss(messageNumber: number): Promise<void>;
   request(
@@ -490,6 +490,7 @@ export interface Mail {
 export type MakeMailbox = (args: {
   selfId: string;
   petStore: PetStore;
+  directory: EndoDirectory;
   context: Context;
 }) => Mail;
 
@@ -580,17 +581,17 @@ export interface EndoHost extends EndoAgent {
     petName?: string,
     opts?: MakeHostOrGuestOptions,
   ): Promise<EndoHost>;
-  makeDirectory(petName: string): Promise<EndoDirectory>;
-  provideWorker(petName: string): Promise<EndoWorker>;
+  makeDirectory(petNamePath: string[]): Promise<EndoDirectory>;
+  provideWorker(petNamePath: string[]): Promise<EndoWorker>;
   evaluate(
     workerPetName: string | undefined,
     source: string,
     codeNames: Array<string>,
     petNames: Array<string>,
-    resultName?: string,
+    resultName?: string[],
   ): Promise<unknown>;
   makeUnconfined(
-    workerName: string | 'NEW' | 'MAIN',
+    workerName: string | undefined | 'MAIN',
     specifier: string,
     powersName: string | 'NONE' | 'SELF' | 'ENDO',
     resultName?: string,


### PR DESCRIPTION
Adds support for dot-delimited petname paths in the `mkdir`, `remove`, and `spawn` commands, plus everywhere there's a `--name` option (the `install`, `make`, `request`, `adopt`, `store`, `eval`, and `bundle` commands).

Ref: #2023 
