### PR TITLE
chore: Release 2025-06-17

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.11](https://github.com/endojs/endo/compare/@endo/base64@1.0.10...@endo/base64@1.0.11) (2025-06-17)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [1.0.10](https://github.com/endojs/endo/compare/@endo/base64@1.0.9...@endo/base64@1.0.10) (2025-06-02)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Transcodes base64",
   "keywords": [
     "base64",

--- a/packages/benchmark/CHANGELOG.md
+++ b/packages/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.3](https://github.com/endojs/endo/compare/@endo/benchmark@0.1.2...@endo/benchmark@0.1.3) (2025-06-17)
+
+**Note:** Version bump only for package @endo/benchmark
+
+
+
+
+
 ### [0.1.2](https://github.com/endojs/endo/compare/@endo/benchmark@0.1.1...@endo/benchmark@0.1.2) (2025-06-02)
 
 **Note:** Version bump only for package @endo/benchmark

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/benchmark",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Endo benchmarking ",
   "keywords": [],

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.1](https://github.com/endojs/endo/compare/@endo/bundle-source@4.1.0...@endo/bundle-source@4.1.1) (2025-06-17)
+
+**Note:** Version bump only for package @endo/bundle-source
+
+
+
+
+
 ## [4.1.0](https://github.com/endojs/endo/compare/@endo/bundle-source@4.0.0...@endo/bundle-source@4.1.0) (2025-06-02)
 
 

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.4.7](https://github.com/endojs/endo/compare/@endo/captp@4.4.6...@endo/captp@4.4.7) (2025-06-17)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ### [4.4.6](https://github.com/endojs/endo/compare/@endo/captp@4.4.5...@endo/captp@4.4.6) (2025-06-02)
 
 

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.4.6",
+  "version": "4.4.7",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.16](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.15...@endo/check-bundle@1.0.16) (2025-06-17)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [1.0.15](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.14...@endo/check-bundle@1.0.15) (2025-06-02)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",

--- a/packages/cjs-module-analyzer/CHANGELOG.md
+++ b/packages/cjs-module-analyzer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.11](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@1.0.10...@endo/cjs-module-analyzer@1.0.11) (2025-06-17)
+
+**Note:** Version bump only for package @endo/cjs-module-analyzer
+
+
+
+
+
 ### [1.0.10](https://github.com/endojs/endo/compare/@endo/cjs-module-analyzer@1.0.9...@endo/cjs-module-analyzer@1.0.10) (2025-06-02)
 
 **Note:** Version bump only for package @endo/cjs-module-analyzer

--- a/packages/cjs-module-analyzer/package.json
+++ b/packages/cjs-module-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cjs-module-analyzer",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A JavaScript lexer dedicated to static analysis and transformation of ECMAScript modules.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.10](https://github.com/endojs/endo/compare/@endo/cli@2.3.9...@endo/cli@2.3.10) (2025-06-17)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [2.3.9](https://github.com/endojs/endo/compare/@endo/cli@2.3.8...@endo/cli@2.3.9) (2025-06-02)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.12](https://github.com/endojs/endo/compare/@endo/common@1.2.11...@endo/common@1.2.12) (2025-06-17)
+
+**Note:** Version bump only for package @endo/common
+
+
+
+
+
 ### [1.2.11](https://github.com/endojs/endo/compare/@endo/common@1.2.10...@endo/common@1.2.11) (2025-06-02)
 
 **Note:** Version bump only for package @endo/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/common",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "common low level utilities",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.6.1...@endo/compartment-mapper@1.6.2) (2025-06-17)
