### PR TITLE
feat: Show memory usage in the Benchmark tests

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -33,7 +33,8 @@
     "prepack": "tsc --build tsconfig.build.json",
     "install-engines": "./install-engines.sh",
     "test": "./run-tests.sh",
-    "cpu-prof-test": "yarn rollup -c && node --jitless --cpu-prof dist/bundle.js"
+    "cpu-prof-test": "yarn rollup -c && node --jitless --cpu-prof dist/bundle.js",
+    "test:node": "yarn rollup -c && node dist/bundle.js"
   },
   "devDependencies": {
     "@endo/init": "workspace:^",

--- a/packages/benchmark/src/benchmark.js
+++ b/packages/benchmark/src/benchmark.js
@@ -32,16 +32,16 @@ function logMemoryUsage(message = '') {
 
 async function test(name, fn) {
   await null;
-  console.log('\n\n')
+  console.log('\n\n');
   console.log('Running test: ', name);
-  logMemoryUsage("Memory Usage Before Test: ");
+  logMemoryUsage('Memory Usage Before Test: ');
   try {
     await fn({ assert, truthy });
     console.log(`✅ Passed`);
   } catch (err) {
     console.log(`❌ Failed: ${err.message}`);
   }
-  logMemoryUsage("Memory Usage After Test: ");
+  logMemoryUsage('Memory Usage After Test: ');
 }
 
 export { benchmark, test };

--- a/packages/benchmark/src/benchmark.js
+++ b/packages/benchmark/src/benchmark.js
@@ -25,15 +25,23 @@ function truthy(value, message = 'Expected a truthy value') {
   if (!value) throw Error(message);
 }
 
+function logMemoryUsage(message = '') {
+  if (typeof process === 'undefined') return;
+  console.log(message, process.memoryUsage());
+}
+
 async function test(name, fn) {
   await null;
+  console.log('\n\n')
+  console.log('Running test: ', name);
+  logMemoryUsage("Memory Usage Before Test: ");
   try {
-    console.log('Running test: ', name);
     await fn({ assert, truthy });
     console.log(`✅ Passed`);
   } catch (err) {
     console.log(`❌ Failed: ${err.message}`);
   }
+  logMemoryUsage("Memory Usage After Test: ");
 }
 
 export { benchmark, test };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

> Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one):

Closes: [Show Memory usage in the benchmark tests](https://github.com/Agoric/product-tasks/issues/250)

## Description

We need to show the `memory` usage before and after each test. Since, we are currently using binaries of the engines and not the runtimes the `process` object won't be available. So, I am creating a new script in the `package.json` (`test:node`). This will run the bundles file using node.

Also, I will be writing another function named `logMemoryUsage`. It will check if the process object is available it will call the `process.memoryUsage` function.

### Security Considerations

N/A

### Scaling Considerations

N/A

### Documentation Considerations

N/A

### Testing Considerations
This PR in itself is addition to our new testing tool.


### Compatibility Considerations

N/A

### Upgrade Considerations

N/A
