### PR TITLE
[WIP] Test cli demo

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",
     "lint:types": "tsc",
-    "test": "exit 0"
+    "test": "ava"
   },
   "dependencies": {
     "@endo/bundle-source": "^3.2.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,6 +57,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.29.1",
+    "execa": "^9.3.0",
     "prettier": "^3.2.5",
     "typescript": "5.5.2"
   },

--- a/packages/cli/test/demo/confined-script.js
+++ b/packages/cli/test/demo/confined-script.js
@@ -1,0 +1,10 @@
+import { withContext as withContextDaemon } from './daemon.js';
+
+export const section = async (execa, testLine) => {
+  await withContextDaemon(execa, async () => {
+    // If a runlet returns a promise for some value, it will print that value before exiting gracefully.
+    await testLine(execa`endo run runlet.js a b c`, {
+      stdout: "Hello, World! [ 'a', 'b', 'c' ]\n42",
+    });
+  });
+};

--- a/packages/cli/test/demo/counter-example.js
+++ b/packages/cli/test/demo/counter-example.js
@@ -1,0 +1,73 @@
+import { withContext as withContextDaemon } from './daemon.js';
+
+export const section = async (execa, testLine) => {
+  await withContextDaemon(execa, async () => {
+    // We can create an instance of the counter and give it a name.
+    await testLine(execa`endo make counter.js --name counter`, {
+      stdout: 'Object [Alleged: Counter] {}',
+    });
+
+    // Then, we can send messages to the counter and see their responses...
+    await testLine(execa`endo eval E(counter).incr() counter`, {
+      stdout: '1',
+    });
+    await testLine(execa`endo eval E(counter).incr() counter`, {
+      stdout: '2',
+    });
+    await testLine(execa`endo eval E(counter).incr() counter`, {
+      stdout: '3',
+    });
+
+    // Aside: in all the above cases, we use counter both as the property name...
+    await testLine(execa`endo eval E(c).incr() c:counter`, {
+      stdout: '4',
+    });
+
+    // Endo preserves the commands that led to the creation of the counter value...
+    await testLine(execa`endo restart`);
+    await testLine(execa`endo eval E(counter).incr() counter`, {
+      stdout: '1',
+    });
+    await testLine(execa`endo eval E(counter).incr() counter`, {
+      stdout: '2',
+    });
+    await testLine(execa`endo eval E(counter).incr() counter`, {
+      stdout: '3',
+    });
+
+    // Aside, since Eventual Send, the machinery under the E operator...
+    await testLine(execa`endo spawn greeter`);
+    await testLine(
+      execa`endo eval --worker greeter '${'Hello, World!'}' --name greeting`,
+      {
+        stdout: 'Hello, World!',
+      },
+    );
+    await testLine(execa`endo show greeting`, {
+      stdout: 'Hello, World!',
+    });
+  });
+};
+
+/**
+ * Wraps a function with the setup and teardown of the endo object state from counter-example.
+ *
+ * @param {*} execa
+ * @param {() => Promise<void>} implementation
+ * @returns {Promise<void>}
+ */
+export const withContext = async (execa, implementation) => {
+  await withContextDaemon(execa, async () => {
+    try {
+      await execa`endo make counter.js --name counter`;
+      await execa`endo eval E(counter).incr() counter`;
+      await execa`endo eval E(counter).incr() counter`;
+      await execa`endo eval E(counter).incr() counter`;
+      await execa`endo spawn greeter`;
+      await implementation();
+    } finally {
+      await execa`endo remove greeter`;
+      await execa`endo remove counter`;
+    }
+  });
+};

--- a/packages/cli/test/demo/daemon.js
+++ b/packages/cli/test/demo/daemon.js
@@ -1,0 +1,21 @@
+/**
+ * Wraps a function with an isolated endo daemon, caveat:
+ * - does not actually create an isolated endo daemon
+ * - until above is remedied, should not be used concurrently
+ *
+ * TODO reuse daemon/test/endo.test.js:prepareConfig for setup
+ *
+ * @param {*} execa
+ * @param {() => Promise<void>} implementation
+ * @returns {Promise<void>}
+ */
+export const withContext = async (execa, implementation) => {
+  try {
+    await execa`endo purge -f`;
+    await execa`endo restart`;
+    await implementation();
+  } finally {
+    await execa`endo purge -f`;
+    await execa`endo stop`;
+  }
+};

