### PR TITLE
fix(ses): Expose ses/console-shim

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -12,6 +12,7 @@ User-visible changes in `ses`:
   - XS and Node >= 22 already have `Array.prototype.transfer`.
   - Node 18, Node 20, and all browsers have `structuredClone`
   - Node <= 16 have neither, but are also no longer supported by Endo.
+- Fixes a missing file for `ses/console-shim.js`.
 
 # v1.8.0 (2024-08-27)
 

--- a/packages/ses/console-shim.js
+++ b/packages/ses/console-shim.js
@@ -1,0 +1,1 @@
+import './src/console-shim.js';


### PR DESCRIPTION
SES exposes `ses/console-shim.js` in `package.json`, but lacked the “thunk” module needed to entrain the actual implementation. Being able to compose all the layers of `ses` *except* `ses/assert-shim.js` proves to be necessary to make progress on parity testing with XS #2252 