### PR TITLE
fix: suggestions for PR #2785

### DIFF
--- a/packages/immutable-arraybuffer/index.js
+++ b/packages/immutable-arraybuffer/index.js
@@ -142,6 +142,13 @@ const {
 
 setPrototypeOf(immutableArrayBufferPrototype, arrayBufferPrototype);
 
+/**
+ * Transfer the contents to a new Immutable ArrayBuffer
+ *
+ * @param {ArrayBuffer} buffer The original buffer.
+ * @param {number} [newLength] The start index.
+ * @returns {ArrayBuffer}
+ */
 export const transferBufferToImmutable = (buffer, newLength = undefined) => {
   if (newLength !== undefined) {
     if (transfer) {
@@ -160,7 +167,8 @@ export const transferBufferToImmutable = (buffer, newLength = undefined) => {
       }
     }
   }
-  return new ImmutableArrayBufferInternal(buffer);
+  const result = new ImmutableArrayBufferInternal(buffer);
+  return /** @type {ArrayBuffer} */ (/** @type {unknown} */ (result));
 };
 
 export const isBufferImmutable = buffer => {
@@ -177,6 +185,14 @@ export const isBufferImmutable = buffer => {
   }
 };
 
+/**
+ * Enforces that `arrayBuffer` is a genuine `ArrayBuffer` exotic object.
+ *
+ * @param {ArrayBuffer} buffer
+ * @param {number} [start]
+ * @param {number} [end]
+ * @returns {ArrayBuffer}
+ */
 const sliceBuffer = (buffer, start = undefined, end = undefined) => {
   try {
     // @ts-expect-error We know it is really there
@@ -189,6 +205,14 @@ const sliceBuffer = (buffer, start = undefined, end = undefined) => {
   }
 };
 
+/**
+ * Creates an immutable slice of the given buffer.
+ *
+ * @param {ArrayBuffer} buffer The original buffer.
+ * @param {number} [start] The start index.
+ * @param {number} [end] The end index.
+ * @returns {ArrayBuffer} The sliced immutable ArrayBuffer.
+ */
 export const sliceBufferToImmutable = (
   buffer,
   start = undefined,

--- a/packages/immutable-arraybuffer/shim-hermes.js
+++ b/packages/immutable-arraybuffer/shim-hermes.js
@@ -12,11 +12,12 @@ const arrayBufferMethods = {
    * @this {ArrayBuffer} buffer The original buffer.
    * @param {number} [start] The start index.
    * @param {number} [end] The end index.
-   * @returns {Partial<Omit<ArrayBuffer, 'slice'>>} The sliced immutable ArrayBuffer.
+   * @returns {ArrayBuffer} The sliced immutable ArrayBuffer.
    */
   sliceToImmutable(start = undefined, end = undefined) {
     return sliceBufferToImmutable(this, start, end);
   },
+
   get immutable() {
     return isBufferImmutable(this);
   },
@@ -28,7 +29,7 @@ if ('transfer' in arrayBufferPrototype) {
   );
 }
 
-if ('transferToImmutable' in arrayBufferPrototype) {
+if ('sliceToImmutable' in arrayBufferPrototype) {
   // Modern shim practice frowns on conditional installation, at least for
   // proposals prior to stage 3. This is so changes to the proposal since
   // an old shim was distributed don't need to worry about the proposal
@@ -40,7 +41,7 @@ if ('transferToImmutable' in arrayBufferPrototype) {
   // by `lockdown`, then this precludes overwriting as expected. However, for
   // this case, the following warning text will be confusing.
   console.warn(
-    'About to overwrite a prior implementation of "transferToImmutable"',
+    'About to overwrite a prior implementation of "sliceToImmutable"',
   );
 }
 

--- a/packages/immutable-arraybuffer/shim.js
+++ b/packages/immutable-arraybuffer/shim.js
@@ -8,18 +8,35 @@ const { getOwnPropertyDescriptors, defineProperties } = Object;
 const { prototype: arrayBufferPrototype } = ArrayBuffer;
 
 const arrayBufferMethods = {
+  /**
+   * Transfer the contents to a new Immutable ArrayBuffer
+   *
+   * @this {ArrayBuffer} buffer The original buffer.
+   * @param {number} [newLength] The start index.
+   * @returns {ArrayBuffer} The sliced immutable ArrayBuffer.
+   */
   transferToImmutable(newLength = undefined) {
     return transferBufferToImmutable(this, newLength);
   },
+
+  /**
+   * Creates an immutable slice of the given buffer.
+   *
+   * @this {ArrayBuffer} buffer The original buffer.
+   * @param {number} [start] The start index.
+   * @param {number} [end] The end index.
+   * @returns {ArrayBuffer} The sliced immutable ArrayBuffer.
+   */
   sliceToImmutable(start = undefined, end = undefined) {
     return sliceBufferToImmutable(this, start, end);
   },
+
   get immutable() {
     return isBufferImmutable(this);
   },
 };
 
-if ('transferToImmutable' in arrayBufferPrototype) {
+if ('sliceToImmutable' in arrayBufferPrototype) {
   // Modern shim practice frowns on conditional installation, at least for
   // proposals prior to stage 3. This is so changes to the proposal since
   // an old shim was distributed don't need to worry about the proposal
@@ -31,7 +48,7 @@ if ('transferToImmutable' in arrayBufferPrototype) {
   // by `lockdown`, then this precludes overwriting as expected. However, for
   // this case, the following warning text will be confusing.
   console.warn(
-    'About to overwrite a prior implementation of "transferToImmutable"',
+    'About to overwrite a prior implementation of "sliceToImmutable"',
   );
 }
 

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -168,17 +168,9 @@ export const getAnonymousIntrinsics = () => {
   }
 
   const ab = new ArrayBuffer(0);
-  let iab;
-  // @ts-expect-error see below
-  if (typeof ab.transferToImmutable === 'function') {
-    // @ts-expect-error TODO How do I add transferToImmutable to ArrayBuffer type?
-    // eslint-disable-next-line @endo/no-polymorphic-call
-    iab = ab.transferToImmutable(); // Note: Unavailable on Hermes
-  } else {
-    // @ts-expect-error TODO How do I add sliceToImmutable to ArrayBuffer type?
-    // eslint-disable-next-line @endo/no-polymorphic-call
-    iab = ab.sliceToImmutable();
-  }
+  // @ts-expect-error TODO How do I add sliceToImmutable to ArrayBuffer type?
+  // eslint-disable-next-line @endo/no-polymorphic-call
+  const iab = ab.sliceToImmutable();
   const iabProto = getPrototypeOf(iab);
   if (iabProto !== ArrayBuffer.prototype) {
     // In a native implementation, these will be the same prototype


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

> Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one):

Closes: #XXXX
Refs: #XXXX

## Description

> Add a description of the changes that this PR introduces and the files that are the most critical to review.

### Security Considerations

> Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?

### Scaling Considerations

> Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated?

### Documentation Considerations

> Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

### Testing Considerations

> Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet? 

### Compatibility Considerations

> Does this change break any prior usage patterns? Does this change allow usage patterns to evolve?

### Upgrade Considerations

> What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed?

> Include `*BREAKING*:` in the commit message with migration instructions for any breaking change.

> Update `NEWS.md` for user-facing changes.

> Delete guidance from pull request description before merge (including this!)
