### PR TITLE
fix(compartment-mapper): specifier of module descriptor returned from findRedirect fixed

### DIFF
--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -101,7 +101,9 @@ const nodejsConventionSearchSuffixes = [
  * @returns {string} Redirect static module interface; the `specifier` prop of this value _must_ be a relative path with leading `./`
  */
 const relativeSpecifier = (moduleSpecifierLocation, location) => {
-  return `./${moduleSpecifierLocation.replace(location, '')}`;
+  assert(moduleSpecifierLocation.startsWith(location), 
+    `Module specifier location "${moduleSpecifierLocation}" does not start with compartment location "${location}"`);
+  return `./${moduleSpecifierLocation.substring(location.length)}`;
 };
 
 /**

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -24,7 +24,6 @@
  *   ChooseModuleDescriptorYieldables,
  *   ExitModuleImportHook,
  *   FindRedirectParams,
- *   HashFn,
  *   ImportHookMaker,
  *   ImportNowHookMaker,
  *   MakeImportHookMakerOptions,
@@ -33,8 +32,6 @@
  *   ParseResult,
  *   ReadFn,
  *   ReadPowers,
- *   SourceMapHook,
- *   Sources,
  *   ReadNowPowers
  * } from './types.js'
  */

--- a/packages/compartment-mapper/src/types/internal.ts
+++ b/packages/compartment-mapper/src/types/internal.ts
@@ -213,8 +213,6 @@ export type FindRedirectParams = {
   compartments: Record<string, Compartment>;
   /* A module specifier which is an absolute path. NOT a `file://` URL. */
   absoluteModuleSpecifier: string;
-  /** Location of the compartment descriptor's package. */
-  packageLocation: string;
 };
 
 /**

--- a/packages/compartment-mapper/test/dynamic-require.test.js
+++ b/packages/compartment-mapper/test/dynamic-require.test.js
@@ -407,7 +407,12 @@ test('inter-package and exit module dynamic require policy is enforced', async t
           },
           'hooked>dynamic': {
             packages: {
-              'is-ok': true,
+              'hooked>dynamic>is-ok': true,
+            },
+          },
+          'hooked>dynamic>is-ok': {
+            packages: {
+              'hooked>dynamic>is-ok>is-not-ok': true,
             },
           },
         },
@@ -469,7 +474,12 @@ test('inter-package and exit module dynamic require works ("node:"-namespaced)',
         },
         'hooked>dynamic': {
           packages: {
-            'is-ok': true,
+            'hooked>dynamic>is-ok': true,
+          },
+        },
+        'hooked>dynamic>is-ok': {
+          packages: {
+            'hooked>dynamic>is-ok>is-not-ok': true,
           },
         },
       },
@@ -619,5 +629,3 @@ test('dynamic require of missing module falls through to importNowHook', async t
     },
   );
 });
-
-// test('dynamic require of external module which imports a third module', async t => {});

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/dynamic/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/dynamic/index.js
@@ -1,3 +1,3 @@
-const pkg = 'is-ok';
+const pkg = require.resolve('is-ok');
 
 exports.isOk = require(pkg).isOk;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/invalid-app/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/invalid-app/README.md
@@ -1,0 +1,1 @@
+This is an app which attempts to dynamically require a package but fails.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/invalid-app/good.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/invalid-app/good.js
@@ -1,0 +1,1 @@
+exports.isOk = true

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/invalid-app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/invalid-app/index.js
@@ -1,0 +1,5 @@
+const path = require('path')
+const goodPath = path.join(__dirname, './good.js')
+const badPath = path.join(__dirname, './missing.js')
+
+exports.isOk = require(goodPath).isOk && require(badPath).isOk;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/invalid-app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/invalid-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "invalid-app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "sprunt": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-not-ok/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-not-ok/README.md
@@ -1,0 +1,1 @@
+This package does nothing interesting.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-not-ok/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-not-ok/index.js
@@ -1,0 +1,3 @@
+
+
+exports.isOk = 0

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-not-ok/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-not-ok/package.json
@@ -1,10 +1,7 @@
 {
-  "name": "is-ok",
+  "name": "is-not-ok",
   "version": "1.0.0",
   "scripts": {
     "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
-  },
-  "dependencies": {
-    "is-not-ok": "^1.0.0"
   }
 }

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/README.md
@@ -1,1 +1,1 @@
-This package does nothing interesting.
+This package requires another uninteresting package

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/is-ok/index.js
@@ -1,1 +1,1 @@
-exports.isOk = 1
+exports.isOk = +!require('is-not-ok').isOk


### PR DESCRIPTION
## Description

`findRedirect`, which is part of `importNowHook`, is called when we encounter a dynamic require where the specifier is an absolute path.

Previous to this change, the `RedirectStaticModuleInterface` (a `ModuleDescriptor`) could contain an absolute path. Absolute paths are not generally assumed by `ses` or `@endo/compartment-mapper`. In the situation where the module referenced in the `RedirectStaticModuleInterface` itself imports _another_ package (via mutual recursion & trampolining), these assumptions were violated and we made an attempt to call `resolve()` (from the `node-module-specifier` module) using its absolute path as the referrer, which is explicitly disallowed by `resolve()`; it throws an exception.

To that end, we need to ensure that whatever `ModuleDescriptor` we return from `importNowHook` with is one where its `specifier` is relative to its package location.

The fact that this nominally "worked" against our tests in both `@endo/compartment-mapper` _and_ `@lavamoat/node` was due to a) chance, and b) lack of a test case against a fixture representing this configuration.

In addition, I removed the `packageLocation` parameter from `findRedirect`'s options bucket since it was serving no practical purpose (as noticed by @naugtur).

### Security Considerations

None that I am aware of

### Scaling Considerations

no

### Documentation Considerations

This is a bugfix

### Testing Considerations

I need to add two more tests against fixtures before I publish this:

1. [x] A fixture which is similar to the configuration mentioned above
2. [x] A fixture where the dynamically-required file is in a different compartment (which should be subject to policy enforcement)

### Compatibility Considerations

None that I am aware of

### Upgrade Considerations

Not breaking. Probably not worth a note in `NEWS.md`
