### PR TITLE
chore(marshal): Add eslint devDependencies

### DIFF
--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -54,7 +54,13 @@
     "@endo/ses-ava": "workspace:^",
     "@fast-check/ava": "^1.1.5",
     "ava": "^6.1.3",
+    "babel-eslint": "^10.1.0",
     "c8": "^7.14.0",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.29.1",
     "typescript": "~5.6.3"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,7 +612,13 @@ __metadata:
     "@endo/ses-ava": "workspace:^"
     "@fast-check/ava": "npm:^1.1.5"
     ava: "npm:^6.1.3"
+    babel-eslint: "npm:^10.1.0"
     c8: "npm:^7.14.0"
+    eslint: "npm:^8.57.0"
+    eslint-config-airbnb-base: "npm:^15.0.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-eslint-comments: "npm:^3.2.0"
+    eslint-plugin-import: "npm:^2.29.1"
     typescript: "npm:~5.6.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
They were apparently missing from the beginning: https://github.com/endojs/endo/blame/bc6f30a1191ac65ec69569379e063296e122ea86/packages/marshal/package.json