### PR TITLE
fix(patterns): use `qp` for nested pattern error messages

### DIFF
--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -1,5 +1,9 @@
 User-visible changes in `@endo/patterns`:
 
+# Next release
+
+- In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Not this quoting is done with `qp`, which renders these nested patterns into readable Justin source code.
+
 # v1.5.0 (2025-03-11)
 
 - New pattern: `M.containerHas(elementPatt, bound = 1n)` motivated to support want patterns in Zoe, to pull out only `bound` number of elements that match `elementPatt`. `bound` must be a positive bigint.

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -2,7 +2,7 @@ User-visible changes in `@endo/patterns`:
 
 # Next release
 
-- In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Not this quoting is done with `qp`, which renders these nested patterns into readable Justin source code.
+- In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Now this quoting is done with `qp`, which renders these nested patterns into readable Justin source code.
 
 # v1.5.0 (2025-03-11)
 

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -2,7 +2,7 @@ User-visible changes in `@endo/patterns`:
 
 # Next release
 
-- In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Now this quoting is done with `qp`, which renders these nested patterns into readable [Justin](https://github.com/agoric-labs/jessica/blob/master/lib/quasi-justin.js.ts) source code.
+- In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Now this quoting is done with `qp`, which renders these nested patterns into readable [Justin](https://github.com/endojs/Jessie/blob/main/packages/parse/src/quasi-justin.js) source code.
 
 # v1.5.0 (2025-03-11)
 

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -2,7 +2,7 @@ User-visible changes in `@endo/patterns`:
 
 # Next release
 
-- In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Now this quoting is done with `qp`, which renders these nested patterns into readable Justin source code.
+- In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Now this quoting is done with `qp`, which renders these nested patterns into readable [Justin](https://github.com/agoric-labs/jessica/blob/master/lib/quasi-justin.js.ts) source code.
 
 # v1.5.0 (2025-03-11)
 

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -21,6 +21,7 @@ import {
   unionRankCovers,
   recordNames,
   recordValues,
+  qp,
 } from '@endo/marshal';
 
 import { keyEQ, keyGT, keyGTE, keyLT, keyLTE } from '../keys/compareKeys.js';
@@ -472,7 +473,7 @@ const makePatternKit = () => {
         if (specimenKind !== 'copyArray') {
           return check(
             false,
-            X`${specimen} - Must be a copyArray to match a copyArray pattern: ${q(
+            X`${specimen} - Must be a copyArray to match a copyArray pattern: ${qp(
               patt,
             )}`,
           );
@@ -481,7 +482,7 @@ const makePatternKit = () => {
         if (specimen.length !== length) {
           return check(
             false,
-            X`Array ${specimen} - Must be as long as copyArray pattern: ${q(
+            X`Array ${specimen} - Must be as long as copyArray pattern: ${qp(
               patt,
             )}`,
           );
@@ -497,7 +498,7 @@ const makePatternKit = () => {
         if (specimenKind !== 'copyRecord') {
           return check(
             false,
-            X`${specimen} - Must be a copyRecord to match a copyRecord pattern: ${q(
+            X`${specimen} - Must be a copyRecord to match a copyRecord pattern: ${qp(
               patt,
             )}`,
           );
@@ -540,7 +541,7 @@ const makePatternKit = () => {
         if (specimenKind !== 'copyMap') {
           return check(
             false,
-            X`${specimen} - Must be a copyMap to match a copyMap pattern: ${q(
+            X`${specimen} - Must be a copyMap to match a copyMap pattern: ${qp(
               patt,
             )}`,
           );
@@ -606,7 +607,7 @@ const makePatternKit = () => {
     // should only throw
     checkMatches(specimen, patt, assertChecker, label);
     const outerError = makeError(
-      X`internal: ${label}: inconsistent pattern match: ${q(patt)}`,
+      X`internal: ${label}: inconsistent pattern match: ${qp(patt)}`,
     );
     if (innerError !== undefined) {
       annotateError(outerError, X`caused by ${innerError}`);
@@ -766,7 +767,7 @@ const makePatternKit = () => {
       const checkIt = patt => checkPattern(patt, check);
       return (
         (passStyleOf(allegedPatts) === 'copyArray' ||
-          check(false, X`Needs array of sub-patterns: ${q(allegedPatts)}`)) &&
+          check(false, X`Needs array of sub-patterns: ${qp(allegedPatts)}`)) &&
         allegedPatts.every(checkIt)
       );
     },
@@ -785,7 +786,7 @@ const makePatternKit = () => {
       if (length === 0) {
         return check(
           false,
-          X`${specimen} - no pattern disjuncts to match: ${q(patts)}`,
+          X`${specimen} - no pattern disjuncts to match: ${qp(patts)}`,
         );
       }
       // Special case disjunctions representing a single optional pattern for
@@ -803,7 +804,7 @@ const makePatternKit = () => {
       if (patts.some(patt => matches(specimen, patt))) {
         return true;
       }
-      return check(false, X`${specimen} - Must match one of ${q(patts)}`);
+      return check(false, X`${specimen} - Must match one of ${qp(patts)}`);
     },
 
     checkIsWellFormed: matchAndHelper.checkIsWellFormed,
@@ -821,7 +822,7 @@ const makePatternKit = () => {
       if (matches(specimen, patt)) {
         return check(
           false,
-          X`${specimen} - Must fail negated pattern: ${q(patt)}`,
+          X`${specimen} - Must fail negated pattern: ${qp(patt)}`,
         );
       } else {
         return true;

--- a/packages/patterns/test/patterns.test.js
+++ b/packages/patterns/test/patterns.test.js
@@ -2,7 +2,7 @@
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { Fail } from '@endo/errors';
-import { makeTagged, Far } from '@endo/marshal';
+import { makeTagged, Far, qp } from '@endo/marshal';
 import {
   makeCopyBag,
   makeCopyMap,
@@ -11,6 +11,8 @@ import {
 } from '../src/keys/checkKey.js';
 import { mustMatch, matches, M } from '../src/patterns/patternMatchers.js';
 import '../src/types.js';
+
+const { stringify: q } = JSON;
 
 /** @import * as ava from 'ava' */
 
@@ -85,11 +87,11 @@ const runTests = (t, successCase, failCase) => {
     successCase(specimen, M.or(3, 4));
 
     failCase(specimen, 4, '3 - Must be: 4');
-    failCase(specimen, M.not(3), '3 - Must fail negated pattern: 3');
+    failCase(specimen, M.not(3), '3 - Must fail negated pattern: "`3`"');
     failCase(
       specimen,
       M.not(M.any()),
-      '3 - Must fail negated pattern: "[match:any]"',
+      '3 - Must fail negated pattern: "`makeTagged(\\"match:any\\", undefined)`"',
     );
     failCase(specimen, M.nat(), 'number 3 - Must be a bigint');
     failCase(specimen, [3, 4], '3 - Must be: [3,4]');
@@ -101,8 +103,8 @@ const runTests = (t, successCase, failCase) => {
     failCase(specimen, M.lte(3n), '3 - Must be <= "[3n]"');
     failCase(specimen, M.gte(3n), '3 - Must be >= "[3n]"');
     failCase(specimen, M.and(3, 4), '3 - Must be: 4');
-    failCase(specimen, M.or(4, 4), '3 - Must match one of [4,4]');
-    failCase(specimen, M.or(), '3 - no pattern disjuncts to match: []');
+    failCase(specimen, M.or(4, 4), `3 - Must match one of ${q(qp([4, 4]))}`);
+    failCase(specimen, M.or(), '3 - no pattern disjuncts to match: "`[]`"');
     failCase(specimen, M.tagged(), 'Expected tagged object, not "number": 3');
   }
   {
@@ -126,11 +128,11 @@ const runTests = (t, successCase, failCase) => {
     successCase(specimen, M.or(0n, 4n));
 
     failCase(specimen, 4n, '"[0n]" - Must be: "[4n]"');
-    failCase(specimen, M.not(0n), '"[0n]" - Must fail negated pattern: "[0n]"');
+    failCase(specimen, M.not(0n), '"[0n]" - Must fail negated pattern: "`0n`"');
     failCase(
       specimen,
       M.not(M.any()),
-      '"[0n]" - Must fail negated pattern: "[match:any]"',
+      '"[0n]" - Must fail negated pattern: "`makeTagged(\\"match:any\\", undefined)`"',
     );
     failCase(specimen, [0n, 4n], '"[0n]" - Must be: ["[0n]","[4n]"]');
     failCase(specimen, M.gte(7n), '"[0n]" - Must be >= "[7n]"');
@@ -144,9 +146,13 @@ const runTests = (t, successCase, failCase) => {
     failCase(
       specimen,
       M.or(4n, 4n),
-      '"[0n]" - Must match one of ["[4n]","[4n]"]',
+      `"[0n]" - Must match one of ${q(qp([4n, 4n]))}`,
     );
-    failCase(specimen, M.or(), '"[0n]" - no pattern disjuncts to match: []');
+    failCase(
+      specimen,
+      M.or(),
+      '"[0n]" - no pattern disjuncts to match: "`[]`"',
+    );
   }
   {
     const specimen = -1n;
@@ -653,7 +659,11 @@ const runTests = (t, successCase, failCase) => {
         failCase(
           specimen,
           M[method](),
-          'match:remotable payload: 88 - Must be a copyRecord to match a copyRecord pattern: {"label":"[match:string]"}',
+          `match:remotable payload: 88 - Must be a copyRecord to match a copyRecord pattern: ${q(
+            qp({
+              label: M.string(),
+            }),
+          )}`,
         );
       }
     }


### PR DESCRIPTION
Closes: #XXXX
Refs: #2799 

## Description

#2799 added a new `q`-like quoter named `qp`, for "quote passable", that renders any value into Justin source text. This was specifically motivated for displaying patterns within error messages in a readable and informative manner.

The `@endo/patterns` package itself formulates many error messages to explain why a specimen did not match a pattern. Some of these message include quoted forms of nested patterns. But those were still quotes with `q`, leading @dckc to report still seeing error messages like

```
Error {
    message: '... - Must match one of ["[match:splitRecord]","[match:splitRecord]"]',
  }
```

This PR changes the quoting of nested errors to use `qp` instead, so a `[match:splitRecord]` might instead render as
```js
`makeTagged("match:splitRecord", [
  {
    assetKind: makeTagged("match:or", [
      "nat",
      "set",
      "copySet",
      "copyBag",
    ]),
    decimalPlaces: makeTagged("match:and", [
      makeTagged("match:gte", -100),
      makeTagged("match:lte", 100),
    ]),
  },
])`
```

This is more verbose. But error messages are designed to carry the critical clues to help find a bug. For nested patterns, this extra information is worth the verbosity.

### Security Considerations

We were already quoting nested patterns with `q`, unredacting them, under the assumption that specimens may carry secrets worth protecting from callers, but patterns typically do not. Switching these from `q` to `qp` is consistent with that assumption, but actually exposes info that `q` happened not to expose. When unredacting happened not to expose secrets it said were ok to expose, it is easy for developers not to notice the secrets that could have been shown but weren't. After this PR, these unredacted secrets will be exposed to callers.

### Scaling Considerations

Where `q` is lazy, `qp` is eager, rendering its argument up front into Justin even if the containing error is never created or thrown. Thus, we must take care to only use `qp` when we're already committed to creating and throwing the error. I believe all such changes in this PR do so, and so do not add overhead to the happy path.

### Documentation Considerations

I don't know what documentation we provide explaining the interpretation of error messages. If we have any explain pattern match error messages, this PR might need us to change those explanations.

### Testing Considerations

Using `qp` to formulate the error messages definitely makes it more awkward to test is the error message is as expected. You can see this in the tests this PR needed to change. Fortunately, as shown in these error message tests, you can use `${q(qp(...))}` to formulate the golden in the test.

### Compatibility Considerations

Because this PR changes the error messages, as pointed out above, golden tests of error message text may no longer match, ***causing old working tests to start failing***. However, this is not ***technically*** a compat break, because we take the stance that the content of error messages is not normative, so the error messages can become more informative over time with a version bump. Thus, I use `:` rather than `!` to recommend that this PR not cause a version bump. (See https://github.com/endojs/endo/pull/2868#pullrequestreview-2955029970 below)

### Upgrade Considerations

None.
