### PR TITLE
refactor(marshal,pass-style): #1687 move deeplyFulfilled to @endo/pas…

### DIFF
--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `@endo/marshal`:
 
+# Next release
+
+- `deeplyFulfilled` moved from @endo/marshal to @endo/pass-style. @endo/marshal still reexports it, to avoid breaking old importers. But importers should be upgraded to import `deeplyFulfilled` directly from @endo/pass-style.
+
 # v1.3.0 (2024-02-22)
 
 - Sending and receiving extended errors.

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -1,5 +1,3 @@
-export { deeplyFulfilled } from './src/deeplyFulfilled.js';
-
 export { QCLASS } from './src/encodeToCapData.js';
 export { makeMarshal } from './src/marshal.js';
 export { stringify, parse } from './src/marshal-stringify.js';
@@ -35,3 +33,9 @@ export * from './src/types.js';
 // For compatibility, but importers of these should instead import these
 // directly from `@endo/pass-style` or (if applicable) `@endo/far`.
 export * from '@endo/pass-style';
+
+/**
+ * @deprecated Import deeplyFulfilled directly from @endo/pass-style.
+ * The re-export here is just for compat with old importers
+ */
+export { deeplyFulfilled } from '@endo/pass-style';

--- a/packages/pass-style/NEWS.md
+++ b/packages/pass-style/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `@endo/pass-style`:
 
+# Next release
+
+- `deeplyFulfilled` moved from @endo/marshal to @endo/pass-style. @endo/marshal still reexports it, to avoid breaking old importers. But importers should be upgraded to import `deeplyFulfilled` directly from @endo/pass-style.
+
 # v1.4.0 (2024-05-06)
 
 - Adds `toThrowable` as a generalization of `toPassableError` that also admits copy data containing passable errors, but still without passable caps, i.e, without remotables or promises. This is in support of the exo boundary throwing only throwables, to ease security review.

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -49,5 +49,7 @@ export {
   isCopyArray,
 } from './src/typeGuards.js';
 
+export * from './src/deeplyFulfilled.js';
+
 // eslint-disable-next-line import/export -- ESLint not aware of type exports in types.d.ts
 export * from './src/types.js';

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -1,7 +1,9 @@
 import { X, q } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { isPromise } from '@endo/promise-kit';
-import { getTag, isObject, makeTagged, passStyleOf } from '@endo/pass-style';
+import { getTag, isObject } from './passStyle-helpers.js';
+import { passStyleOf } from './passStyleOf.js';
+import { makeTagged } from './makeTagged.js';
 
 /**
  * @import {Passable, Primitive, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'

--- a/packages/pass-style/test/deeplyFulfilled.test.js
+++ b/packages/pass-style/test/deeplyFulfilled.test.js
@@ -1,6 +1,5 @@
 import test from '@endo/ses-ava/prepare-endo.js';
-
-import { Far } from '@endo/pass-style';
+import { Far } from '../src/make-far.js';
 import { deeplyFulfilled } from '../src/deeplyFulfilled.js';
 
 // Currently, just copied from deeplyFulfilledObject test.


### PR DESCRIPTION

Closes: #1687 

## Description

`deeplyFulfilled` has no dependence on concepts introduced by the @endo/marshal layer. This PR moves it to the @endo/pass-style layer, whose concepts it is directly about. See #1687 for other possible motives to do this.

For compat, this PR still has @endo/marshal reexport it, but marked as a deprecated reexport, advising importers to import from @endo/pass-style instead. Thus, this PR should count as a pure refactor which cannot break any old code.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

minor. Changes only what packages `deeplyFulfilled` should be explained as part of, and which it should be imported from.
### Testing Considerations

moved the test as well.
### Compatibility Considerations

As above. 
### Upgrade Considerations

none.

> Update `NEWS.md` for user-facing changes.

Both `NEWS.md` updated.