### PR TITLE
chore(ci): attempt to fix bust deploy-pages workflow

### DIFF
--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   pages: write
   id-token: write
 
@@ -43,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This seems to be failing on `master`. Upgrading to `actions/deploy-pages@v4` means we [also have to upgrade](https://github.com/actions/deploy-pages/releases/tag/v4.0.0) to `actions/upload-pages-artifact@v3` and add a new permission.
