### PR TITLE
fix(compartment-mapper): handle invalid peer dependencies

### DIFF
--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -55,7 +55,7 @@ import {
 import { unpackReadPowers } from './powers.js';
 import { search, searchDescriptor } from './search.js';
 
-const { assign, create, keys, values } = Object;
+const { assign, create, keys, values, entries } = Object;
 
 const decoder = new TextDecoder();
 
@@ -521,7 +521,7 @@ const graphPackage = async (
 
   const sourceDirname = basename(packageLocation);
 
-  Object.assign(result, {
+  assign(result, {
     name,
     path: logicalPath,
     label: `${name}${version ? `-v${version}` : ''}`,
@@ -546,7 +546,7 @@ const graphPackage = async (
   await Promise.all(children);
 
   // handle commonDependencyDescriptors package aliases
-  for (const [name, { alias }] of Object.entries(commonDependencyDescriptors)) {
+  for (const [name, { alias }] of entries(commonDependencyDescriptors)) {
     // update the dependencyLocations to point to the common dependency
     const targetLocation = dependencyLocations[name];
     if (targetLocation === undefined) {
@@ -717,7 +717,7 @@ const graphPackages = async (
   /** @type {CommonDependencyDescriptors} */
   const commonDependencyDescriptors = {};
   const packageDescriptorDependencies = packageDescriptor.dependencies || {};
-  for (const [alias, dependencyName] of Object.entries(commonDependencies)) {
+  for (const [alias, dependencyName] of entries(commonDependencies)) {
     const spec = packageDescriptorDependencies[dependencyName];
     if (spec === undefined) {
       throw Error(
@@ -772,7 +772,7 @@ const translateGraph = (
   policy,
 ) => {
   /** @type {CompartmentMapDescriptor['compartments']} */
-  const compartments = Object.create(null);
+  const compartments = create(null);
 
   // For each package, build a map of all the external modules the package can
   // import from other packages.
@@ -795,9 +795,9 @@ const translateGraph = (
       types,
     } = graph[dependeeLocation];
     /** @type {CompartmentDescriptor['modules']} */
-    const moduleDescriptors = Object.create(null);
+    const moduleDescriptors = create(null);
     /** @type {CompartmentDescriptor['scopes']} */
-    const scopes = Object.create(null);
+    const scopes = create(null);
 
     /**
      * List of all the compartments (by name) that this compartment can import from.
@@ -957,10 +957,10 @@ const makeLanguageOptions = ({
   };
 
   const languages = new Set([
-    ...Object.values(moduleLanguageForExtension),
-    ...Object.values(commonjsLanguageForExtension),
-    ...Object.values(workspaceModuleLanguageForExtension),
-    ...Object.values(workspaceCommonjsLanguageForExtension),
+    ...values(moduleLanguageForExtension),
+    ...values(commonjsLanguageForExtension),
+    ...values(workspaceModuleLanguageForExtension),
+    ...values(workspaceCommonjsLanguageForExtension),
     ...additionalLanguages,
   ]);
 

--- a/packages/compartment-mapper/test/fixtures-missing-optional-peer-dependencies/README.md
+++ b/packages/compartment-mapper/test/fixtures-missing-optional-peer-dependencies/README.md
@@ -1,0 +1,1 @@
+This is like [fixtures-optional-peer-dependencies](../fixtures-optional-peer-dependencies/README.md), but the optional peer dependency is not installed.

--- a/packages/compartment-mapper/test/fixtures-missing-optional-peer-dependencies/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-missing-optional-peer-dependencies/node_modules/app/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  paperina: require('paperina')
+};

--- a/packages/compartment-mapper/test/fixtures-missing-optional-peer-dependencies/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-missing-optional-peer-dependencies/node_modules/app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "peerDependencies": {},
+  "peerDependenciesMeta": {
+    "paperina": {
+      "optional": true
+    }
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/README.md
+++ b/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/README.md
@@ -1,0 +1,9 @@
+This fixture is for testing the behavior of `mapNodeModules()` when a package has no declared `peerDependencies` _but_ has a `peerDependenciesMeta` field listing an _optional_ dependency.
+
+The _intent_ of this configuration is to declare _optional_ peer dependencies.  
+
+`npm@7+` requires all dependencies mentioned in `peerDependenciesMeta` must to be declared in `peerDependencies`. This enables automatic installation of the peer dependencies (which is then allowed to fail).
+
+Prior to `npm@7`, there was no way to declare a peer dependency as optional, leading packages to _omit_ optional `peerDependencies` from `package.json`.  
+
+I do not know if `yarn` or `pnpm` (any version) do anything with a lone `peerDependenciesMeta` field. Assuming they don't, `peerDependenciesMeta` w/o a `peerDependencies` is little more than a _hint_ to a human reader.

--- a/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/node_modules/app/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  paperina: require('paperina')
+};

--- a/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/node_modules/app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "peerDependencies": {},
+  "peerDependenciesMeta": {
+    "paperina": {
+      "optional": true
+    }
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/node_modules/paperina/index.js
+++ b/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/node_modules/paperina/index.js
@@ -1,0 +1,1 @@
+module.exports = 'ok';

--- a/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/node_modules/paperina/package.json
+++ b/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/node_modules/paperina/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "paperina",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}


### PR DESCRIPTION
## Description

_May be controversial!_

This adds dependency names found in `peerDependenciesMeta` which are otherwise unspecified in other dependency fields to the list of all dependencies so that a `CompartmentDescriptor` will be created if the package exists.

~~We will prefer any spec already provided in a dependency field instead of the default (which is `*` for lack of a better value).~~

~~A variation on this PR would be to use the version from `devDependencies` if present (regardless of the `dev` flag) and then fall back to `*`. _Most_ packages tend to include `peerDependencies` in `devDependencies`.~~

> [!IMPORTANT]
>
> I noticed that `graphPackage()` was storing the specification for each dependency but this data was unused. I changed the data structures to avoid doing this.

### Security Considerations

n/a

### Scaling Considerations

no

### Documentation Considerations

I don't think this needs any documentation changes.

### Testing Considerations

If someone wants it, I can add a test for this. I'd rather pretend it doesn't exist.

### Compatibility Considerations

no

### Upgrade Considerations

I can't see how this would break anyone who isn't already broken.
