### PR TITLE
feat(cli): Add copy command

### DIFF
--- a/packages/cli/src/commands/copy.js
+++ b/packages/cli/src/commands/copy.js
@@ -1,0 +1,13 @@
+/* global process */
+import os from 'os';
+import { E } from '@endo/far';
+import { withEndoAgent } from '../context.js';
+import { parsePetNamePath } from '../pet-name.js';
+
+export const copy = async ({ agentNames, sourcePath, targetPath }) =>
+  withEndoAgent(agentNames, { os, process }, async ({ agent }) => {
+    await E(agent).copy(
+      parsePetNamePath(sourcePath),
+      parsePetNamePath(targetPath),
+    );
+  });

--- a/packages/cli/src/endo.js
+++ b/packages/cli/src/endo.js
@@ -312,6 +312,17 @@ export const main = async rawArgs => {
     });
 
   program
+    .command('copy <from> <to>')
+    .alias('cp')
+    .option(...commonOptions.as)
+    .description('makes a duplicate of a given value with a new name')
+    .action(async (sourcePath, targetPath, cmd) => {
+      const { as: agentNames } = cmd.opts();
+      const { copy } = await import('./commands/copy.js');
+      return copy({ agentNames, sourcePath, targetPath });
+    });
+
+  program
     .command('show <name>')
     .description('prints the named value')
     .option(...commonOptions.as)


### PR DESCRIPTION
Closes: #2286
Closes #2287 

## Description

Adds the daemon's existing copy command to the cli.
Compare with [previous commit adding mkdir](https://github.com/endojs/endo/pull/2288/commits/63a58b179cd8469b7140c3bc138b33de0869e529).

### Testing Considerations

These changes were tested manually with expected behavior shown below.

```
➜  demo git:(feat-cli-expose-daemon-copy) endo make counter.js --name x
Starting Endo daemon...
Object [Alleged: Counter] {}
➜  demo git:(feat-cli-expose-daemon-copy) endo eval 'E(x).incr()' x
1
➜  demo git:(feat-cli-expose-daemon-copy) endo cp x y
➜  demo git:(feat-cli-expose-daemon-copy) endo eval 'E(y).incr()' y
2
➜  demo git:(feat-cli-expose-daemon-copy) endo eval 'E(x).incr()' x
3
➜  demo git:(cli-expose-daemon-copy) ✗ endo mkguest alice alice-agent
Object [Alleged: EndoGuest] {}
➜  demo git:(cli-expose-daemon-copy) ✗ endo send alice 'All my @x are belong to TX'
➜  demo git:(cli-expose-daemon-copy) ✗ endo adopt --as alice-agent 0 x --name ax
➜  demo git:(cli-expose-daemon-copy) ✗ endo cp --as alice-agent ax ay
➜  demo git:(feat-cli-expose-daemon-copy) endo show --as alice-agent ay                     
Object [Alleged: Counter] {}
```