### PR TITLE
refactor: Decouple passable stack from lockdown with @endo/harden

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -71,5 +71,8 @@
     "extends": [
       "plugin:@endo/internal"
     ]
+  },
+  "dependencies": {
+    "@endo/harden": "workspace:^"
   }
 }

--- a/packages/benchmark/test/index.test.js
+++ b/packages/benchmark/test/index.test.js
@@ -1,4 +1,5 @@
 import '@endo/init';
+import { harden } from '@endo/harden';
 import { passStyleOf } from '@endo/pass-style';
 import { test, benchmark } from '../src/benchmark.js';
 

--- a/packages/bundle-source/README.md
+++ b/packages/bundle-source/README.md
@@ -285,3 +285,7 @@ So, to extract the source-similar program for visual inspection:
 jq -r .__syncModuleProgram module.js > module.source.js
 ```
 
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/bundle-source/README.md
+++ b/packages/bundle-source/README.md
@@ -1,4 +1,4 @@
-# Bundle Source
+# `@endo/bundle-source`
 
 This package creates source bundles from ES Modules, compatible with Endo
 applications, Agoric contracts, and SwingSet vats.

--- a/packages/bundle-source/cache.js
+++ b/packages/bundle-source/cache.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { harden } from '@endo/harden';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
 

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -27,6 +27,7 @@
     "@endo/base64": "workspace:^",
     "@endo/compartment-mapper": "workspace:^",
     "@endo/evasive-transform": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/promise-kit": "workspace:^",
     "@endo/where": "workspace:^",

--- a/packages/bundle-source/src/fs.js
+++ b/packages/bundle-source/src/fs.js
@@ -1,4 +1,7 @@
 // @ts-check
+
+import { harden } from '@endo/harden';
+
 let mutex = Promise.resolve(undefined);
 
 /**

--- a/packages/bundle-source/src/script.js
+++ b/packages/bundle-source/src/script.js
@@ -7,6 +7,7 @@ import url from 'url';
 import fs from 'fs';
 import os from 'os';
 
+import { harden } from '@endo/harden';
 import { makeFunctor } from '@endo/compartment-mapper/functor.js';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
 

--- a/packages/bundle-source/src/zip-base64.js
+++ b/packages/bundle-source/src/zip-base64.js
@@ -7,6 +7,7 @@ import url from 'url';
 import fs from 'fs';
 import os from 'os';
 
+import { harden } from '@endo/harden';
 import { mapNodeModules } from '@endo/compartment-mapper/node-modules.js';
 import { makeAndHashArchiveFromMap } from '@endo/compartment-mapper/archive-lite.js';
 import { encodeBase64 } from '@endo/base64';

--- a/packages/captp/README.md
+++ b/packages/captp/README.md
@@ -63,3 +63,8 @@ the guest unblocks.
 The Loopback implementation provides partial support for TrapCaps, except it
 cannot unwrap promises.  Loopback TrapHandlers must return synchronously, or an
 exception will be thrown.
+
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -55,12 +55,12 @@
     "ava": "^6.4.1",
     "babel-eslint": "^10.1.0",
     "c8": "^7.14.0",
-    "typescript": "~5.9.2",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-import": "^2.29.1"
+    "eslint-plugin-import": "^2.29.1",
+    "typescript": "~5.9.2"
   },
   "dependencies": {
     "@endo/errors": "workspace:^",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/marshal": "workspace:^",
     "@endo/nat": "workspace:^",
     "@endo/pass-style": "workspace:^",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -53,8 +53,14 @@
     "@endo/init": "workspace:^",
     "@endo/ses-ava": "workspace:^",
     "ava": "^6.4.1",
+    "babel-eslint": "^10.1.0",
     "c8": "^7.14.0",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.29.1"
   },
   "dependencies": {
     "@endo/errors": "workspace:^",

--- a/packages/captp/src/atomics.js
+++ b/packages/captp/src/atomics.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { X, Fail } from '@endo/errors';
 
 // This is a pathological minimum, but exercised by the unit test.

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -386,7 +386,6 @@ export const makeCapTP = (
           epoch,
           questionID,
           target,
-          // @ts-expect-error Type 'unknown' is not assignable to type 'Passable<PassableCap, Error>'.
           method: serialize(harden([null, args])),
         });
         return promise;
@@ -403,7 +402,6 @@ export const makeCapTP = (
           epoch,
           questionID,
           target,
-          // @ts-expect-error Type 'unknown' is not assignable to type 'Passable<PassableCap, Error>'.
           method: serialize(harden([prop, args])),
         });
         return promise;

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -5,6 +5,7 @@
 
 // This logic was mostly adapted from an earlier version of Agoric's liveSlots.js with a
 // good dose of https://github.com/capnproto/capnproto/blob/master/c++/src/capnp/rpc.capnp
+import { harden } from '@endo/harden';
 import { Remotable, Far, makeMarshal, QCLASS } from '@endo/marshal';
 import { E, HandledPromise } from '@endo/eventual-send';
 import { isPromise, makePromiseKit } from '@endo/promise-kit';

--- a/packages/captp/src/loopback.js
+++ b/packages/captp/src/loopback.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { Far } from '@endo/marshal';
 import { E, makeCapTP } from './captp.js';
 import { nearTrapImpl } from './trap.js';

--- a/packages/captp/src/trap.js
+++ b/packages/captp/src/trap.js
@@ -1,5 +1,7 @@
 // Lifted mostly from `@endo/eventual-send/src/E.js`.
 
+import { harden } from '@endo/harden';
+
 const { freeze } = Object;
 
 /**

--- a/packages/check-bundle/README.md
+++ b/packages/check-bundle/README.md
@@ -1,4 +1,4 @@
-# check-bundle
+# `@endo/check-bundle`
 
 `checkBundle` verifies the integrity of a bundle, inspects all of its internal hashes and its one external hash.
 `checkBundle` verifies the internal consistency, completeness, coherence, and conciseness (no extra files) of the bundle.

--- a/packages/check-bundle/README.md
+++ b/packages/check-bundle/README.md
@@ -11,3 +11,8 @@ await checkBundle(bundle);
 ```
 
 This must be run in an Endo environment. To run on Node.js, import `@endo/init` before importing `@endo/import-bundle`.
+
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/check-bundle/index.js
+++ b/packages/check-bundle/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 import * as fs from 'fs';
 import * as crypto from 'crypto';
+import { harden } from '@endo/harden';
 import { checkBundle as powerlessCheckBundle } from './lite.js';
 import { parseLocatedJson } from './src/json.js';
 

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "@endo/base64": "workspace:^",
     "@endo/compartment-mapper": "workspace:^",
