### PR TITLE
fix(ses): warn on unsupported lockdownOptions mathTaming + dateTaming

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `ses`:
 
+# Next version
+
+- Specifying the long discontinued `mathTaming` or `dateTaming` options logs a warning.
+
 # v1.10.0 (2024-11-13)
 
 - Permit [Promise.try](https://github.com/tc39/proposal-promise-try),

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -194,8 +194,8 @@ export const repairIntrinsics = (options = {}) => {
       'safe',
     ),
     __hardenTaming__ = getenv('LOCKDOWN_HARDEN_TAMING', 'safe'),
-    dateTaming = 'safe', // deprecated
-    mathTaming = 'safe', // deprecated
+    dateTaming, // deprecated
+    mathTaming, // deprecated
     ...extraOptions
   } = options;
 
@@ -215,6 +215,20 @@ export const repairIntrinsics = (options = {}) => {
     Fail`lockdown(): non supported option ${q(extraOptionsNames)}`;
 
   const reporter = chooseReporter(reporting);
+  const { warn } = reporter;
+
+  if (dateTaming !== undefined) {
+    // eslint-disable-next-line no-console
+    warn(
+      `SES The 'dateTaming' option is deprecated and does nothing. In the future specifying it will be an error.`,
+    );
+  }
+  if (mathTaming !== undefined) {
+    // eslint-disable-next-line no-console
+    warn(
+      `SES The 'mathTaming' option is deprecated and does nothing. In the future specifying it will be an error.`,
+    );
+  }
 
   priorRepairIntrinsics === undefined ||
     // eslint-disable-next-line @endo/no-polymorphic-call
@@ -289,9 +303,9 @@ export const repairIntrinsics = (options = {}) => {
 
   addIntrinsics(tameFunctionConstructors());
 
-  addIntrinsics(tameDateConstructor(dateTaming));
+  addIntrinsics(tameDateConstructor());
   addIntrinsics(tameErrorConstructor(errorTaming, stackFiltering));
-  addIntrinsics(tameMathObject(mathTaming));
+  addIntrinsics(tameMathObject());
   addIntrinsics(tameRegExpConstructor(regExpTaming));
   addIntrinsics(tameSymbolConstructor());
   addIntrinsics(shimArrayBufferTransfer());

--- a/packages/ses/src/tame-date-constructor.js
+++ b/packages/ses/src/tame-date-constructor.js
@@ -8,10 +8,7 @@ import {
   defineProperties,
 } from './commons.js';
 
-export default function tameDateConstructor(dateTaming = 'safe') {
-  if (dateTaming !== 'safe' && dateTaming !== 'unsafe') {
-    throw TypeError(`unrecognized dateTaming ${dateTaming}`);
-  }
+export default function tameDateConstructor() {
   const OriginalDate = Date;
   const DatePrototype = OriginalDate.prototype;
 

--- a/packages/ses/src/tame-math-object.js
+++ b/packages/ses/src/tame-math-object.js
@@ -6,10 +6,7 @@ import {
   objectPrototype,
 } from './commons.js';
 
-export default function tameMathObject(mathTaming = 'safe') {
-  if (mathTaming !== 'safe' && mathTaming !== 'unsafe') {
-    throw TypeError(`unrecognized mathTaming ${mathTaming}`);
-  }
+export default function tameMathObject() {
   const originalMath = Math;
   const initialMath = originalMath; // to follow the naming pattern
 

--- a/packages/ses/test/_lockdown-unsafe.js
+++ b/packages/ses/test/_lockdown-unsafe.js
@@ -1,5 +1,3 @@
 lockdown({
-  dateTaming: 'unsafe',
-  mathTaming: 'unsafe',
   errorTaming: 'unsafe',
 });

--- a/packages/ses/test/lockdown-options.test.js
+++ b/packages/ses/test/lockdown-options.test.js
@@ -3,12 +3,12 @@ import { repairIntrinsics } from '../src/lockdown.js';
 
 test('repairIntrinsics throws with non-recognized options', t => {
   t.throws(
-    () => repairIntrinsics({ mathTaming: 'unsafe', abc: true }),
+    () => repairIntrinsics({ abc: true }),
     undefined,
     'throws with value true',
   );
   t.throws(
-    () => repairIntrinsics({ mathTaming: 'unsafe', abc: false }),
+    () => repairIntrinsics({ abc: false }),
     undefined,
     'throws with value false',
   );

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -27,8 +27,14 @@ export interface RepairOptions {
   reporting?: 'platform' | 'console' | 'none';
   unhandledRejectionTrapping?: 'report' | 'none';
   errorTaming?: 'safe' | 'unsafe' | 'unsafe-debug';
-  dateTaming?: 'safe' | 'unsafe'; // deprecated
-  mathTaming?: 'safe' | 'unsafe'; // deprecated
+  /**
+   * @deprecated Deprecated and does nothing. In the future specifying it will be an error.
+   */
+  dateTaming?: 'safe' | 'unsafe';
+  /**
+   * @deprecated Deprecated and does nothing. In the future specifying it will be an error.
+   */
+  mathTaming?: 'safe' | 'unsafe';
   evalTaming?: 'safeEval' | 'unsafeEval' | 'noEval';
   stackFiltering?: 'concise' | 'verbose';
   overrideTaming?: 'moderate' | 'min' | 'severe';

--- a/packages/ses/types.test-d.ts
+++ b/packages/ses/types.test-d.ts
@@ -10,8 +10,6 @@ lockdown();
 lockdown({});
 lockdown({ errorTaming: 'unsafe' });
 lockdown({
-  mathTaming: 'unsafe',
-  dateTaming: 'unsafe',
   errorTaming: 'unsafe',
   localeTaming: 'unsafe',
   consoleTaming: 'unsafe',


### PR DESCRIPTION
support for lockdown options `mathTaming` and `dateTaming` were [removed in July 2020](https://github.com/endojs/endo/pull/372). Since these options don't do anything, lockdown should **warn** when these options are specified.

For LavaMoat, we were surprised to find they were being provided to lockdown, but had no effect. Any other unrecognized lockdown options are rejected.

Here is a PR for a breaking change that fully removes the options https://github.com/endojs/endo/pull/2583