### PR TITLE
refactor(pass-style): faster `passStyleOf`

### DIFF
--- a/packages/pass-style/src/copyArray.js
+++ b/packages/pass-style/src/copyArray.js
@@ -8,25 +8,17 @@ const { ownKeys } = Reflect;
 const { isArray, prototype: arrayPrototype } = Array;
 
 /**
- * @param {unknown} candidate
- * @param {import('./types.js').Checker} [check]
- * @returns {boolean}
- */
-const canBeValid = (candidate, check = undefined) =>
-  isArray(candidate) ||
-  (!!check && check(false, X`Array expected: ${candidate}`));
-
-/**
  *
  * @type {import('./internal-types.js').PassStyleHelper}
  */
 export const CopyArrayHelper = harden({
   styleName: 'copyArray',
 
-  canBeValid,
+  canBeValid: (candidate, check = undefined) =>
+    isArray(candidate) ||
+    (!!check && check(false, X`Array expected: ${candidate}`)),
 
-  assertValid: (candidate, passStyleOfRecur) => {
-    canBeValid(candidate, assertChecker);
+  assertRestValid: (candidate, passStyleOfRecur) => {
     getPrototypeOf(candidate) === arrayPrototype ||
       assert.fail(X`Malformed array: ${candidate}`, TypeError);
     // Since we're already ensured candidate is an array, it should not be

--- a/packages/pass-style/src/copyRecord.js
+++ b/packages/pass-style/src/copyRecord.js
@@ -64,9 +64,7 @@ export const CopyRecordHelper = harden({
     );
   },
 
-  assertValid: (candidate, passStyleOfRecur) => {
-    checkObjectPrototype(candidate, assertChecker);
-
+  assertRestValid: (candidate, passStyleOfRecur) => {
     // Validate that each own property is appropriate, data/enumerable,
     // and has a recursively passable associated value.
     for (const name of ownKeys(candidate)) {
@@ -76,7 +74,6 @@ export const CopyRecordHelper = harden({
         true,
         assertChecker,
       );
-      checkPropertyCanBeValid(candidate, name, value, assertChecker);
       passStyleOfRecur(value);
     }
   },

--- a/packages/pass-style/src/copyRecord.js
+++ b/packages/pass-style/src/copyRecord.js
@@ -65,8 +65,9 @@ export const CopyRecordHelper = harden({
   },
 
   assertRestValid: (candidate, passStyleOfRecur) => {
-    // Validate that each own property is appropriate, data/enumerable,
-    // and has a recursively passable associated value.
+    // Validate that each own property has a recursively passable associated
+    // value (we already know from canBeValid that the other constraints are
+    // satisfied).
     for (const name of ownKeys(candidate)) {
       const { value } = getOwnDataDescriptor(
         candidate,

--- a/packages/pass-style/src/error.js
+++ b/packages/pass-style/src/error.js
@@ -208,6 +208,6 @@ export const ErrorHelper = harden({
 
   canBeValid: checkErrorLike,
 
-  assertValid: (candidate, passStyleOfRecur) =>
+  assertRestValid: (candidate, passStyleOfRecur) =>
     checkRecursivelyPassableError(candidate, passStyleOfRecur, assertChecker),
 });

--- a/packages/pass-style/src/internal-types.js
+++ b/packages/pass-style/src/internal-types.js
@@ -20,9 +20,9 @@ export {};
  * @property {(candidate: any, check?: Checker) => boolean} canBeValid
  * If `canBeValid` returns true, then the candidate would
  * definitely not be valid for any of the other helpers.
- * `assertValid` still needs to be called to determine if it
- * actually is valid.
+ * `assertRestValid` still needs to be called to determine if it
+ * actually is valid, but only after the `canBeValid` check has passed.
  * @property {(candidate: any,
  *             passStyleOfRecur: (val: any) => PassStyle
- *            ) => void} assertValid
+ *            ) => void} assertRestValid
  */

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -272,7 +272,7 @@ export const RemotableHelper = harden({
     return !!check && CX(check)`unrecognized typeof ${candidate}`;
   },
 
-  assertValid: candidate => checkRemotable(candidate, assertChecker),
+  assertRestValid: candidate => checkRemotable(candidate, assertChecker),
 
   every: (_passable, _fn) => true,
 });

--- a/packages/pass-style/src/tagged.js
+++ b/packages/pass-style/src/tagged.js
@@ -9,12 +9,16 @@ import {
   checkPassStyle,
 } from './passStyle-helpers.js';
 
+/**
+ * @import {PassStyleHelper} from './internal-types.js'
+ */
+
 const { ownKeys } = Reflect;
 const { getOwnPropertyDescriptors } = Object;
 
 /**
  *
- * @type {import('./internal-types.js').PassStyleHelper}
+ * @type {PassStyleHelper}
  */
 export const TaggedHelper = harden({
   styleName: 'tagged',
@@ -22,7 +26,7 @@ export const TaggedHelper = harden({
   canBeValid: (candidate, check = undefined) =>
     checkPassStyle(candidate, candidate[PASS_STYLE], 'tagged', check),
 
-  assertValid: (candidate, passStyleOfRecur) => {
+  assertRestValid: (candidate, passStyleOfRecur) => {
     checkTagRecord(candidate, 'tagged', assertChecker);
 
     // Typecasts needed due to https://github.com/microsoft/TypeScript/issues/1863

--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -56,8 +56,6 @@ import { assert } from './error/assert.js';
  * @import {Harden} from '../types.js'
  */
 
-const { constructor: TypedArray } = typedArrayPrototype;
-
 // Obtain the string tag accessor of of TypedArray so we can indirectly use the
 // TypedArray brand check it employs.
 const typedArrayToStringTag = getOwnPropertyDescriptor(
@@ -75,10 +73,6 @@ assert(getTypedArrayToStringTag);
  * @param {unknown} object
  */
 export const isTypedArray = object => {
-  if (!(object instanceof TypedArray)) {
-    // quicker reject for typical case
-    return false;
-  }
   // The object must pass a brand check or toStringTag will return undefined.
   const tag = apply(getTypedArrayToStringTag, object, []);
   return tag !== undefined;

--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -56,6 +56,8 @@ import { assert } from './error/assert.js';
  * @import {Harden} from '../types.js'
  */
 
+const { constructor: TypedArray } = typedArrayPrototype;
+
 // Obtain the string tag accessor of of TypedArray so we can indirectly use the
 // TypedArray brand check it employs.
 const typedArrayToStringTag = getOwnPropertyDescriptor(
@@ -73,6 +75,10 @@ assert(getTypedArrayToStringTag);
  * @param {unknown} object
  */
 export const isTypedArray = object => {
+  if (!(object instanceof TypedArray)) {
+    // quicker reject for typical case
+    return false;
+  }
   // The object must pass a brand check or toStringTag will return undefined.
   const tag = apply(getTypedArrayToStringTag, object, []);
   return tag !== undefined;


### PR DESCRIPTION
Closes: #XXXX
Refs: https://github.com/Agoric/agoric-sdk/pull/10975 https://github.com/Agoric/agoric-sdk/pull/10982 

## Description

Using the benchmark tool from #10975 by @muhammadahmadasifbhatti as modified by #10982 to produce flamegraphs (interactive in vscode) I iterated on that benchmark test which already had very specific simple examples exercising  `passStyleOf`. Together with the snippet at https://github.com/Agoric/agoric-sdk/blob/acbb5da3c5a52bab8db319fd696aed70146f9a89/.github/actions/restore-node/action.yml#L156 (which @gibson042 brought to my attention)

```sh
$ scripts/get-packed-versions.sh ~/endo | scripts/resolve-versions.sh
$ yarn install && yarn build
$ cd packages/benchmark-test
$ yarn bench
```
and then clicking on the latest *.cpuprofile file, assuming you've already installed the https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-js-profile-flame vscode extension.

I was able to iterate and tinker on possible improvements, to see what made how much of a difference. This PR has the improvements to `passStyleOf` that I and my reviewers have came up with so far.

@gibson042 suggested the main technique used: to avoid redundant checking by breaking up `assertValid` so we could still running the checks of `canBeValid` twice.

### Security Considerations

I claim that this PR is a pure refactoring. If true, none. ***Reviewers***, please review with a skeptical eye. `passStyleOf` is security critical, so any observable difference might lead to an opportunity for an adversary.

### Scaling Considerations

Even though I iterated on a specialized benchmark exercising `passStyleOf`, I believe I only made changes that would also be an improvement for the typical cases.

### Documentation Considerations

If this is a pure refactor, none.

### Testing Considerations

If this is a pure refactor, none. In fact, this PR did not need to change any tests, providing some weak evidence that it is indeed a pure refactor.

### Compatibility Considerations

If this is a pure refactor, none.

### Upgrade Considerations

If this is a pure refactor, none.

