### PR TITLE
docs: add some javadoc on E in hopes that it'll be visible in IDEs

### DIFF
--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -195,6 +195,14 @@ const makeE = HandledPromise => {
        * method calls returns a promise. The method will be invoked on whatever
        * 'x' designates (or resolves to) in a future turn, not this one.
        *
+       * An example call would be
+       *
+       * E(zoe).install(bundle)
+       *   .then(installationHandle => { ... })
+       *   .catch(err => { ... });
+       *
+       *  See https://endojs.github.io/endo/functions/_endo_far.E.html for details.
+       *
        * @template T
        * @param {T} x target for method/function call
        * @returns {ECallableOrMethods<RemoteFunctions<T>>} method/function call proxy

--- a/packages/eventual-send/src/no-shim.js
+++ b/packages/eventual-send/src/no-shim.js
@@ -5,6 +5,17 @@ import makeE from './E.js';
 /** @import {ECallableOrMethods, EGetters, ERef, ERemoteFunctions, ESendOnlyCallableOrMethods, LocalRecord, RemoteFunctions} from './E.js' */
 
 const hp = HandledPromise;
+
+/**
+ * E(x) returns a proxy on which you can call arbitrary methods. Each of these method calls returns a promise.
+ * The method will be invoked on whatever 'x' designates (or resolves to) in a future turn, not this one.
+ *
+ * E.get(x) returns a proxy on which you can get arbitrary properties. Each of these properties returns a
+ * promise for the property.  The promise value will be the property fetched from whatever 'x' designates (or
+ * resolves to) in a future turn, not this one.
+ *
+ * E.when(x, res, rej) is equivalent to HandledPromise.resolve(x).then(res, rej)
+ */
 export const E = makeE(hp);
 export { hp as HandledPromise };
 


### PR DESCRIPTION
Closes: #2706

## Description

Add some documentation on *E*, in hopes that it will appear as hovertext in IDEs.  Also added an example and a link to the API Documentation.

### Security Considerations

No impact

### Scaling Considerations

No consequences.

### Documentation Considerations

No change to any interface. The goal is to add jsDoc to E.

### Testing Considerations

I don't know how to test this before it's deployed. In WebStorm, I was able to see the comment when hovering on *E* in `no-shim.js`, but not anywhere else.

### Compatibility Considerations

No effects

### Upgrade Considerations

None