### PR TITLE
fix(ses): reject unsupported lockdownOptions mathTaming + dateTaming

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `ses`:
 
+# Unreleased
+
+- Specifying the long discontinued `mathTaming` or `dateTaming` options throws an Error.
+
 # v1.9.0 (2024-10-10)
 
 - On platforms without

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -188,8 +188,6 @@ export const repairIntrinsics = (options = {}) => {
       'safe',
     ),
     __hardenTaming__ = getenv('LOCKDOWN_HARDEN_TAMING', 'safe'),
-    dateTaming = 'safe', // deprecated
-    mathTaming = 'safe', // deprecated
     ...extraOptions
   } = options;
 
@@ -281,9 +279,9 @@ export const repairIntrinsics = (options = {}) => {
 
   addIntrinsics(tameFunctionConstructors());
 
-  addIntrinsics(tameDateConstructor(dateTaming));
+  addIntrinsics(tameDateConstructor());
   addIntrinsics(tameErrorConstructor(errorTaming, stackFiltering));
-  addIntrinsics(tameMathObject(mathTaming));
+  addIntrinsics(tameMathObject());
   addIntrinsics(tameRegExpConstructor(regExpTaming));
   addIntrinsics(tameSymbolConstructor());
   addIntrinsics(shimArrayBufferTransfer());

--- a/packages/ses/src/tame-date-constructor.js
+++ b/packages/ses/src/tame-date-constructor.js
@@ -8,10 +8,7 @@ import {
   defineProperties,
 } from './commons.js';
 
-export default function tameDateConstructor(dateTaming = 'safe') {
-  if (dateTaming !== 'safe' && dateTaming !== 'unsafe') {
-    throw TypeError(`unrecognized dateTaming ${dateTaming}`);
-  }
+export default function tameDateConstructor() {
   const OriginalDate = Date;
   const DatePrototype = OriginalDate.prototype;
 

--- a/packages/ses/src/tame-math-object.js
+++ b/packages/ses/src/tame-math-object.js
@@ -6,10 +6,7 @@ import {
   objectPrototype,
 } from './commons.js';
 
-export default function tameMathObject(mathTaming = 'safe') {
-  if (mathTaming !== 'safe' && mathTaming !== 'unsafe') {
-    throw TypeError(`unrecognized mathTaming ${mathTaming}`);
-  }
+export default function tameMathObject() {
   const originalMath = Math;
   const initialMath = originalMath; // to follow the naming pattern
 

--- a/packages/ses/test/_lockdown-unsafe.js
+++ b/packages/ses/test/_lockdown-unsafe.js
@@ -1,5 +1,3 @@
 lockdown({
-  dateTaming: 'unsafe',
-  mathTaming: 'unsafe',
   errorTaming: 'unsafe',
 });

--- a/packages/ses/test/lockdown-options.test.js
+++ b/packages/ses/test/lockdown-options.test.js
@@ -3,13 +3,23 @@ import { repairIntrinsics } from '../src/lockdown.js';
 
 test('repairIntrinsics throws with non-recognized options', t => {
   t.throws(
-    () => repairIntrinsics({ mathTaming: 'unsafe', abc: true }),
+    () => repairIntrinsics({ abc: true }),
     undefined,
     'throws with value true',
   );
   t.throws(
-    () => repairIntrinsics({ mathTaming: 'unsafe', abc: false }),
+    () => repairIntrinsics({ abc: false }),
     undefined,
     'throws with value false',
+  );
+  t.throws(
+    () => repairIntrinsics({ mathTaming: 'unsafe' }),
+    undefined,
+    'throws with deprecated option mathTaming',
+  );
+  t.throws(
+    () => repairIntrinsics({ dateTaming: 'unsafe' }),
+    undefined,
+    'throws with deprecated option dateTaming',
   );
 });

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -26,8 +26,6 @@ export interface RepairOptions {
   errorTrapping?: 'platform' | 'exit' | 'abort' | 'report' | 'none';
   unhandledRejectionTrapping?: 'report' | 'none';
   errorTaming?: 'safe' | 'unsafe' | 'unsafe-debug';
-  dateTaming?: 'safe' | 'unsafe'; // deprecated
-  mathTaming?: 'safe' | 'unsafe'; // deprecated
   evalTaming?: 'safeEval' | 'unsafeEval' | 'noEval';
   stackFiltering?: 'concise' | 'verbose';
   overrideTaming?: 'moderate' | 'min' | 'severe';

--- a/packages/ses/types.test-d.ts
+++ b/packages/ses/types.test-d.ts
@@ -12,8 +12,6 @@ lockdown();
 lockdown({});
 lockdown({ errorTaming: 'unsafe' });
 lockdown({
-  mathTaming: 'unsafe',
-  dateTaming: 'unsafe',
   errorTaming: 'unsafe',
   localeTaming: 'unsafe',
   consoleTaming: 'unsafe',


### PR DESCRIPTION
support for lockdown options `tameMath` and `tameDate` were removed so long ago I'm having trouble finding a proper reference (pre-2020? pre migration from agoric into endo?). Since these options don't do anything, lockdown should fail when these options are specified.

For LavaMoat, we were surprised to find they were being provided to lockdown, but had no effect. Any other unrecognized lockdown options are rejected.