### PR TITLE
chore(patterns,pass-style): Recouple accidental 2.0.0 releases under 1.x train

### DIFF
--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,18 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.0.0](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.4...@endo/pass-style@2.0.0) (2024-10-22)
+## [1.4.5](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.4...@endo/pass-style@1.4.5) (2024-10-22)
 
-
-### ⚠ BREAKING CHANGES
-
-* **marshal:** Update compareRank to terminate comparability at the first remotable (#2597)
+**Also erroneously published as 2.0.0**
 
 ### Bug Fixes
 
 * **marshal:** Update compareRank to terminate comparability at the first remotable ([#2597](https://github.com/endojs/endo/issues/2597)) ([1dea84d](https://github.com/endojs/endo/commit/1dea84d316eb412d864042ffb08b4b6420092a7c)), closes [#2588](https://github.com/endojs/endo/issues/2588)
-
-
 
 ### [1.4.4](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.3...@endo/pass-style@1.4.4) (2024-10-10)
 

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/pass-style",
-  "version": "2.0.0",
-  "description": "pass-style: defines the taxonomy of Passable objects.",
+  "version": "1.4.5",
+  "description": "Defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",
   "license": "Apache-2.0",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,18 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.0.0](https://github.com/endojs/endo/compare/@endo/patterns@1.4.4...@endo/patterns@2.0.0) (2024-10-22)
+## [1.4.5](https://github.com/endojs/endo/compare/@endo/patterns@1.4.4...@endo/patterns@1.4.5) (2024-10-22)
 
-
-### ⚠ BREAKING CHANGES
-
-* **marshal:** Update compareRank to terminate comparability at the first remotable (#2597)
+**Also erroneously published as 2.0.0**
 
 ### Bug Fixes
 
 * **marshal:** Update compareRank to terminate comparability at the first remotable ([#2597](https://github.com/endojs/endo/issues/2597)) ([1dea84d](https://github.com/endojs/endo/commit/1dea84d316eb412d864042ffb08b4b6420092a7c)), closes [#2588](https://github.com/endojs/endo/issues/2588)
-
-
 
 ### [1.4.4](https://github.com/endojs/endo/compare/@endo/patterns@1.4.3...@endo/patterns@1.4.4) (2024-10-10)
 

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/patterns",
-  "version": "2.0.0",
-  "description": "Description forthcoming.",
+  "version": "1.4.5",
+  "description": "Pattern matching for Passable objects, expressed as Passable data",
   "keywords": [],
   "author": "Endo contributors",
   "license": "Apache-2.0",


### PR DESCRIPTION
In https://github.com/endojs/endo/pull/2602, we inadvertently bumped the major versions for patterns and pass-style (while manually intervening in Lerna’s release process to avoid a major version bump for marshal)

In this change, we retroactively resume the 1.x train for these two packages. These two packages will be manually published to npm and assigned git tags.