### PR TITLE
chore(ci): Drop matrix for lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,9 @@ jobs:
 
     # begin macro
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        node-version: [18.x, 20.x]
-        platform: [ubuntu-latest]
 
     steps:
       - name: Checkout
@@ -33,10 +30,10 @@ jobs:
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20.x
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes #2283

In order to avoid unnecessary duplication of effort in CI and to keep the required Lint job name consistent as we upgrade the underlying Node.js version, this change drops the test matrix and hard-codes the platform and node version.