### PR TITLE
chore: Release 2025-01-23

### DIFF
--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.5.1](https://github.com/endojs/endo/compare/@endo/bundle-source@3.5.0...@endo/bundle-source@3.5.1) (2025-01-24)
+
+**Note:** Version bump only for package @endo/bundle-source
+
+
+
+
+
 ## [3.5.0](https://github.com/endojs/endo/compare/@endo/bundle-source@3.4.2...@endo/bundle-source@3.5.0) (2024-11-13)
 
 

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.4.4](https://github.com/endojs/endo/compare/@endo/captp@4.4.3...@endo/captp@4.4.4) (2025-01-24)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ### [4.4.3](https://github.com/endojs/endo/compare/@endo/captp@4.4.2...@endo/captp@4.4.3) (2024-11-13)
 
 **Note:** Version bump only for package @endo/captp

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.13](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.12...@endo/check-bundle@1.0.13) (2025-01-24)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [1.0.12](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.11...@endo/check-bundle@1.0.12) (2024-11-13)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.7](https://github.com/endojs/endo/compare/@endo/cli@2.3.6...@endo/cli@2.3.7) (2025-01-24)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [2.3.6](https://github.com/endojs/endo/compare/@endo/cli@2.3.5...@endo/cli@2.3.6) (2024-11-13)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.9](https://github.com/endojs/endo/compare/@endo/common@1.2.8...@endo/common@1.2.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/common
+
+
+
+
+
 ### [1.2.8](https://github.com/endojs/endo/compare/@endo/common@1.2.7...@endo/common@1.2.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/common",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "common low level utilities",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.4.0...@endo/compartment-mapper@1.5.0) (2025-01-24)
+
+
+### Features
+
+* **compartment-mapper:** Export all parsers ([c5f5d43](https://github.com/endojs/endo/commit/c5f5d433b1df60ef0f74b1a5458675a4e37806e0))
+* **compartment-mapper:** more renames returned from captureFromMap / makeArchiveCompartmentMap ([630592d](https://github.com/endojs/endo/commit/630592d38824316479255453cf49a646a9ff0e75))
+* **compartment-mapper:** Relax package discovery ([ab885a2](https://github.com/endojs/endo/commit/ab885a226eb05eb715df9da05c63c11731abf494))
+* **compartment-mapper:** Thread native flag to opt-in for native XS runtime modules ([aa1e77f](https://github.com/endojs/endo/commit/aa1e77f9af62dca40a357e92fd869ecdb8a35379))
+
+
+### Bug Fixes
+
+* **compartment-mapper:** Development condition only implies devDependencies for entry package ([b7d7b23](https://github.com/endojs/endo/commit/b7d7b2388308e23217dc7d126ba081c465cf4b1f))
+* **compartment-mapper:** Fix path for language for extension test ([99a1cb5](https://github.com/endojs/endo/commit/99a1cb5e960fa62c2dab49ff0724162710730330))
+* **compartment-mapper:** Qualify dynamic import test failure cases ([f470696](https://github.com/endojs/endo/commit/f4706960afef22b98780ca4cbffe6ccf82ed9b1b))
+
+
+
 ## [1.4.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.3.1...@endo/compartment-mapper@1.4.0) (2024-11-13)
 
 

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/compartment-mapper`:
 
-# Next release
+# v1.5.0 (2025-01-23)
 
 - `mapNodeModules` and all functions that use it now tolerate the absence of
   expected packages.

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.4.7](https://github.com/endojs/endo/compare/@endo/daemon@2.4.6...@endo/daemon@2.4.7) (2025-01-24)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ### [2.4.6](https://github.com/endojs/endo/compare/@endo/daemon@2.4.5...@endo/daemon@2.4.6) (2024-11-13)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.9](https://github.com/endojs/endo/compare/@endo/errors@1.2.8...@endo/errors@1.2.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/errors
+
+
+
+
+
 ### [1.2.8](https://github.com/endojs/endo/compare/@endo/errors@1.2.7...@endo/errors@1.2.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/errors

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/errors",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.3.0](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.2.3...@endo/eslint-plugin@2.3.0) (2025-01-24)
+
+
+### Features
+
+* **ses:** Add XS variant of shim ([f6c8456](https://github.com/endojs/endo/commit/f6c84566bb6a698709dc3474726000f07b94f3db))
+
+
+
 ### [2.2.3](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.2.2...@endo/eslint-plugin@2.2.3) (2024-11-13)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/evasive-transform/CHANGELOG.md
+++ b/packages/evasive-transform/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.4](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.3...@endo/evasive-transform@1.3.4) (2025-01-24)
+
+**Note:** Version bump only for package @endo/evasive-transform
+
+
+
+
+
 ### [1.3.3](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.2...@endo/evasive-transform@1.3.3) (2024-11-13)
 
 **Note:** Version bump only for package @endo/evasive-transform

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/evasive-transform",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Source transforms to evade SES censorship",
   "keywords": [
     "ses",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.0](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.8...@endo/eventual-send@1.3.0) (2025-01-24)
+
+
+### Features
+
+* EReturn type ([5aefe10](https://github.com/endojs/endo/commit/5aefe1032be33c70c097663a86f240c857dcd2a1))
+
+
+
 ### [1.2.8](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.7...@endo/eventual-send@1.2.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/eventual-send

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "1.2.8",
+  "version": "1.3.0",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.8](https://github.com/endojs/endo/compare/@endo/exo@1.5.7...@endo/exo@1.5.8) (2025-01-24)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.7](https://github.com/endojs/endo/compare/@endo/exo@1.5.6...@endo/exo@1.5.7) (2024-11-13)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.10](https://github.com/endojs/endo/compare/@endo/far@1.1.9...@endo/far@1.1.10) (2025-01-24)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.9](https://github.com/endojs/endo/compare/@endo/far@1.1.8...@endo/far@1.1.9) (2024-11-13)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/immutable-arraybuffer/CHANGELOG.md
+++ b/packages/immutable-arraybuffer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.3](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@0.2.2...@endo/immutable-arraybuffer@0.2.3) (2025-01-24)
+
+
+### Bug Fixes
+
+* **immutable-arraybuffer:** update to recent spec ([#2688](https://github.com/endojs/endo/issues/2688)) ([daa1e2b](https://github.com/endojs/endo/commit/daa1e2b59894600fea1f1669fa84d14ce307789e))
+
+
+
 ### [0.2.2](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@0.2.1...@endo/immutable-arraybuffer@0.2.2) (2024-11-13)
 
 **Note:** Version bump only for package @endo/immutable-arraybuffer

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/immutable-arraybuffer",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Immutable ArrayBuffer",
   "keywords": [],

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.3](https://github.com/endojs/endo/compare/@endo/import-bundle@1.3.2...@endo/import-bundle@1.3.3) (2025-01-24)
+
+**Note:** Version bump only for package @endo/import-bundle
+
+
+
+
+
 ### [1.3.2](https://github.com/endojs/endo/compare/@endo/import-bundle@1.3.1...@endo/import-bundle@1.3.2) (2024-11-13)
 
 **Note:** Version bump only for package @endo/import-bundle

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "load modules created by @endo/bundle-source",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.8](https://github.com/endojs/endo/compare/@endo/init@1.1.7...@endo/init@1.1.8) (2025-01-24)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [1.1.7](https://github.com/endojs/endo/compare/@endo/init@1.1.6...@endo/init@1.1.7) (2024-11-13)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.14](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.13...@endo/lockdown@1.0.14) (2025-01-24)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [1.0.13](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.12...@endo/lockdown@1.0.13) (2024-11-13)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.9](https://github.com/endojs/endo/compare/@endo/lp32@1.1.8...@endo/lp32@1.1.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [1.1.8](https://github.com/endojs/endo/compare/@endo/lp32@1.1.7...@endo/lp32@1.1.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.3](https://github.com/endojs/endo/compare/@endo/marshal@1.6.2...@endo/marshal@1.6.3) (2025-01-24)
+
+**Note:** Version bump only for package @endo/marshal
+
+
+
+
+
 ### [1.6.2](https://github.com/endojs/endo/compare/@endo/marshal@1.6.1...@endo/marshal@1.6.2) (2024-11-13)
 
 **Note:** Version bump only for package @endo/marshal

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/memoize/CHANGELOG.md
+++ b/packages/memoize/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.9](https://github.com/endojs/endo/compare/@endo/memoize@1.1.8...@endo/memoize@1.1.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/memoize
+
+
+
+
+
 ### [1.1.8](https://github.com/endojs/endo/compare/@endo/memoize@1.1.7...@endo/memoize@1.1.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/memoize

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/memoize",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Safe function memoization",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/module-source/CHANGELOG.md
+++ b/packages/module-source/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.0](https://github.com/endojs/endo/compare/@endo/module-source@1.1.2...@endo/module-source@1.2.0) (2025-01-24)
+
+
+### Features
+
+* **module-source:** Specialize for XS native ModuleSource ([53e5109](https://github.com/endojs/endo/commit/53e5109efa151e1c5d9ddd242cea8e6f906ceb48))
+* **module-source:** Support for dynamic import ([25414d6](https://github.com/endojs/endo/commit/25414d6fb0dc2570c0013d8f58597498c3d6fb21))
+
+
+
 ### [1.1.2](https://github.com/endojs/endo/compare/@endo/module-source@1.1.1...@endo/module-source@1.1.2) (2024-11-13)
 
 **Note:** Version bump only for package @endo/module-source

--- a/packages/module-source/NEWS.md
+++ b/packages/module-source/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/module-source`:
 
-# Next release
+# v1.2.0 (2025-01-23)
 
 - Supports dynamic `import` within a `ModuleSource` in conjunction with
   a related change in `ses`.

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/module-source",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Ponyfill for the SES ModuleSource and module-to-program transformer",
   "keywords": [
     "ses",

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.14](https://github.com/endojs/endo/compare/@endo/nat@5.0.13...@endo/nat@5.0.14) (2025-01-24)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [5.0.13](https://github.com/endojs/endo/compare/@endo/nat@5.0.12...@endo/nat@5.0.13) (2024-11-13)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "5.0.13",
+  "version": "5.0.14",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.14](https://github.com/endojs/endo/compare/@endo/netstring@1.0.13...@endo/netstring@1.0.14) (2025-01-24)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [1.0.13](https://github.com/endojs/endo/compare/@endo/netstring@1.0.12...@endo/netstring@1.0.13) (2024-11-13)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.8](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.7...@endo/pass-style@1.4.8) (2025-01-24)
+
+**Note:** Version bump only for package @endo/pass-style
+
+
+
+
+
 ### [1.4.7](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.6...@endo/pass-style@1.4.7) (2024-11-13)
 
 **Note:** Version bump only for package @endo/pass-style

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.4.8](https://github.com/endojs/endo/compare/@endo/patterns@1.4.7...@endo/patterns@1.4.8) (2025-01-24)
+
+**Note:** Version bump only for package @endo/patterns
+
+
+
+
+
 ### [1.4.7](https://github.com/endojs/endo/compare/@endo/patterns@1.4.6...@endo/patterns@1.4.7) (2024-11-13)
 
 **Note:** Version bump only for package @endo/patterns

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Pattern matching for Passable objects, expressed as Passable data",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.9](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.8...@endo/promise-kit@1.1.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [1.1.8](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.7...@endo/promise-kit@1.1.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Helper for making promises",
   "keywords": [
     "promise"

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.9](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.8...@endo/ses-ava@1.2.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [1.2.8](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.7...@endo/ses-ava@1.2.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.11.0](https://github.com/endojs/endo/compare/ses@1.10.0...ses@1.11.0) (2025-01-24)
+
+
+### Features
+
+* **ses:** Add XS variant of shim ([f6c8456](https://github.com/endojs/endo/commit/f6c84566bb6a698709dc3474726000f07b94f3db))
+* **ses:** Permit legacy properties of ModuleSource shim ([75f2461](https://github.com/endojs/endo/commit/75f2461acc7f53ed448f11fa5b12360109dc364f))
+* **ses:** restrict dynamic permit on Hermes ([14731fe](https://github.com/endojs/endo/commit/14731feff0b335809c5fd846a0ba73ffb7b000f7))
+* **ses:** Support dynamic import ([e56cc04](https://github.com/endojs/endo/commit/e56cc040414d0228cd24bbe2d0e2c8a8a595ae51))
+
+
+### Bug Fixes
+
+* **ses:** Consistently name console methods ([fa7a1c4](https://github.com/endojs/endo/commit/fa7a1c44b48563f0762479469d3d03bc42710c47)), closes [#2643](https://github.com/endojs/endo/issues/2643)
+* **ses:** removeUnpermittedIntrinsics on Hermes via dynamic permit at runtime ([1c61fb5](https://github.com/endojs/endo/commit/1c61fb57feb9d312a302508f521621d375cd9cbc))
+* **ses:** update permits for stage 2.7.4 proposals ([#2693](https://github.com/endojs/endo/issues/2693)) ([35d5ea2](https://github.com/endojs/endo/commit/35d5ea202593362a16b16c466ae69b5f6939c539))
+* **ses:** warn on unsupported lockdownOptions mathTaming + dateTaming ([8ed8a8b](https://github.com/endojs/endo/commit/8ed8a8befb883c390db37a22b0482844590bacd1))
+* **ses:** widen type of globalThis in Compartment ([#2644](https://github.com/endojs/endo/issues/2644)) ([ff6a5ab](https://github.com/endojs/endo/commit/ff6a5ab147822b2b7d87761b9eeeafef808645e2))
+* **ses:** XS accommodations for console groupEnd absence ([fd70235](https://github.com/endojs/endo/commit/fd70235cb697b8c75d4e61d6b017f11d708798ad))
+
+
+
 ## [1.10.0](https://github.com/endojs/endo/compare/ses@1.9.1...ses@1.10.0) (2024-11-13)
 
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `ses`:
 
-# Next release
+# v1.11.0 (2025-01-23)
 
 - Adds support for dynamic `import` in conjunction with an update to
   `@endo/module-source`.

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",

--- a/packages/skel/CHANGELOG.md
+++ b/packages/skel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.9](https://github.com/endojs/endo/compare/@endo/skel@1.1.8...@endo/skel@1.1.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/skel
+
+
+
+
+
 ### [1.1.8](https://github.com/endojs/endo/compare/@endo/skel@1.1.7...@endo/skel@1.1.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/skel

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/skel",
   "private": true,
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": null,
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.9](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.8...@endo/stream-node@1.1.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [1.1.8](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.7...@endo/stream-node@1.1.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.14](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.13...@endo/stream-types-test@1.0.14) (2025-01-24)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [1.0.13](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.12...@endo/stream-types-test@1.0.13) (2024-11-13)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.9](https://github.com/endojs/endo/compare/@endo/stream@1.2.8...@endo/stream@1.2.9) (2025-01-24)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [1.2.8](https://github.com/endojs/endo/compare/@endo/stream@1.2.7...@endo/stream@1.2.8) (2024-11-13)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.44](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.43...@endo/test262-runner@0.1.44) (2025-01-24)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.43](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.42...@endo/test262-runner@0.1.43) (2024-11-13)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "private": true,
   "description": "Hardened JavaScript Test262 Runner",
   "keywords": [],


### PR DESCRIPTION

# ses v1.11.0

- Adds support for dynamic `import` in conjunction with an update to
  `@endo/module-source`.

- Specifying the long-discontinued `mathTaming` or `dateTaming` options logs a
  warning.

Incubating: Please do not rely on these features as they are under development
and subject to breaking changes that will not be signaled by semver.

- Adds support for an XS-specific variant of the SES shim that is triggered
  with the `xs` package export condition.
  This version of SES preserves all the features of `Compartment` provided
  uniquely by the SES shim, but with the `__native__` constructor option,
  loses support for importing precompiled module records and gains support
  for native `ModuleSource`.

# @endo/module-source v1.2.0

- Supports dynamic `import` within a `ModuleSource` in conjunction with
  a related change in `ses`.
  For example, `await import(specifier)` can now call through to the
  surrounding compartment's `importHook` to load and evaluate further modules.
- Provides an XS-specific variant of `@endo/module-source` that adapts the
  native `ModuleSource` instead of entraining Babel.


# @endo/compartment-mapper v1.5.0

- `mapNodeModules` and all functions that use it now tolerate the absence of
  expected packages.
  These packages are now omitted from the generated package skeleton map.
  So, loading a physically missing module now occurs during the load phase
  instead of the mapping phase.
- Adds a `strict` option to all functions that `mapNodeModules` to restore old
  behavior, which produces an error early if, for example, a non-optional
  peer dependency is missing.
  Peer dependencies are strictly required unless `peerDependenciesMeta` has an
  object with a truthy `optional` entry.
  Correct interpretation of `peerDependencies` is not distributed evenly, so
  this behavior is no longer the default.

Incubating: Please do not rely on these features as they are under development
and subject to breaking changes that will not be signaled by semver.

- The module `@endo/compartment-mapper/import-archive-parsers.js` does not
  support modules in archives in their original ESM (`mjs`) or CommonJS (`cjs`)
  formats because they entrain Babel and a full JavaScript lexer that are
  not suitable for use in all environments, specifically XS.
  This version introduces an elective
  `@endo/compartment-mapper/import-archive-all-parsers.js` that has all of the
  precompiled module parsers (`pre-cjs-json` and `pre-mjs-json`) that Endo's
  bundler currently produces by default and additionally parsers for original
  sources (`mjs`, `cjs`).
  Also, provided the `xs` package condition,
  `@endo/compartment-mapper/import-archive-parsers.js` now falls through to the
  native `ModuleSource` and safely includes `mjs` and `cjs` without entraining
  Babel, but is only supported in conjunction with the `__native__` option
  for `Compartment`, `importArchive`, `parseArchive`, and `importBundle`.
  With the `node` package condition (present by default when running ESM on
  `node`), `@endo/compartment-mapper/import-archive-parsers.js` also now
  includes `mjs` and `cjs` by entraining Babel, which performs adequately on
  that platform.
- Adds a `__native__: true` option to all paths to import, that indicates that
  the application will fall through to the native implementation of
  Compartment, currently only available on XS, which lacks support for
  precompiled module sources (as exist in many archived applications,
  particularly Agoric smart contract bundles) and instead supports loading
  modules from original sources (which is not possible at runtime on XS).


