### PR TITLE
chore: Release 2024-08-27

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.7](https://github.com/endojs/endo/compare/@endo/base64@1.0.6...@endo/base64@1.0.7) (2024-08-27)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [1.0.6](https://github.com/endojs/endo/compare/@endo/base64@1.0.5...@endo/base64@1.0.6) (2024-07-30)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Transcodes base64",
   "keywords": [
     "base64",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.4.0](https://github.com/endojs/endo/compare/@endo/bundle-source@3.3.0...@endo/bundle-source@3.4.0) (2024-08-27)
+
+
+### Features
+
+* **bundle-source:** --elide-comments ([0a59732](https://github.com/endojs/endo/commit/0a597328ce779ce95ab8d1675cdd84e4ece955f8))
+
+
+
 ## [3.3.0](https://github.com/endojs/endo/compare/@endo/bundle-source@3.2.3...@endo/bundle-source@3.3.0) (2024-07-30)
 
 

--- a/packages/bundle-source/NEWS.md
+++ b/packages/bundle-source/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/bundle-source`:
 
-# Next version
+# v3.4.0 (2024-08-27)
 
 - Adds support for `--elide-comments` (`-e`) that blanks out the interior of
   comments in `endoScript` and `endoZipBase64` formats to reduce bundle size

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.3.0](https://github.com/endojs/endo/compare/@endo/captp@4.2.2...@endo/captp@4.3.0) (2024-08-27)
+
+
+### Features
+
+* **captp:** handle `send` rejections ([7201ae4](https://github.com/endojs/endo/commit/7201ae48a67aa0526f433ea6e2609b3cc29115dd))
+
+
+
 ### [4.2.2](https://github.com/endojs/endo/compare/@endo/captp@4.2.1...@endo/captp@4.2.2) (2024-08-01)
 
 **Note:** Version bump only for package @endo/captp

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.9](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.8...@endo/check-bundle@1.0.9) (2024-08-27)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [1.0.8](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.7...@endo/check-bundle@1.0.8) (2024-07-30)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.7](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@1.0.6...@endo/cjs-module-analyzer@1.0.7) (2024-08-27)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ### [1.0.6](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@1.0.5...@endo/cjs-module-analyzer@1.0.6) (2024-07-30)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.2](https://github.com/endojs/endo/compare/@endo/cli@2.3.1...@endo/cli@2.3.2) (2024-08-27)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [2.3.1](https://github.com/endojs/endo/compare/@endo/cli@2.3.0...@endo/cli@2.3.1) (2024-08-01)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.5](https://github.com/endojs/endo/compare/@endo/common@1.2.4...@endo/common@1.2.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/common
+
+
+
+
+
 ### [1.2.4](https://github.com/endojs/endo/compare/@endo/common@1.2.3...@endo/common@1.2.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/common",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "common low level utilities",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.2.1...@endo/compartment-mapper@1.2.2) (2024-08-27)
+
+
+### Bug Fixes
+
+* **compartment-mapper:** fix [#2407](https://github.com/endojs/endo/issues/2407) include symbol-named properties ([#2408](https://github.com/endojs/endo/issues/2408)) ([2b799f8](https://github.com/endojs/endo/commit/2b799f8b1f0a1beb6f6841652ff2fa92e8458d23)), closes [#2377](https://github.com/endojs/endo/issues/2377)
+
+
+
 ### [1.2.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.2.0...@endo/compartment-mapper@1.2.1) (2024-08-01)
 
 **Note:** Version bump only for package @endo/compartment-mapper

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.4.2](https://github.com/endojs/endo/compare/@endo/daemon@2.4.1...@endo/daemon@2.4.2) (2024-08-27)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ### [2.4.1](https://github.com/endojs/endo/compare/@endo/daemon@2.4.0...@endo/daemon@2.4.1) (2024-08-01)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/env-options/CHANGELOG.md
+++ b/packages/env-options/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.6](https://github.com/endojs/endo/compare/@endo/env-options@1.1.5...@endo/env-options@1.1.6) (2024-08-27)
+
+**Note:** Version bump only for package @endo/env-options
+
+
+
+
+
 ### [1.1.5](https://github.com/endojs/endo/compare/@endo/env-options@1.1.4...@endo/env-options@1.1.5) (2024-07-30)
 
 **Note:** Version bump only for package @endo/env-options

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/env-options",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Reading environment options.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.5](https://github.com/endojs/endo/compare/@endo/errors@1.2.4...@endo/errors@1.2.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/errors
+
+
+
+
+
 ### [1.2.4](https://github.com/endojs/endo/compare/@endo/errors@1.2.3...@endo/errors@1.2.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/errors

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/errors",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.2.1](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.2.0...@endo/eslint-plugin@2.2.1) (2024-08-27)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ## [2.2.0](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.1.3...@endo/eslint-plugin@2.2.0) (2024-07-30)
 
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/evasive-transform/CHANGELOG.md
+++ b/packages/evasive-transform/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.0](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.2.1...@endo/evasive-transform@1.3.0) (2024-08-27)
+
+
+### Features
+
+* **evasive-transform:** elideComments option ([69ba3d7](https://github.com/endojs/endo/commit/69ba3d768ac9cae9acc99a2322e4691d14a658c2))
+
+
+
 ### [1.2.1](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.2.0...@endo/evasive-transform@1.2.1) (2024-08-01)
 
 **Note:** Version bump only for package @endo/evasive-transform

--- a/packages/evasive-transform/NEWS.md
+++ b/packages/evasive-transform/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/evasive-transform`:
 
-# Next release
+# v1.3.0 (2024-08-27)
 
 - Adds an `elideComments` option to replace the interior of comments with
   minimal blank space with identical cursor advancement behavior.

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/evasive-transform",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Source transforms to evade SES censorship",
   "keywords": [
     "ses",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.5](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.4...@endo/eventual-send@1.2.5) (2024-08-27)
+
+
+### Bug Fixes
+
+* **types:** EProxy / Callable ([ea7e8cc](https://github.com/endojs/endo/commit/ea7e8cc7c0c61c68a8b93aebd51548c898f0ae1e))
+
+
+
 ### [1.2.4](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.3...@endo/eventual-send@1.2.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/eventual-send

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.3](https://github.com/endojs/endo/compare/@endo/exo@1.5.2...@endo/exo@1.5.3) (2024-08-27)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.2](https://github.com/endojs/endo/compare/@endo/exo@1.5.1...@endo/exo@1.5.2) (2024-08-01)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/endojs/endo/compare/@endo/far@1.1.4...@endo/far@1.1.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.4](https://github.com/endojs/endo/compare/@endo/far@1.1.3...@endo/far@1.1.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/immutable-arraybuffer/CHANGELOG.md
+++ b/packages/immutable-arraybuffer/CHANGELOG.md
@@ -2,3 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.2.0 (2024-08-27)
+
+
+### Features
+
+* **immutable-arraybuffer:** transferToImmutable ponyfill and shim ([#2399](https://github.com/endojs/endo/issues/2399)) ([dd3f5c2](https://github.com/endojs/endo/commit/dd3f5c253b3c0b8d448b1330d9f01992075ee97e)), closes [#1538](https://github.com/endojs/endo/issues/1538) [#1331](https://github.com/endojs/endo/issues/1331) [#2309](https://github.com/endojs/endo/issues/2309) [#2311](https://github.com/endojs/endo/issues/2311) [#2309](https://github.com/endojs/endo/issues/2309) [/github.com/endojs/endo/pull/2309#issuecomment-2155513240](https://github.com/endojs//github.com/endojs/endo/pull/2309/issues/issuecomment-2155513240) [#1331](https://github.com/endojs/endo/issues/1331) [/github.com/endojs/endo/pull/2309#issuecomment-2155513240](https://github.com/endojs//github.com/endojs/endo/pull/2309/issues/issuecomment-2155513240) [#2311](https://github.com/endojs/endo/issues/2311) [#2311](https://github.com/endojs/endo/issues/2311) [#2311](https://github.com/endojs/endo/issues/2311) [#1538](https://github.com/endojs/endo/issues/1538) [#2311](https://github.com/endojs/endo/issues/2311)

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/immutable-arraybuffer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Immutable ArrayBuffer",
   "keywords": [],

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.2](https://github.com/endojs/endo/compare/@endo/import-bundle@1.2.1...@endo/import-bundle@1.2.2) (2024-08-27)
+
+**Note:** Version bump only for package @endo/import-bundle
+
+
+
+
+
 ### [1.2.1](https://github.com/endojs/endo/compare/@endo/import-bundle@1.2.0...@endo/import-bundle@1.2.1) (2024-08-01)
 
 

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "load modules created by @endo/bundle-source",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.4](https://github.com/endojs/endo/compare/@endo/init@1.1.3...@endo/init@1.1.4) (2024-08-27)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [1.1.3](https://github.com/endojs/endo/compare/@endo/init@1.1.2...@endo/init@1.1.3) (2024-07-30)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.10](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.9...@endo/lockdown@1.0.10) (2024-08-27)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [1.0.9](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.8...@endo/lockdown@1.0.9) (2024-08-01)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/endojs/endo/compare/@endo/lp32@1.1.4...@endo/lp32@1.1.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [1.1.4](https://github.com/endojs/endo/compare/@endo/lp32@1.1.3...@endo/lp32@1.1.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.3](https://github.com/endojs/endo/compare/@endo/marshal@1.5.2...@endo/marshal@1.5.3) (2024-08-27)
+
+**Note:** Version bump only for package @endo/marshal
+
+
+
+
+
 ### [1.5.2](https://github.com/endojs/endo/compare/@endo/marshal@1.5.1...@endo/marshal@1.5.2) (2024-08-01)
 
 **Note:** Version bump only for package @endo/marshal

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/memoize/CHANGELOG.md
+++ b/packages/memoize/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/endojs/endo/compare/@endo/memoize@1.1.4...@endo/memoize@1.1.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/memoize
+
+
+
+
+
 ### [1.1.4](https://github.com/endojs/endo/compare/@endo/memoize@1.1.3...@endo/memoize@1.1.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/memoize

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/memoize",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Safe function memoization",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/module-source/CHANGELOG.md
+++ b/packages/module-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.2](https://github.com/endojs/endo/compare/@endo/module-source@1.0.1...@endo/module-source@1.0.2) (2024-08-27)
+
+**Note:** Version bump only for package @endo/module-source
+
+
+
+
+
 ### [1.0.1](https://github.com/endojs/endo/compare/@endo/module-source@1.0.0...@endo/module-source@1.0.1) (2024-08-01)
 
 **Note:** Version bump only for package @endo/module-source

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/module-source",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Ponyfill for the SES ModuleSource and module-to-program transformer",
   "keywords": [
     "ses",

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.10](https://github.com/endojs/endo/compare/@endo/nat@5.0.9...@endo/nat@5.0.10) (2024-08-27)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [5.0.9](https://github.com/endojs/endo/compare/@endo/nat@5.0.8...@endo/nat@5.0.9) (2024-08-01)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.10](https://github.com/endojs/endo/compare/@endo/netstring@1.0.9...@endo/netstring@1.0.10) (2024-08-27)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [1.0.9](https://github.com/endojs/endo/compare/@endo/netstring@1.0.8...@endo/netstring@1.0.9) (2024-08-01)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.3](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.2...@endo/pass-style@1.4.3) (2024-08-27)
+
+
+### Bug Fixes
+
+* **types:** void is Passable ([1ecb0e7](https://github.com/endojs/endo/commit/1ecb0e7732978f8907ec58a166d792f19b4c8054))
+
+
+
 ### [1.4.2](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.1...@endo/pass-style@1.4.2) (2024-08-01)
 
 **Note:** Version bump only for package @endo/pass-style

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "pass-style: defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.3](https://github.com/endojs/endo/compare/@endo/patterns@1.4.2...@endo/patterns@1.4.3) (2024-08-27)
+
+**Note:** Version bump only for package @endo/patterns
+
+
+
+
+
 ### [1.4.2](https://github.com/endojs/endo/compare/@endo/patterns@1.4.1...@endo/patterns@1.4.2) (2024-08-01)
 
 **Note:** Version bump only for package @endo/patterns

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Description forthcoming.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.4...@endo/promise-kit@1.1.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [1.1.4](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.3...@endo/promise-kit@1.1.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Helper for making promises",
   "keywords": [
     "promise"

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.5](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.4...@endo/ses-ava@1.2.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [1.2.4](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.3...@endo/ses-ava@1.2.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.8.0](https://github.com/endojs/endo/compare/ses@1.7.0...ses@1.8.0) (2024-08-27)
+
+
+### Features
+
+* add regenerator runtime taming ([#2383](https://github.com/endojs/endo/issues/2383)) ([6ae7995](https://github.com/endojs/endo/commit/6ae799521e6ae8b2e938402ce1f2f9e845c2dcfb)), closes [#621](https://github.com/endojs/endo/issues/621) [#1950](https://github.com/endojs/endo/issues/1950)
+* **ses:** `errorTrapping` reports prepend `"SES_UNCAUGHT_EXCEPTION:"` ([1090063](https://github.com/endojs/endo/commit/1090063003250c1f1f3f84b96455c6eb11b580a7))
+
+
+### Bug Fixes
+
+* Delete obsolete platform-compatibility-test ([#2419](https://github.com/endojs/endo/issues/2419)) ([61660da](https://github.com/endojs/endo/commit/61660dad93d6bebbc5525a60fcfdd857f7855d0b)), closes [#2418](https://github.com/endojs/endo/issues/2418) [#2417](https://github.com/endojs/endo/issues/2417) [#1308](https://github.com/endojs/endo/issues/1308) [/github.com/endojs/endo/pull/2419#pullrequestreview-2252979514](https://github.com/endojs//github.com/endojs/endo/pull/2419/issues/pullrequestreview-2252979514) [#2418](https://github.com/endojs/endo/issues/2418) [#2417](https://github.com/endojs/endo/issues/2417)
+* IteratorResult in getAnonymousIntrinsics ([ccb1b26](https://github.com/endojs/endo/commit/ccb1b267f72d76d0753a10be751b0686a803d9a5))
+* **ses:** make test insensitive to an irrelevant env var ([#2403](https://github.com/endojs/endo/issues/2403)) ([8fc0ef7](https://github.com/endojs/endo/commit/8fc0ef7e8b31f2b03e57c4bee7d1a5bbf7c13afc)), closes [#2383](https://github.com/endojs/endo/issues/2383)
+
+
+
 ## [1.7.0](https://github.com/endojs/endo/compare/ses@1.6.0...ses@1.7.0) (2024-08-01)
 
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `ses`:
 
-# Unreleased
+# v1.8.0 (2024-08-27)
 
 - New `legacyRegeneratorRuntimeTaming: 'unsafe-ignore'` lockdown option to tame
   old `regenerator-runtime` (from 0.10.5 to 0.13.7).

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",

--- a/packages/skel/CHANGELOG.md
+++ b/packages/skel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/endojs/endo/compare/@endo/skel@1.1.4...@endo/skel@1.1.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/skel
+
+
+
+
+
 ### [1.1.4](https://github.com/endojs/endo/compare/@endo/skel@1.1.3...@endo/skel@1.1.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/skel

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/skel",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": null,
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.4...@endo/stream-node@1.1.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [1.1.4](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.3...@endo/stream-node@1.1.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.10](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.9...@endo/stream-types-test@1.0.10) (2024-08-27)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [1.0.9](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.8...@endo/stream-types-test@1.0.9) (2024-08-01)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.5](https://github.com/endojs/endo/compare/@endo/stream@1.2.4...@endo/stream@1.2.5) (2024-08-27)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [1.2.4](https://github.com/endojs/endo/compare/@endo/stream@1.2.3...@endo/stream@1.2.4) (2024-08-01)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.7](https://github.com/endojs/endo/compare/@endo/syrup@1.0.6...@endo/syrup@1.0.7) (2024-08-27)
+
+**Note:** Version bump only for package @endo/syrup
+
+
+
+
+
 ### [1.0.6](https://github.com/endojs/endo/compare/@endo/syrup@1.0.5...@endo/syrup@1.0.6) (2024-07-30)
 
 **Note:** Version bump only for package @endo/syrup

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.40](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.39...@endo/test262-runner@0.1.40) (2024-08-27)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.39](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.38...@endo/test262-runner@0.1.39) (2024-08-01)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": true,
   "description": "Hardened JavaScript Test262 Runner",
   "keywords": [],

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.7](https://github.com/endojs/endo/compare/@endo/where@1.0.6...@endo/where@1.0.7) (2024-08-27)
+
+**Note:** Version bump only for package @endo/where
+
+
+
+
+
 ### [1.0.6](https://github.com/endojs/endo/compare/@endo/where@1.0.5...@endo/where@1.0.6) (2024-07-30)
 
 **Note:** Version bump only for package @endo/where

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Locator for Endo user state, caches, and ephemeral files",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.7](https://github.com/endojs/endo/compare/@endo/zip@1.0.6...@endo/zip@1.0.7) (2024-08-27)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ### [1.0.6](https://github.com/endojs/endo/compare/@endo/zip@1.0.5...@endo/zip@1.0.6) (2024-07-30)
 
 **Note:** Version bump only for package @endo/zip

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",


### PR DESCRIPTION
# `ses` v1.8.0 (2024-08-27)

- New `legacyRegeneratorRuntimeTaming: 'unsafe-ignore'` lockdown option to tame
  old `regenerator-runtime` (from 0.10.5 to 0.13.7).
- If lockdown's `errorTrapping: 'report'` mode is selected (possibly via the
  `'platform'`, or `'exit'` or `'abort'` modes), uncaught exceptions will be
  written to standard error with the new `SES_UNCAUGHT_EXCEPTION: ` prefix.
  This is intended to give valuable context to users of the system, especially
  when an uncaught exception is not an `Error` object, and therefore its origin
  may be hard to find in source code.

  This is not likely to affect most systems built with SES, as stderr is
  generally reserved for user-only messages.  If your SES system sends its
  stderr to a program which parses it, you may need to adapt that program to be
  tolerant of the `SES_UNCAUGHT_EXCEPTION: ` prefix.  Even for such programs, it
  is unlikely they are that sensitive to stderr formatting.

# `@endo/bundle-source` v3.4.0 (2024-08-27)

- Adds support for `--elide-comments` (`-e`) that blanks out the interior of
  comments in `endoScript` and `endoZipBase64` formats to reduce bundle size
  without compromising cursor position correspondence between source and bundle
  code.

# `@endo/evasive-transform` v1.3.0 (2024-08-27)

- Adds an `elideComments` option to replace the interior of comments with
  minimal blank space with identical cursor advancement behavior.