### PR TITLE
feat(types): assert.equal narrows

### DIFF
--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -295,17 +295,17 @@ export interface AssertionFunctions extends BaseAssert {
    *
    * Assert that two values must be `Object.is`.
    */
-  equal(
+  equal<T>(
     /** What we received */
-    actual: any,
+    actual: unknown,
     /** What we wanted */
-    expected: any,
+    expected: T,
     /** The details of what was asserted */
     details?: Details,
     /** An optional alternate error constructor to use */
     errConstructor?: GenericErrorConstructor,
     options?: AssertMakeErrorOptions,
-  ): void;
+  ): asserts actual is T;
 
   /**
    * The `assert.string` method.

--- a/packages/ses/types.test-d.ts
+++ b/packages/ses/types.test-d.ts
@@ -2,6 +2,8 @@
 import { expectType } from 'tsd';
 import type { Assert } from 'ses';
 
+import { equal as nassert } from 'node:assert/strict';
+
 /// <reference types="ses"/>
 
 // Lockdown
@@ -93,6 +95,15 @@ const {
 assert.equal('a', 'b');
 assert.equal('a', 'b', 'equality error');
 assert.equal('a', 'b', X`equality error left:${q('a')}, right:${q('b')}`);
+{
+  // narrowing
+  type NumRecord = { key: 'num'; value: number };
+  type StrRecord = { key: 'str'; value: string };
+  const r: NumRecord | StrRecord = null as any;
+  expectType<string | number>(r.value);
+  assert.equal(r.key, 'str');
+  expectType<string>(r.value);
+}
 
 assert.typeof(10.1, 'number');
 assert.typeof(10n, 'bigint');


### PR DESCRIPTION
_incidental_

## Description

Update `assert.equal` type to convey the type assertion.

### Security Considerations

none

### Scaling Considerations

none
### Documentation Considerations

none

### Testing Considerations

new test

### Compatibility Considerations

none

### Upgrade Considerations

none