### PR TITLE
fix(import-bundle): Adapt inescapable compartment mapper constructor

### DIFF
--- a/packages/import-bundle/test/export-inescapable-global.js
+++ b/packages/import-bundle/test/export-inescapable-global.js
@@ -1,0 +1,1 @@
+export default new Compartment().evaluate('inescapableGlobalValue');

--- a/packages/import-bundle/test/import-bundle.test.js
+++ b/packages/import-bundle/test/import-bundle.test.js
@@ -123,3 +123,45 @@ test('inescapable transforms', async t => {
   });
   t.is(ns.f4('is ok'), 'substitution is ok', `iT ns.f4 ok`);
 });
+
+test('inescapable global properties, get export format', async t => {
+  const bundle = await bundleSource(
+    url.fileURLToPath(new URL('export-inescapable-global.js', import.meta.url)),
+    'getExport',
+  );
+
+  const ns = await importBundle(bundle, {
+    inescapableGlobalProperties: {
+      inescapableGlobalValue: 42,
+    },
+  });
+  t.is(ns.default, 42);
+});
+
+test('inescapable global properties, nested evaluate format', async t => {
+  const bundle = await bundleSource(
+    url.fileURLToPath(new URL('export-inescapable-global.js', import.meta.url)),
+    'nestedEvaluate',
+  );
+
+  const ns = await importBundle(bundle, {
+    inescapableGlobalProperties: {
+      inescapableGlobalValue: 42,
+    },
+  });
+  t.is(ns.default, 42);
+});
+
+test.failing('inescapable global properties, zip base64 format', async t => {
+  const bundle = await bundleSource(
+    url.fileURLToPath(new URL('export-inescapable-global.js', import.meta.url)),
+    'endoZipBase64',
+  );
+
+  const ns = await importBundle(bundle, {
+    inescapableGlobalProperties: {
+      inescapableGlobalValue: 42,
+    },
+  });
+  t.is(ns.default, 42);
+});

--- a/packages/import-bundle/test/import-bundle.test.js
+++ b/packages/import-bundle/test/import-bundle.test.js
@@ -152,7 +152,7 @@ test('inescapable global properties, nested evaluate format', async t => {
   t.is(ns.default, 42);
 });
 
-test.failing('inescapable global properties, zip base64 format', async t => {
+test('inescapable global properties, zip base64 format', async t => {
   const bundle = await bundleSource(
     url.fileURLToPath(new URL('export-inescapable-global.js', import.meta.url)),
     'endoZipBase64',

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -579,4 +579,5 @@ export {
   note as annotateError,
   redactedDetails as X,
   quote as q,
+  bare as b,
 };

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -21,7 +21,7 @@ import {
   weakmapGet,
   weakmapHas,
 } from './commons.js';
-import { makeError, annotateError, q, X } from './error/assert.js';
+import { makeError, annotateError, q, b, X } from './error/assert.js';
 
 const noop = () => {};
 
@@ -154,7 +154,7 @@ function* loadWithoutErrorAnnotation(
         'importNowHook',
       );
       throw makeError(
-        X`${moduleHookName} needed to load module ${q(
+        X`${b(moduleHookName)} needed to load module ${q(
           moduleSpecifier,
         )} in compartment ${q(compartment.name)}`,
       );


### PR DESCRIPTION

## Description

Recent changes to align the Compartment constructor in SES with its XS counterpart changed the argument pattern and this broke the interface of all extant wrappers around the Compartment constructor, of which we only know of one. This change fixes that wrapper and restores continuity of compatibility.

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

Inescapable global properties should cover this failure. It’s not yet clear why it did not reveal the failure earlier.

### Compatibility Considerations

Restores compatibility. Reveals that the Compartment change broke more than we anticipated, but not enough to roll back.

### Upgrade Considerations

None.