### PR TITLE
feat(compartment-mapper): Make bundle using named evaluator

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,11 @@
 User-visible changes to `@endo/compartment-mapper`:
 
+# Next release
+
+- Adds a `useNestedEvaluate` option to `makeBundle` so that a bundle
+  can evaluate each individual module separately, preserving line numbers
+  in stack traces.
+
 # v1.5.0 (2025-01-23)
 
 - `mapNodeModules` and all functions that use it now tolerate the absence of
@@ -14,6 +20,10 @@ User-visible changes to `@endo/compartment-mapper`:
   object with a truthy `optional` entry.
   Correct interpretation of `peerDependencies` is not distributed evenly, so
   this behavior is no longer the default.
+- Adds a `useNamedEvaluate` option to `makeBundle`, which creates bundles that
+  use the named evaluate function to create each module functor at runtime,
+  such that the generated code preserves the line numbers that appear in stack
+  traces.
 
 Experimental:
 

--- a/packages/compartment-mapper/src/bundle-cjs.js
+++ b/packages/compartment-mapper/src/bundle-cjs.js
@@ -61,15 +61,24 @@ function wrapCjsFunctor(num) {
 /** @type {BundlerSupport<CjsModuleSource>} */
 export default {
   runtime,
-  getBundlerKit({
-    index,
-    indexedImports,
-    record: { cjsFunctor, exports: exportsList = {} },
-  }) {
+  getBundlerKit(
+    {
+      index,
+      indexedImports,
+      record: { cjsFunctor, exports: exportsList = {} },
+    },
+    { useNamedEvaluate = undefined },
+  ) {
     const importsMap = JSON.stringify(indexedImports);
 
     return {
-      getFunctor: () => `\
+      getFunctor:
+        useNamedEvaluate !== undefined
+          ? () => `\
+// === functors[${index}] ===
+${useNamedEvaluate}(${JSON.stringify(cjsFunctor)}),
+`
+          : () => `\
 // === functors[${index}] ===
 ${cjsFunctor},
 `,

--- a/packages/compartment-mapper/src/bundle-mjs.js
+++ b/packages/compartment-mapper/src/bundle-mjs.js
@@ -53,19 +53,28 @@ function observeImports(map, importName, importIndex) {
 /** @type {BundlerSupport<PrecompiledModuleSource>} */
 export default {
   runtime,
-  getBundlerKit({
-    index,
-    indexedImports,
-    record: {
-      __syncModuleProgram__,
-      __fixedExportMap__ = {},
-      __liveExportMap__ = {},
-      __reexportMap__ = {},
-      reexports,
+  getBundlerKit(
+    {
+      index,
+      indexedImports,
+      record: {
+        __syncModuleProgram__,
+        __fixedExportMap__ = {},
+        __liveExportMap__ = {},
+        __reexportMap__ = {},
+        reexports,
+      },
     },
-  }) {
+    { useNamedEvaluate = undefined },
+  ) {
     return {
-      getFunctor: () => `\
+      getFunctor:
+        useNamedEvaluate !== undefined
+          ? () => `\
+// === functors[${index}] ===
+${useNamedEvaluate}(${JSON.stringify(__syncModuleProgram__)}),
+`
+          : () => `\
 // === functors[${index}] ===
 ${__syncModuleProgram__},
 `,

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -131,6 +131,14 @@ export type SyncArchiveLiteOptions = SyncOrAsyncArchiveOptions &
 export type ArchiveOptions = Omit<MapNodeModulesOptions, 'language'> &
   ArchiveLiteOptions;
 
+export type BundleOptions = ArchiveOptions & {
+  /**
+   * Evaluates individual module functors in-place so stack traces represent
+   * original source locations better.
+   */
+  useNamedEvaluate?: string;
+};
+
 export type SyncArchiveOptions = Omit<MapNodeModulesOptions, 'languages'> &
   SyncArchiveLiteOptions;
 

--- a/packages/compartment-mapper/test/fixtures-0/node_modules/bundle/main.js
+++ b/packages/compartment-mapper/test/fixtures-0/node_modules/bundle/main.js
@@ -1,5 +1,9 @@
 /* global print */
 
+export const raise = () => {
+  throw new Error('on line 4');
+};
+
 // Import side-effect order:
 import './z-before-a.js';
 import './a-after-z.js';


### PR DESCRIPTION
Refs: #2444 

## Description

Toward better preservation of formatting through the ModuleSource and censorship evasion transforms (#2444), we ran into difficulty in composition with Rollup and source map transformations. The simplest route forward is to replace the Rollup implementation behind `getExport` and `nestedEvaluate` bundle formats with Endo’s own bundler. To that end, the `nestedEvaluate` format needs to be able to evaluate each module functor with the _named evaluate_ function instead of evaluating them inline. This change introduces a `useNamedEvaluate` option to `makeBundle`, which facilitates the `nestedEvaluate` bundle format.

### Security Considerations

The `nestedEvaluate` bundle format runtime in `importBundle` is obliged to provide a confined evaluator and also confine the evaluation of the bundle proper, as the intent is to confine the bundle.

### Scaling Considerations

None.

### Documentation Considerations

In a subsequent change, where we carve out the implementation of `nestedEvaluate`, there must be notes about the change in behavior this implementation will cause over the prior Rollup.

### Testing Considerations

This change includes a pair of tests to cover the bundler behavior and also to verify that the resulting evaluation preserves line numbers in error stacks.

### Compatibility Considerations

This is purely additive at this layer, but does not perfectly emulate the behavior of Rollup.

### Upgrade Considerations

When this change becomes incorporated in `bundleSource`, compensating changes are required in the contemporary versions of Agoric SDK kernel components. These changes have already landed. https://github.com/Agoric/agoric-sdk/pull/10878 https://github.com/Agoric/agoric-sdk/pull/10877