### PR TITLE
chore: update deprecated github action and pin versions, add validation

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - name: Put unstable chrome where playwright would look for it
         run: mv /opt/google/chrome /opt/google/chrome-unstable
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           node-version: 18
       - name: Provide yarn # yarn is missing in the Selenium image
@@ -45,7 +45,7 @@ jobs:
       - name: Run Playwright tests
         working-directory: browser-test
         run: npx playwright test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         if: always()
         with:
           name: browser-test-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           node-version: 20.x
           cache: yarn
@@ -72,13 +72,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -121,13 +121,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -158,13 +158,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -194,13 +194,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -229,13 +229,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22.x
           cache: yarn
@@ -265,13 +265,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -311,7 +311,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
         with:
           path: endo
 
@@ -320,7 +320,7 @@ jobs:
         working-directory: endo
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           path: endo
           node-version: ${{ matrix.node-version }}
@@ -339,7 +339,7 @@ jobs:
 
       - name: Restore XS binary cache
         id: restore-xs
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4
         with:
           path: bin/xst
           key: xst-lin64-${{ matrix.moddable-version }}
@@ -365,7 +365,7 @@ jobs:
 
       - name: Checkout XS
         if: steps.check-release.outputs.release == 'build'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
         with:
           repository: moddable-OpenSource/moddable
           ref: ${{ matrix.moddable-version }}

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -12,14 +12,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
         with:
           submodules: 'true'
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4 (updated from v3)
         with:
           node-version: 18.x
       - name: Install graphviz

--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -23,15 +23,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
+      - uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d #v4
       # Without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
       # Without this the inter-package imports don't resolve
       - run: yarn install
       # Generate the TypeDoc site
       - run: yarn docs
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c #v2
         with:
           path: ./api-docs # the "out" path in typedoc.json
   deploy:
