### PR TITLE
fix(compartment-mapper): Make bundled code more robust against primordial replacement/manipulation

### DIFF
--- a/packages/compartment-mapper/src/bundle-lite.js
+++ b/packages/compartment-mapper/src/bundle-lite.js
@@ -499,7 +499,8 @@ export const makeFunctorFromMap = async (
       }),
       set: freeze((newValue) => {
         value = newValue;
-        for (const observe of observers) {
+        for (let i = 0; i < observers.length; i += 1) {
+          const observe = observers[i];
           observe(value);
         }
       }),


### PR DESCRIPTION
Ref https://github.com/endojs/endo/pull/2707#discussion_r1953346697

Don't rely upon a primordial `Array.prototype[Symbol.iterator]`.