### PR TITLE
test: expand the browser smoke test to break when lockdown doesn't work under CSP denying eval

### DIFF
--- a/browser-test/server.js
+++ b/browser-test/server.js
@@ -7,7 +7,11 @@ const server = http.createServer((req, res) => {
   console.log(req.url);
 
   if (req.url === '/') {
-    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.writeHead(200, { 
+      'Content-Type': 'text/html', 
+      // ensure SES works when eval is firbidden by CSP (no `unsafe-eval` in script-src)
+      'content-security-policy': "default-src 'self'; script-src 'self';" 
+    });
     return res.end('<!doctype html><script src="ses.umd.js"></script>');
   }
   if (req.url === '/ses.umd.js') {


### PR DESCRIPTION
This test will make sure we don't start relying on direct eval for lockdown itself.