### PR TITLE
chore: Release 2025-03-19

### DIFF
--- a/packages/benchmark/CHANGELOG.md
+++ b/packages/benchmark/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+### 0.1.1 (2025-03-24)
+
+
+### Bug Fixes
+
+* add echo to run-test.sh ([0f9bd62](https://github.com/endojs/endo/commit/0f9bd62f853758ea70d11e67ec333924d2c7da3a))
+* **camelCase:** Change  to ([b5a9bf0](https://github.com/endojs/endo/commit/b5a9bf0944c6d96f630e7a1dd5c83f40d371a988))
+* **time:** change the function name to get time ([da0d44f](https://github.com/endojs/endo/commit/da0d44fdfe5de0c96abe1493c2ddf23d8cabff20))

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/benchmark",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Endo benchmarking ",
   "keywords": [],

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.0](https://github.com/endojs/endo/compare/@endo/bundle-source@3.5.1...@endo/bundle-source@4.0.0) (2025-03-24)
+
+
+### ⚠ BREAKING CHANGES
+
+* **bundle-source:** * This change replaces the implementation of getExport
+and nestedEvaluate bundle formats in some ways that are not strictly
+backward-compatible.
+First, the Rollup implementation used different
+heuristics to distinguish a CommonJS module from an ESM, and the new
+algorithm is more in line with precedent as set in Node.js 18.
+Second, the Endo implementation does not support live export bindings.
+Third, the Endo implementation does not tolerate missing dependencies
+or devDependencies.
+Any treatment on the generated source that is not just evaluation is
+fragile and likely to break, and although we make no guarantees about
+stability of the generated string, this change definitely frustrates
+some usage in practice, which we have already addressed in Agoric SDK.
+This change preserves the assumption that getExport and nestedEvaluate
+may reach for devDependencies of the entry package by default.
+
+### Features
+
+* **bundle-source:** Replace getExport and nestedEvaluate implementations with endoScript implementation ([aae5655](https://github.com/endojs/endo/commit/aae5655f889ca2b504096eccfbede0be0dcf22ac))
+
+
+
 ### [3.5.1](https://github.com/endojs/endo/compare/@endo/bundle-source@3.5.0...@endo/bundle-source@3.5.1) (2025-01-24)
 
 **Note:** Version bump only for package @endo/bundle-source

--- a/packages/bundle-source/NEWS.md
+++ b/packages/bundle-source/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/bundle-source`:
 
-# Next release
+# v4.0.0 (2025-03-19)
 
 - Replaces the implementation for the `nestedEvaluate` and `getExport`
   formats with one based on Endo's Compartment Mapper instead of Rollup,

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "3.5.1",
+  "version": "4.0.0",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.4.5](https://github.com/endojs/endo/compare/@endo/captp@4.4.4...@endo/captp@4.4.5) (2025-03-24)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ### [4.4.4](https://github.com/endojs/endo/compare/@endo/captp@4.4.3...@endo/captp@4.4.4) (2025-01-24)
 
 **Note:** Version bump only for package @endo/captp

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.14](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.13...@endo/check-bundle@1.0.14) (2025-03-24)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [1.0.13](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.12...@endo/check-bundle@1.0.13) (2025-01-24)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.8](https://github.com/endojs/endo/compare/@endo/cli@2.3.7...@endo/cli@2.3.8) (2025-03-24)
+
+
+### Bug Fixes
+
+* **cli:** tolerate [#2702](https://github.com/endojs/endo/issues/2702) stderr noise ([#2704](https://github.com/endojs/endo/issues/2704)) ([1bf94a1](https://github.com/endojs/endo/commit/1bf94a146bac85ad1efc1429986368f0dacf2f36))
+* **daemon,cli:** fix [#2700](https://github.com/endojs/endo/issues/2700) use endo/init to prepare async hooks ([aacefe4](https://github.com/endojs/endo/commit/aacefe4ab6266d1096db7939abbed95bbda6f4f5))
+
+
+
 ### [2.3.7](https://github.com/endojs/endo/compare/@endo/cli@2.3.6...@endo/cli@2.3.7) (2025-01-24)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.10](https://github.com/endojs/endo/compare/@endo/common@1.2.9...@endo/common@1.2.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/common
+
+
+
+
+
 ### [1.2.9](https://github.com/endojs/endo/compare/@endo/common@1.2.8...@endo/common@1.2.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/common",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "common low level utilities",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.6.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.5.0...@endo/compartment-mapper@1.6.0) (2025-03-24)
+
+
+### Features
+
+* **compartment-mapper:** a simple version of allowing exports override via define semantics with little new consequences ([8e33f8c](https://github.com/endojs/endo/commit/8e33f8c8c1520e726be36b281ae686e7a95d8870))
+* **compartment-mapper:** add option for custom logger to various functions ([493b4c2](https://github.com/endojs/endo/commit/493b4c24714189c884cb5b648f876cb3ee5ad21c))
+* **compartment-mapper:** cjs - allow overwriting exports field with define semantics ([7b1785c](https://github.com/endojs/endo/commit/7b1785c8a0c93a497f22c3f2a963d2c1acc33cc7))
+* **compartment-mapper:** makeFunctor to go with makeScript from makeBundle ([ee87476](https://github.com/endojs/endo/commit/ee87476e0efcf8f6e412eec93eba5f3853ead6f3))
+
+
+### Bug Fixes
+
+* **compartment-mapper:** Make bundled code more robust against primordial replacement/manipulation ([#2725](https://github.com/endojs/endo/issues/2725)) ([9aac805](https://github.com/endojs/endo/commit/9aac8051275d031d8d6e84c34d20aa9c3c9b64a8)), closes [/github.com/endojs/endo/pull/2707#discussion_r1953346697](https://github.com/endojs//github.com/endojs/endo/pull/2707/issues/discussion_r1953346697)
+* **compartment-mapper:** make the cjs support for `defineProperty(module, 'exports'` work ([433bfbb](https://github.com/endojs/endo/commit/433bfbb1c44f88baf852228bb012972ba2c0cbc0))
+* **compartment-mapper:** sync module transforms in bundle.js ([1d29043](https://github.com/endojs/endo/commit/1d29043e8de08091b1b59059e91eba3be29983b7))
+
+
+
 ## [1.5.0](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.4.0...@endo/compartment-mapper@1.5.0) (2025-01-24)
 
 

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/compartment-mapper`:
 
-# Next release
+# v1.6.0 (2025-03-11)
 
 - Accommodates CommonJS modules that use `defineProperty` on `exports`.
 

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.4.8](https://github.com/endojs/endo/compare/@endo/daemon@2.4.7...@endo/daemon@2.4.8) (2025-03-24)
+
+
+### Bug Fixes
+
+* **daemon,cli:** fix [#2700](https://github.com/endojs/endo/issues/2700) use endo/init to prepare async hooks ([aacefe4](https://github.com/endojs/endo/commit/aacefe4ab6266d1096db7939abbed95bbda6f4f5))
+
+
+
 ### [2.4.7](https://github.com/endojs/endo/compare/@endo/daemon@2.4.6...@endo/daemon@2.4.7) (2025-01-24)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.10](https://github.com/endojs/endo/compare/@endo/errors@1.2.9...@endo/errors@1.2.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/errors
+
+
+
+
+
 ### [1.2.9](https://github.com/endojs/endo/compare/@endo/errors@1.2.8...@endo/errors@1.2.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/errors

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/errors",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/evasive-transform/CHANGELOG.md
+++ b/packages/evasive-transform/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.0](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.4...@endo/evasive-transform@1.4.0) (2025-03-24)
+
+
+### Features
+
+* **evasive-transform:** Preserve format with Babel ([ee78005](https://github.com/endojs/endo/commit/ee780058d3b08a21e0eaa76f0d8fb99238295a17))
+
+
+
 ### [1.3.4](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.3.3...@endo/evasive-transform@1.3.4) (2025-01-24)
 
 **Note:** Version bump only for package @endo/evasive-transform

--- a/packages/evasive-transform/NEWS.md
+++ b/packages/evasive-transform/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/evasive-transform`:
 
-# Next release
+# v1.4.0 (2025-03-11)
 
 - Adds a `sourceMap` option so that the generated sourcemap can project back to
   the original source code without `unmapLoc`.

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/evasive-transform",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Source transforms to evade SES censorship",
   "keywords": [
     "ses",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.1](https://github.com/endojs/endo/compare/@endo/eventual-send@1.3.0...@endo/eventual-send@1.3.1) (2025-03-24)
+
+**Note:** Version bump only for package @endo/eventual-send
+
+
+
+
+
 ## [1.3.0](https://github.com/endojs/endo/compare/@endo/eventual-send@1.2.8...@endo/eventual-send@1.3.0) (2025-01-24)
 
 

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.9](https://github.com/endojs/endo/compare/@endo/exo@1.5.8...@endo/exo@1.5.9) (2025-03-24)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.8](https://github.com/endojs/endo/compare/@endo/exo@1.5.7...@endo/exo@1.5.8) (2025-01-24)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.11](https://github.com/endojs/endo/compare/@endo/far@1.1.10...@endo/far@1.1.11) (2025-03-24)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.10](https://github.com/endojs/endo/compare/@endo/far@1.1.9...@endo/far@1.1.10) (2025-01-24)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/immutable-arraybuffer/CHANGELOG.md
+++ b/packages/immutable-arraybuffer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.4](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@0.2.3...@endo/immutable-arraybuffer@0.2.4) (2025-03-24)
+
+**Note:** Version bump only for package @endo/immutable-arraybuffer
+
+
+
+
+
 ### [0.2.3](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@0.2.2...@endo/immutable-arraybuffer@0.2.3) (2025-01-24)
 
 

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/immutable-arraybuffer",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Immutable ArrayBuffer",
   "keywords": [],

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.0](https://github.com/endojs/endo/compare/@endo/import-bundle@1.3.3...@endo/import-bundle@1.4.0) (2025-03-24)
+
+
+### Features
+
+* **import-bundle:** Add typedImportBundle (instead of type on importBundle) ([6cf51fe](https://github.com/endojs/endo/commit/6cf51fec20ae04bebd3a1d80543ccc070aa6923c))
+* **import-bundle:** Test bundle format [#2719](https://github.com/endojs/endo/issues/2719) ([17ec018](https://github.com/endojs/endo/commit/17ec018b68f0340d24296b62b0917b9a3127a623))
+* **types:** ImportableBundle ([d9c11e1](https://github.com/endojs/endo/commit/d9c11e156c45715620ada45401923a722a8e9317))
+
+
+### Bug Fixes
+
+* **import-bundle:** Generalize type of importBundle to given generic or any ([d3304eb](https://github.com/endojs/endo/commit/d3304eb97246b5db5c36572998feefa914cf75f2))
+
+
+
 ### [1.3.3](https://github.com/endojs/endo/compare/@endo/import-bundle@1.3.2...@endo/import-bundle@1.3.3) (2025-01-24)
 
 **Note:** Version bump only for package @endo/import-bundle

--- a/packages/import-bundle/NEWS.md
+++ b/packages/import-bundle/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes to `@endo/import-bundle`:
 
-# Next release
+# v1.4.0 (2025-03-11)
 
 - Adds support for `test` format bundles, which simply return a promise for an
   object that resembles a module exports namespace with the objects specified

--- a/packages/import-bundle/NEWS.md
+++ b/packages/import-bundle/NEWS.md
@@ -6,6 +6,8 @@ User-visible changes to `@endo/import-bundle`:
   object that resembles a module exports namespace with the objects specified
   on the symbol-named property @exports, which is deliberately not JSON
   serializable or passable.
+- Exports a `typedImportBundle<ExpectedNamespaceType>` function so consumers
+  can subscribe to a narrower type.
 
 # v1.3.0 (2024-10-10)
 

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "load modules created by @endo/bundle-source",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -18,16 +18,8 @@ import { wrapInescapableCompartment } from './compartment-wrapper.js';
  * @typedef {import('@endo/bundle-source').BundleSourceResult<any> | {moduleFormat: 'test'}} ImportableBundle
  */
 
-/**
- * importBundle takes the output of `bundleSource` or `bundleTestExports`, and returns a namespace
- * object (with .default, and maybe other properties for named exports)
- *
- * @template [T=any]
- * @param {ImportableBundle} bundle
- * @param {object} [options]
- * @param {object} [powers]
- * @returns {Promise<T>}
- */
+// Adding a type signature in-place proved difficult to migrate in-place.
+// See typedImportBundle below.
 export async function importBundle(bundle, options = {}, powers = {}) {
   await null;
   const {
@@ -193,6 +185,22 @@ export async function importBundle(bundle, options = {}, powers = {}) {
     return namespace;
   }
 }
+
+/**
+ * typedImportBundle<Expected> takes the output of `bundleSource` or
+ * `bundleTestExports`, and returns a namespace object, with .default, and
+ * maybe other properties for named exports.
+ *
+ * This is the intended signature but produces a type that is not suitable
+ * in integration with legacy code of Agoric SDK.
+ *
+ * @template [T=any]
+ * @param {ImportableBundle} bundle
+ * @param {object} [options]
+ * @param {object} [powers]
+ * @returns {Promise<T>}
+ */
+export const typedImportBundle = importBundle;
 
 /**
  * A utility function for producing test bundles, which are not serializable

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -22,10 +22,11 @@ import { wrapInescapableCompartment } from './compartment-wrapper.js';
  * importBundle takes the output of `bundleSource` or `bundleTestExports`, and returns a namespace
  * object (with .default, and maybe other properties for named exports)
  *
+ * @template [T=any]
  * @param {ImportableBundle} bundle
  * @param {object} [options]
  * @param {object} [powers]
- * @returns {Promise<Record<string, any>>}
+ * @returns {Promise<T>}
  */
 export async function importBundle(bundle, options = {}, powers = {}) {
   await null;

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.9](https://github.com/endojs/endo/compare/@endo/init@1.1.8...@endo/init@1.1.9) (2025-03-24)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [1.1.8](https://github.com/endojs/endo/compare/@endo/init@1.1.7...@endo/init@1.1.8) (2025-01-24)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.15](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.14...@endo/lockdown@1.0.15) (2025-03-24)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [1.0.14](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.13...@endo/lockdown@1.0.14) (2025-01-24)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.10](https://github.com/endojs/endo/compare/@endo/lp32@1.1.9...@endo/lp32@1.1.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [1.1.9](https://github.com/endojs/endo/compare/@endo/lp32@1.1.8...@endo/lp32@1.1.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.4](https://github.com/endojs/endo/compare/@endo/marshal@1.6.3...@endo/marshal@1.6.4) (2025-03-24)
+
+**Note:** Version bump only for package @endo/marshal
+
+
+
+
+
 ### [1.6.3](https://github.com/endojs/endo/compare/@endo/marshal@1.6.2...@endo/marshal@1.6.3) (2025-01-24)
 
 **Note:** Version bump only for package @endo/marshal

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/memoize/CHANGELOG.md
+++ b/packages/memoize/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.10](https://github.com/endojs/endo/compare/@endo/memoize@1.1.9...@endo/memoize@1.1.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/memoize
+
+
+
+
+
 ### [1.1.9](https://github.com/endojs/endo/compare/@endo/memoize@1.1.8...@endo/memoize@1.1.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/memoize

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/memoize",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Safe function memoization",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/module-source/CHANGELOG.md
+++ b/packages/module-source/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.0](https://github.com/endojs/endo/compare/@endo/module-source@1.2.0...@endo/module-source@1.3.0) (2025-03-24)
+
+
+### Features
+
+* **module-source:** Preserve format with Babel integration ([b97b306](https://github.com/endojs/endo/commit/b97b306a48f5166ef156a965a2ece734c956ecfb))
+
+
+
 ## [1.2.0](https://github.com/endojs/endo/compare/@endo/module-source@1.1.2...@endo/module-source@1.2.0) (2025-01-24)
 
 

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/module-source",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Ponyfill for the SES ModuleSource and module-to-program transformer",
   "keywords": [
     "ses",

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.1.0](https://github.com/endojs/endo/compare/@endo/nat@5.0.14...@endo/nat@5.1.0) (2025-03-24)
+
+
+### Features
+
+* **patterns:** M.containerHas(el,n) to support want patterns ([#2710](https://github.com/endojs/endo/issues/2710)) ([01529a5](https://github.com/endojs/endo/commit/01529a53fae5c4259901fdf85335013939aa09d2)), closes [#2002](https://github.com/endojs/endo/issues/2002) [#2008](https://github.com/endojs/endo/issues/2008) [#2113](https://github.com/endojs/endo/issues/2113) [#1739](https://github.com/endojs/endo/issues/1739) [#2008](https://github.com/endojs/endo/issues/2008) [#2008](https://github.com/endojs/endo/issues/2008) [#2002](https://github.com/endojs/endo/issues/2002) [#2008](https://github.com/endojs/endo/issues/2008)
+
+
+
 ### [5.0.14](https://github.com/endojs/endo/compare/@endo/nat@5.0.13...@endo/nat@5.0.14) (2025-01-24)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "5.0.14",
+  "version": "5.1.0",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.15](https://github.com/endojs/endo/compare/@endo/netstring@1.0.14...@endo/netstring@1.0.15) (2025-03-24)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [1.0.14](https://github.com/endojs/endo/compare/@endo/netstring@1.0.13...@endo/netstring@1.0.14) (2025-01-24)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.0](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.8...@endo/pass-style@1.5.0) (2025-03-24)
+
+
+### Features
+
+* **patterns:** M.containerHas(el,n) to support want patterns ([#2710](https://github.com/endojs/endo/issues/2710)) ([01529a5](https://github.com/endojs/endo/commit/01529a53fae5c4259901fdf85335013939aa09d2)), closes [#2002](https://github.com/endojs/endo/issues/2002) [#2008](https://github.com/endojs/endo/issues/2008) [#2113](https://github.com/endojs/endo/issues/2113) [#1739](https://github.com/endojs/endo/issues/1739) [#2008](https://github.com/endojs/endo/issues/2008) [#2008](https://github.com/endojs/endo/issues/2008) [#2002](https://github.com/endojs/endo/issues/2002) [#2008](https://github.com/endojs/endo/issues/2008)
+
+
+
 ### [1.4.8](https://github.com/endojs/endo/compare/@endo/pass-style@1.4.7...@endo/pass-style@1.4.8) (2025-01-24)
 
 **Note:** Version bump only for package @endo/pass-style

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.4.8",
+  "version": "1.5.0",
   "description": "Defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.0](https://github.com/endojs/endo/compare/@endo/patterns@1.4.8...@endo/patterns@1.5.0) (2025-03-24)
+
+
+### Features
+
+* **patterns:** M.containerHas(el,n) to support want patterns ([#2710](https://github.com/endojs/endo/issues/2710)) ([01529a5](https://github.com/endojs/endo/commit/01529a53fae5c4259901fdf85335013939aa09d2)), closes [#2002](https://github.com/endojs/endo/issues/2002) [#2008](https://github.com/endojs/endo/issues/2008) [#2113](https://github.com/endojs/endo/issues/2113) [#1739](https://github.com/endojs/endo/issues/1739) [#2008](https://github.com/endojs/endo/issues/2008) [#2008](https://github.com/endojs/endo/issues/2008) [#2002](https://github.com/endojs/endo/issues/2002) [#2008](https://github.com/endojs/endo/issues/2008)
+
+
+### Bug Fixes
+
+* **patterns:** No default chaining ([e0dc339](https://github.com/endojs/endo/commit/e0dc339d9e72687ed6388ce0702d8727b9a228b5))
+
+
+
 ### [1.4.8](https://github.com/endojs/endo/compare/@endo/patterns@1.4.7...@endo/patterns@1.4.8) (2025-01-24)
 
 **Note:** Version bump only for package @endo/patterns

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/patterns`:
 
-# Next release
+# v1.5.0 (2025-03-11)
 
 - New pattern: `M.containerHas(elementPatt, bound = 1n)` motivated to support want patterns in Zoe, to pull out only `bound` number of elements that match `elementPatt`. `bound` must be a positive bigint.
 - Closely related, `@endo/patterns` now exports `containerHasSplit` to support ERTP's use of `M.containerHas` on non-fungible (`set`, `copySet`) and semifungible (`copyBag`) assets, respectively. See https://github.com/Agoric/agoric-sdk/pull/10952 .

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.4.8",
+  "version": "1.5.0",
   "description": "Pattern matching for Passable objects, expressed as Passable data",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -1293,9 +1293,9 @@ const makePatternKit = () => {
       if (count < bound) {
         if (matches(element, elementPatt)) {
           count += 1n;
-          inResults?.push(element);
-        } else {
-          outResults?.push(element);
+          if (inResults) inResults.push(element);
+        } else if (outResults) {
+          outResults.push(element);
         }
       } else if (outResults === undefined) {
         break;
@@ -1341,15 +1341,15 @@ const makePatternKit = () => {
         if (matches(element, elementPatt)) {
           if (num <= numRest) {
             count += num;
-            inResults?.push([element, num]);
+            if (inResults) inResults.push([element, num]);
           } else {
             const numIn = numRest;
             count += numIn;
-            inResults?.push([element, numRest]);
-            outResults?.push([element, num - numRest]);
+            if (inResults) inResults.push([element, numRest]);
+            if (outResults) outResults.push([element, num - numRest]);
           }
-        } else {
-          outResults?.push([element, num]);
+        } else if (outResults) {
+          outResults.push([element, num]);
         }
       } else if (outResults === undefined) {
         break;

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.10](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.9...@endo/promise-kit@1.1.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [1.1.9](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.8...@endo/promise-kit@1.1.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Helper for making promises",
   "keywords": [
     "promise"

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.10](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.9...@endo/ses-ava@1.2.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [1.2.9](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.8...@endo/ses-ava@1.2.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.12.0](https://github.com/endojs/endo/compare/ses@1.11.0...ses@1.12.0) (2025-03-24)
+
+
+### Features
+
+* **ses:** add AsyncGeneratorFunctionInstance to commons ([07516f5](https://github.com/endojs/endo/commit/07516f5892221258ec0d4e02848047b5ad94808a))
+* **ses:** bundle and export shim compatible with Hermes compiler ([cafc398](https://github.com/endojs/endo/commit/cafc398d91e9b8c99502e25fb6d301e0841112a9))
+* **ses:** create async arrow function transform with Babel for Hermes bundle ([654791e](https://github.com/endojs/endo/commit/654791e91c687d4c38562efc411bc90e67bb81e3))
+* **ses:** include async generators in anonymous intrinsics if supported ([56ae460](https://github.com/endojs/endo/commit/56ae46002452340b89b77943674a4e406657d915))
+* **ses:** support async generators in Hermes transform for CSP ([24bbd5c](https://github.com/endojs/endo/commit/24bbd5caff0a4d4b6478d470970c020815fb5da7))
+* **ses:** support CSP in commons AsyncGeneratorFunctionInstance ([188c5d4](https://github.com/endojs/endo/commit/188c5d4d4795effbe752c54c61177c8776333de1))
+* **ses:** tame async generator function constructors if supported ([eda8a61](https://github.com/endojs/endo/commit/eda8a61846852009ad19e6f39f6c3192ba048f99))
+
+
+### Bug Fixes
+
+* **compartment-mapper:** sync module transforms in bundle.js ([1d29043](https://github.com/endojs/endo/commit/1d29043e8de08091b1b59059e91eba3be29983b7))
+* **ses:** Limit scope proxy exposure to discernably owned properties of host globalThis ([9ced73a](https://github.com/endojs/endo/commit/9ced73a97dc2e86caedf4cbd6c4236d4b5e9236d)), closes [#1305](https://github.com/endojs/endo/issues/1305)
+* **ses:** lockdown options should be kebob-case ([#2739](https://github.com/endojs/endo/issues/2739)) ([85483c0](https://github.com/endojs/endo/commit/85483c0fd34a9a071e0af66d362cd7e930de5bcc)), closes [#961](https://github.com/endojs/endo/issues/961) [#2690](https://github.com/endojs/endo/issues/2690) [#2723](https://github.com/endojs/endo/issues/2723) [#961](https://github.com/endojs/endo/issues/961) [#961](https://github.com/endojs/endo/issues/961) [#2723](https://github.com/endojs/endo/issues/2723) [#2690](https://github.com/endojs/endo/issues/2690)
+
+
+
 ## [1.11.0](https://github.com/endojs/endo/compare/ses@1.10.0...ses@1.11.0) (2025-01-24)
 
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -1,14 +1,23 @@
 User-visible changes in `ses`:
 
-# Next release
+# v1.12.0 (2025-03-11)
 
-The `evalTaming:` option values are renamed
-- from `'safeEval'`, `'unsafeEval'`, and `'noEval'`
-- to `'safe-eval'`, `'unsafe-eval'`, and `'no-eval'`
+- The `evalTaming:` option values are renamed:
 
-in order to follow the convention that lockdown option values use kebob-case
-rather than camelCase. To avoid breaking old programs during the transition,
-the old names are deprecated, but continue to work for now.
+  - from `'safeEval'`, `'unsafeEval'`, and `'noEval'`
+  - to `'safe-eval'`, `'unsafe-eval'`, and `'no-eval'`
+
+  in order to follow the convention that lockdown option values use kebob-case
+  rather than camelCase. To avoid breaking old programs during the transition,
+  the old names are deprecated, but continue to work for now.
+
+- Evaluating a non-lexical name that is also absent on the global object of a
+  compartment no longer throws a `ReferenceError` and instead produces
+  `undefined` because it proves impossible to do so without revealing what
+  properties exist on the host `globalThis` to compartmentalized code with a
+  shim.
+  This is a divergence from the expected behavior of a native Hardened
+  JavaScript implementation, like XS.
 
 # v1.11.0 (2025-01-23)
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",

--- a/packages/skel/CHANGELOG.md
+++ b/packages/skel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.10](https://github.com/endojs/endo/compare/@endo/skel@1.1.9...@endo/skel@1.1.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/skel
+
+
+
+
+
 ### [1.1.9](https://github.com/endojs/endo/compare/@endo/skel@1.1.8...@endo/skel@1.1.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/skel

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/skel",
   "private": true,
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": null,
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.10](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.9...@endo/stream-node@1.1.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [1.1.9](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.8...@endo/stream-node@1.1.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.15](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.14...@endo/stream-types-test@1.0.15) (2025-03-24)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [1.0.14](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.13...@endo/stream-types-test@1.0.14) (2025-01-24)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.10](https://github.com/endojs/endo/compare/@endo/stream@1.2.9...@endo/stream@1.2.10) (2025-03-24)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [1.2.9](https://github.com/endojs/endo/compare/@endo/stream@1.2.8...@endo/stream@1.2.9) (2025-01-24)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.45](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.44...@endo/test262-runner@0.1.45) (2025-03-24)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.44](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.43...@endo/test262-runner@0.1.44) (2025-01-24)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "private": true,
   "description": "Hardened JavaScript Test262 Runner",
   "keywords": [],


### PR DESCRIPTION
# `ses` v1.12.0

- The `evalTaming:` option values are renamed:

  - from `'safeEval'`, `'unsafeEval'`, and `'noEval'`
  - to `'safe-eval'`, `'unsafe-eval'`, and `'no-eval'`

  in order to follow the convention that lockdown option values use kebob-case rather than camelCase. To avoid breaking old programs during the transition, the old names are deprecated, but continue to work for now.

- The value of expressions like `typeof unlikelyGlobal` is now `undefined` instead of producing a `ReferenceError` because it proves impossible to do so without revealing what properties exist on the host `globalThis` to compartmentalized code.

# `@endo/patterns` v1.5.0

- New pattern: `M.containerHas(elementPatt, bound = 1n)` motivated to support want patterns in Zoe, to pull out only `bound` number of elements that match `elementPatt`. `bound` must be a positive bigint.

- Closely related, `@endo/patterns` now exports `containerHasSplit` to support ERTP's use of `M.containerHas` on non-fungible (`set`, `copySet`) and semifungible (`copyBag`) assets, respectively. See https://github.com/Agoric/agoric-sdk/pull/10952 .

# `@endo/import-bundle` v1.4.0

- Adds support for `test` format bundles, which simply return a promise for an object that resembles a module exports namespace with the objects specified on the symbol-named property @exports, which is deliberately not JSON serializable or passable.
- Adds a `typedImportBundle<ExpectedExportsNamespace>` function with a proper type signature, to provide a narrower signature than `any` without disrupting existing usage.

# `@endo/bundle-source` v4.0.0

- Replaces the implementation for the `nestedEvaluate` and `getExport` formats with one based on Endo's Compartment Mapper instead of Rollup, in order to obviate the need to reconcile source map transforms between Rollup and the underlying Babel generator.  As a consequence, we no longer generate a source map for the bundle, but Babel ensures that we preserve line and column numbers between the original source and the bundled source.

# `@endo/compartment-mapper` v1.6.0

- Accommodates CommonJS modules that use `defineProperty` on `exports`.

- Divides the role of `makeBundle` into `makeScript` and `makeFunctor`.  The new `makeScript` replaces `makeBundle` without breaking changes, producing a JavaScript string that is suitable as a `<script>` tag in a web page.
- The new `makeFunctor` produces a JavaScript string that, when evaluated, produces a partially applied function, so the caller can provide runtime options.
- Both `makeScript` and `makeFunctor` now accept `format`, `useEvaluate` and `sourceUrlPrefix` options.
- The functor produced by `makeFunctor` now accepts `evaluate`, `require`, and `sourceUrlPrefix` runtime options.
- Both `makeScript` and `makeFunctor` now accept a `format` option.  Specifiying the `"cjs"` format allows the bundle to exit to the host's CommonJS `require` for host modules.
- Adds `sourceDirname` to compartment descriptors in the compartment maps generated by `mapNodeModules` and uses these to provide better source URL comments for bundles generated by `makeScript` and `makeFunctor`, by default.

These changes collectively allow us to replace the implementation of `nestedEvaluate` and `getExports` formats in `@endo/bundle-source`, including the preservation of useful line numbers and file names in stack traces.

- `mapNodeModules`, `importLocation` and `loadLocation` now accept a `log` option for users to define a custom logging function. As of this writing, _only `mapNodeModules`_ will potentially call this function if provided.  Expansion of log messaging and support for the `log` option in more APIs is expected _in the future_.

# `@endo/evasive-transform` v1.4.0

- Adds a `sourceMap` option so that the generated sourcemap can project back to the original source code without `unmapLoc`.
- Removes support for sourcemap `unmapLoc` because it is not used by contemporary Endo packages.  The option is now ignored.

