### PR TITLE
fix(browser-test): Fix web server start script in browser-test

### DIFF
--- a/browser-test/playwright.config.js
+++ b/browser-test/playwright.config.js
@@ -56,7 +56,7 @@ module.exports = defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run start',
+    command: 'node server.js',
     url: 'http://127.0.0.1:3000',
     reuseExistingServer: true,
   },


### PR DESCRIPTION
Fixes the web server start command in `browser-test/playwright.config.js`. Previously it was set to `npm run start`, but there is no script in the corresponding `package.json` named `start`. Instead we execute the server script directly using `node server.js`.