### PR TITLE
chore: Clean up after #2873

### DIFF
--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -2,7 +2,7 @@ User-visible changes in `@endo/marshal`:
 
 # Next release
 
-- Introduces an environment variable config option `ENDO_RANK_STRINGS`, defaulting off for now, to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN conformant) ordering by Unicode code point. Thus, for now, when this default is not overridden, there is no observable change.
+- Introduces an environment variable config option `ENDO_RANK_STRINGS` to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN-conformant) ordering by Unicode code point. It currently defaults to "utf16-code-unit-order", matching the previously-unconditional behavior.
 
 # v1.7.0 (2025-06-02)
 

--- a/packages/marshal/test/string-rank-both-order.test.js
+++ b/packages/marshal/test/string-rank-both-order.test.js
@@ -17,7 +17,7 @@ import { encodePassable } from './encodePassable-for-testing.js';
  */
 const sorted = (strings, comp) => [...strings].sort(comp);
 
-test('unicode code point order', t => {
+test('string ranking by code point/UTF-16 code unit agreement', t => {
   // Test case from
   // https://icu-project.org/docs/papers/utf16_code_point_order.html
   const str0 = '\u{ff61}';

--- a/packages/marshal/test/string-rank-both-order.test.js
+++ b/packages/marshal/test/string-rank-both-order.test.js
@@ -46,7 +46,14 @@ test('string ranking by code point/UTF-16 code unit agreement', t => {
   t.deepEqual(nativeSorted, [str1, str3, str2, str0]);
 
   t.throws(() => sorted(strs, compareRank), {
-    message: 'Comparisons differed: "𐀂" vs "\\ud800｡", -1 vs 1',
+    message: msg => {
+      t.log(msg);
+      if (!msg.startsWith('Comparisons differed: ')) return false;
+      if (!msg.endsWith('-1 vs 1') && !msg.endsWith('1 vs -1')) return false;
+      if (!msg.includes(JSON.stringify(str3))) return false;
+      if (!msg.includes(JSON.stringify(str2))) return false;
+      return true;
+    },
   });
 
   const nativeEncComp = (left, right) =>

--- a/packages/marshal/test/string-rank-both-order.test.js
+++ b/packages/marshal/test/string-rank-both-order.test.js
@@ -2,64 +2,34 @@ import '../tools/prepare-error-if-order-choice-matters.js';
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { compareRank } from '../src/rankOrder.js';
+import {
+  compareByUtf16CodeUnit,
+  multiplanarStrings,
+  sorted,
+  stringsByUtf16CodeUnit,
+} from '../tools/marshal-test-data.js';
 import { encodePassable } from './encodePassable-for-testing.js';
 
-/**
- * Essentially a ponyfill for Array.prototype.toSorted, for use before
- * we can always rely on the platform to provide it.
- *
- * @param {string[]} strings
- * @param {(
- *   left: string,
- *   right: string
- * ) => import('../src/types.js').RankComparison} comp
- * @returns {string[]}
- */
-const sorted = (strings, comp) => [...strings].sort(comp);
+const { loneSurrogate$bmpHigh, bmpHigh, surrogatePair } = multiplanarStrings;
 
 test('string ranking by code point/UTF-16 code unit agreement', t => {
-  // Test case from
-  // https://icu-project.org/docs/papers/utf16_code_point_order.html
-  const str0 = '\u{ff61}';
-  const str3 = '\u{d800}\u{dc02}';
-
-  // str1 and str2 become impossible examples once we prohibit
-  // non - well - formed strings.
-  // See https://github.com/endojs/endo/pull/2002
-  const str1 = '\u{d800}X';
-  const str2 = '\u{d800}\u{ff61}';
-
-  // harden to ensure it is not sorted in place, just for sanity
-  const strs = harden([str0, str1, str2, str3]);
-
-  /**
-   * @param {string} left
-   * @param {string} right
-   * @returns {import('../src/types.js').RankComparison}
-   */
-  const nativeComp = (left, right) =>
-    // eslint-disable-next-line no-nested-ternary
-    left < right ? -1 : left > right ? 1 : 0;
-
-  const nativeSorted = sorted(strs, nativeComp);
-
-  t.deepEqual(nativeSorted, [str1, str3, str2, str0]);
+  const strs = harden(Object.values(multiplanarStrings));
 
   t.throws(() => sorted(strs, compareRank), {
     message: msg => {
       t.log(msg);
       if (!msg.startsWith('Comparisons differed: ')) return false;
       if (!msg.endsWith('-1 vs 1') && !msg.endsWith('1 vs -1')) return false;
-      if (!msg.includes(JSON.stringify(str3))) return false;
-      if (!msg.includes(JSON.stringify(str2))) return false;
-      return true;
+      if (!msg.includes(JSON.stringify(surrogatePair))) return false;
+      return (
+        msg.includes(JSON.stringify(loneSurrogate$bmpHigh)) ||
+        msg.includes(JSON.stringify(bmpHigh))
+      );
     },
   });
 
   const nativeEncComp = (left, right) =>
-    nativeComp(encodePassable(left), encodePassable(right));
-
+    compareByUtf16CodeUnit(encodePassable(left), encodePassable(right));
   const nativeEncSorted = sorted(strs, nativeEncComp);
-
-  t.deepEqual(nativeEncSorted, nativeSorted);
+  t.deepEqual(nativeEncSorted, stringsByUtf16CodeUnit);
 });

--- a/packages/marshal/test/string-rank-unicode-order.test.js
+++ b/packages/marshal/test/string-rank-unicode-order.test.js
@@ -17,7 +17,7 @@ import { encodePassable } from './encodePassable-for-testing.js';
  */
 const sorted = (strings, comp) => [...strings].sort(comp);
 
-test('unicode code point order', t => {
+test('string ranking by code point', t => {
   // Test case from
   // https://icu-project.org/docs/papers/utf16_code_point_order.html
   const str0 = '\u{ff61}';

--- a/packages/marshal/test/string-rank-unicode-order.test.js
+++ b/packages/marshal/test/string-rank-unicode-order.test.js
@@ -2,64 +2,43 @@ import '../tools/prepare-unicode-code-point-order.js';
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { compareRank } from '../src/rankOrder.js';
+import {
+  compareByUtf16CodeUnit,
+  multiplanarStrings,
+  sorted,
+  stringsByUtf16CodeUnit,
+} from '../tools/marshal-test-data.js';
 import { encodePassable } from './encodePassable-for-testing.js';
 
-/**
- * Essentially a ponyfill for Array.prototype.toSorted, for use before
- * we can always rely on the platform to provide it.
- *
- * @param {string[]} strings
- * @param {(
- *   left: string,
- *   right: string
- * ) => import('../src/types.js').RankComparison} comp
- * @returns {string[]}
- */
-const sorted = (strings, comp) => [...strings].sort(comp);
+const {
+  bmpLow,
+  loneSurrogate,
+  loneSurrogate$bmpLow,
+  loneSurrogate$bmpHigh,
+  bmpHigh,
+  surrogatePair,
+} = multiplanarStrings;
 
 test('string ranking by code point', t => {
-  // Test case from
-  // https://icu-project.org/docs/papers/utf16_code_point_order.html
-  const str0 = '\u{ff61}';
-  const str3 = '\u{d800}\u{dc02}';
-
-  // str1 and str2 become impossible examples once we prohibit
-  // non - well - formed strings.
-  // See https://github.com/endojs/endo/pull/2002
-  const str1 = '\u{d800}X';
-  const str2 = '\u{d800}\u{ff61}';
-
-  // harden to ensure it is not sorted in place, just for sanity
-  const strs = harden([str0, str1, str2, str3]);
-
-  /**
-   * @param {string} left
-   * @param {string} right
-   * @returns {import('../src/types.js').RankComparison}
-   */
-  const nativeComp = (left, right) =>
-    // eslint-disable-next-line no-nested-ternary
-    left < right ? -1 : left > right ? 1 : 0;
-
-  const nativeSorted = sorted(strs, nativeComp);
-
-  t.deepEqual(nativeSorted, [str1, str3, str2, str0]);
+  const strs = harden(Object.values(multiplanarStrings));
 
   const rankSorted = sorted(strs, compareRank);
-
-  t.deepEqual(rankSorted, [str1, str2, str0, str3]);
+  t.deepEqual(rankSorted, [
+    bmpLow,
+    loneSurrogate,
+    loneSurrogate$bmpLow,
+    loneSurrogate$bmpHigh,
+    bmpHigh,
+    surrogatePair,
+  ]);
 
   const nativeEncComp = (left, right) =>
-    nativeComp(encodePassable(left), encodePassable(right));
-
+    compareByUtf16CodeUnit(encodePassable(left), encodePassable(right));
   const nativeEncSorted = sorted(strs, nativeEncComp);
-
-  t.deepEqual(nativeEncSorted, nativeSorted);
+  t.deepEqual(nativeEncSorted, stringsByUtf16CodeUnit);
 
   const rankEncComp = (left, right) =>
     compareRank(encodePassable(left), encodePassable(right));
-
   const rankEncSorted = sorted(strs, rankEncComp);
-
   t.deepEqual(rankEncSorted, rankSorted);
 });

--- a/packages/marshal/test/string-rank-utf16-order.test.js
+++ b/packages/marshal/test/string-rank-utf16-order.test.js
@@ -17,7 +17,7 @@ import { encodePassable } from './encodePassable-for-testing.js';
  */
 const sorted = (strings, comp) => [...strings].sort(comp);
 
-test('unicode code point order', t => {
+test('string ranking by UTF-16 code unit', t => {
   // Test case from
   // https://icu-project.org/docs/papers/utf16_code_point_order.html
   const str0 = '\u{ff61}';

--- a/packages/marshal/test/string-rank-utf16-order.test.js
+++ b/packages/marshal/test/string-rank-utf16-order.test.js
@@ -2,64 +2,43 @@ import '../tools/prepare-utf16-code-unit-order.js';
 import test from '@endo/ses-ava/prepare-endo.js';
 
 import { compareRank } from '../src/rankOrder.js';
+import {
+  compareByUtf16CodeUnit,
+  multiplanarStrings,
+  sorted,
+  stringsByUtf16CodeUnit,
+} from '../tools/marshal-test-data.js';
 import { encodePassable } from './encodePassable-for-testing.js';
 
-/**
- * Essentially a ponyfill for Array.prototype.toSorted, for use before
- * we can always rely on the platform to provide it.
- *
- * @param {string[]} strings
- * @param {(
- *   left: string,
- *   right: string
- * ) => import('../src/types.js').RankComparison} comp
- * @returns {string[]}
- */
-const sorted = (strings, comp) => [...strings].sort(comp);
+const {
+  bmpLow,
+  loneSurrogate,
+  loneSurrogate$bmpLow,
+  loneSurrogate$bmpHigh,
+  bmpHigh,
+  surrogatePair,
+} = multiplanarStrings;
 
 test('string ranking by UTF-16 code unit', t => {
-  // Test case from
-  // https://icu-project.org/docs/papers/utf16_code_point_order.html
-  const str0 = '\u{ff61}';
-  const str3 = '\u{d800}\u{dc02}';
-
-  // str1 and str2 become impossible examples once we prohibit
-  // non - well - formed strings.
-  // See https://github.com/endojs/endo/pull/2002
-  const str1 = '\u{d800}X';
-  const str2 = '\u{d800}\u{ff61}';
-
-  // harden to ensure it is not sorted in place, just for sanity
-  const strs = harden([str0, str1, str2, str3]);
-
-  /**
-   * @param {string} left
-   * @param {string} right
-   * @returns {import('../src/types.js').RankComparison}
-   */
-  const nativeComp = (left, right) =>
-    // eslint-disable-next-line no-nested-ternary
-    left < right ? -1 : left > right ? 1 : 0;
-
-  const nativeSorted = sorted(strs, nativeComp);
-
-  t.deepEqual(nativeSorted, [str1, str3, str2, str0]);
+  const strs = harden(Object.values(multiplanarStrings));
 
   const rankSorted = sorted(strs, compareRank);
-
-  t.deepEqual(rankSorted, [str1, str3, str2, str0]);
+  t.deepEqual(rankSorted, [
+    bmpLow,
+    loneSurrogate,
+    loneSurrogate$bmpLow,
+    surrogatePair,
+    loneSurrogate$bmpHigh,
+    bmpHigh,
+  ]);
 
   const nativeEncComp = (left, right) =>
-    nativeComp(encodePassable(left), encodePassable(right));
-
+    compareByUtf16CodeUnit(encodePassable(left), encodePassable(right));
   const nativeEncSorted = sorted(strs, nativeEncComp);
-
-  t.deepEqual(nativeEncSorted, nativeSorted);
+  t.deepEqual(nativeEncSorted, stringsByUtf16CodeUnit);
 
   const rankEncComp = (left, right) =>
     compareRank(encodePassable(left), encodePassable(right));
-
   const rankEncSorted = sorted(strs, rankEncComp);
-
   t.deepEqual(rankEncSorted, rankSorted);
 });

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -2,7 +2,7 @@ User-visible changes in `@endo/patterns`:
 
 # Next release
 
-- `@endo/marshal` introduces an environment variable config option `ENDO_RANK_STRINGS`, defaulting off for now, to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN conformant) ordering by Unicode code point. Thus, for now, when this default is not overridden, there is no observable change.
+- `@endo/marshal` introduces an environment variable config option `ENDO_RANK_STRINGS` to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN-conformant) ordering by Unicode code point. It currently defaults to "utf16-code-unit-order", matching the previously-unconditional behavior.
   - `@endo/patterns` provides a `compareKeys` partial order that delegates some ordering, including strings, to the rank ordering provided by `@endo/marshal`. So when the `ENDO_RANK_STRINGS` default is not overridden, then `compareKeys` also follows the (incorrect) UTF-16 code unit order. But when it is overridden, then `compareKeys` also follows the (correct) Unicode code-point order.
 - In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Now this quoting is done with `qp`, which renders these nested patterns into readable [Justin](https://github.com/endojs/Jessie/blob/main/packages/parse/src/quasi-justin.js) source code.
 

--- a/packages/patterns/test/string-key-unicode-order.test.js
+++ b/packages/patterns/test/string-key-unicode-order.test.js
@@ -1,49 +1,24 @@
-// modeled on string-rank-unicode-order.test.js
+// modeled on packages/marshal/test/string-rank-unicode-order.test.js
 import '@endo/marshal/tools/prepare-unicode-code-point-order.js';
 import test from '@endo/ses-ava/prepare-endo.js';
 
+import {
+  multiplanarStrings,
+  sorted,
+} from '@endo/marshal/tools/marshal-test-data.js';
 import { compareKeys } from '../src/keys/compareKeys.js';
 
-/**
- * Essentially a ponyfill for Array.prototype.toSorted, for use before
- * we can always rely on the platform to provide it.
- *
- * @param {string[]} strings
- * @param {(
- *   left: string,
- *   right: string
- * ) => import('@endo/marshal').RankComparison} comp
- * @returns {string[]}
- */
-const sorted = (strings, comp) => [...strings].sort(comp);
+const {
+  bmpLow,
+  loneSurrogate,
+  loneSurrogate$bmpLow,
+  loneSurrogate$bmpHigh,
+  bmpHigh,
+  surrogatePair,
+} = multiplanarStrings;
 
 test('unicode code point order', t => {
-  // Test case from
-  // https://icu-project.org/docs/papers/utf16_code_point_order.html
-  const str0 = '\u{ff61}';
-  const str3 = '\u{d800}\u{dc02}';
-
-  // str1 and str2 become impossible examples once we prohibit
-  // non - well - formed strings.
-  // See https://github.com/endojs/endo/pull/2002
-  const str1 = '\u{d800}X';
-  const str2 = '\u{d800}\u{ff61}';
-
-  // harden to ensure it is not sorted in place, just for sanity
-  const strs = harden([str0, str1, str2, str3]);
-
-  /**
-   * @param {string} left
-   * @param {string} right
-   * @returns {import('@endo/marshal').RankComparison}
-   */
-  const nativeComp = (left, right) =>
-    // eslint-disable-next-line no-nested-ternary
-    left < right ? -1 : left > right ? 1 : 0;
-
-  const nativeSorted = sorted(strs, nativeComp);
-
-  t.deepEqual(nativeSorted, [str1, str3, str2, str0]);
+  const strs = harden(Object.values(multiplanarStrings));
 
   // @ts-expect-error We know that for strings, `compareKeys` never returns
   // NaN because it never judges strings to be incomparable. Thus, the
@@ -51,5 +26,12 @@ test('unicode code point order', t => {
   // sort with.
   const keySorted = sorted(strs, compareKeys);
 
-  t.deepEqual(keySorted, [str1, str2, str0, str3]);
+  t.deepEqual(keySorted, [
+    bmpLow,
+    loneSurrogate,
+    loneSurrogate$bmpLow,
+    loneSurrogate$bmpHigh,
+    bmpHigh,
+    surrogatePair,
+  ]);
 });


### PR DESCRIPTION
Refs: #2873

## Description

* Differentiate string rank order tests by name
* DRY out data and functions for string rank order tests
* Accommodate implementation-defined order of `sort(comparator)` comparisons
* Clarify in NEWS.md that ENDO_RANK_STRINGS is not limited to on/off

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

See above

### Compatibility Considerations

n/a

### Upgrade Considerations

n/a