### PR TITLE
chore: Release 2024-10-22

### DIFF
--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.4.2](https://github.com/endojs/endo/compare/@endo/bundle-source@3.4.1...@endo/bundle-source@3.4.2) (2024-10-22)
+
+**Note:** Version bump only for package @endo/bundle-source
+
+
+
+
+
 ### [3.4.1](https://github.com/endojs/endo/compare/@endo/bundle-source@3.4.0...@endo/bundle-source@3.4.1) (2024-10-10)
 
 **Note:** Version bump only for package @endo/bundle-source

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.4.1](https://github.com/endojs/endo/compare/@endo/captp@4.4.0...@endo/captp@4.4.1) (2024-10-22)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ## [4.4.0](https://github.com/endojs/endo/compare/@endo/captp@4.3.0...@endo/captp@4.4.0) (2024-10-10)
 
 

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.11](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.10...@endo/check-bundle@1.0.11) (2024-10-22)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [1.0.10](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.9...@endo/check-bundle@1.0.10) (2024-10-10)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.4](https://github.com/endojs/endo/compare/@endo/cli@2.3.3...@endo/cli@2.3.4) (2024-10-22)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [2.3.3](https://github.com/endojs/endo/compare/@endo/cli@2.3.2...@endo/cli@2.3.3) (2024-10-10)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.7](https://github.com/endojs/endo/compare/@endo/common@1.2.6...@endo/common@1.2.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/common
+
+
+
+
+
 ### [1.2.6](https://github.com/endojs/endo/compare/@endo/common@1.2.5...@endo/common@1.2.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/common",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "common low level utilities",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.3.0...@endo/compartment-mapper@1.3.1) (2024-10-22)
+
+**Note:** Version bump only for package @endo/compartment-mapper
+
+
+
+
+
 ## [1.3.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.2.2...@endo/compartment-mapper@1.3.0) (2024-10-10)
 
 

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.4.4](https://github.com/endojs/endo/compare/@endo/daemon@2.4.3...@endo/daemon@2.4.4) (2024-10-22)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ### [2.4.3](https://github.com/endojs/endo/compare/@endo/daemon@2.4.2...@endo/daemon@2.4.3) (2024-10-10)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.7](https://github.com/endojs/endo/compare/@endo/errors@1.2.6...@endo/errors@1.2.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/errors
+
+
+
+
+
 ### [1.2.6](https://github.com/endojs/endo/compare/@endo/errors@1.2.5...@endo/errors@1.2.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/errors

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/errors",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/evasive-transform/CHANGELOG.md
+++ b/packages/evasive-transform/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.2](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.1...@endo/evasive-transform@1.3.2) (2024-10-22)
+
+**Note:** Version bump only for package @endo/evasive-transform
+
+
+
+
+
 ### [1.3.1](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.0...@endo/evasive-transform@1.3.1) (2024-10-10)
 
 **Note:** Version bump only for package @endo/evasive-transform

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/evasive-transform",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Source transforms to evade SES censorship",
   "keywords": [
     "ses",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.7](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.6...@endo/eventual-send@1.2.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/eventual-send
+
+
+
+
+
 ### [1.2.6](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.5...@endo/eventual-send@1.2.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/eventual-send

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.5](https://github.com/endojs/endo/compare/@endo/exo@1.5.4...@endo/exo@1.5.5) (2024-10-22)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.4](https://github.com/endojs/endo/compare/@endo/exo@1.5.3...@endo/exo@1.5.4) (2024-10-10)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.7](https://github.com/endojs/endo/compare/@endo/far@1.1.6...@endo/far@1.1.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.6](https://github.com/endojs/endo/compare/@endo/far@1.1.5...@endo/far@1.1.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.1](https://github.com/endojs/endo/compare/@endo/import-bundle@1.3.0...@endo/import-bundle@1.3.1) (2024-10-22)
+
+**Note:** Version bump only for package @endo/import-bundle
+
+
+
+
+
 ## [1.3.0](https://github.com/endojs/endo/compare/@endo/import-bundle@1.2.2...@endo/import-bundle@1.3.0) (2024-10-10)
 
 

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "load modules created by @endo/bundle-source",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.6](https://github.com/endojs/endo/compare/@endo/init@1.1.5...@endo/init@1.1.6) (2024-10-22)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [1.1.5](https://github.com/endojs/endo/compare/@endo/init@1.1.4...@endo/init@1.1.5) (2024-10-10)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.12](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.11...@endo/lockdown@1.0.12) (2024-10-22)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [1.0.11](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.10...@endo/lockdown@1.0.11) (2024-10-10)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.7](https://github.com/endojs/endo/compare/@endo/lp32@1.1.6...@endo/lp32@1.1.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [1.1.6](https://github.com/endojs/endo/compare/@endo/lp32@1.1.5...@endo/lp32@1.1.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.0](https://github.com/endojs/endo/compare/@endo/marshal@1.5.4...@endo/marshal@2.0.0) (2024-10-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* **marshal:** Update compareRank to terminate comparability at the first remotable (#2597)
+
+### Bug Fixes
+
+* **marshal:** Update compareRank to terminate comparability at the first remotable ([#2597](https://github.com/endojs/endo/issues/2597)) ([1dea84d](https://github.com/endojs/endo/commit/1dea84d316eb412d864042ffb08b4b6420092a7c)), closes [#2588](https://github.com/endojs/endo/issues/2588)
+
+
+
 ### [1.5.4](https://github.com/endojs/endo/compare/@endo/marshal@1.5.3...@endo/marshal@1.5.4) (2024-10-10)
 
 **Note:** Version bump only for package @endo/marshal

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,14 +3,8 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.0.0](https://github.com/endojs/endo/compare/@endo/marshal@1.5.4...@endo/marshal@2.0.0) (2024-10-22)
+## [1.6.0](https://github.com/endojs/endo/compare/@endo/marshal@1.5.4...@endo/marshal@1.6.0) (2024-10-22)
 
-
-### ⚠ BREAKING CHANGES
-
-* **marshal:** Update compareRank to terminate comparability at the first remotable (#2597)
-
-### Bug Fixes
 
 * **marshal:** Update compareRank to terminate comparability at the first remotable ([#2597](https://github.com/endojs/endo/issues/2597)) ([1dea84d](https://github.com/endojs/endo/commit/1dea84d316eb412d864042ffb08b4b6420092a7c)), closes [#2588](https://github.com/endojs/endo/issues/2588)
 

--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,12 +1,25 @@
 User-visible changes in `@endo/marshal`:
 
-# Next release
+# v1.6.0 (2024-10-22)
 
-- `compareRank` now short-circuits upon encountering remotables to compare, considering the inputs to be tied for the same rank regardless of what would otherwise be visited later in their respective data structures. This ensures that a `fullCompare` which does distinguish remotables will be a refinement of `compareRank`, rather than disagreeing about whether or not two values share a rank ([#2588](https://github.com/endojs/endo/issues/2588)).
+- `compareRank` now short-circuits upon encountering remotables to compare,
+  considering the inputs to be tied for the same rank regardless of what would
+  otherwise be visited later in their respective data structures. This ensures
+  that a `fullCompare` which does distinguish remotables will be a refinement
+  of `compareRank`, rather than disagreeing about whether or not two values
+  share a rank ([#2588](https://github.com/endojs/endo/issues/2588)).
+
+  This change is a bug fix for all purposes off-chain, but will frustrate
+  deterministic replay.
+  So, because of this change and probably many others, the supervisor bundle
+  of vats on chain will need to be created from historical versions, not according
+  to the semantic version of the library.
 
 # v1.5.1 (2024-07-30)
 
-- `deeplyFulfilled` moved from @endo/marshal to @endo/pass-style. @endo/marshal still reexports it, to avoid breaking old importers. But importers should be upgraded to import `deeplyFulfilled` directly from @endo/pass-style.
+- `deeplyFulfilled` moved from @endo/marshal to @endo/pass-style. @endo/marshal
+  still reexports it, to avoid breaking old importers. But importers should be
+  upgraded to import `deeplyFulfilled` directly from @endo/pass-style.
 
 # v1.3.0 (2024-02-22)
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "2.0.0",
+  "version": "1.6.0",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.5.4",
+  "version": "2.0.0",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/memoize/CHANGELOG.md
+++ b/packages/memoize/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.7](https://github.com/endojs/endo/compare/@endo/memoize@1.1.6...@endo/memoize@1.1.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/memoize
+
+
+
+
+
 ### [1.1.6](https://github.com/endojs/endo/compare/@endo/memoize@1.1.5...@endo/memoize@1.1.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/memoize

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/memoize",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Safe function memoization",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/module-source/CHANGELOG.md
+++ b/packages/module-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.1](https://github.com/endojs/endo/compare/@endo/module-source@1.1.0...@endo/module-source@1.1.1) (2024-10-22)
+
+**Note:** Version bump only for package @endo/module-source
+
+
+
+
+
 ## [1.1.0](https://github.com/endojs/endo/compare/@endo/module-source@1.0.2...@endo/module-source@1.1.0) (2024-10-10)
 
 

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/module-source",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Ponyfill for the SES ModuleSource and module-to-program transformer",
   "keywords": [
     "ses",

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.12](https://github.com/endojs/endo/compare/@endo/nat@5.0.11...@endo/nat@5.0.12) (2024-10-22)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [5.0.11](https://github.com/endojs/endo/compare/@endo/nat@5.0.10...@endo/nat@5.0.11) (2024-10-10)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "5.0.11",
+  "version": "5.0.12",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.12](https://github.com/endojs/endo/compare/@endo/netstring@1.0.11...@endo/netstring@1.0.12) (2024-10-22)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [1.0.11](https://github.com/endojs/endo/compare/@endo/netstring@1.0.10...@endo/netstring@1.0.11) (2024-10-10)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.0](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.4...@endo/pass-style@2.0.0) (2024-10-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* **marshal:** Update compareRank to terminate comparability at the first remotable (#2597)
+
+### Bug Fixes
+
+* **marshal:** Update compareRank to terminate comparability at the first remotable ([#2597](https://github.com/endojs/endo/issues/2597)) ([1dea84d](https://github.com/endojs/endo/commit/1dea84d316eb412d864042ffb08b4b6420092a7c)), closes [#2588](https://github.com/endojs/endo/issues/2588)
+
+
+
 ### [1.4.4](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.3...@endo/pass-style@1.4.4) (2024-10-10)
 
 **Note:** Version bump only for package @endo/pass-style

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "description": "pass-style: defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.0](https://github.com/endojs/endo/compare/@endo/patterns@1.4.4...@endo/patterns@2.0.0) (2024-10-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* **marshal:** Update compareRank to terminate comparability at the first remotable (#2597)
+
+### Bug Fixes
+
+* **marshal:** Update compareRank to terminate comparability at the first remotable ([#2597](https://github.com/endojs/endo/issues/2597)) ([1dea84d](https://github.com/endojs/endo/commit/1dea84d316eb412d864042ffb08b4b6420092a7c)), closes [#2588](https://github.com/endojs/endo/issues/2588)
+
+
+
 ### [1.4.4](https://github.com/endojs/endo/compare/@endo/patterns@1.4.3...@endo/patterns@1.4.4) (2024-10-10)
 
 **Note:** Version bump only for package @endo/patterns

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "description": "Description forthcoming.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.7](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.6...@endo/promise-kit@1.1.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [1.1.6](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.5...@endo/promise-kit@1.1.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Helper for making promises",
   "keywords": [
     "promise"

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.7](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.6...@endo/ses-ava@1.2.7) (2024-10-22)
+
+
+### Bug Fixes
+
+* **ses-ava:** wrap test deeply ([#2589](https://github.com/endojs/endo/issues/2589)) ([7a991aa](https://github.com/endojs/endo/commit/7a991aa75b06fc418459b5e5d2d08f9fb73ab113))
+
+
+
 ### [1.2.6](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.5...@endo/ses-ava@1.2.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.9.1](https://github.com/endojs/endo/compare/ses@1.9.0...ses@1.9.1) (2024-10-22)
+
+**Note:** Version bump only for package ses
+
+
+
+
+
 ## [1.9.0](https://github.com/endojs/endo/compare/ses@1.8.0...ses@1.9.0) (2024-10-10)
 
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",

--- a/packages/skel/CHANGELOG.md
+++ b/packages/skel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.7](https://github.com/endojs/endo/compare/@endo/skel@1.1.6...@endo/skel@1.1.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/skel
+
+
+
+
+
 ### [1.1.6](https://github.com/endojs/endo/compare/@endo/skel@1.1.5...@endo/skel@1.1.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/skel

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/skel",
   "private": true,
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": null,
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.7](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.6...@endo/stream-node@1.1.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [1.1.6](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.5...@endo/stream-node@1.1.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.12](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.11...@endo/stream-types-test@1.0.12) (2024-10-22)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [1.0.11](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.10...@endo/stream-types-test@1.0.11) (2024-10-10)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.7](https://github.com/endojs/endo/compare/@endo/stream@1.2.6...@endo/stream@1.2.7) (2024-10-22)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [1.2.6](https://github.com/endojs/endo/compare/@endo/stream@1.2.5...@endo/stream@1.2.6) (2024-10-10)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.42](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.41...@endo/test262-runner@0.1.42) (2024-10-22)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.41](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.40...@endo/test262-runner@0.1.41) (2024-10-10)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "private": true,
   "description": "Hardened JavaScript Test262 Runner",
   "keywords": [],


### PR DESCRIPTION
# `@endo/marshal` v1.6.0

- `compareRank` now short-circuits upon encountering remotables to compare, considering the inputs to be tied for the same rank regardless of what would otherwise be visited later in their respective data structures. This ensures that a `fullCompare` which does distinguish remotables will be a refinement of `compareRank`, rather than disagreeing about whether or not two values share a rank ([#2588](https://github.com/endojs/endo/issues/2588)).

  This change is a bug fix for all purposes off-chain, but will frustrate deterministic replay. So, because of this change and probably many others, the supervisor bundle of vats on chain will need to be created from historical versions, not according to the semantic version of the library.