--- a/packages/cli/test/demo/doubler-agent.js
+++ b/packages/cli/test/demo/doubler-agent.js
@@ -1,0 +1,66 @@
+import { withContext as withContextCounterExample } from './counter-example.js';
+
+export const section = async (execa, testLine) => {
+  await withContextCounterExample(execa, async () => {
+    // We make a doubler mostly the same way we made the counter...
+    await testLine(execa`endo mkguest doubler-handle doubler-agent`, {
+      stdout: 'Object [Alleged: EndoGuest] {}',
+    });
+    await testLine(
+      execa`endo make doubler.js --name doubler --powers doubler-agent`,
+    );
+
+    // This creates a doubler, but the doubler cannot respond until we resolve...
+    await testLine(execa`endo inbox`, {
+      stdout:
+        /^0\. "doubler-handle" requested "a counter, suitable for doubling"/,
+    });
+    await testLine(execa`endo resolve 0 counter`);
+
+    // Now we can get a response from the doubler.
+    await testLine(execa`endo eval E(doubler).incr() doubler`, {
+      stdout: '8',
+    });
+    await testLine(execa`endo eval E(doubler).incr() doubler`, {
+      stdout: '10',
+    });
+    await testLine(execa`endo eval E(doubler).incr() doubler`, {
+      stdout: '12',
+    });
+
+    // Also, in the optional second argument to request, doubler.js names...
+    await testLine(execa`endo restart`);
+    await testLine(execa`endo eval E(doubler).incr() doubler`, {
+      stdout: '2',
+    });
+    await testLine(execa`endo eval E(doubler).incr() doubler`, {
+      stdout: '4',
+    });
+    await testLine(execa`endo eval E(doubler).incr() doubler`, {
+      stdout: '6',
+    });
+  });
+};
+
+/**
+ * Wraps a function with the setup and teardown of the endo object state from doubler-agent.
+ *
+ * @param {*} execa
+ * @param {() => Promise<void} implementation
+ * @returns {Promise<void>}
+ */
+export const withContext = async (execa, implementation) => {
+  await withContextCounterExample(execa, async () => {
+    try {
+      await execa`endo mkguest doubler-handle doubler-agent`;
+      await execa`endo make doubler.js --name doubler --powers doubler-agent`;
+      await execa`endo inbox`;
+      await execa`endo resolve 0 counter`;
+      await implementation();
+    } finally {
+      await execa`endo remove doubler`;
+      await execa`endo remove doubler-agent`;
+      await execa`endo remove doubler-handle`;
+    }
+  });
+};

--- a/packages/cli/test/demo/familiar-chat.js
+++ b/packages/cli/test/demo/familiar-chat.js
@@ -1,0 +1,14 @@
+// Todo: web app should be tested in a browser emulator
+export async function section(testLine, execa) {
+  // Familiar Chat is an example application that provides a web app...
+  await testLine(
+    execa`endo install cat.js --listen 8920 --powers AGENT --name familiar-chat`,
+  );
+  // await testLine(execa`endo open familiar-chat`);
+
+  // So, if you were to simulate a request from your cat:
+  await testLine(execa`endo mkguest cat cat-agent`);
+  await testLine(execa`endo request HOST 'pet me' --as cat-agent`);
+
+  // If you enter the name counter and press [resolve] and return to your terminal...
+}

--- a/packages/cli/test/demo/index.test.js
+++ b/packages/cli/test/demo/index.test.js
@@ -1,0 +1,14 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+import { $ } from 'execa';
+import { makeSectionTest } from './section.js';
+import { withContext as withContextDaemon } from './daemon.js';
+
+test.serial(
+  'trivial',
+  makeSectionTest($({ cwd: 'demo' }), async (execa, testLine) => {
+    await withContextDaemon(execa, async () => {
+      const maxim = 'a failing test is better than failure to test';
+      await testLine(execa`echo ${maxim}`, { stdout: maxim });
+    });
+  }),
+);

--- a/packages/cli/test/demo/mailboxes-are-symmetric.js
+++ b/packages/cli/test/demo/mailboxes-are-symmetric.js
@@ -1,0 +1,15 @@
+import { withContext as withContextNamesInTransit } from './names-in-transit.js';
+
+export const section = async (execa, testLine) => {
+  await withContextNamesInTransit(execa, async () => {
+    // Guests can also send their host messages...
+    await testLine(
+      execa`endo send HOST --as alice-agent ${'This is the @doubler you sent me.'}`,
+    );
+    await testLine(execa`endo inbox`, {
+      stdout: /^0\. \"alice\" sent \"This is the \@doubler you sent me\.\"/,
+    });
+    await testLine(execa`endo adopt 0 doubler doubler-from-alice`);
+    await testLine(execa`endo dismiss 0`);
+  });
+};

