### PR TITLE
ci: bump upload-artifact action

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run Playwright tests
         working-directory: browser-test
         run: npx playwright test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: browser-test-report


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Refs: https://github.com/Agoric/agoric-private/issues/229

## Description

Bumps upload-artifact version from v3 to v4

### Security Considerations

None

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Updates a deprecated action used in CI but that's about it. **Browser Tests** check was in a failing state before this PR and the action version bump is harmless (already done in other repos)

### Compatibility Considerations

None

### Upgrade Considerations

None