### PR TITLE
refactor(pass-style): Avoid name convention conflict

### DIFF
--- a/packages/eslint-plugin/lib/configs/internal.js
+++ b/packages/eslint-plugin/lib/configs/internal.js
@@ -49,6 +49,17 @@ module.exports = {
     // RESM does not support ?? nor ?. operators, so we must avoid them expressly.
     '@endo/no-optional-chaining': 'error',
     '@endo/no-nullish-coalescing': 'error',
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+        custom: {
+          regex: '.*I$',
+          match: false
+        }
+      },
+    ],
   },
   overrides: [
     {

--- a/packages/eslint-plugin/lib/configs/internal.js
+++ b/packages/eslint-plugin/lib/configs/internal.js
@@ -56,8 +56,8 @@ module.exports = {
         format: ['PascalCase'],
         custom: {
           regex: '.*I$',
-          match: false
-        }
+          match: false,
+        },
       },
     ],
   },

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -85,14 +85,14 @@ export type Passable<
 > = void | Primitive | Container<PC, E> | PC | E;
 
 export type Container<PC extends PassableCap, E extends Error> =
-  | CopyArrayCommon<PC, E>
-  | CopyRecordCommon<PC, E>
-  | CopyTaggedCommon<PC, E>;
-interface CopyArrayCommon<PC extends PassableCap, E extends Error>
+  | CopyArrayInterface<PC, E>
+  | CopyRecordInterface<PC, E>
+  | CopyTaggedInterface<PC, E>;
+interface CopyArrayInterface<PC extends PassableCap, E extends Error>
   extends CopyArray<Passable<PC, E>> {}
-interface CopyRecordCommon<PC extends PassableCap, E extends Error>
+interface CopyRecordInterface<PC extends PassableCap, E extends Error>
   extends CopyRecord<Passable<PC, E>> {}
-interface CopyTaggedCommon<PC extends PassableCap, E extends Error>
+interface CopyTaggedInterface<PC extends PassableCap, E extends Error>
   extends CopyTagged<string, Passable<PC, E>> {}
 
 export type PassStyleOf = {

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -85,14 +85,14 @@ export type Passable<
 > = void | Primitive | Container<PC, E> | PC | E;
 
 export type Container<PC extends PassableCap, E extends Error> =
-  | CopyArrayI<PC, E>
-  | CopyRecordI<PC, E>
-  | CopyTaggedI<PC, E>;
-interface CopyArrayI<PC extends PassableCap, E extends Error>
+  | CopyArrayCommon<PC, E>
+  | CopyRecordCommon<PC, E>
+  | CopyTaggedCommon<PC, E>;
+interface CopyArrayCommon<PC extends PassableCap, E extends Error>
   extends CopyArray<Passable<PC, E>> {}
-interface CopyRecordI<PC extends PassableCap, E extends Error>
+interface CopyRecordCommon<PC extends PassableCap, E extends Error>
   extends CopyRecord<Passable<PC, E>> {}
-interface CopyTaggedI<PC extends PassableCap, E extends Error>
+interface CopyTaggedCommon<PC extends PassableCap, E extends Error>
   extends CopyTagged<string, Passable<PC, E>> {}
 
 export type PassStyleOf = {


### PR DESCRIPTION
closes: #XXXX
https://github.com/Agoric/agoric-sdk/pull/10751

## Description

We generally use names of the form `^([A-Z]\w*)I$`, i.e., identifiers beginning with a capital letter and ending with a lone capital "I", for interface guards. However there were some uses of the same form of name for typescript interfaces. Because interfaces and interface guards are adjacent concepts, this could be confusing. This PR fixes this for endo. The companion https://github.com/Agoric/agoric-sdk/pull/10751 fixes it for agoric-sdk. Because the endo names in question were not exported, there is clearly no dependency between these two PRs. 

### Security Considerations

Consistent naming conventions makes code more reviewable, which is good for security.

### Scaling Considerations
none

### Documentation Considerations
Consistent naming conventions helps documentation and its readers.


### Testing Considerations
none

### Compatibility Considerations

Because these names are not exported, and are only type names erased prior to execution, none.

### Upgrade Considerations
Because these are only type names that are erased prior to execution, none.




