### PR TITLE
feat(bundle-source): Add `tag` command-line flag

### DIFF
--- a/packages/bundle-source/NEWS.md
+++ b/packages/bundle-source/NEWS.md
@@ -11,6 +11,8 @@
 - Adds a `-f,--format` command flag to specify other module formats.
 - Adds a new `endoScript` module format.
 - Adds a no-cache, bundle-to-stdout mode.
+- Adds a `-t,--tag` command flag to specify export/import conditions like
+  `"browser"`.
 
 # v3.2.1 (2024-03-20)
 

--- a/packages/bundle-source/demo/node_modules/conditional-exports/a.js
+++ b/packages/bundle-source/demo/node_modules/conditional-exports/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/packages/bundle-source/demo/node_modules/conditional-exports/b.js
+++ b/packages/bundle-source/demo/node_modules/conditional-exports/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/packages/bundle-source/demo/node_modules/conditional-exports/package.json
+++ b/packages/bundle-source/demo/node_modules/conditional-exports/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "conditional-exports",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "a": "./a.js",
+    "b": "./b.js"
+  }
+}

--- a/packages/bundle-source/demo/node_modules/conditional-reexports/entry.js
+++ b/packages/bundle-source/demo/node_modules/conditional-reexports/entry.js
@@ -1,0 +1,2 @@
+import value from 'conditional-exports';
+export default value;

--- a/packages/bundle-source/demo/node_modules/conditional-reexports/package.json
+++ b/packages/bundle-source/demo/node_modules/conditional-reexports/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "conditional-reexports",
+  "version": "0.0.0",
+  "type": "module",
+  "dependencies": {
+    "conditional-exports": "*"
+  }
+}

