### PR TITLE
chore: Release 2024-10-10

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.8](https://github.com/endojs/endo/compare/@endo/base64@1.0.7...@endo/base64@1.0.8) (2024-10-10)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [1.0.7](https://github.com/endojs/endo/compare/@endo/base64@1.0.6...@endo/base64@1.0.7) (2024-08-27)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Transcodes base64",
   "keywords": [
     "base64",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.4.1](https://github.com/endojs/endo/compare/@endo/bundle-source@3.4.0...@endo/bundle-source@3.4.1) (2024-10-10)
+
+**Note:** Version bump only for package @endo/bundle-source
+
+
+
+
+
 ## [3.4.0](https://github.com/endojs/endo/compare/@endo/bundle-source@3.3.0...@endo/bundle-source@3.4.0) (2024-08-27)
 
 

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.4.0](https://github.com/endojs/endo/compare/@endo/captp@4.3.0...@endo/captp@4.4.0) (2024-10-10)
+
+
+### Features
+
+* **captp:** allow external import/export maps ([7bc41cc](https://github.com/endojs/endo/commit/7bc41cca0f80822bb17667d7cce7d035fcf4a674))
+
+
+
 ## [4.3.0](https://github.com/endojs/endo/compare/@endo/captp@4.2.2...@endo/captp@4.3.0) (2024-08-27)
 
 

--- a/packages/captp/NEWS.md
+++ b/packages/captp/NEWS.md
@@ -1,6 +1,10 @@
 User-visible changes in `@endo/captp`:
 
-# Unreleased
+# v4.4.0 (2024-10-10)
+
+- Add optional configuration `makeCapTPImportExportTables` for external management of import/export tables.
+
+# v4.3.0 (2024-08-23)
 
 - Relax typing of `send` to allow `async` functions, and abort the connection if the `send` function returns a rejected promise.
 

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.10](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.9...@endo/check-bundle@1.0.10) (2024-10-10)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [1.0.9](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.8...@endo/check-bundle@1.0.9) (2024-08-27)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.8](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@1.0.7...@endo/cjs-module-analyzer@1.0.8) (2024-10-10)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ### [1.0.7](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@1.0.6...@endo/cjs-module-analyzer@1.0.7) (2024-08-27)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.3](https://github.com/endojs/endo/compare/@endo/cli@2.3.2...@endo/cli@2.3.3) (2024-10-10)
+
+
+### Bug Fixes
+
+* **cli:** Improve number parsing ([aa48722](https://github.com/endojs/endo/commit/aa48722505c19bc77793ecc0f4e4efe51c345db0))
+
+
+
 ### [2.3.2](https://github.com/endojs/endo/compare/@endo/cli@2.3.1...@endo/cli@2.3.2) (2024-08-27)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.6](https://github.com/endojs/endo/compare/@endo/common@1.2.5...@endo/common@1.2.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/common
+
+
+
+
+
 ### [1.2.5](https://github.com/endojs/endo/compare/@endo/common@1.2.4...@endo/common@1.2.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/common",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "common low level utilities",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.2.2...@endo/compartment-mapper@1.3.0) (2024-10-10)
+
+
+### Features
+
+* **compartment-mapper:** support for dynamic requires ([572589c](https://github.com/endojs/endo/commit/572589cbce247b322925cd3c1274ba56d72d3741))
+
+
+### Bug Fixes
+
+* **compartment-mapper:** bad type in assertCompartmentMap ([81d7464](https://github.com/endojs/endo/commit/81d74646756b187306ba0511386aea6365979e78))
+
+
+
 ### [1.2.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.2.1...@endo/compartment-mapper@1.2.2) (2024-08-27)
 
 

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/compartment-mapper`:
 
-# Next release
+# v1.3.0 (2024-10-10)
 
 - Adds support for dynamic requires in CommonJS modules. This requires specific
   configuration to be passed in (including new read powers), and is _not_

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.4.3](https://github.com/endojs/endo/compare/@endo/daemon@2.4.2...@endo/daemon@2.4.3) (2024-10-10)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ### [2.4.2](https://github.com/endojs/endo/compare/@endo/daemon@2.4.1...@endo/daemon@2.4.2) (2024-08-27)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/env-options/CHANGELOG.md
+++ b/packages/env-options/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.7](https://github.com/endojs/endo/compare/@endo/env-options@1.1.6...@endo/env-options@1.1.7) (2024-10-10)
+
+**Note:** Version bump only for package @endo/env-options
+
+
+
+
+
 ### [1.1.6](https://github.com/endojs/endo/compare/@endo/env-options@1.1.5...@endo/env-options@1.1.6) (2024-08-27)
 
 **Note:** Version bump only for package @endo/env-options

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/env-options",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Reading environment options.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.6](https://github.com/endojs/endo/compare/@endo/errors@1.2.5...@endo/errors@1.2.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/errors
+
+
+
+
+
 ### [1.2.5](https://github.com/endojs/endo/compare/@endo/errors@1.2.4...@endo/errors@1.2.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/errors

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/errors",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.2.2](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.2.1...@endo/eslint-plugin@2.2.2) (2024-10-10)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ### [2.2.1](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.2.0...@endo/eslint-plugin@2.2.1) (2024-08-27)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/evasive-transform/CHANGELOG.md
+++ b/packages/evasive-transform/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.1](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.0...@endo/evasive-transform@1.3.1) (2024-10-10)
+
+**Note:** Version bump only for package @endo/evasive-transform
+
+
+
+
+
 ## [1.3.0](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.2.1...@endo/evasive-transform@1.3.0) (2024-08-27)
 
 

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/evasive-transform",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Source transforms to evade SES censorship",
   "keywords": [
     "ses",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.6](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.5...@endo/eventual-send@1.2.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/eventual-send
+
+
+
+
+
 ### [1.2.5](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.4...@endo/eventual-send@1.2.5) (2024-08-27)
 
 

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.4](https://github.com/endojs/endo/compare/@endo/exo@1.5.3...@endo/exo@1.5.4) (2024-10-10)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.3](https://github.com/endojs/endo/compare/@endo/exo@1.5.2...@endo/exo@1.5.3) (2024-08-27)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.6](https://github.com/endojs/endo/compare/@endo/far@1.1.5...@endo/far@1.1.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.5](https://github.com/endojs/endo/compare/@endo/far@1.1.4...@endo/far@1.1.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/immutable-arraybuffer/CHANGELOG.md
+++ b/packages/immutable-arraybuffer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@0.2.0...@endo/immutable-arraybuffer@0.2.1) (2024-10-10)
+
+**Note:** Version bump only for package @endo/immutable-arraybuffer
+
+
+
+
+
 ## 0.2.0 (2024-08-27)
 
 

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/immutable-arraybuffer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Immutable ArrayBuffer",
   "keywords": [],

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.0](https://github.com/endojs/endo/compare/@endo/import-bundle@1.2.2...@endo/import-bundle@1.3.0) (2024-10-10)
+
+
+### Features
+
+* **import-bundle:** Support endoScript ([4af8ebf](https://github.com/endojs/endo/commit/4af8ebfdb19b829b620949359f70a7dcf6a6aae7))
+
+
+
 ### [1.2.2](https://github.com/endojs/endo/compare/@endo/import-bundle@1.2.1...@endo/import-bundle@1.2.2) (2024-08-27)
 
 **Note:** Version bump only for package @endo/import-bundle

--- a/packages/import-bundle/NEWS.md
+++ b/packages/import-bundle/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/import-bundle`:
 
-# Next release
+# v1.3.0 (2024-10-10)
 
 - Adds support for `endoScript` format bundles.
 

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "load modules created by @endo/bundle-source",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/endojs/endo/compare/@endo/init@1.1.4...@endo/init@1.1.5) (2024-10-10)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [1.1.4](https://github.com/endojs/endo/compare/@endo/init@1.1.3...@endo/init@1.1.4) (2024-08-27)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.11](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.10...@endo/lockdown@1.0.11) (2024-10-10)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [1.0.10](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.9...@endo/lockdown@1.0.10) (2024-08-27)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.6](https://github.com/endojs/endo/compare/@endo/lp32@1.1.5...@endo/lp32@1.1.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [1.1.5](https://github.com/endojs/endo/compare/@endo/lp32@1.1.4...@endo/lp32@1.1.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.4](https://github.com/endojs/endo/compare/@endo/marshal@1.5.3...@endo/marshal@1.5.4) (2024-10-10)
+
+**Note:** Version bump only for package @endo/marshal
+
+
+
+
+
 ### [1.5.3](https://github.com/endojs/endo/compare/@endo/marshal@1.5.2...@endo/marshal@1.5.3) (2024-08-27)
 
 **Note:** Version bump only for package @endo/marshal

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/memoize/CHANGELOG.md
+++ b/packages/memoize/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.6](https://github.com/endojs/endo/compare/@endo/memoize@1.1.5...@endo/memoize@1.1.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/memoize
+
+
+
+
+
 ### [1.1.5](https://github.com/endojs/endo/compare/@endo/memoize@1.1.4...@endo/memoize@1.1.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/memoize

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/memoize",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Safe function memoization",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/module-source/CHANGELOG.md
+++ b/packages/module-source/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.0](https://github.com/endojs/endo/compare/@endo/module-source@1.0.2...@endo/module-source@1.1.0) (2024-10-10)
+
+
+### Features
+
+* **module-source:** Introduce a shim that composes with lockdown ([9a3ecca](https://github.com/endojs/endo/commit/9a3ecca305b4a3b4a2e09d03ea84671969a26586))
+
+
+### Bug Fixes
+
+* **module-source:** Sub non-conforming `ZWJ` prefixes with `CGJ` ([862dfd8](https://github.com/endojs/endo/commit/862dfd8a81dfec893300123745c0c3a579c54162))
+
+
+
 ### [1.0.2](https://github.com/endojs/endo/compare/@endo/module-source@1.0.1...@endo/module-source@1.0.2) (2024-08-27)
 
 **Note:** Version bump only for package @endo/module-source

--- a/packages/module-source/NEWS.md
+++ b/packages/module-source/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/module-source`:
 
-# Next release
+# v1.1.0 (2024-10-10)
 
 - Adds `@endo/module-source/shim.js` to shim `globalThis.ModuleSource`.
   The shim currently replaces the native `globalThis.ModuleSource` if present.

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/module-source",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Ponyfill for the SES ModuleSource and module-to-program transformer",
   "keywords": [
     "ses",

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.11](https://github.com/endojs/endo/compare/@endo/nat@5.0.10...@endo/nat@5.0.11) (2024-10-10)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [5.0.10](https://github.com/endojs/endo/compare/@endo/nat@5.0.9...@endo/nat@5.0.10) (2024-08-27)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.11](https://github.com/endojs/endo/compare/@endo/netstring@1.0.10...@endo/netstring@1.0.11) (2024-10-10)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [1.0.10](https://github.com/endojs/endo/compare/@endo/netstring@1.0.9...@endo/netstring@1.0.10) (2024-08-27)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.4](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.3...@endo/pass-style@1.4.4) (2024-10-10)
+
+**Note:** Version bump only for package @endo/pass-style
+
+
+
+
+
 ### [1.4.3](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.2...@endo/pass-style@1.4.3) (2024-08-27)
 
 

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "pass-style: defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.4](https://github.com/endojs/endo/compare/@endo/patterns@1.4.3...@endo/patterns@1.4.4) (2024-10-10)
+
+**Note:** Version bump only for package @endo/patterns
+
+
+
+
+
 ### [1.4.3](https://github.com/endojs/endo/compare/@endo/patterns@1.4.2...@endo/patterns@1.4.3) (2024-08-27)
 
 **Note:** Version bump only for package @endo/patterns

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Description forthcoming.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.6](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.5...@endo/promise-kit@1.1.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [1.1.5](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.4...@endo/promise-kit@1.1.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Helper for making promises",
   "keywords": [
     "promise"

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.6](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.5...@endo/ses-ava@1.2.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [1.2.5](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.4...@endo/ses-ava@1.2.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.9.0](https://github.com/endojs/endo/compare/ses@1.8.0...ses@1.9.0) (2024-10-10)
+
+
+### Features
+
+* **module-source:** Introduce a shim that composes with lockdown ([9a3ecca](https://github.com/endojs/endo/commit/9a3ecca305b4a3b4a2e09d03ea84671969a26586))
+* **ses:** Add ModuleSource shared intrinsic ([541d1ea](https://github.com/endojs/endo/commit/541d1eac7418d1044a3d3f1c9a94bb9c824892e4))
+* **ses:** Anticipate a ModuleSource shared intrinsic ([0d210a3](https://github.com/endojs/endo/commit/0d210a33c7730e59f722fa2c9e5441eb6065e1b3))
+* **ses:** Expose console shim ([70dd851](https://github.com/endojs/endo/commit/70dd851bec5003f5a8aa7ba2cbef4c2fbc4b8cfd))
+* **ses:** shim ArrayBuffer.prototype.transfer ([#2417](https://github.com/endojs/endo/issues/2417)) ([4e5e30e](https://github.com/endojs/endo/commit/4e5e30e3077d90cde4721a235d2a1d1d9a286b85)), closes [#2419](https://github.com/endojs/endo/issues/2419) [#2418](https://github.com/endojs/endo/issues/2418) [#2419](https://github.com/endojs/endo/issues/2419) [#2414](https://github.com/endojs/endo/issues/2414) [#2414](https://github.com/endojs/endo/issues/2414) [#2418](https://github.com/endojs/endo/issues/2418) [#2414](https://github.com/endojs/endo/issues/2414) [#2418](https://github.com/endojs/endo/issues/2418)
+* **ses:** Shim console groupCollapsed and groupEnd as absent on XS ([5e8fd33](https://github.com/endojs/endo/commit/5e8fd33e7c9bf23b12640022a5ca4b11c29d0136))
+* **ses:** Tame ModuleSource ([4702335](https://github.com/endojs/endo/commit/4702335eb102a77fe95538027896f6419372a5a0))
+
+
+### Bug Fixes
+
+* **ses:** Expose ses/console-shim ([8f653b0](https://github.com/endojs/endo/commit/8f653b06c7c9013e2aec42a37d0cefadac126b75))
+* **ses:** package test correctly rejects instead of uncaught exception ([#2566](https://github.com/endojs/endo/issues/2566)) ([d0d2554](https://github.com/endojs/endo/commit/d0d25541615d98c575d392aee111544198deb0ac))
+* **ses:** Use lexical assert, not global ([b58cd9b](https://github.com/endojs/endo/commit/b58cd9be95fc7bde9fbbda7ec0bd775e8880bf01))
+
+
+
 ## [1.8.0](https://github.com/endojs/endo/compare/ses@1.7.0...ses@1.8.0) (2024-08-27)
 
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `ses`:
 
-# Next release
+# v1.9.0 (2024-10-10)
 
 - On platforms without
   [`Array.prototype.transfer`](https://github.com/tc39/proposal-resizablearraybuffer)

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",

--- a/packages/skel/CHANGELOG.md
+++ b/packages/skel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.6](https://github.com/endojs/endo/compare/@endo/skel@1.1.5...@endo/skel@1.1.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/skel
+
+
+
+
+
 ### [1.1.5](https://github.com/endojs/endo/compare/@endo/skel@1.1.4...@endo/skel@1.1.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/skel

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/skel",
   "private": true,
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": null,
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.6](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.5...@endo/stream-node@1.1.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [1.1.5](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.4...@endo/stream-node@1.1.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.11](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.10...@endo/stream-types-test@1.0.11) (2024-10-10)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [1.0.10](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.9...@endo/stream-types-test@1.0.10) (2024-08-27)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.6](https://github.com/endojs/endo/compare/@endo/stream@1.2.5...@endo/stream@1.2.6) (2024-10-10)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [1.2.5](https://github.com/endojs/endo/compare/@endo/stream@1.2.4...@endo/stream@1.2.5) (2024-08-27)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.8](https://github.com/endojs/endo/compare/@endo/syrup@1.0.7...@endo/syrup@1.0.8) (2024-10-10)
+
+**Note:** Version bump only for package @endo/syrup
+
+
+
+
+
 ### [1.0.7](https://github.com/endojs/endo/compare/@endo/syrup@1.0.6...@endo/syrup@1.0.7) (2024-08-27)
 
 **Note:** Version bump only for package @endo/syrup

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.41](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.40...@endo/test262-runner@0.1.41) (2024-10-10)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.40](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.39...@endo/test262-runner@0.1.40) (2024-08-27)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "private": true,
   "description": "Hardened JavaScript Test262 Runner",
   "keywords": [],

--- a/packages/trampoline/CHANGELOG.md
+++ b/packages/trampoline/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### [1.0.2](https://github.com/endojs/endo/compare/@endo/trampoline@1.0.1...@endo/trampoline@1.0.2) (2024-10-10)
+
+**Note:** Version bump only for package @endo/trampoline

--- a/packages/trampoline/package.json
+++ b/packages/trampoline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/trampoline",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Multicolor trampolining for recursive operations",
   "keywords": [
     "trampoline",

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.8](https://github.com/endojs/endo/compare/@endo/where@1.0.7...@endo/where@1.0.8) (2024-10-10)
+
+**Note:** Version bump only for package @endo/where
+
+
+
+
+
 ### [1.0.7](https://github.com/endojs/endo/compare/@endo/where@1.0.6...@endo/where@1.0.7) (2024-08-27)
 
 **Note:** Version bump only for package @endo/where

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Locator for Endo user state, caches, and ephemeral files",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.8](https://github.com/endojs/endo/compare/@endo/zip@1.0.7...@endo/zip@1.0.8) (2024-10-10)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ### [1.0.7](https://github.com/endojs/endo/compare/@endo/zip@1.0.6...@endo/zip@1.0.7) (2024-08-27)
 
 **Note:** Version bump only for package @endo/zip

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",


### PR DESCRIPTION
# `ses` v1.9.0

- On platforms without
  [`Array.prototype.transfer`](https://github.com/tc39/proposal-resizablearraybuffer)
  but with a global `structuredClone`, the ses-shim's `lockdown` will now
  install an emulation of `Array.prototype.transfer`. On platforms with neither,
  the ses-shim will *currently* not install such an emulation.
  However, once we verify that endo is not intended to support platforms
  without both, we may change `lockdown` to throw, failing to lock down.
  - XS and Node >= 22 already have `Array.prototype.transfer`.
  - Node 18, Node 20, and all browsers have `structuredClone`
  - Node <= 16 have neither, but are also no longer supported by Endo.
- Now exports separate layer for console shim: `ses/console-shim.js`.
- Adds permits for `ModuleSource`, either the native implementation or from
  `@endo/module-source/shim.js`.

# `@endo/compartment-mapper` v1.3.0

- Adds support for dynamic requires in CommonJS modules. This requires specific
  configuration to be passed in (including new read powers), and is _not_
  enabled by default. See the signature of `loadFromMap()` in `import-lite.js`
  for details.

# `@endo/import-bundle` v1.3.0

- Adds support for `endoScript` format bundles.

# `@endo/module-source` v1.1.0

- Adds `@endo/module-source/shim.js` to shim `globalThis.ModuleSource`.
  The shim currently replaces the native `globalThis.ModuleSource` if present.

# `@endo/captp` v4.4.0

- Add optional configuration `makeCapTPImportExportTables` for external management of import/export tables.