--- a/packages/cli/test/demo/names-in-transit.js
+++ b/packages/cli/test/demo/names-in-transit.js
@@ -1,0 +1,41 @@
+import { withContext as withContextSendingMessages } from './sending-messages.js';
+
+export const section = async (execa, testLine) => {
+  await withContextSendingMessages(execa, async () => {
+    // In this example, we send alice our "doubler" but let it appear...
+    await testLine(
+      execa`endo send alice ${'Please enjoy this @counter:doubler.'}`,
+    );
+    await testLine(execa`endo inbox --as alice-agent`, {
+      stdout: /^1\. \"HOST\" sent \"Please enjoy this \@counter\.\"/,
+    });
+    await testLine(
+      execa`endo adopt --as alice-agent 1 counter --name redoubler`,
+    );
+    await testLine(execa`endo list --as alice-agent`, {
+      stdout: 'redoubler',
+    });
+    await testLine(execa`endo dismiss --as alice-agent 1`);
+  });
+};
+
+/**
+ * Wraps a function with the setup and teardown of the endo object state from names-in-transit.
+ *
+ * @param {*} execa
+ * @param {() => Promise<void} implementation
+ * @returns {Promise<void>}
+ */
+export const withContext = async (execa, implementation) => {
+  await withContextSendingMessages(execa, async () => {
+    try {
+      await execa`endo send alice ${'Please enjoy this @counter:doubler.'}`;
+      await execa`endo inbox --as alice-agent`;
+      await execa`endo adopt --as alice-agent 1 counter --name redoubler`;
+      await execa`endo dismiss --as alice-agent 1`;
+      await implementation();
+    } finally {
+      return;
+    }
+  });
+};

--- a/packages/cli/test/demo/section.js
+++ b/packages/cli/test/demo/section.js
@@ -1,0 +1,26 @@
+/**
+ *
+ * @param {*} execa - the command execution environment
+ * @param {(execa: *, testCommand: (command: *, expectation: *) => Promise<true>) => Promise<void>} testRoutine - the test logic implementation
+ * @returns {(t: *) => Promise<void>}
+ */
+export function makeSectionTest(execa, testRoutine) {
+  return async t => {
+    const matchExpecation = (expectation, result, errMsg) => {
+      (expectation instanceof RegExp ? t.regex : t.is)(
+        result,
+        expectation ?? '',
+        errMsg,
+      );
+    };
+    const testCommand = async (command, expectation) => {
+      const result = await command;
+      if (expectation !== undefined) {
+        const errMsg = JSON.stringify({ expectation, result }, null, 2);
+        matchExpecation(expectation.stdout, result.stdout, errMsg);
+        matchExpecation(expectation.stderr, result.stderr, errMsg);
+      }
+    };
+    await testRoutine(execa, testCommand);
+  };
+}

