### PR TITLE
feat(ses): call lockdown before bundling SES shim

### DIFF
--- a/packages/ses/scripts/bundle.js
+++ b/packages/ses/scripts/bundle.js
@@ -2,6 +2,7 @@
 /* global process */
 
 import '../index.js';
+import '../lockdown.js';
 
 lockdown();
 

--- a/packages/ses/scripts/bundle.js
+++ b/packages/ses/scripts/bundle.js
@@ -2,10 +2,7 @@
 /* global process */
 
 import '../index.js';
-import '../lockdown.js';
-
-lockdown();
-
+import '../test/lockdown-safe.js';
 import fs from 'fs';
 import { makeBundle } from '@endo/compartment-mapper/bundle.js';
 import { minify } from 'terser';

--- a/packages/ses/scripts/bundle.js
+++ b/packages/ses/scripts/bundle.js
@@ -1,10 +1,7 @@
 /* eslint-disable import/first */
 /* global process */
-
-import '../index.js';
-
 lockdown();
-
+import '../index.js';
 import fs from 'fs';
 import { makeBundle } from '@endo/compartment-mapper/bundle.js';
 import { minify } from 'terser';

--- a/packages/ses/scripts/bundle.js
+++ b/packages/ses/scripts/bundle.js
@@ -1,5 +1,10 @@
+/* eslint-disable import/first */
 /* global process */
+
 import '../index.js';
+
+lockdown();
+
 import fs from 'fs';
 import { makeBundle } from '@endo/compartment-mapper/bundle.js';
 import { minify } from 'terser';

--- a/packages/ses/scripts/bundle.js
+++ b/packages/ses/scripts/bundle.js
@@ -1,7 +1,10 @@
 /* eslint-disable import/first */
 /* global process */
-lockdown();
+
 import '../index.js';
+
+lockdown();
+
 import fs from 'fs';
 import { makeBundle } from '@endo/compartment-mapper/bundle.js';
 import { minify } from 'terser';

--- a/packages/ses/scripts/bundle.js
+++ b/packages/ses/scripts/bundle.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/first */
 /* global process */
-
 import '../index.js';
 import '../test/lockdown-safe.js';
 import fs from 'fs';


### PR DESCRIPTION
## Description

Call lockdown before bundling the SES shim

Discussion: https://youtu.be/qGGeACz4cyM

### Security Considerations

> Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?

- bundle now fails (TypeError) to build if non-standard JS called after `lockdown()`
- `yarn build` now also logs to console (e.g. `Removing unpermitted intrinsics`) if non-standard JS called before `lockdown()`

### Scaling Considerations

> Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated?

### Documentation Considerations

> Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

### Testing Considerations

> Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? 

### Compatibility Considerations

> Does this change break any prior usage patterns? Does this change allow usage patterns to evolve?

### Upgrade Considerations

> What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed?

> Include `*BREAKING*:` in the commit message with migration instructions for any breaking change.

> Update `NEWS.md` for user-facing changes.

> Delete guidance from pull request description before merge (including this!)
