### PR TITLE
feat: add reflect metadata taming

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -90,6 +90,12 @@ export const { stringify: stringifyJson } = JSON;
 // Needed only for the Safari bug workaround below
 const { defineProperty: originalDefineProperty } = Object;
 
+/**
+ * @param {object} object
+ * @param {PropertyKey} prop
+ * @param {PropertyDescriptor} descriptor
+ * @returns
+ */
 export const defineProperty = (object, prop, descriptor) => {
   // We used to do the following, until we had to reopen Safari bug
   // https://bugs.webkit.org/show_bug.cgi?id=222538#c17

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -12,4 +12,5 @@ globalThis.Compartment = makeCompartmentConstructor(
   makeCompartmentConstructor,
   getGlobalIntrinsics(globalThis),
   markVirtualizedNativeFunction,
+  'none',
 );

--- a/packages/ses/src/compartment.js
+++ b/packages/ses/src/compartment.js
@@ -25,6 +25,7 @@ import { link } from './module-link.js';
 import { getDeferredExports } from './module-proxy.js';
 import { compartmentEvaluate } from './compartment-evaluate.js';
 import { makeSafeEvaluator } from './make-safe-evaluator.js';
+import { setGlobalObjectReflectNamespace } from './make-reflect-namespace.js';
 
 // moduleAliases associates every public module exports namespace with its
 // corresponding compartment and specifier so they can be used to link modules
@@ -168,6 +169,7 @@ defineProperties(InertCompartment, {
  * @param {MakeCompartmentConstructor} targetMakeCompartmentConstructor
  * @param {Record<string, any>} intrinsics
  * @param {(object: object) => void} markVirtualizedNativeFunction
+ * @param {import('../types').RepairOptions['reflectMetadataTaming']} reflectMetadataTaming
  * @param {Compartment} [parentCompartment]
  * @returns {Compartment['constructor']}
  */
@@ -177,6 +179,7 @@ export const makeCompartmentConstructor = (
   targetMakeCompartmentConstructor,
   intrinsics,
   markVirtualizedNativeFunction,
+  reflectMetadataTaming,
   parentCompartment = undefined,
 ) => {
   function Compartment(
@@ -235,6 +238,7 @@ export const makeCompartmentConstructor = (
       newGlobalPropertyNames: sharedGlobalPropertyNames,
       makeCompartmentConstructor: targetMakeCompartmentConstructor,
       parentCompartment: this,
+      reflectMetadataTaming,
       markVirtualizedNativeFunction,
     });
 
@@ -244,6 +248,9 @@ export const makeCompartmentConstructor = (
       safeEvaluate,
       markVirtualizedNativeFunction,
     );
+
+    reflectMetadataTaming === 'mutable-per-global' &&
+      setGlobalObjectReflectNamespace(globalObject);
 
     assign(globalObject, endowments);
 

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -4,7 +4,7 @@ import { toStringTagSymbol, iteratorSymbol } from './commons.js';
  * @file Exports {@code enablements}, a recursively defined
  * JSON record defining the optimum set of intrinsics properties
  * that need to be "repaired" before hardening is applied on
- * enviromments subject to the override mistake.
+ * environments subject to the override mistake.
  *
  * @author JF Paradis
  * @author Mark S. Miller
@@ -14,7 +14,7 @@ import { toStringTagSymbol, iteratorSymbol } from './commons.js';
  * <p>Because "repairing" replaces data properties with accessors, every
  * time a repaired property is accessed, the associated getter is invoked,
  * which degrades the runtime performance of all code executing in the
- * repaired enviromment, compared to the non-repaired case. In order
+ * repaired environment, compared to the non-repaired case. In order
  * to maintain performance, we only repair the properties of objects
  * for which hardening causes a breakage of their normal intended usage.
  *

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -73,6 +73,7 @@ export const setGlobalObjectConstantProperties = globalObject => {
  * @param {object} args.intrinsics
  * @param {object} args.newGlobalPropertyNames
  * @param {Function} args.makeCompartmentConstructor
+ * @param {import('../types').RepairOptions['reflectMetadataTaming']} args.reflectMetadataTaming
  * @param {(object) => void} args.markVirtualizedNativeFunction
  * @param {Compartment} [args.parentCompartment]
  */
@@ -82,6 +83,7 @@ export const setGlobalObjectMutableProperties = (
     intrinsics,
     newGlobalPropertyNames,
     makeCompartmentConstructor,
+    reflectMetadataTaming,
     markVirtualizedNativeFunction,
     parentCompartment,
   },
@@ -117,6 +119,7 @@ export const setGlobalObjectMutableProperties = (
       makeCompartmentConstructor,
       intrinsics,
       markVirtualizedNativeFunction,
+      reflectMetadataTaming,
       parentCompartment,
     ),
   );

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -55,6 +55,7 @@ import { makeCompartmentConstructor } from './compartment.js';
 import { tameHarden } from './tame-harden.js';
 import { tameSymbolConstructor } from './tame-symbol-constructor.js';
 import { tameFauxDataProperties } from './tame-faux-data-properties.js';
+import { tameReflectMetadata } from './make-reflect-namespace.js';
 
 /** @import {LockdownOptions} from '../types.js' */
 
@@ -73,7 +74,7 @@ let priorHardenIntrinsics;
  * @param {T} ref
  * @returns {T}
  */
-const safeHarden = makeHardener();
+const { harden: safeHarden, skipHarden } = makeHardener();
 
 /**
  * @callback Transform
@@ -138,6 +139,9 @@ export const repairIntrinsics = (options = {}) => {
   // Reconstructing `option` here also ensures that it is a well
   // behaved record, with only own data properties.
   //
+  // The `reflectMetadataTaming` is not a safety issue. Rather it is a tradeoff
+  // between code compatibility, which is better with the `'unsafe-writable-once'`
+  //
   // The `overrideTaming` is not a safety issue. Rather it is a tradeoff
   // between code compatibility, which is better with the `'moderate'`
   // setting, and tool compatibility, which is better with the `'min'`
@@ -152,7 +156,7 @@ export const repairIntrinsics = (options = {}) => {
   // `stackFrameFiltering` to`'concise'` limits the display to the stack frame
   // information most likely to be relevant, eliminating distracting frames
   // such as those from the infrastructure. However, the bug you're trying to
-  // track down might be in the infrastrure, in which case the `'verbose'` setting
+  // track down might be in the infrastructure, in which case the `'verbose'` setting
   // is useful. See
   // [`stackFiltering` options](https://github.com/Agoric/SES-shim/blob/master/packages/ses/docs/lockdown.md#stackfiltering-options)
   // for an explanation.
@@ -175,6 +179,7 @@ export const repairIntrinsics = (options = {}) => {
     stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise'),
     domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe'),
     evalTaming = getenv('LOCKDOWN_EVAL_TAMING', 'safeEval'),
+    reflectMetadataTaming = getenv('LOCKDOWN_REFLECT_METADATA_TAMING', 'none'),
     overrideDebug = arrayFilter(
       stringSplit(getenv('LOCKDOWN_OVERRIDE_DEBUG', ''), ','),
       /** @param {string} debugName */
@@ -190,6 +195,11 @@ export const repairIntrinsics = (options = {}) => {
     evalTaming === 'safeEval' ||
     evalTaming === 'noEval' ||
     Fail`lockdown(): non supported option evalTaming: ${q(evalTaming)}`;
+
+  reflectMetadataTaming === 'none' ||
+    reflectMetadataTaming === 'keep-and-inherit' ||
+    reflectMetadataTaming === 'mutable-per-global' ||
+    Fail`lockdown(): non supported option reflectMetadataTaming: ${q(reflectMetadataTaming)}`;
 
   // Assert that only supported options were passed.
   // Use Reflect.ownKeys to reject symbol-named properties as well.
@@ -274,6 +284,9 @@ export const repairIntrinsics = (options = {}) => {
   addIntrinsics(tameMathObject(mathTaming));
   addIntrinsics(tameRegExpConstructor(regExpTaming));
   addIntrinsics(tameSymbolConstructor());
+  addIntrinsics(
+    tameReflectMetadata(/** @type {any} */ (reflectMetadataTaming), skipHarden),
+  );
 
   addIntrinsics(getAnonymousIntrinsics());
 
@@ -361,6 +374,7 @@ export const repairIntrinsics = (options = {}) => {
     newGlobalPropertyNames: initialGlobalPropertyNames,
     makeCompartmentConstructor,
     markVirtualizedNativeFunction,
+    reflectMetadataTaming: /** @type {any} */ (reflectMetadataTaming),
   });
 
   if (evalTaming === 'noEval') {

--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -125,13 +125,13 @@ const freezeTypedArray = array => {
 /**
  * Create a `harden` function.
  *
- * @returns {Harden}
+ * @returns {{harden: Harden, skipHarden?: (object: any) => void}}
  */
 export const makeHardener = () => {
   // Use a native hardener if possible.
   if (typeof globalThis.harden === 'function') {
     const safeHarden = globalThis.harden;
-    return safeHarden;
+    return { harden: safeHarden };
   }
 
   const hardened = new WeakSet();
@@ -271,5 +271,5 @@ export const makeHardener = () => {
     },
   };
 
-  return harden;
+  return { harden, skipHarden: object => weaksetAdd(hardened, object) };
 };

--- a/packages/ses/src/make-reflect-namespace.js
+++ b/packages/ses/src/make-reflect-namespace.js
@@ -1,0 +1,144 @@
+import {
+  defineProperties,
+  defineProperty,
+  objectPrototype,
+  Proxy,
+} from './commons.js';
+import { permitted, ReflectWithMetadata, StandardReflect } from './permits.js';
+
+/**
+ * tameReflectMetadata()
+ * A tamed version of the native Reflect namespace which accepts reflect-metadata methods
+ *
+ * @param {import('../types').RepairOptions['reflectMetadataTaming']} reflectMetadataTaming
+ * @param {((object: object) => void) | undefined} skipHarden
+ */
+export const tameReflectMetadata = (reflectMetadataTaming, skipHarden) => {
+  const ReflectSpec =
+    reflectMetadataTaming === 'none' ? StandardReflect : ReflectWithMetadata;
+  permitted['%InitialReflect%'] = ReflectSpec;
+  permitted.Reflect = ReflectSpec;
+
+  if (reflectMetadataTaming !== 'mutable-per-global') {
+    permitted['%SharedReflect%'] = ReflectWithMetadata;
+  }
+
+  if (reflectMetadataTaming === 'none') {
+    return {
+      Reflect: Reflect,
+      '%InitialReflect%': Reflect,
+      '%SharedReflect%': Reflect,
+    };
+  } else if (reflectMetadataTaming === 'keep-and-inherit') {
+    return {
+      Reflect: Reflect,
+      '%InitialReflect%': Reflect,
+      '%SharedReflect%': Reflect,
+    };
+  } else {
+    const InitialReflect = makeReflectNamespace();
+    if (!skipHarden)
+      assert.Fail`lockdown(): option reflectMetadataTaming mutable-per-global is not supported when a native harden exists.`;
+    else skipHarden(InitialReflect);
+    return {
+      Reflect: InitialReflect,
+      '%InitialReflect%': InitialReflect,
+    };
+  }
+};
+
+const reflectMetadataSymbol = Symbol.for('@reflect-metadata:registry');
+/** @type {ProxyHandler<typeof Reflect> & {__proto__: any}} */
+const handlers = {
+  __proto__: null,
+  deleteProperty: (target, prop) => {
+    if (isReflectMetadataProp(prop))
+      return Reflect.deleteProperty(target, prop);
+    if (isNativeReflectProp(prop)) return false;
+    return true;
+  },
+  isExtensible: () => true,
+  preventExtensions: () => false,
+  getPrototypeOf: () => objectPrototype,
+  setPrototypeOf: (_target, proto) => proto === objectPrototype,
+  defineProperty: (target, prop, attribute) => {
+    if (isReflectMetadataProp(prop) || isNativeReflectProp(prop))
+      return Reflect.defineProperty(target, prop, attribute);
+    return false;
+  },
+  set: (target, prop, value, receiver) => {
+    if (isReflectMetadataProp(prop))
+      return Reflect.set(target, prop, value, receiver);
+    return false;
+  },
+};
+const makeReflectNamespace = () => {
+  const underlyingReflect = {};
+  defineProperties(underlyingReflect, {
+    apply: { value: Reflect.apply },
+    construct: { value: Reflect.construct },
+    defineProperty: { value: Reflect.defineProperty },
+    deleteProperty: { value: Reflect.deleteProperty },
+    get: { value: Reflect.get },
+    getOwnPropertyDescriptor: {
+      value: Reflect.getOwnPropertyDescriptor,
+    },
+    getPrototypeOf: { value: Reflect.getPrototypeOf },
+    has: { value: Reflect.has },
+    isExtensible: { value: Reflect.isExtensible },
+    ownKeys: { value: Reflect.ownKeys },
+    preventExtensions: { value: Reflect.preventExtensions },
+    set: { value: Reflect.set },
+    setPrototypeOf: { value: Reflect.setPrototypeOf },
+    [Symbol.toStringTag]: { value: 'Object' },
+  });
+  return new Proxy(underlyingReflect, handlers);
+};
+
+function isReflectMetadataProp(prop) {
+  switch (prop) {
+    case 'decorate':
+    case 'metadata':
+    case 'defineMetadata':
+    case 'hasMetadata':
+    case 'hasOwnMetadata':
+    case 'getMetadata':
+    case 'getOwnMetadata':
+    case 'getMetadataKeys':
+    case 'getOwnMetadataKeys':
+    case 'deleteMetadata':
+    case reflectMetadataSymbol:
+      return true;
+    default:
+      return false;
+  }
+}
+function isNativeReflectProp(prop) {
+  switch (prop) {
+    case 'apply':
+    case 'construct':
+    case 'defineProperty':
+    case 'deleteProperty':
+    case 'get':
+    case 'getOwnPropertyDescriptor':
+    case 'getPrototypeOf':
+    case 'has':
+    case 'isExtensible':
+    case 'ownKeys':
+    case 'preventExtensions':
+    case 'set':
+    case 'setPrototypeOf':
+    case Symbol.toStringTag:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export const setGlobalObjectReflectNamespace = globalObject => {
+  defineProperty(globalObject, 'Reflect', {
+    configurable: true,
+    writable: true,
+    value: makeReflectNamespace(),
+  });
+};

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-globals */
 /* eslint max-lines: 0 */
 
-import { arrayPush } from './commons.js';
+import { arrayPush, proxyRevocable } from './commons.js';
 
 /** @import {GenericErrorConstructor} from '../types.js' */
 
@@ -92,7 +92,6 @@ export const universalPropertyNames = {
   // *** Other Properties of the Global Object
 
   JSON: 'JSON',
-  Reflect: 'Reflect',
 
   // *** Annex B
 
@@ -108,8 +107,7 @@ export const universalPropertyNames = {
 
 /**
  * initialGlobalPropertyNames
- * Those found only on the initial global, i.e., the global of the
- * start compartment, as well as any compartments created before lockdown.
+ * Those found only on the initial global, i.e., the global of the start compartment.
  * These may provide much of the power provided by the original.
  * Maps from property name to the intrinsic name in the whitelist.
  */
@@ -128,6 +126,7 @@ export const initialGlobalPropertyNames = {
   // *** Other Properties of the Global Object
 
   Math: '%InitialMath%',
+  Reflect: '%InitialReflect%',
 
   // ESNext
 
@@ -143,7 +142,7 @@ export const initialGlobalPropertyNames = {
 
 /**
  * sharedGlobalPropertyNames
- * Those found only on the globals of new compartments created after lockdown,
+ * Those found only on the globals of subcompartments,
  * which must therefore be powerless.
  * Maps from property name to the intrinsic name in the whitelist.
  */
@@ -157,36 +156,8 @@ export const sharedGlobalPropertyNames = {
 
   // *** Other Properties of the Global Object
 
+  Reflect: '%SharedReflect%',
   Math: '%SharedMath%',
-};
-
-/**
- * uniqueGlobalPropertyNames
- * Those made separately for each global, including the initial global
- * of the start compartment.
- * Maps from property name to the intrinsic name in the whitelist
- * (which is currently always the same).
- */
-export const uniqueGlobalPropertyNames = {
-  // *** Value Properties of the Global Object
-
-  globalThis: '%UniqueGlobalThis%',
-
-  // *** Function Properties of the Global Object
-
-  eval: '%UniqueEval%',
-
-  // *** Constructor Properties of the Global Object
-
-  Function: '%UniqueFunction%',
-
-  // *** Other Properties of the Global Object
-
-  // ESNext
-
-  Compartment: '%UniqueCompartment%',
-  // According to current agreements, eventually the Realm constructor too.
-  // 'Realm',
 };
 
 // All the "subclasses" of Error. These are collectively represented in the
@@ -228,9 +199,9 @@ export { NativeErrors };
  *     is typeof the given type. For example, {@code "Infinity"} leads to
  *     "number" and property values that fail {@code typeof "number"}.
  *     are removed.
- * <li>A string value equal to an intinsic name ("ObjectPrototype",
+ * <li>A string value equal to an intrinsic name ("ObjectPrototype",
  *     "Array", etc), in which case the property whitelisted if its
- *     value property is equal to the value of the corresponfing
+ *     value property is equal to the value of the corresponding
  *     intrinsics. For example, {@code Map.prototype} leads to
  *     "MapPrototype" and the property is removed if its value is
  *     not equal to %MapPrototype%
@@ -404,6 +375,52 @@ const CommonMath = {
   // See https://github.com/Moddable-OpenSource/moddable/issues/523#issuecomment-1942904505
   irandom: false,
 };
+
+export const StandardReflect = {
+  // The Reflect Object
+  // Not a function object.
+  apply: fn,
+  construct: fn,
+  defineProperty: fn,
+  deleteProperty: fn,
+  get: fn,
+  getOwnPropertyDescriptor: fn,
+  getPrototypeOf: fn,
+  has: fn,
+  isExtensible: fn,
+  ownKeys: fn,
+  preventExtensions: fn,
+  set: fn,
+  setPrototypeOf: fn,
+  '@@toStringTag': 'string',
+};
+
+export const ReflectWithMetadata = {
+  ...StandardReflect,
+  decorate: fn,
+  metadata: fn,
+  defineMetadata: fn,
+  hasMetadata: fn,
+  hasOwnMetadata: fn,
+  getMetadata: fn,
+  getOwnMetadata: fn,
+  getMetadataKeys: fn,
+  getOwnMetadataKeys: fn,
+  deleteMetadata: fn,
+  // since 0.2.0
+  'RegisteredSymbol(@reflect-metadata:registry)': {
+    getProvider: fn,
+    registerProvider: fn,
+    setProvider: fn,
+  },
+};
+
+let never;
+{
+  const { proxy, revoke } = proxyRevocable({}, {});
+  revoke();
+  never = proxy;
+}
 
 export const permitted = {
   // ECMA https://tc39.es/ecma262
@@ -1537,24 +1554,10 @@ export const permitted = {
 
   // Reflection
 
-  Reflect: {
-    // The Reflect Object
-    // Not a function object.
-    apply: fn,
-    construct: fn,
-    defineProperty: fn,
-    deleteProperty: fn,
-    get: fn,
-    getOwnPropertyDescriptor: fn,
-    getPrototypeOf: fn,
-    has: fn,
-    isExtensible: fn,
-    ownKeys: fn,
-    preventExtensions: fn,
-    set: fn,
-    setPrototypeOf: fn,
-    '@@toStringTag': 'string',
-  },
+  // Note: this will be set to StandardReflect or reflectMetadataTaming when lockdown()
+  Reflect: never,
+  '%InitialReflect%': never,
+  '%SharedReflect%': never,
 
   Proxy: {
     // Properties of the Proxy Constructor

--- a/packages/ses/test/global-object.test.js
+++ b/packages/ses/test/global-object.test.js
@@ -28,6 +28,7 @@ test('globalObject', t => {
     intrinsics,
     newGlobalPropertyNames: sharedGlobalPropertyNames,
     makeCompartmentConstructor,
+    reflectMetadataTaming: 'none',
     markVirtualizedNativeFunction,
   });
   setGlobalObjectEvaluators(

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -33,6 +33,14 @@ export interface RepairOptions {
   overrideTaming?: 'moderate' | 'min' | 'severe';
   overrideDebug?: Array<string>;
   domainTaming?: 'safe' | 'unsafe';
+  /**
+   * none (safe): Metadata methods will be removed.
+   *
+   * keep-and-inherit: Metadata methods will be kept, frozen and inherited to new globals if they were installed when lockdown() is called.
+   *
+   * mutable-per-global: Metadata methods will be mutable per global.
+   */
+  reflectMetadataTaming?: 'none' | 'keep-and-inherit' | 'mutable-per-global';
   __hardenTaming__?: 'safe' | 'unsafe';
 }
 


### PR DESCRIPTION
Refs: #1950

## Description

reflect-metadata is a widely used package in the ecosystem. It is used to polyfill an outdated ECMAScript feature about decorators.

It modifies the global `Reflect` namespace object to add several methods. Although in https://github.com/rbuckton/reflect-metadata/pull/131, @rbuckton added a `/no-conflict` version of this package, it is impossible to upgrade every package in the ecosystem.

This PR adds an option called `reflectMetadataTaming`. It has 3 valid options:

- `none` (default): Current behavior, not try to fix it and cause `reflect-metadata` throw.
- `keep-and-inherit`: If the reflect-metadata methods are added **before** the lockdown is called, they will be preserved like they are safe primorials. They will also be inherited by any subcompartments.
- `mutable-per-global`: The Reflect namespace is an exotic object and unique per-global. Reflect-metadata can set (prior 0.2.0) or define methods as it wishes.

Example:

> `keep-and-inherit`, install polyfill before lockdown

```js
import './lockdown.umd.js'
import 'https://cdnjs.cloudflare.com/ajax/libs/reflect-metadata/0.2.2/Reflect.js'
lockdown({ reflectMetadataTaming: 'keep-and-inherit', errorTaming: 'unsafe', consoleTaming: 'unsafe' })
console.log(Reflect.metadata) // function

globalThis.c = new Compartment()
console.log(c.globalThis.Reflect === Reflect) // true
```

> `keep-and-inherit`, install polyfill after lockdown

```js
import './lockdown.umd.js'
lockdown({ reflectMetadataTaming: 'keep-and-inherit', errorTaming: 'unsafe', consoleTaming: 'unsafe' })
await import('https://cdnjs.cloudflare.com/ajax/libs/reflect-metadata/0.2.2/Reflect.js')
// Cannot define property decorate, object is not extensible
```

> `mutable-per-global`, install polyfill inside subcompartment, but not the initial one

```js
import './lockdown.umd.js'
lockdown({ reflectMetadataTaming: 'mutable-per-global', errorTaming: 'unsafe', consoleTaming: 'unsafe' })

globalThis.c = new Compartment()
console.log(c.globalThis.Reflect === Reflect) // false

var data = await fetch('https://cdnjs.cloudflare.com/ajax/libs/reflect-metadata/0.2.2/Reflect.js').then(x => x.text())
c.globalThis.eval(data)
console.log(c.globalThis.Reflect.metadata) // function
console.log(Reflect.metadata) // undefined
```

### Security Considerations

When using `keep-and-inherit`, all compartment and the initial compartment shares the Metadata Registry (which is viable by `Reflect[Symbol.for('@reflect-metadata:registry')]`). They may exchange objects via this registry and break the membrane if there is one.

### Scaling Considerations

No problem.

### Documentation Considerations

If you're hitting problems with `reflect-metadata`, you might need this.

### Testing Considerations

I have not added any tests yet. I hope I can iterate the PR design with the endo team and write the tests after the design is stable.

### Compatibility Considerations

No breaking changes.

### Upgrade Considerations

No breaking changes.

> Update `NEWS.md` for user-facing changes.

TODO.