### PR TITLE
feat(compartment-mapper): support mapping of undiscoverable packages

### DIFF
--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -96,6 +96,9 @@
   "eslintConfig": {
     "extends": [
       "plugin:@endo/internal"
+    ],
+    "ignorePatterns": [
+      "test/fixtures-additional-modules/*.js"
     ]
   },
   "prettier": {

--- a/packages/compartment-mapper/src/capture-lite.js
+++ b/packages/compartment-mapper/src/capture-lite.js
@@ -95,6 +95,7 @@ export const captureFromMap = async (powers, compartmentMap, options = {}) => {
     sourceMapHook = undefined,
     parserForLanguage: parserForLanguageOption = {},
     Compartment = defaultCompartment,
+    additionalPackageDetails = {},
   } = options;
 
   const parserForLanguage = freeze(
@@ -127,6 +128,7 @@ export const captureFromMap = async (powers, compartmentMap, options = {}) => {
     entryModuleSpecifier,
     importHook: consolidatedExitModuleImportHook,
     sourceMapHook,
+    additionalPackageDetails,
   });
   // Induce importHook to record all the necessary modules to import the given module specifier.
   const { compartment, attenuatorsCompartment } = link(compartmentMap, {

--- a/packages/compartment-mapper/src/types/internal.ts
+++ b/packages/compartment-mapper/src/types/internal.ts
@@ -23,6 +23,7 @@ import type {
 } from './powers.js';
 import type { DeferredAttenuatorsProvider } from './policy.js';
 import type {
+  AdditionalPackageDetailsOptions,
   ArchiveOnlyOption,
   AsyncParseFn,
   CompartmentSources,
@@ -83,7 +84,8 @@ export type MakeImportHookMakersOptions = {
   SourceMapHookOption;
 
 export type MakeImportHookMakerOptions = MakeImportHookMakersOptions &
-  ExitModuleImportHookOption;
+  ExitModuleImportHookOption &
+  AdditionalPackageDetailsOptions;
 export type MakeImportNowHookMakerOptions = MakeImportHookMakersOptions &
   ExitModuleImportNowHookOption;
 

--- a/packages/compartment-mapper/src/types/node-modules.ts
+++ b/packages/compartment-mapper/src/types/node-modules.ts
@@ -2,21 +2,17 @@ import type {
   Language,
   LanguageForExtension,
 } from './compartment-map-schema.js';
-import type { LogOptions } from './external.js';
+import type {
+  AdditionalPackageDetailsOptions,
+  LogOptions,
+} from './external.js';
 import type { PackageDescriptor } from './internal.js';
+import type { SomePolicy } from './policy-schema.js';
 
 export type CommonDependencyDescriptors = Record<
   string,
   { spec: string; alias: string }
 >;
-
-export type GraphPackageOptions = {
-  preferredPackageLogicalPathMap?: Map<string, string[]>;
-  logicalPath?: string[];
-  commonDependencyDescriptors?: CommonDependencyDescriptors;
-} & LogOptions;
-
-export type GraphPackagesOptions = LogOptions;
 
 export type GatherDependencyOptions = {
   childLogicalPath?: string[];
@@ -87,3 +83,20 @@ export interface PackageDetails {
   packageLocation: string;
   packageDescriptor: PackageDescriptor;
 }
+
+/**
+ * Options for `translateGraph()`
+ */
+export type TranslateGraphOptions = {
+  policy?: SomePolicy;
+} & AdditionalPackageDetailsOptions;
+
+export type GraphPackageOptions = {
+  preferredPackageLogicalPathMap?: Map<string, string[]>;
+  logicalPath?: string[];
+  commonDependencyDescriptors?: CommonDependencyDescriptors;
+} & LogOptions;
+
+export type GraphPackagesOptions = LogOptions & {
+  graph?: Graph;
+};

--- a/packages/compartment-mapper/test/fixtures-additional-modules/config.js
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  config: require('pippo'),
+};

--- a/packages/compartment-mapper/test/fixtures-additional-modules/index.js
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  paperino: require('paperino'),
+};

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/gambadilegno/index.js
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/gambadilegno/index.js
@@ -1,0 +1,1 @@
+module.exports = require('goofy');

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/gambadilegno/package.json
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/gambadilegno/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gambadilegno",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "goofy": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/goofy/index.js
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/goofy/index.js
@@ -1,0 +1,5 @@
+module.exports = require('paperino/paperino.js')
+
+const config = require.resolve('../../config.js')
+
+require(config);

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/goofy/package.json
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/goofy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "goofy",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "paperino": "1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/paperino/index.js
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/paperino/index.js
@@ -1,0 +1,1 @@
+module.exports = {value: 'index'}

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/paperino/package.json
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/paperino/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "paperino",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/paperino/paperino.js
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/paperino/paperino.js
@@ -1,0 +1,1 @@
+module.exports = {value: 'paperino'}

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/pippo/index.js
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/pippo/index.js
@@ -1,0 +1,1 @@
+module.exports = require('gambadilegno');

--- a/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/pippo/package.json
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/node_modules/pippo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pippo",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "gambadilegno": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-additional-modules/package.json
+++ b/packages/compartment-mapper/test/fixtures-additional-modules/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "dependencies": {
+    "paperino": "^1.0.0",
+    "pippo": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/map-node-modules.test.js
+++ b/packages/compartment-mapper/test/map-node-modules.test.js
@@ -7,7 +7,7 @@ import test from 'ava';
 import { mapNodeModules } from '../src/node-modules.js';
 import { makeReadPowers } from '../src/node-powers.js';
 /**
- * @import {CompartmentDescriptor, MaybeReadFn} from '../src/types.js'
+ * @import {AdditionalPackageDetailsMap, CompartmentDescriptor, MaybeReadFn, PackageDetails} from '../src/types.js'
  */
 
 const { keys, values } = Object;
@@ -96,4 +96,93 @@ test('mapNodeModules() should not consider peerDependenciesMeta without correspo
   const compartmentMap = await mapNodeModules(readPowers, moduleLocation);
 
   t.is(keys(compartmentMap.compartments).length, 1);
+});
+
+test('mapNodeModules() should accept additional module locations', async t => {
+  const readPowers = makeReadPowers({ fs, url });
+
+  const entryModuleLocation = new URL(
+    'fixtures-additional-modules/node_modules/goofy/index.js',
+    import.meta.url,
+  ).href;
+
+  const additionalModuleLocations = {
+    [entryModuleLocation]: [
+      new URL('fixtures-additional-modules/config.js', import.meta.url).href,
+    ],
+  };
+
+  /** @type {AdditionalPackageDetailsMap} */
+  const additionalPackageDetails = {};
+  const compartmentMap = await mapNodeModules(readPowers, entryModuleLocation, {
+    additionalModuleLocations,
+    additionalPackageDetails,
+  });
+
+  t.is(
+    keys(additionalPackageDetails).length,
+    1,
+    'additionalPackageDetails should contain one entry',
+  );
+
+  for (const [packageLocation, [additionalDetail]] of Object.entries(
+    additionalPackageDetails,
+  )) {
+    t.true(
+      packageLocation.endsWith('goofy/'),
+      'the "goofy" package should contain details about an additional module',
+    );
+    t.true(
+      additionalDetail.packageLocation.endsWith('fixtures-additional-modules/'),
+      'the additional module should refer to the package at the root of the fixture',
+    );
+    t.is(
+      additionalDetail.moduleSpecifier,
+      './config.js',
+      'the additional package details module specifier should be config.js',
+    );
+  }
+
+  const { compartment: entryCompartmentName } = compartmentMap.entry;
+  const entryCompartmentDescriptor =
+    compartmentMap.compartments[entryCompartmentName];
+
+  t.truthy(
+    entryCompartmentName.endsWith(
+      'fixtures-additional-modules/node_modules/goofy/',
+    ),
+    'entry compartment descriptor should correspond to the entry module location package',
+  );
+  t.is(
+    keys(entryCompartmentDescriptor.modules).length,
+    4,
+    'entry compartment descriptor should have no extra modules',
+  );
+
+  t.deepEqual(
+    values(compartmentMap.compartments)
+      .map(compartment => compartment.name)
+      .sort(),
+    ['app', 'pippo', 'goofy', 'gambadilegno', 'paperino'].sort(),
+  );
+
+  // the entry module is the module which should reference the additional module,
+  // which is "app"
+  t.deepEqual(
+    keys(entryCompartmentDescriptor.modules).sort(),
+    ['.', 'app', 'goofy', 'paperino'].sort(),
+    'entry compartment descriptor should reference the expected modules',
+  );
+
+  t.deepEqual(
+    keys(entryCompartmentDescriptor.scopes).sort(),
+    ['app', 'goofy', 'paperino'].sort(),
+    'entry compartment descriptor should reference the expected scopes',
+  );
+
+  t.is(
+    entryCompartmentDescriptor.modules.app.module,
+    './index.js',
+    'entry compartment descriptor should reference the additional package in "app" as index.js',
+  );
 });


### PR DESCRIPTION
## Description

This adds the `additionalPackageLocations` and `additionalPackageDetails` options to `mapNodeModules()`. The former is a mapping of module location to one or more additional module locations. The latter is a data structure `mapNodeModules` will populate, which can then be provided to `captureFromMap` (which is in turn provided to `makeImportHookMaker()`.

This is intended to be used when dynamic requires prevent `mapNodeModules` & `captureFromMap` from otherwise creating a complete `CompartmentMapDescriptor` due to its ignorance of what would be dynamically required. Archival is not a use-case.

Also:

- Fixed signature of `chooseModuleDescriptor`
- Tweaked ESLint config to ignore my new fixture
- Add options type for `translateGraph`
- Fixed deprecation notice for `compartmentMapForNodeModules`; it was previously on the options object, but it should only be on the export.
- `graphPackages` now accepts an optional `Graph` object to be able to re-use the same graph between runs

### Questions for Reviewers

- Naming is hard and I was not sure what to name the new options. The `AdditionalPackageDetails` type looks like the existing `PackageDetails` type (with a new field) thus influencing the naming—but they are otherwise unrelated and because of this I did not extend `PackageDetails`.
- I am monkeying with `imports` in a `RecordModuleDescriptor` object in order to influence the module loader. Is there a better way? The things I stuff in `imports` are also _extremely dubious._

### Security Considerations

n/a

These changes do not meddle with systems loading untrusted code, afaik.

### Scaling Considerations

Use of the new option is not free.

### Documentation Considerations

n/a

### Testing Considerations

I did add some tests, but could probably use more.

### Compatibility Considerations

No.

### Upgrade Considerations

This warrants an entry in `NEWS.md` since it is part of a public API.
