### PR TITLE
feat(immutable-arraybuffer): sliceToImmutable Hermes ponyfill and shim

### DIFF
--- a/packages/immutable-arraybuffer/index.js
+++ b/packages/immutable-arraybuffer/index.js
@@ -54,7 +54,7 @@ if (transfer) {
 
 /**
  * This class only exists as an artifact of this ponyfill and shim,
- * as a convience for imperfectly emulating the
+ * as a convenience for imperfectly emulating the
  * *Immutable ArrayBuffer* proposal, which would not have this class.
  * In the proposal,
  * `transferToImmutable` makes a new `ArrayBuffer` that inherits directly from
@@ -142,6 +142,13 @@ const {
 
 setPrototypeOf(immutableArrayBufferPrototype, arrayBufferPrototype);
 
+/**
+ * Transfer the contents to a new Immutable ArrayBuffer
+ *
+ * @param {ArrayBuffer} buffer The original buffer.
+ * @param {number} [newLength] The start index.
+ * @returns {ArrayBuffer}
+ */
 export const transferBufferToImmutable = (buffer, newLength = undefined) => {
   if (newLength !== undefined) {
     if (transfer) {
@@ -160,7 +167,8 @@ export const transferBufferToImmutable = (buffer, newLength = undefined) => {
       }
     }
   }
-  return new ImmutableArrayBufferInternal(buffer);
+  const result = new ImmutableArrayBufferInternal(buffer);
+  return /** @type {ArrayBuffer} */ (/** @type {unknown} */ (result));
 };
 
 export const isBufferImmutable = buffer => {
@@ -177,6 +185,14 @@ export const isBufferImmutable = buffer => {
   }
 };
 
+/**
+ * Enforces that `arrayBuffer` is a genuine `ArrayBuffer` exotic object.
+ *
+ * @param {ArrayBuffer} buffer
+ * @param {number} [start]
+ * @param {number} [end]
+ * @returns {ArrayBuffer}
+ */
 const sliceBuffer = (buffer, start = undefined, end = undefined) => {
   try {
     // @ts-expect-error We know it is really there
@@ -189,6 +205,14 @@ const sliceBuffer = (buffer, start = undefined, end = undefined) => {
   }
 };
 
+/**
+ * Creates an immutable slice of the given buffer.
+ *
+ * @param {ArrayBuffer} buffer The original buffer.
+ * @param {number} [start] The start index.
+ * @param {number} [end] The end index.
+ * @returns {ArrayBuffer} The sliced immutable ArrayBuffer.
+ */
 export const sliceBufferToImmutable = (
   buffer,
   start = undefined,

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -25,6 +25,7 @@
   "exports": {
     ".": "./index.js",
     "./shim.js": "./shim.js",
+    "./shim-hermes.js": "./shim-hermes.js",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -34,7 +35,7 @@
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "prepack": "tsc --build tsconfig.build.json",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",

--- a/packages/immutable-arraybuffer/shim-hermes.js
+++ b/packages/immutable-arraybuffer/shim-hermes.js
@@ -1,27 +1,14 @@
 import {
-  transferBufferToImmutable,
   isBufferImmutable,
   sliceBufferToImmutable,
-} from './index.js';
+} from './src/limited-pony-for-hermes.js';
 
 const { getOwnPropertyDescriptors, defineProperties } = Object;
 const { prototype: arrayBufferPrototype } = ArrayBuffer;
 
 const arrayBufferMethods = {
   /**
-   * Transfer the contents to a new Immutable ArrayBuffer
-   *
-   * @this {ArrayBuffer} buffer The original buffer.
-   * @param {number} [newLength] The start index.
-   * @returns {ArrayBuffer} The sliced immutable ArrayBuffer.
-   */
-  transferToImmutable(newLength = undefined) {
-    return transferBufferToImmutable(this, newLength);
-  },
-
-  /**
    * Creates an immutable slice of the given buffer.
-   *
    * @this {ArrayBuffer} buffer The original buffer.
    * @param {number} [start] The start index.
    * @param {number} [end] The end index.
@@ -30,11 +17,16 @@ const arrayBufferMethods = {
   sliceToImmutable(start = undefined, end = undefined) {
     return sliceBufferToImmutable(this, start, end);
   },
-
   get immutable() {
     return isBufferImmutable(this);
   },
 };
+
+if ('transfer' in arrayBufferPrototype) {
+  console.warn(
+    'Could have used the full shim, rather than the limited one for Hermes',
+  );
+}
 
 if ('sliceToImmutable' in arrayBufferPrototype) {
   // Modern shim practice frowns on conditional installation, at least for

--- a/packages/immutable-arraybuffer/src/limited-pony-for-hermes.js
+++ b/packages/immutable-arraybuffer/src/limited-pony-for-hermes.js
@@ -1,0 +1,118 @@
+const { apply } = Reflect;
+const { prototype: arrayBufferPrototype } = ArrayBuffer;
+
+const { slice } = arrayBufferPrototype;
+
+// Based on the real `../index.js` but lives within the restrictions of
+// current Hermes:
+// - No class syntax, therefore also no private fields
+// - No `ArrayBuffer.prototype.transfer`
+// - No `structuredClone`
+//
+// Within these restrictions we cannot emulate `transferToImmutable`, so
+// we omit it from the pony. We can emulate `sliceToImmutable` using
+// a different technique than used by the original. The omission of
+// `transferToImmutable` will be visible, enabling feature detection.
+// We perfectly emulate the `class` with a `function` function.
+// We perfectly emulate the private `this.#buffer` private field with
+// the encapsulated `buffers` WeakMap.
+
+/**
+ * Enforces that `realBuffer` is a genuine `ArrayBuffer` exotic object.
+ *
+ * @param {ArrayBuffer} realBuffer
+ * @param {number} [start]
+ * @param {number} [end]
+ * @returns {ArrayBuffer}
+ */
+const arrayBufferSlice = (realBuffer, start = undefined, end = undefined) =>
+  apply(slice, realBuffer, [start, end]);
+
+/**
+ * Emulates the `this.#buffer` private field, including its use as a brand check.
+ * Maps from all and only emulated Immutable ArrayBuffers to real ArrayBuffers.
+ */
+const buffers = new WeakMap();
+const getBuffer = immuAB => {
+  const result = buffers.get(immuAB);
+  if (result) {
+    return result;
+  }
+  throw TypeError('Not an emulated Immutable ArrayBuffer');
+};
+
+// Omits `constructor` so `Array.prototype.constructor` is inherited.
+const ImmutableArrayBufferInternalPrototype = {
+  __proto__: arrayBufferPrototype,
+  get byteLength() {
+    return getBuffer(this).byteLength;
+  },
+  get detached() {
+    getBuffer(this); // shim brand check
+    return false;
+  },
+  get maxByteLength() {
+    // Not underlying maxByteLength, which is irrelevant
+    return getBuffer(this).byteLength;
+  },
+  get resizable() {
+    getBuffer(this); // shim brand check
+    return false;
+  },
+  get immutable() {
+    getBuffer(this); // shim brand check
+    return true;
+  },
+  slice(start = undefined, end = undefined) {
+    return arrayBufferSlice(getBuffer(this), start, end);
+  },
+  sliceToImmutable(start = undefined, end = undefined) {
+    // eslint-disable-next-line no-use-before-define
+    return sliceBufferToImmutable(getBuffer(this), start, end);
+  },
+  resize(_newByteLength = undefined) {
+    getBuffer(this); // shim brand check
+    throw TypeError('Cannot resize an immutable ArrayBuffer');
+  },
+};
+
+/**
+ * Emulates the encapsulated `ImmutableArrayBufferInternal` class constructor
+ * from the original except this function takes the `realBuffer` which its
+ * result encapsulates. Security demands that this result has exclusive access
+ * to the `realBuffer` it is given, which its callers must ensure.
+ *
+ * @param {ArrayBuffer} realBuffer
+ * @returns {ArrayBuffer}
+ */
+const makeImmutableArrayBufferInternal = realBuffer => {
+  const result = { __proto__: ImmutableArrayBufferInternalPrototype };
+  buffers.set(result, realBuffer);
+  return /** @type {ArrayBuffer} */ (/** @type {unknown} */ (result));
+};
+// Since `makeImmutableArrayBufferInternal` MUST not escape,
+// this `freeze` is just belt-and-suspenders.
+Object.freeze(makeImmutableArrayBufferInternal);
+
+export const isBufferImmutable = buffer => buffers.has(buffer);
+
+/**
+ * Creates an immutable slice of the given buffer.
+ * @param {ArrayBuffer} buffer The original buffer.
+ * @param {number} [start] The start index.
+ * @param {number} [end] The end index.
+ * @returns {ArrayBuffer} The sliced immutable ArrayBuffer.
+ */
+export const sliceBufferToImmutable = (
+  buffer,
+  start = undefined,
+  end = undefined,
+) => {
+  let realBuffer = buffers.get(buffer);
+  if (realBuffer === undefined) {
+    realBuffer = buffer;
+  }
+  return makeImmutableArrayBufferInternal(
+    arrayBufferSlice(realBuffer, start, end),
+  );
+};

--- a/packages/immutable-arraybuffer/test/limited-pony-for-hermes.test.js
+++ b/packages/immutable-arraybuffer/test/limited-pony-for-hermes.test.js
@@ -1,0 +1,204 @@
+import test from 'ava';
+import {
+  isBufferImmutable,
+  sliceBufferToImmutable,
+} from '../src/limited-pony-for-hermes.js';
+
+const { isFrozen, getPrototypeOf } = Object;
+
+test('Immutable ArrayBuffer ponyfill installed and not hardened', t => {
+  const iab = sliceBufferToImmutable(new ArrayBuffer(0));
+  const iabProto = getPrototypeOf(iab);
+  t.false(isFrozen(iabProto));
+  t.false(isFrozen(iabProto.slice));
+});
+
+test('Immutable ArrayBuffer ponyfill ops', t => {
+  // Absent on Node <= 18
+  const canResize = 'maxByteLength' in ArrayBuffer.prototype;
+
+  const ab1 = new ArrayBuffer(2, { maxByteLength: 7 });
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+  const iab = sliceBufferToImmutable(ab1);
+  t.true(iab instanceof ArrayBuffer);
+  ta1[1] = 5;
+  const ab2 = iab.slice(0);
+  const ta2 = new Uint8Array(ab2);
+  t.is(ta1[1], 5);
+  t.is(ta2[1], 4);
+  ta2[1] = 6;
+
+  const ab3 = iab.slice(0);
+  t.true(ab3 instanceof ArrayBuffer);
+
+  const ta3 = new Uint8Array(ab3);
+  t.is(ta1[1], 5);
+  t.is(ta2[1], 6);
+  t.is(ta3[1], 4);
+
+  t.is(ab1.byteLength, 2);
+  t.is(iab.byteLength, 2);
+  t.is(ab2.byteLength, 2);
+
+  t.is(iab.maxByteLength, 2);
+  if (canResize) {
+    t.is(ab1.maxByteLength, 7);
+    t.is(ab2.maxByteLength, 2);
+  }
+
+  if ('detached' in ab1) {
+    t.false(ab1.detached);
+    t.false(ab2.detached);
+    t.false(ab3.detached);
+  }
+  t.false(iab.detached);
+  t.false(iab.resizable);
+});
+
+test('Standard DataView behavior baseline', t => {
+  t.throws(() => new DataView({}), { instanceOf: TypeError });
+
+  const ab1 = new ArrayBuffer(2);
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+
+  const dv = new DataView(ab1);
+  t.is(dv.byteLength, 2);
+});
+
+// This could have been written as a test.failing as compared to
+// the immutable ArrayBuffer we'll propose. However, I'd rather test what
+// the shim purposely does instead.
+test('DataView on Immutable ArrayBuffer ponyfill limitations', t => {
+  const ab1 = new ArrayBuffer(2);
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+
+  const iab = sliceBufferToImmutable(ab1);
+  t.throws(() => new DataView(iab), {
+    instanceOf: TypeError,
+  });
+});
+
+test('Standard TypedArray behavior baseline', t => {
+  const ab1 = new ArrayBuffer(2);
+  const dv1 = new DataView(ab1);
+  t.is(dv1.buffer, ab1);
+  t.is(dv1.byteLength, 2);
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+  t.is(ta1.byteLength, 2);
+
+  // Unfortutanely, calling a TypeArray constructor with an object that
+  // is not a TypeArray, ArrayBuffer, or Iterable just creates a useless
+  // empty TypedArray, rather than throwing.
+  const ta2 = new Uint8Array({});
+  t.is(ta2.byteLength, 0);
+});
+
+// This could have been written as a test.failing as compared to
+// the immutable ArrayBuffer we'll propose. However, I'd rather test what
+// the shim purposely does instead.
+test('TypedArray on Immutable ArrayBuffer ponyfill limitations', t => {
+  const ab1 = new ArrayBuffer(2);
+  const dv1 = new DataView(ab1);
+  t.is(dv1.buffer, ab1);
+  t.is(dv1.byteLength, 2);
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+  t.is(ta1.byteLength, 2);
+
+  const iab = sliceBufferToImmutable(ab1);
+  // Unfortunately, unlike the immutable ArrayBuffer to be proposed,
+  // calling a TypedArray constructor with the shim implementation of
+  // an immutable ArrayBuffer as argument treats it as an unrecognized object,
+  // rather than throwing an error or acting as a non-changeable TypedArray.
+  t.is(iab.byteLength, 2);
+  const ta3 = new Uint8Array(iab);
+  t.is(ta3.byteLength, 0);
+});
+
+const testTransfer = t => {
+  const ta12 = new Uint8Array([3, 4, 5]);
+  const ab12 = ta12.buffer;
+  t.is(ab12.byteLength, 3);
+  t.deepEqual([...ta12], [3, 4, 5]);
+
+  const ab2 = ab12.transfer(5);
+  t.false(isBufferImmutable(ab2));
+  t.is(ab2.byteLength, 5);
+  t.is(ab12.byteLength, 0);
+  const ta2 = new Uint8Array(ab2);
+  t.deepEqual([...ta2], [3, 4, 5, 0, 0]);
+
+  const ta13 = new Uint8Array([3, 4, 5]);
+  const ab13 = ta13.buffer;
+
+  const ab3 = ab13.transfer(2);
+  t.false(isBufferImmutable(ab3));
+  t.is(ab3.byteLength, 2);
+  t.is(ab13.byteLength, 0);
+  const ta3 = new Uint8Array(ab3);
+  t.deepEqual([...ta3], [3, 4]);
+};
+
+{
+  // `transfer` is absent in Node <= 20. Present in Node >= 22
+  const maybeTest = 'transfer' in ArrayBuffer.prototype ? test : test.skip;
+  maybeTest('Standard buf.transfer(newLength) behavior baseline', testTransfer);
+}
+
+test('Analogous sliceBufferToImmutable(buf, 0, newLength) ponyfill', t => {
+  const ta12 = new Uint8Array([3, 4, 5]);
+  const ab12 = ta12.buffer;
+  t.is(ab12.byteLength, 3);
+  t.deepEqual([...ta12], [3, 4, 5]);
+
+  const ab2 = sliceBufferToImmutable(ab12, 0, 5);
+  t.true(isBufferImmutable(ab2));
+  t.is(ab2.byteLength, 3);
+  t.is(ab12.byteLength, 3);
+  // slice needed due to ponyfill limitations.
+  const ta2 = new Uint8Array(ab2.slice());
+  t.deepEqual([...ta2], [3, 4, 5]);
+
+  const ta13 = new Uint8Array([3, 4, 5]);
+  const ab13 = ta13.buffer;
+
+  const ab3 = sliceBufferToImmutable(ab13, 0, 2);
+  t.true(isBufferImmutable(ab3));
+  t.is(ab3.byteLength, 2);
+  t.is(ab13.byteLength, 3);
+  // slice needed due to ponyfill limitations.
+  const ta3 = new Uint8Array(ab3.slice());
+  t.deepEqual([...ta3], [3, 4]);
+});
+
+test('sliceBufferToImmutable ponyfill', t => {
+  const ta12 = new Uint8Array([3, 4, 5]);
+  const ab12 = ta12.buffer;
+  t.is(ab12.byteLength, 3);
+  t.deepEqual([...ta12], [3, 4, 5]);
+
+  const ab2 = sliceBufferToImmutable(ab12, 1, 5);
+  t.true(isBufferImmutable(ab2));
+  t.is(ab2.byteLength, 2);
+  t.is(ab12.byteLength, 3);
+  // slice needed due to ponyfill limitations.
+  const ta2 = new Uint8Array(ab2.slice());
+  t.deepEqual([...ta2], [4, 5]);
+
+  const ab3 = sliceBufferToImmutable(ab2, 1, 2);
+  t.true(isBufferImmutable(ab3));
+  t.is(ab3.byteLength, 1);
+  t.is(ab2.byteLength, 2);
+  // slice needed due to ponyfill limitations.
+  const ta3 = new Uint8Array(ab3.slice());
+  t.deepEqual([...ta3], [5]);
+});

--- a/packages/immutable-arraybuffer/test/shim-hermes.test.js
+++ b/packages/immutable-arraybuffer/test/shim-hermes.test.js
@@ -1,0 +1,202 @@
+import test from 'ava';
+import '../shim.js';
+
+const { isFrozen, getPrototypeOf } = Object;
+
+test('Immutable ArrayBuffer shim installed but not hardened', t => {
+  const ab1 = new ArrayBuffer(0);
+  const iab = ab1.sliceToImmutable();
+  const iabProto = getPrototypeOf(iab);
+  t.false(isFrozen(iabProto));
+  t.false(isFrozen(iabProto.slice));
+});
+
+test('Immutable ArrayBuffer shim ops', t => {
+  // Absent on Node <= 18
+  const canResize = 'maxByteLength' in ArrayBuffer.prototype;
+
+  const ab1 = new ArrayBuffer(2, { maxByteLength: 7 });
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+  const iab = ab1.sliceToImmutable();
+  t.true(iab instanceof ArrayBuffer);
+  ta1[1] = 5;
+  const ab2 = iab.slice(0);
+  const ta2 = new Uint8Array(ab2);
+  t.is(ta1[1], 5);
+  t.is(ta2[1], 4);
+  ta2[1] = 6;
+
+  const ab3 = iab.slice(0);
+  t.true(ab3 instanceof ArrayBuffer);
+
+  const ta3 = new Uint8Array(ab3);
+  t.is(ta1[1], 5);
+  t.is(ta2[1], 6);
+  t.is(ta3[1], 4);
+
+  t.is(ab1.byteLength, 2);
+  t.is(iab.byteLength, 2);
+  t.is(ab2.byteLength, 2);
+
+  t.is(iab.maxByteLength, 2);
+  if (canResize) {
+    t.is(ab1.maxByteLength, 7);
+    t.is(ab2.maxByteLength, 2);
+  }
+
+  if ('detached' in ab1) {
+    t.false(ab1.detached);
+    t.false(ab2.detached);
+    t.false(ab3.detached);
+  }
+  t.false(iab.detached);
+  t.false(iab.resizable);
+});
+
+test('Standard DataView behavior baseline', t => {
+  t.throws(() => new DataView({}), { instanceOf: TypeError });
+
+  const ab1 = new ArrayBuffer(2);
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+
+  const dv = new DataView(ab1);
+  t.is(dv.byteLength, 2);
+});
+
+// This could have been written as a test.failing as compared to
+// the immutable ArrayBuffer we'll propose. However, I'd rather test what
+// the shim purposely does instead.
+test('DataView on Immutable ArrayBuffer shim limitations', t => {
+  const ab1 = new ArrayBuffer(2);
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+
+  const iab = ab1.sliceToImmutable();
+  t.throws(() => new DataView(iab), {
+    instanceOf: TypeError,
+  });
+});
+
+test('Standard TypedArray behavior baseline', t => {
+  const ab1 = new ArrayBuffer(2);
+  const dv1 = new DataView(ab1);
+  t.is(dv1.buffer, ab1);
+  t.is(dv1.byteLength, 2);
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+  t.is(ta1.byteLength, 2);
+
+  // Unfortutanely, calling a TypeArray constructor with an object that
+  // is not a TypeArray, ArrayBuffer, or Iterable just creates a useless
+  // empty TypedArray, rather than throwing.
+  const ta2 = new Uint8Array({});
+  t.is(ta2.byteLength, 0);
+});
+
+// This could have been written as a test.failing as compared to
+// the immutable ArrayBuffer we'll propose. However, I'd rather test what
+// the shim purposely does instead.
+test('TypedArray on Immutable ArrayBuffer shim limitations', t => {
+  const ab1 = new ArrayBuffer(2);
+  const dv1 = new DataView(ab1);
+  t.is(dv1.buffer, ab1);
+  t.is(dv1.byteLength, 2);
+  const ta1 = new Uint8Array(ab1);
+  ta1[0] = 3;
+  ta1[1] = 4;
+  t.is(ta1.byteLength, 2);
+
+  const iab = ab1.sliceToImmutable();
+  // Unfortunately, unlike the immutable ArrayBuffer to be proposed,
+  // calling a TypedArray constructor with the shim implementation of
+  // an immutable ArrayBuffer as argument treats it as an unrecognized object,
+  // rather than throwing an error or acting as a non-changeable TypedArray.
+  t.is(iab.byteLength, 2);
+  const ta3 = new Uint8Array(iab);
+  t.is(ta3.byteLength, 0);
+});
+
+const testTransfer = t => {
+  const ta12 = new Uint8Array([3, 4, 5]);
+  const ab12 = ta12.buffer;
+  t.is(ab12.byteLength, 3);
+  t.deepEqual([...ta12], [3, 4, 5]);
+
+  const ab2 = ab12.transfer(5);
+  t.false(ab2.immutable);
+  t.is(ab2.byteLength, 5);
+  t.is(ab12.byteLength, 0);
+  const ta2 = new Uint8Array(ab2);
+  t.deepEqual([...ta2], [3, 4, 5, 0, 0]);
+
+  const ta13 = new Uint8Array([3, 4, 5]);
+  const ab13 = ta13.buffer;
+
+  const ab3 = ab13.transfer(2);
+  t.false(ab3.immutable);
+  t.is(ab3.byteLength, 2);
+  t.is(ab13.byteLength, 0);
+  const ta3 = new Uint8Array(ab3);
+  t.deepEqual([...ta3], [3, 4]);
+};
+
+{
+  // `transfer` is absent in Node <= 20. Present in Node >= 22
+  const maybeTest = 'transfer' in ArrayBuffer.prototype ? test : test.skip;
+  maybeTest('Standard buf.transfer(newLength) behavior baseline', testTransfer);
+}
+
+test('Analogous buf.sliceToImmutable(0, newLength) shim', t => {
+  const ta12 = new Uint8Array([3, 4, 5]);
+  const ab12 = ta12.buffer;
+  t.is(ab12.byteLength, 3);
+  t.deepEqual([...ta12], [3, 4, 5]);
+
+  const ab2 = ab12.sliceToImmutable(0, 5);
+  t.true(ab2.immutable);
+  t.is(ab2.byteLength, 3);
+  t.is(ab12.byteLength, 3);
+  // slice needed due to ponyfill limitations.
+  const ta2 = new Uint8Array(ab2.slice());
+  t.deepEqual([...ta2], [3, 4, 5]);
+
+  const ta13 = new Uint8Array([3, 4, 5]);
+  const ab13 = ta13.buffer;
+
+  const ab3 = ab13.sliceToImmutable(0, 2);
+  t.true(ab3.immutable);
+  t.is(ab3.byteLength, 2);
+  t.is(ab13.byteLength, 3);
+  // slice needed due to ponyfill limitations.
+  const ta3 = new Uint8Array(ab3.slice());
+  t.deepEqual([...ta3], [3, 4]);
+});
+
+test('sliceToImmutable shim', t => {
+  const ta12 = new Uint8Array([3, 4, 5]);
+  const ab12 = ta12.buffer;
+  t.is(ab12.byteLength, 3);
+  t.deepEqual([...ta12], [3, 4, 5]);
+
+  const ab2 = ab12.sliceToImmutable(1, 5);
+  t.true(ab2.immutable);
+  t.is(ab2.byteLength, 2);
+  t.is(ab12.byteLength, 3);
+  // slice needed due to ponyfill limitations.
+  const ta2 = new Uint8Array(ab2.slice());
+  t.deepEqual([...ta2], [4, 5]);
+
+  const ab3 = ab2.sliceToImmutable(1, 2);
+  t.true(ab3.immutable);
+  t.is(ab3.byteLength, 1);
+  t.is(ab2.byteLength, 2);
+  // slice needed due to ponyfill limitations.
+  const ta3 = new Uint8Array(ab3.slice());
+  t.deepEqual([...ta3], [5]);
+});

--- a/packages/ses/scripts/hermes-transforms.js
+++ b/packages/ses/scripts/hermes-transforms.js
@@ -61,11 +61,13 @@ const asyncGeneratorDestroyer = {
   FunctionDeclaration: destroyAsyncGenerators,
 };
 
-// Remove on Hermes since classes and private fields are unsupported on Hermes
-const removeImmutableArrayBufferShim = {
+const immutableArrayBufferPonyfier = {
   ImportDeclaration(path) {
+    // Class with private fields and `transferToImmutable`, incompatible with Hermes
     if (path.node.source.value === '@endo/immutable-arraybuffer/shim.js') {
-      path.remove();
+      // Class with private fields perfectly emulated as a `function` with the encapsulated `buffers` WeakMap
+      // and `transferToImmutable` omitted, compatible with Hermes
+      path.node.source.value = '@endo/immutable-arraybuffer/shim-hermes.js';
     }
   },
 };
@@ -75,7 +77,7 @@ export const hermesTransforms = {
     const transforms = {
       ...asyncArrowEliminator,
       ...asyncGeneratorDestroyer,
-      ...removeImmutableArrayBufferShim,
+      ...immutableArrayBufferPonyfier,
       // Some transforms might be added based on the specifier later
     };
 

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -168,16 +168,13 @@ export const getAnonymousIntrinsics = () => {
   }
 
   const ab = new ArrayBuffer(0);
-  // @ts-expect-error see below
-  if (typeof ab.transferToImmutable === 'function') {
-    // @ts-expect-error TODO How do I add transferToImmutable to ArrayBuffer type?
-    // eslint-disable-next-line @endo/no-polymorphic-call
-    const iab = ab.transferToImmutable();
-    const iabProto = getPrototypeOf(iab);
-    if (iabProto !== ArrayBuffer.prototype) {
-      // In a native implementation, these will be the same prototype
-      intrinsics['%ImmutableArrayBufferPrototype%'] = iabProto;
-    }
+  // @ts-expect-error TODO How do I add sliceToImmutable to ArrayBuffer type?
+  // eslint-disable-next-line @endo/no-polymorphic-call
+  const iab = ab.sliceToImmutable();
+  const iabProto = getPrototypeOf(iab);
+  if (iabProto !== ArrayBuffer.prototype) {
+    // In a native implementation, these will be the same prototype
+    intrinsics['%ImmutableArrayBufferPrototype%'] = iabProto;
   }
 
   return intrinsics;

--- a/packages/ses/test/immutable-array-buffer.test.js
+++ b/packages/ses/test/immutable-array-buffer.test.js
@@ -7,7 +7,7 @@ lockdown();
 
 test('ses Immutable ArrayBuffer shim installed and hardened', t => {
   const ab1 = new ArrayBuffer(0);
-  const iab = ab1.transferToImmutable();
+  const iab = ab1.sliceToImmutable();
   const iabProto = getPrototypeOf(iab);
   t.true(isFrozen(iabProto));
   t.true(isFrozen(iabProto.slice));


### PR DESCRIPTION
Refs: (https://github.com/endojs/endo/pull/2399) https://github.com/endojs/endo/pull/2400 https://github.com/endojs/endo/pull/2798

## Description

Rather than [excluding](https://github.com/endojs/endo/pull/2400/commits/75ea396de858d54b57c87999cca3c4ec3bedb98c) the `'@endo/immutable-arraybuffer/shim.js'` import in the Hermes SES shim
(since Hermes lacks `structuredClone`, `transfer`, private fields and `class` syntax),
here we introduce `'@endo/immutable-arraybuffer/shim-hermes.js'` - a limited version achieved without those.

TODO
- [x] add limited hermes pony
- [x] add limited hermes pony shim
- [x] update get anonymous intrinsics
- [x] add/update types
- [x] add/update tests
- [x] improve types
- [x] add transform

### Security Considerations

> Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?

Documented in source code

### Scaling Considerations

> Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated?

### Documentation Considerations

> Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

Documented in source code

### Testing Considerations

> Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? 

Separate tests added for Hermes
- pony
- shim

### Compatibility Considerations

> Does this change break any prior usage patterns? Does this change allow usage patterns to evolve?

See https://github.com/endojs/endo/pull/2785#discussion_r2080692549 RE expanding the transform to support more than side effect imports if one day required

### Upgrade Considerations

> What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed?

> Include `*BREAKING*:` in the commit message with migration instructions for any breaking change.

> Update `NEWS.md` for user-facing changes.

> Delete guidance from pull request description before merge (including this!)

SES NEWS.md bullet already added for next release