### PR TITLE
chore(dependabot): fix all-minor-patch update-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   # for every subpackage, and we expect that bumping this package will cause the
   # yarn.lock to bump the resolved versions for all the subpackages.
   - package-ecosystem: npm
+    # TODO try the `directories` option to get all the subpackages
     directory: /.
     schedule:
       interval: weekly
@@ -17,6 +18,9 @@ updates:
       all-minor-patch:
         patterns:
           - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
_incidental_

## Description

https://github.com/endojs/endo/pull/2559 updated major versions, because there was no limit on `update-types`.

Now following this example: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-3


### Security Considerations

n/a
### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

I wish we could test before master but it appears not

### Compatibility Considerations

n/a

### Upgrade Considerations

n/a