### PR TITLE
chore(compartment-mapper): use @endo/path-compare

### DIFF
--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@endo/cjs-module-analyzer": "workspace:^",
     "@endo/module-source": "workspace:^",
+    "@endo/path-compare": "workspace:^",
     "@endo/trampoline": "workspace:^",
     "@endo/zip": "workspace:^",
     "ses": "workspace:^"

--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -15,55 +15,6 @@ const q = JSON.stringify;
 export const stringCompare = (a, b) => (a === b ? 0 : a < b ? -1 : 1);
 
 /**
- * @param {number} length
- * @param {string} term
- */
-const cumulativeLength = (length, term) => {
-  return length + term.length;
-};
-
-/**
- * @param {Array<string> | undefined} a
- * @param {Array<string> | undefined} b
- */
-export const pathCompare = (a, b) => {
-  // Undefined is not preferred
-  if (a === undefined && b === undefined) {
-    return 0;
-  }
-  if (a === undefined) {
-    return 1;
-  }
-  if (b === undefined) {
-    return -1;
-  }
-  // Prefer the shortest dependency path.
-  if (a.length !== b.length) {
-    return a.length - b.length;
-  }
-  // Otherwise, favor the shortest cumulative length.
-  const aSum = a.reduce(cumulativeLength, 0);
-  const bSum = b.reduce(cumulativeLength, 0);
-  if (aSum !== bSum) {
-    return aSum - bSum;
-  }
-  // Otherwise, compare terms lexically.
-  assert(a.length === b.length); // Reminder
-  // This loop guarantees that if any pair of terms is different, including the
-  // case where one is a prefix of the other, we will return a non-zero value.
-  for (let i = 0; i < a.length; i += 1) {
-    const comparison = stringCompare(a[i], b[i]);
-    if (comparison !== 0) {
-      return comparison;
-    }
-  }
-  // If all pairs of terms are the same respective lengths, we are guaranteed
-  // that they are exactly the same or one of them is lexically distinct and would
-  // have already been caught.
-  return 0;
-};
-
-/**
  * @template T
  * @param {Iterable<T>} iterable
  */

--- a/packages/compartment-mapper/src/digest.js
+++ b/packages/compartment-mapper/src/digest.js
@@ -16,11 +16,8 @@
  * } from './types.js'
  */
 
-import {
-  assertCompartmentMap,
-  pathCompare,
-  stringCompare,
-} from './compartment-map.js';
+import { pathCompare } from '@endo/path-compare';
+import { assertCompartmentMap, stringCompare } from './compartment-map.js';
 
 const { create, fromEntries, entries, keys } = Object;
 

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -42,7 +42,7 @@
  * } from './types/node-modules.js'
  */
 
-import { pathCompare } from './compartment-map.js';
+import { pathCompare } from '@endo/path-compare';
 import { inferExportsAndAliases } from './infer-exports.js';
 import { parseLocatedJson } from './json.js';
 import { join } from './node-module-specifier.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -426,6 +426,7 @@ __metadata:
   dependencies:
     "@endo/cjs-module-analyzer": "workspace:^"
     "@endo/module-source": "workspace:^"
+    "@endo/path-compare": "workspace:^"
     "@endo/trampoline": "workspace:^"
     "@endo/zip": "workspace:^"
     ava: "npm:^6.1.3"
@@ -831,7 +832,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/path-compare@workspace:packages/path-compare":
+"@endo/path-compare@workspace:^, @endo/path-compare@workspace:packages/path-compare":
   version: 0.0.0-use.local
   resolution: "@endo/path-compare@workspace:packages/path-compare"
   dependencies:


### PR DESCRIPTION
This removes the code copied from `@endo/compartment-mapper` to create `@endo/path-compare` and uses `@endo/path-compare` instead.

Ref: #2787
