### PR TITLE
feat(ses): add noAggregateLoadErrors flag

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -14,8 +14,8 @@ User-visible changes in `ses`
   - Unlike `ArrayBuffer` and `SharedArrayBuffer` this shim's ArrayBuffer-like object cannot be transfered or cloned between JS threads.
   - Unlike `ArrayBuffer` and `SharedArrayBuffer`, this shim's ArrayBuffer-like object cannot be used as the backing store of TypeArrays or DataViews.
   - The shim depends on the platform providing either `structuredClone` or `Array.prototype.transfer`. Node <= 16 and provides neither, causing the shim to fail to initialize, and therefore SES to fail to initialize on such platforms.
-  - Current Hermes has even stronger constraints, lacking `structuredClone`, `transfer`, private fields, and even `class` syntax. This requires other coping strategies. See https://github.com/endojs/endo/pull/2785
-  - Even after the upcoming `transferToImmutable` proposal is implemented by the platform, the current code will still replace it with the shim implementation, in accord with shim best practices. See https://github.com/endojs/endo/pull/2311#discussion_r1632607527 . It will require a later manual step to delete the shim or have it avoid overriting a platform implementation, after manual analysis of the compat implications.
+  - Current Hermes has even stronger constraints, lacking `structuredClone`, `transfer`, private fields, and even `class` syntax. This requires other coping strategies. See <https://github.com/endojs/endo/pull/2785>
+  - Even after the upcoming `transferToImmutable` proposal is implemented by the platform, the current code will still replace it with the shim implementation, in accord with shim best practices. See <https://github.com/endojs/endo/pull/2311#discussion_r1632607527> . It will require a later manual step to delete the shim or have it avoid overriting a platform implementation, after manual analysis of the compat implications.
 
 - The [evalTaming](https://github.com/endojs/endo/blob/master/packages/ses/docs/lockdown.md#evaltaming-options)
   option `'safe-eval'` now can only throw error `SES_DIRECT_EVAL`.
@@ -34,6 +34,14 @@ User-visible changes in `ses`
   then Static Hermes when released.
 
   Also `ses/hermes` can now be hooked into bundlers such as Metro to run Hardened JS.
+
+- The `Compartment` constructor now accepts a `boolean` option, `noAggregateLoadErrors`, to control how module-loading errors are reported.
+
+  By default, its value is `false`, which retains the previous behavior (it causes all relevant errors to be collected and rejected or thrown in a single exception from `compartment.import()` or `compartment.importNow()`, respectively).
+
+  If set to `true`, this will cause the *first* module-loading error encountered to be thrown (or rejected) immediately; no further module-loading will be attempted, and no further errors will be collected.
+
+  This is mostly useful for supporting optional dependencies in CommonJS modules.
 
 # v1.12.0 (2025-03-11)
 
@@ -116,7 +124,7 @@ and subject to breaking changes that will not be signaled by semver.
   old `regenerator-runtime` (from 0.10.5 to 0.13.7).
 - If lockdown's `errorTrapping: 'report'` mode is selected (possibly via the
   `'platform'`, or `'exit'` or `'abort'` modes), uncaught exceptions will be
-  written to standard error with the new `SES_UNCAUGHT_EXCEPTION: ` prefix.
+  written to standard error with the new `SES_UNCAUGHT_EXCEPTION:` prefix.
   This is intended to give valuable context to users of the system, especially
   when an uncaught exception is not an `Error` object, and therefore its origin
   may be hard to find in source code.
@@ -124,7 +132,7 @@ and subject to breaking changes that will not be signaled by semver.
   This is not likely to affect most systems built with SES, as stderr is
   generally reserved for user-only messages.  If your SES system sends its
   stderr to a program which parses it, you may need to adapt that program to be
-  tolerant of the `SES_UNCAUGHT_EXCEPTION: ` prefix.  Even for such programs, it
+  tolerant of the `SES_UNCAUGHT_EXCEPTION:` prefix.  Even for such programs, it
   is unlikely they are that sensitive to stderr formatting.
 
 # v1.6.0 (2024-07-30)
@@ -171,13 +179,17 @@ and subject to breaking changes that will not be signaled by semver.
   gives line-numbers into the generated JavaScript, which often don't match the
   the original lines. This happens even with the normal development-time
   lockdown options setting,
+
   ```js
   errorTaming: 'unsafe'
   ```
