### PR TITLE
Promise for non-Passable is not Passable

### DIFF
--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -414,7 +414,7 @@ export const makeCapTP = (
           epoch,
           questionID,
           target,
-          // @ts-expect-error Type 'unknown' is not assignable to type 'Passable<PassableCap, Error>'.
+          // @ts-expect-error Type 'unknown[]' is not assignable to type 'Passable'.
           method: serialize(harden([null, args])),
         });
         return promise;
@@ -430,7 +430,7 @@ export const makeCapTP = (
           epoch,
           questionID,
           target,
-          // @ts-expect-error Type 'unknown' is not assignable to type 'Passable<PassableCap, Error>'.
+          // @ts-expect-error Type 'unknown[]' is not assignable to type 'Passable'.
           method: serialize(harden([prop, args])),
         });
         return promise;

--- a/packages/eventual-send/src/exports.d.ts
+++ b/packages/eventual-send/src/exports.d.ts
@@ -6,6 +6,7 @@ import type { HandledPromiseConstructor } from './types.d.ts';
 //
 
 export type {
+  Callable,
   RemotableBrand,
   DataOnly,
   FarRef,

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -30,23 +30,17 @@ const { fromEntries } = Object;
  */
 
 /**
- * Currently copied from @agoric/internal utils.js.
- * TODO Should migrate here and then, if needed, reexported there.
- *
- * @template {{}} T
+ * @template {Record<string, any>} T
  * @typedef {{
  *   [K in keyof T]: T[K] extends Callable ? T[K] : DeeplyAwaited<T[K]>;
  * }} DeeplyAwaitedObject
  */
 
 /**
- * Currently copied from @agoric/internal utils.js.
- * TODO Should migrate here and then, if needed, reexported there.
- *
  * @template T
  * @typedef {T extends PromiseLike<any>
  *     ? Awaited<T>
- *     : T extends {}
+ *     : T extends Record<string, any>
  *       ? Simplify<DeeplyAwaitedObject<T>>
  *       : Awaited<T>} DeeplyAwaited
  */
@@ -73,7 +67,7 @@ const { fromEntries } = Object;
  * is for the higher "@endo/patterns" level of abstraction to determine,
  * because it defines the `Key` notion in question.
  *
- * @template {Passable} [T=Passable]
+ * @template {Passable} T
  * @param {T} val
  * @returns {Promise<DeeplyAwaited<T>>}
  */

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -6,8 +6,9 @@ import { passStyleOf } from './passStyleOf.js';
 import { makeTagged } from './makeTagged.js';
 
 /**
- * @import {Passable, Primitive, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'
+ * @import {Passable, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'
  */
+/** @import {Callable, RemotableBrand} from '@endo/eventual-send' */
 
 const { ownKeys } = Reflect;
 const { fromEntries } = Object;
@@ -23,26 +24,16 @@ const { fromEntries } = Object;
  */
 
 /**
- * Currently copied from @agoric/internal utils.js.
- * TODO Should migrate here and then, if needed, reexported there.
- *
- * @typedef {(...args: any[]) => any} Callable
- */
-
-/**
- * @template {Record<string, any>} T
- * @typedef {{
- *   [K in keyof T]: T[K] extends Callable ? T[K] : DeeplyAwaited<T[K]>;
- * }} DeeplyAwaitedObject
- */
-
-/**
  * @template T
- * @typedef {T extends PromiseLike<any>
- *     ? Awaited<T>
- *     : T extends Record<string, any>
- *       ? Simplify<DeeplyAwaitedObject<T>>
- *       : Awaited<T>} DeeplyAwaited
+ * @typedef {boolean extends (T extends never ? true : false)
+ *   ? T    // pass through the `any` type
+ *   : T extends PromiseLike<any>
+ *     ? DeeplyAwaited<Awaited<T>>
+ *     : T extends object
+ *       ? T extends (Callable | RemotableBrand<any, any> | RemotableObject)
+ *         ? T
+ *         : Simplify<{[K in keyof T]: DeeplyAwaited<T[K]>}>
+ *       : T} DeeplyAwaited
  */
 
 /**

--- a/packages/pass-style/src/deeplyFulfilled.test-d.ts
+++ b/packages/pass-style/src/deeplyFulfilled.test-d.ts
@@ -1,0 +1,76 @@
+/* eslint-disable */
+import { expectType } from 'tsd';
+import { Far } from './make-far';
+import { makeTagged } from './makeTagged';
+import { deeplyFulfilled } from './deeplyFulfilled';
+import type { CopyTagged, Passable, RemotableObject } from './types';
+
+const remotable = Far('foo', {
+  myFunc() {
+    return 'foo';
+  },
+});
+
+type MyRemotable = typeof remotable;
+type MyNonBrandedRemotable = { myFunc(): 'foo' } & RemotableObject;
+
+const copyTagged = makeTagged('someTag', remotable);
+
+const someUnknown: unknown = null;
+const someAny: any = null;
+
+expectType<undefined>(await deeplyFulfilled(undefined));
+expectType<string>(await deeplyFulfilled('str'));
+expectType<boolean>(await deeplyFulfilled(true));
+expectType<number>(await deeplyFulfilled(1));
+expectType<bigint>(await deeplyFulfilled(1n));
+expectType<symbol>(await deeplyFulfilled(Symbol.for('foo')));
+expectType<null>(await deeplyFulfilled(null));
+expectType<Error>(await deeplyFulfilled(new Error()));
+expectType<MyRemotable>(await deeplyFulfilled(remotable));
+expectType<MyNonBrandedRemotable>(
+  await deeplyFulfilled(remotable as MyNonBrandedRemotable),
+);
+expectType<CopyTagged<'someTag', MyRemotable>>(
+  await deeplyFulfilled(copyTagged),
+);
+expectType<[]>(await deeplyFulfilled([]));
+expectType<{}>(await deeplyFulfilled({}));
+
+expectType<MyRemotable>(await deeplyFulfilled(Promise.resolve(remotable)));
+expectType<{ a: MyRemotable }>(
+  await deeplyFulfilled(Promise.resolve({ a: Promise.resolve(remotable) })),
+);
+
+// By default TS infer an array type instead of a tuple type
+const tuple: [Promise<MyRemotable>] = [Promise.resolve(remotable)];
+
+expectType<Passable>(tuple);
+expectType<[MyRemotable]>(await deeplyFulfilled(tuple));
+expectType<[MyRemotable]>(await deeplyFulfilled(Promise.resolve(tuple)));
+
+expectType<CopyTagged<'someOtherTag', MyRemotable>>(
+  await deeplyFulfilled(
+    Promise.resolve(makeTagged('someOtherTag', Promise.resolve(remotable))),
+  ),
+);
+
+// @ts-expect-error not passable
+deeplyFulfilled(someUnknown);
+// @ts-expect-error not passable
+deeplyFulfilled(Promise.resolve(someUnknown));
+// @ts-expect-error not passable
+deeplyFulfilled(Promise.resolve({ a: Promise.resolve(someUnknown) }));
+// @ts-expect-error not passable
+deeplyFulfilled(Promise.resolve([Promise.resolve(someUnknown)]));
+
+expectType<any>(await deeplyFulfilled(someAny));
+expectType<any>(await deeplyFulfilled(Promise.resolve(someAny)));
+expectType<{ a: any }>(
+  await deeplyFulfilled(Promise.resolve({ a: Promise.resolve(someAny) })),
+);
+expectType<[any]>(
+  await deeplyFulfilled(
+    Promise.resolve([Promise.resolve(someAny)] as [Promise<any>]),
+  ),
+);

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -331,7 +331,7 @@ harden(toPassableError);
  * the results of coercing those errors to passable errors.
  *
  * @param {unknown} specimen
- * @returns {Passable<never, Error>}
+ * @returns {Passable<never, Error, false>}
  */
 export const toThrowable = specimen => {
   harden(specimen);
@@ -378,6 +378,6 @@ export const toThrowable = specimen => {
       }
     }
   }