-    "@endo/errors": "workspace:^"
+    "@endo/errors": "workspace:^",
+    "@endo/harden": "workspace:^"
   },
   "devDependencies": {
     "@endo/bundle-source": "workspace:^",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "@endo/eventual-send": "workspace:^",
     "@endo/exo": "workspace:^",
     "@endo/far": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/import-bundle": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/lockdown": "workspace:^",

--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -1,6 +1,7 @@
 /* global globalThis, process */
 import url from 'url';
 import os from 'os';
+import { harden } from '@endo/harden';
 import { E, Far } from '@endo/far';
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -15,3 +15,8 @@ Currently there are no `src/something.js` files. The only source files that woul
 Generally each utility also has its own test file. (An exception is that `make-iterator.js` is indirectly but adequately tested by `test-make-array-iterator.js`).
 
 See the doc-comments within the source file of each utility for documentation of that utility. Sometimes the associated test files also serve as informative examples.
+
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/common/apply-labeling-error.js
+++ b/packages/common/apply-labeling-error.js
@@ -1,4 +1,5 @@
 import { hideAndHardenFunction } from '@endo/errors';
+import { harden } from '@endo/harden';
 import { E } from '@endo/eventual-send';
 import { isPromise } from '@endo/promise-kit';
 import { throwLabeled } from './throw-labeled.js';

--- a/packages/common/from-unique-entries.js
+++ b/packages/common/from-unique-entries.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { q, Fail } from '@endo/errors';
 
 const { fromEntries } = Object;

--- a/packages/common/ident-checker.js
+++ b/packages/common/ident-checker.js
@@ -20,6 +20,8 @@
  * @returns {boolean}
  */
 
+import { harden } from '@endo/harden';
+
 /**
  * In the `assertFoo`/`isFoo`/`checkFoo` pattern, `checkFoo` has a `check`
  * parameter of type `Checker`. `assertFoo` calls `checkFoo` passes

--- a/packages/common/list-difference.js
+++ b/packages/common/list-difference.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 /**
  * Return a list of all the elements present in the `leftList` and not
  * in the `rightList`. Return in the order of their appearance in `leftList`.

--- a/packages/common/make-array-iterator.js
+++ b/packages/common/make-array-iterator.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { makeIterator } from './make-iterator.js';
 
 /**

--- a/packages/common/make-iterator.js
+++ b/packages/common/make-iterator.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 /**
  * Makes a one-shot iterable iterator from a provided `next` function.
  *

--- a/packages/common/object-map.js
+++ b/packages/common/object-map.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 const { entries, fromEntries } = Object;
 
 /**

--- a/packages/common/object-meta-assign.js
+++ b/packages/common/object-meta-assign.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 const { getOwnPropertyDescriptors, defineProperties } = Object;
 
 /**

--- a/packages/common/object-meta-map.js
+++ b/packages/common/object-meta-map.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 const { getOwnPropertyDescriptors, create, fromEntries } = Object;
 const { ownKeys } = Reflect;
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/promise-kit": "workspace:^"
   },
   "devDependencies": {

--- a/packages/common/throw-labeled.js
+++ b/packages/common/throw-labeled.js
@@ -4,6 +4,7 @@ import {
   annotateError,
   hideAndHardenFunction,
 } from '@endo/errors';
+import { harden } from '@endo/harden';
 
 /**
  * Given an error `innerErr` and a `label`, throws a similar

--- a/packages/compartment-mapper/README.md
+++ b/packages/compartment-mapper/README.md
@@ -1,4 +1,4 @@
-# Compartment mapper
+# `@endo/compartment-mapper`
 
 The compartment mapper builds _compartment maps_ for Node.js style
 applications, finding their dependencies and describing how to create

--- a/packages/compartment-mapper/README.md
+++ b/packages/compartment-mapper/README.md
@@ -771,3 +771,8 @@ The shape of the `policy` object is based on `policy.json` from LavaMoat. MetaMa
   [import attributes]: https://nodejs.org/docs/latest/api/esm.html#import-attributes
   [package entry points]: https://nodejs.org/api/esm.html#esm_package_entry_points
   [`require.resolve()`]: https://nodejs.org/docs/latest/api/modules.html#requireresolverequest-options
+
+# Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@endo/cjs-module-analyzer": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/module-source": "workspace:^",
     "@endo/path-compare": "workspace:^",
     "@endo/trampoline": "workspace:^",

--- a/packages/compartment-mapper/test/_parse-jsonp.js
+++ b/packages/compartment-mapper/test/_parse-jsonp.js
@@ -1,5 +1,7 @@
 /** @module Provides joke language support for importing JSONP modules. */
 
+import { harden } from '@endo/harden';
+
 /**
  * @import {ParseFn, ParserImplementation} from '../src/types.js'
  */

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -51,6 +51,7 @@
     "@endo/eventual-send": "workspace:^",
     "@endo/exo": "workspace:^",
     "@endo/far": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/import-bundle": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/lockdown": "workspace:^",

--- a/packages/daemon/src/context.js
+++ b/packages/daemon/src/context.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { makePromiseKit } from '@endo/promise-kit';
 
 /** @import { PromiseKit } from '@endo/promise-kit' */

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -1,6 +1,7 @@
 // @ts-check
 /* eslint-disable no-void */
 
+import { harden } from '@endo/harden';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makePipe } from '@endo/stream';
 import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -798,7 +798,7 @@ const makeDaemonCore = async (
 
   /** @type {DaemonCore['provideController']} */
   const provideController = id => {
-    let controller = controllerForId.get(id);
+    const controller = controllerForId.get(id);
     if (controller !== undefined) {
       return controller;
     }
@@ -811,16 +811,16 @@ const makeDaemonCore = async (
     // eslint-disable-next-line no-use-before-define
     const context = makeContext(id);
     promise.catch(context.cancel);
-    controller = harden({
+    const newController = harden({
       context,
       value: promise,
     });
-    controllerForId.set(id, controller);
+    controllerForId.set(id, newController);
 
     // The controller must be in place before we evaluate the formula.
     resolve(evaluateFormulaForId(id, context));
 
-    return controller;
+    return newController;
   };
 
   /**

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -1,6 +1,7 @@
 // @ts-check
 /* global setTimeout, clearTimeout */
 
+import { harden } from '@endo/harden';
 import { makeExo } from '@endo/exo';
 import { E, Far } from '@endo/far';
 import { makeMarshal } from '@endo/marshal';

--- a/packages/daemon/src/directory.js
+++ b/packages/daemon/src/directory.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
 import { q } from '@endo/errors';

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { E } from '@endo/eventual-send';
 import { makeExo } from '@endo/exo';
 import { makePromiseKit } from '@endo/promise-kit';

--- a/packages/daemon/src/networks/tcp-netstring.js
+++ b/packages/daemon/src/networks/tcp-netstring.js
@@ -1,6 +1,7 @@
 // @ts-check
 import net from 'net';
 
+import { harden } from '@endo/harden';
 import { E, Far } from '@endo/far';
 import { mapWriter, mapReader } from '@endo/stream';
 import { makeNetstringReader, makeNetstringWriter } from '@endo/netstring';

--- a/packages/daemon/src/pet-sitter.js
+++ b/packages/daemon/src/pet-sitter.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { q } from '@endo/errors';
 import { isPetName } from './pet-name.js';
 import { parseId } from './formula-identifier.js';

--- a/packages/daemon/src/pet-store.js
+++ b/packages/daemon/src/pet-store.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { q } from '@endo/errors';
 import { makeChangeTopic } from './pubsub.js';
 import { parseId, assertValidId, isValidNumber } from './formula-identifier.js';

--- a/packages/daemon/src/pubsub.js
+++ b/packages/daemon/src/pubsub.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeStream } from '@endo/stream';
 

--- a/packages/daemon/src/reader-ref.js
+++ b/packages/daemon/src/reader-ref.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { encodeBase64 } from '@endo/base64';
 import { mapReader } from '@endo/stream';
 import { makeExo } from '@endo/exo';

--- a/packages/daemon/src/serve-private-path.js
+++ b/packages/daemon/src/serve-private-path.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { q } from '@endo/errors';
 import { makeNetstringCapTP } from './connection.js';
 

--- a/packages/daemon/src/serve-private-port-http.js
+++ b/packages/daemon/src/serve-private-port-http.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { E } from '@endo/far';
 import { mapReader, mapWriter } from '@endo/stream';
 import { q } from '@endo/errors';

--- a/packages/daemon/src/web-server-node-powers.js
+++ b/packages/daemon/src/web-server-node-powers.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makePipe } from '@endo/stream';
 

--- a/packages/daemon/src/worker-node-powers.js
+++ b/packages/daemon/src/worker-node-powers.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { harden } from '@endo/harden';
 import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
 
 /** @import {MignonicPowers} from './types.js'; */

--- a/packages/daemon/src/worker.js
+++ b/packages/daemon/src/worker.js
@@ -1,5 +1,6 @@
 /* global globalThis */
 // @ts-check
+import { harden } from '@endo/harden';
 import { E, Far } from '@endo/far';
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -20,9 +20,9 @@
     "postpack": "git clean -fX \"*.d.ts*\" \"*.d.cts*\" \"*.d.mts*\" \"*.tsbuildinfo\""
   },
   "dependencies": {
+    "@endo/harden": "workspace:^",
     "@eslint-community/eslint-utils": "^4.7.0",
     "requireindex": "~1.2.0",
-    "@endo/harden": "workspace:^",
     "tsutils": "~3.21.0",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.39.1"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.7.0",
     "requireindex": "~1.2.0",
+    "@endo/harden": "workspace:^",
     "tsutils": "~3.21.0",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.39.1"

--- a/packages/eventual-send/README.md
+++ b/packages/eventual-send/README.md
@@ -20,6 +20,11 @@ After that, you can use `HandledPromise` in any of your code.  If you need acces
 import { E } from '@endo/eventual-send';
 ```
 
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).
+
 [deps-svg]: https://david-dm.org/Agoric/eventual-send.svg
 [deps-url]: https://david-dm.org/Agoric/eventual-send
 [dev-deps-svg]: https://david-dm.org/Agoric/eventual-send/dev-status.svg

--- a/packages/eventual-send/README.md
+++ b/packages/eventual-send/README.md
@@ -1,4 +1,4 @@
-# HandledPromise
+# `@endo/eventual-send` and `HandledPromise` shim
 
 [![dependency status][deps-svg]][deps-url]
 [![dev dependency status][dev-deps-svg]][dev-deps-url]
@@ -11,13 +11,13 @@ Create a HandledPromise class to implement the eventual-send API.  This API is u
 To install the `HandledPromise` global property shim, do:
 
 ```js
-import '@agoric/eventual-send/shim';
+import '@endo/eventual-send/shim.js';
 ```
 
 After that, you can use `HandledPromise` in any of your code.  If you need access to the `E` proxy maker, do:
 
 ```js
-import { E } from '@agoric/eventual-send';
+import { E } from '@endo/eventual-send';
 ```
 
 [deps-svg]: https://david-dm.org/Agoric/eventual-send.svg

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -39,10 +39,18 @@
   },
   "devDependencies": {
     "@endo/lockdown": "workspace:^",
-    "ava": "^6.4.1",
+    "ava": "^6.1.3",
+    "babel-eslint": "^10.1.0",
     "c8": "^7.14.0",
     "tsd": "^0.32.0",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.29.1",
+    "tsd": "^0.31.2",
+    "typescript": "~5.8.3"
   },
   "keywords": [
     "eventual send",

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -35,7 +35,8 @@
   },
   "homepage": "https://github.com/endojs/endo#readme",
   "dependencies": {
-    "@endo/env-options": "workspace:^"
+    "@endo/env-options": "workspace:^",
+    "@endo/harden": "workspace:^"
   },
   "devDependencies": {
     "@endo/lockdown": "workspace:^",

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -43,8 +43,6 @@
     "ava": "^6.1.3",
     "babel-eslint": "^10.1.0",
     "c8": "^7.14.0",
-    "tsd": "^0.32.0",
-    "typescript": "~5.9.2",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { trackTurns } from './track-turns.js';
 import { makeMessageBreakpointTester } from './message-breakpoints.js';
 

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -76,7 +76,6 @@ const makeEProxyHandler = (recipient, HandledPromise) =>
             }
             return HandledPromise.applyMethod(recipient, propertyKey, args);
           },
-          // @ts-expect-error https://github.com/microsoft/TypeScript/issues/50319
         }[propertyKey],
       );
     },
@@ -132,7 +131,6 @@ const makeESendOnlyProxyHandler = (recipient, HandledPromise) =>
             HandledPromise.applyMethodSendOnly(recipient, propertyKey, args);
             return undefined;
           },
-          // @ts-expect-error https://github.com/microsoft/TypeScript/issues/50319
         }[propertyKey],
       );
     },

--- a/packages/eventual-send/src/exports.test-d.ts
+++ b/packages/eventual-send/src/exports.test-d.ts
@@ -46,7 +46,6 @@ const foo2 = async (a: FarRef<{ bar(): string; baz: number }>) => {
 
   expectType<Promise<number>>(E.get(a).baz);
 
-  // @ts-expect-error - E.get cannot obtain remote functions
   E.get(a).bar;
 
   expectType<number>((await a).baz);

--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -1,5 +1,6 @@
 /// <reference types="ses" />
 
+import { harden } from '@endo/harden';
 import { trackTurns } from './track-turns.js';
 import {
   localApplyFunction,

--- a/packages/eventual-send/src/local.js
+++ b/packages/eventual-send/src/local.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 import { makeMessageBreakpointTester } from './message-breakpoints.js';
 
 const { details: X, quote: q, Fail } = assert;

--- a/packages/exo/README.md
+++ b/packages/exo/README.md
@@ -21,3 +21,8 @@ import { getInterfaceMethodKeys } from '@endo/patterns';
    const methodNames = getInterfaceMethodKeys(interfaceGuard);
 ...
 ```
+
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -38,6 +38,7 @@
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
     "@endo/far": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/pass-style": "workspace:^",
     "@endo/patterns": "workspace:^"
   },

--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { objectMap } from '@endo/common/object-map.js';
 import { environmentOptionsListHas } from '@endo/env-options';
 

--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -1,5 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { getRemotableMethodNames, toThrowable, Far } from '@endo/pass-style';
+import { harden } from '@endo/harden';
 import {
   mustMatch,
   M,

--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -392,6 +392,7 @@ export const defendPrototype = (
       ...(symbolMethodGuards &&
         fromEntries(getCopyMapEntries(symbolMethodGuards))),
     });
+    assert(methodGuards);
     defaultGuards = dg;
     {
       const methodGuardNames = ownKeys(methodGuards);

--- a/packages/exo/test/_make-legacy-guards.js
+++ b/packages/exo/test/_make-legacy-guards.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 /**
  * @param {import('@endo/patterns').AwaitArgGuardPayload} payload
  */

--- a/packages/far/README.md
+++ b/packages/far/README.md
@@ -15,3 +15,8 @@ You can import any of the following from `@endo/far`:
 ```js
 import { E, Far, getInterfaceOf, passStyleOf } from '@endo/far';
 ```
+
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/far/README.md
+++ b/packages/far/README.md
@@ -1,8 +1,8 @@
-# Endo Far Object helpers
+# `@endo/far`: Endo Far Object helpers
 
 The `@endo/far` package provides a convenient way to use the Endo
-[distributed objects system](https://docs.agoric.com/guides/js-programming/) without  relying on the underlying messaging
-implementation.
+[distributed objects system](https://docs.agoric.com/guides/js-programming/)
+without relying on the underlying messaging implementation.
 
 It exists to reduce the boilerplate in Hardened JavaScript vats that are running
 in Agoric's SwingSet kernel,

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/pass-style": "workspace:^"
   },
   "devDependencies": {

--- a/packages/import-bundle/README.md
+++ b/packages/import-bundle/README.md
@@ -161,3 +161,8 @@ await importBundle(
 ```
 
 Use `node --inspect-brk` and `debugger` statements.
+
+# Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/import-bundle/README.md
+++ b/packages/import-bundle/README.md
@@ -1,4 +1,4 @@
-# import-bundle
+# `@endo/import-bundle`
 
 `importBundle` is an async function that evaluates the bundles created by
 `bundle-source`, turning them back into callable functions:
@@ -25,11 +25,11 @@ Each call to `importBundle` creates a new `Compartment`.
 The globals of the new Compartment are frozen before any bundle code is
 evaluated, to enforce ocap rules.
 
-## Module Formats
+# Module Formats
 
 The source can be bundled in a variety of "formats".
 
-### endoZipBase64
+## endoZipBase64
 
 By default, `bundleSource` uses a format named `endoZipBase64`, in which the
 source modules and a "compartment map" are captured in a Zip file and base-64
@@ -38,18 +38,18 @@ The compartment map describes how to construct a set of [Hardened
 JavaScript](https://hardenedjs.org) compartments and how to load and link the
 source modules between them.
 
-### endoScript
+## endoScript
 
 The `endoScript` format captures the sources as a single JavaScript program
 that completes with the entry module's namespace object.
 
-### getExport
+## getExport
 
 The `getExport` format captures the sources as a single CommonJS-style string,
 and wrapped in a callable function that provides the `exports` and
 `module.exports` context to which the exports can be attached.
 
-### nestedEvaluate
+## nestedEvaluate
 
 More sophisticated than `getExport` is named `nestedEvaluate`.
 In this mode, the source tree is converted into a table of evaluable strings,
@@ -67,7 +67,7 @@ Note that the `nestedEvaluate` format receives a global endowment named
 `require`, although it will only be called if the source tree imported one of
 the few modules on the `bundle-source` "external" list.
 
-### test
+## test
 
 The `test` format is useful for mocking a bundle locally for a test and is
 deliberately not serializable or passable.
@@ -85,7 +85,7 @@ test('who tests the tests', async t => {
 });
 ```
 
-## Options
+# Options
 
 `importBundle()` takes an options bag and optional additional powers.
 
@@ -138,7 +138,7 @@ method, not the Compartment constructor itself, and thus cannot be supplied to
 To use `sloppyGlobalsMode`, you will probably want to create a Compartment
 directly (and not freeze its globals).
 
-## Source maps
+# Source maps
 
 For an Endo (zip, base64) bundle, `bundleSource` will add source maps to a
 per-user cache so they can be debugged if imported on the same host.

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -42,6 +42,7 @@
     "@endo/base64": "workspace:^",
     "@endo/compartment-mapper": "workspace:^",
     "@endo/errors": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/where": "workspace:^",
     "ses": "workspace:^"
   },

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,9 +1,10 @@
 /* global globalThis */
 /// <reference types="ses"/>
 
-import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
-import { decodeBase64 } from '@endo/base64';
+import { harden } from '@endo/harden';
 import { Fail } from '@endo/errors';
+import { decodeBase64 } from '@endo/base64';
+import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
 import { wrapInescapableCompartment } from './compartment-wrapper.js';
 
 /**

--- a/packages/import-bundle/test/import-bundle.test.js
+++ b/packages/import-bundle/test/import-bundle.test.js
@@ -1,9 +1,11 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
-import { encodeBase64 } from '@endo/base64';
 import fs from 'node:fs';
 import url from 'node:url';
 import crypto from 'node:crypto';
+
+import { harden } from '@endo/harden';
+import { encodeBase64 } from '@endo/base64';
 import { makeArchive } from '@endo/compartment-mapper/archive.js';
 import bundleSource from '@endo/bundle-source';
 import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@endo/base64": "workspace:^",
     "@endo/eventual-send": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/lockdown": "workspace:^",
     "@endo/promise-kit": "workspace:^"
   },

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -21,6 +21,7 @@
     "postpack": "git clean -fX \"*.d.ts*\" \"*.d.cts*\" \"*.d.mts*\" \"*.tsbuildinfo\""
   },
   "dependencies": {
+    "@endo/harden": "workspace:^",
     "ses": "workspace:^"
   },
   "files": [

--- a/packages/lp32/README.md
+++ b/packages/lp32/README.md
@@ -8,3 +8,8 @@ with Uint8Arrays.
 These streams are "hardened" and depend on Hardened JavaScript.
 Most JavaScript environments can be locked down with the
 [SES shim](../ses/README.md).
+
+# Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@endo/errors": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/stream": "workspace:^",
     "ses": "workspace:^"

--- a/packages/lp32/reader.js
+++ b/packages/lp32/reader.js
@@ -2,6 +2,7 @@
 // We use a DataView to give users choice over endianness.
 // But DataView does not default to host-byte-order like other typed arrays.
 
+import { harden } from '@endo/harden';
 import { Fail, q } from '@endo/errors';
 import { hostIsLittleEndian } from './src/host-endian.js';
 

--- a/packages/lp32/writer.js
+++ b/packages/lp32/writer.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { harden } from '@endo/harden';
 import { Fail, q } from '@endo/errors';
 import { hostIsLittleEndian } from './src/host-endian.js';
 

--- a/packages/marshal/README.md
+++ b/packages/marshal/README.md
@@ -186,3 +186,8 @@ Any encoding into JSON of data that cannot be represented directly, such as
 `NaN`, relies on some kind of escape for the decoding side to detect and use.
 For `stringify` and `parse`, this is signaled by an object with a property named
 `@qclass` per the original encoding described [above](#beyond-json).
+
+# Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/marshal/README.md
+++ b/packages/marshal/README.md
@@ -26,7 +26,7 @@ an object with `toCapData` and `fromCapData` properties. Each callback defaults
 to the identity function.
 
 ```js
-import '@endo/init';
+import '@endo/init'; // for hardenedjs, optional
 import { makeMarshal } from '@endo/marshal';
 
 const m = makeMarshal();

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -48,6 +48,7 @@
     "@endo/env-options": "workspace:^",
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/nat": "workspace:^",
     "@endo/pass-style": "workspace:^",
     "@endo/promise-kit": "workspace:^"

--- a/packages/marshal/src/dot-membrane.js
+++ b/packages/marshal/src/dot-membrane.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define */
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { E } from '@endo/eventual-send';
 import {
   isPrimitive,

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-bitwise */
+import { harden } from '@endo/harden';
+import { b, q, Fail } from '@endo/errors';
 import {
   getTag,
   makeTagged,
@@ -12,8 +14,6 @@ import {
 /**
  * @import {CopyRecord, PassStyle, Passable, RemotableObject as Remotable, ByteArray} from '@endo/pass-style'
  */
-
-import { b, q, Fail } from '@endo/errors';
 
 const { isArray } = Array;
 const { fromEntries, is } = Object;

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -6,6 +6,8 @@
 // encodes to CapData, a JSON-representable data structure, and leaves it to
 // the caller (`marshal.js`) to stringify it.
 
+import { harden } from '@endo/harden';
+import { X, Fail, q } from '@endo/errors';
 import {
   passStyleOf,
   isErrorLike,
@@ -16,7 +18,6 @@ import {
   nameForPassableSymbol,
   passableSymbolForName,
 } from '@endo/pass-style';
-import { X, Fail, q } from '@endo/errors';
 
 /** @import {Passable, RemotableObject} from '@endo/pass-style' */
 /** @import {Encoding, EncodingUnion} from './types.js' */

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -7,6 +7,8 @@
 // encodes to Smallcaps, a JSON-representable data structure, and leaves it to
 // the caller (`marshal.js`) to stringify it.
 
+import { harden } from '@endo/harden';
+import { X, Fail, q } from '@endo/errors';
 import {
   passStyleOf,
   isErrorLike,
@@ -16,7 +18,6 @@ import {
   nameForPassableSymbol,
   passableSymbolForName,
 } from '@endo/pass-style';
-import { X, Fail, q } from '@endo/errors';
 
 /** @import {Passable, Remotable} from '@endo/pass-style' */
 // FIXME define actual types

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -1,5 +1,6 @@
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { q, X, Fail } from '@endo/errors';
 import { Nat } from '@endo/nat';
 import {

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -1,5 +1,6 @@
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { Fail } from '@endo/errors';
 import { makeMarshal } from './marshal.js';
 

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -1,5 +1,7 @@
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
+import { X, Fail, q, makeError, annotateError } from '@endo/errors';
 import { Nat } from '@endo/nat';
 import {
   assertPassable,
@@ -8,7 +10,6 @@ import {
   toPassableError,
 } from '@endo/pass-style';
 
-import { X, Fail, q, makeError, annotateError } from '@endo/errors';
 import { objectMap } from '@endo/common/object-map.js';
 import {
   QCLASS,

--- a/packages/marshal/src/rankOrder.js
+++ b/packages/marshal/src/rankOrder.js
@@ -1,4 +1,5 @@
 import { getEnvironmentOption as getenv } from '@endo/env-options';
+import { harden } from '@endo/harden';
 import { Fail, q } from '@endo/errors';
 import { getTag, passStyleOf, nameForPassableSymbol } from '@endo/pass-style';
 import {

--- a/packages/marshal/src/types.test-d.ts
+++ b/packages/marshal/src/types.test-d.ts
@@ -1,5 +1,6 @@
 import { expectType } from 'tsd';
 
+import { harden } from '@endo/harden';
 import { Far, type AtomStyle, type RemotableObject } from '@endo/pass-style';
 import { makeMarshal } from './marshal.js';
 

--- a/packages/marshal/tools/marshal-test-data.js
+++ b/packages/marshal/tools/marshal-test-data.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { makeTagged, passableSymbolForName } from '@endo/pass-style';
 import {
   exampleAlice,

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -34,6 +34,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@endo/harden": "workspace:^",
     "ses": "workspace:^"
   },
   "devDependencies": {

--- a/packages/memoize/src/memoize.js
+++ b/packages/memoize/src/memoize.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 /**
  * Given a one-argument function `fn` or a WeakMap-key compatible
  * argument `arg`, returns `memoFn`, a memoizing form of that function

--- a/packages/module-source/README.md
+++ b/packages/module-source/README.md
@@ -92,3 +92,8 @@ to report security-sensitive bugs privately.
 
 For non-security bugs, please use the [regular Issues
 page](https://github.com/endojs/endo/issues).
+
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -46,6 +46,7 @@
     "@babel/parser": "~7.28.3",
     "@babel/traverse": "~7.28.3",
     "@babel/types": "~7.28.2",
+    "@endo/harden": "workspace:^",
     "ses": "workspace:^"
   },
   "devDependencies": {

--- a/packages/module-source/src/transform-analyze.js
+++ b/packages/module-source/src/transform-analyze.js
@@ -1,4 +1,5 @@
 // @ts-nocheck XXX Babel types
+import { harden } from '@endo/harden';
 import { makeTransformSource } from './transform-source.js';
 import makeModulePlugins from './babel-plugin.js';
 

--- a/packages/netstring/README.md
+++ b/packages/netstring/README.md
@@ -17,3 +17,8 @@ D. J. Bernstein, <djb@pobox.com> <br>
 1997-02-01
 
 [Netstrings]: https://cr.yp.to/proto/netstrings.txt
+
+# Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -35,6 +35,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@endo/harden": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/promise-kit": "workspace:^",
     "@endo/stream": "workspace:^",

--- a/packages/netstring/reader.js
+++ b/packages/netstring/reader.js
@@ -1,6 +1,8 @@
 // @ts-check
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
+
 const COLON = ':'.charCodeAt(0);
 const COMMA = ','.charCodeAt(0);
 const ZERO = '0'.charCodeAt(0);

--- a/packages/netstring/writer.js
+++ b/packages/netstring/writer.js
@@ -1,6 +1,7 @@
 // @ts-check
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { makePromiseKit } from '@endo/promise-kit';
 
 const COMMA_BUFFER = new Uint8Array([','.charCodeAt(0)]);

--- a/packages/pass-style/README.md
+++ b/packages/pass-style/README.md
@@ -5,3 +5,8 @@ Defines the `Passable` objects, and the `passStyleOf` function for classifying t
 See [types.js](./src/types.js) for the actual type definitions. See also [CopyRecord guarantees](./doc/copyRecord-guarantees.md) and [CopyArray guarantees](./doc/copyArray-guarantees.md).
 
 The Passable objects are those that can be passed by the `@endo/marshal` package. Thus `Passable` defines the layer of abstraction on which we need broad agreement for interoperability. One type of `Passable` is the `Tagged` object, which is the extension point for defining higher level data types, which do not need such broad agreement. The main such higher layer of abstraction is provided by the `@endo/patterns` package.
+
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -38,6 +38,7 @@
     "@endo/env-options": "workspace:^",
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/promise-kit": "workspace:^"
   },
   "devDependencies": {

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { X, Fail } from '@endo/errors';
 
 /**

--- a/packages/pass-style/src/copyArray.js
+++ b/packages/pass-style/src/copyArray.js
@@ -2,6 +2,7 @@
 
 import { Fail, X } from '@endo/errors';
 import { confirmOwnDataDescriptor } from './passStyle-helpers.js';
+import { harden } from '@endo/harden';
 
 const { getPrototypeOf } = Object;
 const { ownKeys } = Reflect;

--- a/packages/pass-style/src/copyRecord.js
+++ b/packages/pass-style/src/copyRecord.js
@@ -3,6 +3,7 @@
 import { Fail } from '@endo/errors';
 import { confirmOwnDataDescriptor } from './passStyle-helpers.js';
 import { canBeMethod } from './remotable.js';
+import { harden } from '@endo/harden';
 
 /**
  * @import {Rejector} from '@endo/errors/rejector.js';

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -104,7 +104,6 @@ export const deeplyFulfilled = async val => {
       const rec = /** @type {CopyRecord} */ (val);
       const names = /** @type {string[]} */ (ownKeys(rec));
       const valPs = names.map(name => deeplyFulfilled(rec[name]));
-      // @ts-expect-error not assignable to type 'DeeplyAwaited<T>'
       return E.when(Promise.all(valPs), vals =>
         harden(fromEntries(vals.map((c, i) => [names[i], c]))),
       );
@@ -112,7 +111,6 @@ export const deeplyFulfilled = async val => {
     case 'copyArray': {
       const arr = /** @type {CopyArray} */ (val);
       const valPs = arr.map(p => deeplyFulfilled(p));
-      // @ts-expect-error not assignable to type 'DeeplyAwaited<T>'
       return E.when(Promise.all(valPs), vals => harden(vals));
     }
     case 'byteArray': {
@@ -123,7 +121,6 @@ export const deeplyFulfilled = async val => {
     case 'tagged': {
       const tgd = /** @type {CopyTagged} */ (val);
       const tag = getTag(tgd);
-      // @ts-expect-error not assignable to type 'DeeplyAwaited<T>'
       return E.when(deeplyFulfilled(tgd.payload), payload =>
         makeTagged(tag, payload),
       );

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { X, q } from '@endo/errors';
 import { E } from '@endo/eventual-send';
 import { isPromise } from '@endo/promise-kit';

--- a/packages/pass-style/src/error.js
+++ b/packages/pass-style/src/error.js
@@ -1,6 +1,7 @@
 /// <reference types="ses"/>
 
 import { Fail, q, hideAndHardenFunction } from '@endo/errors';
+import { harden } from '@endo/harden';
 
 /**
  * @import {Rejector} from '@endo/errors/rejector.js';

--- a/packages/pass-style/src/iter-helpers.js
+++ b/packages/pass-style/src/iter-helpers.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { Far } from './make-far.js';
 
 /**

--- a/packages/pass-style/src/make-far.js
+++ b/packages/pass-style/src/make-far.js
@@ -1,6 +1,7 @@
 /// <reference types="ses"/>
 
 import { getMethodNames } from '@endo/eventual-send/utils.js';
+import { harden } from '@endo/harden';
 import { q, Fail } from '@endo/errors';
 import { PASS_STYLE } from './passStyle-helpers.js';
 import { assertIface, getInterfaceOf, RemotableHelper } from './remotable.js';

--- a/packages/pass-style/src/makeTagged.js
+++ b/packages/pass-style/src/makeTagged.js
@@ -1,5 +1,6 @@
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { Fail } from '@endo/errors';
 import { PASS_STYLE } from './passStyle-helpers.js';
 import { assertPassable } from './passStyleOf.js';

--- a/packages/pass-style/src/passStyle-helpers.js
+++ b/packages/pass-style/src/passStyle-helpers.js
@@ -1,6 +1,7 @@
 /// <reference types="ses"/>
 
 import { q, hideAndHardenFunction } from '@endo/errors';
+import { harden } from '@endo/harden';
 
 /**
  * @import {Rejector} from '@endo/errors/rejector.js';

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -2,6 +2,7 @@
 
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { isPromise } from '@endo/promise-kit';
 import {
   X,

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -2,6 +2,7 @@
 
 import { Fail, q, hideAndHardenFunction } from '@endo/errors';
 import { getMethodNames } from '@endo/eventual-send/utils.js';
+import { harden } from '@endo/harden';
 import {
   PASS_STYLE,
   confirmTagRecord,

--- a/packages/pass-style/src/safe-promise.js
+++ b/packages/pass-style/src/safe-promise.js
@@ -1,5 +1,6 @@
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { isPromise } from '@endo/promise-kit';
 import { Fail, q, hideAndHardenFunction } from '@endo/errors';
 

--- a/packages/pass-style/src/string.js
+++ b/packages/pass-style/src/string.js
@@ -1,5 +1,6 @@
 import { getEnvironmentOption } from '@endo/env-options';
 import { Fail, hideAndHardenFunction } from '@endo/errors';
+import { harden } from '@endo/harden';
 
 // know about`isWellFormed`
 const hasWellFormedStringMethod = !!String.prototype.isWellFormed;

--- a/packages/pass-style/src/symbol.js
+++ b/packages/pass-style/src/symbol.js
@@ -1,4 +1,5 @@
 import { Fail, q, hideAndHardenFunction } from '@endo/errors';
+import { harden } from '@endo/harden';
 
 const { ownKeys } = Reflect;
 

--- a/packages/pass-style/src/tagged.js
+++ b/packages/pass-style/src/tagged.js
@@ -1,5 +1,6 @@
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { Fail } from '@endo/errors';
 import {
   confirmTagRecord,

--- a/packages/pass-style/src/typeGuards.js
+++ b/packages/pass-style/src/typeGuards.js
@@ -1,4 +1,5 @@
 import { Fail, q, hideAndHardenFunction } from '@endo/errors';
+import { harden } from '@endo/harden';
 import { passStyleOf } from './passStyleOf.js';
 
 /**

--- a/packages/pass-style/tools/arb-passable.js
+++ b/packages/pass-style/tools/arb-passable.js
@@ -1,5 +1,6 @@
 // @ts-check
 import '../src/types.js';
+import { harden } from '@endo/harden';
 import { Far } from '../src/make-far.js';
 import { makeTagged } from '../src/makeTagged.js';
 import { passableSymbolForName } from '../src/symbol.js';

--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -33,3 +33,8 @@ Builds on {@link @endo/pass-style!} as described in [`kindOf` and `passStyleOf` 
 In support of the above, there is also {@link compareKeys} and {@link keyEQ} exposing pass-invariant Key comparison, and two concepts with corresponding TypeScript types:
    - {@link Key} -- a Passable arbitrarily deep acyclic data structure in which each non-leaf node is a CopyArray, CopyRecord, CopySet, CopyBag, or CopyMap that is the child of at most one other internal node (forming a possibly-empty tree of containers), and each leaf is either an empty such container or a Passable primitive value or a Remotable (but the same Remotable `r` may be a child of multiple parents, e.g. `{ foo: r, bar: [r] }`). A Key is stable and stably comparable with other Keys via {@link keyEQ}. Key is the most general data type covering valid contents for CopySets and CopyBags and keys for CopyMaps (the last of which explains the "Key" name).
    - {@link Pattern} -- a Passable value that can be used to *match* some subset of Passables. Each Pattern is either a Key that matches itself (and any copy of itself --- `keyEQ` considers identity only for Remotables, where it is shared across all local Presences of the same Remotable), or a Key-like structure in which one or more leaves is a Matcher rather than a primitive or Remotable.
+
+## Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -35,6 +35,7 @@
     "@endo/common": "workspace:^",
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/marshal": "workspace:^",
     "@endo/pass-style": "workspace:^",
     "@endo/promise-kit": "workspace:^"

--- a/packages/patterns/src/keys/checkKey.js
+++ b/packages/patterns/src/keys/checkKey.js
@@ -2,6 +2,7 @@
 
 import { Fail, q, hideAndHardenFunction } from '@endo/errors';
 import { Far, getTag, makeTagged, passStyleOf, isAtom } from '@endo/pass-style';
+import { harden } from '@endo/harden';
 import {
   compareAntiRank,
   makeFullOrderComparatorKit,

--- a/packages/patterns/src/keys/compareKeys.js
+++ b/packages/patterns/src/keys/compareKeys.js
@@ -1,5 +1,7 @@
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
+import { q, Fail } from '@endo/errors';
 import {
   passStyleOf,
   getTag,
@@ -8,7 +10,6 @@ import {
   recordNames,
   recordValues,
 } from '@endo/marshal';
-import { q, Fail } from '@endo/errors';
 import {
   assertKey,
   getCopyBagEntries,

--- a/packages/patterns/src/keys/copyBag.js
+++ b/packages/patterns/src/keys/copyBag.js
@@ -1,4 +1,5 @@
 import { Fail, hideAndHardenFunction } from '@endo/errors';
+import { harden } from '@endo/harden';
 import {
   makeTagged,
   passStyleOf,

--- a/packages/patterns/src/keys/copySet.js
+++ b/packages/patterns/src/keys/copySet.js
@@ -1,4 +1,5 @@
 import { Fail, hideAndHardenFunction } from '@endo/errors';
+import { harden } from '@endo/harden';
 import {
   makeTagged,
   passStyleOf,

--- a/packages/patterns/src/keys/keycollection-operators.js
+++ b/packages/patterns/src/keys/keycollection-operators.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { harden } from '@endo/harden';
 import {
   assertRankSorted,
   compareAntiRank,

--- a/packages/patterns/src/keys/merge-bag-operators.js
+++ b/packages/patterns/src/keys/merge-bag-operators.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import {
   assertRankSorted,
   compareAntiRank,

--- a/packages/patterns/src/keys/merge-set-operators.js
+++ b/packages/patterns/src/keys/merge-set-operators.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import {
   assertRankSorted,
   compareAntiRank,

--- a/packages/patterns/src/patterns/getGuardPayloads.js
+++ b/packages/patterns/src/patterns/getGuardPayloads.js
@@ -1,3 +1,4 @@
+import { harden } from '@endo/harden';
 import { objectMap } from '@endo/common/object-map.js';
 import {
   ArgGuardListShape,

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -9,6 +9,7 @@ import {
   annotateError,
   hideAndHardenFunction,
 } from '@endo/errors';
+import { harden } from '@endo/harden';
 import { applyLabelingError } from '@endo/common/apply-labeling-error.js';
 import { fromUniqueEntries } from '@endo/common/from-unique-entries.js';
 import { listDifference } from '@endo/common/list-difference.js';

--- a/packages/promise-kit/README.md
+++ b/packages/promise-kit/README.md
@@ -3,11 +3,11 @@
 The promise-kit package provides a simple abstraction for creating and managing a promise. It exports, `makePromiseKit` which is a utility function used to create a Promise and its associated resolver and rejector functions. This is particularly useful in asynchronous programming, where you might need to create a promise and resolve or reject it at a later point in time.
 Note that this serves as a "ponyfill" for `Promise.withResolvers`, making certain accommodations to ensure that the resulting promises can pipeline messages through `@endo/eventual-send`.
 
-## Usage
+# Usage
 
 Here’s an example of how `makePromiseKit` might be used in an Agoric smart contract or JavaScript program:
 
-### Basic Example
+## Basic Example
 
 ```javascript
 import { makePromiseKit } from '@endo/promise-kit';
@@ -39,7 +39,7 @@ async function handleAsyncOperation() {
 handleAsyncOperation();
 ```
 
-### Creating Multiple Promise Kits
+## Creating Multiple Promise Kits
 
 You can create multiple promise kits for managing various asynchronous tasks.
 
@@ -55,9 +55,9 @@ kit2.resolve('Second success');
 
 ```
 
-## API
+# API
 
-### `makePromiseKit()`
+## `makePromiseKit()`
 Creates a new promise kit.
 
 **Returns**
@@ -65,8 +65,10 @@ Creates a new promise kit.
 - **`resolve`**: The resolve function for the promise.
 - **`reject`**: The reject function for the promise.
 
-## Links
+# Links
+
 [Repository](https://github.com/endojs/endo/tree/master/packages/promise-kit)
 
-## License
+# License
+
 This package is licensed under the Apache-2.0 License.

--- a/packages/promise-kit/README.md
+++ b/packages/promise-kit/README.md
@@ -65,6 +65,11 @@ Creates a new promise kit.
 - **`resolve`**: The resolve function for the promise.
 - **`reject`**: The reject function for the promise.
 
+# Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).
+
 # Links
 
 [Repository](https://github.com/endojs/endo/tree/master/packages/promise-kit)

--- a/packages/promise-kit/index.js
+++ b/packages/promise-kit/index.js
@@ -1,5 +1,6 @@
 /* global globalThis */
 
+import { harden } from '@endo/harden';
 import { makeReleasingExecutorKit } from './src/promise-executor-kit.js';
 import { memoRace } from './src/memo-race.js';
 

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -37,6 +37,7 @@
     "test:xs": "exit 0"
   },
   "dependencies": {
+    "@endo/harden": "workspace:^",
     "ses": "workspace:^"
   },
   "devDependencies": {

--- a/packages/promise-kit/src/is-promise.js
+++ b/packages/promise-kit/src/is-promise.js
@@ -1,3 +1,5 @@
+import { harden } from '@endo/harden';
+
 /**
  * Determine if the argument is a Promise.
  *

--- a/packages/promise-kit/src/memo-race.js
+++ b/packages/promise-kit/src/memo-race.js
@@ -28,12 +28,14 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 */
 
+import { harden } from '@endo/harden';
+
 /**
  * TODO Consolidate with `isPrimitive` that's currently in `@endo/pass-style`.
  * Layering constraints make this tricky, which is why we haven't yet figured
  * out how to do this.
  *
- * @type {(val: unknown) => val is (undefined
+ * @type {(value: unknown) => value is (undefined
  * | null
  * | boolean
  * | number
@@ -41,8 +43,8 @@ For more information, please refer to <http://unlicense.org/>
  * | string
  * | symbol)}
  */
-const isPrimitive = val =>
-  !val || (typeof val !== 'object' && typeof val !== 'function');
+const isPrimitive = value =>
+  !value || (typeof value !== 'object' && typeof value !== 'function');
 
 /**
  * @template [T=any]

--- a/packages/promise-kit/src/promise-executor-kit.js
+++ b/packages/promise-kit/src/promise-executor-kit.js
@@ -1,5 +1,7 @@
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
+
 /**
  * @template T
  * @callback PromiseExecutor The promise executor

--- a/packages/ses-ava/README.md
+++ b/packages/ses-ava/README.md
@@ -30,7 +30,7 @@ dependency, bundlers might bundle your code with all of Ava.
 
 SES-Ava rhymes with Nineveh.
 
-## Compat note
+# Compatibility
 
 If you were already using `@endo/ses-ava` by doing
 

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@endo/env-options": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/init": "workspace:^",
     "ses": "workspace:^"
   },

--- a/packages/stream-node/README.md
+++ b/packages/stream-node/README.md
@@ -2,3 +2,8 @@
 
 This package provides `makeNodeReader` and `makeNodeWriter` adapters that adapt
 Node.js Reader and Writer to Endo's async iterable streams.
+
+# Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/stream-node/README.md
+++ b/packages/stream-node/README.md
@@ -1,3 +1,4 @@
 # Endo / Node Stream Adapters
 
-This package provides `makeNodeReader` and `makeNodeWriter` adapters that adapt Node.js Reader and Writer to Endo's async iterable streams.
+This package provides `makeNodeReader` and `makeNodeWriter` adapters that adapt
+Node.js Reader and Writer to Endo's async iterable streams.

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@endo/errors": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/stream": "workspace:^",
     "ses": "workspace:^"

--- a/packages/stream-node/reader.js
+++ b/packages/stream-node/reader.js
@@ -6,9 +6,9 @@
 // They however iterate Node.js Buffer values and are not hardened, so this
 // implementation compensates for both.
 
-import { mapReader } from '@endo/stream';
-
+import { harden } from '@endo/harden';
 import { Fail, q } from '@endo/errors';
+import { mapReader } from '@endo/stream';
 
 /**
  * @param {import('stream').Readable} input the source Node.js reader

--- a/packages/stream-node/writer.js
+++ b/packages/stream-node/writer.js
@@ -5,6 +5,7 @@
 // @ts-check
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { Fail } from '@endo/errors';
 
 const sink = harden(() => {});

--- a/packages/stream/README.md
+++ b/packages/stream/README.md
@@ -11,7 +11,7 @@ These streams depend on full Endo environment initialization, as with `@endo/ini
 to ensure that they are run in Hardened JavaScript with remote promise support
 (eventual send).
 
-## Writing
+# Writing
 
 To write to a stream, give a value to the next method.
 
@@ -22,7 +22,7 @@ await writer.next(value);
 
 Awaiting the returned promise slows the writer to match the pace of the reader.
 
-## Reading
+# Reading
 
 To read from a stream, await the value returned by the next method.
 
@@ -32,7 +32,7 @@ for await (const value of reader) {
 }
 ```
 
-## Map
+# Map
 
 To map a reader to a reader through a synchronous value transform, use `mapReader`.
 
@@ -53,7 +53,7 @@ const singleWriter = mapWriter(doubleWriter, n => n * 2);
 In this example, any value written to singleWriter will be writ double to
 doubleWriter.
 
-## Pipe
+# Pipe
 
 The `makePipe` function returns an entangled pair of streams.
 Use one as a reader and the other as a writer.
@@ -73,7 +73,7 @@ which promises settle.
 A stream is consequently a pair of queues that transport iteration results,
 one to send messages forward and another to receive acknowledgements.
 
-## Pump
+# Pump
 
 The `pump` function pumps iterations from a reader to a writer.
 The pump must be primed with the first acknowledgement to send to the reader,
@@ -93,7 +93,7 @@ const reader = makeNodeReader(process.stdin);
 await pump(writer, reader);
 ```
 
-## Prime
+# Prime
 
 Async generator functions are very useful for making reader adapters.
 

--- a/packages/stream/README.md
+++ b/packages/stream/README.md
@@ -127,14 +127,16 @@ const writer = prime(logGenerator());
 await writer.next('First message is not discarded');
 ```
 
-## Hardening
+# Hardening
 
-This library depends on Hardened JavaScript.
-The environment must be locked down before initializing this library.
 All of the exported functions and the streams they produce are hardened.
-
 This implementation of streams ensures that iteration results are shallowly
 frozen.
 The user is responsible for hardening the transported values if that is their
 intent.
 Some values like array buffers cannot be frozen.
+
+# Compatibility
+
+This package works with without [HardenedJS](https://hardenedjs.org) by using
+[`@endo/harden`](https://github.com/endojs/endo/tree/master/packages/harden).

--- a/packages/stream/index.js
+++ b/packages/stream/index.js
@@ -11,6 +11,7 @@
 // @ts-check
 /// <reference types="ses"/>
 
+import { harden } from '@endo/harden';
 import { E } from '@endo/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@endo/eventual-send": "workspace:^",
+    "@endo/harden": "workspace:^",
     "@endo/promise-kit": "workspace:^",
     "ses": "workspace:^"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,6 +160,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/benchmark@workspace:packages/benchmark"
   dependencies:
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/lockdown": "workspace:^"
     "@endo/pass-style": "workspace:^"
@@ -187,6 +188,7 @@ __metadata:
     "@endo/base64": "workspace:^"
     "@endo/compartment-mapper": "workspace:^"
     "@endo/evasive-transform": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/lockdown": "workspace:^"
     "@endo/promise-kit": "workspace:^"
@@ -222,6 +224,7 @@ __metadata:
   dependencies:
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/marshal": "workspace:^"
     "@endo/nat": "workspace:^"
@@ -229,7 +232,13 @@ __metadata:
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"
     ava: "npm:^6.4.1"
+    babel-eslint: "npm:^10.1.0"
     c8: "npm:^7.14.0"
+    eslint: "npm:^8.57.0"
+    eslint-config-airbnb-base: "npm:^15.0.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-eslint-comments: "npm:^3.2.0"
+    eslint-plugin-import: "npm:^2.29.1"
     typescript: "npm:~5.9.2"
   languageName: unknown
   linkType: soft
@@ -242,6 +251,7 @@ __metadata:
     "@endo/bundle-source": "workspace:^"
     "@endo/compartment-mapper": "workspace:^"
     "@endo/errors": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/zip": "workspace:^"
     ava: "npm:^6.4.1"
@@ -285,6 +295,7 @@ __metadata:
     "@endo/eventual-send": "workspace:^"
     "@endo/exo": "workspace:^"
     "@endo/far": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/import-bundle": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/lockdown": "workspace:^"
@@ -317,6 +328,7 @@ __metadata:
   dependencies:
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/lockdown": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"
@@ -332,6 +344,7 @@ __metadata:
   resolution: "@endo/compartment-mapper@workspace:packages/compartment-mapper"
   dependencies:
     "@endo/cjs-module-analyzer": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/module-source": "workspace:^"
     "@endo/path-compare": "workspace:^"
     "@endo/trampoline": "workspace:^"
@@ -362,6 +375,7 @@ __metadata:
     "@endo/eventual-send": "workspace:^"
     "@endo/exo": "workspace:^"
     "@endo/far": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/import-bundle": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/lockdown": "workspace:^"
@@ -424,6 +438,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/eslint-plugin@workspace:packages/eslint-plugin"
   dependencies:
+    "@endo/harden": "workspace:^"
     "@eslint-community/eslint-utils": "npm:^4.7.0"
     "@types/mocha": "npm:^10"
     eslint: "npm:^8.57.1"
@@ -457,11 +472,18 @@ __metadata:
   resolution: "@endo/eventual-send@workspace:packages/eventual-send"
   dependencies:
     "@endo/env-options": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/lockdown": "workspace:^"
-    ava: "npm:^6.4.1"
+    ava: "npm:^6.1.3"
+    babel-eslint: "npm:^10.1.0"
     c8: "npm:^7.14.0"
-    tsd: "npm:^0.32.0"
-    typescript: "npm:~5.9.2"
+    eslint: "npm:^8.57.0"
+    eslint-config-airbnb-base: "npm:^15.0.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-eslint-comments: "npm:^3.2.0"
+    eslint-plugin-import: "npm:^2.29.1"
+    tsd: "npm:^0.31.2"
+    typescript: "npm:~5.8.3"
   languageName: unknown
   linkType: soft
 
@@ -474,6 +496,7 @@ __metadata:
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
     "@endo/far": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/marshal": "workspace:^"
     "@endo/pass-style": "workspace:^"
@@ -497,6 +520,7 @@ __metadata:
   dependencies:
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/pass-style": "workspace:^"
     "@endo/ses-ava": "workspace:^"
@@ -549,6 +573,7 @@ __metadata:
     "@endo/bundle-source": "workspace:^"
     "@endo/compartment-mapper": "workspace:^"
     "@endo/errors": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/ses-ava": "workspace:^"
     "@endo/where": "workspace:^"
@@ -566,6 +591,7 @@ __metadata:
     "@endo/base64": "workspace:^"
     "@endo/compartment-mapper": "workspace:^"
     "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/lockdown": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     ava: "npm:^6.4.1"
@@ -594,6 +620,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/lockdown@workspace:packages/lockdown"
   dependencies:
+    "@endo/harden": "workspace:^"
     ses: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -603,6 +630,7 @@ __metadata:
   resolution: "@endo/lp32@workspace:packages/lp32"
   dependencies:
     "@endo/errors": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/ses-ava": "workspace:^"
     "@endo/stream": "workspace:^"
@@ -628,6 +656,7 @@ __metadata:
     "@endo/env-options": "workspace:^"
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/lockdown": "workspace:^"
     "@endo/nat": "workspace:^"
@@ -651,6 +680,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/memoize@workspace:packages/memoize"
   dependencies:
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/ses-ava": "workspace:^"
     ava: "npm:^6.4.1"
@@ -674,6 +704,7 @@ __metadata:
     "@babel/parser": "npm:~7.28.3"
     "@babel/traverse": "npm:~7.28.3"
     "@babel/types": "npm:~7.28.2"
+    "@endo/harden": "workspace:^"
     ava: "npm:^6.4.1"
     babel-eslint: "npm:^10.1.0"
     benchmark: "npm:^2.1.4"
@@ -709,6 +740,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/netstring@workspace:packages/netstring"
   dependencies:
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/stream": "workspace:^"
@@ -766,6 +798,7 @@ __metadata:
     "@endo/env-options": "workspace:^"
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"
@@ -800,6 +833,7 @@ __metadata:
     "@endo/common": "workspace:^"
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/marshal": "workspace:^"
     "@endo/pass-style": "workspace:^"
@@ -822,6 +856,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/promise-kit@workspace:packages/promise-kit"
   dependencies:
+    "@endo/harden": "workspace:^"
     ava: "npm:^6.4.1"
     babel-eslint: "npm:^10.1.0"
     c8: "npm:^7.14.0"
@@ -841,6 +876,7 @@ __metadata:
   resolution: "@endo/ses-ava@workspace:packages/ses-ava"
   dependencies:
     "@endo/env-options": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/panic": "workspace:^"
     ava: "npm:^6.4.1"
@@ -878,6 +914,7 @@ __metadata:
   resolution: "@endo/stream-node@workspace:packages/stream-node"
   dependencies:
     "@endo/errors": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/ses-ava": "workspace:^"
     "@endo/stream": "workspace:^"
@@ -917,6 +954,7 @@ __metadata:
   resolution: "@endo/stream@workspace:packages/stream"
   dependencies:
     "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"
@@ -2205,6 +2243,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsd/typescript@npm:~5.4.3":
+  version: 5.4.5
+  resolution: "@tsd/typescript@npm:5.4.5"
+  checksum: 10c0/df50a5263809cf28bac6e7615f0960c21b4952237872a1a683c906415e224b747f885d0f05aaaa3665ab4fb66a64f85a8f6901065628c512da9673c8776538e1
+  languageName: node
+  linkType: hard
+
 "@tsd/typescript@npm:~5.8.3":
   version: 5.8.3
   resolution: "@tsd/typescript@npm:5.8.3"
@@ -2966,7 +3011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ava@npm:^6.4.1":
+"ava@npm:^6.1.3, ava@npm:^6.4.1":
   version: 6.4.1
   resolution: "ava@npm:6.4.1"
   dependencies:
@@ -10792,6 +10837,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsd@npm:^0.31.2":
+  version: 0.31.2
+  resolution: "tsd@npm:0.31.2"
+  dependencies:
+    "@tsd/typescript": "npm:~5.4.3"
+    eslint-formatter-pretty: "npm:^4.1.0"
+    globby: "npm:^11.0.1"
+    jest-diff: "npm:^29.0.3"
+    meow: "npm:^9.0.0"
+    path-exists: "npm:^4.0.0"
+    read-pkg-up: "npm:^7.0.0"
+  bin:
+    tsd: dist/cli.js
+  checksum: 10c0/359af4639695cb7c55e011329e24929c257a969194a30ec6a71c6b443b7e1c5de386319a8e47464c8545c979e59ce7fcd6063836ab7883df13cdb0be856d6ab7
+  languageName: node
+  linkType: hard
+
 "tsd@npm:^0.32.0":
   version: 0.32.0
   resolution: "tsd@npm:0.32.0"
@@ -11032,7 +11094,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.1.6 - 5.8.x":
+"typescript@npm:5.1.6 - 5.8.x, typescript@npm:~5.8.3":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
@@ -11052,7 +11114,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.1.6 - 5.8.x#optional!builtin<compat/typescript>":
+"typescript@npm:~5.6.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A5.1.6 - 5.8.x#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
@@ -11069,6 +11141,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A~5.6.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes: #1686

## Description

The change in #2782 introduces `@endo/harden`. This change utilizes it in all applicable Endo packages so that they can run without `lockdown`. This does not completely eliminate a dependency on `ses` because `@endo/errors` entrains a dependency on the global `assert` provided by `ses` or specifically `ses/assert-shim.js`.

### Security Considerations

This change should have no consequences for the security model of the relevant packages. We do rely on #2782 to preserve the invariant that `harden` will never be used both before and after `lockdown`, which it does not absolutely prevent but does strongly discourage.

### Scaling Considerations

This increases the size of bundles by the weight of the `@endo/harden` module. That could be mitigated with a `-C` bundling condition like `-C sessile` (facetious) or `-C hjs` / `-C hardenedjs`.

### Documentation Considerations

Each of the affected packages has a note in its README that it can be used before or after `lockdown`. Currently, they can only be initialized after `lockdown` because of top-level `harden` calls on their module exports.

### Testing Considerations

Existing tests cover the post-lockdown case.

- [ ] It would make sense to create an environment variable for testing the pre-lockdown initialization behavior and instrumenting the `prepare` modules to conditionally lockdown. That might imply generally supporting a `NO_LOCKDOWN` environment variable in `@endo/init` and `@endo/lockdown`.

### Compatibility Considerations

Apart from increasing bundle sizes, this change should have no effect on backward compatibility.

### Upgrade Considerations

None.