### PR TITLE
feat(compartment-mapper): Host module exits

### DIFF
--- a/.changeset/host-module-exits.md
+++ b/.changeset/host-module-exits.md
@@ -1,0 +1,24 @@
+---
+'ses': minor
+'@endo/compartment-mapper': minor
+'@endo/import-bundle': minor
+---
+
+Add support for host module exits in bundled compartments.
+
+`ses` exports a new `StrictModuleDescriptor` type that consists only of the
+`NamespaceModuleDescriptor` and `SourceModuleDescriptor` shapes mutually
+supported by SES and XS.
+
+`compartment-mapper` lets arbitrary module descriptors pass through
+`importHook` when no policy is in effect for that edge (the
+policy-enforcement runtime was previously limited to virtual module sources).
+It also implicitly treats any module specifier with a URL-scheme prefix
+(like `node:fs`) as an exit module when bundling, removing the need for an
+additional bundler flag in the common case.
+
+`import-bundle` threads the `importHook` option through to the underlying
+compartment so that bundled applications can route exits to host-provided
+implementations at import time.
+Host-provided modules must be hardened and pure to avoid being a
+side-channel or man-in-the-middle attack surface between guests.

--- a/packages/compartment-mapper/README.md
+++ b/packages/compartment-mapper/README.md
@@ -304,6 +304,21 @@ location.
 The `-lite.js` modules, in general, do not entrain a specific compartment
 mapper.
 