+
+
+### Bug Fixes
+
+* **compartment-mapper:** stub require.extensions ([37d948e](https://github.com/endojs/endo/commit/37d948e333ecc230b055fe760048879a5eb82eb9)), closes [#2825](https://github.com/endojs/endo/issues/2825)
+
+
+
 ### [1.6.1](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.6.0...@endo/compartment-mapper@1.6.1) (2025-06-02)
 
 

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes to `@endo/compartment-mapper`:
 
+# v1.6.2 (2025-06-17)
+
+- Produces a stub for `require.extensions` in CommonJS modules to increase
+  ecosystem compatibility.
+
 # v1.6.1 (2025-06-02)
 
 - The `dev` flag for `mapNodeModules()` is no longer deprecated.  The concept

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.5.0](https://github.com/endojs/endo/compare/@endo/daemon@2.4.9...@endo/daemon@2.5.0) (2025-06-17)
+
+
+### Features
+
+* **daemon:** PINS restored on startup ([3a348ce](https://github.com/endojs/endo/commit/3a348cee67f74c9ce85623ad79060e426e1965db))
+
+
+
 ### [2.4.9](https://github.com/endojs/endo/compare/@endo/daemon@2.4.8...@endo/daemon@2.4.9) (2025-06-02)
 
 **Note:** Version bump only for package @endo/daemon

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.4.9",
+  "version": "2.5.0",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/env-options/CHANGELOG.md
+++ b/packages/env-options/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.10](https://github.com/endojs/endo/compare/@endo/env-options@1.1.9...@endo/env-options@1.1.10) (2025-06-17)
+
+**Note:** Version bump only for package @endo/env-options
+
+
+
+
+
 ### [1.1.9](https://github.com/endojs/endo/compare/@endo/env-options@1.1.8...@endo/env-options@1.1.9) (2025-06-02)
 
 

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/env-options",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Reading environment options.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.12](https://github.com/endojs/endo/compare/@endo/errors@1.2.11...@endo/errors@1.2.12) (2025-06-17)
+
+**Note:** Version bump only for package @endo/errors
+
+
+
+
+
 ### [1.2.11](https://github.com/endojs/endo/compare/@endo/errors@1.2.10...@endo/errors@1.2.11) (2025-06-02)
 
 **Note:** Version bump only for package @endo/errors

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/errors",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.2](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.3.1...@endo/eslint-plugin@2.3.2) (2025-06-17)
+
+**Note:** Version bump only for package @endo/eslint-plugin
+
+
+
+
+
 ### [2.3.1](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.3.0...@endo/eslint-plugin@2.3.1) (2025-06-02)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/evasive-transform/CHANGELOG.md
+++ b/packages/evasive-transform/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.0.1](https://github.com/endojs/endo/compare/@endo/evasive-transform@2.0.0...@endo/evasive-transform@2.0.1) (2025-06-17)
+
+**Note:** Version bump only for package @endo/evasive-transform
+
+
+
+
+
 ## [2.0.0](https://github.com/endojs/endo/compare/@endo/evasive-transform@1.4.0...@endo/evasive-transform@2.0.0) (2025-06-02)
 
 

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/evasive-transform",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Source transforms to evade SES censorship",
   "keywords": [
     "ses",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.3](https://github.com/endojs/endo/compare/@endo/eventual-send@1.3.2...@endo/eventual-send@1.3.3) (2025-06-17)
+
+**Note:** Version bump only for package @endo/eventual-send
+
+
+
+
+
 ### [1.3.2](https://github.com/endojs/endo/compare/@endo/eventual-send@1.3.1...@endo/eventual-send@1.3.2) (2025-06-02)
 
 **Note:** Version bump only for package @endo/eventual-send

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.11](https://github.com/endojs/endo/compare/@endo/exo@1.5.10...@endo/exo@1.5.11) (2025-06-17)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.10](https://github.com/endojs/endo/compare/@endo/exo@1.5.9...@endo/exo@1.5.10) (2025-06-02)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.13](https://github.com/endojs/endo/compare/@endo/far@1.1.12...@endo/far@1.1.13) (2025-06-17)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.12](https://github.com/endojs/endo/compare/@endo/far@1.1.11...@endo/far@1.1.12) (2025-06-02)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/immutable-arraybuffer/CHANGELOG.md
+++ b/packages/immutable-arraybuffer/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.1](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@1.1.0...@endo/immutable-arraybuffer@1.1.1) (2025-06-17)
+
+
+### Bug Fixes
+
+* **immutable-arraybuffer:** capture structuredClone early ([#2853](https://github.com/endojs/endo/issues/2853)) ([a12c5c5](https://github.com/endojs/endo/commit/a12c5c5d7d2b476a9ff3d383bc9275b6cc5ae052))
+* **pass-style:** better byteArray support ([#2843](https://github.com/endojs/endo/issues/2843)) ([492551a](https://github.com/endojs/endo/commit/492551a936cf74fbeff0935b95fbd02ce02f796a)), closes [#2248](https://github.com/endojs/endo/issues/2248) [#2248](https://github.com/endojs/endo/issues/2248) [#2248](https://github.com/endojs/endo/issues/2248)
+
+
+
 ## [1.1.0](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@1.0.0...@endo/immutable-arraybuffer@1.1.0) (2025-06-02)
 
 

--- a/packages/immutable-arraybuffer/NEWS.md
+++ b/packages/immutable-arraybuffer/NEWS.md
@@ -1,5 +1,12 @@
 User visible changes in `@endo/immutable-arraybuffer`:
 
+# 1.1.1 (2025-06-17)
+
+- Captures `structuredClone` early so that scuttling all properties of `globalThis`
+  after initializing `@endo/immutable-arraybuffer` or
+  `@endo/immutable-arraybuffer/shim.js` does not interfere with this module's
+  designed behavior.
+
 # 1.0.0 (2025-05-07)
 
 First release.

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/immutable-arraybuffer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Immutable ArrayBuffer (the shim!)",
   "keywords": [
     "immutable",

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.1](https://github.com/endojs/endo/compare/@endo/import-bundle@1.5.0...@endo/import-bundle@1.5.1) (2025-06-17)
+
+**Note:** Version bump only for package @endo/import-bundle
+
+
+
+
+
 ## [1.5.0](https://github.com/endojs/endo/compare/@endo/import-bundle@1.4.0...@endo/import-bundle@1.5.0) (2025-06-02)
 
 

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "load modules created by @endo/bundle-source",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.11](https://github.com/endojs/endo/compare/@endo/init@1.1.10...@endo/init@1.1.11) (2025-06-17)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [1.1.10](https://github.com/endojs/endo/compare/@endo/init@1.1.9...@endo/init@1.1.10) (2025-06-02)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.17](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.16...@endo/lockdown@1.0.17) (2025-06-17)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [1.0.16](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.15...@endo/lockdown@1.0.16) (2025-06-02)
 
 

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.12](https://github.com/endojs/endo/compare/@endo/lp32@1.1.11...@endo/lp32@1.1.12) (2025-06-17)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [1.1.11](https://github.com/endojs/endo/compare/@endo/lp32@1.1.10...@endo/lp32@1.1.11) (2025-06-02)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.7.1](https://github.com/endojs/endo/compare/@endo/marshal@1.7.0...@endo/marshal@1.7.1) (2025-06-17)
+
+
+### Bug Fixes
+
+* **marshal:** fix consequence of typo ([#2841](https://github.com/endojs/endo/issues/2841)) ([fbee7d9](https://github.com/endojs/endo/commit/fbee7d9b86b535c5d3f3cb23caa68b5ca0facb89))
+* **pass-style:** better byteArray support ([#2843](https://github.com/endojs/endo/issues/2843)) ([492551a](https://github.com/endojs/endo/commit/492551a936cf74fbeff0935b95fbd02ce02f796a)), closes [#2248](https://github.com/endojs/endo/issues/2248) [#2248](https://github.com/endojs/endo/issues/2248) [#2248](https://github.com/endojs/endo/issues/2248)
+
+
+
 ## [1.7.0](https://github.com/endojs/endo/compare/@endo/marshal@1.6.4...@endo/marshal@1.7.0) (2025-06-02)
 
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/memoize/CHANGELOG.md
+++ b/packages/memoize/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.12](https://github.com/endojs/endo/compare/@endo/memoize@1.1.11...@endo/memoize@1.1.12) (2025-06-17)
+
+**Note:** Version bump only for package @endo/memoize
+
+
+
+
+
 ### [1.1.11](https://github.com/endojs/endo/compare/@endo/memoize@1.1.10...@endo/memoize@1.1.11) (2025-06-02)
 
 **Note:** Version bump only for package @endo/memoize

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/memoize",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Safe function memoization",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/module-source/CHANGELOG.md
+++ b/packages/module-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.2](https://github.com/endojs/endo/compare/@endo/module-source@1.3.1...@endo/module-source@1.3.2) (2025-06-17)
+
+**Note:** Version bump only for package @endo/module-source
+
+
+
+
+
 ### [1.3.1](https://github.com/endojs/endo/compare/@endo/module-source@1.3.0...@endo/module-source@1.3.1) (2025-06-02)
 
 

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/module-source",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Ponyfill for the SES ModuleSource and module-to-program transformer",
   "keywords": [
     "ses",

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.1.2](https://github.com/endojs/endo/compare/@endo/nat@5.1.1...@endo/nat@5.1.2) (2025-06-17)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [5.1.1](https://github.com/endojs/endo/compare/@endo/nat@5.1.0...@endo/nat@5.1.1) (2025-06-02)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.17](https://github.com/endojs/endo/compare/@endo/netstring@1.0.16...@endo/netstring@1.0.17) (2025-06-17)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [1.0.16](https://github.com/endojs/endo/compare/@endo/netstring@1.0.15...@endo/netstring@1.0.16) (2025-06-02)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/ocapn/CHANGELOG.md
+++ b/packages/ocapn/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.1](https://github.com/endojs/endo/compare/@endo/ocapn@0.2.0...@endo/ocapn@0.2.1) (2025-06-17)
+
+**Note:** Version bump only for package @endo/ocapn
+
+
+
+
+
 ## 0.2.0 (2025-06-02)
 
 

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ocapn",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": null,
   "keywords": [],

--- a/packages/panic/CHANGELOG.md
+++ b/packages/panic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.1](https://github.com/endojs/endo/compare/@endo/panic@1.0.0...@endo/panic@1.0.1) (2025-06-17)
+
+**Note:** Version bump only for package @endo/panic
+
+
+
+
+
 ## 0.2.0 (2025-06-02)
 
 

--- a/packages/panic/package.json
+++ b/packages/panic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/panic",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Ponyfill for proposed `panic` function",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.2](https://github.com/endojs/endo/compare/@endo/pass-style@1.6.1...@endo/pass-style@1.6.2) (2025-06-17)
+
+
+### Bug Fixes
+
+* **pass-style:** Shift feature detection from transfer- to slice-ToImmutable ([6afd10c](https://github.com/endojs/endo/commit/6afd10c35be4e20fca73b8583b30523b839689b9))
+
+
+
 ## [1.6.0](https://github.com/endojs/endo/compare/@endo/pass-style@1.5.0...@endo/pass-style@1.6.0) (2025-06-02)
 
 

--- a/packages/pass-style/NEWS.md
+++ b/packages/pass-style/NEWS.md
@@ -1,13 +1,28 @@
 User-visible changes in `@endo/pass-style`:
 
+# v1.6.2 (2024-06-17)
+
+- Fixes, without qualification, so that the package initializes on platforms
+  that lack `ArrayBuffer.prototype.transferToImmutable` and recognizes
+  immutable ArrayBuffers as having a pass-style of `byteArray` on platforms
+  have a `sliceToImmutable`, even if that is emulated with a shim using
+  `slice`, even if they lack `transferToImmutable`.
+
 # v1.6.1 (2024-06-17)
 
+**BROKEN BUT PATCHED** in 1.6.2, contains a fix but published with broken
+dependency versions.
+Inadvertently published without amending workspace protocol dependencies.
+
 - Fixes so that the package initializes on platforms that lack
-  `ArrayBuffer.prototype.transferToImmutable`.
+  `ArrayBuffer.prototype.transferToImmutable` and recognizes immutable
+  ArrayBuffers as having a pass-style of `byteArray` on platforms have a
+  `sliceToImmutable`, even if that is emulated with a shim using `slice`, even
+  if they lack `transferToImmutable`.
 
 # v1.6.0 (2024-06-02)
 
-**BROKEN BUT PATCHED** in 1.6.1, this version introduced a dependence on the
+**BROKEN BUT PATCHED** in 1.6.2, this version introduced a dependence on the
 underlying platform supporting `ArrayBuffer.prototype.transferToImmutable`.
 The patch restores the ability to use `pass-style` on older platforms without
 the immutable `ArrayBuffer` shim (as entrained by `ses`).

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -13,11 +13,11 @@ const { ownKeys, apply } = Reflect;
 const adaptImmutableArrayBuffer = () => {
   const anArrayBuffer = new ArrayBuffer(0);
 
-  // On platforms that do not support transferToImmutable, pass-style byteArray
+  // On platforms that do not support sliceToImmutable, pass-style byteArray
   // cannot be constructed.
   // @ts-expect-error TODO This error will be addressed when updating
   // TypeScript's native types to a version recognizing the upcoming standard.
-  if (anArrayBuffer.transferToImmutable === undefined) {
+  if (anArrayBuffer.sliceToImmutable === undefined) {
     return {
       immutableArrayBufferPrototype: null,
       immutableGetter: () => false,
@@ -26,7 +26,7 @@ const adaptImmutableArrayBuffer = () => {
 
   // @ts-expect-error TODO This error will be addressed when updating
   // TypeScript's native types to a version recognizing the upcoming standard.
-  const anImmutableArrayBuffer = anArrayBuffer.transferToImmutable();
+  const anImmutableArrayBuffer = anArrayBuffer.sliceToImmutable();
 
   /**
    * As proposed, this will be the same as `ArrayBuffer.prototype`. As shimmed,

--- a/packages/path-compare/CHANGELOG.md
+++ b/packages/path-compare/CHANGELOG.md
@@ -3,3 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.1.0 (2025-06-17)
+
+
+### Features
+
+* **path-compare:** create @endo/path-compare ([695b26c](https://github.com/endojs/endo/commit/695b26c42cf61ec23f63c58025a12e802f4d06eb))

--- a/packages/path-compare/package.json
+++ b/packages/path-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/path-compare",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Compare string arrays",
   "keywords": [
     "string",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.1](https://github.com/endojs/endo/compare/@endo/patterns@1.6.0...@endo/patterns@1.6.1) (2025-06-17)
+
+
+### Bug Fixes
+
+* **pass-style:** better byteArray support ([#2843](https://github.com/endojs/endo/issues/2843)) ([492551a](https://github.com/endojs/endo/commit/492551a936cf74fbeff0935b95fbd02ce02f796a)), closes [#2248](https://github.com/endojs/endo/issues/2248) [#2248](https://github.com/endojs/endo/issues/2248) [#2248](https://github.com/endojs/endo/issues/2248)
+
+
+
 ## [1.6.0](https://github.com/endojs/endo/compare/@endo/patterns@1.5.0...@endo/patterns@1.6.0) (2025-06-02)
 
 

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Pattern matching for Passable objects, expressed as Passable data",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.12](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.11...@endo/promise-kit@1.1.12) (2025-06-17)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [1.1.11](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.10...@endo/promise-kit@1.1.11) (2025-06-02)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Helper for making promises",
   "keywords": [
     "promise"

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.1](https://github.com/endojs/endo/compare/@endo/ses-ava@1.3.0...@endo/ses-ava@1.3.1) (2025-06-17)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ## [1.3.0](https://github.com/endojs/endo/compare/@endo/ses-ava@1.2.10...@endo/ses-ava@1.3.0) (2025-06-02)
 
 

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.13.1](https://github.com/endojs/endo/compare/ses@1.13.0...ses@1.13.1) (2025-06-17)
+
+
+### Bug Fixes
+
+* **pass-style:** better byteArray support ([#2843](https://github.com/endojs/endo/issues/2843)) ([492551a](https://github.com/endojs/endo/commit/492551a936cf74fbeff0935b95fbd02ce02f796a)), closes [#2248](https://github.com/endojs/endo/issues/2248) [#2248](https://github.com/endojs/endo/issues/2248) [#2248](https://github.com/endojs/endo/issues/2248)
+
+
+
 ## [1.13.0](https://github.com/endojs/endo/compare/ses@1.12.0...ses@1.13.0) (2025-06-02)
 
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",

--- a/packages/skel/CHANGELOG.md
+++ b/packages/skel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.12](https://github.com/endojs/endo/compare/@endo/skel@1.1.11...@endo/skel@1.1.12) (2025-06-17)
+
+**Note:** Version bump only for package @endo/skel
+
+
+
+
+
 ### [1.1.11](https://github.com/endojs/endo/compare/@endo/skel@1.1.10...@endo/skel@1.1.11) (2025-06-02)
 
 **Note:** Version bump only for package @endo/skel

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/skel",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "private": true,
   "description": null,
   "keywords": [],

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.12](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.11...@endo/stream-node@1.1.12) (2025-06-17)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [1.1.11](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.10...@endo/stream-node@1.1.11) (2025-06-02)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.17](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.16...@endo/stream-types-test@1.0.17) (2025-06-17)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [1.0.16](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.15...@endo/stream-types-test@1.0.16) (2025-06-02)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.12](https://github.com/endojs/endo/compare/@endo/stream@1.2.11...@endo/stream@1.2.12) (2025-06-17)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [1.2.11](https://github.com/endojs/endo/compare/@endo/stream@1.2.10...@endo/stream@1.2.11) (2025-06-02)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.47](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.46...@endo/test262-runner@0.1.47) (2025-06-17)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.46](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.45...@endo/test262-runner@0.1.46) (2025-06-02)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "private": true,
   "description": "Hardened JavaScript Test262 Runner",
   "keywords": [],

--- a/packages/trampoline/CHANGELOG.md
+++ b/packages/trampoline/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.5](https://github.com/endojs/endo/compare/@endo/trampoline@1.0.4...@endo/trampoline@1.0.5) (2025-06-17)
+
+**Note:** Version bump only for package @endo/trampoline
+
+
+
+
+
 ### [1.0.4](https://github.com/endojs/endo/compare/@endo/trampoline@1.0.3...@endo/trampoline@1.0.4) (2025-06-02)
 
 **Note:** Version bump only for package @endo/trampoline

--- a/packages/trampoline/package.json
+++ b/packages/trampoline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/trampoline",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Multicolor trampolining for recursive operations",
   "keywords": [
     "trampoline",

--- a/packages/where/CHANGELOG.md
+++ b/packages/where/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.11](https://github.com/endojs/endo/compare/@endo/where@1.0.10...@endo/where@1.0.11) (2025-06-17)
+
+**Note:** Version bump only for package @endo/where
+
+
+
+
+
 ### [1.0.10](https://github.com/endojs/endo/compare/@endo/where@1.0.9...@endo/where@1.0.10) (2025-06-02)
 
 **Note:** Version bump only for package @endo/where

--- a/packages/where/package.json
+++ b/packages/where/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/where",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Locator for Endo user state, caches, and ephemeral files",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/zip/CHANGELOG.md
+++ b/packages/zip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.11](https://github.com/endojs/endo/compare/@endo/zip@1.0.10...@endo/zip@1.0.11) (2025-06-17)
+
+**Note:** Version bump only for package @endo/zip
+
+
+
+
+
 ### [1.0.10](https://github.com/endojs/endo/compare/@endo/zip@1.0.9...@endo/zip@1.0.10) (2025-06-02)
 
 **Note:** Version bump only for package @endo/zip

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/zip",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A minimal, synchronous Zip reader and writer",
   "keywords": [
     "zip",


### PR DESCRIPTION
This is a special release to mend a breaking change in `@endo/pass-style` as documented in the upcoming release notes:

# `@endo/pass-style` 1.6.2

- Fixes so that the package initializes on platforms that lack
  `ArrayBuffer.prototype.transferToImmutable`.

# `@endo/compartment-mapper` 1.6.2

- Produces a stub for `require.extensions` in CommonJS modules to increase
  ecosystem compatibility.

# `@endo/immutable-arraybuffer` 1.1.1

- Captures `structuredClone` early so that scuttling all properties of `globalThis`
  after initializing `@endo/immutable-arraybuffer` or
  `@endo/immutable-arraybuffer/shim.js` does not interfere with this module's
  designed behavior.
