### PR TITLE
feat(ses): permit toHex etc

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1113,8 +1113,14 @@ export const permitted = {
   Int8Array: TypedArray('%Int8ArrayPrototype%'),
   Uint16Array: TypedArray('%Uint16ArrayPrototype%'),
   Uint32Array: TypedArray('%Uint32ArrayPrototype%'),
-  Uint8Array: TypedArray('%Uint8ArrayPrototype%'),
   Uint8ClampedArray: TypedArray('%Uint8ClampedArrayPrototype%'),
+  Uint8Array: {
+    ...TypedArray('%Uint8ArrayPrototype%'),
+    // https://github.com/tc39/proposal-arraybuffer-base64
+    fromBase64: fn,
+    // https://github.com/tc39/proposal-arraybuffer-base64
+    fromHex: fn,
+  },
 
   '%BigInt64ArrayPrototype%': TypedArrayPrototype('BigInt64Array'),
   '%BigUint64ArrayPrototype%': TypedArrayPrototype('BigUint64Array'),
@@ -1127,8 +1133,18 @@ export const permitted = {
   '%Int8ArrayPrototype%': TypedArrayPrototype('Int8Array'),
   '%Uint16ArrayPrototype%': TypedArrayPrototype('Uint16Array'),
   '%Uint32ArrayPrototype%': TypedArrayPrototype('Uint32Array'),
-  '%Uint8ArrayPrototype%': TypedArrayPrototype('Uint8Array'),
   '%Uint8ClampedArrayPrototype%': TypedArrayPrototype('Uint8ClampedArray'),
+  '%Uint8ArrayPrototype%': {
+    ...TypedArrayPrototype('Uint8Array'),
+    // https://github.com/tc39/proposal-arraybuffer-base64
+    setFromBase64: fn,
+    // https://github.com/tc39/proposal-arraybuffer-base64
+    setFromHex: fn,
+    // https://github.com/tc39/proposal-arraybuffer-base64
+    toBase64: fn,
+    // https://github.com/tc39/proposal-arraybuffer-base64
+    toHex: fn,
+  },
 
   // *** Keyed Collections
 


### PR DESCRIPTION

Closes: #XXXX
Refs: https://github.com/tc39/proposal-arraybuffer-base64

## Description

https://github.com/tc39/proposal-arraybuffer-base64 is now at stage 3, which means we means many engine implementors will proceed to implement and ship it without hiding it behind a flag. And that we should proceed assuming that it will become an official part of the language.

This proposal adds some methods to `Uint8Array` and `Uint8Array.prototype`. While the proposal proceeded through tc39 we did not see any security problems, so we should simply permit this in `permits.js`. The absence of any mention of these currently in `permits.js` cause ses initialization to warn on platforms which implements this proposal -- like Moddable XS. (In fact, these warnings are what alerted us to the need to repair this absence. The warnings accomplished their purpose.)

### Security Considerations

If these new methods introduced security hazards, then we should list them in `permits.js` as `false`, i.e., expected and removed on purpose, which would also suppress the warnings. However, we do not believe they introduce any hazards, and so are unconditionally permitting them with no repair or attenuation needed.

### Scaling Considerations

Might help any code which needs these methods, as they're likely faster implemented as builtins than in JS.

### Documentation Considerations

One less deviation that would have needed to be documented.

### Testing Considerations

This PR is just permitting standard API that will no doubt come with its own test262 tests that we'll eventually get around to testing under SES.

### Compatibility Considerations

None. It is purely additive.

### Upgrade Considerations

None.
