### PR TITLE
feat(captp): allow external import/export tables

### DIFF
--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -284,6 +284,12 @@ export const makeCapTP = (
         }
         // Set up promise listener to inform other side when this promise
         // is fulfilled/broken
+        const resolved = result =>
+          send({
+            type: 'CTP_RESOLVE',
+            promiseID,
+            res: serialize(harden(result)),
+          });
         const rejected = reason =>
           send({
             type: 'CTP_RESOLVE',
@@ -292,12 +298,7 @@ export const makeCapTP = (
           });
         E.when(
           val,
-          result =>
-            send({
-              type: 'CTP_RESOLVE',
-              promiseID,
-              res: serialize(harden(result)),
-            }),
+          resolved,
           rejected,
           // Propagate internal errors as rejections.
         ).catch(rejected);

--- a/packages/captp/test/export-hook.test.js
+++ b/packages/captp/test/export-hook.test.js
@@ -37,7 +37,7 @@ test('exportHook', async t => {
   await expect([], 1, 2, { foo: `I'm just data` });
 
   const pr = Promise.resolve('pr');
-  const [roundPr] = await expect([{ val: pr, slot: 'p+6' }], pr);
+  const [roundPr] = await expect([{ val: pr, slot: 'p+1' }], pr);
   t.is(roundPr, pr);
 
   const pr2 = new globalThis.HandledPromise(() => {});
@@ -51,7 +51,7 @@ test('exportHook', async t => {
     },
   ] = await expect(
     [
-      { val: pr2, slot: 'p+8' },
+      { val: pr2, slot: 'p+2' },
       { val: far, slot: 'o+2' },
     ],
     {

--- a/packages/captp/test/external-import-export.test.js
+++ b/packages/captp/test/external-import-export.test.js
@@ -1,0 +1,111 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { Far, Remotable } from '@endo/marshal';
+import { isPromise } from '@endo/promise-kit';
+import { makeLoopback, E } from '../src/loopback.js';
+
+const getRandomId = () => Math.random().toString(36).slice(2);
+
+// a custom import/export table maker with random slot ids
+const makeMakeCaptpImportExportTables = ({
+  slotToExported = new Map(),
+  slotToImported = new Map(),
+}) => {
+  const makeCapTPImportExportTables = ({ makeRemoteKit }) => {
+    const makeSlotForValue = val => {
+      const type = isPromise(val) ? 'p' : 'o';
+      const slot = `${type}+${getRandomId()}`;
+      return slot;
+    };
+
+    const makeValueForSlot = (slot, iface) => {
+      const type = slot[0];
+      if (type === 'p') {
+        throw new Error(`not implemented`);
+      }
+      const { settler } = makeRemoteKit(slot);
+      const val = Remotable(iface, undefined, settler.resolveWithPresence());
+      return { val, settler };
+    };
+
+    return {
+      makeSlotForValue,
+      makeValueForSlot,
+      hasImport: slot => slotToImported.has(slot),
+      getImport: slot => slotToImported.get(slot),
+      markAsImported: (slot, val) => slotToImported.set(slot, val),
+      hasExport: slot => slotToExported.has(slot),
+      getExport: slot => slotToExported.get(slot),
+      markAsExported: (slot, val) => slotToExported.set(slot, val),
+      deleteExport: slot => slotToExported.delete(slot),
+      didDisconnect: () => {
+        slotToImported.clear();
+        slotToExported.clear();
+      },
+    };
+  };
+  return makeCapTPImportExportTables;
+};
+
+test('prevent crosstalk', async t => {
+  const nearTables = {
+    slotToExported: new Map(),
+    slotToImported: new Map(),
+  };
+  const farTables = {
+    slotToExported: new Map(),
+    slotToImported: new Map(),
+  };
+  const nearCaptpOpts = {
+    makeCapTPImportExportTables: makeMakeCaptpImportExportTables(nearTables),
+  };
+  const farCaptpOpts = {
+    makeCapTPImportExportTables: makeMakeCaptpImportExportTables(farTables),
+  };
+
+  const { makeFar } = makeLoopback('alice', nearCaptpOpts, farCaptpOpts);
+  const rightRef = await makeFar(
+    Far('rightRef', {
+      makeData() {
+        return { key: 'value' };
+      },
+      makeRemotable() {
+        return Far('remotable', {
+          ping() {
+            return 'pong';
+          },
+        });
+      },
+    }),
+  );
+
+  const expectTableSizes = ({
+    near: [nearImported, nearExported],
+    far: [farImported, farExported],
+  }) => {
+    t.is(nearTables.slotToImported.size, nearImported);
+    t.is(nearTables.slotToExported.size, nearExported);
+    t.is(farTables.slotToImported.size, farImported);
+    t.is(farTables.slotToExported.size, farExported);
+  };
+
+  expectTableSizes({
+    near: [4, 1],
+    far: [2, 2],
+  });
+  const remotable = await E(rightRef).makeRemotable();
+  expectTableSizes({
+    near: [6, 1],
+    far: [2, 3],
+  });
+  await E(remotable).ping();
+  expectTableSizes({
+    near: [7, 1],
+    far: [2, 3],
+  });
+  await E(rightRef).makeData();
+  expectTableSizes({
+    near: [8, 1],
+    far: [2, 3],
+  });
+});


### PR DESCRIPTION
alternate implementation of https://github.com/endojs/endo/pull/2562


ExtRef migration notes:
- passing in import/export tables
  - replaces `opts.gcHook` (export table)
  - replaces `opts.missingExportHook` (export table)
  - replaces `captp.exportValue` (export table)
  - replaces `captp.importSlot` (import table)
- providing a slot provider
  - replaces `opts.onBeforeExportHook` (retrieving slot)
- providing a presence creator
  - replaces `opts.onBeforeExportHook` (creating a presence)
- still need `captp.makeRemoteKit`
