### PR TITLE
fix(ses): make test insensitive to an irrelevant env var

### DIFF
--- a/packages/ses/test/enable-default-overrides-default.test.js
+++ b/packages/ses/test/enable-default-overrides-default.test.js
@@ -1,7 +1,10 @@
 import '../index.js';
 import test from 'ava';
 
-lockdown({ __hardenTaming__: 'safe' });
+lockdown({
+  overrideTaming: 'moderate',
+  __hardenTaming__: 'safe',
+});
 
 // See https://github.com/endojs/endo/issues/616#issuecomment-800733101
 

--- a/packages/ses/test/enable-property-overrides-default-unsafeError.test.js
+++ b/packages/ses/test/enable-property-overrides-default-unsafeError.test.js
@@ -2,7 +2,11 @@ import '../index.js';
 import test from 'ava';
 import { overrideTester } from './override-tester.js';
 
-lockdown({ errorTaming: 'unsafe', __hardenTaming__: 'safe' });
+lockdown({
+  errorTaming: 'unsafe',
+  overrideTaming: 'moderate',
+  __hardenTaming__: 'safe',
+});
 
 test('property overrides default with unsafe errorTaming', t => {
   overrideTester(t, 'Error', Error(), [

--- a/packages/ses/test/enable-property-overrides-default.test.js
+++ b/packages/ses/test/enable-property-overrides-default.test.js
@@ -2,7 +2,11 @@ import '../index.js';
 import test from 'ava';
 import { overrideTester } from './override-tester.js';
 
-lockdown({ errorTaming: 'safe', __hardenTaming__: 'safe' });
+lockdown({
+  errorTaming: 'safe',
+  overrideTaming: 'moderate',
+  __hardenTaming__: 'safe',
+});
 
 test('enablePropertyOverrides - on', t => {
   overrideTester(t, 'Object', {}, ['toString', 'valueOf']);


### PR DESCRIPTION

Closes: #XXXX
Refs: #2383 

## Description

Of the various property override tests, the ones testing the default `'moderate'` setting were calling `lockdown` without an `overrideTaming` option, counting on it to default to `'moderate'`. However, if run locally in an environment where the environment variable `LOCKDOWN_OVERRIDE_TAMING` was set to something else, the test would pointlessly misbehave.

This PR merely sets the option explicitly for those cases, so the tests for the `'moderate'` case are as insensitive to environment variables as the tests for the other cases.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

The point. The code before this PR would always work correctly under CI. But the test may pointless fail locally depending on the developers environment variable settings.
### Compatibility Considerations

none
### Upgrade Considerations

none