--- a/packages/cli/test/demo/sending-messages.js
+++ b/packages/cli/test/demo/sending-messages.js
@@ -1,0 +1,41 @@
+import { withContext as withContextDoublerAgent } from './doubler-agent.js';
+
+export const section = async (execa, testLine) => {
+  await withContextDoublerAgent(execa, async () => {
+    // So far, we have run guest programs like the doubler. Guests and hosts can exchange messages...
+    await testLine(execa`endo mkguest alice alice-agent`, {
+      stdout: 'Object [Alleged: EndoGuest] {}',
+    });
+    await testLine(execa`endo send alice ${'Please enjoy this @doubler.'}`);
+    await testLine(execa`endo inbox --as alice-agent`, {
+      stdout: /^0\. \"HOST\" sent \"Please enjoy this \@doubler\.\"/,
+    });
+    await testLine(execa`endo adopt --as alice-agent 0 doubler`);
+    await testLine(execa`endo list --as alice-agent`, {
+      stdout: 'doubler',
+    });
+    await testLine(execa`endo dismiss --as alice-agent 0`);
+  });
+};
+
+/**
+ * Wraps a function with the setup and teardown of the endo object state from sending-messages.
+ *
+ * @param {*} execa
+ * @param {() => Promise<void} implementation
+ * @returns {Promise<void>}
+ */
+export const withContext = async (execa, implementation) => {
+  await withContextDoublerAgent(execa, async () => {
+    try {
+      await execa`endo mkguest alice alice-agent`;
+      await execa`endo send alice ${'Please enjoy this @doubler.'}`;
+      // await execa`endo adopt --as alice-agent 0 doubler`;
+      await execa`endo adopt alice-agent 0 doubler`;
+      await execa`endo dismiss --as alice-agent 0`;
+      await implementation();
+    } finally {
+      await execa`endo remove alice-agent`;
+    }
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,6 +287,7 @@ __metadata:
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-eslint-comments: "npm:^3.2.0"
     eslint-plugin-import: "npm:^2.29.1"
+    execa: "npm:^9.3.0"
     open: "npm:^9.1.0"
     prettier: "npm:^3.2.5"
     ses: "npm:^1.5.0"
@@ -2540,6 +2541,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sec-ant/readable-stream@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@sec-ant/readable-stream@npm:0.4.1"
+  checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.25.16":
   version: 0.25.24
   resolution: "@sinclair/typebox@npm:0.25.24"
@@ -2551,6 +2559,13 @@ __metadata:
   version: 2.3.0
   resolution: "@sindresorhus/merge-streams@npm:2.3.0"
   checksum: 10c0/69ee906f3125fb2c6bb6ec5cdd84e8827d93b49b3892bce8b62267116cc7e197b5cccf20c160a1d32c26014ecd14470a72a5e3ee37a58f1d6dadc0db1ccf3894
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/merge-streams@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@sindresorhus/merge-streams@npm:4.0.0"
+  checksum: 10c0/482ee543629aa1933b332f811a1ae805a213681ecdd98c042b1c1b89387df63e7812248bb4df3910b02b3cc5589d3d73e4393f30e197c9dde18046ccd471fc6b
   languageName: node
   linkType: hard
 
@@ -5600,6 +5615,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "execa@npm:9.3.0"
+  dependencies:
+    "@sindresorhus/merge-streams": "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.3"
+    figures: "npm:^6.1.0"
+    get-stream: "npm:^9.0.0"
+    human-signals: "npm:^7.0.0"
+    is-plain-obj: "npm:^4.1.0"
+    is-stream: "npm:^4.0.1"
+    npm-run-path: "npm:^5.2.0"
+    pretty-ms: "npm:^9.0.0"
+    signal-exit: "npm:^4.1.0"
+    strip-final-newline: "npm:^4.0.0"
+    yoctocolors: "npm:^2.0.0"
+  checksum: 10c0/99ae08e7fb9172d25c453c2a9c414b54c7689e72f68263f6da7bc94c7011720dc8129cc64c2e3be44fb0c6ae8e37a08d346a61dbcfe9f1e79ad24364da2c48ce
+  languageName: node
+  linkType: hard
+
 "execution-time@npm:^1.2.0":
   version: 1.4.1
   resolution: "execution-time@npm:1.4.1"
@@ -5772,7 +5807,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:^6.0.1":
+"figures@npm:^6.0.1, figures@npm:^6.1.0":
   version: 6.1.0
   resolution: "figures@npm:6.1.0"
   dependencies:
@@ -6159,6 +6194,16 @@ __metadata:
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 10c0/49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "get-stream@npm:9.0.1"
+  dependencies:
+    "@sec-ant/readable-stream": "npm:^0.4.1"
+    is-stream: "npm:^4.0.1"
+  checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
   languageName: node
   linkType: hard
 
@@ -6713,6 +6758,13 @@ __metadata:
   version: 4.3.1
   resolution: "human-signals@npm:4.3.1"
   checksum: 10c0/40498b33fe139f5cc4ef5d2f95eb1803d6318ac1b1c63eaf14eeed5484d26332c828de4a5a05676b6c83d7b9e57727c59addb4b1dea19cb8d71e83689e5b336c
+  languageName: node
+  linkType: hard
+
+"human-signals@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "human-signals@npm:7.0.0"
+  checksum: 10c0/ce0c6d62d2e9bfe529d48f7c7fdf4b8c70fce950eef7850719b4e3f5bc71795ae7d61a3699ce13262bed7847705822601cc81f1921ea6a2906852e16228a94ab
   languageName: node
   linkType: hard
 
@@ -7312,6 +7364,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "is-plain-obj@npm:4.1.0"
+  checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
+  languageName: node
+  linkType: hard
+
 "is-plain-object@npm:^2.0.3, is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
@@ -7383,6 +7442,13 @@ __metadata:
   version: 3.0.0
   resolution: "is-stream@npm:3.0.0"
   checksum: 10c0/eb2f7127af02ee9aa2a0237b730e47ac2de0d4e76a4a905a50a11557f2339df5765eaea4ceb8029f1efa978586abe776908720bfcb1900c20c6ec5145f6f29d8
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-stream@npm:4.0.1"
+  checksum: 10c0/2706c7f19b851327ba374687bc4a3940805e14ca496dc672b9629e744d143b1ad9c6f1b162dece81c7bfbc0f83b32b61ccc19ad2e05aad2dd7af347408f60c7f
   languageName: node
   linkType: hard
 
@@ -9035,6 +9101,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "npm-run-path@npm:5.3.0"
+  dependencies:
+    path-key: "npm:^4.0.0"
+  checksum: 10c0/124df74820c40c2eb9a8612a254ea1d557ddfab1581c3e751f825e3e366d9f00b0d76a3c94ecd8398e7f3eee193018622677e95816e8491f0797b21e30b2deba
+  languageName: node
+  linkType: hard
+
 "npmlog@npm:^5.0.1":
   version: 5.0.1
   resolution: "npmlog@npm:5.0.1"
@@ -10636,7 +10711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
@@ -11178,6 +11253,13 @@ __metadata:
   version: 3.0.0
   resolution: "strip-final-newline@npm:3.0.0"
   checksum: 10c0/a771a17901427bac6293fd416db7577e2bc1c34a19d38351e9d5478c3c415f523f391003b42ed475f27e33a78233035df183525395f731d3bfb8cdcbd4da08ce
+  languageName: node
+  linkType: hard
+
+"strip-final-newline@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "strip-final-newline@npm:4.0.0"
+  checksum: 10c0/b0cf2b62d597a1b0e3ebc42b88767f0a0d45601f89fd379a928a1812c8779440c81abba708082c946445af1d6b62d5f16e2a7cf4f30d9d6587b89425fae801ff
   languageName: node
   linkType: hard
 
@@ -12477,5 +12559,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"yoctocolors@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "yoctocolors@npm:2.1.1"
+  checksum: 10c0/85903f7fa96f1c70badee94789fade709f9d83dab2ec92753d612d84fcea6d34c772337a9f8914c6bed2f5fc03a428ac5d893e76fab636da5f1236ab725486d0
   languageName: node
   linkType: hard


### PR DESCRIPTION
Refs: #2368 

## Description

A first pass at test covering the cli demo. Current weaknesses in the implementation include concurrency and independence. They are related and both should be resolved by a change to the daemon initialization in the test setups.

Note that despite these weaknesses, this setup is useful enough to reveal that certain cli commands do not behave as the demo supposes. Notably:
- `endo list --as alice-agent` is rejected because `--as` is not a supported option for `endo list`. This could have been caught with unit tests on the cli endpoints.
- `endo inbox` does not display messages as expected. In some cases the template string for the message has simply been altered, but the discrepancy in the mailboxes-are-symmetric section is unlikely to have been caught with a unit test.

### Testing Considerations

#### Concurrency
Ideally each tested section would run concurrently, however as written the demo sections are implicitly serial. This is a nice UX for a demo and I don't suggest changing it.

Thus tests running on the same daemon which reference the same objects interfere with one another. Possible solutions:
1. Run a different endo daemon per test, configured to its own directory
1. Test a slightly modified version of each section which prefixes petnames with a per-test unique id
1. Run the tests serially
1. Some other solution of which I am unaware.

At the moment I have opted for (3.) _test the sections serially_. The logic to test each section is written in a distinct file bearing the name of that section, but the routines are imported into a common `index.test.js` and declared to ava as serial.

I intend to adopt (1.) in the near future, reusing setup from `daemon/test/endo.test.js`. I think [prepareConfig](https://github.com/endojs/endo/blob/8bebd9416cca3199dba5d5655d98046e2c7781e7/packages/daemon/test/endo.test.js#L209) accomplishes what I have in mind.

#### Independence
Although the tests are run serially, the test files export setup and teardown routines in a `withContext` wrapper which can be used to replay the state-changing commands which lead up to the given test. Although the tests are all declared to ava in the same `index.test.js` file, a test can be run independently with `yarn test --match <test-name>`, for example `yarn test --match doubler-agent`. However, the independence is weak, as any breakage in the state changing commands in the previous sections will cause the setup for subsequent tests to fail. Stronger test independence is ideal.

### Upgrade Considerations

* Adds the execa dev dependency.