### PR TITLE
doc(marshal): adds missing comment from #2799 review

### DIFF
--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -459,6 +459,9 @@ export { decodeToJustin };
  */
 export const passableAsJustin = (passable, shouldIndent = true) => {
   let slotCount = 0;
+  // Using post-increment below only so that the indexes start at zero
+  // and the `slotCount` variable can be initialized to `0` rather than
+  // `-1`.
   // eslint-disable-next-line no-plusplus
   const convertValToSlot = val => `s${slotCount++}`;
   const { toCapData } = makeMarshal(convertValToSlot);


### PR DESCRIPTION
Closes: #XXXX
Refs: https://github.com/endojs/endo/pull/2799#discussion_r2085652080

## Description

At https://github.com/endojs/endo/pull/2799#discussion_r2085652080 @dckc suggested
>  I suggest including it in the comment.

I intended to. But somehow I resolved it before actually doing this, causing me to miss it when evaluating if I should just merge-and-squash #2799. This PR corrects that omission.

Minor internal comment only. It should not have any other implications.