+
   or setting the environment variable
+
   ```sh
-  $ export LOCKDOWN_ERROR_TAMING=unsafe
+  export LOCKDOWN_ERROR_TAMING=unsafe
   ```
+
   To get the original line numbers, this release
   adds `'unsafe-debug'`. This `errorTaming: 'unsafe-debug'` setting
   should be used ***during development only*** when you can
@@ -259,7 +271,7 @@ and subject to breaking changes that will not be signaled by semver.
   It used to do that by omitting the `random` property from the safe `Math`
   namespace object.
   Now, the safe shared `Math` namespace object has a `Math.random()` function
-  that throws a `TypeError whose message begins with `'secure mode'`.
+  that throws a `TypeError whose message begins with`'secure mode'`.
   This again aligns with the XS implementation of HardenedJS.
 
 # v0.18.6 (2023-08-07)
@@ -351,7 +363,7 @@ and subject to breaking changes that will not be signaled by semver.
 - Removes the `__allowUnsafeMonkeyPatching__` option to lockdown. As the name
   should indicate, this was always an unsafe temporary kludge. Its only known
   use was in agoric-sdk, now gone at
-  https://github.com/Agoric/agoric-sdk/pull/5922 . Without this option, a
+  <https://github.com/Agoric/agoric-sdk/pull/5922> . Without this option, a
   successful `lockdown` will now always harden the primordials.
 
 # v0.15.8 (2022-02-18)
@@ -391,7 +403,7 @@ and subject to breaking changes that will not be signaled by semver.
 
 # 0.15.0 (2021-11-02)
 
