### PR TITLE
chore(ses): Revert ModuleSource shared intrinsic

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -13,8 +13,6 @@ User-visible changes in `ses`:
   - Node 18, Node 20, and all browsers have `structuredClone`
   - Node <= 16 have neither, but are also no longer supported by Endo.
 - Now exports separate layer for console shim: `ses/console-shim.js`.
-- Adds permits for `ModuleSource` if present, either the native implementation
-  or from `@endo/module-source/shim.js`.
 
 # v1.8.0 (2024-08-27)
 

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -161,19 +161,5 @@ export const getAnonymousIntrinsics = () => {
     );
   }
 
-  if (globalThis.ModuleSource) {
-    const AbstractModuleSourcePrototype = getPrototypeOf(
-      globalThis.ModuleSource.prototype,
-    );
-    intrinsics['%AbstractModuleSourcePrototype%'] =
-      AbstractModuleSourcePrototype;
-    intrinsics['%AbstractModuleSource%'] =
-      AbstractModuleSourcePrototype.constructor;
-  }
-
-  if (globalThis.ModuleSource) {
-    intrinsics['%ModuleSourcePrototype%'] = globalThis.ModuleSource.prototype;
-  }
-
   return intrinsics;
 };

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -101,12 +101,8 @@ export const universalPropertyNames = {
 
   // ESNext
 
-  // https://github.com/tc39/proposal-source-phase-imports?tab=readme-ov-file#js-module-source
-  ModuleSource: 'ModuleSource',
-
   lockdown: 'lockdown',
   harden: 'harden',
-
   HandledPromise: 'HandledPromise', // TODO: Until Promise.delegate (see below).
 };
 
@@ -1507,25 +1503,6 @@ export const permitted = {
     getSendOnly: fn,
     prototype: '%PromisePrototype%',
     resolve: fn,
-  },
-
-  // https://github.com/tc39/proposal-source-phase-imports?tab=readme-ov-file#js-module-source
-  '%AbstractModuleSourcePrototype%': {
-    constructor: '%AbstractModuleSource%',
-    '@@toStringTag': getter,
-  },
-  '%AbstractModuleSource%': {
-    '[[Proto]]': '%FunctionPrototype%',
-    prototype: '%AbstractModuleSourcePrototype%',
-  },
-  '%ModuleSourcePrototype%': {
-    '[[Proto]]': '%AbstractModuleSourcePrototype%',
-    constructor: 'ModuleSource',
-    '@@toStringTag': getter,
-  },
-  ModuleSource: {
-    '[[Proto]]': '%AbstractModuleSource%',
-    prototype: '%ModuleSourcePrototype%',
   },
 
   Promise: {

--- a/packages/ses/test/module-source.test.js
+++ b/packages/ses/test/module-source.test.js
@@ -44,7 +44,3 @@ test('module source constructor', t => {
     'ModuleSource imports should be frozen',
   );
 });
-
-test('ModuleSource is a shared intrinsic', t => {
-  t.truthy(ModuleSource === new Compartment().globalThis.ModuleSource);
-});

--- a/packages/ses/test/module-source.test.js
+++ b/packages/ses/test/module-source.test.js
@@ -6,19 +6,6 @@ import '@endo/module-source/shim.js';
 
 lockdown();
 
-test('module source property/prototype graph and hardening', t => {
-  const AbstractModuleSource = Object.getPrototypeOf(ModuleSource);
-  t.is(
-    Object.getPrototypeOf(ModuleSource.prototype),
-    AbstractModuleSource.prototype,
-  );
-
-  t.truthy(Object.isFrozen(ModuleSource));
-  t.truthy(Object.isFrozen(AbstractModuleSource));
-  t.truthy(Object.isFrozen(ModuleSource.prototype));
-  t.truthy(Object.isFrozen(AbstractModuleSource.prototype));
-});
-
 test('module source constructor', t => {
   const msr = new ModuleSource(`
     import foo from 'import-default-export-from-me.js';


### PR DESCRIPTION
This reverts commit 0d210a33c7730e59f722fa2c9e5441eb6065e1b3.

## Description

This change caused a failure for Lockdown on XS in Agoric SDK, indicating that it is a breaking change.

### Testing Considerations

Reverting this change is a temporary mitigation.
We will first address the gap in XS CI coverage and then persue a fix.

### Compatibility Considerations

We will pursue a follow-up change that addresses XS coverage in CI #2463 and then consider repairing the native `ModuleSource` intrinsic under `repairIntrinsics` in SES.
