### PR TITLE
refactor(base64): minor improvements

### DIFF
--- a/packages/base64/src/common.js
+++ b/packages/base64/src/common.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+const { freeze } = Object;
+
 export const padding = '=';
 
 export const alphabet64 =
@@ -17,3 +19,4 @@ for (let i = 0; i < alphabet64.length; i += 1) {
   const c = alphabet64[i];
   monodu64[c] = i;
 }
+freeze(monodu64);

--- a/packages/base64/test/main.test.js
+++ b/packages/base64/test/main.test.js
@@ -3,17 +3,22 @@ import { atob as origAtob, btoa as origBtoa } from './_capture-atob-btoa.js';
 import { encodeBase64, decodeBase64, atob, btoa } from '../index.js';
 
 /**
- * @param {string} string Only uses the low byte of each UTF16 code unit, which
- * is ok as long as it is used only for this purpose for a local test, and not
- * exported.
+ * `asciiString` must consist only of characters with code points between
+ * 0 and 255 (or `oxff`), i.e., characters whose code points fit into one byte.
+ * `asciiStringToUint8Array` converts that to a Uint8Array of the same size,
+ * consisting of those code points in order.
+ *
+ * @param {string} asciiString
  * @returns {Uint8Array}
  */
-const encode8BitString = string => {
-  const data = new Uint8Array(string.length);
-  for (let i = 0; i < string.length; i += 1) {
-    const byte = string.charCodeAt(i);
+const asciiStringToUint8Array = asciiString => {
+  const data = new Uint8Array(asciiString.length);
+  for (let i = 0; i < asciiString.length; i += 1) {
+    const byte = asciiString.charCodeAt(i);
     if (byte > 0xff) {
-      throw Error(`invalid character at index ${i}: U+${byte.toString(16).padStart(4, '0')}`);
+      throw Error(
+        `invalid character at index ${i}: U+${byte.toString(16).padStart(4, '0')}`,
+      );
     }
     data[i] = byte;
   }
@@ -21,14 +26,14 @@ const encode8BitString = string => {
 };
 
 /**
- * @param {Uint8Array} data
- * @returns {string} Interpreting each 8-bit value as an 8-bit UTF-16 code
+ * Interpret each 8-bit value as an 8-bit UTF-16 code
  * unit. Since this cannot include any UTF-16 surrogates, this is equivalent
- * to interpreting each 8-bit value as an 8-bit ascii code point. This
- * may be unexpected, and so is ok as long as it is used only for this purpose
- * for a local test, and not exported.
+ * to interpreting each 8-bit value as an 8-bit ascii code point.
+ *
+ * @param {Uint8Array} data
+ * @returns {string}
  */
-const unt8ArrayToString = data => String.fromCharCode(...data);
+const unt8ArrayToAsciiString = data => String.fromCharCode(...data);
 
 test('bytes conversions', t => {
   const insouts = [
@@ -41,8 +46,8 @@ test('bytes conversions', t => {
     ['foobar', 'Zm9vYmFy'],
   ];
   for (const [inp, outp] of insouts) {
-    t.is(encodeBase64(stringToUint8Array(inp)), outp, `${inp} encodes`);
-    t.is(unt8ArrayToString(decodeBase64(outp)), inp, `${outp} decodes`);
+    t.is(encodeBase64(asciiStringToUint8Array(inp)), outp, `${inp} encodes`);
+    t.is(unt8ArrayToAsciiString(decodeBase64(outp)), inp, `${outp} decodes`);
     t.is(btoa(inp), outp, `${inp} encodes with btoa`);
     t.is(atob(outp), inp, `${outp} decodes with atob`);
     origBtoa && t.is(origBtoa(inp), outp, `${inp} encodes with origBtoa`);
@@ -58,7 +63,9 @@ test('bytes conversions', t => {
   ];
   for (const str of inputs) {
     t.is(
-      unt8ArrayToString(decodeBase64(encodeBase64(stringToUint8Array(str)))),
+      unt8ArrayToAsciiString(
+        decodeBase64(encodeBase64(asciiStringToUint8Array(str))),
+      ),
       str,
       `${str} round trips`,
     );

--- a/packages/base64/test/main.test.js
+++ b/packages/base64/test/main.test.js
@@ -24,7 +24,7 @@ const stringToUint8Array = string => {
  * may be unexpected, and so is ok as long as it is used only for this purpose
  * for a local test, and not exported.
  */
-const unit8ArrayToString = data => String.fromCharCode(...data);
+const unt8ArrayToString = data => String.fromCharCode(...data);
 
 test('bytes conversions', t => {
   const insouts = [
@@ -38,7 +38,7 @@ test('bytes conversions', t => {
   ];
   for (const [inp, outp] of insouts) {
     t.is(encodeBase64(stringToUint8Array(inp)), outp, `${inp} encodes`);
-    t.is(unit8ArrayToString(decodeBase64(outp)), inp, `${outp} decodes`);
+    t.is(unt8ArrayToString(decodeBase64(outp)), inp, `${outp} decodes`);
     t.is(btoa(inp), outp, `${inp} encodes with btoa`);
     t.is(atob(outp), inp, `${outp} decodes with atob`);
     origBtoa && t.is(origBtoa(inp), outp, `${inp} encodes with origBtoa`);
@@ -54,7 +54,7 @@ test('bytes conversions', t => {
   ];
   for (const str of inputs) {
     t.is(
-      unit8ArrayToString(decodeBase64(encodeBase64(stringToUint8Array(str)))),
+      unt8ArrayToString(decodeBase64(encodeBase64(stringToUint8Array(str)))),
       str,
       `${str} round trips`,
     );

--- a/packages/base64/test/main.test.js
+++ b/packages/base64/test/main.test.js
@@ -8,10 +8,14 @@ import { encodeBase64, decodeBase64, atob, btoa } from '../index.js';
  * exported.
  * @returns {Uint8Array}
  */
-const stringToUint8Array = string => {
+const encode8BitString = string => {
   const data = new Uint8Array(string.length);
   for (let i = 0; i < string.length; i += 1) {
-    data[i] = string.charCodeAt(i);
+    const byte = string.charCodeAt(i);
+    if (byte > 0xff) {
+      throw Error(`invalid character at index ${i}: U+${byte.toString(16).padStart(4, '0')}`);
+    }
+    data[i] = byte;
   }
   return data;
 };


### PR DESCRIPTION
Closes: #XXXX
Refs: #2844 

## Description

https://github.com/endojs/endo/pull/2844 currently depends on `@endo/base64` for base64 encoding and decoding. @kriskowal asked that it be changed to use a hex encoding instead, for which changes to `@endo/base64` would be irrelevant. So I'm capturing in this PR the minor improvement I made to that package while working on #2844 .

### Security Considerations

exporting mutable data (`monodu64`) from a module is a security hazard. It is not exported from the package, so this is only a hazard, not a vulnerability. In this case there was zero reason not to freeze `monodu64`, so this PR does, leaving us one less security hazard to worry about.

### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

Aside from `monodu64`, the other changes to this PR is to expand the test in ways I noticed while working on #2844 .

### Compatibility Considerations

none

### Upgrade Considerations

none