### PR TITLE
types(pass-style): accept RemotableBrand as PassableCap

### DIFF
--- a/packages/pass-style/src/deeplyFulfilled.js
+++ b/packages/pass-style/src/deeplyFulfilled.js
@@ -7,6 +7,7 @@ import { makeTagged } from './makeTagged.js';
 import { isAtom } from './typeGuards.js';
 
 /**
+ * @import {RemotableBrand} from '@endo/eventual-send';
  * @import {Passable, ByteArray, CopyRecord, CopyArray, CopyTagged, RemotableObject} from '@endo/pass-style'
  */
 
@@ -47,9 +48,11 @@ const { fromEntries } = Object;
  * @template T
  * @typedef {T extends PromiseLike<any>
  *     ? Awaited<T>
- *     : T extends {}
- *       ? Simplify<DeeplyAwaitedObject<T>>
- *       : Awaited<T>} DeeplyAwaited
+ *     : T extends (RemotableBrand<any, any> | RemotableObject)
+ *       ? T
+ *       : T extends {}
+ *         ? Simplify<DeeplyAwaitedObject<T>>
+ *         : Awaited<T>} DeeplyAwaited
  */
 
 /**

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -1,3 +1,4 @@
+import type { RemotableBrand } from '@endo/eventual-send';
 /* eslint-disable no-use-before-define */
 import { PASS_STYLE } from './passStyle-helpers.js';
 
@@ -65,7 +66,9 @@ export type PassByCopy = Atom | Error | CopyArray | CopyRecord | CopyTagged;
 
 export type PassByRef =
   | RemotableObject
+  | RemotableBrand<any, any>
   | Promise<RemotableObject>
+  | Promise<RemotableBrand<any, any>>
   | Promise<PassByCopy>;
 
 /**
@@ -165,7 +168,10 @@ export type RemotableObject<I extends InterfaceSpec = string> = PassStyled<
 /**
  * The authority-bearing leaves of a Passable's pass-by-copy superstructure.
  */
-export type PassableCap = Promise<any> | RemotableObject;
+export type PassableCap =
+  | Promise<any>
+  | RemotableObject
+  | RemotableBrand<any, any>;
 
 /**
  * A Passable sequence of Passable values.

--- a/packages/patterns/src/types.js
+++ b/packages/patterns/src/types.js
@@ -4,6 +4,7 @@ export {};
 
 // NB: as of TS 5.5 nightly, TS thinks RankCover and Checker "is declared but never read" but they are
 /**
+ * @import {RemotableBrand} from '@endo/eventual-send';
  * @import {Checker, CopyArray, CopyRecord, CopyTagged, Passable, PassStyle, Atom, RemotableObject} from '@endo/pass-style';
  * @import {PartialCompare, PartialComparison, RankCompare, RankCover} from '@endo/marshal';
  */
@@ -14,7 +15,7 @@ export {};
  */
 
 /**
- * @typedef {Exclude<Passable<RemotableObject, never>, Error | Promise>} Key
+ * @typedef {Exclude<Passable<RemotableObject | RemotableBrand<any, any>, never>, Error | Promise>} Key
  *
  * Keys are Passable arbitrarily-nested pass-by-copy containers
  * (CopyArray, CopyRecord, CopySet, CopyBag, CopyMap) in which every
@@ -69,7 +70,7 @@ export {};
  */
 
 /**
- * @typedef {Atom | RemotableObject} ScalarKey
+ * @typedef {Atom | RemotableObject | RemotableBrand<any, any>} ScalarKey
  */
 
 /**


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/pull/11454

## Description

In some cases, a remotable object may have a `RemotableBrand` type but not a `RemotableObject` type. This is because the former can easily be "tagged" onto an existing type (as a nominal type without public properties), but the latter would cause type checking issues (as a structural type).

This change enables pass-style and pattern types to accept `RemotableBrand` wherever a `RemotableObject` is accepted as a remotable passable cap.

### Security Considerations

None, types only.

### Scaling Considerations

None

### Documentation Considerations

None

### Testing Considerations

Manually integration tested against agoric-sdk.

### Compatibility Considerations

This may break some  erroneous type checks.

### Upgrade Considerations

Types only are usually considered non breaking.
