### PR TITLE
refactor: Deprecate trivialComparator in favor of type-specific `compareNumerics`

### DIFF
--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -16,6 +16,7 @@ export {
 
 export {
   trivialComparator,
+  compareNumerics,
   assertRankSorted,
   compareRank,
   isRankSorted,

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -308,6 +308,8 @@ harden(assertRankSorted);
  * @returns {T[]}
  */
 export const sortByRank = (passables, compare) => {
+  /** @type {T[]} mutable for in-place sorting, but with hardened elements */
+  let unsorted;
   if (Array.isArray(passables)) {
     harden(passables);
     // Calling isRankSorted gives it a chance to get memoized for
@@ -316,9 +318,10 @@ export const sortByRank = (passables, compare) => {
     if (isRankSorted(passables, compare)) {
       return passables;
     }
+    unsorted = [...passables];
+  } else {
+    unsorted = Array.from(passables, harden);
   }
-  const unsorted = [...passables];
-  unsorted.forEach(harden);
   const sorted = unsorted.sort(compare);
   // For reverse comparison, move `undefined` values from the end to the start.
   // Note that passStylePrefixes (@see {@link ./encodePassable.js}) MUST NOT

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -8,7 +8,7 @@ import {
 
 /**
  * @import {Passable, PassStyle} from '@endo/pass-style'
- * @import {FullCompare, PartialCompare, PartialComparison, RankCompare, RankCover} from './types.js'
+ * @import {FullCompare, PartialCompare, PartialComparison, RankCompare, RankComparison, RankCover} from './types.js'
  */
 
 const { entries, fromEntries, setPrototypeOf, is } = Object;
@@ -44,9 +44,25 @@ const { entries, fromEntries, setPrototypeOf, is } = Object;
  */
 const sameValueZero = (x, y) => x === y || is(x, y);
 
+/**
+ * @deprecated use type-specific `compareNumerics` etc.
+ * @param {any} left
+ * @param {any} right
+ * @returns {RankComparison}
+ */
 export const trivialComparator = (left, right) =>
   // eslint-disable-next-line no-nested-ternary, @endo/restrict-comparison-operands
   left < right ? -1 : left === right ? 0 : 1;
+
+/**
+ * @template {number | bigint} T
+ * @param {T} left
+ * @param {T} right
+ * @returns {RankComparison}
+ */
+export const compareNumerics = (left, right) =>
+  // eslint-disable-next-line no-nested-ternary, @endo/restrict-comparison-operands
+  left < right ? -1 : left > right ? 1 : 0;
 
 /**
  * @typedef {Record<PassStyle, { index: number, cover: RankCover }>} PassStyleRanksRecord
@@ -55,15 +71,20 @@ export const trivialComparator = (left, right) =>
 const passStyleRanks = /** @type {PassStyleRanksRecord} */ (
   fromEntries(
     entries(passStylePrefixes)
-      // Sort entries by ascending prefix.
-      .sort(([_leftStyle, leftPrefixes], [_rightStyle, rightPrefixes]) => {
-        return trivialComparator(leftPrefixes, rightPrefixes);
+      // Sort entries by ascending prefix, assuming that all prefixes are
+      // limited to the Basic Multilingual Plane (U+0000 through U+FFFF) and
+      // thus contain only code units that are equivalent to code points.
+      // In practice, they are entirely printable ASCII
+      // (0x20 SPACE through 0x7E TILDE).
+      .sort(([_aStyle, aPrefixes], [_bStyle, bPrefixes]) => {
+        // eslint-disable-next-line no-nested-ternary
+        return aPrefixes < bPrefixes ? -1 : aPrefixes > bPrefixes ? 1 : 0;
       })
       .map(([passStyle, prefixes], index) => {
-        // Cover all strings that start with any character in `prefixes`,
-        // verifying that it is sorted so that is
+        // Verify that `prefixes` is sorted, and cover all strings that start
+        // with any of its characters, i.e.
         // all s such that prefixes.at(0) ≤ s < successor(prefixes.at(-1)).
-        prefixes === [...prefixes].sort().join('') ||
+        prefixes === prefixes.split('').sort().join('') ||
           Fail`unsorted prefixes for passStyle ${q(passStyle)}: ${q(prefixes)}`;
         const cover = [
           prefixes.charAt(0),
@@ -118,7 +139,7 @@ export const makeComparatorKit = (compareRemotables = (_x, _y) => NaN) => {
     const leftStyle = passStyleOf(left);
     const rightStyle = passStyleOf(right);
     if (leftStyle !== rightStyle) {
-      return trivialComparator(
+      return compareNumerics(
         passStyleRanks[leftStyle].index,
         passStyleRanks[rightStyle].index,
       );

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -190,21 +190,7 @@ export const makeComparatorKit = (compareRemotables = (_x, _y) => NaN) => {
         );
       }
       case 'number': {
-        // `NaN`'s rank is after all other numbers.
-        if (Number.isNaN(left)) {
-          assert(!Number.isNaN(right));
-          return 1;
-        } else if (Number.isNaN(right)) {
-          return -1;
-        }
-        // The rank ordering of non-NaN numbers agrees with JavaScript's
-        // relational operators '<' and '>'.
-        if (left < right) {
-          return -1;
-        } else {
-          assert(left > right);
-          return 1;
-        }
+        return compareNumerics(left, right);
       }
       case 'copyRecord': {
         // Lexicographic by inverse sorted order of property names, then

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -11,6 +11,7 @@ import {
  * @import {FullCompare, PartialCompare, PartialComparison, RankCompare, RankComparison, RankCover} from './types.js'
  */
 
+const { isNaN: NumberIsNaN } = Number;
 const { entries, fromEntries, setPrototypeOf, is } = Object;
 
 /**
@@ -55,14 +56,25 @@ export const trivialComparator = (left, right) =>
   left < right ? -1 : left === right ? 0 : 1;
 
 /**
+ * Compare two same-type numeric values, returning results consistent with
+ * `compareRank`'s "rank order" (i.e., treating both positive and negative zero
+ * as equal and placing NaN as self-equal after all other numbers).
+ *
  * @template {number | bigint} T
  * @param {T} left
  * @param {T} right
  * @returns {RankComparison}
  */
-export const compareNumerics = (left, right) =>
-  // eslint-disable-next-line no-nested-ternary, @endo/restrict-comparison-operands
-  left < right ? -1 : left > right ? 1 : 0;
+export const compareNumerics = (left, right) => {
+  // eslint-disable-next-line @endo/restrict-comparison-operands
+  if (left < right) return -1;
+  // eslint-disable-next-line @endo/restrict-comparison-operands
+  if (left > right) return 1;
+  if (NumberIsNaN(left) === NumberIsNaN(right)) return 0;
+  if (NumberIsNaN(right)) return -1;
+  assert(NumberIsNaN(left));
+  return 1;
+};
 
 /**
  * @typedef {Record<PassStyle, { index: number, cover: RankCover }>} PassStyleRanksRecord

--- a/packages/patterns/src/keys/compareKeys.js
+++ b/packages/patterns/src/keys/compareKeys.js
@@ -3,10 +3,10 @@
 import {
   passStyleOf,
   getTag,
+  compareNumerics,
   compareRank,
   recordNames,
   recordValues,
-  trivialComparator,
 } from '@endo/marshal';
 import { q, Fail } from '@endo/errors';
 import {
@@ -31,7 +31,7 @@ export const setCompare = makeCompareCollection(
     s => harden(getCopySetKeys(s).map(key => [key, 1]))
   ),
   0,
-  trivialComparator,
+  compareNumerics,
 );
 harden(setCompare);
 
@@ -46,7 +46,7 @@ harden(setCompare);
 export const bagCompare = makeCompareCollection(
   getCopyBagEntries,
   0n,
-  trivialComparator,
+  compareNumerics,
 );
 harden(bagCompare);
 

--- a/packages/patterns/src/keys/keycollection-operators.js
+++ b/packages/patterns/src/keys/keycollection-operators.js
@@ -181,7 +181,7 @@ harden(generateCollectionPairEntries);
  * @template [C=KeyCollection]
  * @template [V=unknown]
  * @param {(collection: C) => Array<[Key, V]>} getEntries
- * @param {any} absentValue
+ * @param {V} absentValue
  * @param {KeyCompare} compareValues
  * @returns {(left: C, right: C) => KeyComparison}
  */


### PR DESCRIPTION
Ref #2113

## Description

We want to discourage comparison of strings by UTF-16 code unit as implemented by relational operators.

### Security Considerations

None.

### Scaling Considerations

Includes a trivial (and separable) improvement to `sortByRank`.

### Documentation Considerations

None beyond `@deprecated`.

### Testing Considerations

Covered by existing tests.

### Compatibility Considerations

n/a

### Upgrade Considerations

I don't think a NEWS.md update is warranted, but could be persuaded otherwise.