### PR TITLE
feat: transpile .mts with swc strip-only

### DIFF
--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -58,6 +58,7 @@
     "@endo/cjs-module-analyzer": "^1.0.5",
     "@endo/module-source": "^0.0.0",
     "@endo/zip": "^1.0.5",
+    "@swc/wasm-typescript": "^1.7.2",
     "ses": "^1.5.0"
   },
   "devDependencies": {

--- a/packages/compartment-mapper/src/import-parsers.js
+++ b/packages/compartment-mapper/src/import-parsers.js
@@ -11,11 +11,13 @@ import parserText from './parse-text.js';
 import parserBytes from './parse-bytes.js';
 import parserCjs from './parse-cjs.js';
 import parserMjs from './parse-mjs.js';
+import parserMts from './parse-mts.js';
 
 /** @satisfies {Readonly<ParserForLanguage>} */
 export const defaultParserForLanguage = Object.freeze(
   /** @type {const} */ ({
     mjs: parserMjs,
+    mts: parserMts,
     cjs: parserCjs,
     json: parserJson,
     text: parserText,

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -184,6 +184,7 @@ const findPackage = async (readDescriptor, canonical, directory, name) => {
 
 const defaultLanguages = /** @type {const} */ ([
   'mjs',
+  'mts',
   'cjs',
   'json',
   'text',
@@ -192,6 +193,7 @@ const defaultLanguages = /** @type {const} */ ([
 const defaultUncontroversialParsers = /** @type {const} */ ({
   cjs: 'cjs',
   mjs: 'mjs',
+  mts: 'mts',
   json: 'json',
   text: 'text',
   bytes: 'bytes',

--- a/packages/compartment-mapper/src/parse-mts.js
+++ b/packages/compartment-mapper/src/parse-mts.js
@@ -1,0 +1,43 @@
+/* Provides language behavior (a parser) for importing ESM. */
+
+// @ts-check
+
+import { transform } from '@swc/wasm-typescript';
+import { ModuleSource } from '@endo/module-source';
+
+const textDecoder = new TextDecoder();
+
+/** @type {import('./types.js').ParseFn} */
+export const parseMts = async (
+  bytes,
+  _specifier,
+  sourceUrl,
+  _packageLocation,
+  options = {},
+) => {
+  const { sourceMap, sourceMapHook } = options;
+  const source = textDecoder.decode(bytes);
+  const transformed = await transform(source, {
+    filename: sourceUrl,
+    mode: 'strip-only',
+    module: true,
+  });
+  const record = new ModuleSource(transformed.code, {
+    sourceUrl,
+    // XXX use transformed source map?
+    sourceMap,
+    sourceMapUrl: sourceUrl,
+    sourceMapHook,
+  });
+  return {
+    parser: 'mts',
+    bytes,
+    record,
+  };
+};
+
+/** @type {import('./types.js').ParserImplementation} */
+export default {
+  parse: parseMts,
+  heuristicImports: false,
+};

--- a/packages/compartment-mapper/test/fixtures-esm-imports-cjs-define/0.mts
+++ b/packages/compartment-mapper/test/fixtures-esm-imports-cjs-define/0.mts
@@ -1,0 +1,4 @@
+import { meaning } from './1.cjs';
+if (meaning !== 42) {
+  throw new Error('Fail');
+}

--- a/packages/compartment-mapper/test/mts-imports-cjs-define.test.js
+++ b/packages/compartment-mapper/test/mts-imports-cjs-define.test.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-underscore-dangle */
+// import "./ses-lockdown.js";
+import 'ses';
+import test from 'ava';
+
+import { scaffold } from './scaffold.js';
+
+const fixture = new URL(
+  'fixtures-esm-imports-cjs-define/0.mts',
+  import.meta.url,
+).toString();
+
+const assertFixture = t => t.pass();
+
+const fixtureAssertionCount = 1;
+
+scaffold(
+  'fixtures-esm-imports-cjs-define',
+  test,
+  fixture,
+  assertFixture,
+  fixtureAssertionCount,
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,6 +319,7 @@ __metadata:
     "@endo/cjs-module-analyzer": "npm:^1.0.5"
     "@endo/module-source": "npm:^0.0.0"
     "@endo/zip": "npm:^1.0.5"
+    "@swc/wasm-typescript": "npm:^1.7.2"
     ava: "npm:^6.1.3"
     babel-eslint: "npm:^10.1.0"
     c8: "npm:^7.14.0"
@@ -2596,6 +2597,13 @@ __metadata:
   version: 0.7.2
   resolution: "@sinonjs/text-encoding@npm:0.7.2"
   checksum: 10c0/583a45bf3643169e313ff9d4395aff28b0c4f330d3697e252c3effc13d4303ee30f83df542732c1a68617720e4ea6fc08d48a3d9151c9b354a7fc356a8e9b162
+  languageName: node
+  linkType: hard
+
+"@swc/wasm-typescript@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@swc/wasm-typescript@npm:1.7.2"
+  checksum: 10c0/fb84874ff21865b5b563564026cdec2de16c69c8f659b7070a4a4f15b70d2a53b1f8a8bfc40e00f90933e4c6fad537f3976209cc2fbc79be2558fd0a138785d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/issues/5760
Refs: https://github.com/endojs/endo/issues/2415

## Description

spike on getting Endo to bundle `.ts` syntax files as `.js` using https://github.com/swc-project/swc/pull/9138/

current status:
```
❯ yarn test test/mts-imports-cjs-define.test.js

  ✘ [fail]: fixtures-esm-imports-cjs-define / makeArchive / parseArchive / hashArchive consistency Rejected promise returned by test
  ✘ [fail]: fixtures-esm-imports-cjs-define / makeArchive / parseArchive, but with sha512 corruption of a compartment map Rejected promise returned by test
  ✘ [fail]: fixtures-esm-imports-cjs-define / makeArchive / parseArchive Rejected promise returned by test
  ✘ [fail]: fixtures-esm-imports-cjs-define / makeArchive / parseArchive with a prefix Rejected promise returned by test
  ✘ [fail]: fixtures-esm-imports-cjs-define / writeArchive / loadArchive Rejected promise returned by test
  ✘ [fail]: fixtures-esm-imports-cjs-define / writeArchive / importArchive Rejected promise returned by test
  ✔ fixtures-esm-imports-cjs-define / loadLocation
  ✔ fixtures-esm-imports-cjs-define / importLocation
```

So next steps I think are:
- [ ] make a `parse-pre-mts.js` for `import-archive-parsers.js`
- [ ] make a `parse-archive-mts.js` for `archive-parsers.js`


### Security Considerations

> Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?

### Scaling Considerations

> Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated?

### Documentation Considerations

> Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

### Testing Considerations

> Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? 

### Compatibility Considerations

> Does this change break any prior usage patterns? Does this change allow usage patterns to evolve?

### Upgrade Considerations

> What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed?

> Include `*BREAKING*:` in the commit message with migration instructions for any breaking change.

> Update `NEWS.md` for user-facing changes.

> Delete guidance from pull request description before merge (including this!)
