### PR TITLE
fix(compartment-mapper): fix crawling

### DIFF
--- a/packages/compartment-mapper/test/fixtures-shortest-path/README.md
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/README.md
@@ -1,0 +1,13 @@
+This fixture contains a configuration that has two different paths from the root app (`app`) to the same module (`goofy`). The paths are of the same length, but one if them is shorter in terms of character count. Thus, `app>pippo>topolino>goofy` should be considered the shortest path to `goofy`, and the `path` of `goofy`'s `CompartmentDescriptor` will reflect that.
+
+Diagram of the module graph:
+
+```mermaid
+graph TD
+    app --> paperino
+    app --> pippo
+    paperino --> topolino
+    topolino --> goofy
+    pippo --> gambadilegno
+    gambadilegno --> goofy
+```

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/app/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  pippo: require('pippo'),
+  paperino: require('paperino')
+};

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "paperino": "^1.0.0",
+    "pippo": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/gambadilegno/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/gambadilegno/index.js
@@ -1,0 +1,1 @@
+module.exports = require('goofy');

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/gambadilegno/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/gambadilegno/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gambadilegno",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "goofy": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/goofy/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/goofy/index.js
@@ -1,0 +1,1 @@
+module.exports = 'topolino'

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/goofy/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/goofy/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "goofy",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/paperino/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/paperino/index.js
@@ -1,0 +1,1 @@
+module.exports = require('topolino');

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/paperino/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/paperino/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "paperino",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "topolino": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/pippo/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/pippo/index.js
@@ -1,0 +1,1 @@
+module.exports = require('gambadilegno');

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/pippo/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/pippo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pippo",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "gambadilegno": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/topolino/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/topolino/index.js
@@ -1,0 +1,1 @@
+module.exports = require('goofy');

--- a/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/topolino/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path/node_modules/topolino/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "topolino",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "goofy": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/map-node-modules.test.js
+++ b/packages/compartment-mapper/test/map-node-modules.test.js
@@ -1,0 +1,48 @@
+import 'ses';
+
+import fs from 'node:fs';
+import { scheduler } from 'node:timers/promises';
+import url from 'node:url';
+import test from 'ava';
+import { mapNodeModules } from '../src/node-modules.js';
+import { makeReadPowers } from '../src/node-powers.js';
+
+/**
+ * @import {CompartmentDescriptor} from '../src/types.js'
+ */
+
+// since we cannot dynamically define tests in AVA (🤦‍♂️), this test will run in a loop.
+test(`mapNodeModules() should return compartment descriptor containing shortest path`, async t => {
+  await null;
+  /** @type {string[] | undefined} */
+  let expectedPath;
+  for (let i = 0; i < 100; i++) {
+    t.log(`iteration ${i}`);
+    const readPowers = makeReadPowers({ fs, url });
+    const moduleLocation = new URL(
+      'fixtures-shortest-path/node_modules/app/index.js',
+      import.meta.url,
+    ).href;
+    const compartmentMap = await mapNodeModules(readPowers, moduleLocation);
+
+    const compartmentDescriptor = Object.values(
+      compartmentMap.compartments,
+    ).find(compartment => compartment.label === 'goofy-v1.0.0');
+
+    t.assert(compartmentDescriptor, 'compartment descriptor should exist');
+    // the assert() call above should mean that we do not need this type assertion,
+    // but return type of `t.assert()` is incorrect; it should use the `asserts` keyword.
+
+    if (expectedPath) {
+      t.deepEqual(
+        /** @type {CompartmentDescriptor} */ (compartmentDescriptor).path,
+        expectedPath,
+        `compartment descriptor should have had path: ${expectedPath.join('>')}`,
+      );
+    } else {
+      expectedPath = /** @type {CompartmentDescriptor} */ (
+        compartmentDescriptor
+      ).path;
+    }
+  });
+}

--- a/packages/compartment-mapper/test/map-node-modules.test.js
+++ b/packages/compartment-mapper/test/map-node-modules.test.js
@@ -11,18 +11,26 @@ import { makeReadPowers } from '../src/node-powers.js';
  * @import {CompartmentDescriptor} from '../src/types.js'
  */
 
