### PR TITLE
chore: Release 2024-10-22 Supplemental

### DIFF
--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.4.2](https://github.com/endojs/endo/compare/@endo/captp@4.4.1...@endo/captp@4.4.2) (2024-10-22)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ### [4.4.1](https://github.com/endojs/endo/compare/@endo/captp@4.4.0...@endo/captp@4.4.1) (2024-10-22)
 
 **Note:** Version bump only for package @endo/captp

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.5](https://github.com/endojs/endo/compare/@endo/cli@2.3.4...@endo/cli@2.3.5) (2024-10-22)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [2.3.4](https://github.com/endojs/endo/compare/@endo/cli@2.3.3...@endo/cli@2.3.4) (2024-10-22)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.4.5](https://github.com/endojs/endo/compare/@endo/daemon@2.4.4...@endo/daemon@2.4.5) (2024-10-22)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ### [2.4.4](https://github.com/endojs/endo/compare/@endo/daemon@2.4.3...@endo/daemon@2.4.4) (2024-10-22)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.6](https://github.com/endojs/endo/compare/@endo/exo@1.5.5...@endo/exo@1.5.6) (2024-10-22)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.5](https://github.com/endojs/endo/compare/@endo/exo@1.5.4...@endo/exo@1.5.5) (2024-10-22)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.8](https://github.com/endojs/endo/compare/@endo/far@1.1.7...@endo/far@1.1.8) (2024-10-22)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.7](https://github.com/endojs/endo/compare/@endo/far@1.1.6...@endo/far@1.1.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.1](https://github.com/endojs/endo/compare/@endo/marshal@2.0.0...@endo/marshal@1.6.1) (2024-10-22)
+
+
+### Bug Fixes
+
+* **marshal:** Manually intervene in choice of semver for 1.6.0 instead of 2.0.0 ([c242c28](https://github.com/endojs/endo/commit/c242c28a68d1af29475150e44b5f3e9d0feda8cd))
+
+
+
 ## [1.6.0](https://github.com/endojs/endo/compare/@endo/marshal@1.5.4...@endo/marshal@1.6.0) (2024-10-22)
 
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.6](https://github.com/endojs/endo/compare/@endo/pass-style@2.0.0...@endo/pass-style@1.4.6) (2024-10-22)
+
+
+### Bug Fixes
+
+* **pass-style:** Version 1.4.5 ([5ed625c](https://github.com/endojs/endo/commit/5ed625c8b74983339afe306c89070992f328a410))
+
+
+
 ## [1.4.5](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.4...@endo/pass-style@1.4.5) (2024-10-22)
 
 **Also erroneously published as 2.0.0**

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.6](https://github.com/endojs/endo/compare/@endo/patterns@2.0.0...@endo/patterns@1.4.6) (2024-10-22)
+
+
+### Bug Fixes
+
+* **patterns:** Version 1.4.5 ([5cdb873](https://github.com/endojs/endo/commit/5cdb873cab376192e311487f16a33068a1242161))
+
+
+
 ## [1.4.5](https://github.com/endojs/endo/compare/@endo/patterns@1.4.4...@endo/patterns@1.4.5) (2024-10-22)
 
 **Also erroneously published as 2.0.0**

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Pattern matching for Passable objects, expressed as Passable data",
   "keywords": [],
   "author": "Endo contributors",


### PR DESCRIPTION
In https://github.com/endojs/endo/pull/2602, we erroneously published 2.0 versions of pass-style and patterns. This release recouples these to their 1.x trains, and propagates that version selector to the dependent packages.

We are losing continuity of a published patch version number, but the computers and I are beyond caring.