### PR TITLE
refactor(compartment-mapper): Pivot to module descriptors

### DIFF
--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -259,7 +259,10 @@ const makeModuleMapHook = (
             )}}`,
           );
         }
-        return foreignCompartment.module(foreignModuleSpecifier);
+        return {
+          compartment: foreignCompartment,
+          namespace: foreignModuleSpecifier,
+        };
       }
     }
 
@@ -310,7 +313,10 @@ const makeModuleMapHook = (
           compartment: foreignCompartmentName,
           module: foreignModuleSpecifier,
         };
-        return foreignCompartment.module(foreignModuleSpecifier);
+        return {
+          compartment: foreignCompartment,
+          namespace: foreignModuleSpecifier,
+        };
       }
     }
 


### PR DESCRIPTION
Refs: #400

## Description

XS does not support `compartment.module`. Rather than emulate it, I chose bring SES into closer alignment with XS module descriptors and use those instead. The Compartment Mapper is the only place we use this feature at the moment.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

The existing Compartment Mapper tests exercise this path rigorously.

### Compatibility Considerations

The new version of Compartment Mapper will not work with an older version of SES. Lerna will make sure the constraint gets updated when we release.

### Upgrade Considerations

None.