### PR TITLE
refactor: cleanup type warning

### DIFF
--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -35,10 +35,10 @@ import {
  * https://tc39.es/ecma262/multipage/syntax-directed-operations.html#sec-runtime-semantics-namedevaluation
  * Instead, we hope that tooling uses only the explicit `name` property.
  *
- * @template {function} T
+ * @template {Function} F
  * @param {string} name
- * @param {T} fn
- * @returns {T}
+ * @param {F} fn
+ * @returns {F}
  */
 const defineName = (name, fn) => defineProperty(fn, 'name', { value: name });
 


### PR DESCRIPTION
Closes: #XXXX
Refs: #XXXX

## Description

Was getting the irritating warning

![image](https://github.com/user-attachments/assets/257b1512-2f46-46c4-88e4-3b9f4b22db81)

This PR simply does what that warning suggests.

Verified that with this change
- `yarn lint` runs clean without any warnings.
- `lint` under CI below passes
- No "Unchanged files with check annotations" warnings appear in this PR's code review page.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

none
### Compatibility Considerations

none
### Upgrade Considerations

none