### PR TITLE
chore: remove redundant node version CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - name: Echo node version
-        run: node --version
-
       - name: Install dependencies
         run: yarn install --immutable
 
@@ -89,9 +86,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - name: Echo node version
-        run: node --version
-
       - name: Install dependencies
         run: yarn install --immutable
 
@@ -138,9 +132,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - name: Echo node version
-        run: node --version
-
       # end macro
 
       - name: Install dependencies
@@ -178,9 +169,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - name: Echo node version
-        run: node --version
-
       - name: Install dependencies
         run: yarn install --immutable
 
@@ -217,9 +205,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
-      - name: Echo node version
-        run: node --version
-
       - name: Install dependencies
         run: yarn install --immutable
 
@@ -255,9 +240,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-
-      - name: Echo node version
-        run: node --version
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
## Description

this is automatically already printed by the runner as mentioned [earlier](https://github.com/endojs/endo/pull/2334#discussion_r1761817039) cc @boneskull

<img width="480" alt="Screenshot 2024-09-17 at 1 07 38 PM" src="https://github.com/user-attachments/assets/492210e8-4fa4-460a-85d5-7d31012c8f3c">

### Security Considerations

### Scaling Considerations

### Documentation Considerations

### Testing Considerations

### Compatibility Considerations

### Upgrade Considerations
