### PR TITLE
chore: Release 2024-11-13

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.9](https://github.com/endojs/endo/compare/@endo/base64@1.0.8...@endo/base64@1.0.9) (2024-11-13)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [1.0.8](https://github.com/endojs/endo/compare/@endo/base64@1.0.7...@endo/base64@1.0.8) (2024-10-10)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Transcodes base64",
   "keywords": [
     "base64",

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.5.0](https://github.com/endojs/endo/compare/@endo/bundle-source@3.4.2...@endo/bundle-source@3.5.0) (2024-11-13)
+
+
+### Features
+
+* **bundle-source:** Support TypeScript type erasure ([88a4fb4](https://github.com/endojs/endo/commit/88a4fb46ea4908457a88b806919f1559eadd262a))
+
+
+
 ### [3.4.2](https://github.com/endojs/endo/compare/@endo/bundle-source@3.4.1...@endo/bundle-source@3.4.2) (2024-10-22)
 
 **Note:** Version bump only for package @endo/bundle-source

--- a/packages/bundle-source/NEWS.md
+++ b/packages/bundle-source/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/bundle-source`:
 
-# Next release
+# v3.5.0 (2024-11-13)
 
 - Adds support for TypeScript type erasure using
   [`ts-blank-space`](https://bloomberg.github.io/ts-blank-space/) applied to

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.4.3](https://github.com/endojs/endo/compare/@endo/captp@4.4.2...@endo/captp@4.4.3) (2024-11-13)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ### [4.4.2](https://github.com/endojs/endo/compare/@endo/captp@4.4.1...@endo/captp@4.4.2) (2024-10-22)
 
 **Note:** Version bump only for package @endo/captp

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.12](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.11...@endo/check-bundle@1.0.12) (2024-11-13)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [1.0.11](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.10...@endo/check-bundle@1.0.11) (2024-10-22)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.9](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@1.0.8...@endo/cjs-module-analyzer@1.0.9) (2024-11-13)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ### [1.0.8](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@1.0.7...@endo/cjs-module-analyzer@1.0.8) (2024-10-10)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.6](https://github.com/endojs/endo/compare/@endo/cli@2.3.5...@endo/cli@2.3.6) (2024-11-13)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [2.3.5](https://github.com/endojs/endo/compare/@endo/cli@2.3.4...@endo/cli@2.3.5) (2024-10-22)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.8](https://github.com/endojs/endo/compare/@endo/common@1.2.7...@endo/common@1.2.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/common
+
+
+
+
+
 ### [1.2.7](https://github.com/endojs/endo/compare/@endo/common@1.2.6...@endo/common@1.2.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/common",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "common low level utilities",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.3.1...@endo/compartment-mapper@1.4.0) (2024-11-13)
+
+
+### Features
+
+* **compartment-mapper:** add Compartment option to captureFromMap ([1ac2156](https://github.com/endojs/endo/commit/1ac2156ae46f9b94ac39cd8b241d0f1ac16f5cce))
+* **compartment-mapper:** Collect unretained module descriptors ([e3b310d](https://github.com/endojs/endo/commit/e3b310d4bd4ddd859d4606a87b6bb2c063831d75))
+* **compartment-mapper:** languageForExtensions options but parameterized on package type ([c31c31f](https://github.com/endojs/endo/commit/c31c31fc258f8b733b677216d492b7655af45c0d))
+* **compartment-mapper:** Workspace language-for-extension options ([389de7b](https://github.com/endojs/endo/commit/389de7b6f9ff4b191f17c442199c289f12c5b855))
+
+
+### Bug Fixes
+
+* **compartment-mapper:** Defer all importHook errors when importing a… ([#2610](https://github.com/endojs/endo/issues/2610)) ([28999e8](https://github.com/endojs/endo/commit/28999e8a2da209c28b217f096dc2fb8080898e9a))
+* **compartment-mapper:** Relax ERef to Promise ([169b9fa](https://github.com/endojs/endo/commit/169b9fa17864618b89963aba40dff717946c9ca6))
+* **compartment-mapper:** Thread compartment name to all exit import hooks ([abd1ddd](https://github.com/endojs/endo/commit/abd1ddd48ae1dc3a3ad134a5fa2bedb0600ce412))
+* **compartment-mapper:** top-level "this" is "module.exports" ([#2620](https://github.com/endojs/endo/issues/2620)) ([a923f4e](https://github.com/endojs/endo/commit/a923f4e864b2975b46f7c20bcc7c702ac0d5287d))
+
+
+
 ### [1.3.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.3.0...@endo/compartment-mapper@1.3.1) (2024-10-22)
 
 **Note:** Version bump only for package @endo/compartment-mapper

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/compartment-mapper`:
 
-# Next version
+# v1.4.0 (2024-11-13)
 
 - Adds options `languageForExtension`, `moduleLanguageForExtension`,
   `commonjsLanguageForExtension`, and `languages` to `mapNodeModules` and

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.4.6](https://github.com/endojs/endo/compare/@endo/daemon@2.4.5...@endo/daemon@2.4.6) (2024-11-13)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ### [2.4.5](https://github.com/endojs/endo/compare/@endo/daemon@2.4.4...@endo/daemon@2.4.5) (2024-10-22)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/env-options/CHANGELOG.md
+++ b/packages/env-options/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.8](https://github.com/endojs/endo/compare/@endo/env-options@1.1.7...@endo/env-options@1.1.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/env-options
+
+
+
+
+
 ### [1.1.7](https://github.com/endojs/endo/compare/@endo/env-options@1.1.6...@endo/env-options@1.1.7) (2024-10-10)
 
 **Note:** Version bump only for package @endo/env-options

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/env-options",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Reading environment options.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.8](https://github.com/endojs/endo/compare/@endo/errors@1.2.7...@endo/errors@1.2.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/errors
+
+
+
+
+
 ### [1.2.7](https://github.com/endojs/endo/compare/@endo/errors@1.2.6...@endo/errors@1.2.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/errors

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/errors",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.2.3](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.2.2...@endo/eslint-plugin@2.2.3) (2024-11-13)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ### [2.2.2](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.2.1...@endo/eslint-plugin@2.2.2) (2024-10-10)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/evasive-transform/CHANGELOG.md
+++ b/packages/evasive-transform/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.3](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.2...@endo/evasive-transform@1.3.3) (2024-11-13)
+
+**Note:** Version bump only for package @endo/evasive-transform
+
+
+
+
+
 ### [1.3.2](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.1...@endo/evasive-transform@1.3.2) (2024-10-22)
 
 **Note:** Version bump only for package @endo/evasive-transform

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/evasive-transform",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Source transforms to evade SES censorship",
   "keywords": [
     "ses",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.8](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.7...@endo/eventual-send@1.2.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/eventual-send
+
+
+
+
+
 ### [1.2.7](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.6...@endo/eventual-send@1.2.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/eventual-send

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.7](https://github.com/endojs/endo/compare/@endo/exo@1.5.6...@endo/exo@1.5.7) (2024-11-13)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.6](https://github.com/endojs/endo/compare/@endo/exo@1.5.5...@endo/exo@1.5.6) (2024-10-22)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.9](https://github.com/endojs/endo/compare/@endo/far@1.1.8...@endo/far@1.1.9) (2024-11-13)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.8](https://github.com/endojs/endo/compare/@endo/far@1.1.7...@endo/far@1.1.8) (2024-10-22)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/immutable-arraybuffer/CHANGELOG.md
+++ b/packages/immutable-arraybuffer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@0.2.1...@endo/immutable-arraybuffer@0.2.2) (2024-11-13)
+
+**Note:** Version bump only for package @endo/immutable-arraybuffer
+
+
+
+
+
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@0.2.0...@endo/immutable-arraybuffer@0.2.1) (2024-10-10)
 
 **Note:** Version bump only for package @endo/immutable-arraybuffer

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/immutable-arraybuffer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Immutable ArrayBuffer",
   "keywords": [],

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.2](https://github.com/endojs/endo/compare/@endo/import-bundle@1.3.1...@endo/import-bundle@1.3.2) (2024-11-13)
+
+**Note:** Version bump only for package @endo/import-bundle
+
+
+
+
+
 ### [1.3.1](https://github.com/endojs/endo/compare/@endo/import-bundle@1.3.0...@endo/import-bundle@1.3.1) (2024-10-22)
 
 **Note:** Version bump only for package @endo/import-bundle

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "load modules created by @endo/bundle-source",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.7](https://github.com/endojs/endo/compare/@endo/init@1.1.6...@endo/init@1.1.7) (2024-11-13)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [1.1.6](https://github.com/endojs/endo/compare/@endo/init@1.1.5...@endo/init@1.1.6) (2024-10-22)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.13](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.12...@endo/lockdown@1.0.13) (2024-11-13)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [1.0.12](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.11...@endo/lockdown@1.0.12) (2024-10-22)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.8](https://github.com/endojs/endo/compare/@endo/lp32@1.1.7...@endo/lp32@1.1.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [1.1.7](https://github.com/endojs/endo/compare/@endo/lp32@1.1.6...@endo/lp32@1.1.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.2](https://github.com/endojs/endo/compare/@endo/marshal@1.6.1...@endo/marshal@1.6.2) (2024-11-13)
+
+**Note:** Version bump only for package @endo/marshal
+
+
+
+
+
 ### [1.6.1](https://github.com/endojs/endo/compare/@endo/marshal@2.0.0...@endo/marshal@1.6.1) (2024-10-22)
 
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/memoize/CHANGELOG.md
+++ b/packages/memoize/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.8](https://github.com/endojs/endo/compare/@endo/memoize@1.1.7...@endo/memoize@1.1.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/memoize
+
+
+
+
+
 ### [1.1.7](https://github.com/endojs/endo/compare/@endo/memoize@1.1.6...@endo/memoize@1.1.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/memoize

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/memoize",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Safe function memoization",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/module-source/CHANGELOG.md
+++ b/packages/module-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.2](https://github.com/endojs/endo/compare/@endo/module-source@1.1.1...@endo/module-source@1.1.2) (2024-11-13)
+
+**Note:** Version bump only for package @endo/module-source
+
+
+
+
+
 ### [1.1.1](https://github.com/endojs/endo/compare/@endo/module-source@1.1.0...@endo/module-source@1.1.1) (2024-10-22)
 
 **Note:** Version bump only for package @endo/module-source

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/module-source",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Ponyfill for the SES ModuleSource and module-to-program transformer",
   "keywords": [
     "ses",

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.13](https://github.com/endojs/endo/compare/@endo/nat@5.0.12...@endo/nat@5.0.13) (2024-11-13)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [5.0.12](https://github.com/endojs/endo/compare/@endo/nat@5.0.11...@endo/nat@5.0.12) (2024-10-22)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.13](https://github.com/endojs/endo/compare/@endo/netstring@1.0.12...@endo/netstring@1.0.13) (2024-11-13)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [1.0.12](https://github.com/endojs/endo/compare/@endo/netstring@1.0.11...@endo/netstring@1.0.12) (2024-10-22)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.7](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.6...@endo/pass-style@1.4.7) (2024-11-13)
+
+**Note:** Version bump only for package @endo/pass-style
+
+
+
+
+
 ### [1.4.6](https://github.com/endojs/endo/compare/@endo/pass-style@2.0.0...@endo/pass-style@1.4.6) (2024-10-22)
 
 

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.7](https://github.com/endojs/endo/compare/@endo/patterns@1.4.6...@endo/patterns@1.4.7) (2024-11-13)
+
+**Note:** Version bump only for package @endo/patterns
+
+
+
+
+
 ### [1.4.6](https://github.com/endojs/endo/compare/@endo/patterns@2.0.0...@endo/patterns@1.4.6) (2024-10-22)
 
 

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Pattern matching for Passable objects, expressed as Passable data",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.8](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.7...@endo/promise-kit@1.1.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [1.1.7](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.6...@endo/promise-kit@1.1.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Helper for making promises",
   "keywords": [
     "promise"

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.8](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.7...@endo/ses-ava@1.2.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [1.2.7](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.6...@endo/ses-ava@1.2.7) (2024-10-22)
 
 

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.10.0](https://github.com/endojs/endo/compare/ses@1.9.1...ses@1.10.0) (2024-11-13)
+
+
+### Features
+
+* **ses:** Lockdown reporting option ([81b86ac](https://github.com/endojs/endo/commit/81b86ac3c3d804c0542f63c1e50040ca468960d0)), closes [#2608](https://github.com/endojs/endo/issues/2608)
+* **ses:** permit Promise.prototype.try ([#2609](https://github.com/endojs/endo/issues/2609)) ([d37a434](https://github.com/endojs/endo/commit/d37a43427452bb9e0376006ef5d2d013176433af)), closes [#2607](https://github.com/endojs/endo/issues/2607)
+
+
+### Bug Fixes
+
+* **ses:** Clarify lockdown types ([cf7f299](https://github.com/endojs/endo/commit/cf7f299e4f9dc0ea2ed271ecb91b66cf2792b1ed))
+* **ses:** fix [#2598](https://github.com/endojs/endo/issues/2598) with cauterizeProperty reuse ([#2624](https://github.com/endojs/endo/issues/2624)) ([d13bf9c](https://github.com/endojs/endo/commit/d13bf9c6b083f04fa7f5983fb4f4a07cd263abe9)), closes [#1221](https://github.com/endojs/endo/issues/1221) [#1221](https://github.com/endojs/endo/issues/1221) [#1221](https://github.com/endojs/endo/issues/1221) [#1221](https://github.com/endojs/endo/issues/1221) [#2563](https://github.com/endojs/endo/issues/2563) [#2334](https://github.com/endojs/endo/issues/2334) [#1221](https://github.com/endojs/endo/issues/1221) [#2563](https://github.com/endojs/endo/issues/2563) [#1221](https://github.com/endojs/endo/issues/1221) [#2563](https://github.com/endojs/endo/issues/2563) [#2563](https://github.com/endojs/endo/issues/2563) [#1221](https://github.com/endojs/endo/issues/1221) [#2563](https://github.com/endojs/endo/issues/2563)
+
+
+
 ### [1.9.1](https://github.com/endojs/endo/compare/ses@1.9.0...ses@1.9.1) (2024-10-22)
 
 **Note:** Version bump only for package ses

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `ses`:
 
-# Next release
+# v1.10.0 (2024-11-13)
 
 - Permit [Promise.try](https://github.com/tc39/proposal-promise-try),
   since it has reached Stage 4.

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",

--- a/packages/skel/CHANGELOG.md
+++ b/packages/skel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.8](https://github.com/endojs/endo/compare/@endo/skel@1.1.7...@endo/skel@1.1.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/skel
+
+
+
+
+
 ### [1.1.7](https://github.com/endojs/endo/compare/@endo/skel@1.1.6...@endo/skel@1.1.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/skel

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/skel",
   "private": true,
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": null,
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.8](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.7...@endo/stream-node@1.1.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [1.1.7](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.6...@endo/stream-node@1.1.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.13](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.12...@endo/stream-types-test@1.0.13) (2024-11-13)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [1.0.12](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.11...@endo/stream-types-test@1.0.12) (2024-10-22)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.8](https://github.com/endojs/endo/compare/@endo/stream@1.2.7...@endo/stream@1.2.8) (2024-11-13)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [1.2.7](https://github.com/endojs/endo/compare/@endo/stream@1.2.6...@endo/stream@1.2.7) (2024-10-22)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",

--- a/packages/syrup/CHANGELOG.md
+++ b/packages/syrup/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.9](https://github.com/endojs/endo/compare/@endo/syrup@1.0.8...@endo/syrup@1.0.9) (2024-11-13)
+
+**Note:** Version bump only for package @endo/syrup
+
+
+
+
+
 ### [1.0.8](https://github.com/endojs/endo/compare/@endo/syrup@1.0.7...@endo/syrup@1.0.8) (2024-10-10)
 
 **Note:** Version bump only for package @endo/syrup

--- a/packages/syrup/package.json
+++ b/packages/syrup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/syrup",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Syrup is a language-independent binary serialization format for structured object trees",
   "keywords": [
     "syrup",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.43](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.42...@endo/test262-runner@0.1.43) (2024-11-13)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.42](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.41...@endo/test262-runner@0.1.42) (2024-10-22)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "private": true,
   "description": "Hardened JavaScript Test262 Runner",
   "keywords": [],

--- a/packages/trampoline/CHANGELOG.md
+++ b/packages/trampoline/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.3](https://github.com/endojs/endo/compare/@endo/trampoline@1.0.2...@endo/trampoline@1.0.3) (2024-11-13)
+
+**Note:** Version bump only for package @endo/trampoline
+
+
+
+
+
 ### [1.0.2](https://github.com/endojs/endo/compare/@endo/trampoline@1.0.1...@endo/trampoline@1.0.2) (2024-10-10)
 
 **Note:** Version bump only for package @endo/trampoline

--- a/packages/trampoline/package.json
+++ b/packages/trampoline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/trampoline",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Multicolor trampolining for recursive operations",
   "keywords": [
     "trampoline",

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.9](https://github.com/endojs/endo/compare/@endo/where@1.0.8...@endo/where@1.0.9) (2024-11-13)
+
+**Note:** Version bump only for package @endo/where
+
+
+
+
+
 ### [1.0.8](https://github.com/endojs/endo/compare/@endo/where@1.0.7...@endo/where@1.0.8) (2024-10-10)
 
 **Note:** Version bump only for package @endo/where

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Locator for Endo user state, caches, and ephemeral files",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.9](https://github.com/endojs/endo/compare/@endo/zip@1.0.8...@endo/zip@1.0.9) (2024-11-13)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ### [1.0.8](https://github.com/endojs/endo/compare/@endo/zip@1.0.7...@endo/zip@1.0.8) (2024-10-10)
 
 **Note:** Version bump only for package @endo/zip

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",


### PR DESCRIPTION
# ses v1.10.0

- Permit [Promise.try](https://github.com/tc39/proposal-promise-try),
  since it has reached Stage 4.

- Adds a `reporting` option to `lockdown` and `repairIntrinsics`.

  The default behavior is `"platform"` which will detect the platform and
  report warnings according to whether a web `console`, Node.js `console`, or
  `print` are available.
  The web platform is distinguished by the existence of `window` or
  `importScripts` (WebWorker).
  The Node.js behavior is to report all warnings to `stderr` visually
  consistent with use of a console group.
  SES will use `print` in the absence of a `console`.
  Captures the platform `console` at the time `lockdown` or `repairIntrinsics`
  are called, not at the time `ses` initializes.

  The `"console"` option forces the web platform behavior.
  On Node.js, this results in group labels being reported to `stdout`.

  The `"none"` option mutes warnings.

# @endo/bundle-source v3.5.0

- Adds support for TypeScript type erasure using
  [`ts-blank-space`](https://bloomberg.github.io/ts-blank-space/) applied to
  TypeScript modules with `.ts`, `.mts`, and `.cts` extensions, for any package
  that is not under a `node_modules` directory, immitating `node
  --experimental-strip-types`.
  As with `.js` extensions, the behavior of `.ts` is either consistent with
  `.mts` or `.cts` depending on the `type` in `package.json`.

# @endo/compartment-mapper v1.4.0

- Adds options `languageForExtension`, `moduleLanguageForExtension`,
  `commonjsLanguageForExtension`, and `languages` to `mapNodeModules` and
  `compartmentMapForNodeModules` allowing for certain mappings from extension
  (e.g., `ts`) to language (e.g., `mts` or `cts`) to depend on the each
  package’s `type` in the way we already vary `js` between `cjs` and `mjs`.
  These options enter through the high level functions including `makeArchive`
  and `importLocation`.
- The new options `workspaceLanguageForExtension`,
  `workspaceModuleLanguageForExtension`, and
  `workspaceCommonjsLanguageForExtension` apply like the above except more
  specifically and for packages that are not physically located under a
  `node_modules` directory, indicating that JavaScript has not yet been
  generated from any non-JavaScript source files.
- Omits unused module descriptors from `compartment-map.json` in archived
  applications, potentially reducing file sizes.
- Fixes an issue where errors thrown from exit module hooks (`importHook`) would
  be thrown at parse-time when the parser uses heuristic import analysis
  _instead of_ at runtime. Such errors will now be thrown at runtime, as
  originally intended. To those who expected the previous behavior: if you
  exist, please exercise caution when upgrading.

