### PR TITLE
fix(compartment-mapper): add missing arg to recursive call

### DIFF
--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -192,11 +192,18 @@ const updateShortestPaths = (
           `Expected graph node ${q(node.name)} to contain a dependency location for ${q(name)}`,
         );
       }
-      updateShortestPaths(graph, packageLocation, [...logicalPath, name]);
+      updateShortestPaths(
+        graph,
+        packageLocation,
+        [...logicalPath, name],
+        preferredPackageLogicalPathMap,
+      );
     }
   }
 
-  if (node.path !== bestLogicalPath) {
+  // a path length of 0 means the node represents the eventual entry compartment.
+  // we do not want to mess with that path.
+  if (node.path.length && node.path !== bestLogicalPath) {
     node.path = bestLogicalPath;
   }
 

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/README.md
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/README.md
@@ -1,0 +1,12 @@
+This is like [fixtures-shortest-path](../fixtures-shortest-path/README.md) but contains a cycle on the entry:
+
+```mermaid
+graph TD
+    app --> paperino
+    app --> pippo
+    paperino --> topolino
+    pippo --> gambadilegno
+    topolino --> goofy
+    gambadilegno --> goofy
+    goofy --> app
+```

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/app/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  pippo: require('pippo'),
+  paperino: require('paperino')
+};

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "paperino": "^1.0.0",
+    "pippo": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/gambadilegno/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/gambadilegno/index.js
@@ -1,0 +1,1 @@
+module.exports = require('goofy');

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/gambadilegno/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/gambadilegno/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gambadilegno",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "goofy": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/goofy/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/goofy/index.js
@@ -1,0 +1,1 @@
+module.exports = 'topolino'

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/goofy/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/goofy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "goofy",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  },
+  "dependencies": {
+    "app": "^1.0.0"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/paperino/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/paperino/index.js
@@ -1,0 +1,1 @@
+module.exports = require('topolino');

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/paperino/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/paperino/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "paperino",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "topolino": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/pippo/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/pippo/index.js
@@ -1,0 +1,1 @@
+module.exports = require('gambadilegno');

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/pippo/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/pippo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pippo",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "gambadilegno": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/topolino/index.js
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/topolino/index.js
@@ -1,0 +1,1 @@
+module.exports = require('goofy');

--- a/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/topolino/package.json
+++ b/packages/compartment-mapper/test/fixtures-shortest-path-cycle/node_modules/topolino/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "topolino",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "goofy": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/scripts/mermaid-deptree.cjs
+++ b/scripts/mermaid-deptree.cjs
@@ -1,15 +1,19 @@
+// @ts-check
+
 /**
  * This script generates Mermaid graph of a dependency tree from the root package.
  *
- * Usage: `node mermaid-deptree.cjs <entry> [<node_modules_path>]`
+ * Usage: `node mermaid-deptree.cjs [<entry_dir>] [<node_modules_dir>]`
  *
  * Fair warning: Copilot wrote most of this.
  *
  * @module
  */
+const { Stats } = require('node:fs');
+const fs = require('node:fs/promises');
+const path = require('node:path');
 
-const fs = require('fs');
-const path = require('path');
+const PACKAGE_JSON = 'package.json';
 
 /**
  * Recursively reads all `package.json` files in the `node_modules` directory
@@ -17,44 +21,42 @@ const path = require('path');
  *
  * @param {string} entry - The root package.
  * @param {string} nodeModulesPath - Path to the `node_modules` directory.
- * @returns {Record<string, string[]>} - A dependency graph where keys are package names and values are arrays of dependencies.
+ * @returns {Promise<Record<string, string[]>>} - A dependency graph where keys are package names and values are arrays of dependencies.
  */
-function buildDependencyGraph(entry, nodeModulesPath) {
+async function buildDependencyGraph(entry, nodeModulesPath) {
   /** @type {Record<string, string[]>} */
   const graph = {};
-
+  /** @type {Set<string>} */
   const seen = new Set();
 
   /**
    * @param {string} directory
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  function traverse(directory) {
-    const packageJsonPath = path.join(directory, 'package.json');
-    if (!seen.has(packageJsonPath)) {
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  async function traverse(directory) {
+    await null;
+    if (!seen.has(directory)) {
+      seen.add(directory);
+      const packageJsonPath = path.join(directory, PACKAGE_JSON);
+      const packageJson = JSON.parse(
+        await fs.readFile(packageJsonPath, 'utf8'),
+      );
       const packageName = packageJson.name || path.basename(directory);
       const dependencies = Object.keys(packageJson.dependencies || {});
       graph[packageName] = dependencies;
 
       // Traverse dependencies
-      dependencies.forEach(dependency => {
-        const dependencyPath = path.join(nodeModulesPath, dependency);
-        if (
-          fs.existsSync(dependencyPath) &&
-          fs.statSync(dependencyPath).isDirectory()
-        ) {
-          traverse(dependencyPath);
-        }
-      });
+      await Promise.all(
+        dependencies.map(async dependency => {
+          const dependencyPath = path.join(nodeModulesPath, dependency);
+          await assertIsDir(dependencyPath);
+          return traverse(dependencyPath);
+        }),
+      );
     }
-    seen.add(packageJsonPath);
   }
 
-  // Start traversal from the root of `node_modules`
-  if (fs.statSync(entry).isDirectory()) {
-    traverse(entry);
-  }
+  await traverse(entry);
 
   return graph;
 }
@@ -75,34 +77,54 @@ function generateMermaidGraph(graph) {
   return lines.join('\n');
 }
 
+/**
+ * Asserts the given path `dir` points to a directory.
+ * @param {string} dir
+ * @returns {Promise<void>}
+ */
+const assertIsDir = async dir => {
+  /** @type {Stats} */
+  let stat;
+  try {
+    stat = await fs.stat(dir);
+  } catch (error) {
+    throw new Error(`Error: "${dir}" does not exist`, { cause: error });
+  }
+
+  if (!stat.isDirectory()) {
+    throw new Error(`"${dir}" is not a directory`);
+  }
+};
+
+const printUsage = () => {
+  console.error(
+    `Usage: node mermaid-deptree.cjs [<entry_dir>] [<node_modules_path>]
+
+  - <entry_dir> is the path to the entry dir containing a \`package.json\`; defaults to the current working directory 
+  - <node_modules_dir> is the path to the \`node_modules\` directory; defaults to the parent dir of <entry_dir>
+
+`,
+  );
+};
+
 // Main script
 (async () => {
-  let entry = process.argv[2];
-  if (!entry) {
-    console.error(
-      'Usage: node mermaid-deptree.cjs <entry> [<node_modules_path>]\n\n  - <entry> is the path to the entry package.\n  - <node_modules_path> is the path to the node_modules directory; if not provided, it is assumed to be the parent dir of the entry package',
-    );
-    process.exitCode = 1;
-    return;
-  }
-  entry = path.resolve(entry);
-  console.error(`Entry package resolved to: ${entry}`);
-  let nodeModulesPath = process.argv[3] || path.join(entry, '..');
-  nodeModulesPath = path.resolve(nodeModulesPath);
-
-  if (!fs.existsSync(nodeModulesPath)) {
-    console.error(
-      `Error: Directory "${nodeModulesPath}" does not exist. If not provided, the path is assumed to be the parent dir of the entry package`,
-    );
-    process.exit(1);
-  }
+  const entry = path.resolve(process.argv[2] || process.cwd());
+  const nodeModulesPath = path.resolve(
+    process.argv[3] || path.join(entry, '..'),
+  );
+  await Promise.all([assertIsDir(entry), assertIsDir(nodeModulesPath)]);
 
   console.error('Building dependency graph...');
-  const dependencyGraph = buildDependencyGraph(entry, nodeModulesPath);
+  const dependencyGraph = await buildDependencyGraph(entry, nodeModulesPath);
 
   console.error('Generating Mermaid graph...');
   const mermaidGraph = generateMermaidGraph(dependencyGraph);
 
   console.error('Mermaid graph:\n');
   console.log(mermaidGraph);
-})();
+})().catch(err => {
+  printUsage();
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
This fixes a bug introduced in #2769 which can lead to a "max call stack exceeded" exception.

And another that will potentially overwrite the entry node with a path if a cycle is encountered.