### PR TITLE
refactor: shorten used failure idiom

### DIFF
--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -1,4 +1,4 @@
-import { X } from '@endo/errors';
+import { X, Fail } from '@endo/errors';
 
 /**
  * @import {PassStyleHelper} from './internal-types.js';
@@ -39,7 +39,7 @@ export const ByteArrayHelper = harden({
     getPrototypeOf(candidate) === ImmutableArrayBufferPrototype ||
       assert.fail(X`Malformed ByteArray ${candidate}`, TypeError);
     apply(immutableGetter, candidate, []) ||
-      assert.fail(X`Must be an immutable ArrayBuffer: ${candidate}`);
+      Fail`Must be an immutable ArrayBuffer: ${candidate}`;
     ownKeys(candidate).length === 0 ||
       assert.fail(
         X`ByteArrays must not have own properties: ${candidate}`,

--- a/packages/ses/test/error/assert-log.test.js
+++ b/packages/ses/test/error/assert-log.test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import { assertLogs, throwsAndLogs } from './_throws-and-logs.js';
 import { assert } from '../../src/error/assert.js';
 
-const { details: X, quote: q, bare: b, error: makeError } = assert;
+const { details: X, quote: q, bare: b, error: makeError, Fail } = assert;
 
 // Self-test of the example from the throwsAndLogs comment.
 test('throwsAndLogs with data', t => {
@@ -86,11 +86,11 @@ test('causal tree', t => {
       const fooErr = SyntaxError('foo');
       let err1;
       try {
-        assert.fail(X`synful ${fooErr}`);
+        Fail`synful ${fooErr}`;
       } catch (e1) {
         err1 = e1;
       }
-      assert.fail(X`because ${err1}`);
+      Fail`because ${err1}`;
     },
     /because/,
     [['log', 'Caught', Error]],
@@ -101,11 +101,11 @@ test('causal tree', t => {
       const fooErr = SyntaxError('foo');
       let err1;
       try {
-        assert.fail(X`synful ${fooErr}`);
+        Fail`synful ${fooErr}`;
       } catch (e1) {
         err1 = e1;
       }
-      assert.fail(X`because ${err1}`);
+      Fail`because ${err1}`;
     },
     /because/,
     [
@@ -149,12 +149,12 @@ test('a causal tree falls silently', t => {
     const fooErr = SyntaxError('foo');
     let err1;
     try {
-      assert.fail(X`synful ${fooErr}`);
+      Fail`synful ${fooErr}`;
     } catch (e1) {
       err1 = e1;
     }
     try {
-      assert.fail(X`because ${err1}`);
+      Fail`because ${err1}`;
     } catch (e2) {
       t.assert(e2 instanceof Error);
     }
@@ -165,12 +165,12 @@ test('a causal tree falls silently', t => {
       const fooErr = SyntaxError('foo');
       let err1;
       try {
-        assert.fail(X`synful ${fooErr}`);
+        Fail`synful ${fooErr}`;
       } catch (e1) {
         err1 = e1;
       }
       try {
-        assert.fail(X`because ${err1}`);
+        Fail`because ${err1}`;
       } catch (e2) {
         t.assert(e2 instanceof Error);
       }
@@ -336,15 +336,12 @@ test('makeError named', t => {
 });
 
 test('assert.quote', t => {
+  throwsAndLogs(t, () => Fail`<${'bar'},${q('baz')}>`, /<\(a string\),"baz">/, [
+    ['log', 'Caught', Error],
+  ]);
   throwsAndLogs(
     t,
-    () => assert.fail(X`<${'bar'},${q('baz')}>`),
-    /<\(a string\),"baz">/,
-    [['log', 'Caught', Error]],
-  );
-  throwsAndLogs(
-    t,
-    () => assert.fail(X`<${'bar'},${q('baz')}>`),
+    () => Fail`<${'bar'},${q('baz')}>`,
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
@@ -355,47 +352,45 @@ test('assert.quote', t => {
   );
   /** @type {any[]} */
   const list = ['a', 'b', 'c'];
