### PR TITLE
fix(scripts): Better detect and accommodate BSD sed in create-package.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,9 @@ Note: Endo uses `lerna` only for releasing. `lerna bootstrap` is unlikely to wor
 ## Creating a new package
 
 Run <code>[scripts/create-package.sh](./scripts/create-package.sh) $name</code>,
-then update the resulting README.md, package.json (specifically `description`),
-index.js, and index.test.js files.
+then update the resulting README.md, package.json (specifically setting
+`description` and [if appropriate] removing `"private": false`), index.js, and
+index.test.js files.
 
 ## Rebuilding `ses`
 

--- a/packages/panic/CHANGELOG.md
+++ b/packages/panic/CHANGELOG.md
@@ -4,5 +4,3 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-
-### [1.1.10](https://github.com/endojs/endo/compare/@endo/skel@1.1.9...@endo/skel@1.1.10) (2025-03-24)

--- a/packages/panic/package.json
+++ b/packages/panic/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@endo/panic",
   "version": "0.1.0",
-  "private": false,
   "description": "Ponyfill for proposed `panic` function",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@endo/skel",
-  "private": true,
   "version": "1.1.10",
+  "private": true,
   "description": null,
   "keywords": [],
   "author": "Endo contributors",
@@ -23,23 +23,23 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "build": "exit 0",
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
+    "lint:eslint": "eslint '**/*.js'",
+    "lint:types": "tsc",
+    "prepack": "tsc --build tsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
-    "test:xs": "exit 0",
-    "build": "exit 0",
-    "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
-    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
-    "lint-check": "yarn lint",
-    "lint": "yarn lint:types && yarn lint:eslint",
-    "lint:types": "tsc",
-    "lint:eslint": "eslint '**/*.js'"
+    "test:xs": "exit 0"
   },
   "devDependencies": {
     "@endo/lockdown": "workspace:^",
     "@endo/ses-ava": "workspace:^",
     "ava": "^6.1.3",
     "c8": "^7.14.0",
+    "eslint": "^8.57.0",
     "tsd": "^0.31.2",
     "typescript": "~5.6.3"
   },

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -57,7 +57,7 @@ git cat-file blob "$NEWPKGJSONHASH" > "$PKGJSON"
 
 # update other files in place
 cd "packages/$NAME"
-BSD_SED="$(sed --help 2>&1 | sed 2q | grep -qe '-i ' && echo 1 || true)"
+BSD_SED="$({ sed --help; true; } 2>&1 | sed -n 's/.*-i .*/BSD/p; 2q')"
 function sedi() {
   if [ -n "$BSD_SED" ]; then
     sed -i '' "$@"
@@ -66,7 +66,7 @@ function sedi() {
   fi
 }
 # CHANGELOG.md: remove `skel` content
-sedi -ne '/###/q; p' CHANGELOG.md
+sedi -ne '/###/ { x; q; }; p' CHANGELOG.md
 # LICENSE: current year
 sedi -e "s/\[yyyy\]\ \[name\ of\ copyright\ owner\]/$(date '+%Y') Endo Contributors/g" LICENSE
 # NEWS.md and README.md: package name

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,6 +904,7 @@ __metadata:
     "@endo/ses-ava": "workspace:^"
     ava: "npm:^6.1.3"
     c8: "npm:^7.14.0"
+    eslint: "npm:^8.57.0"
     tsd: "npm:^0.31.2"
     typescript: "npm:~5.6.3"
   languageName: unknown


### PR DESCRIPTION
Fixes #2816

## Description

Updates create-package.sh to better detect BSD `sed` (the old method was disrupted by bash option "pipefail" and a script was not sufficiently portable). Also mentions package.json field "private" in CONTRIBUTING.md as requested, and better aligns the skel package.json with the output of create-package.sh.