### PR TITLE
chore: Delete tsbuildinfo after pack

### DIFF
--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-check": "yarn lint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -30,7 +30,7 @@
     "lint:eslint": "eslint .",
     "lint:types": "tsc",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "exit 0"
   },
   "devDependencies": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -30,7 +30,7 @@
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -14,7 +14,8 @@
     "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "exit 0",
-    "lint-check": "exit 0"
+    "lint-check": "exit 0",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'"
   },
   "dependencies": {
     "requireindex": "~1.1.0",

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -30,7 +30,7 @@
     "test:xs": "exit 0",
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -11,7 +11,7 @@
     "build": "exit 0",
     "clean": "git clean -f '*.d.ts*'",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -14,7 +14,7 @@
     "test:xs": "exit 0",
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -32,7 +32,7 @@
     "test:xs": "exit 0",
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint .",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
     "test:xs": "exit 0",
     "lint-check": "yarn lint",

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -18,7 +18,8 @@
     "test:xs": "exit 0",
     "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'"
   },
   "dependencies": {
     "ses": "workspace:^"

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -30,7 +30,7 @@
     "lint:eslint": "eslint .",
     "lint:types": "tsc",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava"
   },
   "dependencies": {

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc",

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-check": "yarn lint",

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -72,7 +72,8 @@
     "lint:types": "tsc",
     "prepare": "npm run clean && npm run build",
     "qt": "ava",
-    "test": "tsd && ava"
+    "test": "tsd && ava",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'"
   },
   "dependencies": {
     "@endo/env-options": "workspace:^"

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",


### PR DESCRIPTION
Cleans up more dross after building packages for npm.

```sh
#!/bin/bash
set -ueo pipefail
while read -r PKGJSON; do
  echo "$PKGJSON"
  jq '.scripts.postpack = $postpack' \
    --arg postpack "git clean -f '*.d.ts*' '*.tsbuildinfo'" \
    "$PKGJSON" |
    sponge "$PKGJSON"
done < <(
  npm query '.workspace:not([private])' |
  jq -r '.[].location | "\(.)/package.json"'
)
```