### PR TITLE
ci: Pin Node 22.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.4.1]
         platform: [ubuntu-latest]
         # windows-latest exhibited flakey tests that are not yet worth the
         # trouble to investigate, and blocked us from upgrading yarn from 1 to


### PR DESCRIPTION
Node.js 22.5.0 regressed CI with error:

```
Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)
```

Pinning to 22.4.1 unblocks CI.

We should revisit reverting this with the next Node.js release.