### PR TITLE
fix(pass-style): better byteArray support

### DIFF
--- a/packages/immutable-arraybuffer/index.js
+++ b/packages/immutable-arraybuffer/index.js
@@ -1,6 +1,6 @@
 /* global globalThis */
 
-const { setPrototypeOf, getOwnPropertyDescriptors } = Object;
+const { setPrototypeOf, getOwnPropertyDescriptors, defineProperties } = Object;
 const { apply } = Reflect;
 const { prototype: arrayBufferPrototype } = ArrayBuffer;
 // Capture structuredClone before it could be scuttled.
@@ -145,6 +145,16 @@ const {
 } = getOwnPropertyDescriptors(immutableArrayBufferPrototype);
 
 setPrototypeOf(immutableArrayBufferPrototype, arrayBufferPrototype);
+
+// See https://github.com/endojs/endo/tree/master/packages/immutable-arraybuffer#purposeful-violation
+defineProperties(immutableArrayBufferPrototype, {
+  [Symbol.toStringTag]: {
+    value: 'ImmutableArrayBuffer',
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  },
+});
 
 /**
  * Transfer the contents to a new Immutable ArrayBuffer

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -469,7 +469,7 @@ const decodeLegacyArray = (encoded, decodePassable, skip = 0) => {
  */
 const encodeByteArray = (byteArray, _encodePassable) => {
   // TODO implement
-  Fail`encodePassable(copyData) not yet implemented: ${byteArray}`;
+  Fail`encodePassable(byteArray) not yet implemented: ${byteArray}`;
   return ''; // Just for the type
 };
 

--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -115,9 +115,9 @@ export const deeplyFulfilled = async val => {
       return E.when(Promise.all(valPs), vals => harden(vals));
     }
     case 'byteArray': {
-      const bytes = /** @type {ByteArray} */ (/** @type {unknown} */ (val));
+      const byteArray = /** @type {ByteArray} */ (/** @type {unknown} */ (val));
       // @ts-expect-error not assignable to type 'DeeplyAwaited<T>'
-      return bytes;
+      return byteArray;
     }
     case 'tagged': {
       const tgd = /** @type {CopyTagged} */ (val);

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -1209,17 +1209,16 @@ const makePatternKit = () => {
   });
 
   /** @type {MatchHelper} */
