### PR TITLE
feat(ses): Expose ses/console-shim.js for real this time

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -12,7 +12,7 @@ User-visible changes in `ses`:
   - XS and Node >= 22 already have `Array.prototype.transfer`.
   - Node 18, Node 20, and all browsers have `structuredClone`
   - Node <= 16 have neither, but are also no longer supported by Endo.
-- Fixes a missing file for `ses/console-shim.js`.
+- Now exports separate layer for console shim: `ses/console-shim.js`.
 
 # v1.8.0 (2024-08-27)
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -59,6 +59,7 @@
     "./assert-shim.js": "./assert-shim.js",
     "./lockdown-shim.js": "./lockdown-shim.js",
     "./compartment-shim.js": "./compartment-shim.js",
+    "./console-shim.js": "./console-shim.js",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
Stemming from a confusion in #2460, I find that we never exported ses/console-shim.js and that this change was buried in a subsequent change in my stack of coming changes.