### PR TITLE
fix(immutable-arraybuffer): capture structuredClone early

### DIFF
--- a/packages/immutable-arraybuffer/index.js
+++ b/packages/immutable-arraybuffer/index.js
@@ -3,6 +3,8 @@
 const { setPrototypeOf, getOwnPropertyDescriptors } = Object;
 const { apply } = Reflect;
 const { prototype: arrayBufferPrototype } = ArrayBuffer;
+// Capture structuredClone before it could be scuttled.
+const { structuredClone: originalStructuredCloneMaybe } = globalThis;
 
 const {
   slice,
@@ -38,12 +40,12 @@ let arrayBufferTransfer;
 
 if (transfer) {
   arrayBufferTransfer = arrayBuffer => apply(transfer, arrayBuffer, []);
-} else if (globalThis.structuredClone) {
+} else if (originalStructuredCloneMaybe) {
   arrayBufferTransfer = arrayBuffer => {
     // Hopefully, a zero-length slice is cheap, but still enforces that
     // `arrayBuffer` is a genuine `ArrayBuffer` exotic object.
     arrayBufferSlice(arrayBuffer, 0, 0);
-    return globalThis.structuredClone(arrayBuffer, { transfer: [arrayBuffer] });
+    return originalStructuredCloneMaybe(arrayBuffer, { transfer: [arrayBuffer] });
   };
 } else {
   // Indeed, Node <= 16 has neither.

--- a/packages/immutable-arraybuffer/index.js
+++ b/packages/immutable-arraybuffer/index.js
@@ -45,7 +45,9 @@ if (transfer) {
     // Hopefully, a zero-length slice is cheap, but still enforces that
     // `arrayBuffer` is a genuine `ArrayBuffer` exotic object.
     arrayBufferSlice(arrayBuffer, 0, 0);
-    return originalStructuredCloneMaybe(arrayBuffer, { transfer: [arrayBuffer] });
+    return originalStructuredCloneMaybe(arrayBuffer, {
+      transfer: [arrayBuffer],
+    });
   };
 } else {
   // Indeed, Node <= 16 has neither.


### PR DESCRIPTION

Closes: #XXXX
Refs: https://github.com/endojs/endo/pull/2785

## Description

The Immutable ArrayBuffer shim, on non-Hermes, relies on the existence of *either* a global `structuredClone` or `Array.prototype.transfer`. However, I forgot to capture early the global `structuredClone` into a module-local one, and to then use that repeatedly. MetaMask scuttling deleted the global `structuredClone`, running headlong into my mistake on platforms (Node 18 and Node 20) that do not also have `Array.prototype.transfer`.

This PR fixes that mistake, capturing `structuredClone` early, and then using the resulting module-local one.

### Security Considerations

The bug this PR fixes was a security hazard.

### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

In theory, we should add scuttling as an orthogonal dimension of our platform testing matrix. However that is rather expensive for minor benefit.

### Compatibility Considerations

The bug created compat problems that this PR fixes.
### Upgrade Considerations

none