### PR TITLE
docs(patterns): fixed broken link in README

### DIFF
--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -20,7 +20,7 @@ See {@link PatternMatchers} for more on `M.splitRecord()`, `M.number()`, and oth
 
 `M` also has {@link GuardMakers} methods to make {@link InterfaceGuard}s that use Patterns to characterize dynamic behavior such as method argument/response signatures and promise awaiting. The {@link @endo/exo!} package uses `InterfaceGuard`s as the first level of defense for Exo objects against malformed input.
 
-_For best rendering, use the [Endo reference docs](https://endojs.github.io/) site._
+_For best rendering, use the [Endo reference docs](https://endojs.github.io/endo) site._
 
 ## Key Equality, Containers
 


### PR DESCRIPTION
### Description / Documentation Considerations

This commit addresses a broken link to the Endo API Documentation from within the  README. Instead of https://endojs.github.io/, users should be sent to https://endojs.github.io/endo/, which is what this commit addresses.

Ref: #2442 

## Security / Scaling / Testing / Compatibility / Upgrade Considerations

N/A