### PR TITLE
fix(ses): `removeUnpermittedIntrinsics` on Hermes

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-globals */
 /* eslint max-lines: 0 */
 
-import { arrayPush, getOwnPropertyNames, arrayForEach } from './commons.js';
+import { arrayPush, arrayForEach } from './commons.js';
 
 /** @import {GenericErrorConstructor} from '../types.js' */
 
@@ -304,7 +304,8 @@ const strict = function () {
   'use strict';
 };
 
-arrayForEach(getOwnPropertyNames(strict), prop => {
+// TODO Remove this once we no longer support the Hermes that needed this.
+arrayForEach(['caller', 'arguments'], prop => {
   try {
     strict[prop];
   } catch (e) {

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -310,6 +310,7 @@ arrayForEach(getOwnPropertyNames(strict), prop => {
   } catch (e) {
     // https://github.com/facebook/hermes/blob/main/test/hermes/function-non-strict.js
     if (e.message === 'Restricted in strict mode') {
+      // Fixed in Static Hermes: https://github.com/facebook/hermes/issues/1582
       FunctionInstance[prop] = accessor;
     }
   }

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-globals */
 /* eslint max-lines: 0 */
 
-import { arrayPush } from './commons.js';
+import { arrayPush, getOwnPropertyNames, arrayForEach } from './commons.js';
 
 /** @import {GenericErrorConstructor} from '../types.js' */
 
@@ -298,6 +298,22 @@ const accessor = {
   get: fn,
   set: fn,
 };
+
+// eslint-disable-next-line func-names
+const strict = function () {
+  'use strict';
+};
+
+arrayForEach(getOwnPropertyNames(strict), prop => {
+  try {
+    strict[prop];
+  } catch (e) {
+    // https://github.com/facebook/hermes/blob/main/test/hermes/function-non-strict.js
+    if (e.message === 'Restricted in strict mode') {
+      FunctionInstance[prop] = accessor;
+    }
+  }
+});
 
 export const isAccessorPermit = permit => {
   return permit === getter || permit === accessor;


### PR DESCRIPTION
Follow-up to
- https://github.com/endojs/endo/pull/2624

Progresses
- https://github.com/endojs/endo/issues/1891

---

## Description

Fix `removeUnpermittedIntrinsics` (previously `whitelistIntrinsics`) on Hermes

```console
SES Removing unpermitted intrinsics
  Removing intrinsics.Promise.caller
  failed to delete intrinsics.Promise.caller TypeError: Property is not configurable
Uncaught TypeError: Property is not configurable
```

after starting again on the problem (now with https://github.com/endojs/endo/pull/2624 addressing `completePrototypes`), it boils down to tolerating two more undeletable non-standard properties (`.caller` and `.arguments`) on the remaining Hermes functions after attempting to remove them
edit: and `.prototype` on some properties

so we can simply extend `cauterizeProperty` after dealing with prototypes to deal with these additional properties

repro
1.  `gh pr checkout 2334` https://github.com/endojs/endo/pull/2334
2. enable Hermes VM in `packages/ses/scripts/hermes-test.sh`
3. comment `// assertDirectEvalAvailable()` in `packages/ses/src/lockdown.js`
4. `yarn build:hermes`
5. `yarn test:hermes`

<details>
  <summary>Hermes VM output (before)</summary>

```console
➜  endo git:(ses-hermes) ✗ yarn build:hermes && yarn test:hermes
-- Building 'hermes' version of SES --
Bundle size: 448125 bytes
Copied ./types.d.ts to ./dist/types.d.cts
Concatenating: dist/ses-hermes.cjs + test/_hermes-smoke.js
Generated: test/_hermes-smoke-dist.js
Executing: test/_hermes-smoke-dist.js on Hermes compiler
test/_hermes-smoke-dist.js:13007:27: warning: the variable "Compartment" was not declared in function "?anon_0_?anon_0_testCompartmentHooks"
  const compartment = new Compartment({}, {}, { resolveHook, importHook });
                          ^~~~~~~~~~~
test/_hermes-smoke-dist.js:13015:3: warning: the variable "assert" was not declared in function "?anon_0_?anon_0_testCompartmentHooks"
  assert(module);
  ^~~~~~
test/_hermes-smoke-dist.js:3838:12: warning: the variable "AggregateError" was not declared in anonymous function " 119#"
if( typeof AggregateError!==  'undefined') {
           ^~~~~~~~~~~~~~
test/_hermes-smoke-dist.js:7053:5: warning: the variable "console" was not declared in function "getOwnPropertyDescriptor"
    console.warn(
    ^~~~~~~
test/_hermes-smoke-dist.js:8613:5: warning: the variable "harden" was not declared in arrow function "makeCausalConsoleFromLogger"
    harden(baseConsole);
    ^~~~~~
test/_hermes-smoke-dist.js:12978:3: warning: the variable "lockdown" was not declared in arrow function "testLockdown"
  lockdown();
  ^~~~~~~~
Generated: test/_hermes-smoke-dist.hbc
Hermes compiler done
Executing generated bytecode file on Hermes VM
Removing lockdown.prototype
Tolerating undeletable lockdown.prototype === undefined
Removing harden.prototype
Tolerating undeletable harden.prototype === undefined
Removing %InitialGetStackString%.prototype
Tolerating undeletable %InitialGetStackString%.prototype === undefined
SES Removing unpermitted intrinsics
  Removing intrinsics.Promise.caller
  failed to delete intrinsics.Promise.caller TypeError: Property is not configurable
Uncaught TypeError: Property is not configurable
```

</details>

<details>
  <summary>Hermes VM output (after)</summary>

```console
➜  endo git:(ses-hermes) ✗ yarn build:hermes && yarn test:hermes
-- Building 'hermes' version of SES --
Bundle size: 448108 bytes
Copied ./types.d.ts to ./dist/types.d.cts
Concatenating: dist/ses-hermes.cjs + test/_hermes-smoke.js
Generated: test/_hermes-smoke-dist.js
Executing: test/_hermes-smoke-dist.js on Hermes compiler
test/_hermes-smoke-dist.js:13007:27: warning: the variable "Compartment" was not declared in function "?anon_0_?anon_0_testCompartmentHooks"
  const compartment = new Compartment({}, {}, { resolveHook, importHook });
                          ^~~~~~~~~~~
test/_hermes-smoke-dist.js:13015:3: warning: the variable "assert" was not declared in function "?anon_0_?anon_0_testCompartmentHooks"
  assert(module);
  ^~~~~~
test/_hermes-smoke-dist.js:3838:12: warning: the variable "AggregateError" was not declared in anonymous function " 119#"
if( typeof AggregateError!==  'undefined') {
           ^~~~~~~~~~~~~~
test/_hermes-smoke-dist.js:7053:5: warning: the variable "console" was not declared in function "getOwnPropertyDescriptor"
    console.warn(
    ^~~~~~~
test/_hermes-smoke-dist.js:8613:5: warning: the variable "harden" was not declared in arrow function "makeCausalConsoleFromLogger"
    harden(baseConsole);
    ^~~~~~
test/_hermes-smoke-dist.js:12978:3: warning: the variable "lockdown" was not declared in arrow function "testLockdown"
  lockdown();
  ^~~~~~~~
Generated: test/_hermes-smoke-dist.hbc
Hermes compiler done
Executing generated bytecode file on Hermes VM
Removing lockdown.prototype
Tolerating undeletable lockdown.prototype === undefined
Removing harden.prototype
Tolerating undeletable harden.prototype === undefined
Removing %InitialGetStackString%.prototype
Tolerating undeletable %InitialGetStackString%.prototype === undefined
SES Removing unpermitted intrinsics
  Removing intrinsics.Promise.caller
  Tolerating undeletable intrinsics.Promise.caller
  Removing intrinsics.Promise.arguments
  Tolerating undeletable intrinsics.Promise.arguments
  Removing intrinsics.Promise._l
  Removing intrinsics.Promise._m
  Removing intrinsics.Promise._n
  Removing intrinsics.Promise.resolve.caller
  Tolerating undeletable intrinsics.Promise.resolve.caller
  Removing intrinsics.Promise.resolve.arguments
  Tolerating undeletable intrinsics.Promise.resolve.arguments
  Removing intrinsics.Promise.resolve.prototype
  Tolerating undeletable intrinsics.Promise.resolve.prototype === undefined
  Removing intrinsics.Promise.all.caller
  Tolerating undeletable intrinsics.Promise.all.caller
  Removing intrinsics.Promise.all.arguments
  Tolerating undeletable intrinsics.Promise.all.arguments
  Removing intrinsics.Promise.all.prototype
  Tolerating undeletable intrinsics.Promise.all.prototype === undefined
  Removing intrinsics.Promise.reject.caller
  Tolerating undeletable intrinsics.Promise.reject.caller
  Removing intrinsics.Promise.reject.arguments
  Tolerating undeletable intrinsics.Promise.reject.arguments
  Removing intrinsics.Promise.reject.prototype
  Tolerating undeletable intrinsics.Promise.reject.prototype === undefined
  Removing intrinsics.Promise.race.caller
  Tolerating undeletable intrinsics.Promise.race.caller
  Removing intrinsics.Promise.race.arguments
  Tolerating undeletable intrinsics.Promise.race.arguments
  Removing intrinsics.Promise.race.prototype
  Tolerating undeletable intrinsics.Promise.race.prototype === undefined
  Removing intrinsics.lockdown.caller
  Tolerating undeletable intrinsics.lockdown.caller
  Removing intrinsics.lockdown.arguments
  Tolerating undeletable intrinsics.lockdown.arguments
  Removing intrinsics.lockdown.prototype
  Tolerating undeletable intrinsics.lockdown.prototype === undefined
  Removing intrinsics.harden.caller
  Tolerating undeletable intrinsics.harden.caller
  Removing intrinsics.harden.arguments
  Tolerating undeletable intrinsics.harden.arguments
  Removing intrinsics.harden.prototype
  Tolerating undeletable intrinsics.harden.prototype === undefined
  Removing intrinsics.%InertFunction%.caller
  Tolerating undeletable intrinsics.%InertFunction%.caller
  Removing intrinsics.%InertFunction%.arguments
  Tolerating undeletable intrinsics.%InertFunction%.arguments
  Removing intrinsics.%InertGeneratorFunction%.caller
  Tolerating undeletable intrinsics.%InertGeneratorFunction%.caller
  Removing intrinsics.%InertGeneratorFunction%.arguments
  Tolerating undeletable intrinsics.%InertGeneratorFunction%.arguments
  Removing intrinsics.%InertAsyncFunction%.caller
  Tolerating undeletable intrinsics.%InertAsyncFunction%.caller
  Removing intrinsics.%InertAsyncFunction%.arguments
  Tolerating undeletable intrinsics.%InertAsyncFunction%.arguments
  Removing intrinsics.%InitialDate%.caller
  Tolerating undeletable intrinsics.%InitialDate%.caller
  Removing intrinsics.%InitialDate%.arguments
  Tolerating undeletable intrinsics.%InitialDate%.arguments
  Removing intrinsics.%SharedDate%.caller
  Tolerating undeletable intrinsics.%SharedDate%.caller
  Removing intrinsics.%SharedDate%.arguments
  Tolerating undeletable intrinsics.%SharedDate%.arguments
  Removing intrinsics.%SharedDate%.now.caller
  Tolerating undeletable intrinsics.%SharedDate%.now.caller
  Removing intrinsics.%SharedDate%.now.arguments
  Tolerating undeletable intrinsics.%SharedDate%.now.arguments
  Removing intrinsics.%SharedDate%.now.prototype
  Tolerating undeletable intrinsics.%SharedDate%.now.prototype === undefined
  Removing intrinsics.%InitialGetStackString%.caller
  Tolerating undeletable intrinsics.%InitialGetStackString%.caller
  Removing intrinsics.%InitialGetStackString%.arguments
  Tolerating undeletable intrinsics.%InitialGetStackString%.arguments
  Removing intrinsics.%InitialGetStackString%.prototype
  Tolerating undeletable intrinsics.%InitialGetStackString%.prototype === undefined
  Removing intrinsics.%InitialError%.caller
  Tolerating undeletable intrinsics.%InitialError%.caller
  Removing intrinsics.%InitialError%.arguments
  Tolerating undeletable intrinsics.%InitialError%.arguments
  Removing intrinsics.%InitialError%.stackTraceLimit<get>.caller
  Tolerating undeletable intrinsics.%InitialError%.stackTraceLimit<get>.caller
  Removing intrinsics.%InitialError%.stackTraceLimit<get>.arguments
  Tolerating undeletable intrinsics.%InitialError%.stackTraceLimit<get>.arguments
  Removing intrinsics.%InitialError%.stackTraceLimit<get>.prototype
  Tolerating undeletable intrinsics.%InitialError%.stackTraceLimit<get>.prototype === undefined
  Removing intrinsics.%InitialError%.stackTraceLimit<set>.caller
  Tolerating undeletable intrinsics.%InitialError%.stackTraceLimit<set>.caller
  Removing intrinsics.%InitialError%.stackTraceLimit<set>.arguments
  Tolerating undeletable intrinsics.%InitialError%.stackTraceLimit<set>.arguments
  Removing intrinsics.%InitialError%.stackTraceLimit<set>.prototype
  Tolerating undeletable intrinsics.%InitialError%.stackTraceLimit<set>.prototype === undefined
  Removing intrinsics.%InitialError%.captureStackTrace.caller
  Tolerating undeletable intrinsics.%InitialError%.captureStackTrace.caller
  Removing intrinsics.%InitialError%.captureStackTrace.arguments
  Tolerating undeletable intrinsics.%InitialError%.captureStackTrace.arguments
  Removing intrinsics.%InitialError%.captureStackTrace.prototype
  Tolerating undeletable intrinsics.%InitialError%.captureStackTrace.prototype === undefined
  Removing intrinsics.%InitialError%.prepareStackTrace<get>.caller
  Tolerating undeletable intrinsics.%InitialError%.prepareStackTrace<get>.caller
  Removing intrinsics.%InitialError%.prepareStackTrace<get>.arguments
  Tolerating undeletable intrinsics.%InitialError%.prepareStackTrace<get>.arguments
  Removing intrinsics.%InitialError%.prepareStackTrace<get>.prototype
  Tolerating undeletable intrinsics.%InitialError%.prepareStackTrace<get>.prototype === undefined
  Removing intrinsics.%InitialError%.prepareStackTrace<set>.caller
  Tolerating undeletable intrinsics.%InitialError%.prepareStackTrace<set>.caller
  Removing intrinsics.%InitialError%.prepareStackTrace<set>.arguments
  Tolerating undeletable intrinsics.%InitialError%.prepareStackTrace<set>.arguments
  Removing intrinsics.%InitialError%.prepareStackTrace<set>.prototype
  Tolerating undeletable intrinsics.%InitialError%.prepareStackTrace<set>.prototype === undefined
  Removing intrinsics.%SharedError%.caller
  Tolerating undeletable intrinsics.%SharedError%.caller
  Removing intrinsics.%SharedError%.arguments
  Tolerating undeletable intrinsics.%SharedError%.arguments
  Removing intrinsics.%SharedError%.stackTraceLimit<get>.caller
  Tolerating undeletable intrinsics.%SharedError%.stackTraceLimit<get>.caller
  Removing intrinsics.%SharedError%.stackTraceLimit<get>.arguments
  Tolerating undeletable intrinsics.%SharedError%.stackTraceLimit<get>.arguments
  Removing intrinsics.%SharedError%.stackTraceLimit<get>.prototype
  Tolerating undeletable intrinsics.%SharedError%.stackTraceLimit<get>.prototype === undefined
  Removing intrinsics.%SharedError%.stackTraceLimit<set>.caller
  Tolerating undeletable intrinsics.%SharedError%.stackTraceLimit<set>.caller
  Removing intrinsics.%SharedError%.stackTraceLimit<set>.arguments
  Tolerating undeletable intrinsics.%SharedError%.stackTraceLimit<set>.arguments
  Removing intrinsics.%SharedError%.stackTraceLimit<set>.prototype
  Tolerating undeletable intrinsics.%SharedError%.stackTraceLimit<set>.prototype === undefined
  Removing intrinsics.%SharedError%.prepareStackTrace<get>.caller
  Tolerating undeletable intrinsics.%SharedError%.prepareStackTrace<get>.caller
  Removing intrinsics.%SharedError%.prepareStackTrace<get>.arguments
  Tolerating undeletable intrinsics.%SharedError%.prepareStackTrace<get>.arguments
  Removing intrinsics.%SharedError%.prepareStackTrace<get>.prototype
  Tolerating undeletable intrinsics.%SharedError%.prepareStackTrace<get>.prototype === undefined
  Removing intrinsics.%SharedError%.prepareStackTrace<set>.caller
  Tolerating undeletable intrinsics.%SharedError%.prepareStackTrace<set>.caller
  Removing intrinsics.%SharedError%.prepareStackTrace<set>.arguments
  Tolerating undeletable intrinsics.%SharedError%.prepareStackTrace<set>.arguments
  Removing intrinsics.%SharedError%.prepareStackTrace<set>.prototype
  Tolerating undeletable intrinsics.%SharedError%.prepareStackTrace<set>.prototype === undefined
  Removing intrinsics.%SharedError%.captureStackTrace.caller
  Tolerating undeletable intrinsics.%SharedError%.captureStackTrace.caller
  Removing intrinsics.%SharedError%.captureStackTrace.arguments
  Tolerating undeletable intrinsics.%SharedError%.captureStackTrace.arguments
  Removing intrinsics.%SharedError%.captureStackTrace.prototype
  Tolerating undeletable intrinsics.%SharedError%.captureStackTrace.prototype === undefined
  Removing intrinsics.%SharedMath%.random.caller
  Tolerating undeletable intrinsics.%SharedMath%.random.caller
  Removing intrinsics.%SharedMath%.random.arguments
  Tolerating undeletable intrinsics.%SharedMath%.random.arguments
  Removing intrinsics.%SharedMath%.random.prototype
  Tolerating undeletable intrinsics.%SharedMath%.random.prototype === undefined
  Removing intrinsics.%InitialRegExp%.caller
  Tolerating undeletable intrinsics.%InitialRegExp%.caller
  Removing intrinsics.%InitialRegExp%.arguments
  Tolerating undeletable intrinsics.%InitialRegExp%.arguments
  Removing intrinsics.%SharedRegExp%.caller
  Tolerating undeletable intrinsics.%SharedRegExp%.caller
  Removing intrinsics.%SharedRegExp%.arguments
  Tolerating undeletable intrinsics.%SharedRegExp%.arguments
  Removing intrinsics.%SharedSymbol%.caller
  Tolerating undeletable intrinsics.%SharedSymbol%.caller
  Removing intrinsics.%SharedSymbol%.arguments
  Tolerating undeletable intrinsics.%SharedSymbol%.arguments
  Removing intrinsics.%InertCompartment%.caller
  Tolerating undeletable intrinsics.%InertCompartment%.caller
  Removing intrinsics.%InertCompartment%.arguments
  Tolerating undeletable intrinsics.%InertCompartment%.arguments
  Removing intrinsics.%NumberPrototype%.toLocaleString.caller
  Tolerating undeletable intrinsics.%NumberPrototype%.toLocaleString.caller
  Removing intrinsics.%NumberPrototype%.toLocaleString.arguments
  Tolerating undeletable intrinsics.%NumberPrototype%.toLocaleString.arguments
  Removing intrinsics.%NumberPrototype%.toLocaleString.prototype
  Tolerating undeletable intrinsics.%NumberPrototype%.toLocaleString.prototype === undefined
  Removing intrinsics.%PromisePrototype%.then.caller
  Tolerating undeletable intrinsics.%PromisePrototype%.then.caller
  Removing intrinsics.%PromisePrototype%.then.arguments
  Tolerating undeletable intrinsics.%PromisePrototype%.then.arguments
  Removing intrinsics.%PromisePrototype%.then.prototype
  Tolerating undeletable intrinsics.%PromisePrototype%.then.prototype === undefined
  Removing intrinsics.%PromisePrototype%.catch.caller
  Tolerating undeletable intrinsics.%PromisePrototype%.catch.caller
  Removing intrinsics.%PromisePrototype%.catch.arguments
  Tolerating undeletable intrinsics.%PromisePrototype%.catch.arguments
  Removing intrinsics.%PromisePrototype%.catch.prototype
  Tolerating undeletable intrinsics.%PromisePrototype%.catch.prototype === undefined
  Removing intrinsics.%PromisePrototype%.finally.caller
  Tolerating undeletable intrinsics.%PromisePrototype%.finally.caller
  Removing intrinsics.%PromisePrototype%.finally.arguments
  Tolerating undeletable intrinsics.%PromisePrototype%.finally.arguments
  Removing intrinsics.%PromisePrototype%.finally.prototype
  Tolerating undeletable intrinsics.%PromisePrototype%.finally.prototype === undefined
  Removing intrinsics.%StringPrototype%.localeCompare.caller
  Tolerating undeletable intrinsics.%StringPrototype%.localeCompare.caller
  Removing intrinsics.%StringPrototype%.localeCompare.arguments
  Tolerating undeletable intrinsics.%StringPrototype%.localeCompare.arguments
  Removing intrinsics.%StringPrototype%.localeCompare.prototype
  Tolerating undeletable intrinsics.%StringPrototype%.localeCompare.prototype === undefined
  Removing intrinsics.%FunctionPrototype%.toString.caller
  Tolerating undeletable intrinsics.%FunctionPrototype%.toString.caller
  Removing intrinsics.%FunctionPrototype%.toString.arguments
  Tolerating undeletable intrinsics.%FunctionPrototype%.toString.arguments
  Removing intrinsics.%FunctionPrototype%.toString.prototype
  Tolerating undeletable intrinsics.%FunctionPrototype%.toString.prototype === undefined
  Removing intrinsics.%CompartmentPrototype%.globalThis<get>.caller
  Tolerating undeletable intrinsics.%CompartmentPrototype%.globalThis<get>.caller
  Removing intrinsics.%CompartmentPrototype%.globalThis<get>.arguments
  Tolerating undeletable intrinsics.%CompartmentPrototype%.globalThis<get>.arguments
  Removing intrinsics.%CompartmentPrototype%.globalThis<get>.prototype
  Tolerating undeletable intrinsics.%CompartmentPrototype%.globalThis<get>.prototype === undefined
  Removing intrinsics.%CompartmentPrototype%.name<get>.caller
  Tolerating undeletable intrinsics.%CompartmentPrototype%.name<get>.caller
  Removing intrinsics.%CompartmentPrototype%.name<get>.arguments
  Tolerating undeletable intrinsics.%CompartmentPrototype%.name<get>.arguments
  Removing intrinsics.%CompartmentPrototype%.name<get>.prototype
  Tolerating undeletable intrinsics.%CompartmentPrototype%.name<get>.prototype === undefined
  Removing intrinsics.%CompartmentPrototype%.evaluate.caller
  Tolerating undeletable intrinsics.%CompartmentPrototype%.evaluate.caller
  Removing intrinsics.%CompartmentPrototype%.evaluate.arguments
  Tolerating undeletable intrinsics.%CompartmentPrototype%.evaluate.arguments
  Removing intrinsics.%CompartmentPrototype%.evaluate.prototype
  Tolerating undeletable intrinsics.%CompartmentPrototype%.evaluate.prototype === undefined
  Removing intrinsics.%CompartmentPrototype%.module.caller
  Tolerating undeletable intrinsics.%CompartmentPrototype%.module.caller
  Removing intrinsics.%CompartmentPrototype%.module.arguments
  Tolerating undeletable intrinsics.%CompartmentPrototype%.module.arguments
  Removing intrinsics.%CompartmentPrototype%.module.prototype
  Tolerating undeletable intrinsics.%CompartmentPrototype%.module.prototype === undefined
  Removing intrinsics.%CompartmentPrototype%.import.caller
  Tolerating undeletable intrinsics.%CompartmentPrototype%.import.caller
  Removing intrinsics.%CompartmentPrototype%.import.arguments
  Tolerating undeletable intrinsics.%CompartmentPrototype%.import.arguments
  Removing intrinsics.%CompartmentPrototype%.load.caller
  Tolerating undeletable intrinsics.%CompartmentPrototype%.load.caller
  Removing intrinsics.%CompartmentPrototype%.load.arguments
  Tolerating undeletable intrinsics.%CompartmentPrototype%.load.arguments
  Removing intrinsics.%CompartmentPrototype%.importNow.caller
  Tolerating undeletable intrinsics.%CompartmentPrototype%.importNow.caller
  Removing intrinsics.%CompartmentPrototype%.importNow.arguments
  Tolerating undeletable intrinsics.%CompartmentPrototype%.importNow.arguments
  Removing intrinsics.%CompartmentPrototype%.importNow.prototype
  Tolerating undeletable intrinsics.%CompartmentPrototype%.importNow.prototype === undefined
Hermes VM done
Hermes tests complete
Removing: test/_hermes-smoke-dist.js
Removing: test/_hermes-smoke-dist.hbc
```

</details>

### Security Considerations

> Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?

### Scaling Considerations

> Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated?

### Documentation Considerations

> Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

### Testing Considerations

> Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?

### Compatibility Considerations

> Does this change break any prior usage patterns? Does this change allow usage patterns to evolve?

### Upgrade Considerations

> What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed?

> Include `*BREAKING*:` in the commit message with migration instructions for any breaking change.

> Update `NEWS.md` for user-facing changes.

> Delete guidance from pull request description before merge (including this!)
