### PR TITLE
refactor: `hasOwn` rather than `hasOwnPropertyOf` or `objectHasOwnProperty`

### DIFF
--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -1,5 +1,5 @@
 import { getMethodNames } from '@endo/eventual-send/utils.js';
-import { hasOwnPropertyOf, toThrowable } from '@endo/pass-style';
+import { toThrowable } from '@endo/pass-style';
 import { E, Far } from '@endo/far';
 import {
   mustMatch,
@@ -22,7 +22,7 @@ import { GET_INTERFACE_GUARD } from './get-interface.js';
  */
 
 const { apply, ownKeys } = Reflect;
-const { defineProperties, fromEntries } = Object;
+const { defineProperties, fromEntries, hasOwn } = Object;
 
 /**
  * A method guard, for inclusion in an interface guard, that does not
@@ -446,7 +446,7 @@ export const defendPrototype = (
     );
   }
 
-  if (!hasOwnPropertyOf(prototype, GET_INTERFACE_GUARD)) {
+  if (!hasOwn(prototype, GET_INTERFACE_GUARD)) {
     const getInterfaceGuardMethod = {
       [GET_INTERFACE_GUARD]() {
         // Note: May be `undefined`

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -12,7 +12,6 @@ import {
   makeTagged,
   isPrimitive,
   getTag,
-  hasOwnPropertyOf,
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
@@ -31,6 +30,7 @@ const {
   entries,
   fromEntries,
   freeze,
+  hasOwn,
 } = Object;
 
 /**
@@ -41,10 +41,10 @@ const QCLASS = '@qclass';
 export { QCLASS };
 
 /**
- * @param {Encoding} encoded
+ * @param {Encoding & object} encoded
  * @returns {encoded is EncodingUnion}
  */
-const hasQClass = encoded => hasOwnPropertyOf(encoded, QCLASS);
+const hasQClass = encoded => hasOwn(encoded, QCLASS);
 
 /**
  * @param {Encoding} encoded
@@ -164,7 +164,7 @@ export const makeEncodeToCapData = (encodeOptions = {}) => {
         };
       }
       case 'copyRecord': {
-        if (hasOwnPropertyOf(passable, QCLASS)) {
+        if (hasOwn(passable, QCLASS)) {
           // Hilbert hotel
           const { [QCLASS]: qclassValue, ...rest } = passable;
           /** @type {Encoding} */
@@ -394,11 +394,11 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
         }
         case 'hilbert': {
           const { original, rest } = jsonEncoded;
-          hasOwnPropertyOf(jsonEncoded, 'original') ||
+          hasOwn(jsonEncoded, 'original') ||
             Fail`Invalid Hilbert Hotel encoding ${jsonEncoded}`;
           // Don't harden since we're not done mutating it
           const result = { [QCLASS]: decodeFromCapData(original) };
-          if (hasOwnPropertyOf(jsonEncoded, 'rest')) {
+          if (hasOwn(jsonEncoded, 'rest')) {
             const isNonEmptyObject =
               typeof rest === 'object' &&
               rest !== null &&
@@ -410,7 +410,7 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
             // TODO really should assert that `passStyleOf(rest)` is
             // `'copyRecord'` but we'd have to harden it and it is too
             // early to do that.
-            !hasOwnPropertyOf(restObj, QCLASS) ||
+            !hasOwn(restObj, QCLASS) ||
               Fail`Rest must not contain its own definition of ${q(QCLASS)}`;
             defineProperties(result, getOwnPropertyDescriptors(restObj));
           }

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -12,7 +12,6 @@ import {
   isErrorLike,
   makeTagged,
   getTag,
-  hasOwnPropertyOf,
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
@@ -26,7 +25,7 @@ import { X, Fail, q } from '@endo/errors';
 
 const { ownKeys } = Reflect;
 const { isArray } = Array;
-const { is, entries, fromEntries } = Object;
+const { is, entries, fromEntries, hasOwn } = Object;
 
 const BANG = '!'.charCodeAt(0);
 const DASH = '-'.charCodeAt(0);
@@ -124,7 +123,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
   } = encodeOptions;
 
   const assertEncodedError = encoding => {
-    (typeof encoding === 'object' && hasOwnPropertyOf(encoding, '#error')) ||
+    (typeof encoding === 'object' && hasOwn(encoding, '#error')) ||
       Fail`internal: Error encoding must have "#error" property: ${q(
         encoding,
       )}`;
@@ -423,7 +422,7 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
           return encoding.map(val => decodeFromSmallcaps(val));
         }
 
-        if (hasOwnPropertyOf(encoding, '#tag')) {
+        if (hasOwn(encoding, '#tag')) {
           const { '#tag': tag, payload, ...rest } = encoding;
           typeof tag === 'string' ||
             Fail`Value of "#tag", the tag, must be a string: ${encoding}`;
@@ -435,7 +434,7 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
           );
         }
 
-        if (hasOwnPropertyOf(encoding, '#error')) {
+        if (hasOwn(encoding, '#error')) {
           const result = decodeErrorFromSmallcaps(
             encoding,
             decodeFromSmallcaps,

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -5,7 +5,6 @@ import {
   assertPassable,
   getInterfaceOf,
   getErrorConstructor,
-  hasOwnPropertyOf,
   toPassableError,
 } from '@endo/pass-style';
 
@@ -28,7 +27,7 @@ import {
  * @import {Encoding} from './types.js';
  */
 
-const { defineProperties } = Object;
+const { defineProperties, hasOwn } = Object;
 const { isArray } = Array;
 const { ownKeys } = Reflect;
 
@@ -364,7 +363,7 @@ export const makeMarshal = (
 
     const decodeErrorFromSmallcaps = (encoding, decodeRecur) => {
       const { '#error': message, ...restErrData } = encoding;
-      !hasOwnPropertyOf(restErrData, 'message') ||
+      !hasOwn(restErrData, 'message') ||
         Fail`unexpected encoded error property ${q('message')}`;
       return decodeErrorCommon({ message, ...restErrData }, decodeRecur);
     };

--- a/packages/pass-style/src/passStyle-helpers.js
+++ b/packages/pass-style/src/passStyle-helpers.js
@@ -11,7 +11,7 @@ const { prototype: functionPrototype } = Function;
 const {
   getOwnPropertyDescriptor,
   getPrototypeOf,
-  hasOwnProperty: objectHasOwnProperty,
+  hasOwn,
   isFrozen,
   prototype: objectPrototype,
 } = Object;
@@ -27,9 +27,10 @@ assert(typedArrayToStringTagDesc);
 const getTypedArrayToStringTag = typedArrayToStringTagDesc.get;
 assert(typeof getTypedArrayToStringTag === 'function');
 
-export const hasOwnPropertyOf = (obj, prop) =>
-  apply(objectHasOwnProperty, obj, [prop]);
-harden(hasOwnPropertyOf);
+/**
+ * @deprecated Use `Object.hasOwn` instead
+ */
+export const hasOwnPropertyOf = hasOwn;
 
 /**
  * @type {(val: unknown) => val is JSPrimitive}
@@ -133,7 +134,7 @@ export const getOwnDataDescriptor = (
   );
   return (desc !== undefined ||
     (!!check && CX(check)`${q(propName)} property expected: ${candidate}`)) &&
-    (hasOwnPropertyOf(desc, 'value') ||
+    (hasOwn(desc, 'value') ||
       (!!check &&
         CX(
           check,

--- a/packages/pass-style/src/remotable.js
+++ b/packages/pass-style/src/remotable.js
@@ -4,7 +4,6 @@ import { Fail, q } from '@endo/errors';
 import {
   assertChecker,
   canBeMethod,
-  hasOwnPropertyOf,
   PASS_STYLE,
   checkTagRecord,
   checkFunctionTagRecord,
@@ -27,6 +26,7 @@ const {
   isFrozen,
   prototype: objectPrototype,
   getOwnPropertyDescriptors,
+  hasOwn,
 } = Object;
 
 /**
@@ -219,7 +219,7 @@ export const RemotableHelper = harden({
       return ownKeys(descs).every(key => {
         return (
           // Typecast needed due to https://github.com/microsoft/TypeScript/issues/1863
-          (hasOwnPropertyOf(descs[/** @type {string} */ (key)], 'value') ||
+          (hasOwn(descs[/** @type {string} */ (key)], 'value') ||
             (!!check &&
               CX(check)`cannot serialize Remotables with accessors like ${q(
                 String(key),

--- a/packages/pass-style/src/safe-promise.js
+++ b/packages/pass-style/src/safe-promise.js
@@ -2,11 +2,11 @@
 
 import { isPromise } from '@endo/promise-kit';
 import { q } from '@endo/errors';
-import { assertChecker, hasOwnPropertyOf, CX } from './passStyle-helpers.js';
+import { assertChecker, CX } from './passStyle-helpers.js';
 
 /** @import {Checker} from './types.js' */
 
-const { isFrozen, getPrototypeOf, getOwnPropertyDescriptor } = Object;
+const { isFrozen, getPrototypeOf, getOwnPropertyDescriptor, hasOwn } = Object;
 const { ownKeys } = Reflect;
 const { toStringTag } = Symbol;
 
@@ -32,7 +32,7 @@ const checkPromiseOwnKeys = (pr, check) => {
    *   * Those own properties that might be added by Node's async_hooks.
    */
   const unknownKeys = keys.filter(
-    key => typeof key !== 'symbol' || !hasOwnPropertyOf(Promise.prototype, key),
+    key => typeof key !== 'symbol' || !hasOwn(Promise.prototype, key),
   );
 
   if (unknownKeys.length !== 0) {
@@ -69,7 +69,7 @@ const checkPromiseOwnKeys = (pr, check) => {
       const tagDesc = getOwnPropertyDescriptor(pr, toStringTag);
       assert(tagDesc !== undefined);
       return (
-        (hasOwnPropertyOf(tagDesc, 'value') ||
+        (hasOwn(tagDesc, 'value') ||
           CX(
             check,
           )`Own @@toStringTag must be a data property, not an accessor: ${q(tagDesc)}`) &&

--- a/packages/patterns/src/patterns/patternMatchers.js
+++ b/packages/patterns/src/patterns/patternMatchers.js
@@ -11,7 +11,6 @@ import {
   getTag,
   makeTagged,
   passStyleOf,
-  hasOwnPropertyOf,
   nameForPassableSymbol,
 } from '@endo/pass-style';
 import {
@@ -47,7 +46,7 @@ import { generateCollectionPairEntries } from '../keys/keycollection-operators.j
  * @import {MatchHelper, PatternKit} from './types.js'
  */
 
-const { entries, values } = Object;
+const { entries, values, hasOwn } = Object;
 const { ownKeys } = Reflect;
 
 /** @type {WeakSet<Pattern>} */
@@ -1698,9 +1697,9 @@ const makePatternKit = () => {
     /** @type {[string, Passable][]} */
     const restEntries = [];
     for (const [name, value] of entries(specimen)) {
-      if (hasOwnPropertyOf(requiredPatt, name)) {
+      if (hasOwn(requiredPatt, name)) {
         requiredEntries.push([name, value]);
-      } else if (hasOwnPropertyOf(optionalPatt, name)) {
+      } else if (hasOwn(optionalPatt, name)) {
         optionalEntries.push([name, value]);
       } else {
         restEntries.push([name, value]);

--- a/packages/ses/src/cauterize-property.js
+++ b/packages/ses/src/cauterize-property.js
@@ -1,4 +1,4 @@
-import { objectHasOwnProperty } from './commons.js';
+import { hasOwn } from './commons.js';
 
 /**
  * @import {Reporter} from './reporting-types.js'
@@ -52,7 +52,7 @@ export const cauterizeProperty = (
   try {
     delete obj[prop];
   } catch (err) {
-    if (objectHasOwnProperty(obj, prop)) {
+    if (hasOwn(obj, prop)) {
       if (typeof obj === 'function' && prop === 'prototype') {
         obj.prototype = undefined;
         if (obj.prototype === undefined) {

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -77,6 +77,7 @@ export const {
   setPrototypeOf,
   values,
   fromEntries,
+  hasOwn,
 } = Object;
 
 export const {
@@ -166,7 +167,10 @@ const { bind } = functionPrototype;
  */
 export const uncurryThis = bind.bind(bind.call); // eslint-disable-line @endo/no-polymorphic-call
 
-export const objectHasOwnProperty = uncurryThis(objectPrototype.hasOwnProperty);
+/**
+ * @deprecated Use `hasOwn` instead
+ */
+export const objectHasOwnProperty = hasOwn;
 //
 export const arrayFilter = uncurryThis(arrayPrototype.filter);
 export const arrayForEach = uncurryThis(arrayPrototype.forEach);

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -12,7 +12,7 @@ import {
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
   isPrimitive,
-  objectHasOwnProperty,
+  hasOwn,
   ownKeys,
   setHas,
 } from './commons.js';
@@ -109,7 +109,7 @@ export default function enablePropertyOverrides(
                 )}' of '${path}'`,
               );
             }
-            if (objectHasOwnProperty(this, prop)) {
+            if (hasOwn(this, prop)) {
               this[prop] = newValue;
             } else {
               if (isDebug) {

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -39,7 +39,7 @@ import {
   ownKeys,
   create,
   objectPrototype,
-  objectHasOwnProperty,
+  hasOwn,
 } from '../commons.js';
 import { an, bestEffortStringify } from './stringify-utils.js';
 import './types.js';
@@ -307,7 +307,7 @@ export const sanitizeError = error => {
   for (const name of ownKeys(error)) {
     // @ts-expect-error TS still confused by symbols as property names
     const desc = descs[name];
-    if (desc && objectHasOwnProperty(desc, 'get')) {
+    if (desc && hasOwn(desc, 'get')) {
       defineProperty(error, name, {
         value: error[name], // invoke the getter to convert to data property
       });

--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -5,7 +5,7 @@ import {
   defineProperty,
   entries,
   freeze,
-  objectHasOwnProperty,
+  hasOwn,
   unscopablesSymbol,
 } from './commons.js';
 import { makeEvalFunction } from './make-eval-function.js';
@@ -87,7 +87,7 @@ export const setGlobalObjectMutableProperties = (
   },
 ) => {
   for (const [name, intrinsicName] of entries(universalPropertyNames)) {
-    if (objectHasOwnProperty(intrinsics, intrinsicName)) {
+    if (hasOwn(intrinsics, intrinsicName)) {
       defineProperty(globalObject, name, {
         value: intrinsics[intrinsicName],
         writable: true,
@@ -98,7 +98,7 @@ export const setGlobalObjectMutableProperties = (
   }
 
   for (const [name, intrinsicName] of entries(newGlobalPropertyNames)) {
-    if (objectHasOwnProperty(intrinsics, intrinsicName)) {
+    if (hasOwn(intrinsics, intrinsicName)) {
       defineProperty(globalObject, name, {
         value: intrinsics[intrinsicName],
         writable: true,

--- a/packages/ses/src/intrinsics.js
+++ b/packages/ses/src/intrinsics.js
@@ -12,7 +12,7 @@ import {
   globalThis,
   is,
   isPrimitive,
-  objectHasOwnProperty,
+  hasOwn,
   values,
   weaksetHas,
 } from './commons.js';
@@ -37,7 +37,7 @@ const isFunction = obj => typeof obj === 'function';
 // get masked as one overwrites the other. Accordingly, the thrown error
 // complains of a "Conflicting definition".
 function initProperty(obj, name, desc) {
-  if (objectHasOwnProperty(obj, name)) {
+  if (hasOwn(obj, name)) {
     const preDesc = getOwnPropertyDescriptor(obj, name);
     if (
       !preDesc ||
@@ -69,7 +69,7 @@ function initProperties(obj, descs) {
 function sampleGlobals(globalObject, newPropertyNames) {
   const newIntrinsics = { __proto__: null };
   for (const [globalName, intrinsicName] of entries(newPropertyNames)) {
-    if (objectHasOwnProperty(globalObject, globalName)) {
+    if (hasOwn(globalObject, globalName)) {
       newIntrinsics[intrinsicName] = globalObject[globalName];
     }
   }
@@ -98,7 +98,7 @@ export const makeIntrinsicsCollector = reporter => {
         // eslint-disable-next-line no-continue
         continue;
       }
-      if (!objectHasOwnProperty(intrinsic, 'prototype')) {
+      if (!hasOwn(intrinsic, 'prototype')) {
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -120,12 +120,12 @@ export const makeIntrinsicsCollector = reporter => {
       }
       if (
         typeof namePrototype !== 'string' ||
-        !objectHasOwnProperty(permitted, namePrototype)
+        !hasOwn(permitted, namePrototype)
       ) {
         throw TypeError(`Unrecognized ${name}.prototype permits entry`);
       }
       const intrinsicPrototype = intrinsic.prototype;
-      if (objectHasOwnProperty(intrinsics, namePrototype)) {
+      if (hasOwn(intrinsics, namePrototype)) {
         if (intrinsics[namePrototype] !== intrinsicPrototype) {
           throw TypeError(`Conflicting bindings of ${namePrototype}`);
         }

--- a/packages/ses/src/make-hardener.js
+++ b/packages/ses/src/make-hardener.js
@@ -36,7 +36,7 @@ import {
   getPrototypeOf,
   isInteger,
   isPrimitive,
-  objectHasOwnProperty,
+  hasOwn,
   ownKeys,
   preventExtensions,
   setAdd,
@@ -206,7 +206,7 @@ export const makeHardener = () => {
           // test could be confused. We use hasOwnProperty to be sure about
           // whether 'value' is present or not, which tells us for sure that
           // this is a data property.
-          if (objectHasOwnProperty(desc, 'value')) {
+          if (hasOwn(desc, 'value')) {
             enqueue(desc.value);
           } else {
             enqueue(desc.get);

--- a/packages/ses/src/permits-intrinsics.js
+++ b/packages/ses/src/permits-intrinsics.js
@@ -57,7 +57,7 @@ import {
   getPrototypeOf,
   isPrimitive,
   mapGet,
-  objectHasOwnProperty,
+  hasOwn,
   ownKeys,
   symbolKeyFor,
 } from './commons.js';
@@ -185,7 +185,7 @@ export default function removeUnpermittedIntrinsics(
         // Assert: the permit is the name of an intrinsic.
         // Assert: the property value is equal to that intrinsic.
 
-        if (objectHasOwnProperty(intrinsics, permit)) {
+        if (hasOwn(intrinsics, permit)) {
           if (value !== intrinsics[permit]) {
             throw TypeError(`Does not match permit for ${path}`);
           }
@@ -225,7 +225,7 @@ export default function removeUnpermittedIntrinsics(
     }
 
     // Is this a value property?
-    if (objectHasOwnProperty(desc, 'value')) {
+    if (hasOwn(desc, 'value')) {
       if (isAccessorPermit(permit)) {
         throw TypeError(`Accessor expected at ${path}`);
       }
@@ -245,12 +245,12 @@ export default function removeUnpermittedIntrinsics(
    */
   function getSubPermit(obj, permit, prop) {
     const permitProp = prop === '__proto__' ? '--proto--' : prop;
-    if (objectHasOwnProperty(permit, permitProp)) {
+    if (hasOwn(permit, permitProp)) {
       return permit[permitProp];
     }
 
     if (typeof obj === 'function') {
-      if (objectHasOwnProperty(FunctionInstance, permitProp)) {
+      if (hasOwn(FunctionInstance, permitProp)) {
         return FunctionInstance[permitProp];
       }
     }

--- a/packages/ses/src/scope-constants.js
+++ b/packages/ses/src/scope-constants.js
@@ -3,7 +3,7 @@ import {
   arrayIncludes,
   getOwnPropertyDescriptor,
   getOwnPropertyNames,
-  objectHasOwnProperty,
+  hasOwn,
   regexpTest,
 } from './commons.js';
 
@@ -131,7 +131,7 @@ function isImmutableDataProperty(obj, name) {
     // can't have accessors and value properties at the same time, therefore
     // this check is sufficient. Using explicit own property deal with the
     // case where Object.prototype has been poisoned.
-    objectHasOwnProperty(desc, 'value')
+    hasOwn(desc, 'value')
   );
 }
 

--- a/packages/ses/src/tame-regenerator-runtime.js
+++ b/packages/ses/src/tame-regenerator-runtime.js
@@ -2,7 +2,7 @@ import {
   defineProperty,
   iteratorPrototype,
   iteratorSymbol,
-  objectHasOwnProperty,
+  hasOwn,
 } from './commons.js';
 
 export const tameRegeneratorRuntime = () => {
@@ -15,7 +15,7 @@ export const tameRegeneratorRuntime = () => {
     set(value) {
       // ignore the assignment on IteratorPrototype
       if (this === iteratorPrototype) return;
-      if (objectHasOwnProperty(this, iteratorSymbol)) {
+      if (hasOwn(this, iteratorSymbol)) {
         this[iteratorSymbol] = value;
       }
       defineProperty(this, iteratorSymbol, {


### PR DESCRIPTION
Closes: #XXXX
Refs: #1627 

## Description

Replaces #1627 

Starting with Node 16.9, `Object.hasOwn` is supported and does what our hand rolled `hasOwnPropertyOf` or `objectHasOwnProperty` did. This PR changes all uses to use `hasOwn` instead. However, for the sake of compat, it only deprecates the old exports. It does not delete them.

Reviewers, `objectHasOwnProperty` is not exported from ses. Should I delete it instead of deprecating it?

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

one less thing to document
### Testing Considerations

none
### Compatibility Considerations

none, as long as all platforms we still support already provide `Object.hasOwn`.

### Upgrade Considerations

none