--- a/packages/bundle-source/src/main.js
+++ b/packages/bundle-source/src/main.js
@@ -8,9 +8,10 @@ import { jsOpts, jsonOpts, makeNodeBundleCache } from '../cache.js';
 /** @import {ModuleFormat} from './types.js' */
 
 const USAGE = `\
-bundle-source [-Tf] <entry.js>
-bundle-source [-Tf] --cache-js|--cache-json <cache/> (<entry.js> <bundle-name>)*
+bundle-source [-Tft] <entry.js>
+bundle-source [-Tft] --cache-js|--cache-json <cache/> (<entry.js> <bundle-name>)*
   -f,--format endoZipBase64*|nestedEvaluate|getExport
+  -t,--tag <tag> (browser, node, &c)
   -T,--no-transforms`;
 
 const options = /** @type {const} */ ({
@@ -32,6 +33,11 @@ const options = /** @type {const} */ ({
     short: 'f',
     multiple: false,
   },
+  tag: {
+    type: 'string',
+    short: 't',
+    multiple: true,
+  },
   // deprecated
   to: {
     type: 'string',
@@ -52,6 +58,7 @@ export const main = async (args, { loadModule, pid, log }) => {
   const {
     values: {
       format: moduleFormat = 'endoZipBase64',
+      tag: tags = [],
       'no-transforms': noTransforms,
       'cache-json': cacheJson,
       'cache-js': cacheJs,
@@ -84,7 +91,11 @@ export const main = async (args, { loadModule, pid, log }) => {
       throw new Error(USAGE);
     }
     const [entryPath] = positionals;
-    const bundle = await bundleSource(entryPath, { noTransforms, format });
+    const bundle = await bundleSource(entryPath, {
+      noTransforms,
+      format,
+      tags,
+    });
     process.stdout.write(JSON.stringify(bundle));
     process.stdout.write('\n');
     return;
@@ -114,6 +125,7 @@ export const main = async (args, { loadModule, pid, log }) => {
     await cache.validateOrAdd(bundleRoot, bundleName, undefined, {
       noTransforms,
       format,
+      tags,
     });
   }
 };

--- a/packages/bundle-source/src/script.js
+++ b/packages/bundle-source/src/script.js
@@ -37,6 +37,7 @@ export async function bundleScript(
     dev = false,
     cacheSourceMaps = false,
     noTransforms = false,
+    tags = [],
     commonDependencies,
   } = options;
   const powers = { ...readPowers, ...grantedPowers };
@@ -69,6 +70,7 @@ export async function bundleScript(
 
   const source = await makeBundle(powers, entry, {
     dev,
+    tags,
     commonDependencies,
     parserForLanguage,
     moduleTransforms,

--- a/packages/bundle-source/src/types.js
+++ b/packages/bundle-source/src/types.js
@@ -70,6 +70,8 @@ export {};
  * @property {boolean} [noTransforms] - when true, generates a bundle with the
  * original sources instead of SES-shim specific ESM and CJS. This may become
  * default in a future major version.
+ * @property {string[]} [tags] - conditions for package.json conditional
+ * exports and imports.
  */
 
 /**

--- a/packages/bundle-source/src/zip-base64.js
+++ b/packages/bundle-source/src/zip-base64.js
@@ -22,6 +22,7 @@ const readPowers = makeReadPowers({ fs, url, crypto });
  * @param {boolean} [options.dev]
  * @param {boolean} [options.cacheSourceMaps]
  * @param {boolean} [options.noTransforms]
+ * @param {string[]} [options.tags]
  * @param {Record<string, string>} [options.commonDependencies]
  * @param {object} [grantedPowers]
  * @param {(bytes: string | Uint8Array) => string} [grantedPowers.computeSha512]
@@ -39,6 +40,7 @@ export async function bundleZipBase64(
     dev = false,
     cacheSourceMaps = false,
     noTransforms = false,
+    tags = [],
     commonDependencies,
   } = options;
   const powers = { ...readPowers, ...grantedPowers };
@@ -71,6 +73,7 @@ export async function bundleZipBase64(
 
   const compartmentMap = await mapNodeModules(powers, entry, {
     dev,
+    tags,
     commonDependencies,
   });
 

--- a/packages/bundle-source/test/tags-command.test.js
+++ b/packages/bundle-source/test/tags-command.test.js
@@ -1,0 +1,67 @@
+/* global Buffer */
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { spawn } from 'child_process';
+import url from 'url';
+
+const textDecoder = new TextDecoder();
+
+const cwd = url.fileURLToPath(new URL('..', import.meta.url));
+
+const bundleSource = async (...args) => {
+  const bundleBytes = await new Promise((resolve, reject) => {
+    const errorChunks = [];
+    const outputChunks = [];
+    const child = spawn('node', ['bin/bundle-source', ...args], {
+      cwd,
+      stdio: ['inherit', 'pipe', 'pipe'],
+    });
+    child.on('close', code => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `Exit code: ${code}\nError output: ${new TextDecoder().decode(
+              Buffer.concat(errorChunks),
+            )}`,
+          ),
+        );
+      } else {
+        resolve(Buffer.concat(outputChunks));
+      }
+    });
+    child.stdout.on('data', chunk => {
+      outputChunks.push(chunk);
+    });
+    child.stderr.on('data', chunk => {
+      errorChunks.push(chunk);
+    });
+  });
+  const bundleText = textDecoder.decode(bundleBytes);
+  return JSON.parse(bundleText);
+};
+
+test('bundle-source with --format and --tag', async t => {
+  const compartment = new Compartment();
+  {
+    const bundle = await bundleSource(
+      '--tag',
+      'b',
+      '--format',
+      'endoScript',
+      'demo/node_modules/conditional-reexports/entry.js',
+    );
+    const namespace = compartment.evaluate(bundle.source);
+    t.is(namespace.default, 'b');
+  }
+  {
+    const bundle = await bundleSource(
+      '--tag',
+      'a',
+      '--format',
+      'endoScript',
+      'demo/node_modules/conditional-reexports/entry.js',
+    );
+    const namespace = compartment.evaluate(bundle.source);
+    t.is(namespace.default, 'a');
+  }
+});


### PR DESCRIPTION
Refs: #400

## Description

We’ve discovered that, to create an Endo script bundle that captures our `ModuleSource` constructor shim, it will need to entrain Babel. With the default build conditions, Babel entrains a `debug` package, which entrains `node:tty`. So, it is necessary to add the `"browser"` condition, which instead entrains a package with a JSON module (#2352). This change threads arbitrary conditions (build tags) through `bundle-source` to conveniently generate Endo script bundles with different tags like `browser` or `xs`.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

The new flags are advertised in the command’s usage display.

### Testing Considerations

- [ ] test scaffold and manual testing instructions

### Compatibility Considerations

None.

### Upgrade Considerations

None.