### PR TITLE
feat(daemon): PINS restored on startup

### DIFF
--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -69,6 +69,7 @@ export const makeHostMaker = ({
    * @param {string} mainWorkerId
    * @param {string} endoId
    * @param {string} networksDirectoryId
+   * @param {string} pinsDirectoryId
    * @param {string} leastAuthorityId
    * @param {{[name: string]: string}} platformNames
    * @param {Context} context
@@ -81,6 +82,7 @@ export const makeHostMaker = ({
     mainWorkerId,
     endoId,
     networksDirectoryId,
+    pinsDirectoryId,
     leastAuthorityId,
     platformNames,
     context,
@@ -96,6 +98,7 @@ export const makeHostMaker = ({
       MAIN: mainWorkerId,
       ENDO: endoId,
       NETS: networksDirectoryId,
+      PINS: pinsDirectoryId,
       INFO: inspectorId,
       NONE: leastAuthorityId,
     });
@@ -408,6 +411,7 @@ export const makeHostMaker = ({
           await formulateHost(
             endoId,
             networksDirectoryId,
+            pinsDirectoryId,
             getDeferredTasksForAgent(petName, agentName),
           );
         host = { value: Promise.resolve(value), id };

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -60,6 +60,7 @@ type IdRecord = {
 type EndoFormula = {
   type: 'endo';
   networks: string;
+  pins: string;
   peers: string;
   host: string;
   leastAuthority: string;
@@ -93,6 +94,7 @@ type HostFormula = {
   petStore: string;
   endo: string;
   networks: string;
+  pins: string;
 };
 
 type GuestFormula = {
@@ -639,6 +641,7 @@ export type EndoBootstrap = {
   greeter: () => Promise<EndoGreeter>;
   gateway: () => Promise<EndoGateway>;
   reviveNetworks: () => Promise<void>;
+  revivePins: () => Promise<void>;
   addPeerInfo: (peerInfo: PeerInfo) => Promise<void>;
 };
 
@@ -785,6 +788,7 @@ type FormulateNumberedGuestParams = {
 type FormulateHostDependenciesParams = {
   endoId: string;
   networksDirectoryId: string;
+  pinsDirectoryId: string;
   specifiedWorkerId?: string;
 };
 
@@ -797,6 +801,7 @@ type FormulateNumberedHostParams = {
   inspectorId: string;
   endoId: string;
   networksDirectoryId: string;
+  pinsDirectoryId: string;
 };
 
 export type FormulaValueTypes = {
@@ -882,6 +887,7 @@ export interface DaemonCore {
   formulateHost: (
     endoId: string,
     networksDirectoryId: string,
+    pinsDirectoryId: string,
     deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
     specifiedWorkerId?: string | undefined,
   ) => FormulateResult<EndoHost>;


### PR DESCRIPTION
The pet dæmon will revive all of the objects in the PINS special directory whenever it restarts. This is a more general case of NETS, which must also be revived on restart so that they can establish listener sockets, but are more deeply integrated in peer names. The test included illustrates the usage through API.