+# Host module exits in bundles
+
+When bundling for an archive, the compartment mapper implicitly treats any
+module specifier whose prefix matches a URI scheme (per [RFC 3986 section
+3.1](https://www.rfc-editor.org/rfc/rfc3986#section-3.1)) as an exit to a
+host-provided module.
+This covers specifiers like `node:fs`, `wasm:foo`, or any custom
+`my-scheme:thing`, on the assumption that any specifier shaped like a URI
+prefix names a module the host environment is expected to supply at import
+time.
+These exits are omitted from the archive itself; the importer must provide an
+implementation via `importHook` when the archive is later imported.
+Host-provided modules must be hardened and pure to avoid being a side-channel
+or man-in-the-middle attack surface between guests.
+
 # Package Descriptors
 
 The compartment mapper uses [Compartments], one for each Node.js package your

--- a/packages/compartment-mapper/src/import-archive-lite.js
+++ b/packages/compartment-mapper/src/import-archive-lite.js
@@ -136,15 +136,12 @@ const makeArchiveImportHookMaker = (
             // note it's not being marked as exit in sources
             // it could get marked and the second pass, when the archive is being executed, would have the data
             // to enforce which exits can be dynamically imported
-            return {
-              record: await attenuateModuleHook(
-                moduleSpecifier,
-                record,
-                compartmentDescriptor.policy,
-                attenuators,
-              ),
-              specifier: moduleSpecifier,
-            };
+            return attenuateModuleHook(
+              moduleSpecifier,
+              record,
+              compartmentDescriptor.policy,
+              attenuators,
+            );
           } else {
             // if exitModuleImportHook is allowed, the mechanism to defer
             // errors in archive creation is never used. We don't want to

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -22,6 +22,7 @@ import { unpackReadPowers } from './powers.js';
  * @import {
  *   ImportHook,
  *   ImportNowHook,
+ *   ModuleDescriptor,
  *   RedirectStaticModuleInterface,
  *   StaticModuleType,
  *   VirtualModuleSource
@@ -812,7 +813,7 @@ export function makeImportNowHookMaker(
      * If it doesn't exist, then throw an exception.
      * @param {string} moduleSpecifier
      * @param {CompartmentDescriptor} compartmentDescriptor
-     * @returns {VirtualModuleSource}
+     * @returns {ModuleDescriptor}
      */
     const importExitModuleOrFail = (moduleSpecifier, compartmentDescriptor) => {
       if (exitModuleImportNowHook) {

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -70,6 +70,13 @@ const has = (object, key) => apply(hasOwnProperty, object, [key]);
 // q, as in quote, for strings in error messages.
 const { quote: q } = assert;
 
+// See section 3.1 of RFC 3986 URI Scheme Generic Syntax
+// https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+// Scheme names are case-insensitive per the cited section, so the regex
+// accepts both cases on the prefix. Bundlers that produce specifiers like
+// `HTTP:` or `File:` are unusual but valid per the spec.
+const urlish = /^[a-zA-Z][a-zA-Z0-9+\-.]*:/;
+
 /**
  * For a full, absolute module specifier like "dependency",
  * produce the module specifier in the dependency, like ".".
@@ -105,6 +112,7 @@ const trimModuleSpecifierPrefix = (moduleSpecifier, prefix) => {
  * @param {FileUrlString} compartmentName
  * @param {Record<string, FileModuleConfiguration|CompartmentModuleConfiguration>} moduleDescriptors
  * @param {Record<string, ScopeDescriptor<FileUrlString>>} scopeDescriptors
+ * @param {boolean} archiveOnly
  * @returns {ModuleMapHook | undefined}
  */
 const makeModuleMapHook = (
@@ -113,6 +121,7 @@ const makeModuleMapHook = (
   compartmentName,
   moduleDescriptors,
   scopeDescriptors,
+  archiveOnly,
 ) => {
   // Build pattern matcher once per compartment if patterns exist.
   const { patterns } = /** @type {Partial<PackageCompartmentDescriptor>} */ (
@@ -127,6 +136,25 @@ const makeModuleMapHook = (
    */
   const moduleMapHook = moduleSpecifier => {
     compartmentDescriptor.retained = true;
+
+    if (archiveOnly && urlish.test(moduleSpecifier)) {
+      // When creating an archive of an application that imports a platform
+      // module like node:fs, we implicitly expect these to be provided by the
+      // host's importHook on the target platform. Freeze the synthesized
+      // descriptor so the cross-boundary return cannot be tampered with by a
+      // downstream caller.
+      return freeze({
+        source: freeze({
+          imports: freeze([]),
+          exports: freeze([]),
+          execute() {
+            throw new Error(
+              'Cannot import an application loaded strictly for analysis',
+            );
+          },
+        }),
+      });
+    }
 
     const moduleDescriptor = moduleDescriptors[moduleSpecifier];
     if (moduleDescriptor !== undefined) {
@@ -438,6 +466,7 @@ export const link = (
       compartmentName,
       modules,
       scopes,
+      archiveOnly,
     );
 
     const compartment = new Compartment({

--- a/packages/compartment-mapper/src/policy.js
+++ b/packages/compartment-mapper/src/policy.js
@@ -19,7 +19,13 @@
  *   ModuleConfiguration,
  *   CanonicalName,
  * } from './types.js'
- * @import {ThirdPartyStaticModuleInterface} from 'ses'
+ * @import {
+ *   ModuleDescriptor,
+ *   SourceModuleDescriptor,
+ *   StrictModuleDescriptor,
+ *   ThirdPartyStaticModuleInterface,
+ *   VirtualModuleSource,
+ * } from 'ses'
  */
 
 import {
@@ -483,17 +489,18 @@ export const enforcePackagePolicyByCanonicalName = (
 };
 
 /**
- * Attenuates a module
+ * Attenuates a virtual module source.
+ *
  * @param {object} options
  * @param {DeferredAttenuatorsProvider} options.attenuators
  * @param {AttenuationDefinition} options.attenuationDefinition
- * @param {ThirdPartyStaticModuleInterface} options.originalModuleRecord
- * @returns {Promise<ThirdPartyStaticModuleInterface>}
+ * @param {VirtualModuleSource} options.moduleSource
+ * @returns {Promise<VirtualModuleSource>}
  */
-async function attenuateModule({
+async function attenuateVirtualModuleSource({
   attenuators,
   attenuationDefinition,
-  originalModuleRecord,
+  moduleSource,
 }) {
   const attenuate = await importAttenuatorForDefinition(
     attenuationDefinition,
@@ -504,15 +511,17 @@ async function attenuateModule({
   // An async attenuator maker could be introduced here to return a synchronous attenuator.
   // For async attenuators see PR https://github.com/endojs/endo/pull/1535
 
+  // Freeze the returned virtual module source so the attenuator boundary does
+  // not hand callers a mutable wrapper they could tamper with after the fact.
   return freeze(
-    /** @type {ThirdPartyStaticModuleInterface} */ ({
-      imports: originalModuleRecord.imports,
+    /** @type {VirtualModuleSource} */ ({
+      imports: moduleSource.imports,
       // It seems ok to declare the exports but then let the attenuator trim the values.
       // Seems ok for attenuation to leave them undefined - accessing them is malicious behavior.
-      exports: originalModuleRecord.exports,
+      exports: moduleSource.exports,
       execute: (moduleExports, compartment, resolvedImports) => {
         const ns = {};
-        originalModuleRecord.execute(ns, compartment, resolvedImports);
+        moduleSource.execute(ns, compartment, resolvedImports);
         const attenuated = attenuate(ns);
         moduleExports.default = attenuated;
         assign(moduleExports, attenuated);
@@ -522,26 +531,85 @@ async function attenuateModule({
 }
 
 /**
+ * Attenuates a module descriptor whose source is a virtual module source.
+ * Other shapes (including NamespaceModuleDescriptor, which is part of
+ * StrictModuleDescriptor but has no source to attenuate) pass through
+ * unchanged at the call site; this function throws when given a descriptor
+ * the attenuator cannot wrap.
+ *
+ * @param {object} options
+ * @param {DeferredAttenuatorsProvider} options.attenuators
+ * @param {AttenuationDefinition} options.attenuationDefinition
+ * @param {VirtualModuleSource | SourceModuleDescriptor} options.moduleDescriptor
+ * @returns {Promise<SourceModuleDescriptor>}
+ */
+async function attenuateModule({
+  attenuators,
+  attenuationDefinition,
+  moduleDescriptor,
+}) {
+  await null;
+  if ('source' in moduleDescriptor) {
+    const { source: moduleSource } = moduleDescriptor;
+    if (
+      typeof moduleSource !== 'string' &&
+      'imports' in moduleSource &&
+      'exports' in moduleSource &&
+      'execute' in moduleSource
+    ) {
+      return freeze(
+        /** @type {SourceModuleDescriptor} */ ({
+          source: await attenuateVirtualModuleSource({
+            attenuators,
+            attenuationDefinition,
+            moduleSource,
+          }),
+        }),
+      );
+    }
+  } else if (
+    'imports' in moduleDescriptor &&
+    'exports' in moduleDescriptor &&
+    'execute' in moduleDescriptor
+  ) {
+    return freeze(
+      /** @type {SourceModuleDescriptor} */ ({
+        source: await attenuateVirtualModuleSource({
+          attenuators,
+          attenuationDefinition,
+          moduleSource: moduleDescriptor,
+        }),
+      }),
+    );
+  }
+  throw new Error(
+    `attenuateModule received a non-attenuatable module descriptor: ${q(
+      moduleDescriptor,
+    )}`,
+  );
+}
+
+/**
  * Throws if importing of the specifier is not allowed by the policy
  *
  * @param {string} specifier - exit module name
- * @param {ThirdPartyStaticModuleInterface} originalModuleRecord - reference to the exit module
- * @param {PackagePolicy|undefined} policy - local compartment policy
+ * @param {ModuleDescriptor} moduleDescriptor - reference to the exit module
+ * @param {PackagePolicy | undefined} policy - local compartment policy
  * @param {DeferredAttenuatorsProvider} attenuators - a key-value where attenuations can be found
- * @returns {Promise<ThirdPartyStaticModuleInterface>} - the attenuated module
+ * @returns {Promise<ModuleDescriptor>} - the attenuated module descriptor
  */
 export const attenuateModuleHook = async (
   specifier,
-  originalModuleRecord,
+  moduleDescriptor,
   policy,
   attenuators,
 ) => {
   if (!policy) {
-    return originalModuleRecord;
+    return moduleDescriptor;
   }
   const policyValue = policyLookupHelper(policy, 'builtins', specifier);
   if (policyValue === true) {
-    return originalModuleRecord;
+    return moduleDescriptor;
   }
 
   if (!policyValue) {
@@ -551,9 +619,17 @@ export const attenuateModuleHook = async (
       )}`,
     );
   }
+  // Only virtual module sources and source-bearing descriptors are
+  // attenuatable. NamespaceModuleDescriptor (the other half of
+  // StrictModuleDescriptor) has no source to wrap. attenuateModule throws
+  // if the descriptor is not one of the wrappable shapes.
+  const attenuatable =
+    /** @type {VirtualModuleSource | SourceModuleDescriptor} */ (
+      moduleDescriptor
+    );
   return attenuateModule({
     attenuators,
     attenuationDefinition: policyValue,
-    originalModuleRecord,
+    moduleDescriptor: attenuatable,
   });
 };

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -8,6 +8,7 @@
 
 import type {
   FinalStaticModuleType,
+  ModuleDescriptor,
   StaticModuleType,
   ThirdPartyStaticModuleInterface,
   Transform,
@@ -714,12 +715,12 @@ type ModuleTransformResult = {
 export type ExitModuleImportHook = (
   specifier: string,
   packageLocation: string,
-) => Promise<ThirdPartyStaticModuleInterface | undefined>;
+) => Promise<ModuleDescriptor | undefined>;
 
 export type ExitModuleImportNowHook = (
   specifier: string,
   packageLocation: string,
-) => ThirdPartyStaticModuleInterface | undefined;
+) => ModuleDescriptor | undefined;
 
 export type ComputeSourceLocationHook = (
   compartmentName: string,

--- a/packages/compartment-mapper/test/conditional-host-exports.test.js
+++ b/packages/compartment-mapper/test/conditional-host-exports.test.js
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import url from 'url';
+import crypto from 'crypto';
+import 'ses';
+import test from 'ava';
+import { importLocation } from '../import.js';
+import { makeReadPowers } from '../node-powers.js';
+
+const fixture = new URL(
+  'fixtures-conditional-host-exports/node_modules/app/index.js',
+  import.meta.url,
+).toString();
+
+test('conditional host exports should fall through to ponyfill', async t => {
+  const readPowers = makeReadPowers({
+    url,
+    fs,
+    crypto,
+  });
+  const { namespace } = await importLocation(readPowers, fixture, {
+    conditions: new Set([]),
+  });
+  t.is(namespace.feature, 'ponyfill');
+});
+
+test('conditional host exports should exit to import hook', async t => {
+  const readPowers = makeReadPowers({
+    url,
+    fs,
+    crypto,
+  });
+  const { namespace } = await importLocation(readPowers, fixture, {
+    conditions: new Set(['endo:lib']),
+    async importHook(specifier) {
+      t.is(specifier, 'endo:lib');
+      return { namespace: { feature: 'host' } };
+    },
+  });
+  t.is(namespace.feature, 'host');
+});

--- a/packages/compartment-mapper/test/exit.test.js
+++ b/packages/compartment-mapper/test/exit.test.js
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import crypto from 'crypto';
+import url from 'url';
+import 'ses';
+import test from 'ava';
+import { makeArchive, parseArchive } from '../index.js';
+import { makeReadPowers } from '../node-powers.js';
+
+test('can make, parse, and import an archive with a URL-scheme-prefixed importHook exit to a host module', async t => {
+  const fixture = new URL(
+    'fixtures-exit/import-export.js',
+    import.meta.url,
+  ).toString();
+  const readPowers = makeReadPowers({ fs, url, crypto });
+  const archive = await makeArchive(readPowers, fixture);
+  const app = await parseArchive(archive);
+  const { namespace } = await app.import({
+    async importHook(specifier) {
+      t.is(specifier, 'h2g2:meaning');
+      return { namespace: { meaning: 42 } };
+    },
+  });
+  t.is(namespace.meaning, 42);
+});
+
+test.failing(
+  'can make, parse, and import an archive with a URL-scheme-prefixed modules map exit to a host module',
+  async t => {
+    const fixture = new URL(
+      'fixtures-exit/reexport.js',
+      import.meta.url,
+    ).toString();
+    const readPowers = makeReadPowers({ fs, url, crypto });
+    const archive = await makeArchive(readPowers, fixture);
+    const app = await parseArchive(archive);
+    const { namespace } = await app.import({
+      modules: {
+        'h2g2:meaning': { namespace: { meaning: 42 } },
+      },
+    });
+    t.is(namespace.meaning, 42);
+  },
+);

--- a/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/app/index.js
@@ -1,0 +1,1 @@
+export { feature } from 'lib';

--- a/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "app",
+  "type": "module",
+  "dependencies": {
+    "lib": "*"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/lib/endo.js
+++ b/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/lib/endo.js
@@ -1,0 +1,1 @@
+export { feature } from 'endo:lib';

--- a/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/lib/index.js
+++ b/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/lib/index.js
@@ -1,0 +1,1 @@
+export const feature = 'ponyfill';

--- a/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/lib/package.json
+++ b/packages/compartment-mapper/test/fixtures-conditional-host-exports/node_modules/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lib",
+  "type": "module",
+  "exports": {
+    "endo:lib": "./endo.js",
+    "default": "./index.js"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-exit/import-export.js
+++ b/packages/compartment-mapper/test/fixtures-exit/import-export.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-unresolved */
+// @ts-nocheck
+
+import { meaning as m } from 'h2g2:meaning';
+
+export const meaning = m;

--- a/packages/compartment-mapper/test/fixtures-exit/package.json
+++ b/packages/compartment-mapper/test/fixtures-exit/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixtures-exit",
+  "type": "module"
+}

--- a/packages/compartment-mapper/test/fixtures-exit/reexport.js
+++ b/packages/compartment-mapper/test/fixtures-exit/reexport.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-unresolved */
+// @ts-nocheck
+
+// The following form should suffice, but interacts with an apparent SES bug
+// for reexports.
+export { meaning } from 'h2g2:meaning';

--- a/packages/compartment-mapper/test/policy.test.js
+++ b/packages/compartment-mapper/test/policy.test.js
@@ -446,6 +446,43 @@ scaffold(
   },
 );
 
+// Counterpart of `policy - exitModules import` whose importHook returns the
+// `{ source: VirtualModuleSource }` StrictModuleDescriptor shape instead of a
+// bare virtual source. Covers the `'source' in moduleDescriptor` branch of
+// `attenuateModule` in policy.js, which the host-module-exits change added so
+// that arbitrary module descriptors can flow through the attenuating adapter.
+scaffold(
+  'policy - exitModules import returning a strict module descriptor',
+  test,
+  fixture,
+  makeResultAssertions(defaultExpectations),
+  1, // expected number of assertions
+  {
+    addGlobals: globals,
+    policy,
+    additionalOptions: {
+      modules: {},
+      importHook: async specifier => {
+        const ns = {
+          a: 1,
+          b: 2,
+          c: 3,
+        };
+        return Object.freeze({
+          source: Object.freeze({
+            imports: [],
+            exports: Object.keys(ns),
+            execute: moduleExports => {
+              moduleExports.default = ns;
+              Object.assign(moduleExports, ns);
+            },
+          }),
+        });
+      },
+    },
+  },
+);
+
 scaffold(
   'policy - nested export in attenuator',
   test,

--- a/packages/import-bundle/test/import-bundle.test.js
+++ b/packages/import-bundle/test/import-bundle.test.js
@@ -278,3 +278,26 @@ test('bundleTestExports should accept a genuine module exports namespace', t => 
   bundleTestExports(namespace);
   t.pass();
 });
+
+test('importBundle supports exiting to importHook', async t => {
+  const bundle = await bundleSource(
+    url.fileURLToPath(
+      new URL(
+        '../../compartment-mapper/test/fixtures-conditional-host-exports/node_modules/app/index.js',
+        import.meta.url,
+      ),
+    ),
+    {
+      format: 'endoZipBase64',
+      conditions: ['endo:lib'],
+    },
+  );
+
+  const ns = await importBundle(bundle, {
+    async importHook(specifier) {
+      t.is(specifier, 'endo:lib');
+      return { namespace: { feature: 'host' } };
+    },
+  });
+  t.is(ns.feature, 'host');
+});

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -132,6 +132,10 @@ export type ModuleDescriptor =
   | PrecompiledModuleSource
   | string;
 
+export type StrictModuleDescriptor =
+  | SourceModuleDescriptor
+  | NamespaceModuleDescriptor;
+
 // Deprecated type aliases:
 export type PrecompiledStaticModuleInterface = PrecompiledModuleSource;
 export type ThirdPartyStaticModuleInterface = VirtualModuleSource;


### PR DESCRIPTION
## Description

This change closes the remaining gap between Endo as a Zip archive bundler and support for “exits” to host modules from those bundles at import-time.

This begins with a test to demonstrate the latent support for conditional exits to host modules through `importLocation`. The test fixture has a library that exports the host implementation of itself if the bundler specifies the exit (`endo:lib`) as a condition. This causes the module to be omitted from bundles and relies on the importer to provide the implementation. There remained a gap for a round-trip through a bundle.

The subsequent changes fix a bottleneck for exit modules in the compartment-mapper. The LavaMoat policy-enforcement runtime is limited to virtual module sources, which constrained support for other kinds of module descriptor. This change opens that up so arbitrary module descriptors pass-through the attenuating adapter if no policy is in effect for that edge. We can return to explore attenuation of other kinds of module-descriptor.

At this point, all exits have to be explicitly marked with an `importHook` that returns a module descriptor for the named exit module specifier. We then add a feature to the bundler that implicitly recognizes any module specifier that starts with a URI-scheme prefix is an exit, for convenience on the bundler side. This will obviate the need for an additional command-line flag in `bundle-source` in the common case.

Then, we trivially thread the `importHook` through `importBundle` options.

### Security Considerations

Host provided modules must be hardened and pure, to avoid being useful as a side-channel or mitm attack surface between guests.

### Scaling Considerations

This should allow the creation of smaller bundles.

### Documentation Considerations

Any module that implements this feature should document the condition that enables it for bundling and importing.

### Testing Considerations

Just a test.

### Compatibility Considerations

None.

### Upgrade Considerations

None.