### PR TITLE
feat(marshal): passable to quasi-quoted Justin expr

### DIFF
--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,5 +1,13 @@
 User-visible changes in `@endo/marshal`:
 
+# Nest release
+
+- `@endo/marshal` now also exports a `qp` function meaning "quote passable"
+  that renders its passable argument as a quasi-quoted Justin expression.
+  This can be used with `X`, `Fail` etc the same way you currently use `q`.
+  Since Justin is a subset of HardenedJS, there's no need for the quasi-quoted
+  form to explain what language it is in.
+
 # v1.6.0 (2024-10-22)
 
 - `compareRank` now short-circuits upon encountering remotables to compare,

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -2,7 +2,7 @@ export { QCLASS } from './src/encodeToCapData.js';
 export { makeMarshal } from './src/marshal.js';
 export { stringify, parse } from './src/marshal-stringify.js';
 
-export { decodeToJustin } from './src/marshal-justin.js';
+export { decodeToJustin, passableAsJustin, qp } from './src/marshal-justin.js';
 
 export {
   makePassableKit,

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -1,12 +1,12 @@
 /// <reference types="ses"/>
 
+import { q, X, Fail } from '@endo/errors';
 import { Nat } from '@endo/nat';
 import {
   getErrorConstructor,
   isObject,
   passableSymbolForName,
 } from '@endo/pass-style';
-import { q, X, Fail } from '@endo/errors';
 import { QCLASS } from './encodeToCapData.js';
 import { makeMarshal } from './marshal.js';
 
@@ -468,14 +468,40 @@ export const passableAsJustin = (passable, shouldIndent = true) => {
 };
 harden(passableAsJustin);
 
+// The example below is the `patt1` test case from `qp-on-pattern.test.js`.
+// Please co-maintain the following doc-comment and that test module.
 /**
- * qp for quote passable as a quasi-quoted Justin expression.
+ * `qp` for quote passable as a quasi-quoted Justin expression.
  *
- * Modelled on `quote` from `assert.js` in `'ses'`. But uses Justin
- * instead of `bestEffortStringify`. The full name of this would have been
- * `quotePassable`. But since the `quote` from `assert.js` is always used via
- * its rename to `q`, we're skipping the rename and just
- * naming this variable `qp`.
+ * Both `q` from `@endo/errors` and this `qp` from `@endo/marshal` can
+ * be used together with `Fail`, `X`, etc from `@endo/errors` to mark
+ * a substitution value to be both
+ * - visually quoted in some useful manner
+ * - unredacted
+ *
+ * Differences:
+ * - given a pattern `M.and(M.gte(-100), M.lte(100))`,
+ *   ```js
+ *   `${q(patt)}`
+ *   ```
+ *   produces `"[match:and]"`, whereas
+ *   ```js
+ *   `${qp(patt)}`
+ *   ```
+ *   produces quasi-quotes Justin of what would be passed:
+ *   ```js
+ *   `makeTagged("match:and", [
+ *     makeTagged("match:gte", -100),
+ *     makeTagged("match:lte", 100),
+ *   ])`
+ *   ```
+ * - `q` is lazy, minimizing the cost for using it in an error that's never
+ *   logged. Unfortunately, due to layering constraints, `qp` is not
+ *   lazy, always rendering to quasi-quoted Justin immediately.
+ *
+ * Since Justin is a subset of HardenedJS, neither the name `qp` nor the
+ * rendered form need to make clear that the rendered form is in Justin rather
+ * than HardenedJS.
  *
  * @param {Passable} payload
  * @returns {StringablePayload}

--- a/packages/patterns/test/qp-on-pattern.test.js
+++ b/packages/patterns/test/qp-on-pattern.test.js
@@ -1,5 +1,6 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
+import { q } from '@endo/errors';
 import { qp } from '@endo/marshal';
 import { M } from '../src/patterns/patternMatchers.js';
 
@@ -7,19 +8,35 @@ import { M } from '../src/patterns/patternMatchers.js';
 // but is placed here because it uses patterns which don't exist at
 // the `@endo/marshal` layer.
 //
-// This was the original example in a slack thread looking for a more
+// `patt1` is extracted from `patt2` as a simpler example we reproduce in
+// in the `qp` doc-comment. Please co-maintain this test case and
+// the `qp` doc-comment.
+//
+// `patt2` was the original example in a slack thread looking for a more
 // legible way to render patterns. Patterns are Passables, and all
 // Passables can kinda be rendered in Justin. Though Remotables and
 // promises will be rendered only in terms of slot numbers.
 test('qp on a pattern', t => {
-  const patt = M.splitRecord(
+  const patt1 = M.and(M.gte(-100), M.lte(100));
+  t.is(`${q(patt1)}`, '"[match:and]"');
+  t.is(
+    `${qp(patt1)}`,
+    `\
+\`makeTagged("match:and", [
+  makeTagged("match:gte", -100),
+  makeTagged("match:lte", 100),
+])\``,
+  );
+
+  const patt2 = M.splitRecord(
     harden({
       assetKind: M.or('nat', 'set', 'copySet', 'copyBag'),
       decimalPlaces: M.and(M.gte(-100), M.lte(100)),
     }),
   );
+  t.is(`${q(patt2)}`, '"[match:splitRecord]"');
   t.is(
-    qp(patt),
+    `${qp(patt2)}`,
     `\`makeTagged("match:splitRecord", [
   {
     assetKind: makeTagged("match:or", [

--- a/packages/patterns/test/qp-on-pattern.test.js
+++ b/packages/patterns/test/qp-on-pattern.test.js
@@ -1,0 +1,38 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import { qp } from '@endo/marshal';
+import { M } from '../src/patterns/patternMatchers.js';
+
+// This is a continuation of a test case in marshal-justin.test.js,
+// but is placed here because it uses patterns which don't exist at
+// the `@endo/marshal` layer.
+//
+// This was the original example in a slack thread looking for a more
+// legible way to render patterns. Patterns are Passables, and all
+// Passables can kinda be rendered in Justin. Though Remotables and
+// promises will be rendered only in terms of slot numbers.
+test('qp on a pattern', t => {
+  const patt = M.splitRecord(
+    harden({
+      assetKind: M.or('nat', 'set', 'copySet', 'copyBag'),
+      decimalPlaces: M.and(M.gte(-100), M.lte(100)),
+    }),
+  );
+  t.is(
+    qp(patt),
+    `\`makeTagged("match:splitRecord", [
+  {
+    assetKind: makeTagged("match:or", [
+      "nat",
+      "set",
+      "copySet",
+      "copyBag",
+    ]),
+    decimalPlaces: makeTagged("match:and", [
+      makeTagged("match:gte", -100),
+      makeTagged("match:lte", 100),
+    ]),
+  },
+])\``,
+  );
+});


### PR DESCRIPTION
Closes: #XXXX
Refs: https://github.com/Agoric/agoric-sdk/pull/5401

## Description

We often need to see the deep contents of a Passable. Indeed, this was kicked off by a slack thread about wanting to quote
```js
M.splitRecord(
    harden({
      assetKind: M.or('nat', 'set', 'copySet', 'copyBag'),
      decimalPlaces: M.and(M.gte(-100), M.lte(100)),
    }),
  )
```

This PR provides a `qp` function meaning "quote passable". You can use it where you'd use `q`. It produces a quasi-quoted Justin expression of the form in which the passable would be passed. For example, the `qp` of the above pattern is

```js
`makeTagged("match:splitRecord",  [
  {
    assetKind: makeTagged("match:or", [
      "nat",
      "set",
      "copySet",
      "copyBag",
    ]),
    decimalPlaces: makeTagged("match:and", [
      makeTagged("match:gte", -100),
      makeTagged("match:lte", 100),
    ]),
  },
])`
```

### Security Considerations

Unlike `q`, `qp` does not lazily postpone rendering the expression into Justin. `q` can do this easily because it is inside the `'ses'` assert.js module and can use the rights amplification available only there. `qp` depends on `'@endo/marshal'` which is several levels up from `'ses'`. Rather than expose these rights amplification powers (or several other kludges that failed), I just made `qp` non-lazy. Thus there are no security implications.

### Scaling Considerations

Because `qp` is not lazy, simply constructing an error with `Fail` or `makeError(X...)` will pay all the cost of rendering to Justin, whether or not that error is ever used. 

### Documentation Considerations

Because Justin is a subset of HardenedJS, the Justin expressions produced by `qp` can be used in documentation if needed. Though see Compatibility Considerations below.

### Testing Considerations

- [ ] Only minimal tests written for `qp`. We should also write a test that loops through all the `jsonJustinPairs`, just as other Justin tests do.

### Compatibility Considerations

Using Justin with symbols exposes in the rendered string how Justin currently represents passable symbols. That changes in #2793. Whichever of these gets merged first, the other will have to reconcile merge conflicts. And any saved Justin strings containing that old Justin representation will need to be updated or marked stale.

### Upgrade Considerations

Other than the Compatibility Considerations above, none.

- [x] Update `NEWS.md` for user-facing changes.