@@ -43,4 +43,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4 (updated from v3)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "packageManager": "yarn@4.7.0",
   "devDependencies": {
     "@jessie.js/eslint-plugin": "^0.4.2",
+    "@lavamoat/git-safe-dependencies": "^0.2.2",
     "@octokit/core": "^3.4.0",
     "@types/node": "^20.17.24",
     "ava": "^6.1.3",
@@ -35,8 +36,9 @@
     "docs:markdown-for-agoric-documentation-repo": "typedoc --plugin typedoc-plugin-markdown --tsconfig tsconfig.build.json",
     "update": "echo 'DEPRECATED: use \"yarn upgrade-interactive\" or \"yarn dedupe\"'",
     "format": "prettier --write .github packages",
-    "lint": "prettier --check .github packages && yarn workspaces foreach --all run lint",
+    "lint": "yarn scan-workflows && prettier --check .github packages && yarn workspaces foreach --all run lint",
     "lint-fix": "yarn workspaces foreach --all run lint-fix",
+    "scan-workflows": "yarn git-safe-actions",
     "test": "yarn workspaces foreach --all --exclude @endo/skel run test",
     "test:xs": "yarn workspaces foreach --all run test:xs",
     "test262": "yarn workspaces foreach --all run test262",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1259,6 +1259,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lavamoat/git-safe-dependencies@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@lavamoat/git-safe-dependencies@npm:0.2.2"
+  dependencies:
+    glob: "npm:11.0.0"
+    hosted-git-info: "npm:8.1.0"
+    js-yaml: "npm:4.1.0"
+    lockfile-lint-api: "npm:5.9.2"
+  bin:
+    git-safe-actions: src/cli-actions.js
+    git-safe-dependencies: src/cli.js
+  checksum: 10c0/ae09066d469ff9018a36cbec70de83e6cf333687274db4989019b5527489b45154bd434165394097d1215b5c89f776de82b6723b6f84d1e940632f093e02cbfb
+  languageName: node
+  linkType: hard
+
 "@lerna/create@npm:8.1.8":
   version: 8.1.8
   resolution: "@lerna/create@npm:8.1.8"
@@ -2774,6 +2789,16 @@ __metadata:
     js-yaml: "npm:^3.10.0"
     tslib: "npm:^2.4.0"
   checksum: 10c0/c7f421c6885142f351459031c093fb2e79abcce6f4a89765a10e600bb7ab122949c54bcea2b23de9572a2b34ba29f822b17831c1c43ba50373ceb8cb5b336667
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/parsers@npm:^3.0.0-rc.48.1":
+  version: 3.0.3
+  resolution: "@yarnpkg/parsers@npm:3.0.3"
+  dependencies:
+    js-yaml: "npm:^3.10.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/70c2fa011bf28a517a8ee4264dd93d7590f6e3d02c6d4feb50533f405ca3b100cb156f11405b9a34f7c51c6893d3d8b051554dddfd5afaae2067f921512447a3
   languageName: node
   linkType: hard
 
@@ -5887,6 +5912,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^4.0.1"
+    minimatch: "npm:^10.0.0"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/419866015d8795258a8ac51de5b9d1a99c72634fc3ead93338e4da388e89773ab21681e494eac0fbc4250b003451ca3110bb4f1c9393d15d14466270094fdb4e
+  languageName: node
+  linkType: hard
+
 "glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.3.12
   resolution: "glob@npm:10.3.12"
@@ -6158,6 +6199,15 @@ __metadata:
   version: 0.12.0
   resolution: "hermes-engine-cli@npm:0.12.0"
   checksum: 10c0/53a00336632cc7a743e9a88a5199865cf922d118f42f15bed4d2ed2fee635acd0d4d8563803b47e7c1bc2d17650281eb9188be8cfdaa25887243cfee840523be
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:8.1.0":
+  version: 8.1.0
+  resolution: "hosted-git-info@npm:8.1.0"
+  dependencies:
+    lru-cache: "npm:^10.0.1"
+  checksum: 10c0/53cc838ecaa7d4aa69a81d9d8edc362c9d415f67b76ad38cdd781d2a2f5b45ad0aa9f9b013fb4ea54a9f64fd2365d0b6386b5a24bdf4cb90c80477cf3175aaa2
   languageName: node
   linkType: hard
 
@@ -6979,6 +7029,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "jackspeak@npm:4.1.0"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+  checksum: 10c0/08a6a24a366c90b83aef3ad6ec41dcaaa65428ffab8d80bc7172add0fbb8b134a34f415ad288b2a6fbd406526e9a62abdb40ed4f399fbe00cb45c44056d4dce0
+  languageName: node
+  linkType: hard
+
 "jake@npm:^10.8.5":
   version: 10.8.5
   resolution: "jake@npm:10.8.5"
@@ -7456,6 +7515,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lockfile-lint-api@npm:5.9.2":
+  version: 5.9.2
+  resolution: "lockfile-lint-api@npm:5.9.2"
+  dependencies:
+    "@yarnpkg/parsers": "npm:^3.0.0-rc.48.1"
+    debug: "npm:^4.3.4"
+    object-hash: "npm:^3.0.0"
+  checksum: 10c0/5fc80286a5172064946bd370e281a98954c973747e4308b56eae837c71ca4fa03f7f38bed410660355406bc7c41240cc17558dcf91ef68d5b63ee5357c4beb91
+  languageName: node
+  linkType: hard
+
 "lodash.ismatch@npm:^4.4.0":
   version: 4.4.0
   resolution: "lodash.ismatch@npm:4.4.0"
@@ -7500,6 +7570,13 @@ __metadata:
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
   checksum: 10c0/ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "lru-cache@npm:11.1.0"
+  checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
   languageName: node
   linkType: hard
 
@@ -7781,6 +7858,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/e6c29a81fe83e1877ad51348306be2e8aeca18c88fdee7a99df44322314279e15799e41d7cb274e4e8bb0b451a3bc622d6182e157dfa1717d6cda75e9cd8cd5d
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -7904,6 +7990,13 @@ __metadata:
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 10c0/6c7370a6dfd257bf18222da581ba89a5eaedca10e158781232a8b5542a90547540b4b9b7e7f490e4cda43acfbd12e086f0453728ecf8c19e0ef6921bc5958ac5
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
   languageName: node
   linkType: hard
 
@@ -8421,6 +8514,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-hash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "object-hash@npm:3.0.0"
+  checksum: 10c0/a06844537107b960c1c8b96cd2ac8592a265186bfa0f6ccafe0d34eabdb526f6fa81da1f37c43df7ed13b12a4ae3457a16071603bcd39d8beddb5f08c37b0f47
+  languageName: node
+  linkType: hard
+
 "object-inspect@npm:^1.13.1, object-inspect@npm:^1.9.0":
   version: 1.13.1
   resolution: "object-inspect@npm:1.13.1"
@@ -8797,6 +8897,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "package-json-from-dist@npm:1.0.1"
+  checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
+  languageName: node
+  linkType: hard
+
 "pacote@npm:^18.0.0, pacote@npm:^18.0.6":
   version: 18.0.6
   resolution: "pacote@npm:18.0.6"
@@ -8971,6 +9078,16 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/3da4adedaa8e7ef8d6dc4f35a0ff8f05a9b4d8365f2b28047752b62d4c1ad73eec21e37b1579ef2d075920157856a3b52ae8309c480a6f1a8bbe06ff8e52b33c
   languageName: node
   linkType: hard
 
@@ -9737,6 +9854,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@jessie.js/eslint-plugin": "npm:^0.4.2"
+    "@lavamoat/git-safe-dependencies": "npm:^0.2.2"
     "@octokit/core": "npm:^3.4.0"
     "@types/node": "npm:^20.17.24"
     ava: "npm:^6.1.3"


### PR DESCRIPTION
## Description

A long deprecated (and now deleted) version of actions/deploy-pages was used. 

I ran `@lavamoat/git-safe-dependencies` and fixed errors.

Proposing it as a lint step.

Additionally, setting up a Renovate github bot to update the pinned versions could be useful.

### Security Considerations

Pinned versions are not prone to changes from authors, but the repository is only using actions from `actions/*` repositories, which means if github folks push an update to a relevant major, they update automatically, so I'm opening this up to discussion whether we want to pin or not.

`@lavamoat/git-safe-dependencies` verifies that the pinned commit ID belongs to the original repository not a fork.

### Upgrade Considerations

there was a breaking change to deploy-pages, but documentation indicates it should not affect us.