### PR TITLE
feat(ses,module-source): Dynamic import

### DIFF
--- a/packages/compartment-mapper/test/optional.test.js
+++ b/packages/compartment-mapper/test/optional.test.js
@@ -15,7 +15,8 @@ const fixtureOptionalDepsCjs = new URL(
 
 scaffold(
   'optionalDependencies/esm',
-  // this test fails because it relies on dynamic import
+  // fails for archives because dynamic import cannot reach modules not
+  // discovered during archival
   test,
   fixtureOptionalDepsEsm,
   async (t, { namespace }) => {
@@ -41,7 +42,7 @@ scaffold(
     );
   },
   4,
-  { knownFailure: true },
+  { knownArchiveFailure: true },
 );
 
 scaffold(

--- a/packages/compartment-mapper/test/scaffold.js
+++ b/packages/compartment-mapper/test/scaffold.js
@@ -93,6 +93,7 @@ export function scaffold(
     addGlobals = {},
     policy,
     knownFailure = false,
+    knownArchiveFailure = false,
     tags = undefined,
     conditions = tags,
     strict = false,
@@ -111,7 +112,10 @@ export function scaffold(
   // wrapping each time allows for convenient use of test.only
   const wrap = (testFunc, testCategoryHint) => (title, implementation) => {
     // mark as known failure if available (but fallback to support test.only)
-    if (knownFailure) {
+    if (
+      knownFailure ||
+      (knownArchiveFailure && testCategoryHint === 'Archive')
+    ) {
       testFunc = testFunc.failing || testFunc;
     }
     return testFunc(title, async t => {

--- a/packages/module-source/NEWS.md
+++ b/packages/module-source/NEWS.md
@@ -2,6 +2,10 @@ User-visible changes in `@endo/module-source`:
 
 # Next release
 
+- Supports dynamic `import` within a `ModuleSource` in conjunction with
+  a related change in `ses`.
+  For example, `await import(specifier)` can now call through to the
+  surrounding compartment's `importHook` to load and evaluate further modules.
 - Provides an XS-specific variant of `@endo/module-source` that adapts the
   native `ModuleSource` instead of entraining Babel.
 

--- a/packages/module-source/src/babelPlugin.js
+++ b/packages/module-source/src/babelPlugin.js
@@ -49,6 +49,7 @@ function makeModulePlugins(options) {
     reexportMap,
     liveExportMap,
     importMeta,
+    dynamicImport,
   } = options;
 
   if (sourceType !== 'module') {
@@ -286,6 +287,7 @@ function makeModulePlugins(options) {
         CallExpression(path) {
           // import(FOO) -> $h_import(FOO)
           if (path.node.callee.type === 'Import') {
+            dynamicImport.present = true;
             path.node.callee = hiddenIdentifier(h.HIDDEN_IMPORT);
           }
         },

--- a/packages/module-source/src/module-source.js
+++ b/packages/module-source/src/module-source.js
@@ -82,6 +82,7 @@ export function ModuleSource(source, opts = {}) {
     reexportMap,
     fixedExportMap,
     exportAlls,
+    needsImport,
     needsImportMeta,
   } = analyzeModule(source, opts);
   this.imports = freeze([...keys(imports)]);
@@ -97,6 +98,7 @@ export function ModuleSource(source, opts = {}) {
   this.__liveExportMap__ = liveExportMap;
   this.__reexportMap__ = reexportMap;
   this.__fixedExportMap__ = fixedExportMap;
+  this.__needsImport__ = needsImport;
   this.__needsImportMeta__ = needsImportMeta;
   freeze(this);
 }

--- a/packages/module-source/src/transform-analyze.js
+++ b/packages/module-source/src/transform-analyze.js
@@ -41,6 +41,7 @@ const makeCreateStaticRecord = transformSource =>
       hoistedDecls: [],
       importSources: Object.create(null),
       importDecls: [],
+      dynamicImport: { present: false },
       // enables passing import.meta usage hints up.
       importMeta: { present: false },
     };
@@ -103,6 +104,7 @@ const makeCreateStaticRecord = transformSource =>
   imports: ${h.HIDDEN_IMPORTS}, \
   liveVar: ${h.HIDDEN_LIVE}, \
   onceVar: ${h.HIDDEN_ONCE}, \
+  import: ${h.HIDDEN_IMPORT}, \
   importMeta: ${h.HIDDEN_META}, \
 }) => (function () { 'use strict'; \
   ${preamble} \
@@ -119,6 +121,7 @@ const makeCreateStaticRecord = transformSource =>
       liveExportMap: freeze(sourceOptions.liveExportMap),
       fixedExportMap: freeze(sourceOptions.fixedExportMap),
       reexportMap: freeze(sourceOptions.reexportMap),
+      needsImport: sourceOptions.dynamicImport.present,
       needsImportMeta: sourceOptions.importMeta.present,
       functorSource,
     });

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,11 @@ User-visible changes in `ses`:
 
 # Next version
 
-- Specifying the long discontinued `mathTaming` or `dateTaming` options logs a warning.
+- Adds support for dynamic `import` in conjunction with an update to
+  `@endo/module-source`.
+
+- Specifying the long-discontinued `mathTaming` or `dateTaming` options logs a
+  warning.
 
 # v1.10.0 (2024-11-13)
 

--- a/packages/ses/test/import.test.js
+++ b/packages/ses/test/import.test.js
@@ -4,6 +4,7 @@
 /* eslint max-lines: 0 */
 
 import test from 'ava';
+import { ModuleSource } from '@endo/module-source';
 import '../index.js';
 import { resolveNode, makeNodeImporter } from './_node.js';
 import { makeImporter, makeStaticRetriever } from './_import-commons.js';
@@ -599,4 +600,22 @@ test('importMetaHook and meta from record', async t => {
 
   const { default: metaurl } = await compartment.import('./index.js');
   t.is(metaurl, 'https://example.com/index.js?foo');
+});
+
+test('dynamic import from source', async t => {
+  const c = new Compartment({
+    __options__: true,
+    __noNamespaceBox__: true,
+    resolveHook: s => s,
+    modules: {
+      '-': {
+        source: new ModuleSource(`
+          export const dynamic = import('-');
+        `),
+      },
+    },
+  });
+  const namespace = await c.import('-');
+  const namespace2 = await namespace.dynamic;
+  t.is(namespace, namespace2);
 });


### PR DESCRIPTION

Closes: #291

## Description

This change adds support for dynamic `import` to `ses` and `@endo/module-source`, such that `import(x)` in the scope of a module loaded from source (using `ModuleSource` in a `Compartment` module loading hook).

### Security Considerations

This change builds on prior work to ensure that dynamic import is facilitated by a hidden lexical name injected by `ses`. The dynamic import mechanism is isolated to the surrounding compartment and specifiers are resolved on the surrounding module.

### Scaling Considerations

This change introduces a static analysis for the presence of a dynamic `import` in the module source, which it communicates on the module source, even if marshaled through JSON, to `ses` that it should create an `import` closure bound to the calling module’s base specifier. This avoids an allocation for most modules.

### Documentation Considerations

Only news included. Dynamic import is a language feature that is expected to work in general and documented where JavaScript is documented as a language.

### Testing Considerations

This change includes a minimal happy path test that verifies that dynamic import produces a promise that settles on a module namespace object. Note that dynamic import does not box namespaces regardless of the `__noNamespaceBox__` compartment option.

### Compatibility Considerations

Backward compatible.

### Upgrade Considerations

None.