### PR TITLE
remove maxNodeModuleJsDepth

### DIFF
--- a/packages/bundle-source/tsconfig.json
+++ b/packages/bundle-source/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.eslint-base.json",
   "compilerOptions": {
-    "maxNodeModuleJsDepth": 1,
     "checkJs": false
   },
   "include": [

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.eslint-base.json",
   "compilerOptions": {
     "checkJs": true,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/marshal/tsconfig.json
+++ b/packages/marshal/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.eslint-base.json",
   "compilerOptions": {
     "checkJs": true,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",

--- a/packages/pass-style/tsconfig.json
+++ b/packages/pass-style/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.eslint-base.json",
   "compilerOptions": {
     "checkJs": true,
-    "maxNodeModuleJsDepth": 1,
   },
   "include": [
     "*.js",


### PR DESCRIPTION
Refs: #2712

## Description

Remove `maxNodeModuleJsDepth` which is no longer necessary.

One small step towards
- https://github.com/endojs/endo/issues/2712

### Security Considerations

None.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

None.

### Compatibility Considerations

None.

### Upgrade Considerations

None.