### PR TITLE
tsconfig moduleResolution: NodeNext

### DIFF
--- a/packages/bundle-source/src/bundle-source.js
+++ b/packages/bundle-source/src/bundle-source.js
@@ -7,7 +7,7 @@ export const SUPPORTED_FORMATS = [
   'endoScript',
 ];
 
-/** @type {import('./types').BundleSource} */
+/** @type {import('./types.js').BundleSource} */
 // @ts-ignore cast
 const bundleSource = async (
   startFilename,
@@ -18,7 +18,7 @@ const bundleSource = async (
   if (typeof options === 'string') {
     options = { format: options };
   }
-  /** @type {{ format: import('./types').ModuleFormat }} */
+  /** @type {{ format: import('./types.js').ModuleFormat }} */
   // @ts-expect-error cast (xxx params)
   const { format: moduleFormat = DEFAULT_MODULE_FORMAT } = options;
 

--- a/packages/captp/src/atomics.js
+++ b/packages/captp/src/atomics.js
@@ -1,5 +1,3 @@
-/// <reference types="ses"/>
-
 import { X, Fail } from '@endo/errors';
 
 // This is a pathological minimum, but exercised by the unit test.

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -1,5 +1,3 @@
-/// <reference types="ses"/>
-
 /** @import {RemoteKit, Settler} from '@endo/eventual-send' */
 /** @import {CapTPSlot, TrapHost, TrapGuest, TrapImpl} from './types.js' */
 

--- a/packages/captp/test/traplib.js
+++ b/packages/captp/test/traplib.js
@@ -1,5 +1,4 @@
 /* global setTimeout */
-/// <reference types="ses"/>
 
 import { Far } from '@endo/marshal';
 import { X, Fail } from '@endo/errors';

--- a/packages/captp/test/worker.js
+++ b/packages/captp/test/worker.js
@@ -1,5 +1,3 @@
-/// <reference types="ses"/>
-
 import '@endo/init/pre-remoting.js';
 import '@endo/init/debug.js';
 

--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -1,8 +1,6 @@
 /* Validates a compartment map against its schema. */
 
 // @ts-check
-/// <reference types="ses"/>
-
 import { assertPackagePolicy } from './policy-format.js';
 
 // TODO convert to the new `||` assert style.

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1,6 +1,4 @@
 // @ts-check
-/// <reference types="ses"/>
-
 /* global setTimeout, clearTimeout */
 
 import { makeExo } from '@endo/exo';

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -1,7 +1,5 @@
 /* global globalThis */
 // @ts-check
-/// <reference types="ses"/>
-
 import { E, Far } from '@endo/far';
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';

--- a/packages/errors/index.js
+++ b/packages/errors/index.js
@@ -1,6 +1,4 @@
 /* global globalThis */
-/// <reference types="ses"/>
-
 // This module assumes the existence of a non-standard `assert` host object.
 // SES version 0.11.0 introduces this global object and entangles it
 // with the `console` host object in scope when it initializes,

--- a/packages/evasive-transform/src/generate.js
+++ b/packages/evasive-transform/src/generate.js
@@ -37,7 +37,7 @@ const generator = /** @type {typeof import('@babel/generator')['default']} */ (
  * provided to the options.
  *
  * @template {string|undefined} [SourceUrl=undefined]
- * @typedef {{code: string, map: SourceUrl extends string ? import('source-map').RawSourceMap : never}} TransformedResult
+ * @typedef {{code: string, map: SourceUrl extends string ? import('source-map-js').RawSourceMap : never}} TransformedResult
  * @internal
  */
 

--- a/packages/evasive-transform/src/generate.js
+++ b/packages/evasive-transform/src/generate.js
@@ -4,6 +4,7 @@
  * @module
  */
 
+// @ts-ignore XXX no types defined
 import babelGenerator from '@agoric/babel-generator';
 
 // TODO The following is sufficient on Node.js, but for compatibility with

--- a/packages/evasive-transform/src/index.js
+++ b/packages/evasive-transform/src/index.js
@@ -16,7 +16,7 @@ import { generate } from './generate.js';
  * Options for {@link evadeCensorSync}
  *
  * @typedef EvadeCensorOptions
- * @property {string|import('source-map').RawSourceMap} [sourceMap] - Original source map in JSON string or object form
+ * @property {string|import('source-map-js').RawSourceMap} [sourceMap] - Original source map in JSON string or object form
  * @property {string} [sourceUrl] - URL or filepath of the original source in `code`
  * @property {boolean} [useLocationUnmap] - Enable location unmapping. Only applies if `sourceMap` was provided
  * @property {boolean} [elideComments] - Replace comments with an ellipsis but preserve interior newlines.

--- a/packages/evasive-transform/src/transform-ast.js
+++ b/packages/evasive-transform/src/transform-ast.js
@@ -14,7 +14,6 @@ import { makeLocationUnmapper } from './location-unmapper.js';
 // OR, upgrading to Babel 8 probably addresses this defect.
 // const { default: traverse } = /** @type {any} */ (babelTraverse);
 const traverse = /** @type {typeof import('@babel/traverse')['default']} */ (
-  // @ts-expect-error
   babelTraverse.default || babelTraverse
 );
 

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -35,7 +35,7 @@ const baseFreezableProxyHandler = {
  * A Proxy handler for E(x).
  *
  * @param {any} recipient Any value passed to E(x)
- * @param {import('./types').HandledPromiseConstructor} HandledPromise
+ * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeEProxyHandler = (recipient, HandledPromise) =>
@@ -96,7 +96,7 @@ const makeEProxyHandler = (recipient, HandledPromise) =>
  * It is a variant on the E(x) Proxy handler.
  *
  * @param {any} recipient Any value passed to E.sendOnly(x)
- * @param {import('./types').HandledPromiseConstructor} HandledPromise
+ * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
@@ -153,7 +153,7 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
  * It is a variant on the E(x) Proxy handler.
  *
  * @param {any} x Any value passed to E.get(x)
- * @param {import('./types').HandledPromiseConstructor} HandledPromise
+ * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeEGetProxyHandler = (x, HandledPromise) =>
@@ -164,7 +164,7 @@ const makeEGetProxyHandler = (x, HandledPromise) =>
   });
 
 /**
- * @param {import('./types').HandledPromiseConstructor} HandledPromise
+ * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
  */
 const makeE = HandledPromise => {
   return harden(
@@ -255,7 +255,7 @@ export default makeE;
  *
  * @template Primary The type of the primary reference.
  * @template [Local=DataOnly<Primary>] The local properties of the object.
- * @typedef {ERef<Local & import('./types').RemotableBrand<Local, Primary>>} FarRef
+ * @typedef {ERef<Local & import('./types.js').RemotableBrand<Local, Primary>>} FarRef
  */
 
 /**
@@ -263,7 +263,7 @@ export default makeE;
  * properties that are *not* functions.
  *
  * @template T The type to be filtered.
- * @typedef {Omit<T, FilteredKeys<T, import('./types').Callable>>} DataOnly
+ * @typedef {Omit<T, FilteredKeys<T, import('./types.js').Callable>>} DataOnly
  */
 
 /**
@@ -273,7 +273,7 @@ export default makeE;
  */
 
 /**
- * @template {import('./types').Callable} T
+ * @template {import('./types.js').Callable} T
  * @typedef {(
  *   ReturnType<T> extends PromiseLike<infer U>                       // if function returns a promise
  *     ? T                                                            // return the function
@@ -284,7 +284,7 @@ export default makeE;
 /**
  * @template T
  * @typedef {{
- *   readonly [P in keyof T]: T[P] extends import('./types').Callable
+ *   readonly [P in keyof T]: T[P] extends import('./types.js').Callable
  *     ? ECallable<T[P]>
  *     : never;
  * }} EMethods
@@ -300,14 +300,14 @@ export default makeE;
  */
 
 /**
- * @template {import('./types').Callable} T
+ * @template {import('./types.js').Callable} T
  * @typedef {(...args: Parameters<T>) => Promise<void>} ESendOnlyCallable
  */
 
 /**
  * @template T
  * @typedef {{
- *   readonly [P in keyof T]: T[P] extends import('./types').Callable
+ *   readonly [P in keyof T]: T[P] extends import('./types.js').Callable
  *     ? ESendOnlyCallable<T[P]>
  *     : never;
  * }} ESendOnlyMethods
@@ -316,7 +316,7 @@ export default makeE;
 /**
  * @template T
  * @typedef {(
- *   T extends import('./types').Callable
+ *   T extends import('./types.js').Callable
  *     ? ESendOnlyCallable<T> & ESendOnlyMethods<Required<T>>
  *     : ESendOnlyMethods<Required<T>>
  * )} ESendOnlyCallableOrMethods
@@ -325,7 +325,7 @@ export default makeE;
 /**
  * @template T
  * @typedef {(
- *   T extends import('./types').Callable
+ *   T extends import('./types.js').Callable
  *     ? ECallable<T> & EMethods<Required<T>>
  *     : EMethods<Required<T>>
  * )} ECallableOrMethods
@@ -352,9 +352,9 @@ export default makeE;
  *
  * @template T
  * @typedef {(
- *   T extends import('./types').Callable
+ *   T extends import('./types.js').Callable
  *     ? (...args: Parameters<T>) => ReturnType<T>                     // a root callable, no methods
- *     : Pick<T, FilteredKeys<T, import('./types').Callable>>          // any callable methods
+ *     : Pick<T, FilteredKeys<T, import('./types.js').Callable>>          // any callable methods
  * )} PickCallable
  */
 
@@ -363,9 +363,9 @@ export default makeE;
  *
  * @template T
  * @typedef {(
- *   T extends import('./types').RemotableBrand<infer L, infer R>     // if a given T is some remote interface R
+ *   T extends import('./types.js').RemotableBrand<infer L, infer R>     // if a given T is some remote interface R
  *     ? PickCallable<R>                                              // then return the callable properties of R
- *     : Awaited<T> extends import('./types').RemotableBrand<infer L, infer R> // otherwise, if the final resolution of T is some remote interface R
+ *     : Awaited<T> extends import('./types.js').RemotableBrand<infer L, infer R> // otherwise, if the final resolution of T is some remote interface R
  *     ? PickCallable<R>                                              // then return the callable properties of R
  *     : T extends PromiseLike<infer U>                               // otherwise, if T is a promise
  *     ? Awaited<T>                                                   // then return resolved value T
@@ -376,9 +376,9 @@ export default makeE;
 /**
  * @template T
  * @typedef {(
- *   T extends import('./types').RemotableBrand<infer L, infer R>
+ *   T extends import('./types.js').RemotableBrand<infer L, infer R>
  *     ? L
- *     : Awaited<T> extends import('./types').RemotableBrand<infer L, infer R>
+ *     : Awaited<T> extends import('./types.js').RemotableBrand<infer L, infer R>
  *     ? L
  *     : T extends PromiseLike<infer U>
  *     ? Awaited<T>
@@ -390,7 +390,7 @@ export default makeE;
  * @template [R = unknown]
  * @typedef {{
  *   promise: Promise<R>;
- *   settler: import('./types').Settler<R>;
+ *   settler: import('./types.js').Settler<R>;
  * }} EPromiseKit
  */
 
@@ -400,11 +400,11 @@ export default makeE;
  *
  * @template T
  * @typedef {(
- *   T extends import('./types').Callable
+ *   T extends import('./types.js').Callable
  *     ? (...args: Parameters<T>) => ERef<Awaited<EOnly<ReturnType<T>>>>
- *     : T extends Record<PropertyKey, import('./types').Callable>
+ *     : T extends Record<PropertyKey, import('./types.js').Callable>
  *     ? {
- *         [K in keyof T]: T[K] extends import('./types').Callable
+ *         [K in keyof T]: T[K] extends import('./types.js').Callable
  *           ? (...args: Parameters<T[K]>) => ERef<Awaited<EOnly<ReturnType<T[K]>>>>
  *           : T[K];
  *       }

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -4,6 +4,10 @@ import { makeMessageBreakpointTester } from './message-breakpoints.js';
 const { details: X, quote: q, Fail, error: makeError } = assert;
 const { assign, create } = Object;
 
+/**
+ * @import { HandledPromiseConstructor } from './types.js';
+ */
+
 const onSend = makeMessageBreakpointTester('ENDO_SEND_BREAKPOINTS');
 
 /** @type {ProxyHandler<any>} */
@@ -35,7 +39,7 @@ const baseFreezableProxyHandler = {
  * A Proxy handler for E(x).
  *
  * @param {any} recipient Any value passed to E(x)
- * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
+ * @param {HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeEProxyHandler = (recipient, HandledPromise) =>
@@ -96,7 +100,7 @@ const makeEProxyHandler = (recipient, HandledPromise) =>
  * It is a variant on the E(x) Proxy handler.
  *
  * @param {any} recipient Any value passed to E.sendOnly(x)
- * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
+ * @param {HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
@@ -153,7 +157,7 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
  * It is a variant on the E(x) Proxy handler.
  *
  * @param {any} x Any value passed to E.get(x)
- * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
+ * @param {HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler<unknown>} the Proxy handler
  */
 const makeEGetProxyHandler = (x, HandledPromise) =>
@@ -164,7 +168,7 @@ const makeEGetProxyHandler = (x, HandledPromise) =>
   });
 
 /**
- * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
+ * @param {HandledPromiseConstructor} HandledPromise
  */
 const makeE = HandledPromise => {
   return harden(

--- a/packages/eventual-send/src/postponed.js
+++ b/packages/eventual-send/src/postponed.js
@@ -4,8 +4,8 @@
  * Create a simple postponedHandler that just postpones until donePostponing is
  * called.
  *
- * @param {import('./types').HandledPromiseConstructor} HandledPromise
- * @returns {[Required<import('./types').Handler<any>>, () => void]} postponedHandler and donePostponing callback.
+ * @param {import('./types.js').HandledPromiseConstructor} HandledPromise
+ * @returns {[Required<import('./types.js').Handler<any>>, () => void]} postponedHandler and donePostponing callback.
  */
 export const makePostponedHandler = HandledPromise => {
   /** @type {() => void} */
@@ -29,7 +29,7 @@ export const makePostponedHandler = HandledPromise => {
     };
   };
 
-  /** @type {Required<import('./types').Handler<any>>} */
+  /** @type {Required<import('./types.js').Handler<any>>} */
   const postponedHandler = {
     get: makePostponedOperation('get'),
     getSendOnly: makePostponedOperation('getSendOnly'),

--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -1,4 +1,3 @@
-/// <reference types="ses"/>
 import { objectMap } from '@endo/common/object-map.js';
 import { environmentOptionsListHas } from '@endo/env-options';
 

--- a/packages/lp32/reader.js
+++ b/packages/lp32/reader.js
@@ -1,6 +1,4 @@
 // @ts-check
-/// <reference types="ses"/>
-
 // We use a DataView to give users choice over endianness.
 // But DataView does not default to host-byte-order like other typed arrays.
 

--- a/packages/lp32/writer.js
+++ b/packages/lp32/writer.js
@@ -1,6 +1,4 @@
 // @ts-check
-/// <reference types="ses"/>
-
 import { Fail, q } from '@endo/errors';
 import { hostIsLittleEndian } from './src/host-endian.js';
 

--- a/packages/pass-style/src/types.test-d.ts
+++ b/packages/pass-style/src/types.test-d.ts
@@ -1,10 +1,10 @@
 /* eslint-disable */
 import { expectAssignable, expectType, expectNotType } from 'tsd';
-import { Far } from './make-far';
-import { passStyleOf } from './passStyleOf';
-import { makeTagged } from './makeTagged';
-import { CopyTagged, Passable, PassStyle } from './types';
-import { PASS_STYLE } from './passStyle-helpers';
+import { Far } from './make-far.js';
+import { passStyleOf } from './passStyleOf.js';
+import { makeTagged } from './makeTagged.js';
+import { CopyTagged, Passable, PassStyle } from './types.js';
+import { PASS_STYLE } from './passStyle-helpers.js';
 
 const remotable = Far('foo', {});
 

--- a/packages/promise-kit/index.js
+++ b/packages/promise-kit/index.js
@@ -1,7 +1,5 @@
 /* global globalThis */
 
-/// <reference types="ses"/>
-
 import { makeReleasingExecutorKit } from './src/promise-executor-kit.js';
 import { memoRace } from './src/memo-race.js';
 

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -1,5 +1,3 @@
-/// <reference types="ses"/>
-
 import { globalThis } from './commons.js';
 import { makeCompartmentConstructor } from './compartment.js';
 import { tameFunctionToString } from './tame-function-tostring.js';

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -48,6 +48,7 @@ import { makeNoteLogArgsArrayKit } from './note-log-args.js';
 
 /**
  * @import {BaseAssert, Assert, AssertionFunctions, AssertionUtilities, StringablePayload, DetailsToken, MakeAssert} from '../../types.js'
+ * @import {LogArgs, NoteCallback, LoggedErrorHandler} from "./internal-types.js";
  */
 
 // For our internal debugging purposes, uncomment

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -22,8 +22,11 @@ import {
   weaksetAdd,
   weaksetHas,
 } from '../commons.js';
-import './types.js';
-import './internal-types.js';
+
+/**
+ * @import {FilterConsole, LogSeverity, VirtualConsole} from './types.js'
+ * @import {ErrorInfo, ErrorInfoKind, LogRecord, NoteCallback, LoggedErrorHandler, MakeCausalConsole, MakeLoggingConsoleKit} from "./internal-types.js";
+ */
 
 // For our internal debugging purposes, uncomment
 // const internalDebugConsole = console;

--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -1,6 +1,10 @@
 // @ts-check
 
 /**
+ * @import {VirtualConsole} from './types.js'
+ */
+
+/**
  * @typedef {readonly any[]} LogArgs
  *
  * This is an array suitable to be used as arguments of a console

--- a/packages/ses/src/error/note-log-args.js
+++ b/packages/ses/src/error/note-log-args.js
@@ -3,7 +3,10 @@
 /* eslint-disable no-restricted-globals */
 
 import { makeLRUCacheMap } from '../make-lru-cachemap.js';
-import './internal-types.js';
+
+/**
+ * @import {LogArgs} from './internal-types.js';
+ */
 
 const { freeze } = Object;
 const { isSafeInteger } = Number;

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -11,8 +11,11 @@ import {
 import { loggedErrorHandler as defaultHandler } from './assert.js';
 import { makeCausalConsole } from './console.js';
 import { makeRejectionHandlers } from './unhandled-rejection.js';
-import './types.js';
-import './internal-types.js';
+
+/**
+ * @import {VirtualConsole} from './types.js'
+ * @import {GetStackString} from './internal-types.js';
+ */
 
 const failFast = message => {
   throw TypeError(message);

--- a/packages/ses/types.test-d.ts
+++ b/packages/ses/types.test-d.ts
@@ -4,8 +4,6 @@ import type { Assert } from 'ses';
 
 import { equal as nassert } from 'node:assert/strict';
 
-/// <reference types="ses"/>
-
 // Lockdown
 
 lockdown();

--- a/tsconfig.eslint-base.json
+++ b/tsconfig.eslint-base.json
@@ -2,12 +2,12 @@
   "compilerOptions": {
     "allowJs": true,
     "target": "esnext",
-    "module": "esnext",
+    "module": "NodeNext",
     "checkJs": true,
     "noEmit": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
-    "moduleResolution": "node"
+    "moduleResolution": "NodeNext"
   },
   "include": [],
   "exclude": [


### PR DESCRIPTION
_incidental_

## Description

In an a3p test I tried disabling `skipLibCheck` and many errors were from Endo packages's omission of module filename extensions.

That's because Endo was using the default [moduleResolution](https://www.typescriptlang.org/tsconfig/#moduleResolution), `node10`. This changes it to `NodeNext` and also the `module` option for compatibility.

That resulted in new errors which I address mostly by switching to explicit `@import`.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

- https://github.com/Agoric/agoric-sdk/pull/9385

### Compatibility Considerations

This might affect consuming packages that depend on ambient types. That's almost certainly only agoric-sdk which we can solve with https://github.com/Agoric/agoric-sdk/pull/9385

### Upgrade Considerations

If https://github.com/Agoric/agoric-sdk/pull/9385 needs changes then `NEWS.md` should indicate it. I don't think type changes live up to `BREAKING` which would be a semver major bump. 