### PR TITLE
fix(ses): widen type of globalThis in Compartment

### DIFF
--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -558,12 +558,12 @@ declare global {
 
     // Deprecated:
     constructor(
-      globals?: Record<string, any> | undefined,
+      globals?: Record<PropertyKey, any> | undefined,
       modules?: Record<string, ModuleDescriptor>,
       options?: CompartmentOptions,
     );
 
-    get globalThis(): Record<string, any>;
+    get globalThis(): Record<PropertyKey, any>;
 
     get name(): string;
 


### PR DESCRIPTION
`globalThis` can contain `Symbol` keys, so it is more correctly typed as `Record<PropertyKey, any>`.

This also widens the type of the `globals` parameter in the `Compartment` constructor.