-  const matchBytesHelper = Far('match:bytes helper', {
+  const matchByteArrayHelper = Far('match:byteArray helper', {
     checkMatches: (specimen, [limits = undefined], check) => {
       const { byteLengthLimit } = limit(limits);
       // prettier-ignore
       return (
         checkKind(specimen, 'byteArray', check) &&
-        // eslint-disable-next-line @endo/restrict-comparison-operands
-        (/** @type {import('./types.js').ByteArray} */ (specimen).byteLength <= byteLengthLimit ||
+        (/** @type {ArrayBuffer} */ (specimen).byteLength <= byteLengthLimit ||
           check(
             false,
-            X`bytes ${specimen} must not be bigger than ${byteLengthLimit}`,
+            X`byteArray ${specimen} must not be bigger than ${byteLengthLimit}`,
           ))
       );
     },
@@ -1229,7 +1228,7 @@ const makePatternKit = () => {
         payload,
         harden([]),
         check,
-        'match:bytes payload',
+        'match:byteArray payload',
       ),
 
     getRankCover: (_matchPayload, _encodePassable) =>
@@ -1815,7 +1814,7 @@ const makePatternKit = () => {
     'match:gt': matchGTHelper,
 
     'match:arrayOf': matchArrayOfHelper,
-    'match:bytes': matchBytesHelper,
+    'match:byteArray': matchByteArrayHelper,
     'match:recordOf': matchRecordOfHelper,
     'match:setOf': matchSetOfHelper,
     'match:bagOf': matchBagOfHelper,
@@ -1845,7 +1844,7 @@ const makePatternKit = () => {
   const SymbolShape = makeTagged('match:symbol', []);
   const RecordShape = makeTagged('match:recordOf', [AnyShape, AnyShape]);
   const ArrayShape = makeTagged('match:arrayOf', [AnyShape]);
-  const BytesShape = makeTagged('match:bytes', []);
+  const ByteArrayShape = makeTagged('match:byteArray', []);
   const SetShape = makeTagged('match:setOf', [AnyShape]);
   const BagShape = makeTagged('match:bagOf', [AnyShape, AnyShape]);
   const MapShape = makeTagged('match:mapOf', [AnyShape, AnyShape]);
@@ -1939,8 +1938,8 @@ const makePatternKit = () => {
     // For example, a pattern that matches CopyArrays of length 2 that have a
     // string at index 0 and a number at index 1 is:
     // harden([ M.string(), M.number() ]).
-    bytes: (limits = undefined) =>
-      limits ? makeLimitsMatcher('match:bytes', [limits]) : BytesShape,
+    byteArray: (limits = undefined) =>
+      limits ? makeLimitsMatcher('match:byteArray', [limits]) : ByteArrayShape,
     set: (limits = undefined) => (limits ? M.setOf(M.any(), limits) : SetShape),
     bag: (limits = undefined) =>
       limits ? M.bagOf(M.any(), M.any(), limits) : BagShape,

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -298,7 +298,7 @@ export {};
  * @property {(limits?: Limits) => Matcher} array
  * Matches any CopyArray, subject to limits.
  *
- * @property {(limits?: Limits) => Matcher} bytes
+ * @property {(limits?: Limits) => Matcher} byteArray
  * Matches any ByteArray, subject to limits.
  *
  * @property {(limits?: Limits) => Matcher} set

--- a/packages/patterns/test/pattern-limits.test.js
+++ b/packages/patterns/test/pattern-limits.test.js
@@ -223,7 +223,7 @@ const runTests = (successCase, failCase) => {
     failCase(
       specimen,
       M.byteArray(harden({ byteLengthLimit: 999 })),
-      'byteArray "[ArrayBuffer]" must not be bigger than 999',
+      /byteArray "\[.*ArrayBuffer\]" must not be bigger than 999/,
     );
   }
   // numSetElementsLimit

--- a/packages/patterns/test/pattern-limits.test.js
+++ b/packages/patterns/test/pattern-limits.test.js
@@ -213,6 +213,19 @@ const runTests = (successCase, failCase) => {
     successCase(specimen, M.array(harden({ arrayLengthLimit: Infinity })));
     failCase(specimen, M.array(), 'Array length 10001 must be <= limit 10000');
   }
+  // byteLengthLimit
+  {
+    // @ts-expect-error How can shim enhance ArrayBuffer ts type?
+    const specimen = new ArrayBuffer(1000).transferToImmutable();
+    successCase(specimen, M.byteArray());
+    successCase(specimen, M.byteArray(harden({ byteLengthLimit: 1001 })));
+    successCase(specimen, M.byteArray(harden({ byteLengthLimit: 1000 })));
+    failCase(
+      specimen,
+      M.byteArray(harden({ byteLengthLimit: 999 })),
+      'byteArray "[ArrayBuffer]" must not be bigger than 999',
+    );
+  }
   // numSetElementsLimit
   {
     const specimen = makeCopySet([0, 1, 2, 3, 4, 5]);
@@ -268,14 +281,10 @@ test('test pattern limits', t => {
     t.notThrows(() => mustMatch(specimen, yesPattern), `${yesPattern}`);
     t.assert(matches(specimen, yesPattern), `${yesPattern}`);
   };
-  const failCase = (specimen, noPattern, msg) => {
+  const failCase = (specimen, noPattern, message) => {
     harden(specimen);
     harden(noPattern);
-    t.throws(
-      () => mustMatch(specimen, noPattern),
-      { message: msg },
-      `${noPattern}`,
-    );
+    t.throws(() => mustMatch(specimen, noPattern), { message }, `${noPattern}`);
     t.false(matches(specimen, noPattern), `${noPattern}`);
   };
   runTests(successCase, failCase);

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -1372,6 +1372,8 @@ export const permitted = {
     '[[Proto]]': '%ArrayBufferPrototype%',
     byteLength: getter,
     slice: fn,
+    // See https://github.com/endojs/endo/tree/master/packages/immutable-arraybuffer#purposeful-violation
+    '@@toStringTag': 'string',
     // See https://github.com/tc39/proposal-resizablearraybuffer
     transfer: fn,
     resize: fn,


### PR DESCRIPTION

Closes: #XXXX
Refs: #2248 

## Description

While working on #2248, I ran into previously undetected bugs due to confusion between `'bytes'` and `'byteArray'` as the name for passable Immutable ArrayBuffers. This PR is extracted from the portions of #2248 in which I fix this and test the fix.

### Security & Scaling Considerations

The bug manifested in trying to test the pattern-based limits enforcement for byteArrays. The inability to enforce those limits create both security and scaling hazards. This PR fixes those hazards.

### Documentation Considerations

`M.bytes()` should no longer appear in any docs. Use `M.byteArray()` instead.

### Testing Considerations

Had previous PRs tested the limits enforcement, this bug would have been found and fixed earlier. Mea culpa. This PR does add those tests.

### Compatibility Considerations

If there was previous code using `M.bytes()`, or storing the matcher object it produces, then we'd have a compat problem. As long as we merge this PR before the next big agoric-sdk sync, we should avoid any such compat problem. Hence, I'm labeling this as "![image](https://github.com/user-attachments/assets/1c591c7f-1beb-40ac-9833-8d9f13f04f7e)".

### Upgrade Considerations

As long as nothing previously used `M.bytes()` or stored the matcher it creates, none.