### PR TITLE
feat(pass-style,marshal): ByteArray, a binary Passable

### DIFF
--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -10,7 +10,7 @@ import {
 } from '@endo/pass-style';
 
 /**
- * @import {CopyRecord, PassStyle, Passable, RemotableObject as Remotable} from '@endo/pass-style'
+ * @import {CopyRecord, PassStyle, Passable, RemotableObject as Remotable, ByteArray} from '@endo/pass-style'
  */
 
 import { b, q, Fail } from '@endo/errors';
@@ -462,6 +462,17 @@ const decodeLegacyArray = (encoded, decodePassable, skip = 0) => {
   return harden(elements);
 };
 
+/**
+ * @param {ByteArray} byteArray
+ * @param {(byteArray: ByteArray) => string} _encodePassable
+ * @returns {string}
+ */
+const encodeByteArray = (byteArray, _encodePassable) => {
+  // TODO implement
+  Fail`encodePassable(copyData) not yet implemented: ${byteArray}`;
+  return ''; // Just for the type
+};
+
 const encodeRecord = (record, encodeArray, encodePassable) => {
   const names = recordNames(record);
   const values = recordValues(record, names);
@@ -625,6 +636,9 @@ const makeInnerEncode = (encodeStringSuffix, encodeArray, options) => {
       }
       case 'copyArray': {
         return encodeArray(passable, innerEncode);
+      }
+      case 'byteArray': {
+        return encodeByteArray(passable, innerEncode);
       }
       case 'copyRecord': {
         return encodeRecord(passable, encodeArray, innerEncode);
@@ -870,6 +884,7 @@ export const passStylePrefixes = {
   tagged: ':',
   promise: '?',
   copyArray: '[^',
+  byteArray: 'a',
   boolean: 'b',
   number: 'f',
   bigint: 'np',

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -194,6 +194,10 @@ export const makeEncodeToCapData = (encodeOptions = {}) => {
       case 'copyArray': {
         return passable.map(encodeToCapDataRecur);
       }
+      case 'byteArray': {
+        // TODO implement
+        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+      }
       case 'tagged': {
         return {
           [QCLASS]: 'tagged',

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -229,6 +229,10 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
       case 'copyArray': {
         return passable.map(encodeToSmallcapsRecur);
       }
+      case 'byteArray': {
+        // TODO implement
+        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+      }
       case 'tagged': {
         return {
           '#tag': encodeToSmallcapsRecur(getTag(passable)),

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -55,6 +55,8 @@ export const trivialComparator = (left, right) =>
 const passStyleRanks = /** @type {PassStyleRanksRecord} */ (
   fromEntries(
     entries(passStylePrefixes)
+      // TODO Until byteArray prefix is chosen
+      .filter(([_style, prefixes]) => prefixes.length >= 1)
       // Sort entries by ascending prefix.
       .sort(([_leftStyle, leftPrefixes], [_rightStyle, rightPrefixes]) => {
         return trivialComparator(leftPrefixes, rightPrefixes);
@@ -208,6 +210,26 @@ export const makeComparatorKit = (compareRemotables = (_x, _y) => NaN) => {
         // If all matching elements were tied, then according to their lengths.
         // If array X is a prefix of array Y, then X has an earlier rank than Y.
         return comparator(left.length, right.length);
+      }
+      case 'byteArray': {
+        const leftArray = new Uint8Array(left.slice(0));
+        const rightArray = new Uint8Array(right.slice(0));
+        const byteLen = Math.min(left.byteLength, right.byteLength);
+        for (let i = 0; i < byteLen; i += 1) {
+          const leftByte = leftArray[i];
+          const rightByte = rightArray[i];
+          if (leftByte < rightByte) {
+            return -1;
+          }
+          if (leftByte > rightByte) {
+            return 1;
+          }
+        }
+        // If all corresponding bytes are the same,
+        // then according to their lengths.
+        // Thus, if the data of ByteArray X is a prefix of
+        // the data of ByteArray Y, then X is smaller than Y.
+        return comparator(left.byteLength, right.byteLength);
       }
       case 'tagged': {
         // Lexicographic by `[Symbol.toStringTag]` then `.payload`.

--- a/packages/marshal/test/marshal-stringify.test.js
+++ b/packages/marshal/test/marshal-stringify.test.js
@@ -38,11 +38,13 @@ test('marshal stringify errors', t => {
     t.throws(() => stringify({}), {
       message: /Cannot pass non-frozen objects like .*. Use harden()/,
     });
-    // @ts-expect-error intentional error
+    // at-ts-ignore rather than at-expect-error because of disagreement
+    // @ts-ignore intentional error
     t.throws(() => stringify(harden(new Uint8Array(1))), {
       message: 'Cannot pass mutable typed arrays like "[Uint8Array]".',
     });
-    // @ts-expect-error intentional error
+    // at-ts-ignore rather than at-expect-error because of disagreement
+    // @ts-ignore intentional error
     t.throws(() => stringify(harden(new Int16Array(1))), {
       message: 'Cannot pass mutable typed arrays like "[Int16Array]".',
     });

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -37,7 +37,9 @@
     "@endo/env-options": "workspace:^",
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
-    "@endo/promise-kit": "workspace:^"
+    "@endo/immutable-arraybuffer": "workspace:^",
+    "@endo/promise-kit": "workspace:^",
+    "@fast-check/ava": "^1.1.5"
   },
   "devDependencies": {
     "@endo/init": "workspace:^",

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -1,0 +1,57 @@
+import { X } from '@endo/errors';
+import {
+  transferBufferToImmutable,
+  isBufferImmutable,
+} from '@endo/immutable-arraybuffer';
+import { assertChecker } from './passStyle-helpers.js';
+
+const { getPrototypeOf, getOwnPropertyDescriptor } = Object;
+const { ownKeys, apply } = Reflect;
+
+const AnImmutableArrayBuffer = transferBufferToImmutable(new ArrayBuffer(0));
+
+/**
+ * As proposed, this will be the same as `ArrayBuffer.prototype`. As shimmed,
+ * this will be a hidden intrinsic that inherits from `ArrayBuffer.prototype`.
+ * Either way, get this in a way that we can trust it after lockdown, and
+ * require that all immutable ArrayBuffers directly inherit from it.
+ */
+const ImmutableArrayBufferPrototype = getPrototypeOf(AnImmutableArrayBuffer);
+
+// @ts-expect-error ok to implicitly assert the access is found
+const immutableGetter = getOwnPropertyDescriptor(
+  ImmutableArrayBufferPrototype,
+  'immutable',
+).get;
+
+/**
+ * @param {unknown} candidate
+ * @param {import('./types.js').Checker} [check]
+ * @returns {boolean}
+ */
+const canBeValid = (candidate, check = undefined) =>
+  (candidate instanceof ArrayBuffer && isBufferImmutable(candidate)) ||
+  (!!check && check(false, X`Immutable ArrayBuffer expected: ${candidate}`));
+
+/**
+ * @type {import('./internal-types.js').PassStyleHelper}
+ */
+export const ByteArrayHelper = harden({
+  styleName: 'byteArray',
+
+  canBeValid,
+
+  assertValid: (candidate, _passStyleOfRecur) => {
+    canBeValid(candidate, assertChecker);
+    getPrototypeOf(candidate) === ImmutableArrayBufferPrototype ||
+      assert.fail(X`Malformed ByteArray ${candidate}`, TypeError);
+    // @ts-expect-error assume immutableGetter was found
+    apply(immutableGetter, candidate, []) ||
+      assert.fail(X`Must be an immutable ArrayBuffer: ${candidate}`);
+    ownKeys(candidate).length === 0 ||
+      assert.fail(
+        X`ByteArrays must not have own properties: ${candidate}`,
+        TypeError,
+      );
+  },
+});

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -3,7 +3,6 @@ import {
   transferBufferToImmutable,
   isBufferImmutable,
 } from '@endo/immutable-arraybuffer';
-import { assertChecker } from './passStyle-helpers.js';
 
 const { getPrototypeOf, getOwnPropertyDescriptor } = Object;
 const { ownKeys, apply } = Reflect;
@@ -25,24 +24,16 @@ const immutableGetter = getOwnPropertyDescriptor(
 ).get;
 
 /**
- * @param {unknown} candidate
- * @param {import('./types.js').Checker} [check]
- * @returns {boolean}
- */
-const canBeValid = (candidate, check = undefined) =>
-  (candidate instanceof ArrayBuffer && isBufferImmutable(candidate)) ||
-  (!!check && check(false, X`Immutable ArrayBuffer expected: ${candidate}`));
-
-/**
  * @type {import('./internal-types.js').PassStyleHelper}
  */
 export const ByteArrayHelper = harden({
   styleName: 'byteArray',
 
-  canBeValid,
+  canBeValid: (candidate, check = undefined) =>
+    (candidate instanceof ArrayBuffer && isBufferImmutable(candidate)) ||
+    (!!check && check(false, X`Immutable ArrayBuffer expected: ${candidate}`)),
 
-  assertValid: (candidate, _passStyleOfRecur) => {
-    canBeValid(candidate, assertChecker);
+  assertRestValid: (candidate, _passStyleOfRecur) => {
     getPrototypeOf(candidate) === ImmutableArrayBufferPrototype ||
       assert.fail(X`Malformed ByteArray ${candidate}`, TypeError);
     // @ts-expect-error assume immutableGetter was found

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -6,7 +6,7 @@ import { passStyleOf } from './passStyleOf.js';
 import { makeTagged } from './makeTagged.js';
 
 /**
- * @import {Passable, Primitive, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'
+ * @import {Passable, ByteArray, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'
  */
 
 const { ownKeys } = Reflect;
@@ -104,6 +104,13 @@ export const deeplyFulfilled = async val => {
       const valPs = arr.map(p => deeplyFulfilled(p));
       // @ts-expect-error not assignable to type 'DeeplyAwaited<T>'
       return E.when(Promise.all(valPs), vals => harden(vals));
+    }
+    case 'byteArray': {
+      const bytes = /** @type {ByteArray} */ (val);
+      // @ts-expect-error Why
+      // "Type 'ArrayBuffer' is not assignable to type 'DeeplyAwaited<T>'."?
+      // TODO fix.
+      return bytes;
     }
     case 'tagged': {
       const tgd = /** @type {CopyTagged} */ (val);

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -12,6 +12,7 @@ import {
 } from './passStyle-helpers.js';
 
 import { CopyArrayHelper } from './copyArray.js';
+import { ByteArrayHelper } from './byteArray.js';
 import { CopyRecordHelper } from './copyRecord.js';
 import { TaggedHelper } from './tagged.js';
 import {
@@ -48,6 +49,7 @@ const makeHelperTable = passStyleHelpers => {
   const HelperTable = {
     __proto__: null,
     copyArray: undefined,
+    byteArray: undefined,
     copyRecord: undefined,
     tagged: undefined,
     error: undefined,
@@ -236,6 +238,7 @@ export const passStyleOf =
   (globalThis && globalThis[PassStyleOfEndowmentSymbol]) ||
   makePassStyleOf([
     CopyArrayHelper,
+    ByteArrayHelper,
     CopyRecordHelper,
     TaggedHelper,
     ErrorHelper,

--- a/packages/pass-style/src/typeGuards.js
+++ b/packages/pass-style/src/typeGuards.js
@@ -60,9 +60,9 @@ harden(assertCopyArray);
 
 /**
  * @callback AssertByteArray
- * @param {Passable} array
+ * @param {Passable} arr
  * @param {string=} optNameOfArray
- * @returns {asserts array is ByteArray}
+ * @returns {asserts arr is ByteArray}
  */
 
 /** @type {AssertByteArray} */

--- a/packages/pass-style/src/typeGuards.js
+++ b/packages/pass-style/src/typeGuards.js
@@ -59,19 +59,16 @@ const assertCopyArray = (arr, optNameOfArray = 'Alleged array') => {
 harden(assertCopyArray);
 
 /**
- * @callback AssertByteArray
  * @param {Passable} arr
  * @param {string=} optNameOfArray
  * @returns {asserts arr is ByteArray}
  */
-
-/** @type {AssertByteArray} */
-const assertByteArray = (array, optNameOfArray = 'Alleged byteArray') => {
-  const passStyle = passStyleOf(array);
+const assertByteArray = (arr, optNameOfArray = 'Alleged byteArray') => {
+  const passStyle = passStyleOf(arr);
   passStyle === 'byteArray' ||
     Fail`${q(
       optNameOfArray,
-    )} ${array} must be a pass-by-copy binary data, not ${q(passStyle)}`;
+    )} ${arr} must be a pass-by-copy binary data, not ${q(passStyle)}`;
 };
 harden(assertByteArray);
 

--- a/packages/pass-style/src/typeGuards.js
+++ b/packages/pass-style/src/typeGuards.js
@@ -1,7 +1,9 @@
 import { Fail, q } from '@endo/errors';
 import { passStyleOf } from './passStyleOf.js';
 
-/** @import {CopyArray, CopyRecord, Passable, RemotableObject} from './types.js' */
+/**
+ * @import {CopyArray, CopyRecord, Passable, RemotableObject, ByteArray} from './types.js'
+ */
 
 /**
  * Check whether the argument is a pass-by-copy array, AKA a "copyArray"
@@ -12,6 +14,16 @@ import { passStyleOf } from './passStyleOf.js';
  */
 const isCopyArray = arr => passStyleOf(arr) === 'copyArray';
 harden(isCopyArray);
+
+/**
+ * Check whether the argument is a pass-by-copy binary data, AKA a "byteArray"
+ * in @endo/marshal terms
+ *
+ * @param {Passable} arr
+ * @returns {arr is ByteArray}
+ */
+const isByteArray = arr => passStyleOf(arr) === 'byteArray';
+harden(isByteArray);
 
 /**
  * Check whether the argument is a pass-by-copy record, AKA a
@@ -47,6 +59,24 @@ const assertCopyArray = (arr, optNameOfArray = 'Alleged array') => {
 harden(assertCopyArray);
 
 /**
+ * @callback AssertByteArray
+ * @param {Passable} array
+ * @param {string=} optNameOfArray
+ * @returns {asserts array is ByteArray}
+ */
+
+/** @type {AssertByteArray} */
+const assertByteArray = (array, optNameOfArray = 'Alleged byteArray') => {
+  const passStyle = passStyleOf(array);
+  passStyle === 'byteArray' ||
+    Fail`${q(
+      optNameOfArray,
+    )} ${array} must be a pass-by-copy binary data, not ${q(passStyle)}`;
+};
+harden(assertByteArray);
+
+/**
+ * @callback AssertRecord
  * @param {any} record
  * @param {string=} optNameOfRecord
  * @returns {asserts record is CopyRecord<any>}
@@ -80,8 +110,10 @@ harden(assertRemotable);
 export {
   assertRecord,
   assertCopyArray,
+  assertByteArray,
   assertRemotable,
   isRemotable,
   isRecord,
   isCopyArray,
+  isByteArray,
 };

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -22,7 +22,11 @@ export type PrimitiveStyle =
   | 'string'
   | 'symbol';
 
-export type ContainerStyle = 'copyRecord' | 'copyArray' | 'tagged';
+export type ContainerStyle =
+  | 'copyRecord'
+  | 'copyArray'
+  | 'byteArray'
+  | 'tagged';
 
 export type PassStyle =
   | PrimitiveStyle
@@ -49,6 +53,7 @@ export type PassByCopy =
   | Primitive
   | Error
   | CopyArray
+  | ByteArray
   | CopyRecord
   | CopyTagged;
 
@@ -67,6 +72,7 @@ export type PassByRef =
  *     | 'string' | 'symbol'). (Passable considers `void` to be `undefined`.)
  *   * Containers aggregate other Passables into
  *     * sequences as CopyArrays (PassStyle 'copyArray'), or
+ *     * sequences of 8-bit bytes (PassStyle 'byteArray'), or
  *     * string-keyed dictionaries as CopyRecords (PassStyle 'copyRecord'), or
  *     * higher-level types as CopyTaggeds (PassStyle 'tagged').
  *   * PassableCaps (PassStyle 'remotable' | 'promise') expose local values to
@@ -86,6 +92,7 @@ export type Passable<
 
 export type Container<PC extends PassableCap, E extends Error> =
   | CopyArrayInterface<PC, E>
+  | ByteArrayI
   | CopyRecordInterface<PC, E>
   | CopyTaggedInterface<PC, E>;
 interface CopyArrayInterface<PC extends PassableCap, E extends Error>
@@ -116,10 +123,9 @@ export type PassStyleOf = {
 /**
  * A Passable is PureData when its entire data structure is free of PassableCaps
  * (remotables and promises) and error objects.
- * PureData is an arbitrary composition of primitive values into CopyArray
- * and/or
- * CopyRecord and/or CopyTagged containers (or a single primitive value with no
- * container), and is fully pass-by-copy.
+ * PureData is an arbitrary composition of primitive values into CopyArray,
+ * ByteArray, CopyRecord, and/or CopyTagged containers
+ * (or a single primitive value with no container), and is fully pass-by-copy.
  *
  * This restriction assures absence of side effects and interleaving risks *given*
  * that none of the containers can be a Proxy instance.
@@ -155,6 +161,11 @@ export type PassableCap = Promise<any> | RemotableObject;
  * A Passable sequence of Passable values.
  */
 export type CopyArray<T extends Passable = any> = Array<T>;
+
+/**
+ * A `ByteArray` is a normal hardened immutable `ArrayBuffer`
+ */
+export type ByteArray = ArrayBuffer;
 
 /**
  * A Passable dictionary in which each key is a string and each value is Passable.

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -92,7 +92,7 @@ export type Passable<
 
 export type Container<PC extends PassableCap, E extends Error> =
   | CopyArrayInterface<PC, E>
-  | ByteArrayI
+  | ByteArray
   | CopyRecordInterface<PC, E>
   | CopyTaggedInterface<PC, E>;
 interface CopyArrayInterface<PC extends PassableCap, E extends Error>

--- a/packages/patterns/src/keys/checkKey.js
+++ b/packages/patterns/src/keys/checkKey.js
@@ -551,6 +551,9 @@ const checkKeyInternal = (val, check) => {
       // A copyArray is a key iff all its children are keys
       return val.every(checkIt);
     }
+    case 'byteArray': {
+      return true;
+    }
     case 'tagged': {
       const tag = getTag(val);
       switch (tag) {

--- a/packages/patterns/src/keys/compareKeys.js
+++ b/packages/patterns/src/keys/compareKeys.js
@@ -147,6 +147,30 @@ export const compareKeys = (left, right) => {
       // @ts-expect-error narrowed
       return compareRank(left.length, right.length);
     }
+    case 'byteArray': {
+      // @ts-expect-error narrowed
+      const leftArray = new Uint8Array(left.slice(0));
+      // @ts-expect-error narrowed
+      const rightArray = new Uint8Array(right.slice(0));
+      // @ts-expect-error narrowed
+      const byteLen = Math.min(left.byteLength, right.byteLength);
+      for (let i = 0; i < byteLen; i += 1) {
+        const leftByte = leftArray[i];
+        const rightByte = rightArray[i];
+        if (leftByte < rightByte) {
+          return -1;
+        }
+        if (leftByte > rightByte) {
+          return 1;
+        }
+      }
+      // If all corresponding bytes are the same,
+      // then according to their lengths.
+      // Thus, if the data of ByteArray X is a prefix of
+      // the data of ByteArray Y, then X is smaller than Y.
+      // @ts-expect-error narrowed
+      return compareRank(left.byteLength, right.byteLength);
+    }
     case 'copyRecord': {
       // Pareto partial order comparison.
       // @ts-expect-error narrowed

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -17,7 +17,7 @@ export {};
  * @typedef {Exclude<Passable<RemotableObject, never>, Error | Promise>} Key
  *
  * Keys are Passable arbitrarily-nested pass-by-copy containers
- * (CopyArray, CopyRecord, CopySet, CopyBag, CopyMap) in which every
+ * (CopyArray, ByteArray, CopyRecord, CopySet, CopyBag, CopyMap) in which every
  * non-container leaf is either a Passable primitive value or a Remotable (a
  * remotely-accessible object or presence for a remote object), or such leaves
  * in isolation with no container.
@@ -89,9 +89,9 @@ export {};
  * @typedef {Exclude<Passable, Error | Promise>} Pattern
  *
  * Patterns are Passable arbitrarily-nested pass-by-copy containers
- * (CopyArray, CopyRecord, CopySet, CopyBag, CopyMap) in which every
- * non-container leaf is either a Key or a {@link Matcher}, or such leaves in isolation
- * with no container.
+ * (CopyArray, ByteArray, CopyRecord, CopySet, CopyBag, CopyMap) in which every
+ * non-container leaf is either a Key or a {@link Matcher}, or such leaves in
+ * isolation with no container.
  *
  * A Pattern acts as a declarative total predicate over Passables, where each
  * Passable is either matched or not matched by it. Every {@link Key} is also a Pattern
@@ -205,6 +205,7 @@ export {};
  * @property {number} numPropertiesLimit
  * @property {number} propertyNameLengthLimit
  * @property {number} arrayLengthLimit
+ * @property {number} byteLengthLimit
  * @property {number} numSetElementsLimit
  * @property {number} numUniqueBagElementsLimit
  * @property {number} numMapEntriesLimit
@@ -296,6 +297,9 @@ export {};
  *
  * @property {(limits?: Limits) => Matcher} array
  * Matches any CopyArray, subject to limits.
+ *
+ * @property {(limits?: Limits) => Matcher} bytes
+ * Matches any ByteArray, subject to limits.
  *
  * @property {(limits?: Limits) => Matcher} set
  * Matches any CopySet, subject to limits.

--- a/yarn.lock
+++ b/yarn.lock
@@ -524,7 +524,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer":
+"@endo/immutable-arraybuffer@workspace:^, @endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer":
   version: 0.0.0-use.local
   resolution: "@endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer"
   dependencies:
@@ -709,6 +709,7 @@ __metadata:
     "@endo/env-options": "workspace:^"
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
+    "@endo/immutable-arraybuffer": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"


### PR DESCRIPTION
Closes: #1331 
Refs: #1538 https://github.com/ocapn/ocapn/issues/5#issuecomment-1492778252

## Description

Use the `@endo/immutable-arraybuffer` ponyfill directly, rather than the shim `@endo/immutable-arraybuffer/shim.js`, to provide objects that act like the immutable ArrayBuffers that would result from the `transferToImmutable` proposal.

Recognize these objects, when also frozen, as the new pass-style `byteArray`. Add a branch for each of the dispatches on pass-style that must now understand byte-arrays as well. As of this PR, many of those additional branches are stubbed out with "not yet implemented" errors as placeholders.

### Security Considerations

Does correctly enforce immutability. But by depending only on the ponyfill rather than the shim, this PR inherits the eval twin problem of the ponyfill. Each instantiation of `passStyleOf` will only recognize the byte-arrays from the instantiation of `@endo/pass-style` that made that byte-array. For environment that, for example, use the `passStyleOf` endowed to them by liveslots, liveslots will also need to endow them with the corresponding byte-array maker.

In theory, this is not much worse than the need to co-endow `passStyleOf` and `Proxy`, so that `passStyleOf` can reject apparent copy structures that are also proxies.

### Scaling Considerations

The underlying ponyfill implementation helps us handle bulk binary data in a largely no-copy or minimal-copy manner.

### Documentation Considerations

Will add a new pass-style, so everywhere we enumerate all the pass-styles, we'll need to add byte-array.

### Testing Considerations

- [ ] TODO tests. For each stubbed out case, there should be a `test.failing` test.

### Compatibility Considerations

Old code that dispatched only on the pass-styles it knew about will not correctly handle passables that contain byte-arrays.

### Upgrade Considerations

- [ ] TODO BREAKING.md
- [ ] TODO NEWS.md