### PR TITLE
fix(pass-style): rename passable "Primitive" to ocapn "Atom"

### DIFF
--- a/packages/marshal/src/types.test-d.ts
+++ b/packages/marshal/src/types.test-d.ts
@@ -1,18 +1,14 @@
-import { expectType, expectNotType } from 'tsd';
+import { expectType } from 'tsd';
 
-import {
-  Far,
-  type PrimitiveStyle,
-  type RemotableObject,
-} from '@endo/pass-style';
+import { Far, type AtomStyle, type RemotableObject } from '@endo/pass-style';
 import { makeMarshal } from './marshal.js';
 
-expectType<PrimitiveStyle>('string');
-expectType<PrimitiveStyle>('number');
+expectType<AtomStyle>('string');
+expectType<AtomStyle>('number');
 // @ts-expect-error
-expectType<PrimitiveStyle>(1);
+expectType<AtomStyle>(1);
 // @ts-expect-error
-expectType<PrimitiveStyle>('str');
+expectType<AtomStyle>('str');
 
 type KCap = RemotableObject & { getKref: () => string; iface: () => string };
 const valToSlot = (s: KCap) => s.getKref();
@@ -22,11 +18,8 @@ const cycled = marshal.fromCapData(marshal.toCapData(null as unknown as KCap));
 expectType<unknown>(cycled);
 
 const m = makeMarshal();
-type SlottedRemotable = { getBoardId: () => string };
-const foo = Far('foo');
 const foo1 = Far('foo', { getBoardId: () => 'board1' });
 const foo2 = Far('foo', { getBoardId: () => 'board2' });
-const bar = Far('bar');
 const bar1 = Far('bar', { getBoardId: () => 'board1' });
 m.toCapData(harden({ o: foo1 }));
 m.toCapData(harden({ o: foo2 }));

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -47,6 +47,8 @@ export {
   isRemotable,
   isRecord,
   isCopyArray,
+  isAtom,
+  assertAtom,
 } from './src/typeGuards.js';
 
 export * from './src/deeplyFulfilled.js';

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -34,6 +34,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@endo/common": "workspace:^",
     "@endo/env-options": "workspace:^",
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -1,9 +1,10 @@
 import { X, q } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { isPromise } from '@endo/promise-kit';
-import { getTag, isObject } from './passStyle-helpers.js';
+import { getTag } from './passStyle-helpers.js';
 import { passStyleOf } from './passStyleOf.js';
 import { makeTagged } from './makeTagged.js';
