### PR TITLE
feat(ses): Include ses-ava in stack frame filtering

### DIFF
--- a/packages/ses/src/error/tame-v8-error-constructor.js
+++ b/packages/ses/src/error/tame-v8-error-constructor.js
@@ -71,10 +71,9 @@ const FILENAME_NODE_DEPENDENTS_CENSOR = /\/node_modules\//;
 // stack traces.
 const FILENAME_NODE_INTERNALS_CENSOR = /^(?:node:)?internal\//;
 
-// Frames within the `assert.js` package should be dropped from
-// concise stack traces, as these are just steps towards creating the
-// error object in question.
-const FILENAME_ASSERT_CENSOR = /\/packages\/ses\/src\/error\/assert.js$/;
+// Frames within SES `assert.js` should be dropped from concise stack traces, as
+// these are just steps towards creating the error object in question.
+const FILENAME_ASSERT_CENSOR = /\/packages\/ses\/src\/error\/assert\.js$/;
 
 // Frames within the `eventual-send` shim should be dropped so that concise
 // deep stacks omit the internals of the eventual-sending mechanism causing
@@ -82,6 +81,10 @@ const FILENAME_ASSERT_CENSOR = /\/packages\/ses\/src\/error\/assert.js$/;
 // Note that the eventual-send package will move from agoric-sdk to
 // Endo, so this rule will be of general interest.
 const FILENAME_EVENTUAL_SEND_CENSOR = /\/packages\/eventual-send\/src\//;
+
+// Frames within the `ses-ava` package should be dropped from concise stack
+// traces, as they just support exposing error details to AVA.
+const FILENAME_SES_AVA_CENSOR = /\/packages\/ses-ava\/src\/ses-ava-test\.js$/;
 
 // Any stack frame whose `fileName` matches any of these censor patterns
 // will be omitted from concise stacks.
@@ -91,6 +94,7 @@ const FILENAME_CENSORS = [
   FILENAME_NODE_INTERNALS_CENSOR,
   FILENAME_ASSERT_CENSOR,
   FILENAME_EVENTUAL_SEND_CENSOR,
+  FILENAME_SES_AVA_CENSOR,
 ];
 
 // Should a stack frame with this as its fileName be included in a concise


### PR DESCRIPTION
## Description

```diff
     ℹ t.log (Error#1)
     ℹ Error#1: outer t.log containing (Error#2)
     ℹ   at makeError (file:///tmp/censor-ses-ava/ses-ava-log.test.js:6:17)
         at file:///tmp/censor-ses-ava/ses-ava-log.test.js:10:18
-        at logErrorFirst (file:///tmp/endo/packages/ses-ava/src/ses-ava-test.js:97:14)
-        at wrappedFunc (file:///tmp/endo/packages/ses-ava/src/ses-ava-test.js:217:16)
         at async Promise.all (index 0)
       
     ℹ Nested error under Error#1
     ℹ   Error#2: inner t.log REDACTED
     ℹ      at makeError (file:///tmp/censor-ses-ava/ses-ava-log.test.js:5:27) 
            at file:///tmp/censor-ses-ava/ses-ava-log.test.js:10:18 
-           at logErrorFirst (file:///tmp/endo/packages/ses-ava/src/ses-ava-test.js:97:14) 
-           at wrappedFunc (file:///tmp/endo/packages/ses-ava/src/ses-ava-test.js:217:16) 
            at async Promise.all (index 0) 
          
     ℹ DONE
 Error#3: outer console.log containing (Error#4)
   at makeError (file:///tmp/censor-ses-ava/ses-ava-log.test.js:6:17)
   at file:///tmp/censor-ses-ava/ses-ava-log.test.js:11:30
-  at logErrorFirst (file:///tmp/endo/packages/ses-ava/src/ses-ava-test.js:97:14)
-  at wrappedFunc (file:///tmp/endo/packages/ses-ava/src/ses-ava-test.js:217:16)
   at async Promise.all (index 0)
 
 Nested error under Error#3
   Error#4: inner console.log REDACTED
     at makeError (file:///tmp/censor-ses-ava/ses-ava-log.test.js:5:27)
     at file:///tmp/censor-ses-ava/ses-ava-log.test.js:11:30
-    at logErrorFirst (file:///tmp/endo/packages/ses-ava/src/ses-ava-test.js:97:14)
-    at wrappedFunc (file:///tmp/endo/packages/ses-ava/src/ses-ava-test.js:217:16)
     at async Promise.all (index 0)
```

### Security Considerations

None known.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

I don't think we cover this in testing, which seems fine.

### Compatibility Considerations

None.

### Upgrade Considerations

Nothing special is required, and I have declined to update NEWS.md.