### PR TITLE
harden-exports error on 'function' keyword

### DIFF
--- a/packages/eslint-plugin/lib/rules/harden-exports.js
+++ b/packages/eslint-plugin/lib/rules/harden-exports.js
@@ -94,7 +94,7 @@ module.exports = {
             const noun = missingHardenCalls.length === 1 ? 'export' : 'exports';
             context.report({
               node: exportNode,
-              message: `The named ${noun} '${missingHardenCalls.join(', ')}' should be followed by a call to 'harden'.`,
+              message: `Named ${noun} '${missingHardenCalls.join(', ')}' should be followed by a call to 'harden'.`,
               fix: function (fixer) {
                 const hardenCalls = missingHardenCalls
                   .map(name => `harden(${name});`)

--- a/packages/eslint-plugin/lib/rules/harden-exports.js
+++ b/packages/eslint-plugin/lib/rules/harden-exports.js
@@ -59,8 +59,11 @@ module.exports = {
                 }
               }
             } else if (exportNode.declaration.type === 'FunctionDeclaration') {
-              // @ts-expect-error xxx typedef
-              exportNames.push(exportNode.declaration.id.name);
+              context.report({
+                node: exportNode,
+                // The 'function' keyword hoisting makes the valuable mutable before it can be hardened.
+                message: `Export '${exportNode.declaration.id.name}' should be a const declaration with an arrow function.`,
+              });
             }
           } else if (exportNode.specifiers) {
             for (const spec of exportNode.specifiers) {

--- a/packages/eslint-plugin/test/harden-exports.test.js
+++ b/packages/eslint-plugin/test/harden-exports.test.js
@@ -20,37 +20,6 @@ harden(b);
   },
   {
     code: `
-export function foo() {
-      console.log("foo");
-  }
-harden(foo);
-export const a = 1;
-harden(a);
-              `,
-  },
-  {
-    code: `
-export const a = 1;
-harden(a);
-export function bar() {
-      console.log("bar");
-  }
-harden(bar);
-              `,
-  },
-  {
-    code: `
-export const a = 1;
-harden(a);
-export function
-  multilineFunction() {
-      console.log("This is a multiline function.");
-  }
-harden(multilineFunction);
-              `,
-  },
-  {
-    code: `
 export const {
   getEnvironmentOption,
   getEnvironmentOptionsList,
@@ -109,14 +78,13 @@ export function foo() {
     errors: [
       {
         message:
-          "The named export 'foo' should be followed by a call to 'harden'.",
+          "Export 'foo' should be a const declaration with an arrow function.",
       },
     ],
     output: `
 export function foo() {
       console.log("foo");
   }
-harden(foo);
               `,
   },
   {
@@ -129,7 +97,7 @@ export function
     errors: [
       {
         message:
-          "The named export 'multilineFunction' should be followed by a call to 'harden'.",
+          "Export 'multilineFunction' should be a const declaration with an arrow function.",
       },
     ],
     output: `
@@ -137,7 +105,6 @@ export function
   multilineFunction() {
       console.log("This is a multiline function.");
   }
-harden(multilineFunction);
               `,
   },
   {
@@ -167,11 +134,11 @@ export function
       },
       {
         message:
-          "The named export 'foo' should be followed by a call to 'harden'.",
+          "Export 'foo' should be a const declaration with an arrow function.",
       },
       {
         message:
-          "The named export 'multilineFunction' should be followed by a call to 'harden'.",
+          "Export 'multilineFunction' should be a const declaration with an arrow function.",
       },
     ],
     output: `
@@ -186,12 +153,10 @@ harden(alreadyHardened);
 export function foo() {
   console.log("foo");
   }
-harden(foo);
 export function
   multilineFunction() {
   console.log("This is a multiline function.");
   }
-harden(multilineFunction);
         `,
   },
   {

--- a/packages/eslint-plugin/test/harden-exports.test.js
+++ b/packages/eslint-plugin/test/harden-exports.test.js
@@ -42,8 +42,7 @@ harden(a);
               `,
     errors: [
       {
-        message:
-          "The named export 'b' should be followed by a call to 'harden'.",
+        message: "Named export 'b' should be followed by a call to 'harden'.",
       },
     ],
     output: `
@@ -60,8 +59,7 @@ export const a = 1;
               `,
     errors: [
       {
-        message:
-          "The named export 'a' should be followed by a call to 'harden'.",
+        message: "Named export 'a' should be followed by a call to 'harden'.",
       },
     ],
     output: `
@@ -125,12 +123,10 @@ export function
         `,
     errors: [
       {
-        message:
-          "The named export 'a' should be followed by a call to 'harden'.",
+        message: "Named export 'a' should be followed by a call to 'harden'.",
       },
       {
-        message:
-          "The named export 'b' should be followed by a call to 'harden'.",
+        message: "Named export 'b' should be followed by a call to 'harden'.",
       },
       {
         message:
@@ -170,7 +166,7 @@ environmentOptionsListHas,
     errors: [
       {
         message:
-          "The named exports 'getEnvironmentOption, getEnvironmentOptionsList, environmentOptionsListHas' should be followed by a call to 'harden'.",
+          "Named exports 'getEnvironmentOption, getEnvironmentOptionsList, environmentOptionsListHas' should be followed by a call to 'harden'.",
       },
     ],
     output: `


### PR DESCRIPTION
_fixup_

## Description

The new `harden-exports` rule should not allow a function defined by the `function` keyword to be exported, because it can't really be hardened. The hoisting allows the value to be mutated by an import before it can be hardened.

### Security Considerations

improvement

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

new tests

### Compatibility Considerations

bug fix

### Upgrade Considerations

not released yet