### PR TITLE
fix(ses,lockdown): make filenames in stacktraces clickable

### DIFF
--- a/packages/lockdown/commit-debug.js
+++ b/packages/lockdown/commit-debug.js
@@ -21,13 +21,13 @@ lockdown({
   // NOTE TO REVIEWERS: If you see the following line commented out,
   // this may be a development accident that should be fixed before merging.
   //
-  errorTaming: 'unsafe-debug',
+  errorTaming: 'unsafe',
 
   // The default `{stackFiltering: 'concise'}` setting usually makes for a
   // better debugging experience, by severely reducing the noisy distractions
   // of the normal verbose stack traces. Which is why we comment
-  // out the `'verbose'` setting is commented out below. However, some
-  // tools look for the full filename that it expects in order
+  // out the other settings below. However, some
+  // tools look for the full filename path that it expects in order
   // to fetch the source text for diagnostics,
   //
   // Another reason for not commenting it out: The cause
@@ -36,10 +36,14 @@ lockdown({
   // uncomment out the following line. But please do not commit it in that
   // state.
   //
-  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
-  // this may be a development accident that MUST be fixed before merging.
+  // NOTE TO REVIEWERS: If you see the `stackFiltering` settings *not*
+  // commented out below, this may be a development accident that MUST be
+  // fixed before merging.
   //
-  // stackFiltering: 'verbose',
+  // stackFiltering: 'concise', // Omit frames and shorten paths
+  // stackFiltering: 'omit-frames', // Only omit frames. Do not shorten paths
+  // stackFiltering: 'shorten-paths', // Only shorten paths. Do not omit frames
+  // stackFiltering: 'verbose', // Do not omit frames or shorten paths
 
   // The default `{overrideTaming: 'moderate'}` setting does not hurt the
   // debugging experience much. But it will introduce noise into, for example,

--- a/packages/lockdown/pre.js
+++ b/packages/lockdown/pre.js
@@ -102,13 +102,12 @@ export const lockdown = defaultOptions => {
       // this may be a development accident that MUST be fixed before merging.
       //
       // errorTaming: 'unsafe',
-      //
-      //
+
       // The default `{stackFiltering: 'concise'}` setting usually makes for a
       // better debugging experience, by severely reducing the noisy distractions
       // of the normal verbose stack traces. Which is why we comment
-      // out the `'verbose'` setting is commented out below. However, some
-      // tools look for the full filename that it expects in order
+      // out the other settings below. However, some
+      // tools look for the full filename path that it expects in order
       // to fetch the source text for diagnostics,
       //
       // Another reason for not commenting it out: The cause
@@ -117,12 +116,15 @@ export const lockdown = defaultOptions => {
       // uncomment out the following line. But please do not commit it in that
       // state.
       //
-      // NOTE TO REVIEWERS: If you see the following line *not* commented out,
-      // this may be a development accident that MUST be fixed before merging.
+      // NOTE TO REVIEWERS: If you see the `stackFiltering` settings *not*
+      // commented out below, this may be a development accident that MUST be
+      // fixed before merging.
       //
-      // stackFiltering: 'verbose',
-      //
-      //
+      // stackFiltering: 'concise', // Omit frames and shorten paths
+      // stackFiltering: 'omit-frames', // Only omit frames. Do not shorten paths
+      // stackFiltering: 'shorten-paths', // Only shorten paths. Do not omit frames
+      // stackFiltering: 'verbose', // Do not omit frames or shorten paths
+
       // The default `{overrideTaming: 'moderate'}` setting does not hurt the
       // debugging experience much. But it will introduce noise into, for example,
       // the vscode debugger's object inspector. During debug and test, if you can
@@ -134,8 +136,7 @@ export const lockdown = defaultOptions => {
       // this may be a development accident that MUST be fixed before merging.
       //
       // overrideTaming: 'min',
-      //
-      //
+
       // The default `{consoleTaming: 'safe'}` setting usually makes for a
       // better debugging experience, by wrapping the original `console` with
       // the SES replacement `console` that provides more information about

--- a/packages/ses-ava/test/raw-ava-reject.test.js
+++ b/packages/ses-ava/test/raw-ava-reject.test.js
@@ -15,8 +15,10 @@ lockdown({
   // the current relevant environment variable setting. To get results
   // independent of that, always uncomment one setting for each switch.
   //
-  stackFiltering: 'concise', // Default. Hide infrastructure, shorten paths
-  // stackFiltering: 'verbose', // Include `assert` infrastructure
+  stackFiltering: 'concise', // Default. Omit likely uninteresting frames. Shorten paths
+  // stackFiltering: 'omit-frames', // Only omit infrastructure frames
+  // stackFiltering: 'shorten-paths', // Only shorten paths
+  // stackFiltering: 'verbose', // Original frames with original paths
   consoleTaming: 'safe', // Default. Console with access to redacted info
   // consoleTaming: 'unsafe', // Host console lacks access to redacted info
   // errorTaming: 'safe', // Default. Hide redacted info on error

--- a/packages/ses-ava/test/raw-ava-throw.test.js
+++ b/packages/ses-ava/test/raw-ava-throw.test.js
@@ -15,8 +15,10 @@ lockdown({
   // the current relevant environment variable setting. To get results
   // independent of that, always uncomment one setting for each switch.
   //
-  stackFiltering: 'concise', // Default. Hide infrastructure, shorten paths
-  // stackFiltering: 'verbose', // Include `assert` infrastructure
+  stackFiltering: 'concise', // Default. Omit likely uninteresting frames. Shorten paths
+  // stackFiltering: 'omit-frames', // Only omit infrastructure frames
+  // stackFiltering: 'shorten-paths', // Only shorten paths
+  // stackFiltering: 'verbose', // Original frames with original paths
   consoleTaming: 'safe', // Default. Console with access to redacted info
   // consoleTaming: 'unsafe', // Host console lacks access to redacted info
   // errorTaming: 'safe', // Default. Hide redacted info on error

--- a/packages/ses-ava/test/ses-ava-reject.test.js
+++ b/packages/ses-ava/test/ses-ava-reject.test.js
@@ -16,8 +16,10 @@ lockdown({
   // the current relevant environment variable setting. To get results
   // independent of that, always uncomment one setting for each switch.
   //
-  stackFiltering: 'concise', // Default. Hide infrastructure, shorten paths
-  // stackFiltering: 'verbose', // Include `assert` infrastructure
+  stackFiltering: 'concise', // Default. Omit likely uninteresting frames. Shorten paths
+  // stackFiltering: 'omit-frames', // Only omit infrastructure frames
+  // stackFiltering: 'shorten-paths', // Only shorten paths
+  // stackFiltering: 'verbose', // Original frames with original paths
   consoleTaming: 'safe', // Default. Console with access to redacted info
   // consoleTaming: 'unsafe', // Host console lacks access to redacted info
   // errorTaming: 'safe', // Default. Hide redacted info on error

--- a/packages/ses-ava/test/ses-ava-throw.test.js
+++ b/packages/ses-ava/test/ses-ava-throw.test.js
@@ -16,8 +16,10 @@ lockdown({
   // the current relevant environment variable setting. To get results
   // independent of that, always uncomment one setting for each switch.
   //
-  stackFiltering: 'concise', // Default. Hide infrastructure, shorten paths
-  // stackFiltering: 'verbose', // Include `assert` infrastructure
+  stackFiltering: 'concise', // Default. Omit likely uninteresting frames. Shorten paths
+  // stackFiltering: 'omit-frames', // Only omit infrastructure frames
+  // stackFiltering: 'shorten-paths', // Only shorten paths
+  // stackFiltering: 'verbose', // Original frames with original paths
   consoleTaming: 'safe', // Default. Console with access to redacted info
   // consoleTaming: 'unsafe', // Host console lacks access to redacted info
   // errorTaming: 'safe', // Default. Hide redacted info on error

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -27,10 +27,19 @@ User-visible changes in `ses`
 
   Also `ses/hermes` can now be hooked into bundlers such as Metro to run Hardened JS.
 
+# Next release
+
+- Two new `stackFiltering:` options are added
+  - `'omit-frames'` -- Only omit likely uninteresting frames. Keep original paths.
+  - `'shorten-paths'` -- Only shorten paths to text likely clickable in an IDE
+
+  This fills out the matrix of what should have been orthogonal options.
+  The existing `'concise'` setting both omits likely uninteresting frames and
+  shortens their paths. The existing `'verbose'` setting does neither.
+
 # v1.12.0 (2025-03-11)
 
-- The `evalTaming:` option values are renamed:
-
+- The `evalTaming:` option values are renamed
   - from `'safeEval'`, `'unsafeEval'`, and `'noEval'`
   - to `'safe-eval'`, `'unsafe-eval'`, and `'no-eval'`
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,6 +2,14 @@ User-visible changes in `ses`
 
 # Next release
 
+- Two new `stackFiltering:` options are added
+  - `'omit-frames'` -- Only omit likely uninteresting frames. Keep original paths.
+  - `'shorten-paths'` -- Only shorten paths to text likely clickable in an IDE
+
+  This fills out the matrix of what should have been orthogonal options.
+  The existing `'concise'` setting both omits likely uninteresting frames and
+  shortens their paths. The existing `'verbose'` setting does neither.
+
 - Uses the `@endo/immutable-arraybuffer` shim to add `ArrayBuffer.p.immutable`, `ArrayBuffer.p.transferToImmutable`, and `ArrayBuffer.p.sliceToImmutable` to ses, in order to emulate the [Immutable ArrayBuffer proposal](https://github.com/tc39/proposal-immutable-arraybuffer). These make an ArrayBuffer-like object whose contents cannot be mutated. However, due to limitations of the shim
   - Unlike `ArrayBuffer` and `SharedArrayBuffer` this shim's ArrayBuffer-like object cannot be transfered or cloned between JS threads.
   - Unlike `ArrayBuffer` and `SharedArrayBuffer`, this shim's ArrayBuffer-like object cannot be used as the backing store of TypeArrays or DataViews.
@@ -26,16 +34,6 @@ User-visible changes in `ses`
   then Static Hermes when released.
 
   Also `ses/hermes` can now be hooked into bundlers such as Metro to run Hardened JS.
-
-# Next release
-
-- Two new `stackFiltering:` options are added
-  - `'omit-frames'` -- Only omit likely uninteresting frames. Keep original paths.
-  - `'shorten-paths'` -- Only shorten paths to text likely clickable in an IDE
-
-  This fills out the matrix of what should have been orthogonal options.
-  The existing `'concise'` setting both omits likely uninteresting frames and
-  shortens their paths. The existing `'verbose'` setting does neither.
 
 # v1.12.0 (2025-03-11)
 

--- a/packages/ses/docs/lockdown.md
+++ b/packages/ses/docs/lockdown.md
@@ -651,9 +651,9 @@ usually irrelevant to the programmer trying to diagnose a bug. The SES-shim's
 `console`, under the default `consoleTaming` option of `'safe'`, is even more
 voluminous&mdash;displaying "deep stack" traces, tracing back through the
 [eventually sent messages](https://github.com/tc39/proposal-eventual-send)
-from other turns of the event loop. In Endo (TODO docs forthcoming) these deep
-stacks even cross vat/process and machine boundaries, to help debug distributed
-bugs.
+from other turns of the event loop. (Eventually we hope these deep
+stacks will even cross vat/process and machine boundaries, to help debug
+distributed bugs, as in [Causeway](https://github.com/cocoonfx/causeway).)
 
 ```js
 lockdown(); // stackFiltering defaults to 'concise'
@@ -677,10 +677,11 @@ LOCKDOWN_STACK_FILTERING=shorten-paths
 LOCKDOWN_STACK_FILTERING=verbose
 ```
 
-When looking at deep distributed stacks, in order to debug distributed
+When looking at deep stacks, in order to debug asynchronous
 computation, seeing the full stacks is overwhelmingly noisy. The error stack
 proposal leaves it to the host what stack trace info to show. SES virtualizes
-elements of the host. With this freedom in mind, when possible, the SES-shim
+elements of the host. With this freedom in mind, under the `concise` setting,
+the SES-shim
 filters and transforms the stack trace information it shows to be more useful,
 by removing information that is more an artifact of low level infrastructure.
 The SES-shim currently does so only on v8.

--- a/packages/ses/docs/reference.md
+++ b/packages/ses/docs/reference.md
@@ -178,8 +178,10 @@ below.
   </tr>
   <tr>
     <td><code>stackFiltering</code></td>
-    <td><code>'concise'</code> (default) or <code>'verbose'</code></td>
-    <td><code>'concise'</code> preserves important deep stack info,<br>
+    <td><code>'concise'</code> (default) or <code>'omit-frames'</code>  or <code>'shorten-paths'</code> or <code>'verbose'</code></td>
+    <td><code>'concise'</code> preserves important deep stack info, omitting likely unimportant frames and shortening paths<br>
+        <code>'omit-frames'</code> omits likely unimportant frames<br>
+        <code>'shorten-paths'</code> shortens paths to text likely clickable in an IDE<br>
         <code>'verbose'</code> console shows full deep stacks</td>
   </tr>
   <tr>
@@ -314,7 +316,11 @@ option and the platform error behavior.
 ```js
 lockdown(); // stackFiltering defaults to 'concise'
 // or
-lockdown({ stackFiltering: 'concise' }); // Preserve important deep stack info
+lockdown({ stackFiltering: 'concise' }); // Preserve important deep stack info, omitting likely unimportant frames and shortening paths
+// vs
+lockdown({ stackFiltering: 'omit-frames' }); // Omit likely uninteresting frames
+// vs
+lockdown({ stackFiltering: 'shorten-paths' }); // Shorten paths to text likely clickable in an IDE
 // vs
 lockdown({ stackFiltering: 'verbose' }); // Console shows full deep stacks
 ```

--- a/packages/ses/docs/reference.md
+++ b/packages/ses/docs/reference.md
@@ -325,6 +325,8 @@ lockdown({ stackFiltering: 'shorten-paths' }); // Shorten paths to text likely c
 lockdown({ stackFiltering: 'verbose' }); // Console shows full deep stacks
 ```
 
+See [`stackFiltering` Options](./lockdown.md#stackfiltering-options) for more.
+
 ### `overrideTaming` Options
 
 The `overrideTaming` option trades off better code

--- a/packages/ses/src/error/tame-v8-error-constructor.js
+++ b/packages/ses/src/error/tame-v8-error-constructor.js
@@ -156,6 +156,10 @@ const CALLSITE_PACKAGES_PATTERN = /^((?:.*[( ])?)[:/\w_-]*\/(packages\/.+)$/;
 
 // simplifies to
 // `'Object.bar (test/deep-send.test.js:13:21)'`.
+// The reason is that `file:///` usually precedes an absolute path which is
+// clickable without removing the `file:///`, whereas `file://` usually precedes
+// a relative path which, for whatever vscode reason, is not clickable until the
+// `file://` is removed.
 const CALLSITE_FILE_2SLASH_PATTERN = /^((?:.*[( ])?)file:\/\/([^/].*)$/;
 
 // The use of these callSite patterns below assumes that any match will bind

--- a/packages/ses/src/error/tame-v8-error-constructor.js
+++ b/packages/ses/src/error/tame-v8-error-constructor.js
@@ -114,25 +114,49 @@ export const filterFileName = fileName => {
 // likely url-path prefix, ending in a `/.../` should get dropped.
 // Anything to the left of the likely path text is kept.
 // Everything to the right of `/.../` is kept. Thus
-// `'Object.bar (/vat-v1/.../eventual-send/test/test-deep-send.js:13:21)'`
+// `'Object.bar (/vat-v1/.../eventual-send/test/deep-send.test.js:13:21)'`
 // simplifies to
-// `'Object.bar (eventual-send/test/test-deep-send.js:13:21)'`.
+// `'Object.bar (eventual-send/test/deep-send.test.js:13:21)'`.
 //
 // See thread starting at
 // https://github.com/Agoric/agoric-sdk/issues/2326#issuecomment-773020389
-const CALLSITE_ELLIPSES_PATTERN = /^((?:.*[( ])?)[:/\w_-]*\/\.\.\.\/(.+)$/;
+const CALLSITE_ELLIPSIS_PATTERN1 = /^((?:.*[( ])?)[:/\w_-]*\/\.\.\.\/(.+)$/;
+
+// The ad-hoc rule of the current pattern is that any likely-file-path or
+// likely url-path prefix consisting of `.../` should get dropped.
+// Anything to the left of the likely path text is kept.
+// Everything to the right of `.../` is kept. Thus
+// `'Object.bar (.../eventual-send/test/deep-send.test.js:13:21)'`
+// simplifies to
+// `'Object.bar (eventual-send/test/deep-send.test.js:13:21)'`.
+//
+// See thread starting at
+// https://github.com/Agoric/agoric-sdk/issues/2326#issuecomment-773020389
+const CALLSITE_ELLIPSIS_PATTERN2 = /^((?:.*[( ])?)\.\.\.\/(.+)$/;
 
 // The ad-hoc rule of the current pattern is that any likely-file-path or
 // likely url-path prefix, ending in a `/` and prior to `package/` should get
 // dropped.
 // Anything to the left of the likely path prefix text is kept. `package/` and
 // everything to its right is kept. Thus
-// `'Object.bar (/Users/markmiller/src/ongithub/agoric/agoric-sdk/packages/eventual-send/test/test-deep-send.js:13:21)'`
+// `'Object.bar (/Users/markmiller/src/ongithub/agoric/agoric-sdk/packages/eventual-send/test/deep-send.test.js:13:21)'`
 // simplifies to
-// `'Object.bar (packages/eventual-send/test/test-deep-send.js:13:21)'`.
+// `'Object.bar (packages/eventual-send/test/deep-send.test.js:13:21)'`.
 // Note that `/packages/` is a convention for monorepos encouraged by
 // lerna.
 const CALLSITE_PACKAGES_PATTERN = /^((?:.*[( ])?)[:/\w_-]*\/(packages\/.+)$/;
+
+// The ad-hoc rule of the current pattern is that any likely-file-path or
+// likely url-path prefix of the form `file://` but not `file:///` gets
+// dropped.
+// Anything to the left of the likely path prefix text is kept. Everything to
+// the right of `file://` is kept. Thus
+// `'Object.bar (file:///Users/markmiller/src/ongithub/endojs/endo/packages/eventual-send/test/deep-send.test.js:13:21)'` is unchanged but
+// `'Object.bar (file://test/deep-send.test.js:13:21)'`
+
+// simplifies to
+// `'Object.bar (test/deep-send.test.js:13:21)'`.
+const CALLSITE_FILE_2SLASH_PATTERN = /^((?:.*[( ])?)file:\/\/([^/].*)$/;
 
 // The use of these callSite patterns below assumes that any match will bind
 // capture groups containing the parts of the original string we want
@@ -140,8 +164,10 @@ const CALLSITE_PACKAGES_PATTERN = /^((?:.*[( ])?)[:/\w_-]*\/(packages\/.+)$/;
 // stacks.
 // TODO Enable users to configure CALLSITE_PATTERNS via `lockdown` options.
 const CALLSITE_PATTERNS = [
-  CALLSITE_ELLIPSES_PATTERN,
+  CALLSITE_ELLIPSIS_PATTERN1,
+  CALLSITE_ELLIPSIS_PATTERN2,
   CALLSITE_PACKAGES_PATTERN,
+  CALLSITE_FILE_2SLASH_PATTERN,
 ];
 
 // For a stack frame that should be included in a concise stack trace, if
@@ -149,6 +175,9 @@ const CALLSITE_PATTERNS = [
 // possibly-shorter stringified stack frame that should be shown instead.
 // Exported only so it can be unit tested.
 // TODO Move so that it applies not just to v8.
+/**
+ * @param {string} callSiteString
+ */
 export const shortenCallSiteString = callSiteString => {
   for (const filter of CALLSITE_PATTERNS) {
     const match = regexpExec(filter, callSiteString);
@@ -175,18 +204,24 @@ export const tameV8ErrorConstructor = (
 
   const originalCaptureStackTrace = OriginalError.captureStackTrace;
 
+  const omitFrames =
+    stackFiltering === 'concise' || stackFiltering === 'omit-frames';
+
+  const shortenPaths =
+    stackFiltering === 'concise' || stackFiltering === 'shorten-paths';
+
   // const callSiteFilter = _callSite => true;
   const callSiteFilter = callSite => {
-    if (stackFiltering === 'verbose') {
-      return true;
+    if (omitFrames) {
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      return filterFileName(callSite.getFileName());
     }
-    // eslint-disable-next-line @endo/no-polymorphic-call
-    return filterFileName(callSite.getFileName());
+    return true;
   };
 
   const callSiteStringifier = callSite => {
     let callSiteString = `${callSite}`;
-    if (stackFiltering === 'concise') {
+    if (shortenPaths) {
       callSiteString = shortenCallSiteString(callSiteString);
     }
     return `\n  at ${callSiteString}`;

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -205,8 +205,12 @@ export const repairIntrinsics = (options = {}) => {
     overrideTaming = /** @type {'moderate' | 'min' | 'severe'} */ (
       getenv('LOCKDOWN_OVERRIDE_TAMING', 'moderate', ['min', 'severe'])
     ),
-    stackFiltering = /** @type {'safe' | 'unsafe'} */ (
-      getenv('LOCKDOWN_STACK_FILTERING', 'concise', ['verbose'])
+    stackFiltering = /** @type {'concise' | 'omit-frames' | 'shorten-paths' | 'verbose'} */ (
+      getenv('LOCKDOWN_STACK_FILTERING', 'concise', [
+        'omit-frames',
+        'shorten-paths',
+        'verbose',
+      ])
     ),
     domainTaming = /** @type {'safe' | 'unsafe'} */ (
       getenv('LOCKDOWN_DOMAIN_TAMING', 'safe', ['unsafe'])

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -20,6 +20,10 @@
 // version of harden.
 export type Harden = <T>(value: T) => T; // not Hardened<T>;
 
+// TODO Somehow remove the redundancy between these type deinitions and the
+// inline casts on each call to `getenv` in `lockdown.js`. Hopefully we can
+// keep the type info in those casts so it is easily comparable by eye to
+// the parameters of that call to `genev`.
 export interface RepairOptions {
   regExpTaming?: 'safe' | 'unsafe';
   localeTaming?: 'safe' | 'unsafe';

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -44,7 +44,7 @@ export interface RepairOptions {
     | 'safeEval'
     | 'unsafeEval'
     | 'noEval';
-  stackFiltering?: 'concise' | 'verbose';
+  stackFiltering?: 'concise' | 'omit-frames' | 'shorten-paths' | 'verbose';
   overrideTaming?: 'moderate' | 'min' | 'severe';
   overrideDebug?: Array<string>;
   domainTaming?: 'safe' | 'unsafe';


### PR DESCRIPTION
Refs: #2359 

## Description

Added two new `stackFiltering:` options
  - `'omit-frames'` -- Only omit likely uninteresting frames. Keep original paths.
  - `'shorten-paths'` -- Only shorten paths to text likely clickable in an IDE

  This fills out the matrix of what should have been orthogonal options.
  The existing `'concise'` setting both omits likely uninteresting frames and
  shortens their paths. The existing `'verbose'` setting does neither.

The path shortening caused by either `'concise'` or `'shorten-paths'` is also enhanced with two new transformations, in order to make these paths easily and usefully clickable in an IDE like vscode.

- We would already shorten, for example
   ```
   'Object.bar (/vat-v1/.../eventual-send/test/deep-send.test.js:13:21)'
   ```
   to
   ```
   'Object.bar (eventual-send/test/deep-send.test.js:13:21)'.
   ```
   As of this PR, we would also shorten, for example
   ```
   'Object.bar (.../eventual-send/test/deep-send.test.js:13:21)'
   ```
   to
   ```
   'Object.bar (eventual-send/test/deep-send.test.js:13:21)'.
   ```
- As of this PR, we would would shorten, for example
   ```
   'Object.bar (file://test/deep-send.test.js:13:21)'
   ```
   to
   ```
   'Object.bar (test/deep-send.test.js:13:21)'.
   ```
   because the shorter string is a valid relative path, which is therefore usefully clickable.
   But we would still not shorten or transform, for example
   ```
   'file:///Users/markmiller/src/ongithub/endojs/endo/packages/eventual-send/test/deep-send.test.js:13:21'
   ```
   because three slashes are normally followed by an absolute path, which is therefore usefully clickable.

- [x] This PR changes commit-debug.js from `'errorTaming: 'unsafe-debug'` to `errorTaming: 'unsafe'` so that exiting programs whose initialization goes through `commit-debug.js` can benefit from `stackFiltering:` at all, as well as these new enhancements. TODO but this PR must also fix, by other means, the typescript line number bug that motivated `'unsafe-debug'` in the first place. See #2359
  - Manually verified that the typescript bug that motivated `'unsafe-debug'` is now fixed, and so `'unsafe-debug'` is no longer necessary. Presumably this is because we moved to erasable-typescript which does not change line and column numbers.

- [ ] This PR does not change that all this `stackFiltering:` logic is specific to v8. We should move and generalize this code so that it applies to all relevant JS platforms. TODO at least file an issue for that.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

Wherever we document the `stackFiltering:` rules, we should update those. This PR already updates such documentation within agoric-sdk itself.

### Testing Considerations

`stackFiltering:` is hard to automatically test because there is no specified or portable behavior for the platform-provided stacks. Instead, we just have manual inspection tests, where you run it and visually sanity check the output. I have added such checks for the new options setting and manually sanity checked them.

### Compatibility Considerations

The only observable change to existing programs is the more aggressive path shortening explained above. I doubt this will cause any compat problems, especially since the platform stack traces are unspecified anyway.

### Upgrade Considerations

None.

- [x] Update `NEWS.md` for user-facing changes.
