### PR TITLE
fix(marshal): marshal ByteArrays to hex

### DIFF
--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -2,6 +2,7 @@ User-visible changes in `@endo/marshal`:
 
 # 1.8.0 (2025-07-11)
 
+- `@endo/pass-style` had already grown a new `Passable` data type, [`ByteArray`](https://github.com/endojs/endo/pull/2843), which is a frozen [Immutable ArrayBuffer](https://github.com/tc39/proposal-immutable-arraybuffer/). `@endo/marshal` can now serialize and deserialize these to the capData, smallcaps, and Justin formats using a textual hex encoding. The `encodePassable` format does not yet support ByteArrays.
 - Introduces an environment variable config option `ENDO_RANK_STRINGS` to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN-conformant) ordering by Unicode code point. It currently defaults to "utf16-code-unit-order", matching the previously-unconditional behavior.
 
 # v1.7.0 (2025-06-02)

--- a/packages/marshal/docs/smallcaps-cheatsheet.md
+++ b/packages/marshal/docs/smallcaps-cheatsheet.md
@@ -10,7 +10,7 @@ An example-based summary of the Smallcaps encoding on the OCapN [Abstract Syntax
 | bigint           | Integer       | `7n`<br>`-7n`         | `"+7"`<br>`"-7"`     |
 | number           | Float64       | `Infinity`<br>`-Infinity`<br>`NaN`<br>`-0`<br>`7.1` | `"#Infinity"`<br>`"#-Infinity"`<br>`"#NaN"`<br>`"#-0"` // unimplemented<br>`7.1` |
 | string           | String        | `'#foo'`<br>`'foo'`   | `"!#foo"` // special strings<br>`"foo"` // other strings |
-| byteArray        | ByteArray     | `buf.toImmutable()`   | // undecided & unimplemented |
+| byteArray        | ByteArray     | `buf.toImmutable()`   | `"*deadbeef"` // after `*`, hex encoding |
 | selector         | Selector      | `makeSelector('foo')` | `"%foo"` // converting from symbol |
 | copyArray        | List          | `[a,b]`               | `[<a>,<b>]`          |
 | copyRecord       | Struct        | `{x:a,y:b}`           | `{<x>:<a>,<y>:<b>}`  |
@@ -28,6 +28,5 @@ An example-based summary of the Smallcaps encoding on the OCapN [Abstract Syntax
 * Structs [can only have string-named properties](https://github.com/endojs/endo/blob/master/packages/pass-style/doc/copyRecord-guarantees.md).
 * Errors can also carry an optional `errorId` string property.
 * We expect to expand the optional error properties over time.
-* The ByteArray encoding is not yet designed or implemented.
 
 Every JSON encoding with no special strings anywhere decodes to itself.

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -15,6 +15,8 @@ import {
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
+  byteArrayToHex,
+  hexToByteArray,
 } from '@endo/pass-style';
 import { X, Fail, q } from '@endo/errors';
 
@@ -195,8 +197,10 @@ export const makeEncodeToCapData = (encodeOptions = {}) => {
         return passable.map(encodeToCapDataRecur);
       }
       case 'byteArray': {
-        // TODO implement
-        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+        return {
+          [QCLASS]: 'byteArray',
+          data: byteArrayToHex(passable),
+        };
       }
       case 'tagged': {
         return {
@@ -368,6 +372,10 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
           const { tag, payload } = jsonEncoded;
           return makeTagged(tag, decodeFromCapData(payload));
         }
+        case 'byteArray': {
+          const { data } = jsonEncoded;
+          return hexToByteArray(data);
+        }
         case 'slot': {
           // See note above about how the current encoding cannot reliably
           // distinguish which we should call, so in the non-default case
@@ -442,3 +450,4 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
   };
   return harden(decodeFromCapData);
 };
+harden(makeDecodeFromCapData);

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -15,6 +15,8 @@ import {
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
+  byteArrayToHex,
+  hexToByteArray,
 } from '@endo/pass-style';
 import { X, Fail, q } from '@endo/errors';
 
@@ -55,8 +57,9 @@ const DASH = '-'.charCodeAt(0);
  *  * `%` - symbol
  *  * `$` - remotable
  *  * `&` - promise
+ *  * `*` - byteArray (hardened Immutable ArrayBuffer)
  *
- * All other special characters (`"'()*,`) are reserved for future use.
+ * All other special characters (`"'(),`) are reserved for future use.
  *
  * The manifest constants that smallcaps currently uses for values:
  *  * `#undefined`
@@ -229,8 +232,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
         return passable.map(encodeToSmallcapsRecur);
       }
       case 'byteArray': {
-        // TODO implement
-        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+        return `*${byteArrayToHex(passable)}`;
       }
       case 'tagged': {
         return {
@@ -406,6 +408,10 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
             }
             return result;
           }
+          case '*': {
+            const base64str = encoding.slice(1);
+            return hexToByteArray(base64str);
+          }
           default: {
             throw Fail`Special char ${q(
               c,
@@ -471,3 +477,4 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
   };
   return harden(decodeFromSmallcaps);
 };
+harden(makeDecodeFromSmallcaps);

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -178,6 +178,11 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
           assert.typeof(sym, 'symbol');
           return;
         }
+        case 'byteArray': {
+          const { data } = rawTree;
+          assert.typeof(data, 'string');
+          return;
+        }
         case 'tagged': {
           const { tag, payload } = rawTree;
           assert.typeof(tag, 'string');
@@ -339,6 +344,11 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
             return out.next(`Symbol.${suffix}`);
           }
           return out.next(`passableSymbolForName(${quote(registeredName)})`);
+        }
+        case 'byteArray': {
+          const { data } = rawTree;
+          assert.typeof(data, 'string');
+          return out.next(`hexToByteArray(${quote(data)})`);
         }
         case 'tagged': {
           const { tag, payload } = rawTree;

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -47,7 +47,8 @@ export {};
  *           } |
  *           EncodingClass<'tagged'> & { tag: string,
  *                                       payload: Encoding
- *           }
+ *           } |
+ *           EncodingClass<'byteArray'> & { data: string }
  * } EncodingUnion
  *
  * Note that the '@@asyncIterator' encoding is deprecated. Use 'symbol' instead.

--- a/packages/marshal/test/encodePassable.test.js
+++ b/packages/marshal/test/encodePassable.test.js
@@ -451,12 +451,14 @@ const testOrderInvariants = test.macro(async (t, pickEncode) => {
   // Ensure at least one ava assertion.
   t.pass();
 });
-test(
+// Failing because we now need to encode byteArrays
+test.failing(
   'original passable encoding corresponds to rankOrder',
   testOrderInvariants,
   pickLegacy,
 );
-test(
+// Failing because we now need to encode byteArrays
+test.failing(
   'small passable encoding corresponds to rankOrder',
   testOrderInvariants,
   pickCompact,

--- a/packages/marshal/test/marshal-justin.test.js
+++ b/packages/marshal/test/marshal-justin.test.js
@@ -6,6 +6,7 @@ import {
   Remotable,
   makeTagged,
   passableSymbolForName,
+  hexToByteArray,
 } from '@endo/pass-style';
 import { makeMarshal } from '../src/marshal.js';
 import { decodeToJustin, qp } from '../src/marshal-justin.js';
@@ -43,6 +44,7 @@ const fakeJustinCompartment = () => {
     slotToVal,
     makeTagged,
     passableSymbolForName,
+    hexToByteArray,
   });
 };
 

--- a/packages/marshal/test/rankOrder.test.js
+++ b/packages/marshal/test/rankOrder.test.js
@@ -15,6 +15,7 @@ import {
   getPassStyleCover,
   getIndexCover,
   assertRankSorted,
+  compareRankRemotablesTied,
 } from '../src/rankOrder.js';
 import { unsortedSample, sortedSample } from '../tools/marshal-test-data.js';
 
@@ -28,6 +29,8 @@ test('compareRank is reflexive', async t => {
   );
 });
 
+// TODO https://github.com/endojs/endo/issues/2883
+// Should these tests use `compareRank` or `compareRankRemotablesTied`?
 test('compareRank totally orders ranks', async t => {
   await fc.assert(
     fc.property(arbPassable, arbPassable, (a, b) => {
@@ -45,6 +48,8 @@ test('compareRank totally orders ranks', async t => {
   );
 });
 
+// TODO https://github.com/endojs/endo/issues/2883
+// Should these tests use `compareRank` or `compareRankRemotablesTied`?
 test('compareRank is transitive', async t => {
   await fc.assert(
     fc.property(
@@ -105,11 +110,11 @@ test('compareRank is transitive', async t => {
 });
 
 test('compare and sort by rank', t => {
-  assertRankSorted(sortedSample, compareRank);
-  t.false(isRankSorted(unsortedSample, compareRank));
-  const sorted = sortByRank(unsortedSample, compareRank);
+  assertRankSorted(sortedSample);
+  t.false(isRankSorted(unsortedSample));
+  const sorted = sortByRank(unsortedSample);
   t.is(
-    compareRank(sorted, sortedSample),
+    compareRankRemotablesTied(sorted, sortedSample),
     0,
     `Not sorted as expected: ${q(sorted)}`,
   );
@@ -168,9 +173,9 @@ const brokenQueries = harden([
 // adding composite key handling to the durable store implementation) will need
 // to re-enable and (likely) update this test.
 test.skip('range queries', t => {
-  t.assert(isRankSorted(unusedRangeSample, compareRank));
+  t.assert(isRankSorted(unusedRangeSample));
   for (const [rankCover, indexRange] of brokenQueries) {
-    const range = getIndexCover(unusedRangeSample, compareRank, rankCover);
+    const range = getIndexCover(unusedRangeSample, rankCover);
     t.is(range[0], indexRange[0]);
     t.is(range[1], indexRange[1]);
   }

--- a/packages/marshal/tools/marshal-test-data.js
+++ b/packages/marshal/tools/marshal-test-data.js
@@ -1,11 +1,19 @@
-import { makeTagged, passableSymbolForName } from '@endo/pass-style';
+import {
+  makeTagged,
+  passableSymbolForName,
+  hexToByteArray,
+} from '@endo/pass-style';
 import {
   exampleAlice,
   exampleBob,
   exampleCarol,
 } from '@endo/pass-style/tools.js';
 
-/** @import { Passable } from '@endo/pass-style' */
+/**
+ * @import {Passable} from '@endo/pass-style';
+ */
+
+// modeled on byteArray.test.js
 
 /**
  * Essentially a ponyfill for Array.prototype.toSorted, for use before
@@ -107,7 +115,7 @@ export const roundTripPairs = harden([
   // Fails before https://github.com/endojs/endo/issues/1303 fix
   [{ isPrototypeOf: {} }, { isPrototypeOf: {} }],
 
-  // Scalars not represented in JSON
+  // Atoms not representable in JSON
   [undefined, { '@qclass': 'undefined' }],
   [NaN, { '@qclass': 'NaN' }],
   [Infinity, { '@qclass': 'Infinity' }],
@@ -127,6 +135,16 @@ export const roundTripPairs = harden([
   // Normal json reviver cannot make properties with undefined values
   [[undefined], [{ '@qclass': 'undefined' }]],
   [{ foo: undefined }, { foo: { '@qclass': 'undefined' } }],
+
+  // byteArray
+  // modeled on byteArray.test.js
+  [
+    hexToByteArray('0f'),
+    {
+      '@qclass': 'byteArray',
+      data: '0f',
+    },
+  ],
 
   // tagged
   [
@@ -228,6 +246,7 @@ export const roundTripPairs = harden([
  * Justin expression `justin`, and Justin evaluation of that expression produces
  * a Passable which marshals with the legacy "capdata" body format into an
  * encoding whose body is `capdataBody`.
+ * Based on roundTripPairs
  *
  * @type {Array<[capdataBody: string, justin: string, slots?: unknown[]]>}
  */
@@ -242,7 +261,7 @@ export const jsonJustinPairs = harden([
   ['"abc"', '"abc"'],
   ['null', 'null'],
 
-  // Primitives not representable in JSON
+  // Atoms not representable in JSON
   ['{"@qclass":"undefined"}', 'undefined'],
   ['{"@qclass":"NaN"}', 'NaN'],
   ['{"@qclass":"Infinity"}', 'Infinity'],
@@ -256,6 +275,9 @@ export const jsonJustinPairs = harden([
   ['{"@qclass":"symbol","name":"@@match"}', 'passableSymbolForName("@@match")'],
   ['{"@qclass":"symbol","name":"foo"}', 'passableSymbolForName("foo")'],
   ['{"@qclass":"symbol","name":"@@@@foo"}', 'passableSymbolForName("@@@@foo")'],
+
+  // byteArray
+  ['{"@qclass":"byteArray","data":"0aff"}', 'hexToByteArray("0aff")'],
 
   // Arrays and objects
   ['[{"@qclass":"undefined"}]', '[undefined]'],
@@ -333,6 +355,7 @@ export const unsortedSample = harden([
   undefined,
   -Infinity,
   [5],
+  hexToByteArray('0f'),
   exampleAlice,
   [],
   passableSymbolForName('foo'),
@@ -346,6 +369,7 @@ export const unsortedSample = harden([
   [exampleAlice, 'a'],
   [exampleBob, 'z'],
   -0,
+  hexToByteArray('aa'),
   {},
   [5, undefined],
   -3,
@@ -355,6 +379,7 @@ export const unsortedSample = harden([
   ]),
   true,
   'bar',
+  hexToByteArray('0a'),
   [5, null],
   new Promise(() => {}), // forever unresolved
   makeTagged('nonsense', [
@@ -427,6 +452,10 @@ export const sortedSample = harden([
   [exampleAlice, 'a'],
   [exampleCarol, 'm'],
   [exampleBob, 'z'],
+
+  hexToByteArray('0a'),
+  hexToByteArray('0f'),
+  hexToByteArray('aa'),
 
   false,
   true,

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -26,6 +26,15 @@ export {
   assertPassableString,
 } from './src/string.js';
 
+export { uint8ArrayToHex, hexToUint8Array } from './src/hex.js';
+
+export {
+  byteArrayToUint8Array,
+  uint8ArrayToByteArray,
+  byteArrayToHex,
+  hexToByteArray,
+} from './src/byteArray.js';
+
 export {
   passStyleOf,
   isPassable,

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -109,16 +109,21 @@ harden(byteArrayToUint8Array);
  * @param {Uint8Array} uint8Array
  * @returns {ArrayBuffer} A ByteArray, i.e., a hardened Immutable ArrayBuffer
  */
-export const uint8ArrayToByteArray = uint8Array =>
+export const uint8ArrayToByteArray = uint8Array => {
+  const { byteOffset, length } = uint8Array;
   // If we're using a native implementation of the full Immutable ArrayBuffer
   // proposal, and if `uint8Array`'s backing store is such a genuine
   // Immutable ArrayBuffer, and if the native implementation does the obvious
-  // optimization of `immutableArrayBuffer.sliceToImmutable(0, length)`,
-  // then this conversion is zero-copy.
-  // Otherwise, it pays the copy cost implicit in `sliceToImmutable`.
+  // optimization of a non-expanding `sliceToImmutable`, then this conversion is
+  // zero-copy. Otherwise, it pays the copy cost implicit in `sliceToImmutable`.
   //
-  // @ts-expect-error How can shim add to `ArrayBuffer` ts type?
-  harden(uint8Array.buffer.sliceToImmutable(0, uint8Array.length));
+  // @ts-expect-error How can the shim update the `ArrayBuffer` TS type?
+  const byteArray = uint8Array.buffer.sliceToImmutable(
+    byteOffset,
+    byteOffset + length,
+  );
+  return harden(byteArray);
+};
 harden(uint8ArrayToByteArray);
 
 /**

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -1,6 +1,8 @@
 import { X, Fail } from '@endo/errors';
+import { uint8ArrayToHex, hexToUint8Array } from './hex.js';
 
 /**
+ * @import {ByteArray} from './types.js';
  * @import {PassStyleHelper} from './internal-types.js';
  */
 
@@ -65,3 +67,82 @@ export const ByteArrayHelper = harden({
       );
   },
 });
+harden(ByteArrayHelper);
+
+// /////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Returns a Uint8Array reflecting the current contents of `byteArray`.
+ *
+ * @param {ArrayBuffer} byteArray i.e., a hardened Immutable ArrayBuffer whose
+ * `passStyle` is `'byteArray'`. NOTE: A normal (mutable) ArrayBuffer is also
+ * accepted, in which case the returned `Uint8Array` is a non-freezeable
+ * read-write view of `byteArray`.
+ * (Due to a special case in `harden`, the returned Uint8Array, even if
+ * permanently non-freezable, can still be hardened.)
+ * @returns {Uint8Array} a view into the contents of `byteArray`.
+ */
+export const byteArrayToUint8Array = byteArray => {
+  if (getPrototypeOf(byteArray) === ArrayBuffer.prototype) {
+    // If `byteArray` inherits directly from `ArrayBuffer.prototype`,
+    // then assume `byteArray` is a genuine `ArrayBuffer`,
+    // as it would be in a native implementation
+    // of the Immutable ArrayBuffer proposal. This conversion to a Uint8Array
+    // is then zero-copy. If `byteArray` is indeed an Immutable ArrayBuffer,
+    // then the returned Uint8Array is freezable.
+    return new Uint8Array(byteArray);
+  } else {
+    // Otherwise, assume `byteArray` may be a shim-emulated
+    // Immutable ArrayBuffer. This `.slice()` would then cost a copy into a
+    // fresh mutable normal ArrayBuffer, and the returned Uint8Array would
+    // be a read-write window into that mutable ArrayBuffer.
+    const genuineArrayBuffer = byteArray.slice();
+    return byteArrayToUint8Array(genuineArrayBuffer);
+  }
+};
+harden(byteArrayToUint8Array);
+
+/**
+ * Converts a `Uint8Array` to a `ByteArray`, i.e., a hardened
+ * Immutable ArrayBuffer whose `passStyleOf` is `'byteArray'`.
+ *
+ * @param {Uint8Array} uint8Array
+ * @returns {ArrayBuffer} A ByteArray, i.e., a hardened Immutable ArrayBuffer
+ */
+export const uint8ArrayToByteArray = uint8Array =>
+  // If we're using a native implementation of the full Immutable ArrayBuffer
+  // proposal, and if `uint8Array`'s backing store is such a genuine
+  // Immutable ArrayBuffer, and if the native implementation does the obvious
+  // optimization of `immutableArrayBuffer.sliceToImmutable(0, length)`,
+  // then this conversion is zero-copy.
+  // Otherwise, it pays the copy cost implicit in `sliceToImmutable`.
+  //
+  // @ts-expect-error How can shim add to `ArrayBuffer` ts type?
+  harden(uint8Array.buffer.sliceToImmutable(0, uint8Array.length));
+harden(uint8ArrayToByteArray);
+
+/**
+ * Like `uint8ArrayToHex` but starting from a presumably frozen
+ * Immutable ArrayBuffer.
+ *
+ * @param {ByteArray} buffer
+ * @returns {string} hex encoded string
+ */
+export const byteArrayToHex = buffer =>
+  // TODO This is what we want, but the Immutable ArrayBuffer shim does not
+  // support a Uint8Array on an emulated Immutable ArrayBuffer.
+  // uint8ArrayToHex(new Uint8Array(buffer));
+  // instead:
+  uint8ArrayToHex(byteArrayToUint8Array(buffer));
+harden(byteArrayToHex);
+
+/**
+ * Like `hexToUint8Array` but produces a frozen Immutable ArrayBuffer
+ * instead.
+ *
+ * @param {string} encoding hex-encoded string
+ * @returns {ByteArray} decoded bytes
+ */
+export const hexToByteArray = encoding =>
+  uint8ArrayToByteArray(hexToUint8Array(encoding));
+harden(hexToByteArray);

--- a/packages/pass-style/src/hex.js
+++ b/packages/pass-style/src/hex.js
@@ -101,7 +101,7 @@ export const makePortableHexCodec = () => {
   const hexToUint8Array = hex => {
     const inputLen = hex.length;
     if (inputLen % 2 !== 0) {
-      throw Fail`Invalid hex string: ${hex}`;
+      throw Fail`${hex} must be an even number of characters`;
     }
     const u8 = new Uint8Array(inputLen / 2);
     for (let i = 0; i < inputLen; i += 2) {
@@ -140,67 +140,71 @@ harden(makePortableHexCodec);
  *   is the portion of the Node.js Buffer API we need for hex conversion.
  */
 
-/**
- * Create a hex codec using parts of the Node.js Buffer API.
- *
- * @deprecated Just use the exported `uint8ArrayToHex` and `hexToUint8Array`
- * which are already best efforts based on feature detecting `Buffer`.
- * @param {BufferishConstructor} Bufferish the object that implements the
- *   necessary pieces of Buffer
- * @returns {HexCodec}
- */
-export const makeBufferishHexCodec = Bufferish => {
-  /**
-   * @param {Uint8Array} u8
-   * @returns {string}
-   */
-  const uint8ArrayToHex = u8 =>
-    (Bufferish.isBuffer?.(u8) ? u8 : Bufferish.from(u8)).toString('hex');
+// Not actually plug compat with `makePortableHexCodec`. More lenient about
+// what is an error.
+// /**
+//  * Create a hex codec using parts of the Node.js Buffer API.
+//  *
+//  * @deprecated Just use the exported `uint8ArrayToHex` and `hexToUint8Array`
+//  * which are already best efforts based on feature detecting `Buffer`.
+//  * @param {BufferishConstructor} Bufferish the object that implements the
+//  *   necessary pieces of Buffer
+//  * @returns {HexCodec}
+//  */
+// export const makeBufferishHexCodec = Bufferish => {
+//   /**
+//    * @param {Uint8Array} u8
+//    * @returns {string}
+//    */
+//   const uint8ArrayToHex = u8 =>
+//     (Bufferish.isBuffer?.(u8) ? u8 : Bufferish.from(u8)).toString('hex');
 
-  /**
-   * @deprecated Use `uint8ArrayToHex` instead
-   * @param {Uint8Array} u8
-   * @returns {string}
-   */
-  const encodeHex = u8 => uint8ArrayToHex(u8);
+//   /**
+//    * @deprecated Use `uint8ArrayToHex` instead
+//    * @param {Uint8Array} u8
+//    * @returns {string}
+//    */
+//   const encodeHex = u8 => uint8ArrayToHex(u8);
 
-  /**
-   * @param {string} hex
-   * @returns {Uint8Array}
-   */
-  const hexToUint8Array = hex => {
-    const buf = Bufferish.from(hex, 'hex');
+//   /**
+//    * @param {string} hex
+//    * @returns {Uint8Array}
+//    */
+//   const hexToUint8Array = hex => {
+//     const buf = Bufferish.from(hex, 'hex');
 
-    // Coerce to Uint8Array to avoid leaking the abstraction.
-    const u8a = new Uint8Array(
-      buf.buffer,
-      buf.byteOffset,
-      buf.byteLength / Uint8Array.BYTES_PER_ELEMENT,
-    );
-    return u8a;
-  };
+//     // Coerce to Uint8Array to avoid leaking the abstraction.
+//     const u8a = new Uint8Array(
+//       buf.buffer,
+//       buf.byteOffset,
+//       buf.byteLength / Uint8Array.BYTES_PER_ELEMENT,
+//     );
+//     return u8a;
+//   };
 
-  /**
-   * @deprecated Use `hexToUint8Array` instead
-   * @param {string} hex
-   * @returns {Uint8Array}
-   */
-  const decodeHex = hex => hexToUint8Array(hex);
+//   /**
+//    * @deprecated Use `hexToUint8Array` instead
+//    * @param {string} hex
+//    * @returns {Uint8Array}
+//    */
+//   const decodeHex = hex => hexToUint8Array(hex);
 
-  return harden({
-    uint8ArrayToHex,
-    encodeHex,
-    hexToUint8Array,
-    decodeHex,
-  });
-};
-harden(makeBufferishHexCodec);
+//   return harden({
+//     uint8ArrayToHex,
+//     encodeHex,
+//     hexToUint8Array,
+//     decodeHex,
+//   });
+// };
+// harden(makeBufferishHexCodec);
 
 /**
  * Export a hex codec that can work with standard JS engines, but takes
  * advantage of optimizations on some platforms (like Node.js's Buffer API).
  */
 export const { uint8ArrayToHex, encodeHex, hexToUint8Array, decodeHex } =
-  typeof Buffer === 'undefined'
-    ? makePortableHexCodec()
-    : makeBufferishHexCodec(Buffer);
+  makePortableHexCodec();
+// Enable once `makeBufferishHexCodec` is plug compat
+// typeof Buffer === 'undefined'
+//   ? makePortableHexCodec()
+//   : makeBufferishHexCodec(Buffer);

--- a/packages/pass-style/src/hex.js
+++ b/packages/pass-style/src/hex.js
@@ -1,0 +1,207 @@
+/* global Buffer */
+
+// This module should eventually replace
+// https://github.com/Agoric/agoric-sdk/blob/master/packages/internal/src/hex.js
+// It makes the following observable improvements, none of which should cause
+// practical compat problems:
+// - It defensively hardens at least the things that should be defensively
+//   hardened.
+// - It makes clearer that the `decodings` map, once created, is then treated
+//   as read-only by further defining a `getDecoding` function that does not
+//   yet encapsulate the `decodings` map, but should.
+// - The old code internally referred to Uint8Arrays with variable names like
+//   `buf`, which confusingly implies an ArrayBuffer rather than a Uint8Array.
+//   The new code here uses names like `u8` instead.
+// - It still supports but deprecates the confusing names `encodeHex` and
+//   `decodeHex`, while providing clearer replacement names
+//   `uint8ArrayToHex` and `hexToUint8Array` respectively.
+// - Deprecates the internal codec makers since they are the input to
+//   feature detecting on `Buffer`. Advise to use use the exported
+//   `uint8ArrayToHex` or `hexToUint8Array` functions directly, since those
+//   are already best efforts based on this feature detection.
+// - Use `Fail` so substitutions (which can reveal user data) get redacted
+//   in the normal production environment.
+
+// TODO https://github.com/Agoric/agoric-sdk/issues/11592 Eventually replace
+// https://github.com/Agoric/agoric-sdk/blob/master/packages/internal/src/hex.js
+// with this module.
+
+
+import { Fail } from '@endo/errors';
+
+/**
+ * @typedef {ReturnType<typeof makePortableHexCodec>} HexCodec
+ */
+
+/** @type {string[]} */
+const encodings = Array.from({ length: 256 }, (_, b) =>
+  // Write the hex representation of the byte.
+  b.toString(16).padStart(2, '0'),
+);
+harden(encodings);
+
+/**
+ * Create map entries for all four permutations of lowercase and uppercase
+ * transformations of the two hex digits per byte. The map is keyed by the hex
+ * string and the value is the byte value. This allows for fast lookups when
+ * decoding hex strings.
+ *
+ * @type {Map<string, number>}
+ */
+const decodings = new Map(
+  encodings.flatMap((hexdigits, b) => {
+    const lo = hexdigits.toLowerCase();
+    const UP = hexdigits.toUpperCase();
+    return [
+      [lo, b],
+      [`${lo[0]}${UP[1]}`, b],
+      [`${UP[0]}${lo[1]}`, b],
+      [UP, b],
+    ];
+  }),
+);
+harden(decodings);
+
+/**
+ * @param {string} hexPair Two hex digits, where each may be lower case or upper
+ * case.
+ * @returns {number}
+ */
+const getDecoding = hexPair => {
+  const result = decodings.get(hexPair);
+  if (result === undefined) {
+    throw Fail`Invalid hex string: ${hexPair}`;
+  }
+  return result;
+};
+harden(getDecoding);
+
+/**
+ * Create a hex codec that is portable across standard JS environments.
+ * @deprecated Just use the exported `uint8ArrayToHex` and `hexToUint8Array`
+ * which are already best efforts based on feature detecting `Buffer`.
+ */
+export const makePortableHexCodec = () => {
+  /**
+   * @param {Uint8Array} u8
+   * @returns {string}
+   */
+  const uint8ArrayToHex = u8 => Array.from(u8, b => encodings[b]).join('');
+
+  /**
+   * @deprecated Use `uint8ArrayToHex` instead
+   * @param {Uint8Array} u8
+   * @returns {string}
+   */
+  const encodeHex = u8 => uint8ArrayToHex(u8);
+
+  /**
+   * @param {string} hex
+   * @returns {Uint8Array}
+   */
+  const hexToUint8Array = hex => {
+    const inputLen = hex.length;
+    if (inputLen % 2 !== 0) {
+      throw Fail`Invalid hex string: ${hex}`;
+    }
+    const u8 = new Uint8Array(inputLen / 2);
+    for (let i = 0; i < inputLen; i += 2) {
+      const b = getDecoding(hex.slice(i, i + 2));
+      // eslint-disable-next-line no-bitwise
+      u8[i >> 1] = b;
+    }
+    // TODO once we can rely on a native implementation of
+    // Immutable ArrayBuffer, do a transferToImmutable and return a new
+    // hardened Uint8Array on that buffer. Cannot yet because the
+    // Immutable ArrayBuffer shim does not support TypedArrays on
+    // emulated Immutable ArrayBuffers.
+    return harden(u8); // special case does not freeze index members.
+  };
+
+  /**
+   * @deprecated Use `hexToUint8Array` instead
+   * @param {string} hex
+   * @returns {Uint8Array}
+   */
+  const decodeHex = hex => hexToUint8Array(hex);
+
+  return harden({
+    uint8ArrayToHex,
+    encodeHex,
+    hexToUint8Array,
+    decodeHex,
+  });
+};
+harden(makePortableHexCodec);
+
+/**
+ * @typedef {Pick<BufferConstructor, 'from' | 'isBuffer'> & {
+ *   prototype: Pick<Buffer, 'toString'> & Uint8Array;
+ * }} BufferishConstructor
+ *   is the portion of the Node.js Buffer API we need for hex conversion.
+ */
+
+/**
+ * Create a hex codec using parts of the Node.js Buffer API.
+ *
+ * @deprecated Just use the exported `uint8ArrayToHex` and `hexToUint8Array`
+ * which are already best efforts based on feature detecting `Buffer`.
+ * @param {BufferishConstructor} Bufferish the object that implements the
+ *   necessary pieces of Buffer
+ * @returns {HexCodec}
+ */
+export const makeBufferishHexCodec = Bufferish => {
+  /**
+   * @param {Uint8Array} u8
+   * @returns {string}
+   */
+  const uint8ArrayToHex = u8 =>
+    (Bufferish.isBuffer?.(u8) ? u8 : Bufferish.from(u8)).toString('hex');
+
+  /**
+   * @deprecated Use `uint8ArrayToHex` instead
+   * @param {Uint8Array} u8
+   * @returns {string}
+   */
+  const encodeHex = u8 => uint8ArrayToHex(u8);
+
+  /**
+   * @param {string} hex
+   * @returns {Uint8Array}
+   */
+  const hexToUint8Array = hex => {
+    const buf = Bufferish.from(hex, 'hex');
+
+    // Coerce to Uint8Array to avoid leaking the abstraction.
+    const u8a = new Uint8Array(
+      buf.buffer,
+      buf.byteOffset,
+      buf.byteLength / Uint8Array.BYTES_PER_ELEMENT,
+    );
+    return u8a;
+  };
+
+  /**
+   * @deprecated Use `hexToUint8Array` instead
+   * @param {string} hex
+   * @returns {Uint8Array}
+   */
+  const decodeHex = hex => hexToUint8Array(hex);
+
+  return harden({
+    uint8ArrayToHex,
+    encodeHex,
+    hexToUint8Array,
+    decodeHex,
+  });
+};
+harden(makeBufferishHexCodec);
+
+/**
+ * Export a hex codec that can work with standard JS engines, but takes
+ * advantage of optimizations on some platforms (like Node.js's Buffer API).
+ */
+export const { uint8ArrayToHex, encodeHex, hexToUint8Array, decodeHex } =
+  typeof Buffer === 'undefined'
+    ? makePortableHexCodec()
+    : makeBufferishHexCodec(Buffer);

--- a/packages/pass-style/src/hex.js
+++ b/packages/pass-style/src/hex.js
@@ -26,7 +26,6 @@
 // https://github.com/Agoric/agoric-sdk/blob/master/packages/internal/src/hex.js
 // with this module.
 
-
 import { Fail } from '@endo/errors';
 
 /**

--- a/packages/pass-style/src/hex.js
+++ b/packages/pass-style/src/hex.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+// /* global Buffer */
 
 // This module should eventually replace
 // https://github.com/Agoric/agoric-sdk/blob/master/packages/internal/src/hex.js

--- a/packages/pass-style/test/byteArray.test.js
+++ b/packages/pass-style/test/byteArray.test.js
@@ -1,0 +1,85 @@
+import test from '@endo/ses-ava/prepare-endo.js';
+import {
+  byteArrayToUint8Array,
+  hexToByteArray,
+  byteArrayToHex,
+  uint8ArrayToByteArray,
+} from '../src/byteArray.js';
+
+// modeled on `@endo/base64`'s main.test.js
+
+/**
+ * @param {string} string Only uses the low byte of each UTF16 code unit, which
+ * is ok as long as it is used only for this purpose for a local test, and not
+ * exported.
+ * @returns {ArrayBuffer} A ByteArray, i.e., a hardened Immutable ArrayBuffer
+ */
+const stringToByteArray = string => {
+  const data = new Uint8Array(string.length);
+  for (let i = 0; i < string.length; i += 1) {
+    data[i] = string.charCodeAt(i);
+  }
+  return uint8ArrayToByteArray(data);
+};
+
+/**
+ * @param {ArrayBuffer} byteArray
+ * @returns {string} Interpreting each 8-bit value as an 8-bit UTF-16 code
+ * unit. Since this cannot include any UTF-16 surrogates, this is equivalent
+ * to interpreting each 8-bit value as an 8-bit ascii code point. This
+ * may be unexpected, and so is ok as long as it is used only for this purpose
+ * for a local test, and not exported.
+ */
+const byteArrayToString = byteArray => {
+  return String.fromCharCode(...byteArrayToUint8Array(byteArray));
+};
+
+test('byteArray / base64 conversion', t => {
+  const insouts = [
+    ['', ''],
+    ['f', '66'],
+    ['fo', '666f'],
+    ['foo', '666f6f'],
+    ['foob', '666f6f62'],
+    ['fooba', '666f6f6261'],
+    ['foobar', '666f6f626172'],
+  ];
+  for (const [inp, outp] of insouts) {
+    t.is(byteArrayToHex(stringToByteArray(inp)), outp, `${inp} encodes`);
+    t.is(byteArrayToString(hexToByteArray(outp)), inp, `${outp} decodes`);
+  }
+  const inputs = [
+    'a',
+    'ab',
+    'abc',
+    'Hello, world!',
+    '\x0d\x02\x09\xff\xfe',
+    'other--+iadtedata',
+  ];
+  for (const str of inputs) {
+    t.is(
+      byteArrayToString(hexToByteArray(byteArrayToHex(stringToByteArray(str)))),
+      str,
+      `${str} round trips`,
+    );
+  }
+});
+
+test('invalid encodings', t => {
+  const badInputs = [
+    ['%', '"%" should be an even number of characters'],
+    ['0%', '"0%" is not a hex digit'], // this input is bad in multiple ways
+
+    ['a', '"a" should be an even number of characters'],
+    ['a00', '"a00" should be an even number of characters'],
+
+    // non-zero padding bits (MAY reject): ['Qf==', ...],
+  ];
+  for (const [badInput, message] of badInputs) {
+    t.throws(
+      () => hexToByteArray(badInput),
+      { message },
+      `${badInput} is rejected`,
+    );
+  }
+});

--- a/packages/pass-style/test/byteArray.test.js
+++ b/packages/pass-style/test/byteArray.test.js
@@ -67,11 +67,11 @@ test('byteArray / base64 conversion', t => {
 
 test('invalid encodings', t => {
   const badInputs = [
-    ['%', '"%" should be an even number of characters'],
-    ['0%', '"0%" is not a hex digit'], // this input is bad in multiple ways
+    ['%', '"%" must be an even number of characters'],
+    ['0%', 'Invalid hex string: "0%"'], // this input is bad in multiple ways
 
-    ['a', '"a" should be an even number of characters'],
-    ['a00', '"a00" should be an even number of characters'],
+    ['a', '"a" must be an even number of characters'],
+    ['a00', '"a00" must be an even number of characters'],
 
     // non-zero padding bits (MAY reject): ['Qf==', ...],
   ];


### PR DESCRIPTION
Closes: #XXXX
Refs: #XXXX

## Description

Provides for serialization and unserialization of ByteArrays (passable frozen Immutable ArrayBuffers) to our various textual encodings (capData, smallcaps, justin).

It does not yet add any encoding for ByteArrays to `encodePassable`. Attn @gibson042 

Alternative to https://github.com/endojs/endo/pull/2844 using hex instead of base64

### Security Considerations

Assuming this PR is correct, none

### Scaling Considerations

Hex is a terribly inefficient encoding of binary, but that's the price of using a textual format.

Further, with https://github.com/tc39/proposal-arraybuffer-base64 not yet being part of the platform, Doing this conversion in JS vs native is horribly inefficient, especially on XS.

Hopefully, most of the time when we actually want to marshal large ByteArrays, we'll have switched to a binary format that needs no translation.

### Documentation Considerations

Just an extension of the passable types that marshal should accept.

### Testing Considerations

Includes tests

### Compatibility Considerations

If a system post this PR sends a ByteArray through marshal to a receiver that is pre this PR, the receiver will error since this is a case it does not know about.

### Upgrade Considerations

When storing a ByteArray to durable storage, you'll actually be storing this hex-based encoding. That durable storage can only be understood post this PR, which is a problem if there is a co-existence of code in one vat, some of which has bundled pre this PR and some post this PR.
