### PR TITLE
feat(bundle-source): Add format flags, add new endoScript format

### DIFF
--- a/packages/bundle-source/NEWS.md
+++ b/packages/bundle-source/NEWS.md
@@ -8,6 +8,9 @@
   they cannot be made to run on the web without further work on module
   virtualization in the platform without entraining a client-side
   dependency on a JavaScript parser framework (namely Babel).
+- Adds a `-f,--format` command flag to specify other module formats.
+- Adds a new `endoScript` module format.
+- Adds a no-cache, bundle-to-stdout mode.
 
 # v3.2.1 (2024-03-20)
 

--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -7,6 +7,8 @@ import { makeFileReader, makeAtomicFileWriter } from './src/fs.js';
 
 const { Fail, quote: q } = assert;
 
+/** @import {ModuleFormat} from './src/types.js' */
+
 /**
  * @typedef {(...args: unknown[]) => void} Logger A message logger.
  */
@@ -17,6 +19,7 @@ const { Fail, quote: q } = assert;
  * @property {string} bundleTime ISO format
  * @property {number} bundleSize
  * @property {boolean} noTransforms
+ * @property {ModuleFormat} format
  * @property {{ relative: string, absolute: string }} moduleSource
  * @property {Array<{ relativePath: string, mtime: string, size: number }>} contents
  */
@@ -48,11 +51,12 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
    * @param {Logger} [log]
    * @param {object} [options]
    * @param {boolean} [options.noTransforms]
+   * @param {ModuleFormat} [options.format]
    */
   const add = async (rootPath, targetName, log = defaultLog, options = {}) => {
     const srcRd = cwd.neighbor(rootPath);
 
-    const { noTransforms = false } = options;
+    const { noTransforms = false, format = 'endoZipBase64' } = options;
 
     const statsByPath = new Map();
 
@@ -81,15 +85,12 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
 
     const bundle = await bundleSource(
       rootPath,
-      { ...bundleOptions, noTransforms },
+      { ...bundleOptions, noTransforms, format },
       {
         ...readPowers,
         read: loggedRead,
       },
     );
-
-    const { moduleFormat } = bundle;
-    assert.equal(moduleFormat, 'endoZipBase64');
 
     const code = encodeBundle(bundle);
     await wr.mkdir({ recursive: true });
@@ -113,6 +114,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
         }),
       ),
       noTransforms,
+      format,
     };
 
     await metaWr.atomicWriteText(JSON.stringify(meta, null, 2));
@@ -139,6 +141,9 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
    * @param {any} rootOpt
    * @param {Logger} [log]
    * @param {BundleMeta} [meta]
