### PR TITLE
refactor(marshal): Cleanup some Justin code

### DIFF
--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -349,7 +349,7 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
         }
 
         case 'slot': {
-          let { iface } = rawTree;
+          const { iface } = rawTree;
           const index = Number(Nat(rawTree.index));
           const nestedRender = arg => {
             const oldOut = out;
@@ -362,17 +362,14 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
             }
           };
           if (index < slots.length) {
-            const slot = nestedRender(slots[index]);
-            if (iface === undefined) {
-              return out.next(`slotToVal(${slot})`);
-            }
-            iface = nestedRender(iface);
-            return out.next(`slotToVal(${slot},${iface})`);
-          } else if (iface === undefined) {
-            return out.next(`slot(${index})`);
+            const renderedSlot = nestedRender(slots[index]);
+            return iface === undefined
+              ? out.next(`slotToVal(${renderedSlot})`)
+              : out.next(`slotToVal(${renderedSlot},${nestedRender(iface)})`);
           }
-          iface = nestedRender(iface);
-          return out.next(`slot(${index},${iface})`);
+          return iface === undefined
+            ? out.next(`slot(${index})`)
+            : out.next(`slot(${index},${nestedRender(iface)})`);
         }
 
         case 'hilbert': {

--- a/packages/marshal/test/marshal-justin.test.js
+++ b/packages/marshal/test/marshal-justin.test.js
@@ -78,11 +78,18 @@ test('serialize decodeToJustin indented eval round trip', t => {
     // TODO make Justin work with smallcaps
     serializeBodyFormat: 'capdata',
   });
-  for (const [body, _, slots] of jsonJustinPairs) {
+  for (const [body, justinSrc, slots] of jsonJustinPairs) {
     const c = fakeJustinCompartment();
     const encoding = JSON.parse(body);
     const justinExpr = decodeToJustin(encoding, true, slots);
     t.log(justinExpr);
+    const condensed = justinExpr.replaceAll(
+      // Remove whitespace except in quoted strings, and commas after terminal
+      // array elements and object members.
+      /("(?:[^\\"]|\\.)*")|\s+|,\n\s*([\]}])/gs,
+      (_m, quotedStr, closePunc) => quotedStr || closePunc || '',
+    );
+    t.is(condensed, justinSrc);
     const value = harden(c.evaluate(`(${justinExpr})`));
     const { body: newBody } = serialize(value);
     t.is(newBody, body);

--- a/packages/marshal/tools/marshal-test-data.js
+++ b/packages/marshal/tools/marshal-test-data.js
@@ -5,10 +5,15 @@ import {
   exampleCarol,
 } from '@endo/pass-style/tools.js';
 
+/** @import { Passable } from '@endo/pass-style' */
+
 /**
- * A list of `[plain, encoding]` pairs, where plain serializes to the
- * stringification of `encoding`, which unserializes to something deepEqual
- * to `plain`.
+ * A list of `[passable, capdataBodyEncoding]` pairs, where marshalling
+ * `passable` with the legacy "capdata" body format produces an encoding whose
+ * body is the JSON serialization of `encoding`, and unmarshalling an encoding
+ * whose body is that JSON text produces a value deepEqual to `passable`.
+ *
+ * @type {Array<[passable: Passable, capdataBodyEncoding: unknown]>}
  */
 export const roundTripPairs = harden([
   // Simple JSON data encodes as itself
@@ -155,13 +160,13 @@ export const roundTripPairs = harden([
 ]);
 
 /**
- * Based on roundTripPairs from round-trip-pairs.js
+ * A list of `[capdataBody, justin, slots?]` tuples, where `capdataBody` is the
+ * JSON serialization of a value that can be paired with `slots` to produce
+ * Justin expression `justin`, and Justin evaluation of that expression produces
+ * a Passable which marshals with the legacy "capdata" body format into an
+ * encoding whose body is `capdataBody`.
  *
- * A list of `[body, justinSrc]` pairs, where the body parses into
- * an encoding that decodes to a Justin expression that evaluates to something
- * that has the same encoding.
- *
- * @type {([string, string] | [string, string, unknown[]])[]}
+ * @type {Array<[capdataBody: string, justin: string, slots?: unknown[]]>}
  */
 export const jsonJustinPairs = harden([
   // Justin is the same as the JSON encoding but without unnecessary quoting


### PR DESCRIPTION
## Description

* Improve JSDoc comments for `roundTripPairs` and `jsonJustinPairs`
* Improve test coverage for indented Justin by removing non-semantic whitespace
* Improve the readability of `decodeToJustion` slot rendering

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

See above.

### Testing Considerations

See above.

### Compatibility Considerations

n/a

### Upgrade Considerations

n/a