### PR TITLE
docs(ses): Missing lockdown in Compartment doc

### DIFF
--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -168,6 +168,8 @@ function on `globalThis`.
 ```js
 import 'ses';
 
+lockdown();
+
 const c = new Compartment({
   globals: {
     print: harden(console.log),


### PR DESCRIPTION
This addresses a speed bump in our documentation of how to use SES, as seen at https://github.com/endojs/endo/issues/1281#issuecomment-2418717060