-  return /** @type {Passable<never,never>} */ (specimen);
+  return /** @type {Passable<never, never, false>} */ (specimen);
 };
 harden(toThrowable);

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -80,20 +80,43 @@ export type PassByRef =
  * using 'slots').
  */
 export type Passable<
-  PC extends PassableCap = PassableCap,
+  R extends RemotableObject = RemotableObject,
   E extends Error = Error,
-> = void | Primitive | Container<PC, E> | PC | E;
+  AllowPromise extends boolean = any,
+  AllowTopLevelPromise extends boolean = AllowPromise,
+> =
+  | void
+  | Primitive
+  | Container<R, E, AllowPromise>
+  | R
+  | E
+  | (true extends AllowTopLevelPromise
+      ? Promise<Passable<R, E, AllowPromise, false>>
+      : never);
 
-export type Container<PC extends PassableCap, E extends Error> =
-  | CopyArrayI<PC, E>
-  | CopyRecordI<PC, E>
-  | CopyTaggedI<PC, E>;
-interface CopyArrayI<PC extends PassableCap, E extends Error>
-  extends CopyArray<Passable<PC, E>> {}
-interface CopyRecordI<PC extends PassableCap, E extends Error>
-  extends CopyRecord<Passable<PC, E>> {}
-interface CopyTaggedI<PC extends PassableCap, E extends Error>
-  extends CopyTagged<string, Passable<PC, E>> {}
+export type Container<
+  R extends RemotableObject,
+  E extends Error,
+  AllowPromise extends boolean = any,
+> =
+  | CopyArrayI<R, E, AllowPromise>
+  | CopyRecordI<R, E, AllowPromise>
+  | CopyTaggedI<R, E, AllowPromise>;
+interface CopyArrayI<
+  R extends RemotableObject,
+  E extends Error,
+  AllowPromise extends boolean,
+> extends CopyArray<Passable<R, E, AllowPromise>> {}
+interface CopyRecordI<
+  R extends RemotableObject,
+  E extends Error,
+  AllowPromise extends boolean,
+> extends CopyRecord<Passable<R, E, AllowPromise>> {}
+interface CopyTaggedI<
+  R extends RemotableObject,
+  E extends Error,
+  AllowPromise extends boolean,
+> extends CopyTagged<string, Passable<R, E, AllowPromise>> {}
 
 export type PassStyleOf = {
   (p: undefined): 'undefined';
@@ -135,7 +158,7 @@ export type PassStyleOf = {
  * trip (as exists between vats) to produce data structures disconnected from
  * any potential proxies.
  */
-export type PureData = Passable<never, never>;
+export type PureData = Passable<never, never, false>;
 /**
  * An object marked as remotely accessible using the `Far` or `Remotable`
  * functions, or a local presence representing such a remote object.
@@ -150,9 +173,10 @@ export type RemotableObject<I extends InterfaceSpec = string> = PassStyled<
 /**
  * The authority-bearing leaves of a Passable's pass-by-copy superstructure.
  */
-export type PassableCap<E extends Error = Error> =
-  | Promise<Passable<PassableCap<E>, E>>
-  | RemotableObject;
+export type PassableCap<
+  R extends RemotableObject = RemotableObject,
+  AllowPromise extends boolean = any,
+> = R | (true extends AllowPromise ? Promise<R> : never);
 
 /**
  * A Passable sequence of Passable values.

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -150,7 +150,10 @@ export type RemotableObject<I extends InterfaceSpec = string> = PassStyled<
 /**
  * The authority-bearing leaves of a Passable's pass-by-copy superstructure.
  */
-export type PassableCap = Promise<any> | RemotableObject;
+export type PassableCap<E extends Error = Error> =
+  | Promise<Passable<PassableCap<E>, E>>
+  | RemotableObject;
+
 /**
  * A Passable sequence of Passable values.
  */

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -99,24 +99,35 @@ export type Container<
   E extends Error,
   AllowPromise extends boolean = any,
 > =
-  | CopyArrayI<R, E, AllowPromise>
-  | CopyRecordI<R, E, AllowPromise>
-  | CopyTaggedI<R, E, AllowPromise>;
-interface CopyArrayI<
-  R extends RemotableObject,
-  E extends Error,
-  AllowPromise extends boolean,
-> extends CopyArray<Passable<R, E, AllowPromise>> {}
-interface CopyRecordI<
-  R extends RemotableObject,
-  E extends Error,
-  AllowPromise extends boolean,
-> extends CopyRecord<Passable<R, E, AllowPromise>> {}
-interface CopyTaggedI<
-  R extends RemotableObject,
-  E extends Error,
-  AllowPromise extends boolean,
-> extends CopyTagged<string, Passable<R, E, AllowPromise>> {}
+  | CopyArrayI<Passable<R, E, AllowPromise>>
+  | CopyRecordI<Passable<R, E, AllowPromise>>
+  | CopyTaggedI<Passable<R, E, AllowPromise>>;
+interface CopyArrayI<T extends Passable = any> extends CopyArray<T> {}
+interface CopyRecordI<T extends Passable = any> extends CopyRecord<T> {}
+interface CopyTaggedI<T extends Passable = any> extends CopyTagged<string, T> {}
+
+export type PassableSubset<
+  T extends Passable<RemotableObject, Error, false> = Passable<
+    RemotableObject,
+    Error,
+    false
+  >,
+  AllowPromise extends boolean = false,
+  AllowTopLevelPromise extends boolean = AllowPromise,
+> =
+  | T
+  | SubsetContainer<T, AllowPromise>
+  | (true extends AllowTopLevelPromise
+      ? PromiseLike<PassableSubset<T, AllowPromise, false>>
+      : never);
+
+type SubsetContainer<
+  T extends Passable<RemotableObject, Error, false>,
+  AllowPromise extends boolean = false,
+> =
+  | CopyArrayI<PassableSubset<T, AllowPromise>>
+  | CopyRecordI<PassableSubset<T, AllowPromise>>
+  | CopyTaggedI<PassableSubset<T, AllowPromise>>;
 
 export type PassStyleOf = {
   (p: undefined): 'undefined';

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -54,8 +54,8 @@ export type PassByCopy =
 
 export type PassByRef =
   | RemotableObject
-  | Promise<RemotableObject>
-  | Promise<PassByCopy>;
+  | PromiseLike<RemotableObject>
+  | PromiseLike<PassByCopy>;
 
 /**
  * A Passable is acyclic data that can be marshalled. It must be hardened to
@@ -91,7 +91,7 @@ export type Passable<
   | R
   | E
   | (true extends AllowTopLevelPromise
-      ? Promise<Passable<R, E, AllowPromise, false>>
+      ? PromiseLike<Passable<R, E, AllowPromise, false>>
       : never);
 
 export type Container<
@@ -126,7 +126,7 @@ export type PassStyleOf = {
   (p: bigint): 'bigint';
   (p: symbol): 'symbol';
   (p: null): 'null';
-  (p: Promise<any>): 'promise';
+  (p: PromiseLike<any>): 'promise';
   (p: Error): 'error';
   (p: CopyTagged): 'tagged';
   (p: any[]): 'copyArray';
@@ -134,7 +134,7 @@ export type PassStyleOf = {
   (p: Iterator<any, any, undefined>): 'remotable';
   <T extends PassStyled<TaggedOrRemotable, any>>(p: T): ExtractStyle<T>;
   (p: { [key: string]: any }): 'copyRecord';
-  (p: any): PassStyle;
+  (p: any): never;
 };
 /**
  * A Passable is PureData when its entire data structure is free of PassableCaps
@@ -176,7 +176,7 @@ export type RemotableObject<I extends InterfaceSpec = string> = PassStyled<
 export type PassableCap<
   R extends RemotableObject = RemotableObject,
   AllowPromise extends boolean = any,
-> = R | (true extends AllowPromise ? Promise<R> : never);
+> = R | (true extends AllowPromise ? PromiseLike<R> : never);
 
 /**
  * A Passable sequence of Passable values.

--- a/packages/pass-style/src/types.test-d.ts
+++ b/packages/pass-style/src/types.test-d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { expectAssignable, expectType, expectNotType } from 'tsd';
+import { expectAssignable, expectType, expectNever, expectNotType } from 'tsd';
 import { Far } from './make-far';
 import { passStyleOf } from './passStyleOf';
 import { makeTagged } from './makeTagged';
@@ -34,7 +34,9 @@ expectType<'copyRecord'>(passStyleOf({}));
 // though the object is specifying a PASS_STYLE, it doesn't match the case for extracting it
 expectType<'copyRecord'>(passStyleOf({ [PASS_STYLE]: 'arbitrary' } as const));
 expectType<'remotable'>(passStyleOf(remotable));
-expectType<PassStyle>(passStyleOf(someUnknown));
+try {
+  expectNever(passStyleOf(someUnknown));
+} catch {}
 
 const expectPassable = (val: Passable) => {};
 const expectPureData = (val: PureData) => {
@@ -55,12 +57,23 @@ expectPureData(fn());
 
 expectPureData({});
 expectPureData({ a: {} });
+expectPureData([]);
+expectPureData([{}]);
 // @ts-expect-error not passable
 expectPassable(fn);
 // @ts-expect-error Promise for not passable
 expectPassable(Promise.resolve(fn));
 // @ts-expect-error not passable
 expectPassable({ a: { b: fn } });
+
+// @ts-expect-error not passable
+expectPassable(someUnknown);
+// @ts-expect-error Promise for not passable
+expectPassable(Promise.resolve(someUnknown));
+// @ts-expect-error not passable
+expectPassable({ a: { b: someUnknown } });
+// @ts-expect-error not passable
+expectPassable([someUnknown]);
 
 expectPassable(remotable);
 expectPassableCap(remotable);
@@ -71,16 +84,29 @@ expectPassable({ a: remotable });
 expectPassableCap({ a: remotable });
 // @ts-expect-error not pure-data
 expectPureData({ a: remotable });
+expectPassable([remotable]);
+// @ts-expect-error not passable capability
+expectPassableCap([remotable]);
+// @ts-expect-error not pure-data
+expectPureData([remotable]);
 expectPassable(copyTagged);
 // @ts-expect-error not passable capability
 expectPassableCap(copyTagged);
 // @ts-expect-error not pure-data
 expectPureData(copyTagged);
+
 expectPassable(Promise.resolve(remotable));
 expectPassableCap(Promise.resolve(remotable));
 // @ts-expect-error not pure-data
 expectPureData(Promise.resolve(remotable));
 expectPassable({ a: Promise.resolve(remotable) });
+expectPassable([Promise.resolve(remotable)]);
+expectPassable(Promise.resolve({ a: Promise.resolve(remotable) }));
+expectPassable(Promise.resolve([Promise.resolve(remotable)]));
+expectPassable([remotable] as const);
+expectPassable([Promise.resolve(remotable)] as const);
+expectPassable(Promise.resolve({ a: Promise.resolve(remotable) } as const));
+expectPassable(Promise.resolve([Promise.resolve(remotable)] as const));
 // @ts-expect-error not passable capability
 expectPassableCap({ a: Promise.resolve(remotable) });
 // @ts-expect-error not pure-data

--- a/packages/pass-style/src/types.test-d.ts
+++ b/packages/pass-style/src/types.test-d.ts
@@ -45,7 +45,7 @@ expectPassable({});
 expectPassable({ a: {} });
 // @ts-expect-error not passable
 expectPassable(fn);
-// FIXME promise for a non-Passable is not Passable
+// @ts-expect-error Promise for not passable
 expectPassable(Promise.resolve(fn));
 // @ts-expect-error not passable
 expectPassable({ a: { b: fn } });
@@ -55,4 +55,5 @@ expectPassable({ a: remotable });
 expectPassable(copyTagged);
 expectPassable(Promise.resolve(remotable));
 expectPassable({ a: Promise.resolve(remotable) });
+// @ts-expect-error Promise for not passable
 expectPassable({ a: Promise.resolve(fn) });

--- a/packages/pass-style/src/types.test-d.ts
+++ b/packages/pass-style/src/types.test-d.ts
@@ -3,7 +3,13 @@ import { expectAssignable, expectType, expectNotType } from 'tsd';
 import { Far } from './make-far';
 import { passStyleOf } from './passStyleOf';
 import { makeTagged } from './makeTagged';
-import { CopyTagged, Passable, PassStyle } from './types';
+import {
+  CopyTagged,
+  Passable,
+  PassableCap,
+  PassStyle,
+  PureData,
+} from './types';
 import { PASS_STYLE } from './passStyle-helpers';
 
 const remotable = Far('foo', {});
@@ -31,18 +37,24 @@ expectType<'remotable'>(passStyleOf(remotable));
 expectType<PassStyle>(passStyleOf(someUnknown));
 
 const expectPassable = (val: Passable) => {};
+const expectPureData = (val: PureData) => {
+  expectPassable(val);
+};
+const expectPassableCap = (val: PassableCap) => {
+  expectPassable(val);
+};
 
 const fn = () => {};
 
-expectPassable(1);
-expectPassable(null);
-expectPassable('str');
-expectPassable(undefined);
-// void is really `undefined`, and thus Passable
-expectPassable(fn());
+expectPureData(1);
+expectPureData(null);
+expectPureData('str');
+expectPureData(undefined);
+// void is really `undefined`, and thus pure-data Passable
+expectPureData(fn());
 
-expectPassable({});
-expectPassable({ a: {} });
+expectPureData({});
+expectPureData({ a: {} });
 // @ts-expect-error not passable
 expectPassable(fn);
 // @ts-expect-error Promise for not passable
@@ -51,9 +63,27 @@ expectPassable(Promise.resolve(fn));
 expectPassable({ a: { b: fn } });
 
 expectPassable(remotable);
+expectPassableCap(remotable);
+// @ts-expect-error not pure-data
+expectPureData(remotable);
 expectPassable({ a: remotable });
+// @ts-expect-error not passable capability
+expectPassableCap({ a: remotable });
+// @ts-expect-error not pure-data
+expectPureData({ a: remotable });
 expectPassable(copyTagged);
+// @ts-expect-error not passable capability
+expectPassableCap(copyTagged);
+// @ts-expect-error not pure-data
+expectPureData(copyTagged);
 expectPassable(Promise.resolve(remotable));
+expectPassableCap(Promise.resolve(remotable));
+// @ts-expect-error not pure-data
+expectPureData(Promise.resolve(remotable));
 expectPassable({ a: Promise.resolve(remotable) });
+// @ts-expect-error not passable capability
+expectPassableCap({ a: Promise.resolve(remotable) });
+// @ts-expect-error not pure-data
+expectPureData({ a: Promise.resolve(remotable) });
 // @ts-expect-error Promise for not passable
 expectPassable({ a: Promise.resolve(fn) });

--- a/packages/patterns/src/keys/checkKey.js
+++ b/packages/patterns/src/keys/checkKey.js
@@ -509,7 +509,7 @@ harden(copyMapKeySet);
 
 /**
  * @template {Key} K
- * @template {Passable} V
+ * @template {Passable} [V=any]
  * @param {Iterable<[K, V]>} entries
  * @returns {CopyMap<K,V>}
  */

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -52,7 +52,7 @@ export {};
  */
 
 /**
- * @typedef {Exclude<Passable, Error | Promise>} Pattern
+ * @typedef {Exclude<Passable<RemotableObject, never, false>, never>} Pattern
  *
  * Patterns are Passable arbitrarily-nested pass-by-copy containers
  * (CopyArray, CopyRecord, CopySet, CopyBag, CopyMap) in which every
@@ -136,7 +136,7 @@ export {};
 
 // TODO: enumerate Matcher tag values?
 /**
- * @typedef {CopyTagged<`match:${string}`, Passable>} Matcher
+ * @typedef {CopyTagged<`match:${string}`, Pattern>} Matcher
  *
  * A Pattern representing the predicate characterizing a category of Passables,
  * such as strings or 8-bit unsigned integer numbers or CopyArrays of Remotables.
@@ -202,7 +202,7 @@ export {};
 
 /**
  * @callback CheckPattern
- * @param {Passable} allegedPattern
+ * @param {Pattern} allegedPattern
  * @param {Checker} check
  * @returns {boolean}
  */

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -9,7 +9,7 @@ export {};
  */
 
 /**
- * @typedef {Exclude<Passable<RemotableObject, never>, Error | Promise>} Key
+ * @typedef {Exclude<Passable<RemotableObject, never, false>, never>} Key
  *
  * Keys are Passable arbitrarily-nested pass-by-copy containers
  * (CopyArray, CopyRecord, CopySet, CopyBag, CopyMap) in which every

--- a/packages/patterns/test/patterns.test.js
+++ b/packages/patterns/test/patterns.test.js
@@ -532,7 +532,6 @@ const runTests = (t, successCase, failCase) => {
     t.throws(
       () => {
         copyMapComparison || Fail`No CopyMap comparison support`;
-        // @ts-expect-error XXX Key types
         successCase(specimen, M.gt(makeCopyMap([])));
       },
       { message: 'No CopyMap comparison support' },


### PR DESCRIPTION
Refs: #2406

## Description

@mhofman [suggested a fix for the FIXME](https://github.com/endojs/endo/pull/2406#discussion_r1723844078) in #2406. As expected it trip on recursion:
```
packages/pass-style/src/deeplyFulfilled.js:74:32 - error TS2589: Type instantiation is excessively deep and possibly infinite.

74 export const deeplyFulfilled = async val => {
                                  ~~~~~~~~~~~~~~
```

Leaving this PR in draft until that's solved.  @mhofman @michaelfig feel free to push commits.

### Security Considerations

> Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?

### Scaling Considerations

> Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated?

### Documentation Considerations

> Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

### Testing Considerations

> Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? 

### Compatibility Considerations

> Does this change break any prior usage patterns? Does this change allow usage patterns to evolve?

### Upgrade Considerations

> What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed?

> Include `*BREAKING*:` in the commit message with migration instructions for any breaking change.

> Update `NEWS.md` for user-facing changes.

> Delete guidance from pull request description before merge (including this!)
