### PR TITLE
chore: Improve package.json uniformity

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -29,7 +29,7 @@
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "prepack": "tsc --build tsconfig.build.json",
     "install-engines": "./install-engines.sh",
     "test": "./run-tests.sh",

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -25,7 +25,6 @@
   "scripts": {
     "build": "exit 0",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint-check": "yarn lint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -19,7 +19,6 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc"

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -44,7 +44,6 @@
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
-    "lint-check": "yarn lint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint": "yarn lint:eslint && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -32,7 +32,6 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint-check": "yarn lint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "exit 0",
     "prepack": "tsc --build tsconfig.build.json",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -25,7 +25,6 @@
     "build": "exit 0",
     "clean": "git clean -f '*.d.ts*'",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint-check": "yarn lint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -14,7 +14,6 @@
     "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "exit 0",
-    "lint-check": "exit 0",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'"
   },
   "dependencies": {

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -32,7 +32,6 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
-    "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc",
     "lint:eslint": "eslint '**/*.js'",

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -13,7 +13,6 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
-    "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc",
     "lint:eslint": "eslint '**/*.js'"

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -16,7 +16,6 @@
     "prepack": "tsc --build tsconfig.build.json",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
-    "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc",
     "lint:eslint": "eslint '**/*.js'"

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -31,7 +31,6 @@
   "scripts": {
     "build": "exit 0",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint-check": "yarn lint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -23,7 +23,6 @@
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "test": "ava",
     "test:xs": "exit 0",
-    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint": "yarn lint:types && eslint '**/*.js'",
     "lint:types": "tsc"

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -16,7 +16,6 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
-    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint": "eslint '**/*.js'",
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'"

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -21,7 +21,6 @@
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
-    "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc",
     "lint:eslint": "eslint '**/*.js'"

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -25,7 +25,6 @@
   "scripts": {
     "build": "exit 0",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint-check": "yarn lint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -29,7 +29,7 @@
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "prepack": "tsc --build tsconfig.build.json",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",

--- a/packages/panic/package.json
+++ b/packages/panic/package.json
@@ -24,7 +24,6 @@
   "scripts": {
     "build": "exit 0",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint-check": "yarn lint",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",

--- a/packages/panic/package.json
+++ b/packages/panic/package.json
@@ -28,7 +28,7 @@
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc",
-    "postpack": "git clean -f '*.d.ts*'",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "prepack": "tsc --build tsconfig.build.json",
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -30,7 +30,6 @@
     "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
     "cover": "c8 ava",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",
     "lint:types": "tsc",


### PR DESCRIPTION
Refs: #2821

## Description

* Add *.tsbuildinfo to `"postpack": "git clean -f ..."` scripts (cf. https://github.com/endojs/endo/pull/2821#discussion_r2103392181 )
* Remove lint-check package.json scripts (they are redundant aliases for `lint`)

### Security Considerations

None known.

### Scaling Considerations

n/a

### Documentation Considerations

I could not find any existing references to the `lint-check` scripts.

### Testing Considerations

n/a

### Compatibility Considerations

n/a

### Upgrade Considerations

n/a