### PR TITLE
refactor: prepare for non-trapping integrity trait

### DIFF
--- a/packages/captp/src/trap.js
+++ b/packages/captp/src/trap.js
@@ -59,26 +59,32 @@ const TrapProxyHandler = (x, trapImpl) => {
 };
 
 /**
+ * `freeze` but not `harden` the proxy target so it remains trapping.
+ * Thus, it should not be shared outside this module.
+ *
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+ */
+const funcTarget = freeze(() => {});
+
+/**
+ * `freeze` but not `harden` the proxy target so it remains trapping.
+ * Thus, it should not be shared outside this module.
+ *
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+ */
+const objTarget = freeze({ __proto__: null });
+
+/**
  * @param {import('./types.js').TrapImpl} trapImpl
  * @returns {import('./ts-types.js').Trap}
  */
 export const makeTrap = trapImpl => {
   const Trap = x => {
-    /**
-     * `freeze` but not `harden` the proxy target so it remains trapping.
-     * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
-     */
-    const target = freeze(() => {});
     const handler = TrapProxyHandler(x, trapImpl);
-    return new Proxy(target, handler);
+    return new Proxy(funcTarget, handler);
   };
 
   const makeTrapGetterProxy = x => {
-    /**
-     * `freeze` but not `harden` the proxy target so it remains trapping.
-     * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
-     */
-    const target = freeze(Object.create(null));
     const handler = harden({
       ...baseFreezableProxyHandler,
       has(_target, _prop) {
@@ -89,7 +95,7 @@ export const makeTrap = trapImpl => {
         return trapImpl.get(x, prop);
       },
     });
-    return new Proxy(target, handler);
+    return new Proxy(objTarget, handler);
   };
   Trap.get = makeTrapGetterProxy;
 

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -2,7 +2,7 @@ import { trackTurns } from './track-turns.js';
 import { makeMessageBreakpointTester } from './message-breakpoints.js';
 
 const { details: X, quote: q, Fail, error: makeError } = assert;
-const { assign, create, freeze } = Object;
+const { assign, freeze } = Object;
 
 /**
  * @import { HandledPromiseConstructor } from './types.js';
@@ -169,35 +169,20 @@ const makeEGetProxyHandler = (x, HandledPromise) =>
 
 /**
  * `freeze` but not `harden` the proxy target so it remains trapping.
- * This is safe to share between proxy instances because they are encapsulated
- * within the proxy.
- * - Before stabilize/suppressTrapping, this is safe
- *   because they are already frozen, and so they cannot be damaged by the
- *   proxies that encapsulate them.
- * - After stabilize/suppressTrapping, this is safe because the only damage
- *   that could be done would be by stabilize/suppressTrapping. These proxies
- *   do not explicitly provide such a trap, and thus will use the default
- *   behavior which is to refuse to be made non-trapping.
+ * Thus, it should not be shared outside this module.
  *
  * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
  */
 const funcTarget = freeze(() => {});
 
 /**
+/**
  * `freeze` but not `harden` the proxy target so it remains trapping.
- * This is safe to share between proxy instances because they are encapsulated
- * within the proxy.
- * - Before stabilize/suppressTrapping, this is safe
- *   because they are already frozen, and so they cannot be damaged by the
- *   proxies that encapsulate them.
- * - After stabilize/suppressTrapping, this is safe because the only damage
- *   that could be done would be by stabilize/suppressTrapping. These proxies
- *   do not explicitly provide such a trap, and thus will use the default
- *   behavior which is to refuse to be made non-trapping.
+ * Thus, it should not be shared outside this module.
  *
  * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
  */
-const objTarget = freeze(create(null));
+const objTarget = freeze({ __proto__: null });
 
 /**
  * @param {HandledPromiseConstructor} HandledPromise

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -168,19 +168,41 @@ const makeEGetProxyHandler = (x, HandledPromise) =>
   });
 
 /**
+ * `freeze` but not `harden` the proxy target so it remains trapping.
+ * This is safe to share between proxy instances because they are encapsulated
+ * within the proxy.
+ * - Before stabilize/suppressTrapping, this is safe
+ *   because they are already frozen, and so they cannot be damaged by the
+ *   proxies that encapsulate them.
+ * - After stabilize/suppressTrapping, this is safe because the only damage
+ *   that could be done would be by stabilize/suppressTrapping. These proxies
+ *   do not explicitly provide such a trap, and thus will use the default
+ *   behavior which is to refuse to be made non-trapping.
+ *
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+ */
+const funcTarget = freeze(() => {});
+
+/**
+ * `freeze` but not `harden` the proxy target so it remains trapping.
+ * This is safe to share between proxy instances because they are encapsulated
+ * within the proxy.
+ * - Before stabilize/suppressTrapping, this is safe
+ *   because they are already frozen, and so they cannot be damaged by the
+ *   proxies that encapsulate them.
+ * - After stabilize/suppressTrapping, this is safe because the only damage
+ *   that could be done would be by stabilize/suppressTrapping. These proxies
+ *   do not explicitly provide such a trap, and thus will use the default
+ *   behavior which is to refuse to be made non-trapping.
+ *
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+ */
+const objTarget = freeze(create(null));
+
+/**
  * @param {HandledPromiseConstructor} HandledPromise
  */
 const makeE = HandledPromise => {
-  /**
-   * `freeze` but not `harden` the proxy target so it remains trapping.
-   * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
-   */
-  const funcTarget = freeze(() => {});
-  /**
-   * `freeze` but not `harden` the proxy target so it remains trapping.
-   * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
-   */
-  const objTarget = freeze(create(null));
   return harden(
     assign(
       /**

--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -309,6 +309,9 @@ export const makeHandledPromise = () => {
         if (proxyOpts) {
           const {
             handler: proxyHandler,
+            // The proxy target can be frozen but should not be hardened
+            // so it remains trapping.
+            // See https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
             target: proxyTarget,
             revokerCallback,
           } = proxyOpts;

--- a/packages/far/test/marshal-far-function.test.js
+++ b/packages/far/test/marshal-far-function.test.js
@@ -58,7 +58,7 @@ test('Data can contain far functions', t => {
   const arrow = Far('arrow', a => a + 1);
   t.is(passStyleOf(harden({ x: 8, foo: arrow })), 'copyRecord');
   const mightBeMethod = a => a + 1;
-  t.throws(() => passStyleOf(freeze({ x: 8, foo: mightBeMethod })), {
+  t.throws(() => passStyleOf(harden({ x: 8, foo: mightBeMethod })), {
     message: /Remotables with non-methods like "x" /,
   });
 });

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -5,6 +5,8 @@ import { makeMarshal } from './marshal.js';
 
 /** @import {Passable} from '@endo/pass-style' */
 
+const { freeze } = Object;
+
 /** @type {import('./types.js').ConvertValToSlot<any>} */
 const doNotConvertValToSlot = val =>
   Fail`Marshal's stringify rejects presences and promises ${val}`;
@@ -23,7 +25,12 @@ const badArrayHandler = harden({
   },
 });
 
-const badArray = harden(new Proxy(harden([]), badArrayHandler));
+/**
+ * `freeze` but not `harden` the proxy target so it remains trapping.
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+ */
+const arrayTarget = freeze(/** @type {any[]} */ ([]));
+const badArray = new Proxy(arrayTarget, badArrayHandler);
 
 const { serialize, unserialize } = makeMarshal(
   doNotConvertValToSlot,
@@ -48,7 +55,10 @@ harden(stringify);
  */
 const parse = str =>
   unserialize(
-    harden({
+    // `freeze` but not `harden` since the `badArray` proxy and its target
+    // must remain trapping.
+    // See https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+    freeze({
       body: str,
       slots: badArray,
     }),

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -27,6 +27,8 @@ const badArrayHandler = harden({
 
 /**
  * `freeze` but not `harden` the proxy target so it remains trapping.
+ * Thus, it should not be shared outside this module.
+ *
  * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
  */
 const arrayTarget = freeze(/** @type {any[]} */ ([]));

--- a/packages/marshal/test/marshal-far-function.test.js
+++ b/packages/marshal/test/marshal-far-function.test.js
@@ -60,7 +60,7 @@ test('Data can contain far functions', t => {
   const arrow = Far('arrow', a => a + 1);
   t.is(passStyleOf(harden({ x: 8, foo: arrow })), 'copyRecord');
   const mightBeMethod = a => a + 1;
-  t.throws(() => passStyleOf(freeze({ x: 8, foo: mightBeMethod })), {
+  t.throws(() => passStyleOf(harden({ x: 8, foo: mightBeMethod })), {
     message: /Remotables with non-methods like "x" /,
   });
 });

--- a/packages/pass-style/test/passStyleOf.test.js
+++ b/packages/pass-style/test/passStyleOf.test.js
@@ -110,13 +110,17 @@ test('some passStyleOf rejections', t => {
 });
 
 /**
- * For testing purposes, makes a TagRecord-like object with
+ * For testing purposes, makes a *non-frozen* TagRecord-like object with
  * non-enumerable PASS_STYLE and Symbol.toStringTag properties.
  * A valid Remotable must inherit from a valid TagRecord.
+ * - Before stabilize/suppressTrapping, a valid TagRecord must be frozen.
+ * - After stabilize/suppressTrapping, a valid TagRecord must also be
+ *   stable/non-trapping, for example, because it was hardened.
  *
  * @param {string} [tag]
  * @param {object|null} [proto]
  * @returns {{ [PASS_STYLE]: 'remotable', [Symbol.toStringTag]: string }}
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
  */
 const makeTagishRecord = (tag = 'Remotable', proto = undefined) => {
   return Object.create(proto === undefined ? Object.prototype : proto, {
@@ -193,16 +197,21 @@ test('passStyleOf testing remotables', t => {
 
   const tagRecord1 = harden(makeTagishRecord('Alleged: manually constructed'));
   /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObj1 = harden({ __proto__: tagRecord1 });
   t.is(passStyleOf(farObj1), 'remotable');
 
   const tagRecord2 = makeTagishRecord('Alleged: tagRecord not hardened');
   /**
+   * Do not freeze `tagRecord2` in order to test that an object with
+   * a non-frozen __proto__ is not passable.
+   *
    * TODO In order to run this test before we have explicit support for a
    * non-trapping integrity trait, we have to `freeze` here but not `harden`.
    * However, once we do have that support, and `passStyleOf` checks that
    * its argument is also non-trapping, we still need to avoid `harden`
-   * because that would also hardden `__proto__`. So we will need to
+   * because that would also harden `__proto__`. So we will need to
    * explicitly make this non-trapping, which we cannot yet express.
    * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
    *
@@ -220,15 +229,21 @@ test('passStyleOf testing remotables', t => {
 
   const tagRecord3 = harden(makeTagishRecord('Alleged: both manually frozen'));
   /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObj3 = harden({ __proto__: tagRecord3 });
   t.is(passStyleOf(farObj3), 'remotable');
 
   const tagRecord4 = harden(makeTagishRecord('Remotable'));
   /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObj4 = harden({ __proto__: tagRecord4 });
   t.is(passStyleOf(farObj4), 'remotable');
 
   const tagRecord5 = harden(makeTagishRecord('Not alleging'));
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObj5 = harden({ __proto__: tagRecord5 });
   t.throws(() => passStyleOf(farObj5), {
     message:
@@ -236,8 +251,12 @@ test('passStyleOf testing remotables', t => {
   });
 
   const tagRecord6 = harden(makeTagishRecord('Alleged: manually constructed'));
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObjProto6 = harden({ __proto__: tagRecord6 });
   /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObj6 = harden({ __proto__: farObjProto6 });
   t.is(passStyleOf(farObj6), 'remotable', 'tagRecord grandproto is accepted');
 
@@ -292,6 +311,8 @@ test('passStyleOf testing remotables', t => {
   const tagRecordA1 = harden(
     makeTagishRecord('Alleged: null-proto tagRecord proto', null),
   );
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObjA1 = harden({ __proto__: tagRecordA1 });
   t.throws(
     () => passStyleOf(farObjA1),
@@ -302,7 +323,11 @@ test('passStyleOf testing remotables', t => {
   const tagRecordA2 = harden(
     makeTagishRecord('Alleged: null-proto tagRecord grandproto', null),
   );
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObjProtoA2 = harden({ __proto__: tagRecordA2 });
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObjA2 = harden({ __proto__: farObjProtoA2 });
   t.throws(
     () => passStyleOf(farObjA2),
@@ -317,7 +342,11 @@ test('passStyleOf testing remotables', t => {
   const fauxTagRecordB = harden(
     makeTagishRecord('Alleged: manually constructed', harden({})),
   );
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObjProtoB = harden({ __proto__: fauxTagRecordB });
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const farObjB = harden({ __proto__: farObjProtoB });
   t.throws(() => passStyleOf(farObjB), {
     message:
@@ -329,6 +358,8 @@ test('passStyleOf testing remotables', t => {
   );
   Object.defineProperty(farObjProtoWithExtra, 'extra', { value: () => {} });
   harden(farObjProtoWithExtra);
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const badFarObjExtraProtoProp = harden({ __proto__: farObjProtoWithExtra });
   t.throws(() => passStyleOf(badFarObjExtraProtoProp), {
     message: 'Unexpected properties on Remotable Proto ["extra"]',
@@ -378,11 +409,17 @@ test('remotables - safety from the gibson042 attack', t => {
   );
 
   /**
+   * Do not freeze `mercurialProto` in order to test that an object with
+   * a non-frozen __proto__ is not passable. Once we have support for
+   * non-trapping, we should generalize this test (or add a new one) where
+   * `mercurialProto` is frozen but still trapping. This test would then
+   * test that a valid TagRecord must be non-trapping.
+   *
    * TODO In order to run this test before we have explicit support for a
    * non-trapping integrity trait, we have to `freeze` here but not `harden`.
    * However, once we do have that support, and `passStyleOf` checks that
    * its argument is also non-trapping, we still need to avoid `harden`
-   * because that would also hardden `__proto__`. So we will need to
+   * because that would also harden `__proto__`. So we will need to
    * explicitly make this non-trapping, which we cannot yet express.
    * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
    */
@@ -448,12 +485,16 @@ test('Allow toStringTag overrides', t => {
   t.is(`${q(alice)}`, '"[DebugName: Allison]"');
 
   /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const carol = harden({ __proto__: alice });
   t.is(passStyleOf(carol), 'remotable');
   t.is(`${carol}`, '[object DebugName: Allison]');
   t.is(`${q(carol)}`, '"[DebugName: Allison]"');
 
   /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
+  // TODO Once we have support for explicit non-trapping, this should change
+  // from `harden` to `suppressTrapping` or `stabilize`.
   const bob = harden({
     __proto__: carol,
     [Symbol.toStringTag]: 'DebugName: Robert',

--- a/packages/pass-style/test/passStyleOf.test.js
+++ b/packages/pass-style/test/passStyleOf.test.js
@@ -14,6 +14,34 @@ const harden = /** @type {import('ses').Harden & { isFake?: boolean }} */ (
 );
 
 const { getPrototypeOf, defineProperty, freeze } = Object;
+/**
+ * Local alias of `harden` to eventually be switched to whatever applies
+ * the suppress-trapping integrity trait. For the shim at
+ * https://github.com/endojs/endo/pull/2673
+ * that is `suppressTrapping`, which is why we choose that name for the
+ * placeholder here. But it is a separate definition so these aliased uses
+ * do not yet depend on the final name.
+ *
+ * TODO Once we do have support for an explicit `suppressTrapping` operation,
+ * we should import that instead, and if necessary rename all uses to that
+ * operation's final name.
+ */
+const hardenToBeSuppressTrapping = harden;
+
+/**
+ * Local alias of `harden` to eventually be switched to whatever applies
+ * the suppress-trapping integrity trait. For the shim at
+ * https://github.com/endojs/endo/pull/2673
+ * that is `suppressTrapping`, which is why we choose that name for the
+ * placeholder here. But it is a separate definition so these aliased uses
+ * do not yet depend on the final name.
+ *
+ * TODO Once we do have support for an explicit `suppressTrapping` operation,
+ * we should import that instead, and if necessary rename all uses to that
+ * operation's final name.
+ */
+const freezeToBeSuppressTrapping = freeze;
+
 const { ownKeys } = Reflect;
 
 test('passStyleOf basic success cases', t => {
@@ -196,10 +224,7 @@ test('passStyleOf testing remotables', t => {
   t.is(passStyleOf(Far('foo', () => 'far function')), 'remotable');
 
   const tagRecord1 = harden(makeTagishRecord('Alleged: manually constructed'));
-  /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObj1 = harden({ __proto__: tagRecord1 });
+  const farObj1 = hardenToBeSuppressTrapping({ __proto__: tagRecord1 });
   t.is(passStyleOf(farObj1), 'remotable');
 
   const tagRecord2 = makeTagishRecord('Alleged: tagRecord not hardened');
@@ -214,10 +239,8 @@ test('passStyleOf testing remotables', t => {
    * because that would also harden `__proto__`. So we will need to
    * explicitly make this non-trapping, which we cannot yet express.
    * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
-   *
-   * @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385
    */
-  const farObj2 = freeze({ __proto__: tagRecord2 });
+  const farObj2 = freezeToBeSuppressTrapping({ __proto__: tagRecord2 });
   if (harden.isFake) {
     t.is(passStyleOf(farObj2), 'remotable');
   } else {
@@ -228,36 +251,23 @@ test('passStyleOf testing remotables', t => {
   }
 
   const tagRecord3 = harden(makeTagishRecord('Alleged: both manually frozen'));
-  /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObj3 = harden({ __proto__: tagRecord3 });
+  const farObj3 = hardenToBeSuppressTrapping({ __proto__: tagRecord3 });
   t.is(passStyleOf(farObj3), 'remotable');
 
   const tagRecord4 = harden(makeTagishRecord('Remotable'));
-  /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObj4 = harden({ __proto__: tagRecord4 });
+  const farObj4 = hardenToBeSuppressTrapping({ __proto__: tagRecord4 });
   t.is(passStyleOf(farObj4), 'remotable');
 
   const tagRecord5 = harden(makeTagishRecord('Not alleging'));
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObj5 = harden({ __proto__: tagRecord5 });
+  const farObj5 = hardenToBeSuppressTrapping({ __proto__: tagRecord5 });
   t.throws(() => passStyleOf(farObj5), {
     message:
       /For now, iface "Not alleging" must be "Remotable" or begin with "Alleged: " or "DebugName: "; unimplemented/,
   });
 
   const tagRecord6 = harden(makeTagishRecord('Alleged: manually constructed'));
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObjProto6 = harden({ __proto__: tagRecord6 });
-  /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObj6 = harden({ __proto__: farObjProto6 });
+  const farObjProto6 = hardenToBeSuppressTrapping({ __proto__: tagRecord6 });
+  const farObj6 = hardenToBeSuppressTrapping({ __proto__: farObjProto6 });
   t.is(passStyleOf(farObj6), 'remotable', 'tagRecord grandproto is accepted');
 
   // Our current agoric-sdk plans for far classes are to create a class-like
@@ -311,9 +321,7 @@ test('passStyleOf testing remotables', t => {
   const tagRecordA1 = harden(
     makeTagishRecord('Alleged: null-proto tagRecord proto', null),
   );
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObjA1 = harden({ __proto__: tagRecordA1 });
+  const farObjA1 = hardenToBeSuppressTrapping({ __proto__: tagRecordA1 });
   t.throws(
     () => passStyleOf(farObjA1),
     { message: unusualTagRecordProtoMessage },
@@ -323,12 +331,8 @@ test('passStyleOf testing remotables', t => {
   const tagRecordA2 = harden(
     makeTagishRecord('Alleged: null-proto tagRecord grandproto', null),
   );
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObjProtoA2 = harden({ __proto__: tagRecordA2 });
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObjA2 = harden({ __proto__: farObjProtoA2 });
+  const farObjProtoA2 = hardenToBeSuppressTrapping({ __proto__: tagRecordA2 });
+  const farObjA2 = hardenToBeSuppressTrapping({ __proto__: farObjProtoA2 });
   t.throws(
     () => passStyleOf(farObjA2),
     { message: unusualTagRecordProtoMessage },
@@ -342,12 +346,10 @@ test('passStyleOf testing remotables', t => {
   const fauxTagRecordB = harden(
     makeTagishRecord('Alleged: manually constructed', harden({})),
   );
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObjProtoB = harden({ __proto__: fauxTagRecordB });
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const farObjB = harden({ __proto__: farObjProtoB });
+  const farObjProtoB = hardenToBeSuppressTrapping({
+    __proto__: fauxTagRecordB,
+  });
+  const farObjB = hardenToBeSuppressTrapping({ __proto__: farObjProtoB });
   t.throws(() => passStyleOf(farObjB), {
     message:
       'cannot serialize Remotables with non-methods like "Symbol(passStyle)" in "[Alleged: manually constructed]"',
@@ -358,9 +360,9 @@ test('passStyleOf testing remotables', t => {
   );
   Object.defineProperty(farObjProtoWithExtra, 'extra', { value: () => {} });
   harden(farObjProtoWithExtra);
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const badFarObjExtraProtoProp = harden({ __proto__: farObjProtoWithExtra });
+  const badFarObjExtraProtoProp = hardenToBeSuppressTrapping({
+    __proto__: farObjProtoWithExtra,
+  });
   t.throws(() => passStyleOf(badFarObjExtraProtoProp), {
     message: 'Unexpected properties on Remotable Proto ["extra"]',
   });
@@ -484,18 +486,12 @@ test('Allow toStringTag overrides', t => {
   t.is(`${alice}`, '[object DebugName: Allison]');
   t.is(`${q(alice)}`, '"[DebugName: Allison]"');
 
-  /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const carol = harden({ __proto__: alice });
+  const carol = hardenToBeSuppressTrapping({ __proto__: alice });
   t.is(passStyleOf(carol), 'remotable');
   t.is(`${carol}`, '[object DebugName: Allison]');
   t.is(`${q(carol)}`, '"[DebugName: Allison]"');
 
-  /** @type {any} UNTIL https://github.com/microsoft/TypeScript/issues/38385 */
-  // TODO Once we have support for explicit non-trapping, this should change
-  // from `harden` to `suppressTrapping` or `stabilize`.
-  const bob = harden({
+  const bob = hardenToBeSuppressTrapping({
     __proto__: carol,
     [Symbol.toStringTag]: 'DebugName: Robert',
   });

--- a/packages/pass-style/test/passStyleOf.test.js
+++ b/packages/pass-style/test/passStyleOf.test.js
@@ -29,7 +29,7 @@ const { getPrototypeOf, defineProperty, freeze } = Object;
 const hardenToBeSuppressTrapping = harden;
 
 /**
- * Local alias of `harden` to eventually be switched to whatever applies
+ * Local alias of `freeze` to eventually be switched to whatever applies
  * the suppress-trapping integrity trait. For the shim at
  * https://github.com/endojs/endo/pull/2673
  * that is `suppressTrapping`, which is why we choose that name for the
@@ -425,7 +425,8 @@ test('remotables - safety from the gibson042 attack', t => {
    * explicitly make this non-trapping, which we cannot yet express.
    * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
    */
-  const makeInput = () => freeze({ __proto__: mercurialProto });
+  const makeInput = () =>
+    freezeToBeSuppressTrapping({ __proto__: mercurialProto });
   const input1 = makeInput();
   const input2 = makeInput();
 

--- a/packages/ses/docs/preparing-for-stabilize.md
+++ b/packages/ses/docs/preparing-for-stabilize.md
@@ -5,7 +5,7 @@ The [Stabilize proposal](https://github.com/tc39/proposal-stabilize) is currentl
 - ***overridable***: would mitigate the assignment-override mistake by enabling non-writable properties inherited from an object with this trait to be overridden by property assignment on an inheriting object.
 - ***non-trapping***: would mitigate proxy-based reentrancy hazards by having a proxy whose target carries this trait never trap to its handler, but rather just perform the default action directly on this non-trapping target.
 
-Draft PR [feat(non-trapping-shim): ponyfill and shim for the non-trapping integrity trait #2673](https://github.com/endojs/endo/pull/2673) is a ponyfill and shim for this non-trapping integrity trait. The names it introduces are placeholders, since the bikeshedding process for these names has not yet concluded.
+Draft PR [feat(non-trapping-shim): shim of the non-trapping integrity trait #2673](https://github.com/endojs/endo/pull/2673) is a shim for this non-trapping integrity trait. The names it introduces are placeholders, since the bikeshedding process for these names has not yet concluded.
 
 Draft PR [feat(ses,pass-style): use non-trapping integrity trait for safety #2675](https://github.com/endojs/endo/pull/2675) uses this support for the non-trapping integity trait to mitigate reentrancy attacks from hardened objects, expecially passable copy-data objects like copyLists, copyRecords, and taggeds. To do so, it makes two fundamental changes:
 - Where `harden` made the object at every step frozen, that PR changes `harden` to also make those objects non-trapping.

--- a/packages/ses/docs/preparing-for-stabilize.md
+++ b/packages/ses/docs/preparing-for-stabilize.md
@@ -1,0 +1,24 @@
+# Preparing for the Non-trapping Integrity Trait
+
+The [Stabilize proposal](https://github.com/tc39/proposal-stabilize) is currently at stage 1 of the tc39 process. It proposes three distinct integrity traits whose current placeholder names are:
+- ***fixed***: would mitigate the return-override mistake by preventing objects with this trait from being stamped with new class-private-fields.
+- ***overridable***: would mitigate the assignment-override mistake by enabling non-writable properties inherited from an object with this trait to be overridden by property assignment on an inheriting object.
+- ***non-trapping***: would mitigate proxy-based reentrancy hazards by having a proxy whose target carries this trait never trap to its handler, but rather just perform the default action directly on this non-trapping target.
+
+Draft PR [feat(non-trapping-shim): ponyfill and shim for the non-trapping integrity trait #2673](https://github.com/endojs/endo/pull/2673) is a ponyfill and shim for this non-trapping integrity trait. The names it introduces are placeholders, since the bikeshedding process for these names has not yet concluded.
+
+Draft PR [feat(ses,pass-style): use non-trapping integrity trait for safety #2675](https://github.com/endojs/endo/pull/2675) uses this support for the non-trapping integity trait to mitigate reentrancy attacks from hardened objects, expecially passable copy-data objects like copyLists, copyRecords, and taggeds. To do so, it makes two fundamental changes:
+- Where `harden` made the object at every step frozen, that PR changes `harden` to also make those objects non-trapping.
+- Where `passStyleOf` checked that objects are frozen, that PR changes `passStyleOf` to also check that those objects are non-trapping.
+
+## How proxy code should prepare
+
+[#2673](https://github.com/endojs/endo/pull/2673) will *by default* produce proxies that refuse to be made non-trapping. An explicit handler trap (whose name is TBD) will need to be explicitly provided to make a proxy that allows itself to be made non-trapping. This is the right default, because proxies on frozen almost-empty objects can still have useful trap behavior for their `get`, `set`, `has`, and `apply` traps. Even on a frozen target
+- The `get`, `set`, and `has` traps applied to a non-own property name are still general traps that can have useful trapping behavior.
+- The `apply` trap can ignore the target's call behavior and just do its own thing.
+
+However, to prepare for these changes, we need to avoid hardening both such proxies and their targets. We need to avoid hardening their target because this will bypass the traps. We need to avoid hardening the proxy because such proxies will *by default* refuse to be made non-trapping, and thus refuse to be hardened.
+
+## How passable objects should prepare
+
+Although we think of `passStyleOf` as requiring its input to be hardened, `passStyleOf` instead checked that each relevant object is frozen. Manually freezing all objects reachable from a root object had been equivalent to hardening that root object. With these changes, even such manual transitive freezing will not make an object passable. To prepare for these changes, use `harden` explicitly instead.

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -270,12 +270,6 @@ export const getConstructorOf = fn =>
   reflectGet(getPrototypeOf(fn), 'constructor');
 
 /**
- * immutableObject
- * An immutable (frozen) empty object that is safe to share.
- */
-export const immutableObject = freeze(create(null));
-
-/**
  * isObject tests whether a value is an object.
  * Today, this is equivalent to:
  *

--- a/packages/ses/src/sloppy-globals-scope-terminator.js
+++ b/packages/ses/src/sloppy-globals-scope-terminator.js
@@ -13,9 +13,10 @@ import {
 /**
  * `freeze` but not `harden` the proxy target so it remains trapping.
  * Thus, it should not be shared outside this module.
+ *
  * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
  */
-const onlyFrozenObject = freeze(create(null));
+const objTarget = freeze({ __proto__: null });
 
 /*
  * createSloppyGlobalsScopeTerminator()
@@ -51,7 +52,7 @@ export const createSloppyGlobalsScopeTerminator = globalObject => {
   );
 
   const sloppyGlobalsScopeTerminator = new Proxy(
-    onlyFrozenObject,
+    objTarget,
     sloppyGlobalsScopeTerminatorHandler,
   );
 

--- a/packages/ses/src/sloppy-globals-scope-terminator.js
+++ b/packages/ses/src/sloppy-globals-scope-terminator.js
@@ -3,13 +3,19 @@ import {
   create,
   freeze,
   getOwnPropertyDescriptors,
-  immutableObject,
   reflectSet,
 } from './commons.js';
 import {
   strictScopeTerminatorHandler,
   alwaysThrowHandler,
 } from './strict-scope-terminator.js';
+
+/**
+ * `freeze` but not `harden` the proxy target so it remains trapping.
+ * Thus, it should not be shared outside this module.
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+ */
+const onlyFrozenObject = freeze(create(null));
 
 /*
  * createSloppyGlobalsScopeTerminator()
@@ -45,7 +51,7 @@ export const createSloppyGlobalsScopeTerminator = globalObject => {
   );
 
   const sloppyGlobalsScopeTerminator = new Proxy(
-    immutableObject,
+    onlyFrozenObject,
     sloppyGlobalsScopeTerminatorHandler,
   );
 

--- a/packages/ses/src/strict-scope-terminator.js
+++ b/packages/ses/src/strict-scope-terminator.js
@@ -7,11 +7,17 @@ import {
   freeze,
   getOwnPropertyDescriptors,
   globalThis,
-  immutableObject,
 } from './commons.js';
 import { assert } from './error/assert.js';
 
 const { Fail, quote: q } = assert;
+
+/**
+ * `freeze` but not `harden` the proxy target so it remains trapping.
+ * Thus, it should not be shared outside this module.
+ * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
+ */
+const onlyFrozenObject = freeze(create(null));
 
 /**
  * alwaysThrowHandler
@@ -21,7 +27,7 @@ const { Fail, quote: q } = assert;
  * create one and share it between all Proxy handlers.
  */
 export const alwaysThrowHandler = new Proxy(
-  immutableObject,
+  onlyFrozenObject,
   freeze({
     get(_shadow, prop) {
       Fail`Please report unexpected scope handler trap: ${q(String(prop))}`;
@@ -88,6 +94,6 @@ export const strictScopeTerminatorHandler = freeze(
 );
 
 export const strictScopeTerminator = new Proxy(
-  immutableObject,
+  onlyFrozenObject,
   strictScopeTerminatorHandler,
 );

--- a/packages/ses/src/strict-scope-terminator.js
+++ b/packages/ses/src/strict-scope-terminator.js
@@ -15,9 +15,10 @@ const { Fail, quote: q } = assert;
 /**
  * `freeze` but not `harden` the proxy target so it remains trapping.
  * Thus, it should not be shared outside this module.
+ *
  * @see https://github.com/endojs/endo/blob/master/packages/ses/docs/preparing-for-stabilize.md
  */
-const onlyFrozenObject = freeze(create(null));
+const objTarget = freeze({ __proto__: null });
 
 /**
  * alwaysThrowHandler
@@ -27,7 +28,7 @@ const onlyFrozenObject = freeze(create(null));
  * create one and share it between all Proxy handlers.
  */
 export const alwaysThrowHandler = new Proxy(
-  onlyFrozenObject,
+  objTarget,
   freeze({
     get(_shadow, prop) {
       Fail`Please report unexpected scope handler trap: ${q(String(prop))}`;
@@ -94,6 +95,6 @@ export const strictScopeTerminatorHandler = freeze(
 );
 
 export const strictScopeTerminator = new Proxy(
-  onlyFrozenObject,
+  objTarget,
   strictScopeTerminatorHandler,
 );


### PR DESCRIPTION
Closes: #XXXX
Refs: https://github.com/Agoric/agoric-sdk/pull/10795

## Description

Prepare for anticipated introduction and use of the non-trapping integrity trait as explained at https://github.com/endojs/endo/blob/b12eb434b6672f0ceae41be55aac7f24c4562b7b/packages/ses/docs/preparing-for-stabilize.md

These preparations must work now, before these traits are introduced, and should continue to work after these traits are introduced and used.

### Security Considerations

Some things that had been deeply frozen automatically by `harden` are now manually frozen by explicit calls to `freeze`. We need to review these carefully to ensure that nothing has inadvertently be left unfrozen as a result of the changes in this PR.

Some proxies will become unhardenable, but they will still be hardenable as of now, so mistaken hardenings will not be detected.

### Scaling Considerations

For this PR by itself, none. Using the shim-based implementation of the non-trapping trait will have scaling consequences: https://github.com/endojs/endo/pull/2675

### Documentation Considerations

https://github.com/endojs/endo/blob/b12eb434b6672f0ceae41be55aac7f24c4562b7b/packages/ses/docs/preparing-for-stabilize.md will need to be reflected in developer docs.

### Testing Considerations

Since this PR by itself should be a pure refactor with no observable changes, there is nothing to test at this stage. The testing burden will come with https://github.com/endojs/endo/pull/2675 to see how adequate these preparations were.

### Compatibility Considerations

The point. This changes to coding patterns that should be compat both with the current status quo and with https://github.com/endojs/endo/pull/2675

### Upgrade Considerations

As a pure refactor, none.