### PR TITLE
feat(patterns): M.containerHas(el,n) to support want patterns

### DIFF
--- a/packages/nat/src/index.js
+++ b/packages/nat/src/index.js
@@ -55,7 +55,7 @@ function isNat(allegedNum) {
  */
 function Nat(allegedNum) {
   if (typeof allegedNum === 'bigint') {
-    if (allegedNum < 0) {
+    if (allegedNum < 0n) {
       throw RangeError(`${allegedNum} is negative`);
     }
     return allegedNum;

--- a/packages/pass-style/src/makeTagged.js
+++ b/packages/pass-style/src/makeTagged.js
@@ -4,14 +4,18 @@ import { Fail } from '@endo/errors';
 import { PASS_STYLE } from './passStyle-helpers.js';
 import { assertPassable } from './passStyleOf.js';
 
+/**
+ * @import {Passable,CopyTagged} from './types.js'
+ */
+
 const { create, prototype: objectPrototype } = Object;
 
 /**
  * @template {string} T
- * @template {import('./types.js').Passable} P
+ * @template {Passable} P
  * @param {T} tag
  * @param {P} payload
- * @returns {import('./types.js').CopyTagged<T,P>}
+ * @returns {CopyTagged<T,P>}
  */
 export const makeTagged = (tag, payload) => {
   typeof tag === 'string' ||

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in `@endo/patterns`:
 
+# Next release
+
+- New pattern: `M.containerHas(elementPatt, bound = 1n)` motivated to support want patterns in Zoe, to pull out only `bound` number of elements that match `elementPatt`. `bound` must be a positive bigint.
+- Closely related, `@endo/patterns` now exports `containerHasSplit` to support ERTP's use of `M.containerHas` on non-fungible (`set`, `copySet`) and semifungible (`copyBag`) assets, respectively. See https://github.com/Agoric/agoric-sdk/pull/10952 .
+
 # v1.4.0 (2024-05-06)
 
 - `Passable` is now an accurate type instead of `any`. Downstream type checking may require changes ([example](https://github.com/Agoric/agoric-sdk/pull/8774))

--- a/packages/patterns/index.js
+++ b/packages/patterns/index.js
@@ -65,6 +65,7 @@ export {
   assertMethodGuard,
   assertInterfaceGuard,
   kindOf,
+  containerHasSplit,
 } from './src/patterns/patternMatchers.js';
 
 export {

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -36,6 +36,7 @@
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
     "@endo/marshal": "workspace:^",
+    "@endo/pass-style": "workspace:^",
     "@endo/promise-kit": "workspace:^"
   },
   "devDependencies": {

--- a/packages/patterns/src/keys/merge-bag-operators.js
+++ b/packages/patterns/src/keys/merge-bag-operators.js
@@ -8,7 +8,6 @@ import { q, Fail } from '@endo/errors';
 import { assertNoDuplicateKeys, makeBagOfEntries } from './copyBag.js';
 
 /**
- * @import {Passable} from '@endo/pass-style';
  * @import {FullCompare, RankCompare} from '@endo/marshal'
  * @import {Key} from '../types.js'
  */

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -380,6 +380,13 @@ export {};
  * `countPatt` is expected to rarely be useful,
  * but is provided to minimize surprise.
  *
+ * @property {(elementPatt?: Pattern,
+ *             bound?: bigint,
+ *             limits?: Limits
+ * ) => Matcher} containerHas
+ * Matches any array, CopySet, or CopyBag in which the bigint number of
+ * elements that match `elementPatt` is >= `bound` (which defaults to `1n`).
+ *
  * @property {(keyPatt?: Pattern,
  *             valuePatt?: Pattern,
  *             limits?: Limits

--- a/packages/patterns/test/patterns.test.js
+++ b/packages/patterns/test/patterns.test.js
@@ -199,6 +199,10 @@ const runTests = (t, successCase, failCase) => {
 
     successCase(specimen, M.arrayOf(M.number()));
 
+    successCase(specimen, M.containerHas(3));
+    successCase(specimen, M.containerHas(3, 1n));
+    successCase(specimen, M.containerHas(M.number(), 2n));
+
     failCase(specimen, [4, 3], '[3,4] - Must be: [4,3]');
     failCase(specimen, [3], '[3,4] - Must be: [3]');
     failCase(
@@ -226,6 +230,12 @@ const runTests = (t, successCase, failCase) => {
       specimen,
       M.arrayOf(M.string()),
       '[0]: number 3 - Must be a string',
+    );
+
+    failCase(
+      specimen,
+      M.containerHas('c'),
+      'Has only "[0n]" matches, but needs "[1n]"',
     );
   }
   {
@@ -419,6 +429,10 @@ const runTests = (t, successCase, failCase) => {
     successCase(specimen, M.lte(makeCopySet([3, 4, 5])));
     successCase(specimen, M.setOf(M.number()));
 
+    successCase(specimen, M.containerHas(3));
+    successCase(specimen, M.containerHas(3, 1n));
+    successCase(specimen, M.containerHas(M.number(), 2n));
+
     failCase(specimen, makeCopySet([]), '"[copySet]" - Must be: "[copySet]"');
     failCase(
       specimen,
@@ -439,6 +453,12 @@ const runTests = (t, successCase, failCase) => {
       specimen,
       M.setOf(M.string()),
       'set elements[0]: number 4 - Must be a string',
+    );
+
+    failCase(
+      specimen,
+      M.containerHas('c'),
+      'Has only "[0n]" matches, but needs "[1n]"',
     );
   }
   {
@@ -472,6 +492,14 @@ const runTests = (t, successCase, failCase) => {
     );
     successCase(specimen, M.bagOf(M.string()));
     successCase(specimen, M.bagOf(M.string(), M.lt(5n)));
+    successCase(specimen, M.bagOf(M.string(), M.gte(2n)));
+
+    successCase(specimen, M.containerHas('a'));
+    successCase(specimen, M.containerHas('a', 2n));
+    successCase(specimen, M.containerHas(M.string(), 5n));
+    successCase(specimen, M.containerHas('a', 1n));
+    successCase(specimen, M.containerHas('a'));
+    successCase(specimen, M.containerHas('b', 2n));
 
     failCase(
       specimen,
@@ -499,15 +527,11 @@ const runTests = (t, successCase, failCase) => {
       'bag keys[0]: string "b" - Must be a boolean',
     );
     failCase(specimen, M.bagOf('b'), 'bag keys[1]: "a" - Must be: "b"');
+
     failCase(
       specimen,
-      M.bagOf(M.any(), M.gt(5n)),
-      'bag counts[0]: "[3n]" - Must be > "[5n]"',
-    );
-    failCase(
-      specimen,
-      M.bagOf(M.any(), M.gt(2n)),
-      'bag counts[1]: "[2n]" - Must be > "[2n]"',
+      M.containerHas('c'),
+      'Has only "[0n]" matches, but needs "[1n]"',
     );
   }
   {
@@ -866,5 +890,18 @@ test('well formed patterns', t => {
   // @ts-expect-error purposeful type violation for testing
   t.throws(() => M.remotable(88), {
     message: 'match:remotable payload: label: number 88 - Must be a string',
+  });
+
+  t.throws(() => M.containerHas('c', 0n), {
+    message: 'M.containerHas payload: [1]: "[0n]" - Must be >= "[1n]"',
+  });
+  // @ts-expect-error purposeful type violation for testing
+  t.throws(() => M.containerHas('c', M.nat()), {
+    message:
+      'M.containerHas payload: [1]: A passable tagged "match:nat" is not a key: "[match:nat]"',
+  });
+  // @ts-expect-error purposeful type violation for testing
+  t.throws(() => M.containerHas(3, 1), {
+    message: 'M.containerHas payload: [1]: 1 - Must be >= "[1n]"',
   });
 });


### PR DESCRIPTION
Closes: #XXXX
Refs: #2002 #2008 #2113 #1739 https://github.com/Agoric/agoric-sdk/pull/10952

## Description

This PR adds a new `M.containerHas(elementPatt, positiveBigint)` matcher, and exported `containerHasSplit` function. This is motivated to support https://github.com/Agoric/agoric-sdk/pull/10952 , which introduces a minimal form of want pattern in terms of `M.containerHas`.

- [x] Actually merging this must happen only after we've decided either to move forward with #2008 or to give up on it. Once a decision is made, and even before it is acted on, then this PR can move forward. (Any decision to move forward or not with #2008 should also consider changing the default of the feature flag introduced by #2002 .)

### Security Considerations

none

### Scaling Considerations

Might help due to early termination of the split operations, which https://github.com/Agoric/agoric-sdk/pull/10952 uses for `AmountMath.isGTE`.

### Documentation Considerations

Already doc-documents `M.containerHas` in the types.js file for `M`. That's probably good enough for this PR. The interesting documentation will be explaining want patterns in https://github.com/Agoric/agoric-sdk/pull/10952

### Testing Considerations

Added tests for `M.containerHas`

### Compatibility Considerations

The reason to postpone merging this PR until decisions are made on #2008 is that this PR will further expose `rankOrder` in the API, amplifying the danger that changing the string order will cause surprising observable changes.

### Upgrade Considerations

This PR itself does not introduce any BREAKING changes or Upgrade issues.

- [x] Update `NEWS.md` for user-facing changes.
