### PR TITLE
fix(module-source): allow defaults in destructuring assignments

### DIFF
--- a/packages/module-source/src/babel-plugin.js
+++ b/packages/module-source/src/babel-plugin.js
@@ -31,6 +31,8 @@ const collectPatternIdentifiers = (path, pattern) => {
         // Non-elided pattern.
         return collectPatternIdentifiers(path, pat);
       });
+    case 'AssignmentPattern':
+      return collectPatternIdentifiers(path, pattern.left);
     default:
       throw path.buildCodeFrameError(
         `Pattern type ${pattern.type} is not recognized`,

--- a/packages/module-source/test/module-source.test.js
+++ b/packages/module-source/test/module-source.test.js
@@ -789,8 +789,14 @@ test('should handle package "immer" source', t => {
   });
 });
 
-// https://github.com/endojs/endo/issues/2094
-test.failing('should support export of defaulted extraction', t => {
+test('should support basic assignment of defaulted extraction', t => {
+  const _ = new ModuleSource(`
+    const { x, y = x } = globalThis;
+  `);
+  t.pass();
+});
+
+test('should support export of defaulted extraction', t => {
   const _ = new ModuleSource(`
     const { x, y = x } = globalThis;
     export { x, y };
@@ -798,11 +804,26 @@ test.failing('should support export of defaulted extraction', t => {
   t.pass();
 });
 
-test.failing('should support export const object with default', t => {
+test('should support export const object with default', t => {
   const _ = new ModuleSource(`
     export const {
       x = undefined,
     } = globalThis;
+  `);
+  t.pass();
+});
+
+test('should support nested assignment of defaulted extraction', t => {
+  const _ = new ModuleSource(`
+    const { x, y: {z: u = v} = x } = globalThis;
+  `);
+  t.pass();
+});
+
+test('should support export of nested assignment of defaulted extraction', t => {
+  const _ = new ModuleSource(`
+    const { x, y: {z: u = v} = x } = globalThis;
+    export { x, u };
   `);
   t.pass();
 });


### PR DESCRIPTION
Closes: #2094

## Description

Modifies `babel-plugin.js` to allow for defaults when destructuring.

The problem noted in #2094 was affecting _all_ such assignments, not just those which are exported.

I'm _extremely suspicious_ of this change because it was so easy that it _must_ be wrong.

### Security Considerations

If there is a security-related reason for not implementing this, I don't know what it is.

### Scaling Considerations

no

### Documentation Considerations

n/a

### Testing Considerations

Could throw this in a test fixture, I suppose.

### Compatibility Considerations

Well, it allows for parsing code containing destructuring assignments with defaults, so take that as you will.

### Upgrade Considerations

May want a `NEWS.md` entry? I'm honestly surprised somebody isn't complaining about this already.