-- _BREAKING CHANGE_: The lockdown option `domainTaming` is now `safe` by
+- *BREAKING CHANGE*: The lockdown option `domainTaming` is now `safe` by
   default, which will break any application that depends transtively on the
   Node.js `domain` module.
   Notably, [standard-things/esm](https://github.com/standard-things/esm)
@@ -399,11 +411,11 @@ and subject to breaking changes that will not be signaled by semver.
 
   This protects against the unhardened `domain` property appearing on shared
   objects like callbacks and promises.
-  This overcomes the last _known_ obstacle toward object capability containment.
+  This overcomes the last *known* obstacle toward object capability containment.
 
 - Lockdown will now read options from the environment as defined by the Node.js
   `process.env` parameter space.
-- _BREAKING CHANGE_: Lockdown may no longer be called more than once.
+- *BREAKING CHANGE*: Lockdown may no longer be called more than once.
   Lockdown no longer returns a boolean to indicate whether it was effective
   (true) or redundant (false). Instead, Lockdown will return undefined for
   its first invocation or throw an error otherwise.
@@ -449,7 +461,7 @@ and subject to breaking changes that will not be signaled by semver.
 
 # 0.14.0 (2021-07-22)
 
-- _BREAKING_: Any precompiled static module records from prior versions
+- *BREAKING*: Any precompiled static module records from prior versions
   will not load in this version of SES or beyond. The format of the preamble
   has been changed to admit the possibility of a variable named `Map` declared
   in the scope of a module.
@@ -478,25 +490,25 @@ and subject to breaking changes that will not be signaled by semver.
 
 # 0.13.0 (2021-06-01)
 
-- _BREAKING CHANGE_ The `ses/lockdown` module is again just `ses`.
+- *BREAKING CHANGE* The `ses/lockdown` module is again just `ses`.
   Instead of having a light 43KB `ses/lockdown` and a heavy 3.1MB `ses`, there
   is just a 52KB `ses` that has everything except `StaticModuleRecord`.
   For this release, there remains a `ses/lockdown` alias to `ses`.
-- _BREAKING CHANGE_ Third-party static module interface implementations _must_
+- *BREAKING CHANGE* Third-party static module interface implementations *must*
   now explicitly list their exported names.
   For CommonJS, this implies using a heuristic static analysis of `exports`
   changes.
   Consequently, third-party modules can now participate in linkage with ESM
   including support for `export * from './spec.cjs'` and also named imports
   like `import * from './spec.cjs'`.
-- _BREAKING CHANGE_ The `StaticModuleRecord` constructor has been removed in
+- *BREAKING CHANGE* The `StaticModuleRecord` constructor has been removed in
   favor of a duck-type for compiled static module records that is intrinsic to
   the shim and may be emulated by a third-party `StaticModuleRecord`
   constructor.
   The constructor must perform the module analysis and transform the source,
   and present this duck-type to the Compartment `importHook`.
   This relieves SES of a dependency on Babel and simplifies its API.
-- _BREAKING CHANGE_ The UMD distribution of SES must have the UTF-8 charset.
+- *BREAKING CHANGE* The UMD distribution of SES must have the UTF-8 charset.
   The prior versions were accidentally ASCII, so SES would have worked
   in any web page, regardless of the charset.
   To remedy this, be sure to include `<head><meta charset="utf-8"></head>` in
@@ -547,8 +559,8 @@ and subject to breaking changes that will not be signaled by semver.
 
 # 0.12.5 (2021-03-25)
 
-- The 0.12.4 release was broken by https://github.com/endojs/endo/pull/552
-  since fixed by https://github.com/endojs/endo/pull/638
+- The 0.12.4 release was broken by <https://github.com/endojs/endo/pull/552>
+  since fixed by <https://github.com/endojs/endo/pull/638>
 - These merely remove a repair needed by an old v8 / Node version that
   no one any longer supports.
 
@@ -678,7 +690,7 @@ inspector.
 
 The new `'moderate'` setting only tames those properties we know or expect to
 be problematic. If you run into an override mistake problem not addressed at
-the `'moderate'` setting **_please file an issue._**
+the `'moderate'` setting ***please file an issue.***
 
 <details>
   <summary>Expand for { overrideTaming: 'moderate' } vscode inspector display</summary>
@@ -707,9 +719,9 @@ all the code you're running under SES.
 - Added an `overrideTaming` option to `lockdown` with two settings,
   `'min'` and `'moderate'`. See
   [Enabling Override by Assignment](README.md#enabling-override-by-assignment)
-  for an explanation of when to use which. **_(This documentation has moved
+  for an explanation of when to use which. ***(This documentation has moved
   to [`overrideTaming`
-  options](./lockdown-options.md#overridetaming-options))_**
+  options](./lockdown-options.md#overridetaming-options))***
 - Modules and evaluated code that contains the censored substrings
   for dynamic eval, dynamic import, and HTML comments will now
   throw errors that contain the `sourceURL` from any `//#sourceURL=` comment
@@ -753,7 +765,7 @@ all the code you're running under SES.
   Errors that propagate through the module loader will be rethrown anew with
   the name of the module and compartment so they can be traced.
   At this time, the intermediate stacks of the causal chain are lost.
-  https://github.com/Agoric/SES-shim/issues/440
+  <https://github.com/Agoric/SES-shim/issues/440>
 
 # 0.10.2 (2020-08-20)
 
@@ -768,7 +780,7 @@ all the code you're running under SES.
 
 - Updates the whitelist to allow a `HandledPromise` global, which is provided
   by `@agoric/eventual-send`, an early implementation of
-  https://github.com/tc39/proposal-eventual-send.
+  <https://github.com/tc39/proposal-eventual-send>.
 - Corrects our fix for the override mistake, so that it correctly emulates
   how assignment would work in the absence of the override mistake.
   A property created by assignment will now be a writable, enumerable,
@@ -849,7 +861,7 @@ all the code you're running under SES.
 
 - This version decouples lockdown and the Compartment constructor.
   The Compartment constructor is now exported by `ses` (was previously only
-  available as a property of `globalThis` _after_ lockdown).
+  available as a property of `globalThis` *after* lockdown).
   The Compartment constructor will also create "privileged" compartments when
   constructed before lockdown.
 
@@ -918,23 +930,23 @@ dependencies.
 - SECURITY UPDATE: This release fixes a sandbox escape discovered in the
   realms-shim by GitHub user "XmiliaH", which works by causing an infinite
   loop and extracting the real function constructor from the RangeError
-  exception object. See https://github.com/Agoric/realms-shim/issues/48 for
+  exception object. See <https://github.com/Agoric/realms-shim/issues/48> for
   more details.
 
 # 0.6.0 (2019-09-03)
 
 - Breaking change: `options.transforms` may no longer specify `endow()`
   transforms. Instead, use `rewrite()`, which can now modify endowments.
-  See https://github.com/Agoric/realms-shim/pull/38 for details.
+  See <https://github.com/Agoric/realms-shim/pull/38> for details.
 - Repair the "override mistake", with optional repair plan in
   `options.dataPropertiesToRepair`. See src/bundle/dataPropertiesToRepair.js
-  and https://github.com/Agoric/SES/pull/146 for details.
+  and <https://github.com/Agoric/SES/pull/146> for details.
 - `options.sloppyGlobals` is rejected by `makeSESRootRealm()`, since all SES
   root realms are frozen. `sloppyGlobals` can only be used in a new
   "Compartment", made by calling `Realm.makeCompartment(options)`. See
-  https://github.com/Agoric/SES/issues/142
-  https://github.com/Agoric/realms-shim/pull/33
-  https://github.com/Agoric/realms-shim/pull/30 for details.
+  <https://github.com/Agoric/SES/issues/142>
+  <https://github.com/Agoric/realms-shim/pull/33>
+  <https://github.com/Agoric/realms-shim/pull/30> for details.
 - Add `options.whitelist` to override the set of properties that are retained
   in the new realm. The default gives you SES, but it could be overridden to
   e.g. enforce a Jessie-only environment.
@@ -951,10 +963,10 @@ Dependency updates only, no user-visible changes.
 
 - The 'realms-shim' module, upon which SES depends, has been split out of the
   TC39 'proposal-realms' repository, and now lives in
-  https://github.com/Agoric/realms-shim. It has not been released to NPM,
+  <https://github.com/Agoric/realms-shim>. It has not been released to NPM,
   rather SES incorporates it as a git submodule. (#110)
 - The documentation is now hosted on ReadTheDocs at
-  https://ses-secure-ecmascript.readthedocs.io/en/latest/ (#111, #117)
+  <https://ses-secure-ecmascript.readthedocs.io/en/latest/> (#111, #117)
 - SES.makeRootRealm() now accepts a 'transforms' option. This is a list of `{ endow, rewrite }` functions which can add/modify endowments and/or rewrite
   source code each time an `evaluate()` is performed. (#125)
 

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -32,12 +32,12 @@ systems.
 [![Agoric Logo](docs/agoric-x100.png)](https://agoric.com/)
 [![MetaMask Logo](docs/metamask-x100.png)](https://metamask.io/)
 
-See https://github.com/Agoric/Jessie to see how SES fits into the various
+See <https://github.com/Agoric/Jessie> to see how SES fits into the various
 flavors of confined JavaScript execution. And visit
-https://ses-demo.agoric.app/demos/ for a demo.
+<https://ses-demo.agoric.app/demos/> for a demo.
 
 SES starts where the Caja project left off
-https://github.com/google/caja/wiki/SES, and goes on to introduce compartments
+<https://github.com/google/caja/wiki/SES>, and goes on to introduce compartments
 and modernize the permitted JavaScript features.
 
 Please join the conversation on our [Mailing List][SES Strategy Group] and
@@ -45,11 +45,11 @@ Please join the conversation on our [Mailing List][SES Strategy Group] and
 We record a [weekly conference call][SES Strategy Recordings] with the Hardened
 JavaScript engineering community.
 
-_Hardened JavaScript_, Kris Kowal:
+*Hardened JavaScript*, Kris Kowal:
 
 [![Primer on Hardened JavaScript](https://img.youtube.com/vi/RZ7bBIU8DRc/0.jpg)](https://www.youtube.com/watch?v=RZ7bBIU8DRc)
 
-_Don't add Security, Remove Insecurity_, Mark Miller:
+*Don't add Security, Remove Insecurity*, Mark Miller:
 
 [![Don't add Security, Remove Insecurity](https://img.youtube.com/vi/u-XETUbxNUU/0.jpg)](https://www.youtube.com/watch?v=u-XETUbxNUU)
 
@@ -151,7 +151,6 @@ Note that although the **surface** of the capability is frozen, the capability
 still closes over the mutable counter.
 Hardening an object graph makes the surface immutable, but does not guarantee
 that methods are free of side effects.
-
 
 ### Compartment
 
@@ -278,10 +277,10 @@ module descriptors.
 A compartment can be configured with module descriptors, from highest to lowest
 precedence:
 
-- the `modules` map provided to the `Compartment` constructor,
-- returned by a `moduleMapHook(specifier)` passed as an option to the
+* the `modules` map provided to the `Compartment` constructor,
+* returned by a `moduleMapHook(specifier)` passed as an option to the
   `Compartment` constructor.
-- returned by either the `importHook(specifier)` or `importNowHook(specifier)`
+* returned by either the `importHook(specifier)` or `importNowHook(specifier)`
   option passed to the `Compartment` constructor. Calling
   `compartment.import(specifier)` falls through to the `importHook` which may
   return a promises, whereas `compartment.importNow(specifier)` falls through
@@ -341,13 +340,13 @@ forms.
 
 ##### Descriptors with `source` property
 
-- If fhe value of the `source` property is a string, the parent compartment
+* If fhe value of the `source` property is a string, the parent compartment
   loads the module but the compartment itself initializes the module.
 
-- Otherwise, if the value of the `source` property is the module source, the
+* Otherwise, if the value of the `source` property is the module source, the
   module is initialized from the module source.
 
-- Otherwise, the value of the `source` property must be an object. The module
+* Otherwise, the value of the `source` property must be an object. The module
   is loaded and initialized from the object according to the [virtual module
   source](#VirtualModuleSource) pattern.
 
@@ -363,20 +362,20 @@ are resolved using the `resolveHook`.
 
 ##### Descriptors with `namespace` property
 
-- If fhe value of the `namespace` property is a string, the descriptor shares a
+* If fhe value of the `namespace` property is a string, the descriptor shares a
   module to be loaded and initialized by the compartment referred by the
   `compartment` property.
 
-    - If the `compartment` property is present, its value must be a
+  * If the `compartment` property is present, its value must be a
       compartment.
-    - If absent, the `compartment` property defaults to the compartment being
+  * If absent, the `compartment` property defaults to the compartment being
       constructed in the `modules` option, or being hooked in the `loadHook`
       and `loadNowHook` options.
 
-- Otherwise, if the value of the `namespace` property is a module namepace, the
+* Otherwise, if the value of the `namespace` property is a module namepace, the
   descriptor shares a module that is already available.
 
-- Otherwise, the value of `namespace` property must be an object. The module is
+* Otherwise, the value of `namespace` property must be an object. The module is
   loaded and initialized from the object according to the [virtual module
   namespace](#VirtualModuleNamespace) pattern.
 
@@ -390,11 +389,11 @@ and return a module that has a different "response specifier" than the original
 The `importHook` may return an "alias" object with `source`, `compartment`,
 and `specifier` properties.
 
-- `source` must be a module source, either a virtual module source
+* `source` must be a module source, either a virtual module source
   or a compiled module source.
-- `compartment` is optional, to be specified if the alias transits to a
+* `compartment` is optional, to be specified if the alias transits to a
   the specified different compartment, and
-- `specifier` is the full module specifier of the module in its compartment.
+* `specifier` is the full module specifier of the module in its compartment.
   This defaults to the request specifier, which is only useful if the
   compartment is different.
 
@@ -556,45 +555,45 @@ using a particular calling convention to initialize a module instance.
 
 A compiled module source record has the following shape:
 
-- `imports` is a record that maps partial module specifiers to a list of
+* `imports` is a record that maps partial module specifiers to a list of
   names imported from the corresponding module.
-- `exports` is an array of all the names that the module will export.
-- `reexports` is an array of partial module specifier for which this
+* `exports` is an array of all the names that the module will export.
+* `reexports` is an array of partial module specifier for which this
   module exports all imported names.
   This field is optional.
-- `__syncModuleProgram__` is a string that evaluates to a function that accepts
+* `__syncModuleProgram__` is a string that evaluates to a function that accepts
   an initialization record and initializes the module.
   This property distinguishes this type of module record.
   The name implies a future record type that supports top-level await.
-  - An initialization record has the properties `imports`, `liveVar`, `importMeta` and
+  * An initialization record has the properties `imports`, `liveVar`, `importMeta` and
     `onceVar`.
-    - `imports` is a function that accepts a map from partial import
+    * `imports` is a function that accepts a map from partial import
       module specifiers to maps from names that the corresponding module
       exports to notifier functions.
       A notifier function accepts an update function and registers
       to receive updates for the value exported by the other module.
-    - `importMeta` is a null-prototype object with keys transferred from `importMeta`
+    * `importMeta` is a null-prototype object with keys transferred from `importMeta`
       property in the envelope returned by importHook and/or mutated by
       calling `importMetaHook(moduleSpecifier, importMeta)`
-    - `liveVar` is a record that maps names exported by this module
+    * `liveVar` is a record that maps names exported by this module
       to a function that may be called to initialize or update
       the corresponding value in another module.
-    - `onceVar` is a record that maps constants exported by this
+    * `onceVar` is a record that maps constants exported by this
       module to a function that may be called to initialize the
       corresponding value in another module.
-- `__syncModuleFunctor__` is an optional function that if present is used
+* `__syncModuleFunctor__` is an optional function that if present is used
   instead of the evaluation of the `__syncModuleProgram__` string. It will be
   called with the initialization record described above. It is intended to be
   used in environments where eval is not available. Sandboxing of the functor is
   the responsibility of the author of the ModuleSource.
-- `__liveExportsMap__` is a record that maps import names or names in the lexical
+* `__liveExportsMap__` is a record that maps import names or names in the lexical
   scope of the module to export names, for variables that may change after
   initialization. Any reexported name is assumed to possibly change.
   The exported name is wrapped in a duple array like `["exportedName", true]`.
   The second value, a boolean, indicates that the variable has a temporal
   dead-zone (a time between creation and initialization) when access to that
   name should throw a `ReferenceError`.
-- `__fixedExportsMap__` is a record that maps import names to export names
+* `__fixedExportsMap__` is a record that maps import names to export names
   for constants exported by this module.
   The fixed exports map is an aesthetic subtype of the live exports map,
   so the value is wrapped in a simple array like `["exportedName"]`
@@ -673,6 +672,24 @@ system generates other diagnostic information hidden in side tables. The tamed
 console uses these side tables to output more informative diagnostics.
 [Logging Errors](./src/error/README.md) explains the design.
 
+### Controlling Module-Loading Errors
+
+The `Compartment` constructor now accepts a `boolean` option, `noAggregateLoadErrors`, to control how module-loading errors are reported.
+
+By default, its value is `false`, which causes all relevant errors to be collected and rejected or thrown in a single exception from `compartment.import()` or `compartment.importNow()`, respectively.
+
+If set to `true`, this will cause the *first* module-loading error encountered to be thrown (or rejected) immediately; no further module-loading will be attempted, and no further errors will be collected.
+
+This is mostly useful for supporting optional dependencies in CommonJS modules, for example:
+
+```js
+try {
+  require('something-optional')
+} catch (err) {
+  // continue
+}
+```
+
 ## Security claims and caveats
 
 The `ses` shim concerns boundaries between programs in the same process and
@@ -696,20 +713,20 @@ Provided that the `ses` implementation and its
 program can evaluate a guest program (`program`) in a compartment after
 `lockdown` and that the guest program:
 
-- will initially only have access to one mutable object, the compartment's
+* will initially only have access to one mutable object, the compartment's
   `globalThis`,
-- specifically cannot modify any shared primordial objects, which are part of
+* specifically cannot modify any shared primordial objects, which are part of
   the default execution environment,
-- cannot initially perform any I/O (except I/O necessarily performed by the
+* cannot initially perform any I/O (except I/O necessarily performed by the
   trusted compute base like paging virtual memory),
-- and specifically cannot measure the passage of time at any resolution.
+* and specifically cannot measure the passage of time at any resolution.
 
 However, such a program can:
 
-- execute for an indefinite amount of time,
-- allocate arbitrary amounts of memory,
-- detect the platform endianness,
-- in some JavaScript engines, observe the contents of the stack.
+* execute for an indefinite amount of time,
+* allocate arbitrary amounts of memory,
+* detect the platform endianness,
+* in some JavaScript engines, observe the contents of the stack.
   This may include sensitive information about the layout of files on the host
   disk.
   In cases where the stack is data-dependent, a guest can infer the data.
@@ -729,10 +746,10 @@ be frozen, we additionally claim that the host can evaluate any two guest
 programs (`program1` and `program2`) in that compartment such that neither
 guest program will:
 
-- initially share *any* mutable objects.
-- be able to observe the relative passage of time of the other program,
+* initially share *any* mutable objects.
+* be able to observe the relative passage of time of the other program,
   as they would had they been given a reference to a working `Date.now()`.
-- be able to communicate, as they would if they had shared access to mutable
+* be able to communicate, as they would if they had shared access to mutable
   state like an unfrozen object, a hardened collection like a `Map`, or even
   `Math.random()`.
 
@@ -826,18 +843,18 @@ capabilities at runtime.
 
 The trusted compute base (TCB) for `ses` includes:
 
-- the host hardware,
-- the host operating system,
-- any intermediate virtual operating systems or hypervisors,
-- the process memory manager,
-- an implementation of JavaScript conforming to ECMAScript 262 as of
+* the host hardware,
+* the host operating system,
+* any intermediate virtual operating systems or hypervisors,
+* the process memory manager,
+* an implementation of JavaScript conforming to ECMAScript 262 as of
   2021, providing no unspecified embedding host behavior like the introduction of syntax
   that when evaluated reveals a mutable object.
   `ses` accounts for one such host behavior provided by Node.js, namely the `domain`
   property on promises, by preventing the use of `ses` in concert with the
   `domain` module.
-- Also, any attached debugger, and
-- any JavaScript that has executed in the same realm before the host program calls
+* Also, any attached debugger, and
+* any JavaScript that has executed in the same realm before the host program calls
   `lockdown`, including JavaScript that executes after `ses` initializes.
 
 ## Audits
@@ -894,6 +911,7 @@ the code is often incompatible with *all* environments in which intrinsic
 objects are frozen (such as in Node.js with the
 [`--frozen-intrinsics`][Node frozen intrinsics] option) and can be fixed by
 replacing `<lhs>.<propertyKey> = <rhs>;` or `<lhs>[<propertyKey>] = <rhs>;` with
+
 ```js
 Object.defineProperties(<lhs>, {
   [<propertyKey>]: {

--- a/packages/ses/src/compartment.js
+++ b/packages/ses/src/compartment.js
@@ -104,6 +104,7 @@ const moduleAliases = new WeakMap();
  * @property {Compartment} [parentCompartment]
  * @property {boolean} noNamespaceBox
  * @property {(fullSpecifier: string) => Promise<ModuleExportsNamespace>} compartmentImport
+ * @property {boolean} [noAggregateLoadErrors]
  */
 
 /**
@@ -173,16 +174,17 @@ export const CompartmentPrototype = {
   },
 
   async import(specifier) {
-    const { noNamespaceBox } = /** @type {CompartmentFields} */ (
-      weakmapGet(privateFields, this)
-    );
+    const { noNamespaceBox, noAggregateLoadErrors } =
+      /** @type {CompartmentFields} */ (weakmapGet(privateFields, this));
 
     if (typeof specifier !== 'string') {
       throw TypeError('first argument of import() must be a string');
     }
 
     return promiseThen(
-      load(privateFields, moduleAliases, this, specifier),
+      load(privateFields, moduleAliases, this, specifier, {
+        noAggregateErrors: noAggregateLoadErrors,
+      }),
       () => {
         // The namespace box is a contentious design and likely to be a breaking
         // change in an appropriately numbered future version.
@@ -205,16 +207,27 @@ export const CompartmentPrototype = {
       throw TypeError('first argument of load() must be a string');
     }
 
-    return load(privateFields, moduleAliases, this, specifier);
+    const { noAggregateLoadErrors } = /** @type {CompartmentFields} */ (
+      weakmapGet(privateFields, this)
+    );
+
+    return load(privateFields, moduleAliases, this, specifier, {
+      noAggregateErrors: noAggregateLoadErrors,
+    });
   },
 
   importNow(specifier) {
     if (typeof specifier !== 'string') {
       throw TypeError('first argument of importNow() must be a string');
     }
+    const { noAggregateLoadErrors } = /** @type {CompartmentFields} */ (
+      weakmapGet(privateFields, this)
+    );
 
-    loadNow(privateFields, moduleAliases, this, specifier);
-    return compartmentImportNow(this, specifier);
+    loadNow(privateFields, moduleAliases, this, specifier, {
+      noAggregateErrors: noAggregateLoadErrors,
+    });
+    return compartmentImportNow(/** @type {Compartment} */ (this), specifier);
   },
 };
 
@@ -345,6 +358,7 @@ export const makeCompartmentConstructor = (
       moduleMapHook,
       importMetaHook,
       __noNamespaceBox__: noNamespaceBox = false,
+      noAggregateLoadErrors = false,
     } = compartmentOptions(...args);
     const globalTransforms = arrayFlatMap(
       [transforms, __shimTransforms__],
@@ -422,7 +436,9 @@ export const makeCompartmentConstructor = (
           `Compartment does not support dynamic import: no configured resolveHook for compartment ${q(name)}`,
         );
       }
-      await load(privateFields, moduleAliases, compartment, fullSpecifier);
+      await load(privateFields, moduleAliases, compartment, fullSpecifier, {
+        noAggregateErrors: noAggregateLoadErrors,
+      });
       const { execute, exportsProxy } = link(
         privateFields,
         moduleAliases,
@@ -451,6 +467,7 @@ export const makeCompartmentConstructor = (
       parentCompartment,
       noNamespaceBox,
       compartmentImport,
+      noAggregateLoadErrors,
     });
   }
 

--- a/packages/ses/test/import.test.js
+++ b/packages/ses/test/import.test.js
@@ -620,3 +620,78 @@ test('dynamic import from source', async t => {
   const namespace2 = await namespace.dynamic;
   t.is(namespace, namespace2);
 });
+
+test('rejects immediately when error aggregation is disabled', async t => {
+  t.plan(1);
+
+  const importHook = specifier => {
+    if (specifier === './meaning.mjs') {
+      return new ModuleSource(
+        `
+        export { meaning as default } from './missing.mjs';
+      `,
+        'https://example.com/meaning.mjs',
+      );
+    }
+    if (specifier === './main.js') {
+      return new ModuleSource(
+        `
+        import meaning from './meaning.mjs';
+        t.is(meaning, 42);
+      `,
+        'https://example.com/main.js',
+      );
+    }
+    throw Error(`Cannot load module for specifier ${specifier}`);
+  };
+
+  const compartment = new Compartment({
+    globals: { t },
+    resolveHook: resolveNode,
+    importHook,
+    noAggregateLoadErrors: true,
+    __options__: true,
+  });
+
+  await t.throwsAsync(() => compartment.import('./main.js'), {
+    message: `Cannot load module for specifier ./missing.mjs`,
+    name: 'Error',
+  });
+});
+
+test('rejects w/ aggregate error when error aggregation is enabled', async t => {
+  t.plan(1);
+
+  const importHook = specifier => {
+    if (specifier === './meaning.mjs') {
+      return new ModuleSource(
+        `
+        export { meaning as default } from './missing.mjs';
+      `,
+        'https://example.com/meaning.mjs',
+      );
+    }
+    if (specifier === './main.js') {
+      return new ModuleSource(
+        `
+        import meaning from './meaning.mjs';
+        t.is(meaning, 42);
+      `,
+        'https://example.com/main.js',
+      );
+    }
+    throw Error(`Cannot load module for specifier ${specifier}`);
+  };
+
+  const compartment = new Compartment({
+    globals: { t },
+    resolveHook: resolveNode,
+    importHook,
+    noAggregateLoadErrors: false,
+    __options__: true,
+  });
+
+  await t.throwsAsync(() => compartment.import('./main.js'), {
+    message: /1 underlying failures/,
+  });
+});

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -172,6 +172,11 @@ export interface CompartmentOptions {
   /** @deprecated */
   loadNowHook?: (specifier: string) => ModuleDescriptor;
   __native__?: boolean;
+
+  /**
+   * If `true`, the first error encountered during module loading will be thrown immediately
+   */
+  noAggregateLoadErrors?: boolean;
 }
 
 export interface EvaluateOptions {


### PR DESCRIPTION
Refs: #2820

## Description

This adds the `noAggregateLoadErrors` flag to the `Compartment` constructor in its `CompartmentOptions`. The default value of this flag is `false`, which retains the current behavior.

If `true`, this will cause the first error encountered during load (`load` or `loadNow`) to be thrown or rejected.

> ~~A second PR (or subsequent commit in this PR) will thread this flag through `@endo/compartment-mapper` where it can more easily be provided (e.g., to `importLocation()`, `loadFromMap()`, etc.).~~
> This won't be strictly necessary for `@lavamoat/node`'s use-case, so I'd rather just kick the can down the road until it's needed.

### Security Considerations

none that I'm aware of

### Scaling Considerations

n/a

### Documentation Considerations

The `aggregateLoadErrors` flag should be documented w/ the rest of `CompartmentOptions`.

### Testing Considerations

This has tests which cover both `load` and `loadNow` cases.

### Compatibility Considerations

non-breaking

### Upgrade Considerations

- [ ] Update `NEWS.md` for user-facing changes.
