### PR TITLE
refactor(bundle-source): Remove vestigial internal dev option

### DIFF
--- a/packages/bundle-source/src/endo.js
+++ b/packages/bundle-source/src/endo.js
@@ -12,7 +12,7 @@ const textDecoder = new TextDecoder();
 
 export const makeBundlingKit = (
   { pathResolve, userInfo, computeSha512, platform, env },
-  { cacheSourceMaps, elideComments, noTransforms, commonDependencies, dev },
+  { cacheSourceMaps, elideComments, noTransforms, commonDependencies },
 ) => {
   if (noTransforms && elideComments) {
     throw new Error(

--- a/packages/bundle-source/src/zip-base64.js
+++ b/packages/bundle-source/src/zip-base64.js
@@ -70,7 +70,6 @@ export async function bundleZipBase64(
         noTransforms,
         elideComments,
         commonDependencies,
-        dev,
       },
     );
 


### PR DESCRIPTION
This removes dead code. The bundler uses the `dev` flag only for discovery of `devDependencies` in `mapNodeModules`, and makes no further use of it in the bundling kit.