### PR TITLE
refactor(ses): getenv detects more errors

### DIFF
--- a/packages/env-options/src/env-options.js
+++ b/packages/env-options/src/env-options.js
@@ -44,17 +44,19 @@ const Fail = (literals, ...args) => {
  * names used.
  */
 export const makeEnvironmentCaptor = (aGlobal, dropNames = false) => {
+  /** @type {string[]} */
   const capturedEnvironmentOptionNames = [];
 
   /**
    * Gets an environment option by name and returns the option value or the
    * given default.
    *
+   * @template {string} [T=string]
    * @param {string} optionName
-   * @param {string} defaultSetting
-   * @param {string[]} [optOtherValues]
+   * @param {T} defaultSetting
+   * @param {T[]} [optOtherValues]
    * If provided, the option value must be included or match `defaultSetting`.
-   * @returns {string}
+   * @returns {T}
    */
   const getEnvironmentOption = (
     optionName,
@@ -95,13 +97,14 @@ export const makeEnvironmentCaptor = (aGlobal, dropNames = false) => {
       Fail`Unrecognized ${q(optionName)} value ${q(
         setting,
       )}. Expected one of ${q([defaultSetting, ...optOtherValues])}`;
-    return setting;
+    return /** @type {T} */ (setting);
   };
   freeze(getEnvironmentOption);
 
   /**
+   * @template {string} [T=string]
    * @param {string} optionName
-   * @returns {string[]}
+   * @returns {T[]}
    */
   const getEnvironmentOptionsList = optionName => {
     const option = getEnvironmentOption(optionName, '');
@@ -109,6 +112,12 @@ export const makeEnvironmentCaptor = (aGlobal, dropNames = false) => {
   };
   freeze(getEnvironmentOptionsList);
 
+  /**
+   * @template {string} [T=string]
+   * @param {string} optionName
+   * @param {T} element
+   * @returns {boolean}
+   */
   const environmentOptionsListHas = (optionName, element) =>
     arrayIncludes(getEnvironmentOptionsList(optionName), element);
 

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -27,7 +27,8 @@ const VERBOSE = environmentOptionsListHas('DEBUG', 'track-turns');
 // Track-turns is disabled by default and can be enabled by an environment
 // option.
 const ENABLED =
-  getEnvironmentOption('TRACK_TURNS', 'disabled', ['enabled']) === 'enabled';
+  /** @type {'disabled' | 'enabled'} */
+  (getEnvironmentOption('TRACK_TURNS', 'disabled', ['enabled'])) === 'enabled';
 
 // We hoist the following functions out of trackTurns() to discourage the
 // closures from holding onto 'args' or 'func' longer than necessary,

--- a/packages/ses/src/error/tame-console.js
+++ b/packages/ses/src/error/tame-console.js
@@ -41,10 +41,6 @@ export const tameConsole = (
   unhandledRejectionTrapping = 'report',
   optGetStackString = undefined,
 ) => {
-  consoleTaming === 'safe' ||
-    consoleTaming === 'unsafe' ||
-    failFast(`unrecognized consoleTaming ${consoleTaming}`);
-
   let loggedErrorHandler;
   if (optGetStackString === undefined) {
     loggedErrorHandler = defaultHandler;

--- a/packages/ses/src/error/tame-error-constructor.js
+++ b/packages/ses/src/error/tame-error-constructor.js
@@ -1,6 +1,5 @@
 import {
   FERAL_ERROR,
-  TypeError,
   apply,
   construct,
   defineProperties,
@@ -36,16 +35,6 @@ export default function tameErrorConstructor(
   errorTaming = 'safe',
   stackFiltering = 'concise',
 ) {
-  if (
-    errorTaming !== 'safe' &&
-    errorTaming !== 'unsafe' &&
-    errorTaming !== 'unsafe-debug'
-  ) {
-    throw TypeError(`unrecognized errorTaming ${errorTaming}`);
-  }
-  if (stackFiltering !== 'concise' && stackFiltering !== 'verbose') {
-    throw TypeError(`unrecognized stackFiltering ${stackFiltering}`);
-  }
   const ErrorPrototype = FERAL_ERROR.prototype;
 
   const { captureStackTrace: originalCaptureStackTrace } = FERAL_ERROR;

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -176,28 +176,43 @@ export const repairIntrinsics = (options = {}) => {
   // for an explanation.
 
   const {
-    errorTaming = getenv('LOCKDOWN_ERROR_TAMING', 'safe'),
+    errorTaming = getenv('LOCKDOWN_ERROR_TAMING', 'safe', [
+      'unsafe',
+      'unsafe-debug',
+    ]),
     errorTrapping = /** @type {"platform" | "none" | "report" | "abort" | "exit"} */ (
-      getenv('LOCKDOWN_ERROR_TRAPPING', 'platform')
+      getenv('LOCKDOWN_ERROR_TRAPPING', 'platform', [
+        'none',
+        'report',
+        'abort',
+        'exit',
+      ])
     ),
     reporting = /** @type {"platform" | "console" | "none"} */ (
-      getenv('LOCKDOWN_REPORTING', 'platform')
+      getenv('LOCKDOWN_REPORTING', 'platform', ['console', 'none'])
     ),
     unhandledRejectionTrapping = /** @type {"none" | "report"} */ (
-      getenv('LOCKDOWN_UNHANDLED_REJECTION_TRAPPING', 'report')
+      getenv('LOCKDOWN_UNHANDLED_REJECTION_TRAPPING', 'report', ['none'])
     ),
-    regExpTaming = getenv('LOCKDOWN_REGEXP_TAMING', 'safe'),
-    localeTaming = getenv('LOCKDOWN_LOCALE_TAMING', 'safe'),
+    regExpTaming = getenv('LOCKDOWN_REGEXP_TAMING', 'safe', ['unsafe']),
+    localeTaming = getenv('LOCKDOWN_LOCALE_TAMING', 'safe', ['unsafe']),
 
     consoleTaming = /** @type {'unsafe' | 'safe'} */ (
-      getenv('LOCKDOWN_CONSOLE_TAMING', 'safe')
+      getenv('LOCKDOWN_CONSOLE_TAMING', 'safe', ['unsafe'])
     ),
     overrideTaming = /** @type {'moderate' | 'min' | 'severe'} */ (
-      getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate')
+      getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate', ['min', 'severe'])
     ),
-    stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise'),
-    domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe'),
-    evalTaming = getenv('LOCKDOWN_EVAL_TAMING', 'safe-eval'),
+    stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise', ['verbose']),
+    domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe', ['unsafe']),
+    evalTaming = getenv('LOCKDOWN_EVAL_TAMING', 'safe-eval', [
+      'unsafe-eval',
+      'no-eval',
+      // deprecated
+      'safeEval',
+      'unsafeEval',
+      'noEval',
+    ]),
     overrideDebug = arrayFilter(
       stringSplit(getenv('LOCKDOWN_OVERRIDE_DEBUG', ''), ','),
       /** @param {string} debugName */
@@ -206,24 +221,13 @@ export const repairIntrinsics = (options = {}) => {
     legacyRegeneratorRuntimeTaming = getenv(
       'LOCKDOWN_LEGACY_REGENERATOR_RUNTIME_TAMING',
       'safe',
+      ['unsafe-ignore'],
     ),
-    __hardenTaming__ = getenv('LOCKDOWN_HARDEN_TAMING', 'safe'),
+    __hardenTaming__ = getenv('LOCKDOWN_HARDEN_TAMING', 'safe', ['unsafe']),
     dateTaming, // deprecated
     mathTaming, // deprecated
     ...extraOptions
   } = options;
-
-  legacyRegeneratorRuntimeTaming === 'safe' ||
-    legacyRegeneratorRuntimeTaming === 'unsafe-ignore' ||
-    Fail`lockdown(): non supported option legacyRegeneratorRuntimeTaming: ${q(legacyRegeneratorRuntimeTaming)}`;
-
-  evalTaming === 'unsafe-eval' ||
-    evalTaming === 'unsafeEval' || // deprecated
-    evalTaming === 'safe-eval' ||
-    evalTaming === 'safeEval' || // deprecated
-    evalTaming === 'no-eval' ||
-    evalTaming === 'noEval' || // deprecated
-    Fail`lockdown(): non supported option evalTaming: ${q(evalTaming)}`;
 
   // Assert that only supported options were passed.
   // Use Reflect.ownKeys to reject symbol-named properties as well.

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -176,11 +176,10 @@ export const repairIntrinsics = (options = {}) => {
   // for an explanation.
 
   const {
-    errorTaming = getenv('LOCKDOWN_ERROR_TAMING', 'safe', [
-      'unsafe',
-      'unsafe-debug',
-    ]),
-    errorTrapping = /** @type {"platform" | "none" | "report" | "abort" | "exit"} */ (
+    errorTaming = /** @type {'safe' | 'unsafe' | 'unsafe-debug'} */ (
+      getenv('LOCKDOWN_ERROR_TAMING', 'safe', ['unsafe', 'unsafe-debug'])
+    ),
+    errorTrapping = /** @type {'platform' | 'none' | 'report' | 'abort' | 'exit'} */ (
       getenv('LOCKDOWN_ERROR_TRAPPING', 'platform', [
         'none',
         'report',
@@ -188,42 +187,55 @@ export const repairIntrinsics = (options = {}) => {
         'exit',
       ])
     ),
-    reporting = /** @type {"platform" | "console" | "none"} */ (
+    reporting = /** @type {'platform' | 'console' | 'none'} */ (
       getenv('LOCKDOWN_REPORTING', 'platform', ['console', 'none'])
     ),
-    unhandledRejectionTrapping = /** @type {"none" | "report"} */ (
+    unhandledRejectionTrapping = /** @type {'none' | 'report'} */ (
       getenv('LOCKDOWN_UNHANDLED_REJECTION_TRAPPING', 'report', ['none'])
     ),
-    regExpTaming = getenv('LOCKDOWN_REGEXP_TAMING', 'safe', ['unsafe']),
-    localeTaming = getenv('LOCKDOWN_LOCALE_TAMING', 'safe', ['unsafe']),
-
+    regExpTaming = /** @type {'safe' | 'unsafe'} */ (
+      getenv('LOCKDOWN_REGEXP_TAMING', 'safe', ['unsafe'])
+    ),
+    localeTaming = /** @type {'safe' | 'unsafe'} */ (
+      getenv('LOCKDOWN_LOCALE_TAMING', 'safe', ['unsafe'])
+    ),
     consoleTaming = /** @type {'unsafe' | 'safe'} */ (
       getenv('LOCKDOWN_CONSOLE_TAMING', 'safe', ['unsafe'])
     ),
     overrideTaming = /** @type {'moderate' | 'min' | 'severe'} */ (
       getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate', ['min', 'severe'])
     ),
-    stackFiltering = getenv('LOCKDOWN_STACK_FILTERING', 'concise', ['verbose']),
-    domainTaming = getenv('LOCKDOWN_DOMAIN_TAMING', 'safe', ['unsafe']),
-    evalTaming = getenv('LOCKDOWN_EVAL_TAMING', 'safe-eval', [
-      'unsafe-eval',
-      'no-eval',
-      // deprecated
-      'safeEval',
-      'unsafeEval',
-      'noEval',
-    ]),
-    overrideDebug = arrayFilter(
-      stringSplit(getenv('LOCKDOWN_OVERRIDE_DEBUG', ''), ','),
-      /** @param {string} debugName */
-      debugName => debugName !== '',
+    stackFiltering = /** @type {'safe' | 'unsafe'} */ (
+      getenv('LOCKDOWN_STACK_FILTERING', 'concise', ['verbose'])
     ),
-    legacyRegeneratorRuntimeTaming = getenv(
-      'LOCKDOWN_LEGACY_REGENERATOR_RUNTIME_TAMING',
-      'safe',
-      ['unsafe-ignore'],
+    domainTaming = /** @type {'safe' | 'unsafe'} */ (
+      getenv('LOCKDOWN_DOMAIN_TAMING', 'safe', ['unsafe'])
     ),
-    __hardenTaming__ = getenv('LOCKDOWN_HARDEN_TAMING', 'safe', ['unsafe']),
+    evalTaming = /** @type {'safe-eval' | 'unsafe-eval' | 'no-eval'} */ (
+      getenv('LOCKDOWN_EVAL_TAMING', 'safe-eval', [
+        'unsafe-eval',
+        'no-eval',
+        // deprecated
+        'safeEval',
+        'unsafeEval',
+        'noEval',
+      ])
+    ),
+    overrideDebug = /** @type {string[]} */ (
+      arrayFilter(
+        stringSplit(getenv('LOCKDOWN_OVERRIDE_DEBUG', ''), ','),
+        /** @param {string} debugName */
+        debugName => debugName !== '',
+      )
+    ),
+    legacyRegeneratorRuntimeTaming = /** @type {'safe' | 'unsafe-ignore'} */ (
+      getenv('LOCKDOWN_LEGACY_REGENERATOR_RUNTIME_TAMING', 'safe', [
+        'unsafe-ignore',
+      ])
+    ),
+    __hardenTaming__ = /** @type {'safe' | 'unsafe'} */ (
+      getenv('LOCKDOWN_HARDEN_TAMING', 'safe', ['unsafe'])
+    ),
     dateTaming, // deprecated
     mathTaming, // deprecated
     ...extraOptions
@@ -328,7 +340,6 @@ export const repairIntrinsics = (options = {}) => {
   const { addIntrinsics, completePrototypes, finalIntrinsics } =
     makeIntrinsicsCollector(reporter);
 
-  // @ts-expect-error __hardenTaming__ could be any string
   const tamedHarden = tameHarden(safeHarden, __hardenTaming__);
   addIntrinsics({ harden: tamedHarden });
 

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -553,7 +553,8 @@ const throwAggregateError = ({ errors, errorPrefix }) => {
   // Throw an aggregate error if there were any errors.
   if (errors.length > 0) {
     const verbose =
-      getenv('COMPARTMENT_LOAD_ERRORS', '', ['verbose']) === 'verbose';
+      /** @type {'' | 'verbose'} */
+      (getenv('COMPARTMENT_LOAD_ERRORS', '', ['verbose'])) === 'verbose';
     throw TypeError(
       `${errorPrefix} (${errors.length} underlying failures: ${arrayJoin(
         arrayMap(errors, error => error.message + (verbose ? error.stack : '')),

--- a/packages/ses/src/reporting.js
+++ b/packages/ses/src/reporting.js
@@ -1,4 +1,4 @@
-import { TypeError, functionBind, globalThis } from './commons.js';
+import { functionBind, globalThis } from './commons.js';
 import { assert } from './error/assert.js';
 
 /**
@@ -50,9 +50,6 @@ const mute = () => {};
 export const chooseReporter = reporting => {
   if (reporting === 'none') {
     return makeReportPrinter(mute);
-  }
-  if (reporting !== 'platform' && reporting !== 'console') {
-    throw new TypeError(`Invalid lockdown reporting option: ${reporting}`);
   }
   if (
     reporting === 'console' ||

--- a/packages/ses/src/tame-domains.js
+++ b/packages/ses/src/tame-domains.js
@@ -8,10 +8,6 @@ import {
 } from './commons.js';
 
 export function tameDomains(domainTaming = 'safe') {
-  if (domainTaming !== 'safe' && domainTaming !== 'unsafe') {
-    throw TypeError(`unrecognized domainTaming ${domainTaming}`);
-  }
-
   if (domainTaming === 'unsafe') {
     return;
   }

--- a/packages/ses/src/tame-harden.js
+++ b/packages/ses/src/tame-harden.js
@@ -1,14 +1,10 @@
 /* eslint-disable no-restricted-globals */
-import { TypeError, freeze } from './commons.js';
+import { freeze } from './commons.js';
 
 /** @import {Harden} from '../types.js'; */
 
 /** @type {(safeHarden: Harden, hardenTaming: 'safe' | 'unsafe') => Harden} */
 export const tameHarden = (safeHarden, hardenTaming) => {
-  if (hardenTaming !== 'safe' && hardenTaming !== 'unsafe') {
-    throw TypeError(`unrecognized fakeHardenOption ${hardenTaming}`);
-  }
-
   if (hardenTaming === 'safe') {
     return safeHarden;
   }

--- a/packages/ses/src/tame-locale-methods.js
+++ b/packages/ses/src/tame-locale-methods.js
@@ -44,9 +44,6 @@ const nonLocaleCompare = tamedMethods.localeCompare;
 const numberToString = tamedMethods.toString;
 
 export default function tameLocaleMethods(intrinsics, localeTaming = 'safe') {
-  if (localeTaming !== 'safe' && localeTaming !== 'unsafe') {
-    throw TypeError(`unrecognized localeTaming ${localeTaming}`);
-  }
   if (localeTaming === 'unsafe') {
     return;
   }

--- a/packages/ses/src/tame-regexp-constructor.js
+++ b/packages/ses/src/tame-regexp-constructor.js
@@ -8,9 +8,6 @@ import {
 } from './commons.js';
 
 export default function tameRegExpConstructor(regExpTaming = 'safe') {
-  if (regExpTaming !== 'safe' && regExpTaming !== 'unsafe') {
-    throw TypeError(`unrecognized regExpTaming ${regExpTaming}`);
-  }
   const RegExpPrototype = FERAL_REG_EXP.prototype;
 
   const makeRegExpConstructor = (_ = {}) => {


### PR DESCRIPTION
Closes: #XXXX
Refs: https://github.com/endojs/endo/pull/1710

## Description

https://github.com/endojs/endo/pull/1710 enhanced `getEnvironmentOption` with an optional third argument listing all the other allowed choices aside from the default choice. Previously, we had only manual code to detect and complain of unrecognized environment option values. #1710 provides a more declarative form, and reuses the checking-and-complaining logic. However, following #1710 we did not retire much of the previous ad-hoc manual code, nor did we make enough use of this declarative alternative. This PR fixes that.

### Security Considerations

An advantage to the old ad-hoc manual style is that the enumeration of all possible alternatives was textually close to the dispatch on the alternative. This makes it easy to keep the two in sync. Thus, a comparative disadvantage of this PR is their separation, leading to maintenance hazards if one is updated but not the other. For example, if the declarative form adds another option that the dispatch code does not take into account, that other option might fall into the dispatch's fall-through case. This may or may not be good, depending on whether the fall through case is carefully chosen to also be appropriate for new not-previously-recognized options.

### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

The text of the error messages for unrecognized options will likely be different. But aside from that there should be no observable difference. Since we do not consider a change to the text of an error message a correctness concern, we consider this PR to effectively be a pure refactor.

### Compatibility and Upgrade Considerations

Both before and after this PR, we generally reject unrecognized environment options settings. This makes it difficult to grow existing options with new settings that are ignored if seen by previous code. This hinders plausible development patterns. This PR by itself does not change that. But by centralizing the detect-and-complaint logic and making it more declarative, perhaps we become better set up to address this issue later.
