### PR TITLE
fix(cli): Handle unspecified result names for multiple commands

### DIFF
--- a/packages/cli/src/commands/eval.js
+++ b/packages/cli/src/commands/eval.js
@@ -35,7 +35,7 @@ export const evalCommand = async ({
       source,
       codeNames,
       petNames,
-      parsePetNamePath(resultName),
+      resultName === undefined ? undefined : parsePetNamePath(resultName),
     );
     console.log(result);
   });

--- a/packages/cli/src/commands/eval.js
+++ b/packages/cli/src/commands/eval.js
@@ -2,7 +2,7 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
-import { parsePetNamePath } from '../pet-name.js';
+import { parsePetNamePath, parseOptionalPetNamePath } from '../pet-name.js';
 
 export const evalCommand = async ({
   source,
@@ -35,7 +35,7 @@ export const evalCommand = async ({
       source,
       codeNames,
       petNames,
-      resultName === undefined ? undefined : parsePetNamePath(resultName),
+      parseOptionalPetNamePath(resultName),
     );
     console.log(result);
   });

--- a/packages/cli/src/commands/make.js
+++ b/packages/cli/src/commands/make.js
@@ -8,7 +8,7 @@ import bundleSource from '@endo/bundle-source';
 import { makeReaderRef } from '@endo/daemon';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
-import { parsePetNamePath } from '../pet-name.js';
+import { parseOptionalPetNamePath } from '../pet-name.js';
 import { randomHex16 } from '../random.js';
 
 const textEncoder = new TextEncoder();
@@ -40,8 +40,7 @@ export const makeCommand = async ({
     return;
   }
 
-  assert(resultName === undefined || typeof resultName === 'string');
-  const resultPath = resultName && parsePetNamePath(resultName);
+  const resultPath = parseOptionalPetNamePath(resultName);
 
   /** @type {import('@endo/eventual-send').FarRef<import('@endo/stream').Reader<string>> | undefined} */
   let bundleReaderRef;

--- a/packages/cli/src/commands/request.js
+++ b/packages/cli/src/commands/request.js
@@ -2,7 +2,7 @@
 import os from 'os';
 import { E } from '@endo/far';
 import { withEndoAgent } from '../context.js';
-import { parsePetNamePath } from '../pet-name.js';
+import { parseOptionalPetNamePath } from '../pet-name.js';
 
 export const request = async ({
   description,
@@ -14,7 +14,7 @@ export const request = async ({
     const result = await E(agent).request(
       toName,
       description,
-      parsePetNamePath(resultName),
+      parseOptionalPetNamePath(resultName),
     );
     console.log(result);
   });

--- a/packages/cli/src/pet-name.js
+++ b/packages/cli/src/pet-name.js
@@ -2,12 +2,14 @@ import { q } from '@endo/errors';
 
 /**
  * Splits a dot-delimited pet name path into an array of pet names.
- * Throws if any of the path segments are empty.
+ * Throws if the path is not a string or if any of the path segments are empty.
  *
  * @param {string} petNamePath - A dot-delimited pet name path.
  * @returns {string[]} - The pet name path, as an array of pet names.
  */
 export const parsePetNamePath = petNamePath => {
+  assert(typeof petNamePath === 'string');
+
   const petNames = petNamePath.split('.');
   for (const petName of petNames) {
     if (petName === '') {
@@ -17,4 +19,23 @@ export const parsePetNamePath = petNamePath => {
     }
   }
   return petNames;
+};
+
+/**
+ * Like {@link parsePetNamePath}, but immediately returns `undefined` values.
+ *
+ * @param {string | undefined} optionalPetNamePath - A dot-delimited pet name path,
+ * or `undefined`.
+ * @returns {string[] | undefined} - The pet name path as an array of pet names, or
+ * `undefined`.
+ */
+export const parseOptionalPetNamePath = optionalPetNamePath => {
+  assert(
+    optionalPetNamePath === undefined ||
+      typeof optionalPetNamePath === 'string',
+  );
+
+  return optionalPetNamePath === undefined
+    ? undefined
+    : parsePetNamePath(optionalPetNamePath);
 };


### PR DESCRIPTION
It was discovered that the CLI's `eval` and `request` commands were broken for unspecified result names. This restores functionality to these commands by introducing a new utility function, `parseOptionalPetNamePath()`, which directly returns `undefined` values, and forwards `string` values to `parsePetNamePath()`. Assertions are added in both functions to ensure that the provided path is of the expected type.