+   * @param {object} [options]
+   * @param {boolean} [options.noTransforms}
+   * @param {ModuleFormat} [options.format}
    * @returns {Promise<BundleMeta>}
    */
   const validate = async (
@@ -146,8 +151,11 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
     rootOpt,
     log = defaultLog,
     meta = undefined,
+    options = {},
   ) => {
     await null;
+    const { noTransforms: expectedNoTransforms, format: expectedFormat } =
+      options;
     if (!meta) {
       const metaJson = await loadMetaText(targetName, log);
       if (metaJson) {
@@ -170,8 +178,12 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
       bundleSize,
       contents,
       moduleSource: { absolute: moduleSource },
+      format = 'endoZipBase64',
+      noTransforms = false,
     } = meta;
     assert.equal(bundleFileName, toBundleName(targetName));
+    assert.equal(format, expectedFormat);
+    assert.equal(noTransforms, expectedNoTransforms);
     if (rootOpt) {
       moduleSource === cwd.neighbor(rootOpt).absolute() ||
         Fail`bundle ${targetName} was for ${moduleSource}, not ${rootOpt}`;
@@ -217,6 +229,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
    * @param {Logger} [log]
    * @param {object} [options]
    * @param {boolean} [options.noTransforms]
+   * @param {ModuleFormat} [options.format]
    * @returns {Promise<BundleMeta>}
    */
   const validateOrAdd = async (
@@ -232,8 +245,17 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
 
     if (meta !== undefined) {
       try {
-        meta = await validate(targetName, rootPath, log, meta);
-        const { bundleTime, bundleSize, contents, noTransforms } = meta;
+        meta = await validate(targetName, rootPath, log, meta, {
+          format: options.format,
+          noTransforms: options.noTransforms,
+        });
+        const {
+          bundleTime,
+          bundleSize,
+          contents,
+          noTransforms,
+          format = 'endoZipBase64',
+        } = meta;
         log(
           `${wr}`,
           toBundleName(targetName),
@@ -244,6 +266,8 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
           'with size',
           bundleSize,
           noTransforms ? 'w/o transforms' : 'with transforms',
+          'with format',
+          format,
         );
       } catch (invalid) {
         meta = undefined;
@@ -254,7 +278,13 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
     if (meta === undefined) {
       log(`${wr}`, 'add:', targetName, 'from', rootPath);
       meta = await add(rootPath, targetName, log, options);
-      const { bundleFileName, bundleTime, contents, noTransforms } = meta;
+      const {
+        bundleFileName,
+        bundleTime,
+        contents,
+        noTransforms,
+        format = 'endoZipBase64',
+      } = meta;
       log(
         `${wr}`,
         'bundled',
@@ -264,6 +294,8 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
         'at',
         bundleTime,
         noTransforms ? 'w/o transforms' : 'with transforms',
+        'with format',
+        format,
       );
     }
 
@@ -277,6 +309,7 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
    * @param {Logger} [log]
    * @param {object} [options]
    * @param {boolean} [options.noTransforms]
+   * @param {ModuleFormat} [options.format]
    */
   const load = async (
     rootPath,
@@ -297,7 +330,6 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
           import(`${wr.readOnly().neighbor(bundleFileName)}`),
       )
       .then(m => harden(m.default));
-    assert.equal(bundle.moduleFormat, 'endoZipBase64');
     todo.resolve(bundle);
     return bundle;
   };

--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -142,8 +142,8 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
    * @param {Logger} [log]
    * @param {BundleMeta} [meta]
    * @param {object} [options]
-   * @param {boolean} [options.noTransforms}
-   * @param {ModuleFormat} [options.format}
+   * @param {boolean} [options.noTransforms]
+   * @param {ModuleFormat} [options.format]
    * @returns {Promise<BundleMeta>}
    */
   const validate = async (

--- a/packages/bundle-source/demo/meaning.js
+++ b/packages/bundle-source/demo/meaning.js
@@ -1,0 +1,1 @@
+export { meaning } from './meaningful.js';

--- a/packages/bundle-source/demo/meaningful.js
+++ b/packages/bundle-source/demo/meaningful.js
@@ -1,0 +1,1 @@
+export const meaning = 42;

--- a/packages/bundle-source/src/bundle-source.js
+++ b/packages/bundle-source/src/bundle-source.js
@@ -1,6 +1,10 @@
 // @ts-check
 const DEFAULT_MODULE_FORMAT = 'endoZipBase64';
-const SUPPORTED_FORMATS = ['getExport', 'nestedEvaluate', 'endoZipBase64'];
+export const SUPPORTED_FORMATS = [
+  'getExport',
+  'nestedEvaluate',
+  'endoZipBase64',
+];
 
 /** @type {import('./types').BundleSource} */
 // @ts-ignore cast

--- a/packages/bundle-source/src/bundle-source.js
+++ b/packages/bundle-source/src/bundle-source.js
@@ -4,6 +4,7 @@ export const SUPPORTED_FORMATS = [
   'getExport',
   'nestedEvaluate',
   'endoZipBase64',
+  'endoScript',
 ];
 
 /** @type {import('./types').BundleSource} */
@@ -25,6 +26,10 @@ const bundleSource = async (
     case 'endoZipBase64': {
       const { bundleZipBase64 } = await import('./zip-base64.js');
       return bundleZipBase64(startFilename, options, powers);
+    }
+    case 'endoScript': {
+      const { bundleScript } = await import('./script.js');
+      return bundleScript(startFilename, options, powers);
     }
     case 'getExport': {
       const { bundleNestedEvaluateAndGetExports } = await import(

--- a/packages/bundle-source/src/endo.js
+++ b/packages/bundle-source/src/endo.js
@@ -1,0 +1,163 @@
+// @ts-nocheck
+
+import fs from 'fs';
+
+import { evadeCensor } from '@endo/evasive-transform';
+import { whereEndoCache } from '@endo/where';
+import { defaultParserForLanguage as transformingParserForLanguage } from '@endo/compartment-mapper/archive-parsers.js';
+import { defaultParserForLanguage as transparentParserForLanguage } from '@endo/compartment-mapper/import-parsers.js';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export const makeBundlingKit = (
+  { pathResolve, userInfo, computeSha512, platform, env },
+  { cacheSourceMaps, noTransforms, commonDependencies, dev },
+) => {
+  const sourceMapJobs = new Set();
+  let writeSourceMap = Function.prototype;
+  if (cacheSourceMaps) {
+    const { homedir: home } = userInfo();
+    const cacheDirectory = whereEndoCache(platform, env, { home });
+    const sourceMapsCacheDirectory = pathResolve(cacheDirectory, 'source-map');
+    const sourceMapsTrackerDirectory = pathResolve(
+      cacheDirectory,
+      'source-map-track',
+    );
+    writeSourceMap = async (
+      sourceMap,
+      { sha512, compartment: packageLocation, module: moduleSpecifier },
+    ) => {
+      const location = new URL(moduleSpecifier, packageLocation).href;
+      const locationSha512 = computeSha512(location);
+      const locationSha512Head = locationSha512.slice(0, 2);
+      const locationSha512Tail = locationSha512.slice(2);
+      const sha512Head = sha512.slice(0, 2);
+      const sha512Tail = sha512.slice(2);
+      const sourceMapTrackerDirectory = pathResolve(
+        sourceMapsTrackerDirectory,
+        locationSha512Head,
+      );
+      const sourceMapTrackerPath = pathResolve(
+        sourceMapTrackerDirectory,
+        locationSha512Tail,
+      );
+      const sourceMapDirectory = pathResolve(
+        sourceMapsCacheDirectory,
+        sha512Head,
+      );
+      const sourceMapPath = pathResolve(
+        sourceMapDirectory,
+        `${sha512Tail}.map.json`,
+      );
+
+      await fs.promises
+        .readFile(sourceMapTrackerPath, 'utf-8')
+        .then(async oldSha512 => {
+          oldSha512 = oldSha512.trim();
+          if (oldSha512 === sha512) {
+            return;
+          }
+          const oldSha512Head = oldSha512.slice(0, 2);
+          const oldSha512Tail = oldSha512.slice(2);
+          const oldSourceMapDirectory = pathResolve(
+            sourceMapsCacheDirectory,
+            oldSha512Head,
+          );
+          const oldSourceMapPath = pathResolve(
+            oldSourceMapDirectory,
+            `${oldSha512Tail}.map.json`,
+          );
+          await fs.promises.unlink(oldSourceMapPath);
+          const entries = await fs.promises.readdir(oldSourceMapDirectory);
+          if (entries.length === 0) {
+            await fs.promises.rmdir(oldSourceMapDirectory);
+          }
+        })
+        .catch(error => {
+          if (error.code !== 'ENOENT') {
+            throw error;
+          }
+        });
+
+      await fs.promises.mkdir(sourceMapDirectory, { recursive: true });
+      await fs.promises.writeFile(sourceMapPath, sourceMap);
+
+      await fs.promises.mkdir(sourceMapTrackerDirectory, { recursive: true });
+      await fs.promises.writeFile(sourceMapTrackerPath, sha512);
+    };
+  }
+
+  /**
+   * @param {import('@endo/compartment-mapper/src/types.js').Language} parser
+   * @param {Uint8Array} sourceBytes
+   * @param {string} specifier
+   * @param {string} location
+   * @param {string|import('source-map').RawSourceMap} sourceMap
+   */
+  const transformModuleSource = async (
+    parser,
+    sourceBytes,
+    specifier,
+    location,
+    sourceMap,
+  ) => {
+    if (!['mjs', 'cjs'].includes(parser)) {
+      throw Error(`Parser ${parser} not supported in evadeEvalCensor`);
+    }
+    const babelSourceType = parser === 'mjs' ? 'module' : 'script';
+    const source = textDecoder.decode(sourceBytes);
+    let object;
+    ({ code: object, map: sourceMap } = await evadeCensor(source, {
+      sourceType: babelSourceType,
+      sourceMap,
+      sourceMapUrl: new URL(specifier, location).href,
+    }));
+    const objectBytes = textEncoder.encode(object);
+    return { bytes: objectBytes, parser, sourceMap };
+  };
+
+  let parserForLanguage = transparentParserForLanguage;
+  let moduleTransforms = {};
+  if (!noTransforms) {
+    parserForLanguage = transformingParserForLanguage;
+    moduleTransforms = {
+      async mjs(
+        sourceBytes,
+        specifier,
+        location,
+        _packageLocation,
+        { sourceMap },
+      ) {
+        return transformModuleSource(
+          'mjs',
+          sourceBytes,
+          specifier,
+          location,
+          sourceMap,
+        );
+      },
+      async cjs(
+        sourceBytes,
+        specifier,
+        location,
+        _packageLocation,
+        { sourceMap },
+      ) {
+        return transformModuleSource(
+          'cjs',
+          sourceBytes,
+          specifier,
+          location,
+          sourceMap,
+        );
+      },
+    };
+  }
+
+  const sourceMapHook = (sourceMap, sourceDescriptor) => {
+    sourceMapJobs.add(writeSourceMap(sourceMap, sourceDescriptor));
+  };
+
+  return { sourceMapHook, sourceMapJobs, moduleTransforms, parserForLanguage };
+};

--- a/packages/bundle-source/src/main.js
+++ b/packages/bundle-source/src/main.js
@@ -44,10 +44,11 @@ const options = /** @type {const} */ ({
  * @param {import('../cache.js').Logger} [powers.log]
  * @returns {Promise<void>}
  */
-      format: moduleFormat = 'endoZipBase64',
+export const main = async (args, { loadModule, pid, log }) => {
+  await null;
   const {
     values: {
-      format = 'endoZipBase64',
+      format: moduleFormat = 'endoZipBase64',
       'no-transforms': noTransforms,
       'cache-json': cacheJson,
       'cache-js': cacheJs,
@@ -66,6 +67,7 @@ const options = /** @type {const} */ ({
   ) {
     throw Error(USAGE);
   }
+  const format = /** @type {ModuleFormat} */ (moduleFormat);
 
   /** @type {string} */
   let dest;
@@ -102,7 +104,7 @@ const options = /** @type {const} */ ({
     // eslint-disable-next-line no-await-in-loop
     await cache.validateOrAdd(bundleRoot, bundleName, undefined, {
       noTransforms,
-      format: /** @type {ModuleFormat} */ (format),
+      format,
     });
   }
 };

--- a/packages/bundle-source/src/script.js
+++ b/packages/bundle-source/src/script.js
@@ -1,0 +1,213 @@
+// @ts-nocheck
+/* global process */
+
+import crypto from 'crypto';
+import path from 'path';
+import url from 'url';
+import fs from 'fs';
+import os from 'os';
+
+import { makeBundle } from '@endo/compartment-mapper/bundle.js';
+import { defaultParserForLanguage as transformingParserForLanguage } from '@endo/compartment-mapper/archive-parsers.js';
+import { defaultParserForLanguage as transparentParserForLanguage } from '@endo/compartment-mapper/import-parsers.js';
+import { whereEndoCache } from '@endo/where';
+import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
+import { evadeCensor } from '@endo/evasive-transform';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+const readPowers = makeReadPowers({ fs, url, crypto });
+
+/**
+ * @param {string} startFilename
+ * @param {object} [options]
+ * @param {boolean} [options.dev]
+ * @param {boolean} [options.cacheSourceMaps]
+ * @param {boolean} [options.noTransforms]
+ * @param {Record<string, string>} [options.commonDependencies]
+ * @param {object} [grantedPowers]
+ * @param {(bytes: string | Uint8Array) => string} [grantedPowers.computeSha512]
+ * @param {typeof import('path)['resolve']} [grantedPowers.pathResolve]
+ * @param {typeof import('os')['userInfo']} [grantedPowers.userInfo]
+ * @param {typeof process['env']} [grantedPowers.env]
+ * @param {typeof process['platform']} [grantedPowers.platform]
+ */
+export async function bundleScript(
+  startFilename,
+  options = {},
+  grantedPowers = {},
+) {
+  const {
+    dev = false,
+    cacheSourceMaps = false,
+    noTransforms = false,
+    commonDependencies,
+  } = options;
+  const powers = { ...readPowers, ...grantedPowers };
+  const {
+    computeSha512,
+    pathResolve = path.resolve,
+    userInfo = os.userInfo,
+    env = process.env,
+    platform = process.platform,
+  } = powers;
+
+  const entry = url.pathToFileURL(pathResolve(startFilename));
+
+  const sourceMapJobs = new Set();
+  let writeSourceMap = Function.prototype;
+  if (cacheSourceMaps) {
+    const { homedir: home } = userInfo();
+    const cacheDirectory = whereEndoCache(platform, env, { home });
+    const sourceMapsCacheDirectory = pathResolve(cacheDirectory, 'source-map');
+    const sourceMapsTrackerDirectory = pathResolve(
+      cacheDirectory,
+      'source-map-track',
+    );
+    writeSourceMap = async (
+      sourceMap,
+      { sha512, compartment: packageLocation, module: moduleSpecifier },
+    ) => {
+      const location = new URL(moduleSpecifier, packageLocation).href;
+      const locationSha512 = computeSha512(location);
+      const locationSha512Head = locationSha512.slice(0, 2);
+      const locationSha512Tail = locationSha512.slice(2);
+      const sha512Head = sha512.slice(0, 2);
+      const sha512Tail = sha512.slice(2);
+      const sourceMapTrackerDirectory = pathResolve(
+        sourceMapsTrackerDirectory,
+        locationSha512Head,
+      );
+      const sourceMapTrackerPath = pathResolve(
+        sourceMapTrackerDirectory,
+        locationSha512Tail,
+      );
+      const sourceMapDirectory = pathResolve(
+        sourceMapsCacheDirectory,
+        sha512Head,
+      );
+      const sourceMapPath = pathResolve(
+        sourceMapDirectory,
+        `${sha512Tail}.map.json`,
+      );
+
+      await fs.promises
+        .readFile(sourceMapTrackerPath, 'utf-8')
+        .then(async oldSha512 => {
+          oldSha512 = oldSha512.trim();
+          if (oldSha512 === sha512) {
+            return;
+          }
+          const oldSha512Head = oldSha512.slice(0, 2);
+          const oldSha512Tail = oldSha512.slice(2);
+          const oldSourceMapDirectory = pathResolve(
+            sourceMapsCacheDirectory,
+            oldSha512Head,
+          );
+          const oldSourceMapPath = pathResolve(
+            oldSourceMapDirectory,
+            `${oldSha512Tail}.map.json`,
+          );
+          await fs.promises.unlink(oldSourceMapPath);
+          const entries = await fs.promises.readdir(oldSourceMapDirectory);
+          if (entries.length === 0) {
+            await fs.promises.rmdir(oldSourceMapDirectory);
+          }
+        })
+        .catch(error => {
+          if (error.code !== 'ENOENT') {
+            throw error;
+          }
+        });
+
+      await fs.promises.mkdir(sourceMapDirectory, { recursive: true });
+      await fs.promises.writeFile(sourceMapPath, sourceMap);
+
+      await fs.promises.mkdir(sourceMapTrackerDirectory, { recursive: true });
+      await fs.promises.writeFile(sourceMapTrackerPath, sha512);
+    };
+  }
+
+  /**
+   * @param {import('@endo/compartment-mapper/src/types.js').Language} parser
+   * @param {Uint8Array} sourceBytes
+   * @param {string} specifier
+   * @param {string} location
+   * @param {string|import('source-map').RawSourceMap} sourceMap
+   */
+  const transformModuleSource = async (
+    parser,
+    sourceBytes,
+    specifier,
+    location,
+    sourceMap,
+  ) => {
+    if (!['mjs', 'cjs'].includes(parser)) {
+      throw Error(`Parser ${parser} not supported in evadeEvalCensor`);
+    }
+    const babelSourceType = parser === 'mjs' ? 'module' : 'script';
+    const source = textDecoder.decode(sourceBytes);
+    let object;
+    ({ code: object, map: sourceMap } = await evadeCensor(source, {
+      sourceType: babelSourceType,
+      sourceMap,
+      sourceMapUrl: new URL(specifier, location).href,
+    }));
+    const objectBytes = textEncoder.encode(object);
+    return { bytes: objectBytes, parser, sourceMap };
+  };
+
+  let parserForLanguage = transparentParserForLanguage;
+  let moduleTransforms = {};
+  if (!noTransforms) {
+    parserForLanguage = transformingParserForLanguage;
+    moduleTransforms = {
+      async mjs(
+        sourceBytes,
+        specifier,
+        location,
+        _packageLocation,
+        { sourceMap },
+      ) {
+        return transformModuleSource(
+          'mjs',
+          sourceBytes,
+          specifier,
+          location,
+          sourceMap,
+        );
+      },
+      async cjs(
+        sourceBytes,
+        specifier,
+        location,
+        _packageLocation,
+        { sourceMap },
+      ) {
+        return transformModuleSource(
+          'cjs',
+          sourceBytes,
+          specifier,
+          location,
+          sourceMap,
+        );
+      },
+    };
+  }
+
+  const source = await makeBundle(powers, entry, {
+    dev,
+    commonDependencies,
+    parserForLanguage,
+    moduleTransforms,
+    sourceMapHook(sourceMap, sourceDescriptor) {
+      sourceMapJobs.add(writeSourceMap(sourceMap, sourceDescriptor));
+    },
+  });
+  await Promise.all(sourceMapJobs);
+  return harden({
+    moduleFormat: /** @type {const} */ ('endoScript'),
+    source,
+    // TODO sourceMap
+  });
+}

--- a/packages/bundle-source/src/script.js
+++ b/packages/bundle-source/src/script.js
@@ -8,14 +8,10 @@ import fs from 'fs';
 import os from 'os';
 
 import { makeBundle } from '@endo/compartment-mapper/bundle.js';
-import { defaultParserForLanguage as transformingParserForLanguage } from '@endo/compartment-mapper/archive-parsers.js';
-import { defaultParserForLanguage as transparentParserForLanguage } from '@endo/compartment-mapper/import-parsers.js';
-import { whereEndoCache } from '@endo/where';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
-import { evadeCensor } from '@endo/evasive-transform';
 
-const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
+import { makeBundlingKit } from './endo.js';
+
 const readPowers = makeReadPowers({ fs, url, crypto });
 
 /**
@@ -54,157 +50,33 @@ export async function bundleScript(
 
   const entry = url.pathToFileURL(pathResolve(startFilename));
 
-  const sourceMapJobs = new Set();
-  let writeSourceMap = Function.prototype;
-  if (cacheSourceMaps) {
-    const { homedir: home } = userInfo();
-    const cacheDirectory = whereEndoCache(platform, env, { home });
-    const sourceMapsCacheDirectory = pathResolve(cacheDirectory, 'source-map');
-    const sourceMapsTrackerDirectory = pathResolve(
-      cacheDirectory,
-      'source-map-track',
+  const { sourceMapHook, sourceMapJobs, moduleTransforms, parserForLanguage } =
+    makeBundlingKit(
+      {
+        pathResolve,
+        userInfo,
+        platform,
+        env,
+        computeSha512,
+      },
+      {
+        cacheSourceMaps,
+        noTransforms,
+        commonDependencies,
+        dev,
+      },
     );
-    writeSourceMap = async (
-      sourceMap,
-      { sha512, compartment: packageLocation, module: moduleSpecifier },
-    ) => {
-      const location = new URL(moduleSpecifier, packageLocation).href;
-      const locationSha512 = computeSha512(location);
-      const locationSha512Head = locationSha512.slice(0, 2);
-      const locationSha512Tail = locationSha512.slice(2);
-      const sha512Head = sha512.slice(0, 2);
-      const sha512Tail = sha512.slice(2);
-      const sourceMapTrackerDirectory = pathResolve(
-        sourceMapsTrackerDirectory,
-        locationSha512Head,
-      );
-      const sourceMapTrackerPath = pathResolve(
-        sourceMapTrackerDirectory,
-        locationSha512Tail,
-      );
-      const sourceMapDirectory = pathResolve(
-        sourceMapsCacheDirectory,
-        sha512Head,
-      );
-      const sourceMapPath = pathResolve(
-        sourceMapDirectory,
-        `${sha512Tail}.map.json`,
-      );
-
-      await fs.promises
-        .readFile(sourceMapTrackerPath, 'utf-8')
-        .then(async oldSha512 => {
-          oldSha512 = oldSha512.trim();
-          if (oldSha512 === sha512) {
-            return;
-          }
-          const oldSha512Head = oldSha512.slice(0, 2);
-          const oldSha512Tail = oldSha512.slice(2);
-          const oldSourceMapDirectory = pathResolve(
-            sourceMapsCacheDirectory,
-            oldSha512Head,
-          );
-          const oldSourceMapPath = pathResolve(
-            oldSourceMapDirectory,
-            `${oldSha512Tail}.map.json`,
-          );
-          await fs.promises.unlink(oldSourceMapPath);
-          const entries = await fs.promises.readdir(oldSourceMapDirectory);
-          if (entries.length === 0) {
-            await fs.promises.rmdir(oldSourceMapDirectory);
-          }
-        })
-        .catch(error => {
-          if (error.code !== 'ENOENT') {
-            throw error;
-          }
-        });
-
-      await fs.promises.mkdir(sourceMapDirectory, { recursive: true });
-      await fs.promises.writeFile(sourceMapPath, sourceMap);
-
-      await fs.promises.mkdir(sourceMapTrackerDirectory, { recursive: true });
-      await fs.promises.writeFile(sourceMapTrackerPath, sha512);
-    };
-  }
-
-  /**
-   * @param {import('@endo/compartment-mapper/src/types.js').Language} parser
-   * @param {Uint8Array} sourceBytes
-   * @param {string} specifier
-   * @param {string} location
-   * @param {string|import('source-map').RawSourceMap} sourceMap
-   */
-  const transformModuleSource = async (
-    parser,
-    sourceBytes,
-    specifier,
-    location,
-    sourceMap,
-  ) => {
-    if (!['mjs', 'cjs'].includes(parser)) {
-      throw Error(`Parser ${parser} not supported in evadeEvalCensor`);
-    }
-    const babelSourceType = parser === 'mjs' ? 'module' : 'script';
-    const source = textDecoder.decode(sourceBytes);
-    let object;
-    ({ code: object, map: sourceMap } = await evadeCensor(source, {
-      sourceType: babelSourceType,
-      sourceMap,
-      sourceMapUrl: new URL(specifier, location).href,
-    }));
-    const objectBytes = textEncoder.encode(object);
-    return { bytes: objectBytes, parser, sourceMap };
-  };
-
-  let parserForLanguage = transparentParserForLanguage;
-  let moduleTransforms = {};
-  if (!noTransforms) {
-    parserForLanguage = transformingParserForLanguage;
-    moduleTransforms = {
-      async mjs(
-        sourceBytes,
-        specifier,
-        location,
-        _packageLocation,
-        { sourceMap },
-      ) {
-        return transformModuleSource(
-          'mjs',
-          sourceBytes,
-          specifier,
-          location,
-          sourceMap,
-        );
-      },
-      async cjs(
-        sourceBytes,
-        specifier,
-        location,
-        _packageLocation,
-        { sourceMap },
-      ) {
-        return transformModuleSource(
-          'cjs',
-          sourceBytes,
-          specifier,
-          location,
-          sourceMap,
-        );
-      },
-    };
-  }
 
   const source = await makeBundle(powers, entry, {
     dev,
     commonDependencies,
     parserForLanguage,
     moduleTransforms,
-    sourceMapHook(sourceMap, sourceDescriptor) {
-      sourceMapJobs.add(writeSourceMap(sourceMap, sourceDescriptor));
-    },
+    sourceMapHook,
   });
+
   await Promise.all(sourceMapJobs);
+
   return harden({
     moduleFormat: /** @type {const} */ ('endoScript'),
     source,

--- a/packages/bundle-source/src/types.js
+++ b/packages/bundle-source/src/types.js
@@ -2,7 +2,7 @@
 export {};
 
 /**
- * @typedef {'endoZipBase64' | 'nestedEvaluate' | 'getExport'} ModuleFormat
+ * @typedef {'endoZipBase64' | 'endoScript' | 'nestedEvaluate' | 'getExport'} ModuleFormat
  */
 
 // The order of these intersections matters, insofar as Typescript treats the
@@ -25,6 +25,9 @@ export {};
  *   moduleFormat: T,
  *   source: string,
  *   sourceMap: string,
+ * } : T extends 'endoScript' ? {
+ *   moduleFormat: T,
+ *   source: string,
  * } : never} BundleSourceResult
  */
 

--- a/packages/bundle-source/src/zip-base64.js
+++ b/packages/bundle-source/src/zip-base64.js
@@ -7,17 +7,13 @@ import url from 'url';
 import fs from 'fs';
 import os from 'os';
 
-import { defaultParserForLanguage as transformingParserForLanguage } from '@endo/compartment-mapper/archive-parsers.js';
-import { defaultParserForLanguage as transparentParserForLanguage } from '@endo/compartment-mapper/import-parsers.js';
 import { mapNodeModules } from '@endo/compartment-mapper/node-modules.js';
 import { makeAndHashArchiveFromMap } from '@endo/compartment-mapper/archive-lite.js';
 import { encodeBase64 } from '@endo/base64';
-import { whereEndoCache } from '@endo/where';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
-import { evadeCensor } from '@endo/evasive-transform';
 
-const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
+import { makeBundlingKit } from './endo.js';
+
 const readPowers = makeReadPowers({ fs, url, crypto });
 
 /**
@@ -56,146 +52,22 @@ export async function bundleZipBase64(
 
   const entry = url.pathToFileURL(pathResolve(startFilename));
 
-  const sourceMapJobs = new Set();
-  let writeSourceMap = Function.prototype;
-  if (cacheSourceMaps) {
-    const { homedir: home } = userInfo();
-    const cacheDirectory = whereEndoCache(platform, env, { home });
-    const sourceMapsCacheDirectory = pathResolve(cacheDirectory, 'source-map');
-    const sourceMapsTrackerDirectory = pathResolve(
-      cacheDirectory,
-      'source-map-track',
+  const { sourceMapHook, sourceMapJobs, moduleTransforms, parserForLanguage } =
+    makeBundlingKit(
+      {
+        pathResolve,
+        userInfo,
+        platform,
+        env,
+        computeSha512,
+      },
+      {
+        cacheSourceMaps,
+        noTransforms,
+        commonDependencies,
+        dev,
+      },
     );
-    writeSourceMap = async (
-      sourceMap,
-      { sha512, compartment: packageLocation, module: moduleSpecifier },
-    ) => {
-      const location = new URL(moduleSpecifier, packageLocation).href;
-      const locationSha512 = computeSha512(location);
-      const locationSha512Head = locationSha512.slice(0, 2);
-      const locationSha512Tail = locationSha512.slice(2);
-      const sha512Head = sha512.slice(0, 2);
-      const sha512Tail = sha512.slice(2);
-      const sourceMapTrackerDirectory = pathResolve(
-        sourceMapsTrackerDirectory,
-        locationSha512Head,
-      );
-      const sourceMapTrackerPath = pathResolve(
-        sourceMapTrackerDirectory,
-        locationSha512Tail,
-      );
-      const sourceMapDirectory = pathResolve(
-        sourceMapsCacheDirectory,
-        sha512Head,
-      );
-      const sourceMapPath = pathResolve(
-        sourceMapDirectory,
-        `${sha512Tail}.map.json`,
-      );
-
-      await fs.promises
-        .readFile(sourceMapTrackerPath, 'utf-8')
-        .then(async oldSha512 => {
-          oldSha512 = oldSha512.trim();
-          if (oldSha512 === sha512) {
-            return;
-          }
-          const oldSha512Head = oldSha512.slice(0, 2);
-          const oldSha512Tail = oldSha512.slice(2);
-          const oldSourceMapDirectory = pathResolve(
-            sourceMapsCacheDirectory,
-            oldSha512Head,
-          );
-          const oldSourceMapPath = pathResolve(
-            oldSourceMapDirectory,
-            `${oldSha512Tail}.map.json`,
-          );
-          await fs.promises.unlink(oldSourceMapPath);
-          const entries = await fs.promises.readdir(oldSourceMapDirectory);
-          if (entries.length === 0) {
-            await fs.promises.rmdir(oldSourceMapDirectory);
-          }
-        })
-        .catch(error => {
-          if (error.code !== 'ENOENT') {
-            throw error;
-          }
-        });
-
-      await fs.promises.mkdir(sourceMapDirectory, { recursive: true });
-      await fs.promises.writeFile(sourceMapPath, sourceMap);
-
-      await fs.promises.mkdir(sourceMapTrackerDirectory, { recursive: true });
-      await fs.promises.writeFile(sourceMapTrackerPath, sha512);
-    };
-  }
-
-  /**
-   * @param {import('@endo/compartment-mapper/src/types.js').Language} parser
-   * @param {Uint8Array} sourceBytes
-   * @param {string} specifier
-   * @param {string} location
-   * @param {string|import('source-map').RawSourceMap} sourceMap
-   */
-  const transformModuleSource = async (
-    parser,
-    sourceBytes,
-    specifier,
-    location,
-    sourceMap,
-  ) => {
-    if (!['mjs', 'cjs'].includes(parser)) {
-      throw Error(`Parser ${parser} not supported in evadeEvalCensor`);
-    }
-    const babelSourceType = parser === 'mjs' ? 'module' : 'script';
-    const source = textDecoder.decode(sourceBytes);
-    let object;
-    ({ code: object, map: sourceMap } = await evadeCensor(source, {
-      sourceType: babelSourceType,
-      sourceMap,
-      sourceMapUrl: new URL(specifier, location).href,
-    }));
-    const objectBytes = textEncoder.encode(object);
-    return { bytes: objectBytes, parser, sourceMap };
-  };
-
-  let parserForLanguage = transparentParserForLanguage;
-  let moduleTransforms = {};
-  if (!noTransforms) {
-    parserForLanguage = transformingParserForLanguage;
-    moduleTransforms = {
-      async mjs(
-        sourceBytes,
-        specifier,
-        location,
-        _packageLocation,
-        { sourceMap },
-      ) {
-        return transformModuleSource(
-          'mjs',
-          sourceBytes,
-          specifier,
-          location,
-          sourceMap,
-        );
-      },
-      async cjs(
-        sourceBytes,
-        specifier,
-        location,
-        _packageLocation,
-        { sourceMap },
-      ) {
-        return transformModuleSource(
-          'cjs',
-          sourceBytes,
-          specifier,
-          location,
-          sourceMap,
-        );
-      },
-    };
-  }
 
   const compartmentMap = await mapNodeModules(powers, entry, {
     dev,
@@ -208,9 +80,7 @@ export async function bundleZipBase64(
     {
       parserForLanguage,
       moduleTransforms,
-      sourceMapHook(sourceMap, sourceDescriptor) {
-        sourceMapJobs.add(writeSourceMap(sourceMap, sourceDescriptor));
-      },
+      sourceMapHook,
     },
   );
   assert(sha512);

--- a/packages/bundle-source/test/endo-script-format.tests.js
+++ b/packages/bundle-source/test/endo-script-format.tests.js
@@ -1,0 +1,19 @@
+// @ts-check
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import * as url from 'url';
+import bundleSource from '../src/index.js';
+
+test('endo script format', async t => {
+  const entryPath = url.fileURLToPath(
+    new URL(`../demo/meaning.js`, import.meta.url),
+  );
+  const bundle = await bundleSource(entryPath, {
+    format: 'endoScript',
+  });
+  t.is(bundle.moduleFormat, 'endoScript');
+  const { source } = bundle;
+  const compartment = new Compartment();
+  const ns = compartment.evaluate(source);
+  t.is(ns.meaning, 42);
+});

--- a/packages/bundle-source/test/tool-command.test.js
+++ b/packages/bundle-source/test/tool-command.test.js
@@ -1,3 +1,4 @@
+/* global Buffer */
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { spawn } from 'child_process';

--- a/packages/bundle-source/test/tool-command.test.js
+++ b/packages/bundle-source/test/tool-command.test.js
@@ -3,7 +3,6 @@ import test from '@endo/ses-ava/prepare-endo.js';
 
 import { spawn } from 'child_process';
 import url from 'url';
-import Buffer from 'buffer';
 
 const cwd = url.fileURLToPath(new URL('..', import.meta.url));
 

--- a/packages/compartment-mapper/src/bundle.js
+++ b/packages/compartment-mapper/src/bundle.js
@@ -1,18 +1,21 @@
 // @ts-check
 /* eslint no-shadow: 0 */
 
-/** @import {PrecompiledStaticModuleInterface} from 'ses' */
+/** @import {ArchiveOptions} from './types.js' */
 /** @import {CompartmentDescriptor} from './types.js' */
 /** @import {CompartmentSources} from './types.js' */
+/** @import {MaybeReadPowers} from './types.js' */
+/** @import {PrecompiledStaticModuleInterface} from 'ses' */
 /** @import {ReadFn} from './types.js' */
+/** @import {ReadPowers} from './types.js' */
 /** @import {Sources} from './types.js' */
 /** @import {WriteFn} from './types.js' */
-/** @import {ArchiveOptions} from './types.js' */
 
 import { resolve } from './node-module-specifier.js';
 import { compartmentMapForNodeModules } from './node-modules.js';
 import { search } from './search.js';
 import { link } from './link.js';
+import { unpackReadPowers } from './powers.js';
 import { makeImportHookMaker } from './import-hook.js';
 import { defaultParserForLanguage } from './archive-parsers.js';
 import { parseLocatedJson } from './json.js';
@@ -141,12 +144,14 @@ function getBundlerKitForModule(module) {
 }
 
 /**
- * @param {ReadFn} read
+ * @param {ReadFn | ReadPowers | MaybeReadPowers} readPowers
  * @param {string} moduleLocation
  * @param {ArchiveOptions} [options]
  * @returns {Promise<string>}
  */
-export const makeBundle = async (read, moduleLocation, options) => {
+export const makeBundle = async (readPowers, moduleLocation, options) => {
+  const { read, maybeRead } = unpackReadPowers(readPowers);
+
   const {
     moduleTransforms,
     dev,
@@ -175,7 +180,7 @@ export const makeBundle = async (read, moduleLocation, options) => {
     packageDescriptorText,
     packageDescriptorLocation,
     moduleSpecifier,
-  } = await search(read, moduleLocation);
+  } = await search(maybeRead, moduleLocation);
 
   const packageDescriptor = parseLocatedJson(
     packageDescriptorText,

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -797,7 +797,7 @@ export const compartmentMapForNodeModules = async (
 };
 
 /**
- * @param {ReadFn | ReadPowers} readPowers
+ * @param {ReadFn | ReadPowers | MaybeReadPowers} readPowers
  * @param {string} moduleLocation
  * @param {object} [options]
  * @param {Set<string>} [options.tags]
@@ -813,14 +813,14 @@ export const mapNodeModules = async (
 ) => {
   const { tags = new Set(), dev = false, commonDependencies, policy } = options;
 
-  const { read } = unpackReadPowers(readPowers);
+  const { maybeRead } = unpackReadPowers(readPowers);
 
   const {
     packageLocation,
     packageDescriptorText,
     packageDescriptorLocation,
     moduleSpecifier,
-  } = await search(read, moduleLocation);
+  } = await search(maybeRead, moduleLocation);
 
   const packageDescriptor = parseLocatedJson(
     packageDescriptorText,


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/issues/9686

## Description

Endo’s `bundle-source` currently generates bundles with the `endoZipBase64` format, which requires the `importBundle` runtime. We typically bootstrap `importBundle` using the `getExport` or `nestedEvaluate` bundle format, which only need `eval` or `compartment.evaluate` to run. These use Rollup internally.

Elsewhere, for distributing SES and toward bootstrapping XS and Hermes variants of SES, we have our own bundler. In this change, we expose this format as `endoScript`, an alternative to `getExport` and `nestedEvaluate` which do not depend on Rollup.

We introduce a `--format` flag to `bundle-source` so any of the old and the new bundle formats are addressable from the CLI.

For easy hacking, we introduce a no-cache mode to `bundle-source` so we can just write a bundle to `stdout`.

This required a minor fix to the Compartment Mapper.

### Security Considerations

This will introduce a bundle format that is somewhat easier to audit because it preserves the lexical encapsulation of each module.

### Scaling Considerations

This may not perform as well as `nestedEvaluate` for bootstrapping, or will at least perform differently.

### Documentation Considerations

With this change, we can treat `bundle-source` as a one-stop-shop for all bundling concerns.

### Testing Considerations

To manually verify these changes, in `packages/bundle-source`:

```
yarn bundle-source demo/circular/a.js --format endoScript | jq .source -r
node -e "$(yarn bundle-source demo/circular/a.js --format endoScript | jq .source -r)"
yarn bundle-source -f endoScript --cache-json bundles/ demo/circular/a.js a
jq . bundles/bundle-a.json
jq -r .source bundles/bundle-a.json | less
```

### Compatibility Considerations

No changes to prior workflows.

### Upgrade Considerations

None.