### PR TITLE
types misc, Passable, fix EProxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ dist/
 /packages-graph*
 api-docs
 
+.aider*

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -36,7 +36,7 @@ const baseFreezableProxyHandler = {
  *
  * @param {any} recipient Any value passed to E(x)
  * @param {import('./types').HandledPromiseConstructor} HandledPromise
- * @returns {ProxyHandler} the Proxy handler
+ * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeEProxyHandler = (recipient, HandledPromise) =>
   harden({
@@ -48,6 +48,7 @@ const makeEProxyHandler = (recipient, HandledPromise) =>
           // In order to be `this` sensitive it is defined using concise method
           // syntax rather than as an arrow function. To ensure the function
           // is not constructable, it also avoids the `function` syntax.
+          /** @type {(...args: any[]) => Promise<unknown>} */
           [propertyKey](...args) {
             if (this !== receiver) {
               // Reject the async function call
@@ -96,7 +97,7 @@ const makeEProxyHandler = (recipient, HandledPromise) =>
  *
  * @param {any} recipient Any value passed to E.sendOnly(x)
  * @param {import('./types').HandledPromiseConstructor} HandledPromise
- * @returns {ProxyHandler} the Proxy handler
+ * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
   harden({
@@ -108,6 +109,7 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
           // In order to be `this` sensitive it is defined using concise method
           // syntax rather than as an arrow function. To ensure the function
           // is not constructable, it also avoids the `function` syntax.
+          /** @type {(...args: any[]) => undefined} */
           [propertyKey](...args) {
             // Throw since the function returns nothing
             this === receiver ||
@@ -152,7 +154,7 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
  *
  * @param {any} x Any value passed to E.get(x)
  * @param {import('./types').HandledPromiseConstructor} HandledPromise
- * @returns {ProxyHandler} the Proxy handler
+ * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeEGetProxyHandler = (x, HandledPromise) =>
   harden({
@@ -176,6 +178,7 @@ const makeE = HandledPromise => {
        * @param {T} x target for method/function call
        * @returns {ECallableOrMethods<RemoteFunctions<T>>} method/function call proxy
        */
+      // @ts-expect-error XXX typedef
       x => harden(new Proxy(() => {}, makeEProxyHandler(x, HandledPromise))),
       {
         /**
@@ -190,6 +193,7 @@ const makeE = HandledPromise => {
          * @readonly
          */
         get: x =>
+          // @ts-expect-error XXX typedef
           harden(
             new Proxy(create(null), makeEGetProxyHandler(x, HandledPromise)),
           ),
@@ -215,6 +219,7 @@ const makeE = HandledPromise => {
          * @readonly
          */
         sendOnly: x =>
+          // @ts-expect-error XXX typedef
           harden(
             new Proxy(() => {}, makeESendOnlyProxyHandler(x, HandledPromise)),
           ),

--- a/packages/eventual-send/src/exports.test-d.ts
+++ b/packages/eventual-send/src/exports.test-d.ts
@@ -64,3 +64,8 @@ E.when(
 ).then(result => {
   expectType<{ something: string }>(result);
 });
+
+{
+  const local = { getVal: () => 'val' };
+  expectType<Promise<string>>(E(local).getVal());
+}

--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -115,12 +115,13 @@ export const makeHandledPromise = () => {
    * @type {Required<Handler<any>>}
    */
   let forwardingHandler;
+  /** @type {(...args: any[]) => Promise<unknown>} */
   let handle;
 
   /**
    * @param {string} handlerName
    * @param {Handler<any>} handler
-   * @param {string} operation
+   * @param {keyof Handler<any>} operation
    * @param {any} o
    * @param {any[]} opArgs
    * @param {Promise<unknown>} [returnedP]
@@ -147,7 +148,9 @@ export const makeHandledPromise = () => {
 
     if (matchSendOnly && typeof handler[actualOp] !== 'function') {
       // Substitute for sendonly with the corresponding non-sendonly operation.
-      actualOp = matchSendOnly[1];
+      actualOp = /** @type {'get' | 'applyMethod' | 'applyFunction'} */ (
+        matchSendOnly[1]
+      );
     }
 
     // Fast path: just call the actual operation.
@@ -207,6 +210,7 @@ export const makeHandledPromise = () => {
     let handledReject;
     let resolved = false;
     let resolvedTarget = null;
+    /** @type {Promise<R>} */
     let handledP;
     let continueForwarding = () => {};
     const assertNotYetForwarded = () => {
@@ -379,7 +383,7 @@ export const makeHandledPromise = () => {
    * must not have any own properties. The requirements are otherwise
    * identical.
    *
-   * @param {Promise} p
+   * @param {Promise<unknown>} p
    * @returns {boolean}
    */
   const isSafePromise = p => {
@@ -439,6 +443,7 @@ export const makeHandledPromise = () => {
       }
       // Assimilate the `resolvedPromise` as an actual frozen Promise, by
       // treating `resolvedPromise` as if it is a non-promise thenable.
+      /** @type {Promise['then']} */
       const executeThen = (resolve, reject) =>
         resolvedPromise.then(resolve, reject);
       return harden(
@@ -497,6 +502,7 @@ export const makeHandledPromise = () => {
       // We run in a future turn to prevent synchronous attacks,
       let raceIsOver = false;
 
+      /** @type {(handlerName: string, handler: any, o: any) => any} */
       const win = (handlerName, handler, o) => {
         if (raceIsOver) {
           return;
@@ -509,6 +515,7 @@ export const makeHandledPromise = () => {
         raceIsOver = true;
       };
 
+      /** @type {(reason: unknown) => void} */
       const lose = reason => {
         if (raceIsOver) {
           return;

--- a/packages/eventual-send/src/types.d.ts
+++ b/packages/eventual-send/src/types.d.ts
@@ -17,7 +17,7 @@ export type * from './track-turns.js';
 //   Types exposed to modules.
 //
 
-export type Callable = (...args: unknown[]) => any;
+export type Callable = (...args: any[]) => any;
 
 /**
  * Nominal type to carry the local and remote interfaces of a Remotable.

--- a/packages/eventual-send/tsconfig.json
+++ b/packages/eventual-send/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
+    "strict": true,
     "noImplicitAny": false,
     "useUnknownInCatchVariables": false,
     "skipLibCheck": false

--- a/packages/exo/test/types.test-d.ts
+++ b/packages/exo/test/types.test-d.ts
@@ -1,0 +1,18 @@
+import { expectAssignable } from 'tsd';
+
+import type { Passable } from '@endo/pass-style';
+
+import { defineExoClassKit, makeExo } from '../src/exo-makers.js';
+
+const exo = makeExo('foo', undefined, { sayHi: () => 'hi' });
+
+expectAssignable<Passable>(exo);
+expectAssignable<Passable>({ foo: exo });
+// @ts-expect-error functions not passable
+expectAssignable<Passable>(exo.sayHi);
+
+const exoKit = defineExoClassKit('foo', undefined, () => {}, {
+  public: { sayHi: () => 'hi' },
+})();
+expectAssignable<Passable>(exoKit);
+expectAssignable<Passable>(exoKit.public);

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -64,7 +64,7 @@ export type PassByRef =
  * and is classified by PassStyle:
  *   * Atomic primitive values have a PrimitiveStyle (PassStyle
  *     'undefined' | 'null' | 'boolean' | 'number' | 'bigint'
- *     | 'string' | 'symbol').
+ *     | 'string' | 'symbol'). (Passable considers `void` to be `undefined`.)
  *   * Containers aggregate other Passables into
  *     * sequences as CopyArrays (PassStyle 'copyArray'), or
  *     * string-keyed dictionaries as CopyRecords (PassStyle 'copyRecord'), or
@@ -82,7 +82,7 @@ export type PassByRef =
 export type Passable<
   PC extends PassableCap = PassableCap,
   E extends Error = Error,
-> = Primitive | Container<PC, E> | PC | E;
+> = void | Primitive | Container<PC, E> | PC | E;
 
 export type Container<PC extends PassableCap, E extends Error> =
   | CopyArrayI<PC, E>

--- a/packages/pass-style/src/types.test-d.ts
+++ b/packages/pass-style/src/types.test-d.ts
@@ -40,3 +40,19 @@ expectPassable('str');
 expectPassable(undefined);
 // void is really `undefined`, and thus Passable
 expectPassable(fn());
+
+expectPassable({});
+expectPassable({ a: {} });
+// @ts-expect-error not passable
+expectPassable(fn);
+// FIXME promise for a non-Passable is not Passable
+expectPassable(Promise.resolve(fn));
+// @ts-expect-error not passable
+expectPassable({ a: { b: fn } });
+
+expectPassable(remotable);
+expectPassable({ a: remotable });
+expectPassable(copyTagged);
+expectPassable(Promise.resolve(remotable));
+expectPassable({ a: Promise.resolve(remotable) });
+expectPassable({ a: Promise.resolve(fn) });

--- a/packages/pass-style/src/types.test-d.ts
+++ b/packages/pass-style/src/types.test-d.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
-import { expectType, expectNotType } from 'tsd';
+import { expectAssignable, expectType, expectNotType } from 'tsd';
 import { Far } from './make-far';
 import { passStyleOf } from './passStyleOf';
 import { makeTagged } from './makeTagged';
-import { CopyTagged, PassStyle } from './types';
+import { CopyTagged, Passable, PassStyle } from './types';
 import { PASS_STYLE } from './passStyle-helpers';
 
 const remotable = Far('foo', {});
@@ -29,3 +29,14 @@ expectType<'copyRecord'>(passStyleOf({}));
 expectType<'copyRecord'>(passStyleOf({ [PASS_STYLE]: 'arbitrary' } as const));
 expectType<'remotable'>(passStyleOf(remotable));
 expectType<PassStyle>(passStyleOf(someUnknown));
+
+const expectPassable = (val: Passable) => {};
+
+const fn = () => {};
+
+expectPassable(1);
+expectPassable(null);
+expectPassable('str');
+expectPassable(undefined);
+// void is really `undefined`, and thus Passable
+expectPassable(fn());

--- a/packages/promise-kit/index.js
+++ b/packages/promise-kit/index.js
@@ -40,9 +40,9 @@ harden(makePromiseKit);
  * Unlike `Promise.race` it cleans up after itself so a non-resolved value doesn't hold onto
  * the result promise.
  *
- * @template T
- * @param {Iterable<T>} values An iterable of Promises.
- * @returns {Promise<Awaited<T>>} A new Promise.
+ * @template {readonly unknown[] | []} T
+ * @param {T} values An iterable of Promises.
+ * @returns {Promise<Awaited<T[number]>>} A new Promise.
  */
 export function racePromises(values) {
   return harden(memoRace.call(BestPipelinablePromise, values));

--- a/packages/promise-kit/src/memo-race.js
+++ b/packages/promise-kit/src/memo-race.js
@@ -111,15 +111,16 @@ const { race } = {
    * Unlike `Promise.race` it cleans up after itself so a non-resolved value doesn't hold onto
    * the result promise.
    *
-   * @template T
+   * @template {readonly unknown[] | []} T
    * @template {PromiseConstructor} [P=PromiseConstructor]
    * @this {P}
-   * @param {Iterable<T>} values An iterable of Promises.
-   * @returns {Promise<Awaited<T>>} A new Promise.
+   * @param {T} values An iterable of Promises.
+   * @returns {Promise<Awaited<T[number]>>} A new Promise.
    */
   race(values) {
     let deferred;
-    /** @type {T[]} */
+    /** @type {[...T]} */
+    // @ts-expect-error filled by the loop
     const cachedValues = [];
     const C = this;
     const result = new C((resolve, reject) => {

--- a/packages/promise-kit/tsconfig.json
+++ b/packages/promise-kit/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.eslint-base.json",
   "compilerOptions": {
-    "checkJs": true
+    "checkJs": true,
+    "strictFunctionTypes": true
   },
   "include": [
     "*.js",

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -213,8 +213,10 @@ export const stringReplace = /** @type {any} */ (
 );
 export const stringSearch = uncurryThis(stringPrototype.search);
 export const stringSlice = uncurryThis(stringPrototype.slice);
-/** @type {(thisArg: string, splitter: string | RegExp | { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number) => string[]} */
-export const stringSplit = uncurryThis(stringPrototype.split);
+export const stringSplit =
+  /** @type {(thisArg: string, splitter: string | RegExp | { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number) => string[]} */ (
+    uncurryThis(stringPrototype.split)
+  );
 export const stringStartsWith = uncurryThis(stringPrototype.startsWith);
 export const iterateString = uncurryThis(stringPrototype[iteratorSymbol]);
 //

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -10,7 +10,7 @@ import { repairIntrinsics } from './lockdown.js';
 /** @import {LockdownOptions} from '../types.js' */
 
 /**
- * @param {LockdownOptions} options
+ * @param {LockdownOptions} [options]
  */
 globalThis.lockdown = options => {
   const hardenIntrinsics = repairIntrinsics(options);
@@ -18,7 +18,7 @@ globalThis.lockdown = options => {
 };
 
 /**
- * @param {LockdownOptions} options
+ * @param {LockdownOptions} [options]
  */
 globalThis.repairIntrinsics = options => {
   const hardenIntrinsics = repairIntrinsics(options);

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -273,6 +273,7 @@ export const repairIntrinsics = (options = {}) => {
   const { addIntrinsics, completePrototypes, finalIntrinsics } =
     makeIntrinsicsCollector();
 
+  // @ts-expect-error __hardenTaming__ could be any string
   const tamedHarden = tameHarden(safeHarden, __hardenTaming__);
   addIntrinsics({ harden: tamedHarden });
 

--- a/packages/ses/src/tame-harden.js
+++ b/packages/ses/src/tame-harden.js
@@ -1,6 +1,9 @@
 /* eslint-disable no-restricted-globals */
 import { TypeError, freeze } from './commons.js';
 
+/** @import {Harden} from '../types.js'; */
+
+/** @type {(safeHarden: Harden, hardenTaming: 'safe' | 'unsafe') => Harden} */
 export const tameHarden = (safeHarden, hardenTaming) => {
   if (hardenTaming !== 'safe' && hardenTaming !== 'unsafe') {
     throw TypeError(`unrecognized fakeHardenOption ${hardenTaming}`);
@@ -16,6 +19,7 @@ export const tameHarden = (safeHarden, hardenTaming) => {
   Object.isSealed = () => true;
   Reflect.isExtensible = () => false;
 
+  // @ts-expect-error secret property
   if (safeHarden.isFake) {
     // The "safe" hardener is already a fake hardener.
     // Just use it.

--- a/packages/ses/tsconfig.json
+++ b/packages/ses/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.eslint-base.json",
   "compilerOptions": {
-    "allowJs": true
+    "allowJs": true,
+    "strictFunctionTypes": true,
   },
   "include": [
     "*.js",


### PR DESCRIPTION
_incidental_


## Description

I was exploring why `tsc` is so slow in agoric-sdk and read that `"strictFunctionTypes": true` might offer a significant speed bump. With that I ran into some problems with `EProxy` that its methods were `never`. That was because the `Callable` type expect `...args: unknown[]` and real values aren't. `unknown` shouldn't be used as a test for extension. The fix was to make it `...args: any[]`.

This does that, and a bunch of other changes that came up while exploring.

The change for Aider is completely unrelated but didn't seem worth its own PR.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

CI

### Compatibility Considerations

Fixes types bugs

### Upgrade Considerations

Will be noted in conventional commits changelog