### PR TITLE
feat(compartment-mapper): add option for custom logger to varied functions

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,13 @@
 User-visible changes to `@endo/compartment-mapper`:
 
+# Next release
+
+- `mapNodeModules`, `importLocation` and `loadLocation` now accept a `log`
+  option for users to define a custom logging function. As of this writing,
+  _only `mapNodeModules`_ will potentially call this function if provided.
+  Expansion of log messaging and support for the `log` option in more APIs is
+  expected _in the future_.
+
 # v1.5.0 (2025-01-23)
 
 - `mapNodeModules` and all functions that use it now tolerate the absence of

--- a/packages/compartment-mapper/src/policy.js
+++ b/packages/compartment-mapper/src/policy.js
@@ -240,6 +240,7 @@ export const makeDeferredAttenuatorsProvider = (
   compartments,
   compartmentDescriptors,
 ) => {
+  /** @type {DeferredAttenuatorsProvider['import']} */
   let importAttenuator;
   let defaultAttenuator;
   // Attenuators compartment is not created when there's no policy.
@@ -255,11 +256,6 @@ export const makeDeferredAttenuatorsProvider = (
     // At the time of this function being called, attenuators compartment won't
     // exist yet, we need to defer looking them up in the compartment to the
     // time of the import function being called.
-    /**
-     *
-     * @param {string} attenuatorSpecifier
-     * @returns {Promise<Attenuator>}
-     */
     importAttenuator = async attenuatorSpecifier => {
       if (!attenuatorSpecifier) {
         if (!defaultAttenuator) {
@@ -267,8 +263,9 @@ export const makeDeferredAttenuatorsProvider = (
         }
         attenuatorSpecifier = defaultAttenuator;
       }
-      const { namespace } =
-        await compartments[ATTENUATORS_COMPARTMENT].import(attenuatorSpecifier);
+      const { namespace } = await compartments[ATTENUATORS_COMPARTMENT].import(
+        /** @type {string} */ (attenuatorSpecifier),
+      );
       return namespace;
     };
   }

--- a/packages/compartment-mapper/src/search.js
+++ b/packages/compartment-mapper/src/search.js
@@ -8,6 +8,9 @@
  *   ReadFn,
  *   ReadPowers,
  *   MaybeReadPowers,
+ *   SearchResult,
+ *   SearchDescriptorResult,
+ *   MaybeReadDescriptorFn,
  * } from './types.js'
  */
 
@@ -35,10 +38,13 @@ const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
  *
  * @template T
  * @param {string} location
- * @param {(location:string)=>Promise<T|undefined>} maybeReadDescriptor
- * @returns {Promise<{data:T, directory: string, location:string, packageDescriptorLocation: string}>}
+ * @param {MaybeReadDescriptorFn<T>} maybeReadDescriptor
+ * @returns {Promise<SearchDescriptorResult<T>>}
  */
-export const searchDescriptor = async (location, maybeReadDescriptor) => {
+export const searchDescriptor = async (
+  location,
+  maybeReadDescriptor,
+) => {
   await null;
   let directory = resolveLocation('./', location);
   for (;;) {
@@ -91,17 +97,16 @@ const maybeReadDescriptorDefault = async (
  *
  * @param {ReadFn | ReadPowers | MaybeReadPowers} readPowers
  * @param {string} moduleLocation
- * @returns {Promise<{
- *   packageLocation: string,
- *   packageDescriptorLocation: string,
- *   packageDescriptorText: string,
- *   moduleSpecifier: string,
- * }>}
+ * @returns {Promise<SearchResult>}
  */
-export const search = async (readPowers, moduleLocation) => {
+export const search = async (
+  readPowers,
+  moduleLocation,
+) => {
   const { data, directory, location, packageDescriptorLocation } =
-    await searchDescriptor(moduleLocation, loc =>
-      maybeReadDescriptorDefault(readPowers, loc),
+    await searchDescriptor(
+      moduleLocation,
+      loc => maybeReadDescriptorDefault(readPowers, loc),
     );
 
   if (!data) {

--- a/packages/compartment-mapper/src/search.js
+++ b/packages/compartment-mapper/src/search.js
@@ -8,9 +8,11 @@
  *   ReadFn,
  *   ReadPowers,
  *   MaybeReadPowers,
+ *   SearchOptions,
  *   SearchResult,
  *   SearchDescriptorResult,
  *   MaybeReadDescriptorFn,
+ *   SearchDescriptorOptions,
  * } from './types.js'
  */
 
@@ -20,6 +22,11 @@ import { unpackReadPowers } from './powers.js';
 
 // q, as in quote, for enquoting strings in error messages.
 const q = JSON.stringify;
+
+/**
+ * Default logger that does nothing
+ */
+const noop = () => {};
 
 const decoder = new TextDecoder();
 
@@ -39,11 +46,13 @@ const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
  * @template T
  * @param {string} location
  * @param {MaybeReadDescriptorFn<T>} maybeReadDescriptor
+ * @param {SearchDescriptorOptions} options
  * @returns {Promise<SearchDescriptorResult<T>>}
  */
 export const searchDescriptor = async (
   location,
   maybeReadDescriptor,
+  { log: _log = noop } = {},
 ) => {
   await null;
   let directory = resolveLocation('./', location);
@@ -97,16 +106,19 @@ const maybeReadDescriptorDefault = async (
  *
  * @param {ReadFn | ReadPowers | MaybeReadPowers} readPowers
  * @param {string} moduleLocation
+ * @param {SearchOptions} [options]
  * @returns {Promise<SearchResult>}
  */
 export const search = async (
   readPowers,
   moduleLocation,
+  { log = noop } = {},
 ) => {
   const { data, directory, location, packageDescriptorLocation } =
     await searchDescriptor(
       moduleLocation,
       loc => maybeReadDescriptorDefault(readPowers, loc),
+      { log },
     );
 
   if (!data) {

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -11,8 +11,8 @@ import type {
   Transform,
 } from 'ses';
 import type {
-  CompartmentMapDescriptor,
   CompartmentDescriptor,
+  CompartmentMapDescriptor,
   Language,
   LanguageForExtension,
 } from './compartment-map-schema.js';
@@ -48,8 +48,23 @@ export type ParseArchiveOptions = Partial<{
 
 export type LoadArchiveOptions = ParseArchiveOptions;
 
+/**
+ * Options having an optional `log` property.
+ */
+export interface LogOptions {
+  /**
+   * A logger (for logging)
+   */
+  log?: LogFn;
+}
+
+/**
+ * Options for `mapNodeModules()`
+ */
 export type MapNodeModulesOptions = MapNodeModulesOptionsOmitPolicy &
-  PolicyOption;
+  PolicyOption &
+  LogOptions;
+
 type MapNodeModulesOptionsOmitPolicy = Partial<{
   /** @deprecated renamed `conditions` to be consistent with Node.js */
   tags: Set<string>;
@@ -115,7 +130,8 @@ export type CompartmentMapForNodeModulesOptions = Omit<
 
 export type CaptureLiteOptions = ImportingOptions &
   LinkingOptions &
-  PolicyOption;
+  PolicyOption &
+  LogOptions;
 
 export type ArchiveLiteOptions = SyncOrAsyncArchiveOptions &
   ModuleTransformsOption &
@@ -137,15 +153,24 @@ export type SyncArchiveOptions = Omit<MapNodeModulesOptions, 'languages'> &
 /**
  * Options for `loadLocation()`
  */
-export type LoadLocationOptions = ArchiveOptions & SyncArchiveOptions;
+export type LoadLocationOptions = ArchiveOptions &
+  SyncArchiveOptions &
+  LogOptions;
 
 /**
  * Options for `importLocation()` necessary (but not sufficient--see
  * `ReadNowPowers`) for dynamic require support
  */
-export type SyncImportLocationOptions = SyncArchiveOptions & ExecuteOptions;
+export type SyncImportLocationOptions = SyncArchiveOptions &
+  ExecuteOptions &
+  LogOptions;
 
-export type ImportLocationOptions = ArchiveOptions & ExecuteOptions;
+/**
+ * Options for `importLocation()` without dynamic require support
+ */
+export type ImportLocationOptions = ArchiveOptions &
+  ExecuteOptions &
+  LogOptions;
 
 // ////////////////////////////////////////////////////////////////////////////////
 // Single Options
@@ -426,3 +451,8 @@ export type ParseFn = { isSyncParser?: true } & ((
  * ParserImplementations}
  */
 export type ParserForLanguage = Record<Language | string, ParserImplementation>;
+
+/**
+ * Generic logging function accepted by various functions.
+ */
+export type LogFn = (message: string, ...args: any[]) => void;

--- a/packages/compartment-mapper/src/types/internal.ts
+++ b/packages/compartment-mapper/src/types/internal.ts
@@ -218,6 +218,11 @@ export type MakeMapParsersOptions = {
 };
 
 /**
+ * Options for `search()`
+ */
+export type SearchOptions = LogOptions;
+
+/**
  * Object fulfilled from `search()`
  */
 export interface SearchResult {
@@ -238,6 +243,11 @@ export interface SearchDescriptorResult<T> {
   location: string;
   packageDescriptorLocation: string;
 }
+
+/**
+ * Options for `searchDescriptor()`
+ */
+export type SearchDescriptorOptions = LogOptions;
 
 /**
  * A power to read a package descriptor

--- a/packages/compartment-mapper/src/types/internal.ts
+++ b/packages/compartment-mapper/src/types/internal.ts
@@ -26,6 +26,7 @@ import type {
   CompartmentSources,
   ExecuteOptions,
   ExitModuleImportNowHook,
+  LogOptions,
   ModuleTransforms,
   ParseFn,
   ParserForLanguage,
@@ -215,3 +216,68 @@ export type MakeMapParsersOptions = {
    */
   syncModuleTransforms?: SyncModuleTransforms;
 };
+
+/**
+ * Object fulfilled from `search()`
+ */
+export interface SearchResult {
+  packageLocation: string;
+  packageDescriptorLocation: string;
+  packageDescriptorText: string;
+  moduleSpecifier: string;
+}
+
+/**
+ * Object fulfilled from `searchDescriptor()`
+ *
+ * @template T The datatype; may be a {@link PackageDescriptor}, blob, string, etc.
+ */
+export interface SearchDescriptorResult<T> {
+  data: T;
+  directory: string;
+  location: string;
+  packageDescriptorLocation: string;
+}
+
+/**
+ * A power to read a package descriptor
+ * @template T Format of package descriptor
+ */
+export type ReadDescriptorFn<T = PackageDescriptor> = (
+  location: string,
+) => Promise<T>;
+
+/**
+ * A power to _maybe_ read a package descriptor
+ * @template T Format of package descriptor
+ */
+export type MaybeReadDescriptorFn<T = PackageDescriptor> = (
+  location: string,
+) => Promise<T | undefined>;
+
+/**
+ * The type of a `package.json` file containing relevant fields; used by `graphPackages` and its ilk
+ */
+export interface PackageDescriptor {
+  /**
+   * TODO: In reality, this is optional, but `graphPackage` does not consider it to be. This will need to be fixed once support for "anonymous" packages lands; see https://github.com/endojs/endo/pull/2664
+   */
+  name: string;
+  version?: string;
+  /**
+   * TODO: Update with proper type when this field is handled.
+   */
+  exports?: unknown;
+  type?: 'module' | 'commonjs';
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  bundleDependencies?: string[];
+  peerDependenciesMeta?: Record<
+    string,
+    { optional?: boolean; [k: string]: unknown }
+  >;
+
+  [k: string]: unknown;
+}

--- a/packages/compartment-mapper/src/types/node-modules.ts
+++ b/packages/compartment-mapper/src/types/node-modules.ts
@@ -1,0 +1,84 @@
+import type {
+  Language,
+  LanguageForExtension,
+} from './compartment-map-schema.js';
+import type { LogOptions } from './external.js';
+import type { PackageDescriptor } from './internal.js';
+
+export type CommonDependencyDescriptors = Record<
+  string,
+  { spec: string; alias: string }
+>;
+
+export type GraphPackageOptions = {
+  preferredPackageLogicalPathMap?: Map<string, string[]>;
+  logicalPath?: string[];
+  commonDependencyDescriptors?: CommonDependencyDescriptors;
+} & LogOptions;
+
+export type GraphPackagesOptions = LogOptions;
+
+export type GatherDependencyOptions = {
+  childLogicalPath?: string[];
+  /**
+   * If `true` the dependency is optional
+   */
+  optional?: boolean;
+  /**
+   * Dependencies added to _all_ packages
+   */
+  commonDependencyDescriptors?: CommonDependencyDescriptors;
+} & LogOptions;
+
+export interface Node {
+  /**
+   * Informative compartment label based on the package name and version (if available)
+   */
+  label: string;
+  /**
+   * Package name
+   */
+  name: string;
+  path: Array<string>;
+  logicalPath: Array<string>;
+  /**
+   * `true` if the package's {@link PackageDescriptor} has an `exports` field
+   */
+  explicitExports: boolean;
+  internalAliases: Record<string, string>;
+  externalAliases: Record<string, string>;
+  /**
+   * An object whose keys are the thing being imported, and the values are the
+   * names of the matching module (relative to the containing package's root;
+   * i.e. the URL that was used as the key of graph).
+   *
+   * The values are the keys of other {@link Node Nodes} in the {@link Graph}.
+   */
+  dependencyLocations: Record<string, string>;
+  parsers: LanguageForExtension;
+  types: Record<string, Language>;
+}
+
+/**
+ * The graph is an intermediate object model that the functions of this module
+ * build by exploring the `node_modules` tree dropped by tools like npm and
+ * consumed by tools like Node.js.
+ * This gets translated finally into a compartment map.
+ */
+export type Graph = Record<string, Node>;
+
+export interface LanguageOptions {
+  commonjsLanguageForExtension: LanguageForExtension;
+  moduleLanguageForExtension: LanguageForExtension;
+  workspaceCommonjsLanguageForExtension: LanguageForExtension;
+  workspaceModuleLanguageForExtension: LanguageForExtension;
+  languages: Set<string>;
+}
+
+/**
+ * Object result of `findPackage()`
+ */
+export interface PackageDetails {
+  packageLocation: string;
+  packageDescriptor: PackageDescriptor;
+}


### PR DESCRIPTION
## Description

I'd like `@endo/compartment-mapper` to a) emit more information about what it's doing and b) allow me to control how it emits that information.

In lieu of a ~~larger~~ ~~complicated~~ reporting/diagnostics system (potentially invoking the spectre of `EventEmitter`), I've allowed a custom logger to be passed in to a handful of functions in `@endo/compartment-mapper` (including both private and public APIs). Generally speaking, `@endo/compartment-mapper` currently _doesn't log anything_ (except the one place that it _does_); I intend to add more `log()` calls in future PRs to aid debugging.

This change:

- adds a `LogFn` type which can be accepted in an options bucket (`LogOptions`)
- `mapNodeModules` and its internal functions now support this option
- `search`, `captureFromMap`, `loadLocation` and `importLocation` all support this option (but do not yet use it)
- rewrote a (the) log message in `graphPackage` to use a static string message and data object
- added `types/node-modules.ts` for types specific to `node-modules.js`; these should all be considered internal
- moved some typedefs from `node-modules.js` into `types/node-modules.ts`
- created a `PackageDescriptor` type, which is a rough approximation of a `package.json` and leveraged it throughout functions involved in reading one
- cleaned up weird type in `policy.js`
- refactored signatures of some internal functions to use options buckets

### Security Considerations

None that I'm aware of, but we should be careful about what and how we log in the future. @kriskowal suggested that log messages should be static, and all dynamic context should be provided to the logger as data.

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Tests may provide null loggers to functions which accept `LogFn`s.

### Compatibility Considerations

This will break anybody parsing the single extant log message emitted from `@endo/compartment-mapper`, since the message is now different. This is unlikely to affect anyone—but if it does, I will personally apologize to them.

### Upgrade Considerations

Will need to update `NEWS.md`.
