### PR TITLE
fix(compartment-mapper): handle missing optional packages in dynamically-required modules

### DIFF
--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -346,6 +346,7 @@ export const link = (
       packageName: name,
       parse,
       compartments,
+      shouldDeferError,
     });
 
     const moduleMapHook = makeModuleMapHook(

--- a/packages/compartment-mapper/test/dynamic-require.test.js
+++ b/packages/compartment-mapper/test/dynamic-require.test.js
@@ -629,3 +629,13 @@ test('dynamic require of missing module falls through to importNowHook', async t
     },
   );
 });
+
+test('dynamic require of package missing an optional module', async t => {
+  const fixture = new URL(
+    'fixtures-dynamic/node_modules/missing-app/index.js',
+    import.meta.url,
+  ).toString();
+
+  const { namespace } = await importLocation(readPowers, fixture);
+  t.like(namespace, { isOk: true, default: { isOk: true } });
+});

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-app/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-app/README.md
@@ -1,0 +1,1 @@
+Provides an app which dynamically requires a module which has a missing optional dependency

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-app/index.js
@@ -1,0 +1,5 @@
+const packageName = 'missing-optional';
+
+require(packageName);
+
+module.exports = {isOk: true}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "missing-app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "missing-optional": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-optional/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-optional/README.md
@@ -1,0 +1,2 @@
+This is the root application package for testing.
+This package depends transitively upon other packages that trigger various errors.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-optional/main.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-optional/main.js
@@ -1,0 +1,3 @@
+try {
+  require('missing');
+} catch {}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-optional/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/missing-optional/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "missing-optional",
+  "version": "1.0.0",
+  "main": "./main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  },
+  "optionalDependencies": {
+    "missing": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Closes: #2819

## Description

This adds support for deferred errors to the `importNowHook` implementation. In practice, that means _dynamically-required packages may now attempt to load missing optional dependencies_ without blowing up at load time.

To avoid algorithm divergence, I created a factory function `makeDeferError()` which returns a `deferError()` function that both `makeImportHook()` and `makeImportNowHook()` use. `makeImportNowHook` now requires a `shouldDeferError` option, like `makeImportHook`.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

I added a test

### Compatibility Considerations

I don't believe `makeImportNowHook` is a public API, so there should be no compatibility issues.

### Upgrade Considerations

This is just a bugfix.