-  throwsAndLogs(t, () => assert.fail(X`${q(list)}`), /\["a","b","c"\]/, [
+  throwsAndLogs(t, () => Fail`${q(list)}`, /\["a","b","c"\]/, [
     ['log', 'Caught', Error],
   ]);
   const repeat = { x: list, y: list };
   throwsAndLogs(
     t,
-    () => assert.fail(X`${q(repeat)}`),
+    () => Fail`${q(repeat)}`,
     /{"x":\["a","b","c"\],"y":"\[Seen\]"}/,
     [['log', 'Caught', Error]],
   );
   // Make it into a cycle
   list[1] = list;
-  throwsAndLogs(t, () => assert.fail(X`${q(list)}`), /\["a","\[Seen\]","c"\]/, [
+  throwsAndLogs(t, () => Fail`${q(list)}`, /\["a","\[Seen\]","c"\]/, [
     ['log', 'Caught', Error],
   ]);
   throwsAndLogs(
     t,
-    () => assert.fail(X`${q(repeat)}`),
+    () => Fail`${q(repeat)}`,
     /{"x":\["a","\[Seen\]","c"\],"y":"\[Seen\]"}/,
     [['log', 'Caught', Error]],
   );
 });
 
 test('assert.bare', t => {
-  throwsAndLogs(t, () => assert.fail(X`${b('foo')}`), 'foo', [
-    ['log', 'Caught', Error],
-  ]);
+  throwsAndLogs(t, () => Fail`${b('foo')}`, 'foo', [['log', 'Caught', Error]]);
   // Spaces are allowed in bare values.
-  throwsAndLogs(t, () => assert.fail(X`${b('foo bar')}`), 'foo bar', [
+  throwsAndLogs(t, () => Fail`${b('foo bar')}`, 'foo bar', [
     ['log', 'Caught', Error],
   ]);
   // Multiple consecutive spaces are disallowed and fall back to quote.
-  throwsAndLogs(t, () => assert.fail(X`${b('foo  bar')}`), '"foo  bar"', [
+  throwsAndLogs(t, () => Fail`${b('foo  bar')}`, '"foo  bar"', [
     ['log', 'Caught', Error],
   ]);
   // Strings with non-word punctuation also fall back.
-  throwsAndLogs(t, () => assert.fail(X`${b('foo%bar')}`), '"foo%bar"', [
+  throwsAndLogs(t, () => Fail`${b('foo%bar')}`, '"foo%bar"', [
     ['log', 'Caught', Error],
   ]);
   // Non-strings also fall back.
-  throwsAndLogs(t, () => assert.fail(X`${b(undefined)}`), '"[undefined]"', [
+  throwsAndLogs(t, () => Fail`${b(undefined)}`, '"[undefined]"', [
     ['log', 'Caught', Error],
   ]);
 });

--- a/packages/ses/test/error/tame-console-unfilteredError.test.js
+++ b/packages/ses/test/error/tame-console-unfilteredError.test.js
@@ -6,10 +6,10 @@ const originalConsole = console;
 
 lockdown({ errorTaming: 'safe', stackFiltering: 'verbose' });
 
-const { details: X, quote: q, note: annotateError } = assert;
+const { details: X, quote: q, note: annotateError, Fail } = assert;
 
 test('ava message disclosure quiet', t => {
-  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => Fail`a secret ${666} and a public ${q(777)}`, {
     message: /a secret \(a number\) and a public 777/,
   });
 });
@@ -50,7 +50,7 @@ test('assert - safe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -61,7 +61,7 @@ test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   });
 });
 

--- a/packages/ses/test/error/tame-console-unsafe-unfilteredError.test.js
+++ b/packages/ses/test/error/tame-console-unsafe-unfilteredError.test.js
@@ -10,10 +10,10 @@ lockdown({
   stackFiltering: 'verbose',
 });
 
-const { details: X, quote: q, note: annotateError } = assert;
+const { details: X, quote: q, note: annotateError, Fail } = assert;
 
 test('ava message disclosure quiet', t => {
-  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => Fail`a secret ${666} and a public ${q(777)}`, {
     message: /a secret \(a number\) and a public 777/,
   });
 });
@@ -57,7 +57,7 @@ test('assert - unsafe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -68,7 +68,7 @@ test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   });
 });
 

--- a/packages/ses/test/error/tame-console-unsafe-unsafeError-unfilteredError.test.js
+++ b/packages/ses/test/error/tame-console-unsafe-unsafeError-unfilteredError.test.js
@@ -12,10 +12,10 @@ lockdown({
 });
 
 // Grab `details` only after lockdown
-const { details: X, quote: q, note: annotateError } = assert;
+const { details: X, quote: q, note: annotateError, Fail } = assert;
 
 test('ava message disclosure blabs', t => {
-  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => Fail`a secret ${666} and a public ${q(777)}`, {
     message: /a secret 666 and a public 777/,
   });
 });
@@ -59,7 +59,7 @@ test('assert - unsafe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -70,7 +70,7 @@ test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   });
 });
 

--- a/packages/ses/test/error/tame-console-unsafe-unsafeError.test.js
+++ b/packages/ses/test/error/tame-console-unsafe-unsafeError.test.js
@@ -11,10 +11,10 @@ lockdown({
 });
 
 // Grab `details` only after lockdown
-const { details: X, quote: q, note: annotateError } = assert;
+const { details: X, quote: q, note: annotateError, Fail } = assert;
 
 test('ava message disclosure blabs', t => {
-  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => Fail`a secret ${666} and a public ${q(777)}`, {
     message: /a secret 666 and a public 777/,
   });
 });
@@ -58,7 +58,7 @@ test('assert - unsafe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -69,7 +69,7 @@ test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   });
 });
 

--- a/packages/ses/test/error/tame-console-unsafe.test.js
+++ b/packages/ses/test/error/tame-console-unsafe.test.js
@@ -6,10 +6,10 @@ const originalConsole = console;
 
 lockdown({ errorTaming: 'safe', consoleTaming: 'unsafe' });
 
-const { details: X, quote: q, note: annotateError } = assert;
+const { details: X, quote: q, note: annotateError, Fail } = assert;
 
 test('ava message disclosure quiet', t => {
-  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => Fail`a secret ${666} and a public ${q(777)}`, {
     message: /a secret \(a number\) and a public 777/,
   });
 });
@@ -54,7 +54,7 @@ test('assert - unsafe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -65,7 +65,7 @@ test('assert - unlogged unsafe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   });
 });
 

