### PR TITLE
fix(compartment-mapper): un-deprecate the dev flag

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes to `@endo/compartment-mapper`:
 
+# Next release
+
+- The `dev` flag for `mapNodeModules()` is no longer deprecated. The concept of a "condition" ([conditional exports](https://nodejs.org/api/packages.html#conditional-exports)) is disinct from the flag's original meaning (instructs `mapNodeModules()` to consider `devDependencies` when graphing packages). Users who have switched to using a `development` condition for `dev`'s purpose are encouraged to _switch back_ to using the `dev` flag instead. **In a future release, the presence of a `development` condition will no longer mimic an enabled `dev` flag** and will only be considered when evaluating conditional exports.
+
 # v1.6.0 (2025-03-11)
 
 - Accommodates CommonJS modules that use `defineProperty` on `exports`.

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -72,18 +72,22 @@ type MapNodeModulesOptionsOmitPolicy = Partial<{
   tags: Set<string>;
   /**
    * Conditions for package `"imports"` and `"exports"`.
-   * The `"development"` condition also implies that `devDependencies` of the
-   * entry package should be reachable.
+   *
    * Common conditions include `"node"`, `"browser"`, `"require"`, `"import"`,
-   * and `"default"`.
-   * The conditions `"import"`, `"default"`, and `"endo"` need not be
-   * specified.
+   * and `"default"`. The conditions `"import"`, `"default"`, and `"endo"` need
+   * not be specified.
+   *
+   * _If using the `"development"` condition_ and you just need to map
+   * `devDependencies`, use the {@link MapNodeModulesOptions.dev dev} flag
+   * instead.
    */
   conditions: Set<string>;
   /**
-   * @deprecated add `"development"` to the `conditions` Set option.
-   * Including `devDependencies` has been subsumed by implication
-   * of having the `"development"` condition.
+   * If `true`, include packages from `devDependencies` in the resulting {@link CompartmentMapDescriptor}.
+   *
+   * Historically this is synonymous with the `"development"`
+   * {@link MapNodeModulesOptions.conditions condition}, but this behavior may
+   * be deprecated in a future version.
    */
   dev: boolean;
   /**


### PR DESCRIPTION
## Description

This un-deprecates (de-deprecates?) the `dev` option to `mapNodeModules`. This flag was deprecated in `@endo/compartment-mapper` v1.2.0 in lieu of using the `conditions` option, but it was not removed. These two options were conflated with each other in an unintended way.

`dev` instructs `mapNodeModules` to consider `devDependencies` when mapping. `conditions` is for satisfying conditional exports.

Added a note to both options clarifying the situation.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

Updated `NEWS.md`.

### Testing Considerations

n/a

### Compatibility Considerations

This change is documentation-only.

### Upgrade Considerations

This change is documentation-only.