+import { isAtom } from './typeGuards.js';
 
 /**
  * @import {Passable, ByteArray, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'
@@ -82,7 +83,7 @@ export const deeplyFulfilled = async val => {
   // and fix if possible.
   // https://github.com/endojs/endo/issues/1257 may be relevant.
 
-  if (!isObject(val)) {
+  if (isAtom(val)) {
     return /** @type {DeeplyAwaited<T>} */ (val);
   }
   if (isPromise(val)) {
@@ -106,7 +107,7 @@ export const deeplyFulfilled = async val => {
       return E.when(Promise.all(valPs), vals => harden(vals));
     }
     case 'byteArray': {
-      const bytes = /** @type {ByteArray} */ (val);
+      const bytes = /** @type {ByteArray} */ (/** @type {unknown} */ (val));
       // @ts-expect-error not assignable to type 'DeeplyAwaited<T>'
       return bytes;
     }

--- a/packages/patterns/docs/marshal-vs-patterns-level.md
+++ b/packages/patterns/docs/marshal-vs-patterns-level.md
@@ -22,28 +22,28 @@ Where the parameters
 
 The OCapN language-independent ocap protocol is in flux. As of May 20 2023, the best draft of the OCapN data model is [the thread starting here](https://github.com/ocapn/ocapn/issues/5#issuecomment-1549012122). Although the Endo `passStyleOf` names differ, the taxonomy and data models will be the same. The [`@endo/pass-style`](https://www.npmjs.com/package/@endo/pass-style) package defines the language binding of this abstract data model to JavaScript language values, which are therefore considered *Passable values*.
 
-|            | OCapN name    | `passStyleOf`        | `typeof`      | JS notes                      |
-|------------|---------------|----------------------|---------------|-------------------------------|
-| Atoms      |               |                      |               |                               |
-|            | Null          | `"null"`             | `"object"`    | null                          |
-|            | Undefined     | `"undefined"`        | `"undefined"` |                               |
-|            | Boolean       | `"boolean"`          | `"boolean"`   |                               |
-|            | Float64       | `"number"`           | `"number"`    | Only one zero, only one NaN   |
-|            | SignedInteger | `"bigint"`           | `"bigint"`    |                               |
-|            | Symbol        | `"symbol"`           | `"symbol"`    | well-known & registered only (names TBD) |
-|            | String        | `"string"`           | `"string"`    | surrogate confusion (TBD)     |
-|            | ByteString    | `"byteString"` (TBD) | `"object"`    | UInt8Array (TBD)              |
-| Containers |               |                      |               |                               |
-|            | Sequence      | `"copyArray"`        | `"object"`    | Array                         |
-|            | Struct        | `"copyRecord"`       | `"object"`    | POJO                          |
-|            | Tagged        | `"tagged"`           | `"object"`    | Tagged/CopyTagged             |
-| Capability |               |                      |               |                               |
-|            |               | `"remotable"`        | `"function"`  | Remotable function            |
-|            |               | `"remotable"`        | `"object"`    | Remotable object with methods |
-|            |               | `"remotable"`        | `"object"`    | Remote Presence               |
-|            |               | `"promise"`          | `"object"`    | Promise                       |
-| Others     |               |                      |               |                               |
-|            | Error         | `"error"`            | `"object"`    | Error                         |
+|            | OCapN name    | `passStyleOf`  | `typeof`                 | JS notes                      |
+|------------|---------------|----------------|--------------------------|-------------------------------|
+| Atoms      |               |                |                          |                               |
+|            | Null          | `"null"`       | `"object"`               | null                          |
+|            | Undefined     | `"undefined"`  | `"undefined"`            |                               |
+|            | Boolean       | `"boolean"`    | `"boolean"`              |                               |
+|            | Float64       | `"number"`     | `"number"`               | Only one zero, only one NaN   |
+|            | SignedInteger | `"bigint"`     | `"bigint"`               |                               |
+|            | Symbol        | `"symbol"`     | `"symbol"` -> `"object"` | will represent as JS object   |
+|            | String        | `"string"`     | `"string"`               | surrogate confusion (TBD)     |
+|            | ByteArray     | `"byteArray"`  | `"object"`               | Immutable ArrayBuffer         |
+| Containers |               |                |                          |                               |
+|            | Sequence      | `"copyArray"`  | `"object"`               | Array                         |
+|            | Struct        | `"copyRecord"` | `"object"`               | POJO                          |
+|            | Tagged        | `"tagged"`     | `"object"`               | Tagged/CopyTagged             |
+| Capability |               |                |                          |                               |
+|            |               | `"remotable"`  | `"function"`             | Remotable function            |
+|            |               | `"remotable"`  | `"object"`               | Remotable object with methods |
+|            |               | `"remotable"`  | `"object"`               | Remote Presence               |
+|            |               | `"promise"`    | `"object"`               | Promise                       |
+| Others     |               |                |                          |                               |
+|            | Error         | `"error"`      | `"object"`               | Error                         |
 
 The [`@endo/marshal`](https://www.npmjs.com/package/@endo/marshal) package defines encodings of the data model for purposes of serialization and transmission.
 It also defines a "rank order" over all Passable values (a [total preorder](https://en.wikipedia.org/wiki/Weak_ordering) in which different values are always comparable but can be tied for the *same rank*) that can be used for sorting but is not intended to make sense for an application programmer.

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -4,7 +4,7 @@ export {};
 
 // NB: as of TS 5.5 nightly, TS thinks RankCover and Checker "is declared but never read" but they are
 /**
- * @import {Checker, CopyArray, CopyRecord, CopyTagged, Passable, PassStyle, Primitive, RemotableObject} from '@endo/pass-style';
+ * @import {Checker, CopyArray, CopyRecord, CopyTagged, Passable, PassStyle, Atom, RemotableObject} from '@endo/pass-style';
  * @import {PartialCompare, PartialComparison, RankCompare, RankCover} from '@endo/marshal';
  */
 
@@ -69,7 +69,7 @@ export {};
  */
 
 /**
- * @typedef {Primitive | RemotableObject} ScalarKey
+ * @typedef {Atom | RemotableObject} ScalarKey
  */
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,6 +794,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/pass-style@workspace:packages/pass-style"
   dependencies:
+    "@endo/common": "workspace:^"
     "@endo/env-options": "workspace:^"
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"


### PR DESCRIPTION

Closes: #XXXX
Refs: #XXXX

## Description

For describing Passables that correspond to OCapN Atoms, the terms around "primitive" because increasingly awkward because not all of these are (byteArray) or will be (symbol) represented by JS language-level primitives. Instead, they are/will be represented by JS objects. Thus, we adopt the OCapN name `Atom` instead. We still export the "Primitive*" type names, but deprecate them to remove them once we're past this transition.

We also fixed a few remaining bugs where we were using the JS-level `isObject` to partition Passable types between Atom and non-Atom. We now use `isAtom` instead.

### Security Considerations

Aside from the naming clarity and the bug fixes, none.

### Scaling Considerations

none
### Documentation Considerations

It will now be more natural to delegate much of the `@endo/pass-style` documentation to OCapN
### Testing Considerations

- [ ] Should add test cases that fail before these bugs were fixed.

### Compatibility Considerations

We might need to preserve a few more exported names while deprecating them, to avoid breaking clients of endo like agoric-sdk

### Upgrade Considerations

