### PR TITLE
feat(captp): handle `send` rejections

### DIFF
--- a/packages/captp/NEWS.md
+++ b/packages/captp/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `@endo/captp`:
 
+# Unreleased
+
+- Relax typing of `send` to allow `async` functions, and abort the connection if the `send` function returns a rejected promise.
+
 # v3.1.0 (2023-04-14)
 
 - Disable GC by default to work around known issues with dropping

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -19,6 +19,9 @@ export { E };
 
 const WELL_KNOWN_SLOT_PROPERTIES = harden(['answerID', 'questionID', 'target']);
 
+const sink = () => {};
+harden(sink);
+
 /**
  * @param {any} maybeThenable
  * @returns {boolean}
@@ -126,7 +129,7 @@ export const makeCapTP = (
     // Silence the unhandled rejection warning, but don't affect
     // the user's handlers.
     const p = Promise.reject(reason);
-    p.catch(_ => {});
+    p.catch(sink);
     return p;
   };
 
@@ -680,7 +683,7 @@ export const makeCapTP = (
       trapIteratorResultP.set(questionID, nextResultP);
 
       // Ensure that our caller handles any rejection.
-      return nextResultP.then(() => {});
+      return nextResultP.then(sink);
     },
     // Answer to one of our questions.
     CTP_RETURN(obj) {


### PR DESCRIPTION
Closes: #2412

## Description

Have CapTP abort the connection if `send` returns a promise rejection.  The existing implementation only aborted if `send` threw a synchronous exception.

### Security Considerations

Crisper handling of async transport-layer failures.

### Scaling Considerations

n/a

### Documentation Considerations

Allows effective use of `async` CapTP send functions.

### Testing Considerations

Usual CI.

### Compatibility Considerations

Will abort the connection if an `async` `send` rejects.  Before, the rejection was ignored.

### Upgrade Considerations

n/a
