### PR TITLE
fix(ses): Limit scope proxy exposure to discernably owned properties …

### DIFF
--- a/packages/ses/src/strict-scope-terminator.js
+++ b/packages/ses/src/strict-scope-terminator.js
@@ -6,7 +6,6 @@ import {
   create,
   freeze,
   getOwnPropertyDescriptors,
-  globalThis,
 } from './commons.js';
 import { assert } from './error/assert.js';
 
@@ -55,7 +54,7 @@ const scopeProxyHandlerProperties = {
 
   has(_shadow, prop) {
     // we must at least return true for all properties on the realm globalThis
-    return prop in globalThis;
+    return true;
   },
 
   // note: this is likely a bug of safari

--- a/packages/ses/test/compartment.test.js
+++ b/packages/ses/test/compartment.test.js
@@ -13,7 +13,7 @@ test('SES compartment does not see primal realm names', t => {
   // eslint-disable-next-line no-unused-vars
   const hidden = 1;
   const c = new Compartment();
-  t.throws(() => c.evaluate('hidden+1'), { instanceOf: ReferenceError });
+  t.is(c.evaluate('hidden'), undefined);
 });
 
 test('SES compartment also has compartments', t => {

--- a/packages/ses/test/evalTaming-default.test.js
+++ b/packages/ses/test/evalTaming-default.test.js
@@ -7,7 +7,7 @@ test('safe eval when evalTaming is undefined.', t => {
   // eslint-disable-next-line no-unused-vars
   const a = 0;
   // eslint-disable-next-line no-eval
-  t.throws(() => eval('a'));
+  t.is(eval('a'), undefined);
   // eslint-disable-next-line no-eval
   t.is(eval('1 + 1'), 2);
 

--- a/packages/ses/test/evalTaming-safe-eval.test.js
+++ b/packages/ses/test/evalTaming-safe-eval.test.js
@@ -7,7 +7,7 @@ test('safe eval when evalTaming is safe-eval.', t => {
   // eslint-disable-next-line no-unused-vars
   const a = 0;
   // eslint-disable-next-line no-eval
-  t.throws(() => eval('a'));
+  t.is(eval('a'), undefined);
   // eslint-disable-next-line no-eval
   t.is(eval('1 + 1'), 2);
   // eslint-disable-next-line no-eval

--- a/packages/ses/test/evalTaming-safeEval.test.js
+++ b/packages/ses/test/evalTaming-safeEval.test.js
@@ -8,7 +8,7 @@ test('safe eval when evalTaming is safeEval.', t => {
   // eslint-disable-next-line no-unused-vars
   const a = 0;
   // eslint-disable-next-line no-eval
-  t.throws(() => eval('a'));
+  t.is(eval('a'), undefined);
   // eslint-disable-next-line no-eval
   t.is(eval('1 + 1'), 2);
   // eslint-disable-next-line no-eval

--- a/packages/ses/test/global-lexicals-evaluate.test.js
+++ b/packages/ses/test/global-lexicals-evaluate.test.js
@@ -36,9 +36,7 @@ test('endowments prototypically inherited properties are not mentionable', t => 
     __options__: true,
   });
 
-  t.throws(() => compartment.evaluate('hello'), {
-    message: /hello is not defined/,
-  });
+  t.is(compartment.evaluate('hello'), undefined);
 });
 
 test('endowments prototypically inherited properties are not enumerable', t => {

--- a/packages/ses/test/make-eval-function.test.js
+++ b/packages/ses/test/make-eval-function.test.js
@@ -6,14 +6,14 @@ import test from 'ava';
 import { makeEvalFunction } from '../src/make-eval-function.js';
 import { makeSafeEvaluator } from '../src/make-safe-evaluator.js';
 
-test('makeEvalFunction - leak', t => {
+test('makeEvalFunction - no leak', t => {
   t.plan(8);
 
   const globalObject = {};
   const { safeEvaluate } = makeSafeEvaluator({ globalObject });
   const safeEval = makeEvalFunction(safeEvaluate);
 
-  t.throws(() => safeEval('none'), { instanceOf: ReferenceError });
+  t.is(safeEval('none'), undefined);
   t.is(safeEval('this.none'), undefined);
 
   globalThis.none = 5;

--- a/packages/ses/test/permits.test.js
+++ b/packages/ses/test/permits.test.js
@@ -10,18 +10,8 @@ test('indirect eval is possible', t => {
 
 test('SharedArrayBuffer should be removed because it is not permitted', t => {
   const c = new Compartment();
-  // we seem to manage both of these for properties that never existed
-  // in the first place
-  t.throws(() => c.evaluate('XYZ'), { instanceOf: ReferenceError });
-  t.is(c.evaluate('typeof XYZ'), 'undefined');
-  const have = typeof SharedArrayBuffer !== 'undefined';
-  if (have) {
-    // we ideally want both of these, but the realms magic can only
-    // manage one at a time (for properties that previously existed but
-    // which were removed by the permits check)
-    // t.throws(() => c.evaluate('SharedArrayBuffer'), ReferenceError);
-    t.is(c.evaluate('typeof SharedArrayBuffer'), 'undefined');
-  }
+  t.is(c.evaluate('typeof SharedArrayBuffer'), 'undefined');
+  t.is(c.evaluate('SharedArrayBuffer'), undefined);
 });
 
 test('remove RegExp.prototype.compile', t => {

--- a/packages/ses/test/ses.test.js
+++ b/packages/ses/test/ses.test.js
@@ -71,7 +71,7 @@ test('create', t => {
 test('SES compartment does not see primal realm names', t => {
   const hidden = 1; // eslint-disable-line no-unused-vars
   const c = new Compartment();
-  t.throws(() => c.evaluate('hidden+1'), { instanceOf: ReferenceError });
+  t.is(c.evaluate('hidden'), undefined);
 });
 
 test('SES compartment also has compartments', t => {

--- a/packages/ses/test/strict-scope-terminator.test.js
+++ b/packages/ses/test/strict-scope-terminator.test.js
@@ -1,13 +1,13 @@
 import test from 'ava';
 import { strictScopeTerminator } from '../src/strict-scope-terminator.js';
 
-test('strictScopeTerminator/get - always has start compartment properties but they are undefined', t => {
+test('strictScopeTerminator/get - has all properties and they are undefined', t => {
   t.plan(4);
 
   t.is(Reflect.has(strictScopeTerminator, 'eval'), true);
   t.is(Reflect.get(strictScopeTerminator, 'eval'), undefined);
 
-  t.is(Reflect.has(strictScopeTerminator, 'xyz'), false);
+  t.is(Reflect.has(strictScopeTerminator, 'xyz'), true);
   t.is(Reflect.get(strictScopeTerminator, 'xyz'), undefined);
 });
 
@@ -30,7 +30,7 @@ test('strictScopeTerminator/getPrototypeOf - has null prototype', t => {
   t.is(Reflect.getPrototypeOf(strictScopeTerminator), null);
 });
 
-test('strictScopeTerminator/getOwnPropertyDescriptor - always has start compartment properties but provides no prop desc', t => {
+test('strictScopeTerminator/getOwnPropertyDescriptor - traps all properties and provides no prop desc', t => {
   t.plan(9);
 
   const originalWarn = console.warn;
@@ -46,7 +46,7 @@ test('strictScopeTerminator/getOwnPropertyDescriptor - always has start compartm
     undefined,
   );
   t.is(didWarn, 1);
-  t.is(Reflect.has(strictScopeTerminator, 'xyz'), false);
+  t.is(Reflect.has(strictScopeTerminator, 'xyz'), true);
   t.is(didWarn, 1);
   t.is(
     Reflect.getOwnPropertyDescriptor(strictScopeTerminator, 'xyz'),

--- a/packages/ses/test/typeof.test.js
+++ b/packages/ses/test/typeof.test.js
@@ -7,9 +7,7 @@ test('typeof', t => {
 
   const c = new Compartment();
 
-  t.throws(() => c.evaluate('DEFINITELY_NOT_DEFINED'), {
-    instanceOf: ReferenceError,
-  });
+  t.is(c.evaluate('DEFINITELY_NOT_DEFINED'), undefined);
   t.is(c.evaluate('typeof DEFINITELY_NOT_DEFINED'), 'undefined');
 
   t.is(c.evaluate('typeof 4'), 'number');


### PR DESCRIPTION
…of host globalThis

Closes #1305

## Description

This change circles back to an old observation about the scope proxy, where we deliberately allow guest code to sense which properties of the host globalThis exist in order to provide a higher fidelity behavior for `typeof` style feature detection. This change reflects a shift in our preference to avoid this information leak at the expense of ecosystem compatibility. We have come to believe closing the leak is worth the expense, especially given that the work-around of checking `globalThis` properties explicitly has become a norm.

### Security Considerations

This change increases confinement in exchange for a minor loss of ecosystem compatibility.

### Scaling Considerations

None.

### Documentation Considerations

Forthcoming.

### Testing Considerations

This change will be validated with an integration PR with Agoric SDK to expose any extant compatibility risks.

### Compatibility Considerations

This change may uncover existing code that relied on `typeof` for feature detection, which is not strictly compatible. We are treating these considerations as bug fixes.

### Upgrade Considerations

These changes will become observable to vats upon restart after this software arrives in an Agoric chain software update.