--- a/packages/ses/test/error/tame-console-unsafeError.test.js
+++ b/packages/ses/test/error/tame-console-unsafeError.test.js
@@ -7,10 +7,10 @@ const originalConsole = console;
 lockdown({ errorTaming: 'unsafe' });
 
 // Grab `details` only after lockdown
-const { details: X, quote: q, note: annotateError } = assert;
+const { details: X, quote: q, note: annotateError, Fail } = assert;
 
 test('ava message disclosure blabs', t => {
-  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => Fail`a secret ${666} and a public ${q(777)}`, {
     message: /a secret 666 and a public 777/,
   });
 });
@@ -51,7 +51,7 @@ test('assert - safe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -62,7 +62,7 @@ test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   });
 });
 

--- a/packages/ses/test/error/tame-console.test.js
+++ b/packages/ses/test/error/tame-console.test.js
@@ -6,10 +6,10 @@ const originalConsole = console;
 
 lockdown({ errorTaming: 'safe' });
 
-const { details: X, quote: q, note: annotateError } = assert;
+const { details: X, quote: q, note: annotateError, Fail } = assert;
 
 test('ava message disclosure default', t => {
-  t.throws(() => assert.fail(X`a secret ${666} and a public ${q(777)}`), {
+  t.throws(() => Fail`a secret ${666} and a public ${q(777)}`, {
     message: /a secret \(a number\) and a public 777/,
   });
 });
@@ -58,7 +58,7 @@ test('assert - safe', t => {
   try {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   } catch (barErr) {
     console.error('bar happens', barErr);
   }
@@ -73,7 +73,7 @@ test('assert - unlogged safe', t => {
   t.throws(() => {
     const obj = {};
     const fooErr = SyntaxError('foo');
-    assert.fail(X`caused by ${fooErr},${obj}`);
+    Fail`caused by ${fooErr},${obj}`;
   });
 });
 

--- a/packages/ses/types.test-d.ts
+++ b/packages/ses/types.test-d.ts
@@ -224,7 +224,7 @@ expectType<Error>(
   }),
 );
 
-expectType<never>(assert.fail(X`details are ${stringable}`));
+expectType<never>(Fail`details are ${stringable}`);
 
 // eslint-disable-next-line no-unreachable
 expectType<never>(Fail`details are ${stringable}`);


### PR DESCRIPTION

Closes: #XXXX
Refs: https://github.com/Agoric/agoric-sdk/pull/11458

## Description

Whenever we say, for example, 
```js
assert.fail(X`...`)
```
we should instead say
```js
Fail`...`
```

This PR is a refactor doing exactly this.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

Most of the uses were in tests.

### Compatibility Considerations

none
### Upgrade Considerations

none