### PR TITLE
chore(ses): add typings to job queues to ensure arguments match

### DIFF
--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -514,9 +514,10 @@ const asyncJobQueue = (errors = []) => {
   /**
    * Enqueues a job that starts immediately but won't be awaited until drainQueue is called.
    *
-   * @template {any[]} T
-   * @param {(...args: T)=>Promise<*>} func
-   * @param {T} args
+   * @template {(...args: any[]) => Promise<void>} F
+   * @param {F} func - An async function to execute
+   * @param {Parameters<F>} args - Arguments to pass to the function
+   * @returns {void}
    */
   const enqueueJob = (func, args) => {
     setAdd(
@@ -542,6 +543,15 @@ const asyncJobQueue = (errors = []) => {
 const syncJobQueue = (errors = []) => {
   let current = [];
   let next = [];
+
+  /**
+   * Enqueues a job
+   *
+   * @template {(...args: any[]) => void} F
+   * @param {F} func - An async function to execute
+   * @param {Parameters<F>} args - Arguments to pass to the function
+   * @returns {void}
+   */
   const enqueueJob = (func, args) => {
     arrayPush(next, [func, args]);
   };


### PR DESCRIPTION
Much less types but better ROI than https://github.com/endojs/endo/pull/2808

Internals of job queues are not typed precisely, but what this gives us and previous didn't is TS complaining when 
`enqueueJob(memoizedLoadWithErrorAnnotation, [ wrong, argz, go, here ]`