### PR TITLE
fix(pass-style): no symbol named methods in remotables

### DIFF
--- a/packages/exo/test/heap-classes.test.js
+++ b/packages/exo/test/heap-classes.test.js
@@ -3,7 +3,7 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { getInterfaceMethodKeys, M } from '@endo/patterns';
-import { compareRank } from '@endo/marshal';
+import { testFullOrderEQ } from '@endo/marshal/tools/ava-full-order-eq.js';
 import {
   GET_INTERFACE_GUARD,
   defineExoClass,
@@ -91,7 +91,7 @@ test('test defineExoClass', t => {
   // our distributed object semantics. Unfortunately, `compareRank` is
   // too imprecise. We'd like to also test `keyEQ`, but that would violate
   // our package layering.
-  t.is(compareRank(getInterfaceMethodKeys(FooI), harden(['m', 'm2'])), 0);
+  testFullOrderEQ(t, getInterfaceMethodKeys(FooI), ['m', 'm2']);
   const makeFoo = defineExoClass('Foo', FooI, () => ({}), {
     m() {},
     m2() {},

--- a/packages/exo/test/heap-classes.test.js
+++ b/packages/exo/test/heap-classes.test.js
@@ -82,33 +82,26 @@ test('test defineExoClass', t => {
   t.deepEqual(upCounter[GET_INTERFACE_GUARD]?.(), UpCounterI);
   t.deepEqual(getInterfaceMethodKeys(UpCounterI), ['incr']);
 
-  const symbolic = Symbol('symbolic');
   const FooI = M.interface('Foo', {
     m: M.call().returns(),
-    [symbolic]: M.call(M.boolean()).returns(),
+    m2: M.call(M.boolean()).returns(),
   });
   // Cannot use `t.deepEqual` because it does not recognize that two
   // unregistered symbols with the same `description` are the same in
   // our distributed object semantics. Unfortunately, `compareRank` is
   // too imprecise. We'd like to also test `keyEQ`, but that would violate
   // our package layering.
-  t.is(
-    compareRank(
-      getInterfaceMethodKeys(FooI),
-      harden(['m', Symbol('symbolic')]),
-    ),
-    0,
-  );
+  t.is(compareRank(getInterfaceMethodKeys(FooI), harden(['m', 'm2'])), 0);
   const makeFoo = defineExoClass('Foo', FooI, () => ({}), {
     m() {},
-    [symbolic]() {},
+    m2() {},
   });
   const foo = makeFoo();
   t.deepEqual(foo[GET_INTERFACE_GUARD]?.(), FooI);
   // @ts-expect-error intentional for test
-  t.throws(() => foo[symbolic]('invalid arg'), {
+  t.throws(() => foo.m2('invalid arg'), {
     message:
-      'In "[Symbol(symbolic)]" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
+      'In "m2" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
   });
 });
 

--- a/packages/exo/test/heap-classes.test.js
+++ b/packages/exo/test/heap-classes.test.js
@@ -86,11 +86,6 @@ test('test defineExoClass', t => {
     m: M.call().returns(),
     m2: M.call(M.boolean()).returns(),
   });
-  // Cannot use `t.deepEqual` because it does not recognize that two
-  // unregistered symbols with the same `description` are the same in
-  // our distributed object semantics. Unfortunately, `compareRank` is
-  // too imprecise. We'd like to also test `keyEQ`, but that would violate
-  // our package layering.
   testFullOrderEQ(t, getInterfaceMethodKeys(FooI), ['m', 'm2']);
   const makeFoo = defineExoClass('Foo', FooI, () => ({}), {
     m() {},

--- a/packages/exo/test/non-enumerable-methods.test.js
+++ b/packages/exo/test/non-enumerable-methods.test.js
@@ -1,7 +1,7 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { objectMetaMap } from '@endo/common/object-meta-map.js';
-import { compareRank } from '@endo/marshal';
+import { testFullOrderEQ } from '@endo/marshal/tools/ava-full-order-eq.js';
 import { getInterfaceMethodKeys, M } from '@endo/patterns';
 import { defineExoClass } from '../src/exo-makers.js';
 import { GET_INTERFACE_GUARD } from '../src/get-interface.js';
@@ -59,7 +59,7 @@ test('test defineExoClass', t => {
   // our distributed object semantics. Unfortunately, `compareRank` is
   // too imprecise. We'd like to also test `keyEQ`, but that would violate
   // our package layering.
-  t.is(compareRank(getInterfaceMethodKeys(FooI), harden(['m', 'm2'])), 0);
+  testFullOrderEQ(t, getInterfaceMethodKeys(FooI), ['m', 'm2']);
   const makeFoo = defineExoClass(
     'Foo',
     FooI,

--- a/packages/exo/test/non-enumerable-methods.test.js
+++ b/packages/exo/test/non-enumerable-methods.test.js
@@ -50,36 +50,29 @@ test('test defineExoClass', t => {
   t.deepEqual(upCounter[GET_INTERFACE_GUARD](), UpCounterI);
   t.deepEqual(getInterfaceMethodKeys(UpCounterI), ['incr']);
 
-  const symbolic = Symbol('symbolic');
   const FooI = M.interface('Foo', {
     m: M.call().returns(),
-    [symbolic]: M.call(M.boolean()).returns(),
+    m2: M.call(M.boolean()).returns(),
   });
   // Cannot use `t.deepEqual` because it does not recognize that two
   // unregistered symbols with the same `description` are the same in
   // our distributed object semantics. Unfortunately, `compareRank` is
   // too imprecise. We'd like to also test `keyEQ`, but that would violate
   // our package layering.
-  t.is(
-    compareRank(
-      getInterfaceMethodKeys(FooI),
-      harden(['m', Symbol('symbolic')]),
-    ),
-    0,
-  );
+  t.is(compareRank(getInterfaceMethodKeys(FooI), harden(['m', 'm2'])), 0);
   const makeFoo = defineExoClass(
     'Foo',
     FooI,
     () => ({}),
     denumerate({
       m() {},
-      [symbolic]() {},
+      m2() {},
     }),
   );
   const foo = makeFoo();
   t.deepEqual(foo[GET_INTERFACE_GUARD](), FooI);
-  t.throws(() => foo[symbolic]('invalid arg'), {
+  t.throws(() => foo.m2('invalid arg'), {
     message:
-      'In "[Symbol(symbolic)]" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
+      'In "m2" method of (Foo): arg 0: string "invalid arg" - Must be a boolean',
   });
 });

--- a/packages/exo/test/non-enumerable-methods.test.js
+++ b/packages/exo/test/non-enumerable-methods.test.js
@@ -54,11 +54,6 @@ test('test defineExoClass', t => {
     m: M.call().returns(),
     m2: M.call(M.boolean()).returns(),
   });
-  // Cannot use `t.deepEqual` because it does not recognize that two
-  // unregistered symbols with the same `description` are the same in
-  // our distributed object semantics. Unfortunately, `compareRank` is
-  // too imprecise. We'd like to also test `keyEQ`, but that would violate
-  // our package layering.
   testFullOrderEQ(t, getInterfaceMethodKeys(FooI), ['m', 'm2']);
   const makeFoo = defineExoClass(
     'Foo',

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./tools/*": "./tools/*"
   },
   "directories": {
     "test": "test"

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -53,7 +53,7 @@ harden(stringify);
 
 /**
  * @param {string} str
- * @returns {unknown}
+ * @returns {Passable}
  */
 const parse = str =>
   unserialize(

--- a/packages/marshal/test/marshal-capdata.test.js
+++ b/packages/marshal/test/marshal-capdata.test.js
@@ -50,11 +50,6 @@ test('serialize unserialize round trip pairs', t => {
     const encoding = JSON.stringify(encoded);
     t.is(body, encoding);
     const decoding = unserialize({ body, slots: [] });
-    // Cannot use `t.deepEqual` because it does not recognize that two
-    // unregistered symbols with the same `description` are the same in
-    // our distributed object semantics. Unfortunately, `compareRank` is
-    // too imprecise. We'd like to also test `keyEQ`, but that would violate
-    // our package layering.
     testFullOrderEQ(t, decoding, plain);
     t.assert(isFrozen(decoding));
   }

--- a/packages/marshal/test/marshal-capdata.test.js
+++ b/packages/marshal/test/marshal-capdata.test.js
@@ -3,7 +3,7 @@ import test from '@endo/ses-ava/prepare-endo.js';
 import { passStyleOf, Far } from '@endo/pass-style';
 import { makeMarshal } from '../src/marshal.js';
 import { roundTripPairs } from './_marshal-test-data.js';
-import { compareRank } from '../src/rankOrder.js';
+import { testFullOrderEQ } from '../tools/ava-full-order-eq.js';
 
 const {
   freeze,
@@ -55,7 +55,7 @@ test('serialize unserialize round trip pairs', t => {
     // our distributed object semantics. Unfortunately, `compareRank` is
     // too imprecise. We'd like to also test `keyEQ`, but that would violate
     // our package layering.
-    t.is(compareRank(decoding, plain), 0);
+    testFullOrderEQ(t, decoding, plain);
     t.assert(isFrozen(decoding));
   }
 });

--- a/packages/marshal/test/marshal-far-obj.test.js
+++ b/packages/marshal/test/marshal-far-obj.test.js
@@ -229,6 +229,7 @@ test('transitional remotables', t => {
   const FAR_NOACC = /cannot serialize Remotables with accessors/;
   const FAR_ONLYMETH = /cannot serialize Remotables with non-methods/;
   const FAR_EXPLICIT = /Remotables must be explicitly declared/;
+  const FAR_SYMBOL_METHODS = /Remotables can only have string-named methods:/;
 
   // Far('iface', {})
   // all cases: pass-by-ref
@@ -237,9 +238,10 @@ test('transitional remotables', t => {
   // Far('iface', {key: func})
   // all cases: pass-by-ref
   t.deepEqual(ser(build('far', 'enumStringFunc')), yesIface);
-  t.deepEqual(ser(build('far', 'enumSymbolFunc')), yesIface);
   t.deepEqual(ser(build('far', 'nonenumStringFunc')), yesIface);
-  t.deepEqual(ser(build('far', 'nonenumSymbolFunc')), yesIface);
+
+  shouldThrow(['enumSymbolFunc'], FAR_SYMBOL_METHODS);
+  shouldThrow(['nonenumSymbolFunc'], FAR_SYMBOL_METHODS);
 
   // { key: func }
   // old: pass-by-ref without warning
@@ -247,9 +249,9 @@ test('transitional remotables', t => {
   // interim2: reject
   // final: reject
   shouldThrow(['enumStringFunc'], FAR_EXPLICIT);
-  shouldThrow(['enumSymbolFunc'], FAR_EXPLICIT);
+  shouldThrow(['enumSymbolFunc'], FAR_SYMBOL_METHODS);
   shouldThrow(['nonenumStringFunc'], FAR_EXPLICIT);
-  shouldThrow(['nonenumSymbolFunc'], FAR_EXPLICIT);
+  shouldThrow(['nonenumSymbolFunc'], FAR_SYMBOL_METHODS);
 
   // Far('iface', { key: data, key: func }) : rejected
   // (some day this might add auxilliary data, but not now

--- a/packages/marshal/test/marshal-smallcaps.test.js
+++ b/packages/marshal/test/marshal-smallcaps.test.js
@@ -44,11 +44,6 @@ test('smallcaps serialize unserialize round trip half pairs', t => {
   for (const [plain, _] of roundTripPairs) {
     const { body } = serialize(plain);
     const decoding = unserialize({ body, slots: [] });
-    // Cannot use `t.deepEqual` because it does not recognize that two
-    // unregistered symbols with the same `description` are the same in
-    // our distributed object semantics. Unfortunately, `compareRank` is
-    // too imprecise. We'd like to also test `keyEQ`, but that would violate
-    // our package layering.
     testFullOrderEQ(t, decoding, plain);
     t.assert(isFrozen(decoding));
   }
@@ -354,11 +349,6 @@ test('smallcaps encoding examples', t => {
     assertSer(val, body, slots, message);
     const val2 = unserialize(harden({ body, slots }));
     assertSer(val2, body, slots, message);
-    // Cannot use `t.deepEqual` because it does not recognize that two
-    // unregistered symbols with the same `description` are the same in
-    // our distributed object semantics. Unfortunately, `compareRank` is
-    // too imprecise. We'd like to also test `keyEQ`, but that would violate
-    // our package layering.
     testFullOrderEQ(t, val, val2, message);
   };
 

--- a/packages/marshal/test/marshal-smallcaps.test.js
+++ b/packages/marshal/test/marshal-smallcaps.test.js
@@ -4,7 +4,7 @@ import { Far, makeTagged, passStyleOf } from '@endo/pass-style';
 import { makeMarshal } from '../src/marshal.js';
 
 import { roundTripPairs } from './_marshal-test-data.js';
-import { compareRank } from '../src/rankOrder.js';
+import { testFullOrderEQ } from '../tools/ava-full-order-eq.js';
 
 const {
   freeze,
@@ -49,7 +49,7 @@ test('smallcaps serialize unserialize round trip half pairs', t => {
     // our distributed object semantics. Unfortunately, `compareRank` is
     // too imprecise. We'd like to also test `keyEQ`, but that would violate
     // our package layering.
-    t.is(compareRank(decoding, plain), 0);
+    testFullOrderEQ(t, decoding, plain);
     t.assert(isFrozen(decoding));
   }
 });
@@ -359,7 +359,7 @@ test('smallcaps encoding examples', t => {
     // our distributed object semantics. Unfortunately, `compareRank` is
     // too imprecise. We'd like to also test `keyEQ`, but that would violate
     // our package layering.
-    t.is(compareRank(val, val2), 0, message);
+    testFullOrderEQ(t, val, val2, message);
   };
 
   // Numbers

--- a/packages/marshal/test/marshal-stringify.test.js
+++ b/packages/marshal/test/marshal-stringify.test.js
@@ -3,7 +3,7 @@ import test from '@endo/ses-ava/prepare-endo.js';
 import { Far } from '@endo/pass-style';
 import { stringify, parse } from '../src/marshal-stringify.js';
 import { roundTripPairs } from './_marshal-test-data.js';
-import { compareRank } from '../src/rankOrder.js';
+import { testFullOrderEQ } from '../tools/ava-full-order-eq.js';
 
 const { isFrozen } = Object;
 
@@ -23,7 +23,7 @@ test('stringify parse round trip pairs', t => {
     // our distributed object semantics. Unfortunately, `compareRank` is
     // too imprecise. We'd like to also test `keyEQ`, but that would violate
     // our package layering.
-    t.is(compareRank(decoding, plain), 0);
+    testFullOrderEQ(t, decoding, plain);
     t.assert(isFrozen(decoding));
   }
 });

--- a/packages/marshal/test/marshal-stringify.test.js
+++ b/packages/marshal/test/marshal-stringify.test.js
@@ -18,11 +18,6 @@ test('stringify parse round trip pairs', t => {
     const encoding = JSON.stringify(encoded);
     t.is(str, encoding);
     const decoding = parse(str);
-    // Cannot use `t.deepEqual` because it does not recognize that two
-    // unregistered symbols with the same `description` are the same in
-    // our distributed object semantics. Unfortunately, `compareRank` is
-    // too imprecise. We'd like to also test `keyEQ`, but that would violate
-    // our package layering.
     testFullOrderEQ(t, decoding, plain);
     t.assert(isFrozen(decoding));
   }

--- a/packages/marshal/test/rankOrder.test.js
+++ b/packages/marshal/test/rankOrder.test.js
@@ -16,6 +16,7 @@ import {
   getIndexCover,
   assertRankSorted,
 } from '../src/rankOrder.js';
+import { testFullOrderEQ } from '../tools/ava-full-order-eq.js';
 import { unsortedSample, sortedSample } from './_marshal-test-data.js';
 
 const { arbPassable } = makeArbitraries(fc);
@@ -23,7 +24,7 @@ const { arbPassable } = makeArbitraries(fc);
 test('compareRank is reflexive', async t => {
   await fc.assert(
     fc.property(arbPassable, x => {
-      return t.is(compareRank(x, x), 0);
+      return testFullOrderEQ(t, x, x);
     }),
   );
 });
@@ -108,9 +109,10 @@ test('compare and sort by rank', t => {
   assertRankSorted(sortedSample, compareRank);
   t.false(isRankSorted(unsortedSample, compareRank));
   const sorted = sortByRank(unsortedSample, compareRank);
-  t.is(
-    compareRank(sorted, sortedSample),
-    0,
+  testFullOrderEQ(
+    t,
+    sorted,
+    sortedSample,
     `Not sorted as expected: ${q(sorted)}`,
   );
 });

--- a/packages/marshal/test/rankOrder.test.js
+++ b/packages/marshal/test/rankOrder.test.js
@@ -16,7 +16,6 @@ import {
   getIndexCover,
   assertRankSorted,
 } from '../src/rankOrder.js';
-import { testFullOrderEQ } from '../tools/ava-full-order-eq.js';
 import { unsortedSample, sortedSample } from './_marshal-test-data.js';
 
 const { arbPassable } = makeArbitraries(fc);
@@ -24,7 +23,7 @@ const { arbPassable } = makeArbitraries(fc);
 test('compareRank is reflexive', async t => {
   await fc.assert(
     fc.property(arbPassable, x => {
-      return testFullOrderEQ(t, x, x);
+      return t.is(compareRank(x, x), 0);
     }),
   );
 });
@@ -109,10 +108,9 @@ test('compare and sort by rank', t => {
   assertRankSorted(sortedSample, compareRank);
   t.false(isRankSorted(unsortedSample, compareRank));
   const sorted = sortByRank(unsortedSample, compareRank);
-  testFullOrderEQ(
-    t,
-    sorted,
-    sortedSample,
+  t.is(
+    compareRank(sorted, sortedSample),
+    0,
     `Not sorted as expected: ${q(sorted)}`,
   );
 });

--- a/packages/marshal/tools/ava-full-order-eq.js
+++ b/packages/marshal/tools/ava-full-order-eq.js
@@ -1,5 +1,9 @@
 import { makeFullOrderComparatorKit } from '../src/rankOrder.js';
 
+// TODO once we're on the other side of this transition, migrate all importers
+// of `testFullOrderEQ` from `@agoric/internal/tools/ava-full-order-eq.js`
+// to import instead from `@endo/marshal/tools/ava-full-order-eq.js
+
 /**
  * @import {Passable} from '@endo/pass-style';
  */

--- a/packages/marshal/tools/ava-full-order-eq.js
+++ b/packages/marshal/tools/ava-full-order-eq.js
@@ -1,0 +1,46 @@
+import { makeFullOrderComparatorKit } from '../src/rankOrder.js';
+
+/**
+ * @import {Passable} from '@endo/pass-style';
+ */
+
+/**
+ * We often used `t.deepEqual` to compare whether two Passables are the same in
+ * our distributed object semantics. This was never correct, but worked well
+ * enough until https://github.com/endojs/endo/pull/2777 when Passable symbols
+ * that were not `t.deepEqual` could still be equal in our distributed object
+ * semantics. For at least those cases, switch from
+ *
+ * ```js
+ * t.deepEqual(specimen, expected, message?)
+ * ```
+ *
+ * to
+ *
+ * ```js
+ * testFullOrderEQ(t, specimen, expected, message?)
+ * ```
+ *
+ * Even aside from symbols, this is not quite testing the same thing. In our
+ * distributed object semantics, neither promises nor errors have comparable
+ * equality. All promises and of the same rank, and all errors are of the same
+ * rank. `compareFull` differs from `compareRank` only in the comparisons
+ * remotables, for which `compareFull` only judges two remotable to be equal if
+ * if they are the same remotable, which is what we want here.
+ *
+ * Since `testFullOrderEQ` is a convenience only for testing, some normal
+ * security constraints do not apply. `testFullOrderEQ` hardens the `specimen`
+ * and `expected` arguments, so that if the only reason they were not passable
+ * is that they were not yet hardened, `testFullOrderEQ` takes case of that for
+ * you.
+ *
+ * @param {import('ava').ExecutionContext} t
+ * @param {Passable} specimen
+ * @param {Passable} expected
+ * @param {string} [message]
+ */
+export const testFullOrderEQ = (t, specimen, expected, message) => {
+  const { comparator: compareFull } = makeFullOrderComparatorKit();
+  return t.is(compareFull(harden(specimen), harden(expected)), 0, message);
+};
+harden(testFullOrderEQ);

--- a/packages/pass-style/src/iter-helpers.js
+++ b/packages/pass-style/src/iter-helpers.js
@@ -13,7 +13,7 @@ import { Far } from './make-far.js';
  */
 export const mapIterable = (baseIterable, func) =>
   /** @type {Iterable<U>} */
-  Far('mapped iterable', {
+  harden({
     [Symbol.iterator]: () => {
       const baseIterator = baseIterable[Symbol.iterator]();
       return Far('mapped iterator', {
@@ -40,7 +40,7 @@ harden(mapIterable);
  */
 export const filterIterable = (baseIterable, pred) =>
   /** @type {Iterable<U>} */
-  Far('filtered iterable', {
+  harden({
     [Symbol.iterator]: () => {
       const baseIterator = baseIterable[Symbol.iterator]();
       return Far('filtered iterator', {

--- a/packages/pass-style/src/passStyle-helpers.js
+++ b/packages/pass-style/src/passStyle-helpers.js
@@ -4,6 +4,7 @@
 /** @import {PassStyle} from './types.js' */
 
 import { X, q } from '@endo/errors';
+import { specialCaseAsyncIteratorSymbol } from './symbol.js';
 
 const { isArray } = Array;
 const { prototype: functionPrototype } = Function;
@@ -64,6 +65,16 @@ export const PASS_STYLE = Symbol.for('passStyle');
 export const canBeMethod = func =>
   typeof func === 'function' && !(PASS_STYLE in func);
 harden(canBeMethod);
+
+/**
+ * To ease the transition, if `PASS_STYLE_LEGACY_ASYNC_ITERATOR_SYMBOL` is
+ * `'enabled'`, then we do allow `Symbol.asyncIterator` as a method name.
+ *
+ * @param {PropertyKey} key
+ */
+export const canBeMethodName = key =>
+  typeof key === 'string' ||
+  (specialCaseAsyncIteratorSymbol && key === Symbol.asyncIterator);
 
 /**
  * Below we have a series of predicate functions and their (curried) assertion

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -11,6 +11,7 @@ import {
   isObject,
   getTag,
   CX,
+  canBeMethodName,
 } from './passStyle-helpers.js';
 
 /**
@@ -230,9 +231,11 @@ export const RemotableHelper = harden({
                 CX(check)`cannot serialize Remotables with non-methods like ${q(
                   String(key),
                 )} in ${candidate}`)) &&
-              (key !== PASS_STYLE ||
+              (canBeMethodName(key) ||
                 (!!check &&
-                  CX(check)`A pass-by-remote cannot shadow ${q(PASS_STYLE)}`))))
+                  CX(
+                    check,
+                  )`Remotables can only have string-named methods: ${candidate}`))))
         );
       });
     } else if (typeof candidate === 'function') {

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -235,7 +235,7 @@ export const RemotableHelper = harden({
                 (!!check &&
                   CX(
                     check,
-                  )`Remotables can only have string-named methods: ${candidate}`))))
+                  )`Remotables can only have string-named methods: ${String(key)}`))))
         );
       });
     } else if (typeof candidate === 'function') {

--- a/packages/pass-style/src/symbol.js
+++ b/packages/pass-style/src/symbol.js
@@ -72,4 +72,4 @@ harden(passableSymbolForName);
  * @param {string} name
  * @returns {symbol}
  */
-export const unpassableSymbolForName = name => Symbol(name);
+export const unpassableSymbolForName = name => Symbol.for(name);

--- a/packages/pass-style/src/symbol.js
+++ b/packages/pass-style/src/symbol.js
@@ -31,9 +31,9 @@ harden(nameForPassableSymbol);
 
 const symbolAsyncIteratorDescription = Symbol.asyncIterator.description;
 
-const specialCaseAsyncIteratorSymbol =
-  getEnvironmentOption('PASS_STYLE_LEGACY_ASYNC_ITERATOR_SYMBOL', 'disabled', [
-    'enabled',
+export const specialCaseAsyncIteratorSymbol =
+  getEnvironmentOption('PASS_STYLE_LEGACY_ASYNC_ITERATOR_SYMBOL', 'enabled', [
+    'disabled',
   ]) === 'enabled';
 
 /**
@@ -45,6 +45,11 @@ const specialCaseAsyncIteratorSymbol =
  * is `'enabled'` (not the default) and the name is either `'@@asyncIterator'`
  * or the `description` string of `Symbol.asyncIterator`, then return
  * `Symbol.asyncIterator`.
+ *
+ * NOTE: In this PR we make `'enabled'` the default, so agoric-sdk testing
+ * can switch between `#endo-branch: ` with this fork vs the "normal" fork
+ * described above. When this is `'enabled'` then `Symbol.asyncIterator`
+ * itself is still allowed as a method name.
  *
  * TODO Once we're on the other side of this transition, we will eventually
  * stop supporting this config switch.

--- a/packages/patterns/src/keys/checkKey.js
+++ b/packages/patterns/src/keys/checkKey.js
@@ -452,7 +452,7 @@ export const getCopyMapEntries = m => {
     payload: { keys, values },
   } = m;
   const { length } = /** @type {Array} */ (keys);
-  return Far('CopyMap entries iterable', {
+  return harden({
     [Symbol.iterator]: () => {
       let i = 0;
       return Far('CopyMap entries iterator', {

--- a/packages/patterns/test/copyMap.test.js
+++ b/packages/patterns/test/copyMap.test.js
@@ -127,7 +127,10 @@ test('getCopyMapEntries', t => {
   ]);
   t.deepEqual([...getCopyMapEntries(m)], getCopyMapEntryArray(m));
   const entriesIterable = getCopyMapEntries(m);
-  t.is(passStyleOf(entriesIterable), 'remotable');
+  t.throws(() => passStyleOf(entriesIterable), {
+    message:
+      'Remotables can only have string-named methods: "Symbol(Symbol.iterator)"',
+  });
   const entriesIterator = entriesIterable[Symbol.iterator]();
   t.is(passStyleOf(entriesIterator), 'remotable');
   const iterResult = entriesIterator.next();


### PR DESCRIPTION
Staged on https://github.com/endojs/endo/pull/2777

Closes: #XXXX
Refs: #XXXX

## Description

No more symbol named methods in remotable. Needed for #2777 to make sense. But a separate PR for now because it causes more errors to investigate.

### Security Considerations

> Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?

### Scaling Considerations

> Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated?

### Documentation Considerations

> Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

### Testing Considerations

> Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? 

### Compatibility Considerations

> Does this change break any prior usage patterns? Does this change allow usage patterns to evolve?

### Upgrade Considerations

> What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed?

> Include `*BREAKING*:` in the commit message with migration instructions for any breaking change.

> Update `NEWS.md` for user-facing changes.

> Delete guidance from pull request description before merge (including this!)
