### PR TITLE
feat(ci): Divide lint/docs and add linear-history and no-fixups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,3 +398,76 @@ jobs:
         run: |
           PATH=$PATH:$GITHUB_WORKSPACE/bin
           yarn test:xs
+
+  linear-history:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.base.ref == 'master' &&
+      !contains(github.event.pull_request.labels.*.name, 'bypass:linear-history')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - shell: bash
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_LABEL: ${{ github.event.pull_request.head.label }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_LABEL: ${{ github.event.pull_request.base.label }}
+        run: |
+          merge_commits=$(git rev-list --merges "$BASE_SHA".."$HEAD_SHA")
+
+          if [ -n "$merge_commits" ]; then
+            echo "Error: merge commits found in $BASE_LABEL..$HEAD_LABEL"
+
+            for merge_commit in $merge_commits; do
+              echo "$merge_commit"
+            done
+
+            exit 1
+          fi
+
+          fixup_commits=
+          for commit in $(git rev-list $BASE_SHA..$HEAD_SHA); do
+            case $(git show --pretty=format:%s -s $commit) in fixup\!*|squash\!*|amend\!*)
+              fixup_commits="$fixup_commits\n$commit"
+              ;;
+            esac
+          done
+
+          if [ -n "$fixup_commits" ]; then
+            echo "Error: fixup/squash/amend commits found in $BASE_LABEL..$HEAD_LABEL"
+            echo -e "$fixup_commits"
+            exit 1
+          fi
+
+  no-fixup-commits:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.base.ref == 'master' &&
+      !contains(github.event.pull_request.labels.*.name, 'bypass:linear-history')
+
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for fixup commits
+        id: fixup-commits
+        run: |
+          if ! git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
+             echo "PR is not up to date with target branch, skipping fixup commit check"
+          elif [[ $(git rev-list "$BASE_SHA".."$HEAD_SHA" --grep="^\(fixup\|amend\|squash\)! " | wc -l) -eq 0 ]]; then
+            echo "No fixup/amend/squash commits found in commit history"
+          else
+            echo "fixup/amend/squash commits found in commit history"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
         uses: actions/checkout@v4
 
       # without this, setup-node errors on mismatched yarn versions
-      - run: corepack enable
+      - name: Enable corepack
+        run: corepack enable
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -44,6 +45,35 @@ jobs:
 
       - name: Run yarn lint
         run: yarn lint
+
+  docs:
+    # begin macro
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # without this, setup-node errors on mismatched yarn versions
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      # end macro
+
+      - name: Run yarn build
+        run: yarn build
 
       # build the API docs to verify it works
       - name: build API docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ on:
 
 jobs:
   lint:
-    name: lint
-
     # begin macro
 
     runs-on: ubuntu-latest
@@ -56,8 +54,6 @@ jobs:
         run: yarn docs:markdown-for-agoric-documentation-repo
 
   test:
-    name: test
-
     # begin macro
 
     runs-on: ${{ matrix.platform }}
@@ -98,8 +94,6 @@ jobs:
         run: yarn test
 
   test-async-hooks:
-    name: test-async-hooks
-
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -145,8 +139,6 @@ jobs:
         run: yarn test
 
   cover:
-    name: cover
-
     # begin macro
 
     runs-on: ${{ matrix.platform }}
@@ -181,8 +173,6 @@ jobs:
         run: yarn cover
 
   test262:
-    name: test262
-
     # begin macro
 
     runs-on: ${{ matrix.platform }}
@@ -217,8 +207,6 @@ jobs:
         run: exit 0 # TODO remove test262 from required tests for CI
 
   test-hermes:
-    name: test-hermes
-
     # begin macro
 
     runs-on: ${{ matrix.platform }}
@@ -252,8 +240,6 @@ jobs:
         run: yarn test:hermes
 
   viable-release:
-    name: viable-release
-
     # begin macro
 
     runs-on: ${{ matrix.platform }}
@@ -296,8 +282,6 @@ jobs:
         run: yarn lerna run --reject-cycles --concurrency 1 prepack
 
   test-xs:
-    name: test-xs
-
     # begin macro
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
These are CI workflow improvements.

I’ve copied no-fixups and linear-history from Agoric SDK, but removed their predicates on Mergify labels. We will simply see failures for these jobs for any change that is under review, so CI may have a couple failed jobs for otherwise ready changes.

I’ve also divided the lint job into separate lint and doc generation jobs in hopes that this takes some time off of CI. We should consolidate type checking so we do not duplicate effort for every package, but that remains a separate ambition.