### PR TITLE
harden-exports rule for eslint plugin

### DIFF
--- a/packages/eslint-plugin/lib/rules/harden-exports.js
+++ b/packages/eslint-plugin/lib/rules/harden-exports.js
@@ -1,53 +1,78 @@
 module.exports = {
-  meta: /** @type {const} */ ({
+  meta: {
     type: 'problem',
     docs: {
-      description: 'Ensure all named exports are passed to `harden` function',
+      description:
+        'Ensure each named export is followed by a call to `harden` function',
       category: 'Possible Errors',
       recommended: false,
     },
-    schema: [], // no options
-  }),
+    fixable: 'code',
+    schema: [],
+  },
   create: function (context) {
-    let namedExports = [];
-    let hardenCallNode = null;
+    let exportNodes = [];
 
     return {
       ExportNamedDeclaration(node) {
-        if (node.declaration && node.declaration.declarations) {
-          namedExports = namedExports.concat(
-            node.declaration.declarations.map(decl => decl.id.name),
-          );
-        } else if (node.specifiers) {
-          namedExports = namedExports.concat(
-            node.specifiers.map(spec => spec.exported.name),
-          );
-        }
+        exportNodes.push(node);
       },
-      CallExpression(node) {
-        if (node.callee.name === 'harden') {
-          hardenCallNode = node;
-          const args = node.arguments[0];
-          if (args && args.type === 'ObjectExpression') {
-            const properties = args.properties.map(prop => prop.key.name);
-            const missingExports = namedExports.filter(
-              exp => !properties.includes(exp),
-            );
-            if (missingExports.length > 0) {
-              context.report({
-                node,
-                message: `Missing exports in harden call: ${missingExports.join(', ')}`,
-              });
+      'Program:exit'() {
+        const sourceCode = context.getSourceCode();
+
+        for (const exportNode of exportNodes) {
+          let exportNames = [];
+          if (exportNode.declaration) {
+            if (exportNode.declaration.declarations) {
+              for (const declaration of exportNode.declaration.declarations) {
+                if (declaration.id.type === 'ObjectPattern') {
+                  for (const prop of declaration.id.properties) {
+                    exportNames.push(prop.key.name);
+                  }
+                } else {
+                  exportNames.push(declaration.id.name);
+                }
+              }
+            } else {
+              // Handling function exports
+              exportNames.push(exportNode.declaration.id.name);
+            }
+          } else if (exportNode.specifiers) {
+            for (const spec of exportNode.specifiers) {
+              exportNames.push(spec.exported.name);
             }
           }
-        }
-      },
-      'Program:exit'(node) {
-        if (namedExports.length > 0 && !hardenCallNode) {
-          context.report({
-            node,
-            message: `No call to 'harden' found in the module.`,
-          });
+
+          const missingHardenCalls = [];
+          for (const exportName of exportNames) {
+            const hasHardenCall = sourceCode.ast.body.some(statement => {
+              return (
+                statement.type === 'ExpressionStatement' &&
+                statement.expression.type === 'CallExpression' &&
+                statement.expression.callee.name === 'harden' &&
+                statement.expression.arguments.length === 1 &&
+                statement.expression.arguments[0].name === exportName
+              );
+            });
+
+            if (!hasHardenCall) {
+              missingHardenCalls.push(exportName);
+            }
+          }
+
+          if (missingHardenCalls.length > 0) {
+            const noun = missingHardenCalls.length === 1 ? 'export' : 'exports';
+            context.report({
+              node: exportNode,
+              message: `The named ${noun} '${missingHardenCalls.join(', ')}' should be followed by a call to 'harden'.`,
+              fix: function (fixer) {
+                const hardenCalls = missingHardenCalls
+                  .map(name => `harden(${name});`)
+                  .join('\n');
+                return fixer.insertTextAfter(exportNode, `\n${hardenCalls}`);
+              },
+            });
+          }
         }
       },
     };

--- a/packages/eslint-plugin/lib/rules/harden-exports.js
+++ b/packages/eslint-plugin/lib/rules/harden-exports.js
@@ -1,3 +1,18 @@
+/**
+ * @fileoverview Ensure each named export is followed by a call to `harden` function
+ */
+
+'use strict';
+
+/**
+ * @import {Rule} from 'eslint';
+ * @import * as ESTree from 'estree';
+ */
+
+/**
+ * ESLint rule module for ensuring each named export is followed by a call to `harden` function.
+ * @type {Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',
@@ -10,10 +25,17 @@ module.exports = {
     fixable: 'code',
     schema: [],
   },
-  create: function (context) {
+  /**
+   * Create function for the rule.
+   * @param {Rule.RuleContext} context - The rule context.
+   * @returns {Object} The visitor object.
+   */
+  create(context) {
+    /** @type {Array<ESTree.ExportNamedDeclaration & Rule.NodeParentExtension>} */
     let exportNodes = [];
 
     return {
+      /** @param {ESTree.ExportNamedDeclaration & Rule.NodeParentExtension} node */
       ExportNamedDeclaration(node) {
         exportNodes.push(node);
       },
@@ -21,9 +43,12 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         for (const exportNode of exportNodes) {
+          /** @type {string[]} */
           let exportNames = [];
           if (exportNode.declaration) {
+            // @ts-expect-error xxx typedef
             if (exportNode.declaration.declarations) {
+              // @ts-expect-error xxx typedef
               for (const declaration of exportNode.declaration.declarations) {
                 if (declaration.id.type === 'ObjectPattern') {
                   for (const prop of declaration.id.properties) {
@@ -33,8 +58,8 @@ module.exports = {
                   exportNames.push(declaration.id.name);
                 }
               }
-            } else {
-              // Handling function exports
+            } else if (exportNode.declaration.type === 'FunctionDeclaration') {
+              // @ts-expect-error xxx typedef
               exportNames.push(exportNode.declaration.id.name);
             }
           } else if (exportNode.specifiers) {
@@ -49,8 +74,10 @@ module.exports = {
               return (
                 statement.type === 'ExpressionStatement' &&
                 statement.expression.type === 'CallExpression' &&
+                // @ts-expect-error xxx typedef
                 statement.expression.callee.name === 'harden' &&
                 statement.expression.arguments.length === 1 &&
+                // @ts-expect-error xxx typedef
                 statement.expression.arguments[0].name === exportName
               );
             });

--- a/packages/eslint-plugin/lib/rules/harden-exports.js
+++ b/packages/eslint-plugin/lib/rules/harden-exports.js
@@ -1,0 +1,55 @@
+module.exports = {
+  meta: /** @type {const} */ ({
+    type: 'problem',
+    docs: {
+      description: 'Ensure all named exports are passed to `harden` function',
+      category: 'Possible Errors',
+      recommended: false,
+    },
+    schema: [], // no options
+  }),
+  create: function (context) {
+    let namedExports = [];
+    let hardenCallNode = null;
+
+    return {
+      ExportNamedDeclaration(node) {
+        if (node.declaration && node.declaration.declarations) {
+          namedExports = namedExports.concat(
+            node.declaration.declarations.map(decl => decl.id.name),
+          );
+        } else if (node.specifiers) {
+          namedExports = namedExports.concat(
+            node.specifiers.map(spec => spec.exported.name),
+          );
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.name === 'harden') {
+          hardenCallNode = node;
+          const args = node.arguments[0];
+          if (args && args.type === 'ObjectExpression') {
+            const properties = args.properties.map(prop => prop.key.name);
+            const missingExports = namedExports.filter(
+              exp => !properties.includes(exp),
+            );
+            if (missingExports.length > 0) {
+              context.report({
+                node,
+                message: `Missing exports in harden call: ${missingExports.join(', ')}`,
+              });
+            }
+          }
+        }
+      },
+      'Program:exit'(node) {
+        if (namedExports.length > 0 && !hardenCallNode) {
+          context.report({
+            node,
+            message: `No call to 'harden' found in the module.`,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -10,7 +10,7 @@
   "author": "Endo contributors",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "exit 0",
+    "test": "mocha",
     "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "exit 0",
@@ -24,7 +24,9 @@
     "typescript-eslint": "^7.3.1"
   },
   "devDependencies": {
-    "eslint": "^8.57.0"
+    "@types/mocha": "^10",
+    "eslint": "^8.57.0",
+    "mocha": "^10.6.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/packages/eslint-plugin/test/harden-exports.test.js
+++ b/packages/eslint-plugin/test/harden-exports.test.js
@@ -1,0 +1,34 @@
+const { RuleTester } = require('eslint');
+const rule = require('../lib/rules/harden-exports');
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+});
+ruleTester.run('harden-exports', rule, {
+  valid: [
+    {
+      code: `
+                export const a = 1;
+                export const b = 2;
+                harden({ a, b });
+            `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+                export const a = 1;
+                export const b = 2;
+                harden({ a });
+            `,
+      errors: [{ message: 'Missing exports in harden call: b' }],
+    },
+    {
+      code: `
+                export const a = 1;
+                export const b = 2;
+            `,
+      errors: [{ message: "No call to 'harden' found in the module." }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/test/harden-exports.test.js
+++ b/packages/eslint-plugin/test/harden-exports.test.js
@@ -1,150 +1,147 @@
 const { RuleTester } = require('eslint');
 const rule = require('../lib/rules/harden-exports');
 
-const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
-});
-ruleTester.run('harden-exports', rule, {
-  valid: [
-    {
-      code: `
+const jsValid = [
+  {
+    code: `
 export const a = 1;
 harden(a);
 export const b = 2;
 harden(b);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export const a = 1;
 harden(a);
 export const b = 2;
 harden(b);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export function foo() {
-        console.log("foo");
-    }
+      console.log("foo");
+  }
 harden(foo);
 export const a = 1;
 harden(a);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export const a = 1;
 harden(a);
 export function bar() {
-        console.log("bar");
-    }
+      console.log("bar");
+  }
 harden(bar);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export const a = 1;
 harden(a);
 export function
-    multilineFunction() {
-        console.log("This is a multiline function.");
-    }
+  multilineFunction() {
+      console.log("This is a multiline function.");
+  }
 harden(multilineFunction);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export const {
-    getEnvironmentOption,
-    getEnvironmentOptionsList,
-    environmentOptionsListHas,
-    } = makeEnvironmentCaptor();
+  getEnvironmentOption,
+  getEnvironmentOptionsList,
+  environmentOptionsListHas,
+  } = makeEnvironmentCaptor();
 harden(getEnvironmentOption);
 harden(getEnvironmentOptionsList);
 harden(environmentOptionsListHas);
-          `,
-    },
-  ],
-  invalid: [
-    {
-      code: `
+        `,
+  },
+];
+
+const invalid = [
+  {
+    code: `
 export const a = 'alreadyHardened';
 export const b = 'toHarden';
 
 harden(a);
-                `,
-      errors: [
-        {
-          message:
-            "The named export 'b' should be followed by a call to 'harden'.",
-        },
-      ],
-      output: `
+              `,
+    errors: [
+      {
+        message:
+          "The named export 'b' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
 export const a = 'alreadyHardened';
 export const b = 'toHarden';
 harden(b);
 
 harden(a);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export const a = 1;
-                `,
-      errors: [
-        {
-          message:
-            "The named export 'a' should be followed by a call to 'harden'.",
-        },
-      ],
-      output: `
+              `,
+    errors: [
+      {
+        message:
+          "The named export 'a' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
 export const a = 1;
 harden(a);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export function foo() {
-        console.log("foo");
-    }
-                `,
-      errors: [
-        {
-          message:
-            "The named export 'foo' should be followed by a call to 'harden'.",
-        },
-      ],
-      output: `
+      console.log("foo");
+  }
+              `,
+    errors: [
+      {
+        message:
+          "The named export 'foo' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
 export function foo() {
-        console.log("foo");
-    }
+      console.log("foo");
+  }
 harden(foo);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export function
-    multilineFunction() {
-        console.log("This is a multiline function.");
-    }
-                `,
-      errors: [
-        {
-          message:
-            "The named export 'multilineFunction' should be followed by a call to 'harden'.",
-        },
-      ],
-      output: `
+  multilineFunction() {
+      console.log("This is a multiline function.");
+  }
+              `,
+    errors: [
+      {
+        message:
+          "The named export 'multilineFunction' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
 export function
-    multilineFunction() {
-        console.log("This is a multiline function.");
-    }
+  multilineFunction() {
+      console.log("This is a multiline function.");
+  }
 harden(multilineFunction);
-                `,
-    },
-    {
-      code: `
+              `,
+  },
+  {
+    code: `
 export const a = 1;
 export const b = 2;
 
@@ -152,32 +149,32 @@ export const alreadyHardened = 3;
 harden(alreadyHardened);
 
 export function foo() {
-    console.log("foo");
-    }
+  console.log("foo");
+  }
 export function
-    multilineFunction() {
-    console.log("This is a multiline function.");
-    }
-          `,
-      errors: [
-        {
-          message:
-            "The named export 'a' should be followed by a call to 'harden'.",
-        },
-        {
-          message:
-            "The named export 'b' should be followed by a call to 'harden'.",
-        },
-        {
-          message:
-            "The named export 'foo' should be followed by a call to 'harden'.",
-        },
-        {
-          message:
-            "The named export 'multilineFunction' should be followed by a call to 'harden'.",
-        },
-      ],
-      output: `
+  multilineFunction() {
+  console.log("This is a multiline function.");
+  }
+        `,
+    errors: [
+      {
+        message:
+          "The named export 'a' should be followed by a call to 'harden'.",
+      },
+      {
+        message:
+          "The named export 'b' should be followed by a call to 'harden'.",
+      },
+      {
+        message:
+          "The named export 'foo' should be followed by a call to 'harden'.",
+      },
+      {
+        message:
+          "The named export 'multilineFunction' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
 export const a = 1;
 harden(a);
 export const b = 2;
@@ -187,40 +184,67 @@ export const alreadyHardened = 3;
 harden(alreadyHardened);
 
 export function foo() {
-    console.log("foo");
-    }
+  console.log("foo");
+  }
 harden(foo);
 export function
-    multilineFunction() {
-    console.log("This is a multiline function.");
-    }
+  multilineFunction() {
+  console.log("This is a multiline function.");
+  }
 harden(multilineFunction);
-          `,
-    },
-    {
-      code: `
+        `,
+  },
+  {
+    code: `
 export const {
-  getEnvironmentOption,
-  getEnvironmentOptionsList,
-  environmentOptionsListHas,
+getEnvironmentOption,
+getEnvironmentOptionsList,
+environmentOptionsListHas,
 } = makeEnvironmentCaptor();
-      `,
-      errors: [
-        {
-          message:
-            "The named exports 'getEnvironmentOption, getEnvironmentOptionsList, environmentOptionsListHas' should be followed by a call to 'harden'.",
-        },
-      ],
-      output: `
+    `,
+    errors: [
+      {
+        message:
+          "The named exports 'getEnvironmentOption, getEnvironmentOptionsList, environmentOptionsListHas' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
 export const {
-  getEnvironmentOption,
-  getEnvironmentOptionsList,
-  environmentOptionsListHas,
+getEnvironmentOption,
+getEnvironmentOptionsList,
+environmentOptionsListHas,
 } = makeEnvironmentCaptor();
 harden(getEnvironmentOption);
 harden(getEnvironmentOptionsList);
 harden(environmentOptionsListHas);
-      `,
+    `,
+  },
+];
+
+const jsTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+});
+jsTester.run('harden JS exports', rule, {
+  valid: jsValid,
+  invalid,
+});
+
+const tsTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+});
+tsTester.run('harden TS exports', rule, {
+  valid: [
+    ...jsValid,
+    {
+      // harden() on only value exports
+      code: `
+export type Foo = string;
+export interface Bar {
+    baz: number;
+}
+          `,
     },
   ],
+  invalid,
 });

--- a/packages/eslint-plugin/test/harden-exports.test.js
+++ b/packages/eslint-plugin/test/harden-exports.test.js
@@ -8,27 +8,219 @@ ruleTester.run('harden-exports', rule, {
   valid: [
     {
       code: `
-                export const a = 1;
-                export const b = 2;
-                harden({ a, b });
-            `,
+export const a = 1;
+harden(a);
+export const b = 2;
+harden(b);
+                `,
+    },
+    {
+      code: `
+export const a = 1;
+harden(a);
+export const b = 2;
+harden(b);
+                `,
+    },
+    {
+      code: `
+export function foo() {
+        console.log("foo");
+    }
+harden(foo);
+export const a = 1;
+harden(a);
+                `,
+    },
+    {
+      code: `
+export const a = 1;
+harden(a);
+export function bar() {
+        console.log("bar");
+    }
+harden(bar);
+                `,
+    },
+    {
+      code: `
+export const a = 1;
+harden(a);
+export function
+    multilineFunction() {
+        console.log("This is a multiline function.");
+    }
+harden(multilineFunction);
+                `,
+    },
+    {
+      code: `
+export const {
+    getEnvironmentOption,
+    getEnvironmentOptionsList,
+    environmentOptionsListHas,
+    } = makeEnvironmentCaptor();
+harden(getEnvironmentOption);
+harden(getEnvironmentOptionsList);
+harden(environmentOptionsListHas);
+          `,
     },
   ],
   invalid: [
     {
       code: `
-                export const a = 1;
-                export const b = 2;
-                harden({ a });
-            `,
-      errors: [{ message: 'Missing exports in harden call: b' }],
+export const a = 'alreadyHardened';
+export const b = 'toHarden';
+
+harden(a);
+                `,
+      errors: [
+        {
+          message:
+            "The named export 'b' should be followed by a call to 'harden'.",
+        },
+      ],
+      output: `
+export const a = 'alreadyHardened';
+export const b = 'toHarden';
+harden(b);
+
+harden(a);
+                `,
     },
     {
       code: `
-                export const a = 1;
-                export const b = 2;
-            `,
-      errors: [{ message: "No call to 'harden' found in the module." }],
+export const a = 1;
+                `,
+      errors: [
+        {
+          message:
+            "The named export 'a' should be followed by a call to 'harden'.",
+        },
+      ],
+      output: `
+export const a = 1;
+harden(a);
+                `,
+    },
+    {
+      code: `
+export function foo() {
+        console.log("foo");
+    }
+                `,
+      errors: [
+        {
+          message:
+            "The named export 'foo' should be followed by a call to 'harden'.",
+        },
+      ],
+      output: `
+export function foo() {
+        console.log("foo");
+    }
+harden(foo);
+                `,
+    },
+    {
+      code: `
+export function
+    multilineFunction() {
+        console.log("This is a multiline function.");
+    }
+                `,
+      errors: [
+        {
+          message:
+            "The named export 'multilineFunction' should be followed by a call to 'harden'.",
+        },
+      ],
+      output: `
+export function
+    multilineFunction() {
+        console.log("This is a multiline function.");
+    }
+harden(multilineFunction);
+                `,
+    },
+    {
+      code: `
+export const a = 1;
+export const b = 2;
+
+export const alreadyHardened = 3;
+harden(alreadyHardened);
+
+export function foo() {
+    console.log("foo");
+    }
+export function
+    multilineFunction() {
+    console.log("This is a multiline function.");
+    }
+          `,
+      errors: [
+        {
+          message:
+            "The named export 'a' should be followed by a call to 'harden'.",
+        },
+        {
+          message:
+            "The named export 'b' should be followed by a call to 'harden'.",
+        },
+        {
+          message:
+            "The named export 'foo' should be followed by a call to 'harden'.",
+        },
+        {
+          message:
+            "The named export 'multilineFunction' should be followed by a call to 'harden'.",
+        },
+      ],
+      output: `
+export const a = 1;
+harden(a);
+export const b = 2;
+harden(b);
+
+export const alreadyHardened = 3;
+harden(alreadyHardened);
+
+export function foo() {
+    console.log("foo");
+    }
+harden(foo);
+export function
+    multilineFunction() {
+    console.log("This is a multiline function.");
+    }
+harden(multilineFunction);
+          `,
+    },
+    {
+      code: `
+export const {
+  getEnvironmentOption,
+  getEnvironmentOptionsList,
+  environmentOptionsListHas,
+} = makeEnvironmentCaptor();
+      `,
+      errors: [
+        {
+          message:
+            "The named exports 'getEnvironmentOption, getEnvironmentOptionsList, environmentOptionsListHas' should be followed by a call to 'harden'.",
+        },
+      ],
+      output: `
+export const {
+  getEnvironmentOption,
+  getEnvironmentOptionsList,
+  environmentOptionsListHas,
+} = makeEnvironmentCaptor();
+harden(getEnvironmentOption);
+harden(getEnvironmentOptionsList);
+harden(environmentOptionsListHas);
+      `,
     },
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,7 +406,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/eslint-plugin@workspace:packages/eslint-plugin"
   dependencies:
+    "@types/mocha": "npm:^10"
     eslint: "npm:^8.57.0"
+    mocha: "npm:^10.6.0"
     requireindex: "npm:~1.1.0"
     ts-api-utils: "npm:~1.0.1"
     tsutils: "npm:~3.21.0"
@@ -2705,6 +2707,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mocha@npm:^10":
+  version: 10.0.7
+  resolution: "@types/mocha@npm:10.0.7"
+  checksum: 10c0/48a2df4dd02b6e66a11129dca6a23cf0cc3995faf8525286eb851043685bd8b7444780f4bb29a1c42df7559ed63294e5308bfce3a6b862ad2e0359cb21c21329
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 20.12.7
   resolution: "@types/node@npm:20.12.7"
@@ -3066,7 +3075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:^4.1.1":
+"ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
   checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
@@ -3715,6 +3724,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browser-stdout@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "browser-stdout@npm:1.3.1"
+  checksum: 10c0/c40e482fd82be872b6ea7b9f7591beafbf6f5ba522fe3dade98ba1573a1c29a11101564993e4eb44e5488be8f44510af072df9a9637c739217eb155ceb639205
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -3924,6 +3940,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase@npm:^6.0.0":
+  version: 6.3.0
+  resolution: "camelcase@npm:6.3.0"
+  checksum: 10c0/0d701658219bd3116d12da3eab31acddb3f9440790c0792e0d398f0a520a6a4058018e546862b6fba89d7ae990efaeb97da71e1913e9ebf5a8b5621a3d55c710
+  languageName: node
+  linkType: hard
+
 "cbor@npm:^9.0.1":
   version: 9.0.2
   resolution: "cbor@npm:9.0.2"
@@ -3994,6 +4017,25 @@ __metadata:
     fsevents:
       optional: true
   checksum: 10c0/1076953093e0707c882a92c66c0f56ba6187831aa51bb4de878c1fec59ae611a3bf02898f190efec8e77a086b8df61c2b2a3ea324642a0558bdf8ee6c5dc9ca1
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.5.3":
+  version: 3.6.0
+  resolution: "chokidar@npm:3.6.0"
+  dependencies:
+    anymatch: "npm:~3.1.2"
+    braces: "npm:~3.0.2"
+    fsevents: "npm:~2.3.2"
+    glob-parent: "npm:~5.1.2"
+    is-binary-path: "npm:~2.1.0"
+    is-glob: "npm:~4.0.1"
+    normalize-path: "npm:~3.0.0"
+    readdirp: "npm:~3.6.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 10c0/8361dcd013f2ddbe260eacb1f3cb2f2c6f2b0ad118708a343a5ed8158941a39cb8fb1d272e0f389712e74ee90ce8ba864eece9e0e62b9705cb468a2f6d917462
   languageName: node
   linkType: hard
 
@@ -4605,6 +4647,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.5":
+  version: 4.3.5
+  resolution: "debug@npm:4.3.5"
+  dependencies:
+    ms: "npm:2.1.2"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/082c375a2bdc4f4469c99f325ff458adad62a3fc2c482d59923c260cb08152f34e2659f72b3767db8bb2f21ca81a60a42d1019605a412132d7b9f59363a005cc
+  languageName: node
+  linkType: hard
+
 "debug@npm:~3.1.0":
   version: 3.1.0
   resolution: "debug@npm:3.1.0"
@@ -4644,6 +4698,13 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 10c0/85c39fe8fbf0482d4a1e224ef0119db5c1897f8503bcef8b826adff7a1b11414972f6fef2d7dec2ee0b4be3863cf64ac1439137ae9e6af23a3d8dcbe26a5b4b2
+  languageName: node
+  linkType: hard
+
+"decamelize@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "decamelize@npm:4.0.0"
+  checksum: 10c0/e06da03fc05333e8cd2778c1487da67ffbea5b84e03ca80449519b8fa61f888714bbc6f459ea963d5641b4aa98832130eb5cd193d90ae9f0a27eee14be8e278d
   languageName: node
   linkType: hard
 
@@ -4839,6 +4900,13 @@ __metadata:
   version: 5.1.0
   resolution: "diff@npm:5.1.0"
   checksum: 10c0/77a0d9beb9ed54796154ac2511872288432124ac90a1cabb1878783c9b4d81f1847f3b746a0630b1e836181461d2c76e1e6b95559bef86ed16294d114862e364
+  languageName: node
+  linkType: hard
+
+"diff@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "diff@npm:5.2.0"
+  checksum: 10c0/aed0941f206fe261ecb258dc8d0ceea8abbde3ace5827518ff8d302f0fc9cc81ce116c4d8f379151171336caf0516b79e01abdc1ed1201b6440d895a66689eb4
   languageName: node
   linkType: hard
 
@@ -6267,6 +6335,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "glob@npm:8.1.0"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^5.0.1"
+    once: "npm:^1.3.0"
+  checksum: 10c0/cb0b5cab17a59c57299376abe5646c7070f8acb89df5595b492dba3bfb43d301a46c01e5695f01154e6553168207cb60d4eaf07d3be4bc3eb9b0457c5c561d0f
+  languageName: node
+  linkType: hard
+
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -6513,6 +6594,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/5d415b114f410661208c95e7ab4879f1cc2765b8daceff4dc8718317d1cb7b9ffa7c5d1eafd9a4389c9aab7445d6ea88e05f3096cb1e529618b55304956b87fc
+  languageName: node
+  linkType: hard
+
+"he@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "he@npm:1.2.0"
+  bin:
+    he: bin/he
+  checksum: 10c0/a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
   languageName: node
   linkType: hard
 
@@ -7215,7 +7305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^2.0.0":
+"is-plain-obj@npm:^2.0.0, is-plain-obj@npm:^2.1.0":
   version: 2.1.0
   resolution: "is-plain-obj@npm:2.1.0"
   checksum: 10c0/e5c9814cdaa627a9ad0a0964ded0e0491bfd9ace405c49a5d63c88b30a162f1512c069d5b80997893c4d0181eadc3fed02b4ab4b81059aba5620bfcdfdeb9c53
@@ -8326,6 +8416,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^5.1.6":
+  version: 5.1.6
+  resolution: "minimatch@npm:5.1.6"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/3defdfd230914f22a8da203747c42ee3c405c39d4d37ffda284dac5e45b7e1f6c49aa8be606509002898e73091ff2a3bbfc59c2c6c71d4660609f63aa92f98e3
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.1":
   version: 9.0.4
   resolution: "minimatch@npm:9.0.4"
@@ -8521,6 +8620,37 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
+  languageName: node
+  linkType: hard
+
+"mocha@npm:^10.6.0":
+  version: 10.6.0
+  resolution: "mocha@npm:10.6.0"
+  dependencies:
+    ansi-colors: "npm:^4.1.3"
+    browser-stdout: "npm:^1.3.1"
+    chokidar: "npm:^3.5.3"
+    debug: "npm:^4.3.5"
+    diff: "npm:^5.2.0"
+    escape-string-regexp: "npm:^4.0.0"
+    find-up: "npm:^5.0.0"
+    glob: "npm:^8.1.0"
+    he: "npm:^1.2.0"
+    js-yaml: "npm:^4.1.0"
+    log-symbols: "npm:^4.1.0"
+    minimatch: "npm:^5.1.6"
+    ms: "npm:^2.1.3"
+    serialize-javascript: "npm:^6.0.2"
+    strip-json-comments: "npm:^3.1.1"
+    supports-color: "npm:^8.1.1"
+    workerpool: "npm:^6.5.1"
+    yargs: "npm:^16.2.0"
+    yargs-parser: "npm:^20.2.9"
+    yargs-unparser: "npm:^2.0.0"
+  bin:
+    _mocha: bin/_mocha
+    mocha: bin/mocha.js
+  checksum: 10c0/30b2f810014af6b5701563c6ee6ee78708dcfefc1551801c70018682bc6ca9327a6a27e93c101905a355d130a1ffe1f990975d51459c289bfcb72726ea5f7a50
   languageName: node
   linkType: hard
 
@@ -9810,6 +9940,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"randombytes@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "randombytes@npm:2.1.0"
+  dependencies:
+    safe-buffer: "npm:^5.1.0"
+  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.0.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
@@ -10227,6 +10366,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:^5.1.0":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
@@ -10334,6 +10480,15 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.13.1"
   checksum: 10c0/7982937d578cd901276c8ab3e2c6ed8a4c174137730f1fb0402d005af209a0e84d04acc874e317c936724c7b5b26c7a96ff7e4b8d11a469f4924a4b0ea814c05
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "serialize-javascript@npm:6.0.2"
+  dependencies:
+    randombytes: "npm:^2.1.0"
+  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
   languageName: node
   linkType: hard
 
@@ -11089,6 +11244,15 @@ __metadata:
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10c0/ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
   languageName: node
   linkType: hard
 
@@ -12010,6 +12174,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workerpool@npm:^6.5.1":
+  version: 6.5.1
+  resolution: "workerpool@npm:6.5.1"
+  checksum: 10c0/58e8e969782292cb3a7bfba823f1179a7615250a0cefb4841d5166234db1880a3d0fe83a31dd8d648329ec92c2d0cd1890ad9ec9e53674bb36ca43e9753cdeac
+  languageName: node
+  linkType: hard
+
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
@@ -12232,6 +12403,18 @@ __metadata:
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 10c0/0685a8e58bbfb57fab6aefe03c6da904a59769bd803a722bb098bd5b0f29d274a1357762c7258fb487512811b8063fb5d2824a3415a0a4540598335b3b086c72
+  languageName: node
+  linkType: hard
+
+"yargs-unparser@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "yargs-unparser@npm:2.0.0"
+  dependencies:
+    camelcase: "npm:^6.0.0"
+    decamelize: "npm:^4.0.0"
+    flat: "npm:^5.0.2"
+    is-plain-obj: "npm:^2.1.0"
+  checksum: 10c0/a5a7d6dc157efa95122e16780c019f40ed91d4af6d2bac066db8194ed0ec5c330abb115daa5a79ff07a9b80b8ea80c925baacf354c4c12edd878c0529927ff03
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/pull/9726

## Description

A new lint rule, `harden-exports`, to support https://github.com/Agoric/agoric-sdk/pull/9726

Includes an autofixer

### Security Considerations

Could enhance security

### Scaling Considerations

n/a

### Documentation Considerations

We don't yet document provided rules: https://endojs.github.io/endo/modules/_endo_eslint_plugin.html

I think that's okay for now. If that is requested I'd file it as a separate issue, out of scope of this one.

### Testing Considerations

I temporarily enabled this in the **recommended** config and ran `lint-fix` on the repo. All the changes looked correct. However `harden()` isn't always available so I don't think we should enable it in any of Endo's shared configs.

### Compatibility Considerations

n/a

### Upgrade Considerations

n/a
