### PR TITLE
feat(ses): Lockdown reporting option

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -5,6 +5,24 @@ User-visible changes in `ses`:
 - Permit [Promise.try](https://github.com/tc39/proposal-promise-try),
   since it has reached Stage 4.
 
+- Adds a `reporting` option to `lockdown` and `repairIntrinsics`.
+
+  The default behavior is `"platform"` which will detect the platform and
+  report warnings according to whether a web `console`, Node.js `console`, or
+  `print` are available.
+  The web platform is distinguished by the existence of `window` or
+  `importScripts` (WebWorker).
+  The Node.js behavior is to report all warnings to `stderr` visually
+  consistent with use of a console group.
+  SES will use `print` in the absence of a `console`.
+  Captures the platform `console` at the time `lockdown` or `repairIntrinsics`
+  are called, not at the time `ses` initializes.
+
+  The `"console"` option forces the web platform behavior.
+  On Node.js, this results in group labels being reported to `stdout`.
+
+  The `"none"` option mutes warnings.
+
 # v1.9.0 (2024-10-10)
 
 - On platforms without

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -23,6 +23,8 @@ import {
   severeEnablements,
 } from './enablements.js';
 
+/** @import {Reporter} from './reporting-types.js' */
+
 /**
  * For a special set of properties defined in the `enablement` whitelist,
  * `enablePropertyOverrides` ensures that the effect of freezing does not
@@ -75,11 +77,13 @@ import {
  *
  * @param {Record<string, any>} intrinsics
  * @param {'min' | 'moderate' | 'severe'} overrideTaming
+ * @param {Reporter} reporter
  * @param {Iterable<string | symbol>} [overrideDebug]
  */
 export default function enablePropertyOverrides(
   intrinsics,
   overrideTaming,
+  { warn },
   overrideDebug = [],
 ) {
   const debugProperties = new Set(overrideDebug);
@@ -109,8 +113,7 @@ export default function enablePropertyOverrides(
               this[prop] = newValue;
             } else {
               if (isDebug) {
-                // eslint-disable-next-line @endo/no-polymorphic-call
-                console.error(TypeError(`Override property ${prop}`));
+                warn(TypeError(`Override property ${prop}`));
               }
               defineProperty(this, prop, {
                 value: newValue,

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -163,22 +163,24 @@ export const repairIntrinsics = (options = {}) => {
 
   const {
     errorTaming = getenv('LOCKDOWN_ERROR_TAMING', 'safe'),
-    errorTrapping = /** @type {"platform" | "none" | "report" | "abort" | "exit" | undefined} */ (
+    errorTrapping = /** @type {"platform" | "none" | "report" | "abort" | "exit"} */ (
       getenv('LOCKDOWN_ERROR_TRAPPING', 'platform')
     ),
     reporting = /** @type {"platform" | "console" | "none"} */ (
       getenv('LOCKDOWN_REPORTING', 'platform')
     ),
-    unhandledRejectionTrapping = /** @type {"none" | "report" | undefined} */ (
+    unhandledRejectionTrapping = /** @type {"none" | "report"} */ (
       getenv('LOCKDOWN_UNHANDLED_REJECTION_TRAPPING', 'report')
     ),
     regExpTaming = getenv('LOCKDOWN_REGEXP_TAMING', 'safe'),
     localeTaming = getenv('LOCKDOWN_LOCALE_TAMING', 'safe'),
 
-    consoleTaming = /** @type {'unsafe' | 'safe' | undefined} */ (
+    consoleTaming = /** @type {'unsafe' | 'safe'} */ (
       getenv('LOCKDOWN_CONSOLE_TAMING', 'safe')
     ),
-    overrideTaming = getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate'),
+    overrideTaming = /** @type {'moderate' | 'min' | 'severe'} */ (
+      getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate')
+    ),
     stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise'),
     domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe'),
     evalTaming = getenv('LOCKDOWN_EVAL_TAMING', 'safeEval'),

--- a/packages/ses/src/reporting-types.d.ts
+++ b/packages/ses/src/reporting-types.d.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-restricted-globals */
+
+export type Reporter = {
+  warn: (...message: Array<any>) => void;
+  error: (...message: Array<string>) => void;
+};
+
+export type GroupReporter = Reporter & {
+  groupCollapsed: (label: string) => void;
+  groupEnd: () => void;
+};
+
+// Console implements GroupReporter

--- a/packages/ses/src/reporting.js
+++ b/packages/ses/src/reporting.js
@@ -1,0 +1,106 @@
+import { TypeError, functionBind, globalThis } from './commons.js';
+import { assert } from './error/assert.js';
+
+/**
+ * @import {Reporter, GroupReporter} from './reporting-types.js'
+ */
+
+/**
+ * Creates a suitable reporter for internal errors and warnings out of the
+ * Node.js console.error to ensure all messages to go stderr, including the
+ * group label.
+ * Accounts for the extra space introduced by console.error as a delimiter
+ * between the indent and subsequent arguments.
+ *
+ * @param {(...message: Array<any>) => void} print
+ */
+const makeReportPrinter = print => {
+  let indent = false;
+  /** @param {Array<any>} args */
+  const printIndent = (...args) => {
+    if (indent) {
+      print(' ', ...args);
+    } else {
+      print(...args);
+    }
+  };
+  return /** @type {GroupReporter} */ ({
+    warn(...args) {
+      printIndent(...args);
+    },
+    error(...args) {
+      printIndent(...args);
+    },
+    groupCollapsed(...args) {
+      assert(!indent);
+      print(...args);
+      indent = true;
+    },
+    groupEnd() {
+      indent = false;
+    },
+  });
+};
+
+const mute = () => {};
+
+/**
+ * @param {"platform" | "console" | "none"} reporting
+ */
+export const chooseReporter = reporting => {
+  if (reporting === 'none') {
+    return makeReportPrinter(mute);
+  }
+  if (reporting !== 'platform' && reporting !== 'console') {
+    throw new TypeError(`Invalid lockdown reporting option: ${reporting}`);
+  }
+  if (
+    reporting === 'console' ||
+    globalThis.window === globalThis ||
+    globalThis.importScripts !== undefined
+  ) {
+    return console;
+  }
+  if (globalThis.console !== undefined) {
+    // On Node.js, we send all feedback to stderr, regardless of purported level.
+    const console = globalThis.console;
+    const error = functionBind(console.error, console);
+    return makeReportPrinter(error);
+  }
+  if (globalThis.print !== undefined) {
+    return makeReportPrinter(globalThis.print);
+  }
+  return makeReportPrinter(mute);
+};
+
+/**
+ * @param {string} groupLabel
+ * @param {GroupReporter} console
+ * @param {(internalConsole: Reporter) => void} callback
+ */
+export const reportInGroup = (groupLabel, console, callback) => {
+  const { warn, error, groupCollapsed, groupEnd } = console;
+  let groupStarted = false;
+  try {
+    return callback({
+      warn(...args) {
+        if (!groupStarted) {
+          groupCollapsed(groupLabel);
+          groupStarted = true;
+        }
+        warn(...args);
+      },
+      error(...args) {
+        if (!groupStarted) {
+          groupCollapsed(groupLabel);
+          groupStarted = true;
+        }
+        error(...args);
+      },
+    });
+  } finally {
+    if (groupStarted) {
+      groupEnd();
+    }
+  }
+};

--- a/packages/ses/test/error/_lockdown-with-extra-intrinsics.js
+++ b/packages/ses/test/error/_lockdown-with-extra-intrinsics.js
@@ -1,0 +1,3 @@
+import './_prepare-with-extra-intrinsics.js';
+
+lockdown();

--- a/packages/ses/test/error/_prepare-with-extra-intrinsics.js
+++ b/packages/ses/test/error/_prepare-with-extra-intrinsics.js
@@ -1,0 +1,25 @@
+import '../../index.js';
+
+const { defineProperties } = Object;
+const { apply } = Reflect;
+
+const originalIsArray = Array.isArray;
+
+defineProperties(Array, {
+  extraRemovableDataProperty: {
+    value: 'extra removable data property',
+    configurable: true,
+  },
+  isArray: {
+    value: function isArrayWithCleanablePrototype(...args) {
+      return apply(originalIsArray, this, args);
+    },
+  },
+  // To ensure that the test below remains tolerant of future engines
+  // adding unexpected properties, causing extra warnings on removal.
+  // See https://github.com/endojs/endo/issues/1973
+  anotherOne: {
+    value: `another removable property`,
+    configurable: true,
+  },
+});

--- a/packages/ses/test/error/permit-removal-warnings-node.test.js
+++ b/packages/ses/test/error/permit-removal-warnings-node.test.js
@@ -1,0 +1,56 @@
+/* global Buffer */
+import test from 'ava';
+import url from 'url';
+import { spawn } from 'child_process';
+
+const cwd = url.fileURLToPath(new URL('./', import.meta.url));
+
+const stdio = ['ignore', 'pipe', 'pipe'];
+
+test('node reporting to stderr with indented group', async t => {
+  const child = spawn('node', ['_lockdown-with-extra-intrinsics.js'], {
+    cwd,
+    stdio,
+  });
+  const stdoutChunks = [];
+  const stderrChunks = [];
+  child.stdout.on('data', chunk => {
+    stdoutChunks.push(chunk);
+  });
+  child.stderr.on('data', chunk => {
+    stderrChunks.push(chunk);
+  });
+  await new Promise((resolve, reject) => {
+    child.on('close', actualCode => {
+      try {
+        t.is(actualCode, 0);
+        resolve(true);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+
+  // Nothing written to stdout
+  t.deepEqual(Buffer.concat(stdoutChunks), Buffer.alloc(0));
+
+  const stderrBytes = Buffer.concat(stderrChunks);
+  const stderrText = new TextDecoder().decode(stderrBytes);
+  const stderrLines = stderrText.trim().split('\n');
+
+  // Group label for removing unpermitted intrinsics
+  t.is(stderrLines.shift(), 'SES Removing unpermitted intrinsics');
+  // And all remaining lines have exactly a two space indent
+  t.assert(stderrLines.every(line => /^\s{2}\w/.test(line)));
+
+  const expectedLines = [
+    '  Removing intrinsics.Array.isArray.prototype',
+    '  Tolerating undeletable intrinsics.Array.isArray.prototype === undefined',
+    '  Removing intrinsics.Array.extraRemovableDataProperty',
+    '  Removing intrinsics.Array.anotherOne',
+  ];
+
+  for (const expectedLine of expectedLines) {
+    t.assert(stderrLines.some(line => line === expectedLine));
+  }
+});

--- a/packages/ses/test/error/permit-removal-warnings.test.js
+++ b/packages/ses/test/error/permit-removal-warnings.test.js
@@ -1,30 +1,6 @@
 import test from 'ava';
-import '../../index.js';
+import './_prepare-with-extra-intrinsics.js';
 import { assertLogs } from './_throws-and-logs.js';
-
-const { defineProperties } = Object;
-const { apply } = Reflect;
-
-const originalIsArray = Array.isArray;
-
-defineProperties(Array, {
-  extraRemovableDataProperty: {
-    value: 'extra removable data property',
-    configurable: true,
-  },
-  isArray: {
-    value: function isArrayWithCleanablePrototype(...args) {
-      return apply(originalIsArray, this, args);
-    },
-  },
-  // To ensure that the test below remains tolerant of future engines
-  // adding unexpected properties, causing extra warnings on removal.
-  // See https://github.com/endojs/endo/issues/1973
-  anotherOne: {
-    value: `another removable property`,
-    configurable: true,
-  },
-});
 
 const logRecordMatches = (logRecord, goldenRecord) =>
   Array.isArray(logRecord) &&
@@ -73,9 +49,9 @@ const compareLogs = (t, log, goldenLog) => {
 test('permit removal warnings', t => {
   assertLogs(
     t,
-    () => lockdown(),
+    () => lockdown({ reporting: 'console' }),
     [
-      ['groupCollapsed', 'Removing unpermitted intrinsics'],
+      ['groupCollapsed', 'SES Removing unpermitted intrinsics'],
       ['warn', 'Removing intrinsics.Array.isArray.prototype'],
       [
         'warn',

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -24,6 +24,7 @@ export interface RepairOptions {
   localeTaming?: 'safe' | 'unsafe';
   consoleTaming?: 'safe' | 'unsafe';
   errorTrapping?: 'platform' | 'exit' | 'abort' | 'report' | 'none';
+  reporting?: 'platform' | 'console' | 'none';
   unhandledRejectionTrapping?: 'report' | 'none';
   errorTaming?: 'safe' | 'unsafe' | 'unsafe-debug';
   dateTaming?: 'safe' | 'unsafe'; // deprecated


### PR DESCRIPTION
Closes: #2608

## Description

This change introduces a `"reporting"` option to `lockdown` and `repairIntrinsics` that determines the means by which SES will send warnings to diagnostic tools like the web or node `console`, `print`, or nowhere at all.

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

Relevant documentation added to lockdown options and NEWS.

### Testing Considerations

This adjusts the existing test to use the `"reporting": "console"` option, since it already verifies that behavior and consequently is suitable for verifying the web behavior while standing on Node.js.

This adds a new test that verifies that reporting with the `"platform"` default behavior on node generates no output on stderr and confirms the presence of expected indented and non-indented messages, while being resilient to additional intrinsics being added to the platform.

### Compatibility Considerations

None.

### Upgrade Considerations

None.