### PR TITLE
fix(pass-style)! flip which symbols are passable

### DIFF
--- a/packages/eventual-send/test/eventual-send.test.js
+++ b/packages/eventual-send/test/eventual-send.test.js
@@ -181,7 +181,7 @@ test('new HandledPromise expected errors', async t => {
     /* eslint-disable no-await-in-loop */
     const { [method]: elide, ...handler2 } = handler;
     Object.setPrototypeOf(handler2, {
-      [Symbol.for('extraMethod')]() {
+      [Symbol('extraMethod')]() {
         return 'extra method';
       },
     });

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@endo/init": "workspace:^",
+    "@endo/marshal": "workspace:^",
     "@endo/ses-ava": "workspace:^",
     "ava": "^6.1.3",
     "babel-eslint": "^10.1.0",

--- a/packages/exo/test/heap-classes.test.js
+++ b/packages/exo/test/heap-classes.test.js
@@ -3,6 +3,7 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { getInterfaceMethodKeys, M } from '@endo/patterns';
+import { testFullOrderEQ } from '@endo/marshal/tools/ava-full-order-eq.js';
 import {
   GET_INTERFACE_GUARD,
   defineExoClass,
@@ -81,22 +82,21 @@ test('test defineExoClass', t => {
   t.deepEqual(upCounter[GET_INTERFACE_GUARD]?.(), UpCounterI);
   t.deepEqual(getInterfaceMethodKeys(UpCounterI), ['incr']);
 
-  const symbolic = Symbol.for('symbolic');
   const FooI = M.interface('Foo', {
     m: M.call().returns(),
-    [symbolic]: M.call(M.boolean()).returns(),
+    m2: M.call(M.boolean()).returns(),
   });
-  t.deepEqual(getInterfaceMethodKeys(FooI), ['m', Symbol.for('symbolic')]);
+  testFullOrderEQ(t, getInterfaceMethodKeys(FooI), ['m', 'm2']);
   const makeFoo = defineExoClass('Foo', FooI, () => ({}), {
     m() {},
-    [symbolic]() {},
+    m2() {},
   });
   const foo = makeFoo();
   t.deepEqual(foo[GET_INTERFACE_GUARD]?.(), FooI);
   // @ts-expect-error intentional for test
-  t.throws(() => foo[symbolic]('invalid arg'), {
+  t.throws(() => foo.m2('invalid arg'), {
     message:
-      'In "[Symbol(symbolic)]" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
+      'In "m2" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
   });
 });
 

--- a/packages/exo/test/non-enumerable-methods.test.js
+++ b/packages/exo/test/non-enumerable-methods.test.js
@@ -1,6 +1,7 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { objectMetaMap } from '@endo/common/object-meta-map.js';
+import { testFullOrderEQ } from '@endo/marshal/tools/ava-full-order-eq.js';
 import { getInterfaceMethodKeys, M } from '@endo/patterns';
 import { defineExoClass } from '../src/exo-makers.js';
 import { GET_INTERFACE_GUARD } from '../src/get-interface.js';
@@ -49,25 +50,24 @@ test('test defineExoClass', t => {
   t.deepEqual(upCounter[GET_INTERFACE_GUARD](), UpCounterI);
   t.deepEqual(getInterfaceMethodKeys(UpCounterI), ['incr']);
 
-  const symbolic = Symbol.for('symbolic');
   const FooI = M.interface('Foo', {
     m: M.call().returns(),
-    [symbolic]: M.call(M.boolean()).returns(),
+    m2: M.call(M.boolean()).returns(),
   });
-  t.deepEqual(getInterfaceMethodKeys(FooI), ['m', Symbol.for('symbolic')]);
+  testFullOrderEQ(t, getInterfaceMethodKeys(FooI), ['m', 'm2']);
   const makeFoo = defineExoClass(
     'Foo',
     FooI,
     () => ({}),
     denumerate({
       m() {},
-      [symbolic]() {},
+      m2() {},
     }),
   );
   const foo = makeFoo();
   t.deepEqual(foo[GET_INTERFACE_GUARD](), FooI);
-  t.throws(() => foo[symbolic]('invalid arg'), {
+  t.throws(() => foo.m2('invalid arg'), {
     message:
-      'In "[Symbol(symbolic)]" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
+      'In "m2" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
   });
 });

--- a/packages/far/test/e.test.js
+++ b/packages/far/test/e.test.js
@@ -104,7 +104,7 @@ test('E call missing class methods', async t => {
       this.quarter = n => n / 4;
     }
 
-    [Symbol.for('half')](n) {
+    [Symbol('half')](n) {
       return n / 2;
     }
   }

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./tools/*": "./tools/*"
   },
   "directories": {
     "test": "test"

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -53,7 +53,7 @@ harden(stringify);
 
 /**
  * @param {string} str
- * @returns {unknown}
+ * @returns {Passable}
  */
 const parse = str =>
   unserialize(

--- a/packages/marshal/test/_marshal-test-data.js
+++ b/packages/marshal/test/_marshal-test-data.js
@@ -49,12 +49,10 @@ export const roundTripPairs = harden([
   [9007199254740993n, { '@qclass': 'bigint', digits: '9007199254740993' }],
 
   // Well known symbols
-  [Symbol.asyncIterator, { '@qclass': 'symbol', name: '@@asyncIterator' }],
-  [Symbol.match, { '@qclass': 'symbol', name: '@@match' }],
-  // Registered symbols
-  [Symbol.for('foo'), { '@qclass': 'symbol', name: 'foo' }],
-  // Registered symbol hilbert hotel
-  [Symbol.for('@@foo'), { '@qclass': 'symbol', name: '@@@@foo' }],
+  [Symbol.asyncIterator, { '@qclass': 'symbol', name: 'Symbol.asyncIterator' }],
+  [Symbol.match, { '@qclass': 'symbol', name: 'Symbol.match' }],
+  // Unregistered symbols
+  [Symbol('foo'), { '@qclass': 'symbol', name: 'foo' }],
 
   // Normal json reviver cannot make properties with undefined values
   [[undefined], [{ '@qclass': 'undefined' }]],
@@ -80,7 +78,7 @@ export const roundTripPairs = harden([
 
   // errors
   [
-    Error(),
+    Error(''),
     {
       '@qclass': 'error',
       message: '',
@@ -181,10 +179,13 @@ export const jsonJustinPairs = harden([
   ['{"@qclass":"-Infinity"}', '-Infinity'],
   ['{"@qclass":"bigint","digits":"4"}', '4n'],
   ['{"@qclass":"bigint","digits":"9007199254740993"}', '9007199254740993n'],
-  ['{"@qclass":"symbol","name":"@@asyncIterator"}', 'Symbol.asyncIterator'],
-  ['{"@qclass":"symbol","name":"@@match"}', 'Symbol.match'],
-  ['{"@qclass":"symbol","name":"foo"}', 'Symbol.for("foo")'],
-  ['{"@qclass":"symbol","name":"@@@@foo"}', 'Symbol.for("@@foo")'],
+  [
+    '{"@qclass":"symbol","name":"Symbol.asyncIterator"}',
+    'Symbol("Symbol.asyncIterator")',
+  ],
+  ['{"@qclass":"symbol","name":"Symbol.match"}', 'Symbol("Symbol.match")'],
+  ['{"@qclass":"symbol","name":"foo"}', 'Symbol("foo")'],
+  ['{"@qclass":"symbol","name":"@@foo"}', 'Symbol("@@foo")'],
 
   // Arrays and objects
   ['[{"@qclass":"undefined"}]', '[undefined]'],
@@ -264,11 +265,11 @@ export const unsortedSample = harden([
   [5],
   exampleAlice,
   [],
-  Symbol.for('foo'),
+  Symbol('foo'),
   Error('not erroneous'),
-  Symbol.for('@@foo'),
+  Symbol('@@foo'),
   [5, { bar: 5 }],
-  Symbol.for(''),
+  Symbol(''),
   false,
   exampleCarol,
   [exampleCarol, 'm'],
@@ -385,10 +386,10 @@ export const sortedSample = harden([
   'foo',
 
   null,
-  Symbol.for(''),
-  Symbol.for('@@foo'),
+  Symbol(''),
+  Symbol('@@foo'),
   Symbol.isConcatSpreadable,
-  Symbol.for('foo'),
+  Symbol('foo'),
 
   undefined,
   undefined,

--- a/packages/marshal/test/marshal-capdata.test.js
+++ b/packages/marshal/test/marshal-capdata.test.js
@@ -3,6 +3,7 @@ import test from '@endo/ses-ava/prepare-endo.js';
 import { passStyleOf, Far } from '@endo/pass-style';
 import { makeMarshal } from '../src/marshal.js';
 import { roundTripPairs } from './_marshal-test-data.js';
+import { testFullOrderEQ } from '../tools/ava-full-order-eq.js';
 
 const {
   freeze,
@@ -49,7 +50,7 @@ test('serialize unserialize round trip pairs', t => {
     const encoding = JSON.stringify(encoded);
     t.is(body, encoding);
     const decoding = unserialize({ body, slots: [] });
-    t.deepEqual(decoding, plain);
+    testFullOrderEQ(t, decoding, plain);
     t.assert(isFrozen(decoding));
   }
 });
@@ -68,9 +69,8 @@ test('serialize static data', t => {
   t.deepEqual(ser(-0), { body: '0', slots: [] });
   t.deepEqual(ser(-0), ser(0));
   // unregistered symbols
-  t.throws(() => ser(Symbol('sym2')), {
-    // An anonymous symbol is not Passable
-    message: /Only registered symbols or well-known symbols are passable:/,
+  t.throws(() => ser(Symbol.for('sym2')), {
+    message: 'Only unregistered symbols are passable: "[Symbol(sym2)]"',
   });
 
   const cd = ser(harden([1, 2]));

--- a/packages/marshal/test/marshal-far-obj.test.js
+++ b/packages/marshal/test/marshal-far-obj.test.js
@@ -175,11 +175,11 @@ test('transitional remotables', t => {
   };
 
   // For objects with Symbol-named properties
-  const symEnumData = Symbol.for('symEnumData');
-  const symEnumFunc = Symbol.for('symEnumFunc');
-  const symNonenumData = Symbol.for('symNonenumData');
-  const symNonenumFunc = Symbol.for('symNonenumFunc');
-  const symNonenumGetFunc = Symbol.for('symNonenumGetFunc');
+  const symEnumData = Symbol('symEnumData');
+  const symEnumFunc = Symbol('symEnumFunc');
+  const symNonenumData = Symbol('symNonenumData');
+  const symNonenumFunc = Symbol('symNonenumFunc');
+  const symNonenumGetFunc = Symbol('symNonenumGetFunc');
 
   function build(...opts) {
     const props = {};
@@ -229,6 +229,7 @@ test('transitional remotables', t => {
   const FAR_NOACC = /cannot serialize Remotables with accessors/;
   const FAR_ONLYMETH = /cannot serialize Remotables with non-methods/;
   const FAR_EXPLICIT = /Remotables must be explicitly declared/;
+  const FAR_SYMBOL_METHODS = /Remotables can only have string-named methods:/;
 
   // Far('iface', {})
   // all cases: pass-by-ref
@@ -237,9 +238,10 @@ test('transitional remotables', t => {
   // Far('iface', {key: func})
   // all cases: pass-by-ref
   t.deepEqual(ser(build('far', 'enumStringFunc')), yesIface);
-  t.deepEqual(ser(build('far', 'enumSymbolFunc')), yesIface);
   t.deepEqual(ser(build('far', 'nonenumStringFunc')), yesIface);
-  t.deepEqual(ser(build('far', 'nonenumSymbolFunc')), yesIface);
+
+  shouldThrow(['enumSymbolFunc'], FAR_SYMBOL_METHODS);
+  shouldThrow(['nonenumSymbolFunc'], FAR_SYMBOL_METHODS);
 
   // { key: func }
   // old: pass-by-ref without warning
@@ -247,9 +249,9 @@ test('transitional remotables', t => {
   // interim2: reject
   // final: reject
   shouldThrow(['enumStringFunc'], FAR_EXPLICIT);
-  shouldThrow(['enumSymbolFunc'], FAR_EXPLICIT);
+  shouldThrow(['enumSymbolFunc'], FAR_SYMBOL_METHODS);
   shouldThrow(['nonenumStringFunc'], FAR_EXPLICIT);
-  shouldThrow(['nonenumSymbolFunc'], FAR_EXPLICIT);
+  shouldThrow(['nonenumSymbolFunc'], FAR_SYMBOL_METHODS);
 
   // Far('iface', { key: data, key: func }) : rejected
   // (some day this might add auxilliary data, but not now

--- a/packages/marshal/test/marshal-stringify.test.js
+++ b/packages/marshal/test/marshal-stringify.test.js
@@ -3,6 +3,7 @@ import test from '@endo/ses-ava/prepare-endo.js';
 import { Far } from '@endo/pass-style';
 import { stringify, parse } from '../src/marshal-stringify.js';
 import { roundTripPairs } from './_marshal-test-data.js';
+import { testFullOrderEQ } from '../tools/ava-full-order-eq.js';
 
 const { isFrozen } = Object;
 
@@ -17,7 +18,7 @@ test('stringify parse round trip pairs', t => {
     const encoding = JSON.stringify(encoded);
     t.is(str, encoding);
     const decoding = parse(str);
-    t.deepEqual(decoding, plain);
+    testFullOrderEQ(t, decoding, plain);
     t.assert(isFrozen(decoding));
   }
 });

--- a/packages/marshal/tools/ava-full-order-eq.js
+++ b/packages/marshal/tools/ava-full-order-eq.js
@@ -1,0 +1,50 @@
+import { makeFullOrderComparatorKit } from '../src/rankOrder.js';
+
+// TODO once we're on the other side of this transition, migrate all importers
+// of `testFullOrderEQ` from `@agoric/internal/tools/ava-full-order-eq.js`
+// to import instead from `@endo/marshal/tools/ava-full-order-eq.js
+
+/**
+ * @import {Passable} from '@endo/pass-style';
+ */
+
+/**
+ * We often used `t.deepEqual` to compare whether two Passables are the same in
+ * our distributed object semantics. This was never correct, but worked well
+ * enough until https://github.com/endojs/endo/pull/2777 when Passable symbols
+ * that were not `t.deepEqual` could still be equal in our distributed object
+ * semantics. For at least those cases, switch from
+ *
+ * ```js
+ * t.deepEqual(specimen, expected, message?)
+ * ```
+ *
+ * to
+ *
+ * ```js
+ * testFullOrderEQ(t, specimen, expected, message?)
+ * ```
+ *
+ * Even aside from symbols, this is not quite testing the same thing. In our
+ * distributed object semantics, neither promises nor errors have comparable
+ * equality. All promises and of the same rank, and all errors are of the same
+ * rank. `compareFull` differs from `compareRank` only in the comparisons
+ * remotables, for which `compareFull` only judges two remotable to be equal if
+ * if they are the same remotable, which is what we want here.
+ *
+ * Since `testFullOrderEQ` is a convenience only for testing, some normal
+ * security constraints do not apply. `testFullOrderEQ` hardens the `specimen`
+ * and `expected` arguments, so that if the only reason they were not passable
+ * is that they were not yet hardened, `testFullOrderEQ` takes case of that for
+ * you.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {Passable} specimen
+ * @param {Passable} expected
+ * @param {string} [message]
+ */
+export const testFullOrderEQ = (t, specimen, expected, message) => {
+  const { comparator: compareFull } = makeFullOrderComparatorKit();
+  return t.is(compareFull(harden(specimen), harden(expected)), 0, message);
+};
+harden(testFullOrderEQ);

--- a/packages/pass-style/src/iter-helpers.js
+++ b/packages/pass-style/src/iter-helpers.js
@@ -13,7 +13,7 @@ import { Far } from './make-far.js';
  */
 export const mapIterable = (baseIterable, func) =>
   /** @type {Iterable<U>} */
-  Far('mapped iterable', {
+  harden({
     [Symbol.iterator]: () => {
       const baseIterator = baseIterable[Symbol.iterator]();
       return Far('mapped iterator', {
@@ -40,7 +40,7 @@ harden(mapIterable);
  */
 export const filterIterable = (baseIterable, pred) =>
   /** @type {Iterable<U>} */
-  Far('filtered iterable', {
+  harden({
     [Symbol.iterator]: () => {
       const baseIterator = baseIterable[Symbol.iterator]();
       return Far('filtered iterator', {

--- a/packages/pass-style/src/passStyle-helpers.js
+++ b/packages/pass-style/src/passStyle-helpers.js
@@ -4,6 +4,7 @@
 /** @import {PassStyle} from './types.js' */
 
 import { X, q } from '@endo/errors';
+import { specialCaseAsyncIteratorSymbol } from './symbol.js';
 
 const { isArray } = Array;
 const { prototype: functionPrototype } = Function;
@@ -64,6 +65,16 @@ export const PASS_STYLE = Symbol.for('passStyle');
 export const canBeMethod = func =>
   typeof func === 'function' && !(PASS_STYLE in func);
 harden(canBeMethod);
+
+/**
+ * To ease the transition, if `PASS_STYLE_LEGACY_ASYNC_ITERATOR_SYMBOL` is
+ * `'enabled'`, then we do allow `Symbol.asyncIterator` as a method name.
+ *
+ * @param {PropertyKey} key
+ */
+export const canBeMethodName = key =>
+  typeof key === 'string' ||
+  (specialCaseAsyncIteratorSymbol && key === Symbol.asyncIterator);
 
 /**
  * Below we have a series of predicate functions and their (curried) assertion

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -11,6 +11,7 @@ import {
   isObject,
   getTag,
   CX,
+  canBeMethodName,
 } from './passStyle-helpers.js';
 
 /**
@@ -230,9 +231,11 @@ export const RemotableHelper = harden({
                 CX(check)`cannot serialize Remotables with non-methods like ${q(
                   String(key),
                 )} in ${candidate}`)) &&
-              (key !== PASS_STYLE ||
+              (canBeMethodName(key) ||
                 (!!check &&
-                  CX(check)`A pass-by-remote cannot shadow ${q(PASS_STYLE)}`))))
+                  CX(
+                    check,
+                  )`Remotables can only have string-named methods: ${String(key)}`))))
         );
       });
     } else if (typeof candidate === 'function') {

--- a/packages/pass-style/src/symbol.js
+++ b/packages/pass-style/src/symbol.js
@@ -1,117 +1,75 @@
+import { getEnvironmentOption } from '@endo/env-options';
 import { Fail, q } from '@endo/errors';
 
-const { ownKeys } = Reflect;
-
 /**
- * The well known symbols are static symbol values on the `Symbol` constructor.
- */
-const wellKnownSymbolNames = new Map(
-  ownKeys(Symbol)
-    .filter(
-      name => typeof name === 'string' && typeof Symbol[name] === 'symbol',
-    )
-    .filter(name => {
-      // @ts-expect-error It doesn't know name cannot be a symbol
-      !name.startsWith('@@') ||
-        Fail`Did not expect Symbol to have a symbol-valued property name starting with "@@" ${q(
-          name,
-        )}`;
-      return true;
-    })
-    // @ts-ignore It doesn't know name cannot be a symbol
-    .map(name => [Symbol[name], `@@${name}`]),
-);
-
-/**
- * The passable symbols are the well known symbols (the symbol values
- * of static properties of the `Symbol` constructor) and the registered
- * symbols.
+ * A symbol is passable iff it is not a registered symbol. In the distributed
+ * object semantics, two passable symbols are "equal" iff they have the same
+ * `description`.
  *
  * @param {any} sym
  * @returns {boolean}
  */
 export const isPassableSymbol = sym =>
-  typeof sym === 'symbol' &&
-  (typeof Symbol.keyFor(sym) === 'string' || wellKnownSymbolNames.has(sym));
+  typeof sym === 'symbol' && Symbol.keyFor(sym) === undefined;
 harden(isPassableSymbol);
 
 export const assertPassableSymbol = sym =>
   isPassableSymbol(sym) ||
-  Fail`Only registered symbols or well-known symbols are passable: ${q(sym)}`;
+  Fail`Only unregistered symbols are passable: ${q(sym)}`;
 harden(assertPassableSymbol);
 
 /**
- * If `sym` is a passable symbol, return a string that uniquely identifies this
- * symbol. If `sym` is a non-passable symbol, return `undefined`.
- *
- * The passable symbols are the well known symbols (the symbol values
- * of static properties of the `Symbol` constructor) and the registered
- * symbols. Since the registration string of a registered symbol can be any
- * string, if we simply used that to identify those symbols, there would not
- * be any remaining strings left over to identify the well-known symbols.
- * Instead, we reserve strings beginning with `"@@"` for purposes of this
- * encoding. We identify a well known symbol such as `Symbol.iterator`
- * by prefixing the property name with `"@@"`, such as `"@@iterator"`.
- * For registered symbols whose name happens to begin with `"@@"`, such
- * as `Symbol.for('@@iterator')` or `Symbol.for('@@foo')`, we identify
- * them by prefixing them with an extra `"@@"`, such as
- * `"@@@@iterator"` or `"@@@@foo"`. (This is the Hilbert Hotel encoding
- * technique.)
+ * If `sym` is a passable symbol, return its `description`.
+ * If `sym` is not a passable symbol, return `undefined`.
  *
  * @param {symbol} sym
  * @returns {string=}
  */
-export const nameForPassableSymbol = sym => {
-  const name = Symbol.keyFor(sym);
-  if (name === undefined) {
-    return wellKnownSymbolNames.get(sym);
-  }
-  if (name.startsWith('@@')) {
-    return `@@${name}`;
-  }
-  return name;
-};
+export const nameForPassableSymbol = sym =>
+  isPassableSymbol(sym) ? sym.description : undefined;
 harden(nameForPassableSymbol);
 
-const AtAtPrefixPattern = /^@@(.*)$/;
-harden(AtAtPrefixPattern);
+const symbolAsyncIteratorDescription = Symbol.asyncIterator.description;
+
+export const specialCaseAsyncIteratorSymbol =
+  getEnvironmentOption('PASS_STYLE_LEGACY_ASYNC_ITERATOR_SYMBOL', 'enabled', [
+    'disabled',
+  ]) === 'enabled';
 
 /**
- * If `name` is a string that could have been produced by
- * `nameForPassableSymbol`, return the symbol argument it was produced to
- * represent.
+ * Return a *fresh* unregistered not-well-known symbol whose `description`
+ * is `name`.
  *
- *    If `name` does not begin with `"@@"`, then just the corresponding
- *      registered symbol, `Symbol.for(name)`.
- *    If `name` is `"@@"` followed by a well known symbol's property name on
- *      `Symbol` such `"@@iterator", return that well known symbol such as
- *      `Symbol.iterator`
- *    If `name` begins with `"@@@@"` it encodes the registered symbol whose
- *      name begins with `"@@"` instead.
- *    Otherwise, if name begins with `"@@"` it may encode a registered symbol
- *      from a future version of JavaScript, but it is not one we can decode
- *      yet, so throw.
+ * Alternatively, to soften the transition from legacy,
+ * if environment variable `PASS_STYLE_LEGACY_ASYNC_ITERATOR_SYMBOL`
+ * is `'enabled'` (not the default) and the name is either `'@@asyncIterator'`
+ * or the `description` string of `Symbol.asyncIterator`, then return
+ * `Symbol.asyncIterator`.
+ *
+ * NOTE: In this PR we make `'enabled'` the default, so agoric-sdk testing
+ * can switch between `#endo-branch: ` with this fork vs the "normal" fork
+ * described above. When this is `'enabled'` then `Symbol.asyncIterator`
+ * itself is still allowed as a method name.
+ *
+ * TODO Once we're on the other side of this transition, we will eventually
+ * stop supporting this config switch.
  *
  * @param {string} name
- * @returns {symbol=}
+ * @returns {symbol}
  */
-export const passableSymbolForName = name => {
-  if (typeof name !== 'string') {
-    return undefined;
-  }
-  const match = AtAtPrefixPattern.exec(name);
-  if (match) {
-    const suffix = match[1];
-    if (suffix.startsWith('@@')) {
-      return Symbol.for(suffix);
-    } else {
-      const sym = Symbol[suffix];
-      if (typeof sym === 'symbol') {
-        return sym;
-      }
-      Fail`Reserved for well known symbol ${q(suffix)}: ${q(name)}`;
-    }
-  }
-  return Symbol.for(name);
-};
+export const passableSymbolForName = name =>
+  specialCaseAsyncIteratorSymbol &&
+  ['@@asyncIterator', symbolAsyncIteratorDescription].includes(name)
+    ? Symbol.asyncIterator
+    : Symbol(name);
 harden(passableSymbolForName);
+
+/**
+ * An adapter to help transition to flip which symbols are passable.
+ * See `ses-utils.js` in `@agoric/internal` at
+ * https://github.com/Agoric/agoric-sdk/pull/11338
+ *
+ * @param {string} name
+ * @returns {symbol}
+ */
+export const unpassableSymbolForName = name => Symbol.for(name);

--- a/packages/pass-style/test/passStyleOf.test.js
+++ b/packages/pass-style/test/passStyleOf.test.js
@@ -52,7 +52,7 @@ test('passStyleOf basic success cases', t => {
   t.is(passStyleOf(true), 'boolean');
   t.is(passStyleOf(33), 'number');
   t.is(passStyleOf(33n), 'bigint');
-  t.is(passStyleOf(Symbol.for('foo')), 'symbol');
+  t.is(passStyleOf(Symbol('foo')), 'symbol');
   t.is(passStyleOf(Symbol.iterator), 'symbol');
   t.is(passStyleOf(null), 'null');
   t.is(passStyleOf(harden(Promise.resolve(null))), 'promise');
@@ -79,9 +79,8 @@ test('some passStyleOf rejections', t => {
       'Passable Error must have an own "message" string property: "[Error: ]"',
   });
 
-  t.throws(() => passStyleOf(Symbol('unique')), {
-    message:
-      /Only registered symbols or well-known symbols are passable: "\[Symbol\(unique\)\]"/,
+  t.throws(() => passStyleOf(Symbol.for('unique')), {
+    message: 'Only unregistered symbols are passable: "[Symbol(unique)]"',
   });
   if (harden.isFake) {
     t.is(passStyleOf({}), 'copyRecord');

--- a/packages/pass-style/tools/arb-passable.js
+++ b/packages/pass-style/tools/arb-passable.js
@@ -21,13 +21,12 @@ export const makeArbitraries = (fc, exclusions = []) => {
   const keyableLeaves = [
     fc.constantFrom(null, undefined, false, true),
     arbString,
-    arbString.map(s => Symbol.for(s)),
-    // primordial symbols and registered lookalikes
+    arbString.map(s => Symbol(s)),
     fc.constantFrom(
       ...Object.getOwnPropertyNames(Symbol).flatMap(k => {
         const v = Symbol[k];
-        if (typeof v !== 'symbol') return [];
-        return [v, Symbol.for(k), Symbol.for(`@@${k}`)];
+        if (typeof v !== 'symbol' || Symbol.keyFor(v) !== undefined) return [];
+        return [v, Symbol(k), Symbol(k)];
       }),
     ),
     fc.bigInt(),

--- a/packages/patterns/src/keys/checkKey.js
+++ b/packages/patterns/src/keys/checkKey.js
@@ -415,7 +415,7 @@ export const getCopyMapEntries = m => {
     payload: { keys, values },
   } = m;
   const { length } = /** @type {Array} */ (keys);
-  return Far('CopyMap entries iterable', {
+  return harden({
     [Symbol.iterator]: () => {
       let i = 0;
       return Far('CopyMap entries iterator', {

--- a/packages/patterns/test/copyMap.test.js
+++ b/packages/patterns/test/copyMap.test.js
@@ -127,7 +127,10 @@ test('getCopyMapEntries', t => {
   ]);
   t.deepEqual([...getCopyMapEntries(m)], getCopyMapEntryArray(m));
   const entriesIterable = getCopyMapEntries(m);
-  t.is(passStyleOf(entriesIterable), 'remotable');
+  t.throws(() => passStyleOf(entriesIterable), {
+    message:
+      'Remotables can only have string-named methods: "Symbol(Symbol.iterator)"',
+  });
   const entriesIterator = entriesIterable[Symbol.iterator]();
   t.is(passStyleOf(entriesIterator), 'remotable');
   const iterResult = entriesIterator.next();

--- a/packages/patterns/test/pattern-limits.test.js
+++ b/packages/patterns/test/pattern-limits.test.js
@@ -117,7 +117,7 @@ const runTests = (successCase, failCase) => {
   }
   // symbolNameLengthLimit
   {
-    const specimen = Symbol.for('moderate length string');
+    const specimen = Symbol('moderate length string');
     successCase(specimen, M.symbol());
     successCase(specimen, M.symbol(harden({ symbolNameLengthLimit: 40 })));
 
@@ -128,7 +128,7 @@ const runTests = (successCase, failCase) => {
     );
   }
   {
-    const specimen = Symbol.for(
+    const specimen = Symbol(
       'x'.repeat(defaultLimits.symbolNameLengthLimit + 1),
     );
     successCase(

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,6 +562,7 @@ __metadata:
     "@endo/eventual-send": "workspace:^"
     "@endo/far": "workspace:^"
     "@endo/init": "workspace:^"
+    "@endo/marshal": "workspace:^"
     "@endo/pass-style": "workspace:^"
     "@endo/patterns": "workspace:^"
     "@endo/ses-ava": "workspace:^"


### PR DESCRIPTION
Closes: #XXXX
Refs: https://github.com/ocapn/ocapn/issues/165 https://github.com/endojs/endo/pull/2772 https://github.com/endojs/endo/pull/2774 #2778 #2779 https://github.com/tc39/proposal-symbol-predicates https://github.com/Agoric/agoric-sdk/pull/11338

## Description

@kriskowal and @kumavis just had a great idea! Instead of simply avoiding symbols altogether because of gc worries, switch from treating only registered and well known symbols as passable to treating only unregistered symbols as passable. Then, treat two unregistered symbols as equal within our distributed object semantics iff they have the same `description` string. 

This does what I thought impossible: it recapitulates at the user level for unregistered symbols the implementation technique that I had recommended engines do internally for registered symbols --- forget any registry, and just treat two registered symbols are equal if they have the same contents. Just like JS already does for strings.

Most well known symbols are unregistered. I think they all must be unregistered, but at least on Node, `Symbol.dispose` and `Symbol.asyncDispose` are mistakenly registered symbols.

- [ ] file bugs that `Symbol.dispose` and `Symbol.asyncDispose` are mistakenly registered symbols.

In any case, for all well-known symbols that are unregistered, these are passable with no special case. But remember that they unserialize to fresh symbol with distinct JS identities.

### Security Considerations

By always unserializing to fresh symbols, we avoid coinciding with the identity of pre-existing JS symbols. This helps separate concerns in ways helpful to security.

### Scaling Considerations

This fixes the gc problem we had with registered symbols without introducing a separate `Selector` object type. This scales better.

### Documentation Considerations

This will make harmonization with ocapn smoother.

### Testing Considerations

So far, the change has only required changes that were testing how symbols pass. We have not seen any other breakage yet. But the real test will be integration with agoric-sdk.

### Compatibility Considerations

I marked this PR with `!` because it is a compat break. To ease the transition I also added a `PASS_STYLE_LEGACY_ASYNC_ITERATOR_SYMBOL` environment variable which defaults to `'disabled'`. But if set to `'enabled'`, it tries to be somewhat accommodating to legacy uses of `Symbol.asyncIterator` until we can retire those.

- [x] This change is fundamentally incompatible with remotables having symbol-named methods. This PR should enhance `passStyleOf` to reject any such objects rather than classifying them as remotables.


### Upgrade Considerations

If we currently have any old-style passable symbols in durable storage, or if there are elsewhere persistent samples of serialized data containing old-style passable symbols, we may be in trouble. We need to check. If we are in trouble, we'll need an upgrade strategy to get across this transition.