-// since we cannot dynamically define tests in AVA (🤦‍♂️), this test will run in a loop.
-test(`mapNodeModules() should return compartment descriptor containing shortest path`, async t => {
-  await null;
-  /** @type {string[] | undefined} */
-  let expectedPath;
-  for (let i = 0; i < 100; i++) {
-    t.log(`iteration ${i}`);
+const n = 50;
+for (let i = 0; i < n; i += 1) {
+  test(`mapNodeModules() should return compartment descriptors containing shortest path (iteration ${i}/${n})`, async t => {
+    t.timeout(5000);
+    /** @type {string[] | undefined} */
+    let expectedPath;
     const readPowers = makeReadPowers({ fs, url });
+    const { maybeRead } = readPowers;
+
+    // inserts a random delay before the read
+    readPowers.maybeRead = async specifier => {
+      await scheduler.wait(Math.random() * 50);
+      return maybeRead(specifier);
+    };
+
     const moduleLocation = new URL(
       'fixtures-shortest-path/node_modules/app/index.js',
       import.meta.url,
     ).href;
+
     const compartmentMap = await mapNodeModules(readPowers, moduleLocation);
 
     const compartmentDescriptor = Object.values(
@@ -37,12 +45,16 @@ test(`mapNodeModules() should return compartment descriptor containing shortest 
       t.deepEqual(
         /** @type {CompartmentDescriptor} */ (compartmentDescriptor).path,
         expectedPath,
-        `compartment descriptor should have had path: ${expectedPath.join('>')}`,
+        `compartment descriptor should have had path: ${expectedPath.join('>')} (iteration ${i})`,
       );
     } else {
       expectedPath = /** @type {CompartmentDescriptor} */ (
         compartmentDescriptor
       ).path;
+      t.assert(expectedPath, 'expectedPath should exist');
+      t.log(
+        `Expected path: ${/** @type {string[]} */ (expectedPath).join('>')}`,
+      );
     }
   });
 }

--- a/scripts/mermaid-deptree.cjs
+++ b/scripts/mermaid-deptree.cjs
@@ -1,0 +1,108 @@
+/**
+ * This script generates Mermaid graph of a dependency tree from the root package.
+ *
+ * Usage: `node mermaid-deptree.cjs <entry> [<node_modules_path>]`
+ *
+ * Fair warning: Copilot wrote most of this.
+ *
+ * @module
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Recursively reads all `package.json` files in the `node_modules` directory
+ * and builds a dependency graph.
+ *
+ * @param {string} entry - The root package.
+ * @param {string} nodeModulesPath - Path to the `node_modules` directory.
+ * @returns {Record<string, string[]>} - A dependency graph where keys are package names and values are arrays of dependencies.
+ */
+function buildDependencyGraph(entry, nodeModulesPath) {
+  /** @type {Record<string, string[]>} */
+  const graph = {};
+
+  const seen = new Set();
+
+  /**
+   * @param {string} directory
+   * @returns {void}
+   */
+  function traverse(directory) {
+    const packageJsonPath = path.join(directory, 'package.json');
+    if (!seen.has(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+      const packageName = packageJson.name || path.basename(directory);
+      const dependencies = Object.keys(packageJson.dependencies || {});
+      graph[packageName] = dependencies;
+
+      // Traverse dependencies
+      dependencies.forEach(dependency => {
+        const dependencyPath = path.join(nodeModulesPath, dependency);
+        if (
+          fs.existsSync(dependencyPath) &&
+          fs.statSync(dependencyPath).isDirectory()
+        ) {
+          traverse(dependencyPath);
+        }
+      });
+    }
+    seen.add(packageJsonPath);
+  }
+
+  // Start traversal from the root of `node_modules`
+  if (fs.statSync(entry).isDirectory()) {
+    traverse(entry);
+  }
+
+  return graph;
+}
+
+/**
+ * Converts a dependency graph into a Mermaid graph definition.
+ *
+ * @param {Record<string, string[]>} graph - The dependency graph.
+ * @returns {string} - A Mermaid graph definition.
+ */
+function generateMermaidGraph(graph) {
+  const lines = ['graph TD'];
+  for (const [packageName, dependencies] of Object.entries(graph)) {
+    dependencies.forEach(dependency => {
+      lines.push(`    ${packageName} --> ${dependency}`);
+    });
+  }
+  return lines.join('\n');
+}
+
+// Main script
+(async () => {
+  let entry = process.argv[2];
+  if (!entry) {
+    console.error(
+      'Usage: node mermaid-deptree.cjs <entry> [<node_modules_path>]\n\n  - <entry> is the path to the entry package.\n  - <node_modules_path> is the path to the node_modules directory; if not provided, it is assumed to be the parent dir of the entry package',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  entry = path.resolve(entry);
+  console.error(`Entry package resolved to: ${entry}`);
+  let nodeModulesPath = process.argv[3] || path.join(entry, '..');
+  nodeModulesPath = path.resolve(nodeModulesPath);
+
+  if (!fs.existsSync(nodeModulesPath)) {
+    console.error(
+      `Error: Directory "${nodeModulesPath}" does not exist. If not provided, the path is assumed to be the parent dir of the entry package`,
+    );
+    process.exit(1);
+  }
+
+  console.error('Building dependency graph...');
+  const dependencyGraph = buildDependencyGraph(entry, nodeModulesPath);
+
+  console.error('Generating Mermaid graph...');
+  const mermaidGraph = generateMermaidGraph(dependencyGraph);
+
+  console.error('Mermaid graph:\n');
+  console.log(mermaidGraph);
+})();


### PR DESCRIPTION
The `node_modules`-crawler in `@endo/compartment-mapper` is currently unstable. When there are multiple paths to a module, the "shortest path" to that module remains the first path that was found.

The first path that is found is non-deterministic.  As a result, a `CompartmentDescriptor.path` value can differ from run to run.

This fixes the problem: when a package location in the graph is encountered for the _second_ time (and every time thereafter), we recursively (and its dependency tree, if that too needs updating) check if it still has the shortest path, and update paths as appropriate within the graph.

A fixture in `packages/compartment-mapper/test/fixtures-shortest-path` shows an example of the structure necessary to trigger the original problem.  Previous to the change, this test would typically fail within 20 iterations, thus exhibiting non-determinism.

