### PR TITLE
fix(ses): Restrict global assert

### DIFF
--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -118,6 +118,7 @@
     "rules": {
       "no-restricted-globals": [
         "error",
+        "AggregateError",
         "Array",
         "ArrayBuffer",
         "Atomics",
@@ -125,6 +126,7 @@
         "BigInt64Array",
         "BigUint64Array",
         "Boolean",
+        "Compartment",
         "DataView",
         "Date",
         "Error",
@@ -160,6 +162,7 @@
         "Uint8ClampedArray",
         "WeakMap",
         "WeakSet",
+        "assert",
         "decodeURI",
         "decodeURIComponent",
         "encodeURI",
@@ -169,10 +172,10 @@
         "globalThis",
         "isFinite",
         "isNaN",
+        "lockdown",
         "parseFloat",
         "parseInt",
-        "unescape",
-        "AggregateError"
+        "unescape"
       ],
       "@endo/no-polymorphic-call": "error"
     },

--- a/packages/ses/src/compartment.js
+++ b/packages/ses/src/compartment.js
@@ -19,7 +19,7 @@ import {
   setGlobalObjectMutableProperties,
   setGlobalObjectEvaluators,
 } from './global-object.js';
-import { assertEqual } from './error/assert.js';
+import { assert, assertEqual } from './error/assert.js';
 import { sharedGlobalPropertyNames } from './permits.js';
 import { load, loadNow } from './module-load.js';
 import { link } from './module-link.js';


### PR DESCRIPTION
SES restricts access to globals in the lexical scope of SES itself, except for their initial capture in `commons.js`, in order to avoid subsequent modifications to the global environment from damaging the integrity of SES itself. This has the side-effect of making SES itself non-reliant on the side-effects of its own shimming behavior, especially when the application applies the shim layers selectively. This is about to become important because we must omit the `ses/assert-shim.js` layer when running SES under test262, since that conflicts with test262’s own `harness/assert.js`. Capturing `assert` lexically allows SES to rely on its own `assert` API without interfering with the different global.

I’ve added all the Hardened JavaScript API, but did not add `console`. We might add `console` in a future change, but the current behavior is to defer `console` to whatever is installed globally at the time of the log line, and that can be overridden by vetted shims.