### PR TITLE
feat(ses): ArrayBuffer.prototype.transferToImmutable

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,6 +2,13 @@ User-visible changes in `ses`
 
 # Next release
 
+- Uses the `@endo/immutable-arraybuffer` shim to add `ArrayBuffer.p.immutable`, `ArrayBuffer.p.transferToImmutable`, and `ArrayBuffer.p.sliceToImmutable` to ses, in order to emulate the [Immutable ArrayBuffer proposal](https://github.com/tc39/proposal-immutable-arraybuffer). These make an ArrayBuffer-like object whose contents cannot be mutated. However, due to limitations of the shim
+  - Unlike `ArrayBuffer` and `SharedArrayBuffer` this shim's ArrayBuffer-like object cannot be transfered or cloned between JS threads.
+  - Unlike `ArrayBuffer` and `SharedArrayBuffer`, this shim's ArrayBuffer-like object cannot be used as the backing store of TypeArrays or DataViews.
+  - The shim depends on the platform providing either `structuredClone` or `Array.prototype.transfer`. Node <= 16 and provides neither, causing the shim to fail to initialize, and therefore SES to fail to initialize on such platforms.
+  - Current Hermes has even stronger constraints, lacking `structuredClone`, `transfer`, private fields, and even `class` syntax. This requires other coping strategies. See https://github.com/endojs/endo/pull/2785
+  - Even after the upcoming `transferToImmutable` proposal is implemented by the platform, the current code will still replace it with the shim implementation, in accord with shim best practices. See https://github.com/endojs/endo/pull/2311#discussion_r1632607527 . It will require a later manual step to delete the shim or have it avoid overriting a platform implementation, after manual analysis of the compat implications.
+
 - The [evalTaming](https://github.com/endojs/endo/blob/master/packages/ses/docs/lockdown.md#evaltaming-options)
   option `'safe-eval'` now can only throw error `SES_DIRECT_EVAL`.
   This allows SES to initialize with `'unsafe-eval'` or `'no-eval'` on hosts with no
@@ -40,12 +47,6 @@ User-visible changes in `ses`
   JavaScript implementation, like XS.
 
 # v1.11.0 (2025-01-23)
-
-- Uses the `@endo/immutable-arraybuffer` shim to add `ArrayBuffer.p.immutable`, `ArrayBuffer.p.transferToImmutable`, and `ArrayBuffer.p.sliceToImmutable` to ses, in order to emulate the [Immutable ArrayBuffer proposal](https://github.com/tc39/proposal-immutable-arraybuffer). These make an ArrayBuffer-like object whose contents cannot be mutated. However, due to limitations of the shim
-  - Unlike `ArrayBuffer` and `SharedArrayBuffer` this shim's ArrayBuffer-like object cannot be transfered or cloned between JS threads.
-  - Unlike `ArrayBuffer` and `SharedArrayBuffer`, this shim's ArrayBuffer-like object cannot be used as the backing store of TypeArrays or DataViews.
-  - The shim depends on the platform providing either `structuredClone` or `Array.prototype.transfer`. Node <= 16 provides neither, causing the shim to fail to initialize, and therefore SES to fail to initialize on such platforms.
-  - Even after the upcoming `transferToImmutable` proposal is implemented by the platform, the current code will still replace it with the shim implementation, in accord with shim best practices. See https://github.com/endojs/endo/pull/2311#discussion_r1632607527 . It will require a later manual step to delete the shim, after manual analysis of the compat implications.
 
 - Adds support for dynamic `import` in conjunction with an update to
   `@endo/module-source`.

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -41,6 +41,12 @@ User-visible changes in `ses`
 
 # v1.11.0 (2025-01-23)
 
+- Uses the `@endo/immutable-arraybuffer` shim to add `ArrayBuffer.p.immutable`, `ArrayBuffer.p.transferToImmutable`, and `ArrayBuffer.p.sliceToImmutable` to ses, in order to emulate the [Immutable ArrayBuffer proposal](https://github.com/tc39/proposal-immutable-arraybuffer). These make an ArrayBuffer-like object whose contents cannot be mutated. However, due to limitations of the shim
+  - Unlike `ArrayBuffer` and `SharedArrayBuffer` this shim's ArrayBuffer-like object cannot be transfered or cloned between JS threads.
+  - Unlike `ArrayBuffer` and `SharedArrayBuffer`, this shim's ArrayBuffer-like object cannot be used as the backing store of TypeArrays or DataViews.
+  - The shim depends on the platform providing either `structuredClone` or `Array.prototype.transfer`. Node <= 16 provides neither, causing the shim to fail to initialize, and therefore SES to fail to initialize on such platforms.
+  - Even after the upcoming `transferToImmutable` proposal is implemented by the platform, the current code will still replace it with the shim implementation, in accord with shim best practices. See https://github.com/endojs/endo/pull/2311#discussion_r1632607527 . It will require a later manual step to delete the shim, after manual analysis of the compat implications.
+
 - Adds support for dynamic `import` in conjunction with an update to
   `@endo/module-source`.
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -94,7 +94,8 @@
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'"
   },
   "dependencies": {
-    "@endo/env-options": "workspace:^"
+    "@endo/env-options": "workspace:^",
+    "@endo/immutable-arraybuffer": "workspace:^"
   },
   "devDependencies": {
     "@babel/generator": "^7.26.3",

--- a/packages/ses/scripts/hermes-transforms.js
+++ b/packages/ses/scripts/hermes-transforms.js
@@ -61,11 +61,21 @@ const asyncGeneratorDestroyer = {
   FunctionDeclaration: destroyAsyncGenerators,
 };
 
+// Remove on Hermes since classes and private fields are unsupported on Hermes
+const removeImmutableArrayBufferShim = {
+  ImportDeclaration(path) {
+    if (path.node.source.value === '@endo/immutable-arraybuffer/shim.js') {
+      path.remove();
+    }
+  },
+};
+
 export const hermesTransforms = {
   mjs: (sourceBytes, specifier, location, _packageLocation, { sourceMap }) => {
     const transforms = {
       ...asyncArrowEliminator,
       ...asyncGeneratorDestroyer,
+      ...removeImmutableArrayBufferShim,
       // Some transforms might be added based on the specifier later
     };
 

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -16,6 +16,7 @@ import {
   globalThis,
   assign,
   AsyncGeneratorFunctionInstance,
+  ArrayBuffer,
 } from './commons.js';
 import { InertCompartment } from './compartment.js';
 
@@ -164,6 +165,16 @@ export const getAnonymousIntrinsics = () => {
       // eslint-disable-next-line @endo/no-polymorphic-call
       globalThis.AsyncIterator.from({ next() {} }),
     );
+  }
+
+  const ab = new ArrayBuffer(0);
+  // @ts-expect-error TODO How do I add transferToImmutable to ArrayBuffer type?
+  // eslint-disable-next-line @endo/no-polymorphic-call
+  const iab = ab.transferToImmutable();
+  const iabProto = getPrototypeOf(iab);
+  if (iabProto !== ArrayBuffer.prototype) {
+    // In a native implementation, these will be the same prototype
+    intrinsics['%ImmutableArrayBufferPrototype%'] = iabProto;
   }
 
   return intrinsics;

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -168,13 +168,16 @@ export const getAnonymousIntrinsics = () => {
   }
 
   const ab = new ArrayBuffer(0);
-  // @ts-expect-error TODO How do I add transferToImmutable to ArrayBuffer type?
-  // eslint-disable-next-line @endo/no-polymorphic-call
-  const iab = ab.transferToImmutable();
-  const iabProto = getPrototypeOf(iab);
-  if (iabProto !== ArrayBuffer.prototype) {
-    // In a native implementation, these will be the same prototype
-    intrinsics['%ImmutableArrayBufferPrototype%'] = iabProto;
+  // @ts-expect-error see below
+  if (typeof ab.transferToImmutable === 'function') {
+    // @ts-expect-error TODO How do I add transferToImmutable to ArrayBuffer type?
+    // eslint-disable-next-line @endo/no-polymorphic-call
+    const iab = ab.transferToImmutable();
+    const iabProto = getPrototypeOf(iab);
+    if (iabProto !== ArrayBuffer.prototype) {
+      // In a native implementation, these will be the same prototype
+      intrinsics['%ImmutableArrayBufferPrototype%'] = iabProto;
+    }
   }
 
   return intrinsics;

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -15,6 +15,7 @@
 // @ts-check
 
 import { getEnvironmentOption as getenv } from '@endo/env-options';
+import '@endo/immutable-arraybuffer/shim.js';
 import {
   FERAL_FUNCTION,
   FERAL_EVAL,

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1358,6 +1358,33 @@ export const permitted = {
     // https://github.com/tc39/proposal-arraybuffer-transfer
     transferToFixedLength: fn,
     detached: getter,
+    // https://github.com/endojs/endo/pull/2309#issuecomment-2155513240
+    // to be proposed
+    transferToImmutable: fn,
+    sliceToImmutable: fn,
+    immutable: getter,
+  },
+
+  // If this exists, it is purely an artifact of how we currently shim
+  // `transferToImmutable`. As natively implemented, there would be no
+  // such extra prototype.
+  '%ImmutableArrayBufferPrototype%': {
+    '[[Proto]]': '%ArrayBufferPrototype%',
+    byteLength: getter,
+    slice: fn,
+    // See https://github.com/tc39/proposal-resizablearraybuffer
+    transfer: fn,
+    resize: fn,
+    resizable: getter,
+    maxByteLength: getter,
+    // https://github.com/tc39/proposal-arraybuffer-transfer
+    transferToFixedLength: fn,
+    detached: getter,
+    // https://github.com/endojs/endo/pull/2309#issuecomment-2155513240
+    // to be proposed
+    transferToImmutable: fn,
+    sliceToImmutable: fn,
+    immutable: getter,
   },
 
   // SharedArrayBuffer Objects

--- a/packages/ses/test/immutable-array-buffer.test.js
+++ b/packages/ses/test/immutable-array-buffer.test.js
@@ -1,0 +1,14 @@
+import test from 'ava';
+import '../index.js';
+
+const { isFrozen, getPrototypeOf } = Object;
+
+lockdown();
+
+test('ses Immutable ArrayBuffer shim installed and hardened', t => {
+  const ab1 = new ArrayBuffer(0);
+  const iab = ab1.transferToImmutable();
+  const iabProto = getPrototypeOf(iab);
+  t.true(isFrozen(iabProto));
+  t.true(isFrozen(iabProto.slice));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,7 +592,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer":
+"@endo/immutable-arraybuffer@workspace:^, @endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer":
   version: 0.0.0-use.local
   resolution: "@endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer"
   dependencies:
@@ -9926,6 +9926,7 @@ __metadata:
     "@babel/types": "npm:~7.26.0"
     "@endo/compartment-mapper": "workspace:^"
     "@endo/env-options": "workspace:^"
+    "@endo/immutable-arraybuffer": "workspace:^"
     "@endo/module-source": "workspace:^"
     "@endo/test262-runner": "workspace:^"
     "@types/babel__traverse": "npm:^7.20.5"


### PR DESCRIPTION
Closes: #XXXX
Refs: #XXXX

## Description

Now that the Immutable ArrayBuffer proposal is at 2.7 and looks likely to proceed to 3, and then on to 4 and the official language, we are now allowing ourselves to build on the shim to emulate it already being in the language. In this PR ses imports the shim (not just the ponyfill) and then permits it's additions as harmless for ses users.

### Security Considerations

We carefully designed the proposal to maintain our high security standards. Likewise, in our shim, an Immutable ArrayBuffer encapsulates a normal mutable ArrayBuffer. But it is careful not to mutate it or to let it escape. The shim is low fidelity in terms of what it must practically omit --- TypedArrays and DavaView backed by Immutable ArrayBuffers. But these omissions do not raise security hazards, only compat hazards.

### Scaling Considerations

Because Immutable ArrayBuffers obviate the need for defensive copying and support safe zero-copy sharing, it will help scalability.

- [ ] When on XS, we should somehow arrange to use its high-speed high-fidelity highly tested Immutable ArrayBuffer implementation. We should also figure out our migration strategy as other engines of interest ship their own standards compliant implementations. All these steps will help scaling immensely. But it is unclear how to handle the transition.

### Documentation Considerations

Mostly, we can just point at the docs for Immutable ArrayBuffer itself, currently in the proposal and soon in the JS standard.

### Testing Considerations

The XS native Immutable ArrayBuffer implementation is also highly tested by the test262 tests in the PR they submitted, which will also test other native implementations.

- [ ] Our shim is not highly tested. We should somehow test it against the relevant subset of those submitted test262 tests.

### Compatibility Considerations

The shim is low fidelity in terms of what it omits from the standard. The shim is also low fidelity in that it cannot hide an internal shim implementation artifact, the hidden prototype that all and only Immutable ArrayBuffers share. A correct implementation of the proposal will have no such extra prototype object.

### Upgrade Considerations

- [x] Update `NEWS.md` for user-facing changes.
