### PR TITLE
compartment-mapper: fix dynamic require of relative paths

### DIFF
--- a/packages/compartment-mapper/src/types/powers.ts
+++ b/packages/compartment-mapper/src/types/powers.ts
@@ -71,9 +71,9 @@ export type MaybeReadNowFn = (location: string) => Uint8Array | undefined;
 
 export type HashFn = (bytes: Uint8Array) => string;
 
-export type FileURLToPathFn = typeof import('node:url').fileURLToPath;
+export type FileURLToPathFn = (url: URL | string) => string;
 
-export type PathToFileURLFn = typeof import('node:url').pathToFileURL;
+export type PathToFileURLFn = (path: string) => URL;
 
 export type RequireResolveFn = (
   fromLocation: string,

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/README.md
@@ -1,0 +1,1 @@
+App whose dependency attempts to load a file from a location not within the compartment map.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/index.js
@@ -1,0 +1,1 @@
+exports.value = require('grabby-app-broken/node_modules/grabby').value

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/node_modules/grabby/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/node_modules/grabby/index.js
@@ -1,0 +1,5 @@
+const macguffinPath = '../../../grabby-app/macguffin';
+
+const {value} = require(macguffinPath);
+
+exports.value = value;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/node_modules/grabby/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/node_modules/grabby/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "grabby",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app-broken/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "grabby-app-broken",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "grabby": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/README.md
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/README.md
@@ -1,0 +1,1 @@
+App whose dependency attempts to load a file from outside of its compartment.

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/index.js
@@ -1,0 +1,1 @@
+exports.value = require('grabby').value

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/macguffin.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/macguffin.js
@@ -1,0 +1,3 @@
+module.exports = {
+  value: 'buried treasure'
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/node_modules/grabby/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/node_modules/grabby/index.js
@@ -1,0 +1,5 @@
+const macguffinPath = '../../macguffin';
+
+const {value} = require(macguffinPath);
+
+exports.value = value;

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/node_modules/grabby/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/node_modules/grabby/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "grabby",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic/node_modules/grabby-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "grabby-app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "grabby": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}


### PR DESCRIPTION
## Description

This fixes a situation in which a dynamically-required _relative_ path (specifically, starting with `../`) could not be resolved. It is converted to an absolute path, which is subequently resolved the same way `importNowHook` resolves all other absolute paths.

This behavior is _only_ applicable to dynamic requires; it is not supported by static imports of any kind.

Additionally, I simplified a couple types (`FileURLToPathFn` and `PathToFileURLFn`). This is not a breaking change, since `node:url`'s `fileURLToPath` and `pathToFileURL` functions _extend_ the new types.

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

I've added a couple test cases. I did not add a test to assert this fails for static imports, since I expect such a test already exists.

### Compatibility Considerations

This enables dynamic requires of ancestor relative paths.

### Upgrade Considerations

Kind of an edge case as most dynamic requires use absolute paths; probably not worth announcing.
