### PR TITLE
fix(bundle-source): Recognize default metadata

### DIFF
--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -2,7 +2,7 @@
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
 
-import bundleSource from './src/index.js';
+import bundleSource, { DEFAULT_MODULE_FORMAT } from './src/bundle-source.js';
 import { makeFileReader, makeAtomicFileWriter } from './src/fs.js';
 
 const { Fail, quote: q } = assert;
@@ -167,8 +167,8 @@ export const makeBundleCache = (wr, cwd, readPowers, opts) => {
   ) => {
     await null;
     const {
-      noTransforms: expectedNoTransforms,
-      format: expectedFormat,
+      noTransforms: expectedNoTransforms = false,
+      format: expectedFormat = DEFAULT_MODULE_FORMAT,
       conditions: expectedConditions = [],
     } = options;
     expectedConditions.sort();

--- a/packages/bundle-source/src/bundle-source.js
+++ b/packages/bundle-source/src/bundle-source.js
@@ -1,5 +1,5 @@
 // @ts-check
-const DEFAULT_MODULE_FORMAT = 'endoZipBase64';
+export const DEFAULT_MODULE_FORMAT = 'endoZipBase64';
 export const SUPPORTED_FORMATS = [
   'getExport',
   'nestedEvaluate',

--- a/packages/bundle-source/test/cache.test.js
+++ b/packages/bundle-source/test/cache.test.js
@@ -1,0 +1,18 @@
+import url from 'url';
+import test from '@endo/ses-ava/prepare-endo.js';
+import { makeNodeBundleCache } from '../cache.js';
+
+test('cache can capture and verify metadata', async t => {
+  const dest = url.fileURLToPath(new URL('../bundles/', import.meta.url));
+  const entry = url.fileURLToPath(
+    new URL('../demo/meaning.js', import.meta.url),
+  );
+  const cache = await makeNodeBundleCache(
+    dest,
+    {},
+    specifier => import(specifier),
+  );
+  await cache.validateOrAdd(entry, 'cache-test-meaning', t.log);
+  await cache.validate('cache-test-meaning', undefined, t.log);
+  t.pass();
+});


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/pull/9735

## Description

Agoric SDK integration revealed a regression in the `bundle-source/cache.js` implementation, where the validator didn’t recognize default metadata.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

This change includes a regression test.

### Compatibility Considerations

Restores backward compatibility.

### Upgrade Considerations

None.