### PR TITLE
test(module-source): Should export const object with default values

### DIFF
--- a/packages/module-source/test/module-source.test.js
+++ b/packages/module-source/test/module-source.test.js
@@ -797,3 +797,12 @@ test.failing('should support export of defaulted extraction', t => {
   `);
   t.pass();
 });
+
+test.failing('should support export const object with default', t => {
+  const _ = new ModuleSource(`
+    export const {
+      x = undefined,
+    } = globalThis;
+  `);
+  t.pass();
+});


### PR DESCRIPTION
Refs: #2094

## Description

Elaborates failing tests for a known defect of ModuleSource, encountered in the development of #400