### PR TITLE
chore: Release 2025-07-11

### DIFF
--- a/packages/base64/CHANGELOG.md
+++ b/packages/base64/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.12](https://github.com/endojs/endo/compare/@endo/base64@1.0.11...@endo/base64@1.0.12) (2025-07-12)
+
+**Note:** Version bump only for package @endo/base64
+
+
+
+
+
 ### [1.0.11](https://github.com/endojs/endo/compare/@endo/base64@1.0.10...@endo/base64@1.0.11) (2025-06-17)
 
 **Note:** Version bump only for package @endo/base64

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/base64",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Transcodes base64",
   "keywords": [
     "base64",

--- a/packages/benchmark/CHANGELOG.md
+++ b/packages/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.4](https://github.com/endojs/endo/compare/@endo/benchmark@0.1.3...@endo/benchmark@0.1.4) (2025-07-12)
+
+**Note:** Version bump only for package @endo/benchmark
+
+
+
+
+
 ### [0.1.3](https://github.com/endojs/endo/compare/@endo/benchmark@0.1.2...@endo/benchmark@0.1.3) (2025-06-17)
 
 **Note:** Version bump only for package @endo/benchmark

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/benchmark",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Endo benchmarking ",
   "keywords": [],

--- a/packages/bundle-source/CHANGELOG.md
+++ b/packages/bundle-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.2](https://github.com/endojs/endo/compare/@endo/bundle-source@4.1.1...@endo/bundle-source@4.1.2) (2025-07-12)
+
+**Note:** Version bump only for package @endo/bundle-source
+
+
+
+
+
 ### [4.1.1](https://github.com/endojs/endo/compare/@endo/bundle-source@4.1.0...@endo/bundle-source@4.1.1) (2025-06-17)
 
 **Note:** Version bump only for package @endo/bundle-source

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/bundle-source",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Create source bundles from ES Modules",
   "type": "module",
   "main": "src/index.js",

--- a/packages/cache-map/CHANGELOG.md
+++ b/packages/cache-map/CHANGELOG.md
@@ -3,3 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.1.0 (2025-07-12)
+
+
+### Features
+
+* **cache-map:** Promote makeLRUCacheMap into a new package ([a39db9e](https://github.com/endojs/endo/commit/a39db9e03dd9bdcc20e25bb857351ca5bfe314ef))
+* **cache-map:** Return a kit for exposing metrics ([f513ebd](https://github.com/endojs/endo/commit/f513ebd36c01ce45eb2684d5f9db4db57a4ac526))
+* **cache-map:** Support creation of caches with strongly-held keys ([6671bc8](https://github.com/endojs/endo/commit/6671bc8655a62f3238df7ff4364a39d556d218cc))
+
+
+### Bug Fixes
+
+* **cache-map:** Does not depend on lockdown or ses-ava ([1e2206e](https://github.com/endojs/endo/commit/1e2206e25ff534443319704a93e0d72ab77ffb62))
+
+
+### Performance Improvements
+
+* **cache-map:** Clean up the implementation to reuse cells and avoid redundant operations ([a5c3cf9](https://github.com/endojs/endo/commit/a5c3cf9d67b42486c7dfca4d92264962badc7504))

--- a/packages/cache-map/package.json
+++ b/packages/cache-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cache-map",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "bounded-size caches having WeakMap-compatible methods",
   "keywords": [
     "cache",

--- a/packages/cache-map/package.json
+++ b/packages/cache-map/package.json
@@ -42,8 +42,6 @@
     "test:xs": "exit 0"
   },
   "devDependencies": {
-    "@endo/lockdown": "workspace:^",
-    "@endo/ses-ava": "workspace:^",
     "ava": "^6.1.3",
     "c8": "^7.14.0",
     "eslint": "^8.57.0",

--- a/packages/captp/CHANGELOG.md
+++ b/packages/captp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.4.8](https://github.com/endojs/endo/compare/@endo/captp@4.4.7...@endo/captp@4.4.8) (2025-07-12)
+
+**Note:** Version bump only for package @endo/captp
+
+
+
+
+
 ### [4.4.7](https://github.com/endojs/endo/compare/@endo/captp@4.4.6...@endo/captp@4.4.7) (2025-06-17)
 
 **Note:** Version bump only for package @endo/captp

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/captp",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "description": "Capability Transfer Protocol for distributed objects",
   "type": "module",
   "keywords": [

--- a/packages/check-bundle/CHANGELOG.md
+++ b/packages/check-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.17](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.16...@endo/check-bundle@1.0.17) (2025-07-12)
+
+**Note:** Version bump only for package @endo/check-bundle
+
+
+
+
+
 ### [1.0.16](https://github.com/endojs/endo/compare/@endo/check-bundle@1.0.15...@endo/check-bundle@1.0.16) (2025-06-17)
 
 **Note:** Version bump only for package @endo/check-bundle

--- a/packages/check-bundle/package.json
+++ b/packages/check-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/check-bundle",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Checks the integrity of an Endo bundle.",
   "keywords": [
     "endo",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.11](https://github.com/endojs/endo/compare/@endo/cli@2.3.10...@endo/cli@2.3.11) (2025-07-12)
+
+**Note:** Version bump only for package @endo/cli
+
+
+
+
+
 ### [2.3.10](https://github.com/endojs/endo/compare/@endo/cli@2.3.9...@endo/cli@2.3.10) (2025-06-17)
 
 **Note:** Version bump only for package @endo/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/cli",
-  "version": "2.3.10",
+  "version": "2.3.11",
   "private": true,
   "description": "Endo command line interface",
   "keywords": [],

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.13](https://github.com/endojs/endo/compare/@endo/common@1.2.12...@endo/common@1.2.13) (2025-07-12)
+
+**Note:** Version bump only for package @endo/common
+
+
+
+
+
 ### [1.2.12](https://github.com/endojs/endo/compare/@endo/common@1.2.11...@endo/common@1.2.12) (2025-06-17)
 
 **Note:** Version bump only for package @endo/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/common",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "common low level utilities",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/compartment-mapper/CHANGELOG.md
+++ b/packages/compartment-mapper/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.3](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.6.2...@endo/compartment-mapper@1.6.3) (2025-07-12)
+
+
+### Bug Fixes
+
+* **compartment-mapper:** convert dynamically-required relative paths to absolute ([208f2a8](https://github.com/endojs/endo/commit/208f2a8d8936421c485846909d7cbcb225a80552))
+* **compartment-mapper:** guarantee stable paths ([#2872](https://github.com/endojs/endo/issues/2872)) ([5ff31f9](https://github.com/endojs/endo/commit/5ff31f950beef17bbdfd8e3f1dbc33eb1d60d782))
+
+
+
 ### [1.6.2](https://github.com/endojs/endo/compare/@endo/compartment-mapper@1.6.1...@endo/compartment-mapper@1.6.2) (2025-06-17)
 
 

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/compartment-mapper",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "The compartment mapper assembles Node applications in a sandbox",
   "keywords": [
     "node",

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.5.1](https://github.com/endojs/endo/compare/@endo/daemon@2.5.0...@endo/daemon@2.5.1) (2025-07-12)
+
+**Note:** Version bump only for package @endo/daemon
+
+
+
+
+
 ## [2.5.0](https://github.com/endojs/endo/compare/@endo/daemon@2.4.9...@endo/daemon@2.5.0) (2025-06-17)
 
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/daemon",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "description": "Endo daemon",
   "keywords": [

--- a/packages/env-options/CHANGELOG.md
+++ b/packages/env-options/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.11](https://github.com/endojs/endo/compare/@endo/env-options@1.1.10...@endo/env-options@1.1.11) (2025-07-12)
+
+**Note:** Version bump only for package @endo/env-options
+
+
+
+
+
 ### [1.1.10](https://github.com/endojs/endo/compare/@endo/env-options@1.1.9...@endo/env-options@1.1.10) (2025-06-17)
 
 **Note:** Version bump only for package @endo/env-options

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/env-options",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Reading environment options.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.13](https://github.com/endojs/endo/compare/@endo/errors@1.2.12...@endo/errors@1.2.13) (2025-07-12)
+
+**Note:** Version bump only for package @endo/errors
+
+
+
+
+
 ### [1.2.12](https://github.com/endojs/endo/compare/@endo/errors@1.2.11...@endo/errors@1.2.12) (2025-06-17)
 
 **Note:** Version bump only for package @endo/errors

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/errors",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Package exports of the `assert` global",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.4.0](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.3.2...@endo/eslint-plugin@2.4.0) (2025-07-12)
+
+
+### Features
+
+* **eslint-plugin:** Add ses configuration ([eeed479](https://github.com/endojs/endo/commit/eeed479d407fcb15334eb85929a5148421cadb8c))
+
+
+
 ### [2.3.2](https://github.com/endojs/endo/compare/@endo/eslint-plugin@2.3.1...@endo/eslint-plugin@2.3.2) (2025-06-17)
 
 **Note:** Version bump only for package @endo/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eslint-plugin",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "ESLint plugin for using Endo",
   "keywords": [
     "eslint",

--- a/packages/evasive-transform/CHANGELOG.md
+++ b/packages/evasive-transform/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.0.2](https://github.com/endojs/endo/compare/@endo/evasive-transform@2.0.1...@endo/evasive-transform@2.0.2) (2025-07-12)
+
+**Note:** Version bump only for package @endo/evasive-transform
+
+
+
+
+
 ### [2.0.1](https://github.com/endojs/endo/compare/@endo/evasive-transform@2.0.0...@endo/evasive-transform@2.0.1) (2025-06-17)
 
 **Note:** Version bump only for package @endo/evasive-transform

--- a/packages/evasive-transform/package.json
+++ b/packages/evasive-transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/evasive-transform",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Source transforms to evade SES censorship",
   "keywords": [
     "ses",

--- a/packages/eventual-send/CHANGELOG.md
+++ b/packages/eventual-send/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.4](https://github.com/endojs/endo/compare/@endo/eventual-send@1.3.3...@endo/eventual-send@1.3.4) (2025-07-12)
+
+**Note:** Version bump only for package @endo/eventual-send
+
+
+
+
+
 ### [1.3.3](https://github.com/endojs/endo/compare/@endo/eventual-send@1.3.2...@endo/eventual-send@1.3.3) (2025-06-17)
 
 **Note:** Version bump only for package @endo/eventual-send

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/eventual-send",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Extend a Promise class to implement the eventual-send API",
   "type": "module",
   "main": "src/no-shim.js",

--- a/packages/exo/CHANGELOG.md
+++ b/packages/exo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.12](https://github.com/endojs/endo/compare/@endo/exo@1.5.11...@endo/exo@1.5.12) (2025-07-12)
+
+**Note:** Version bump only for package @endo/exo
+
+
+
+
+
 ### [1.5.11](https://github.com/endojs/endo/compare/@endo/exo@1.5.10...@endo/exo@1.5.11) (2025-06-17)
 
 **Note:** Version bump only for package @endo/exo

--- a/packages/exo/package.json
+++ b/packages/exo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/exo",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "exo: remotable objects protected by interface guards.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/far/CHANGELOG.md
+++ b/packages/far/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.14](https://github.com/endojs/endo/compare/@endo/far@1.1.13...@endo/far@1.1.14) (2025-07-12)
+
+**Note:** Version bump only for package @endo/far
+
+
+
+
+
 ### [1.1.13](https://github.com/endojs/endo/compare/@endo/far@1.1.12...@endo/far@1.1.13) (2025-06-17)
 
 **Note:** Version bump only for package @endo/far

--- a/packages/far/package.json
+++ b/packages/far/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/far",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Helpers for distributed objects.",
   "type": "module",
   "main": "src/index.js",

--- a/packages/immutable-arraybuffer/CHANGELOG.md
+++ b/packages/immutable-arraybuffer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.2](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@1.1.1...@endo/immutable-arraybuffer@1.1.2) (2025-07-12)
+
+
+### Bug Fixes
+
+* **immutable-arraybuffer:** unify shim to work on more platforms ([#2855](https://github.com/endojs/endo/issues/2855)) ([25039f5](https://github.com/endojs/endo/commit/25039f561d5e0c1bac48260adcf7e1a26d661659)), closes [#2785](https://github.com/endojs/endo/issues/2785) [#2399](https://github.com/endojs/endo/issues/2399) [#2785](https://github.com/endojs/endo/issues/2785) [#2785](https://github.com/endojs/endo/issues/2785)
+
+
+
 ### [1.1.1](https://github.com/endojs/endo/compare/@endo/immutable-arraybuffer@1.1.0...@endo/immutable-arraybuffer@1.1.1) (2025-06-17)
 
 

--- a/packages/immutable-arraybuffer/NEWS.md
+++ b/packages/immutable-arraybuffer/NEWS.md
@@ -1,6 +1,6 @@
 User visible changes in `@endo/immutable-arraybuffer`:
 
-# Next release
+# 1.1.2 (2025-07-11)
 
 - Removes `@endo/immutable-arraybufer/shim-hermes.js` and absorbs the necessary features into `@endo/immutable-arraybuffer/shim.js`. We are not qualifying this as a breaking change since the feature did not exist long enough to become relied upon.
 

--- a/packages/immutable-arraybuffer/package.json
+++ b/packages/immutable-arraybuffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/immutable-arraybuffer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Immutable ArrayBuffer (the shim!)",
   "keywords": [
     "immutable",

--- a/packages/import-bundle/CHANGELOG.md
+++ b/packages/import-bundle/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.5.2](https://github.com/endojs/endo/compare/@endo/import-bundle@1.5.1...@endo/import-bundle@1.5.2) (2025-07-12)
+
+**Note:** Version bump only for package @endo/import-bundle
+
+
+
+
+
 ### [1.5.1](https://github.com/endojs/endo/compare/@endo/import-bundle@1.5.0...@endo/import-bundle@1.5.1) (2025-06-17)
 
 **Note:** Version bump only for package @endo/import-bundle

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/import-bundle",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "load modules created by @endo/bundle-source",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.12](https://github.com/endojs/endo/compare/@endo/init@1.1.11...@endo/init@1.1.12) (2025-07-12)
+
+**Note:** Version bump only for package @endo/init
+
+
+
+
+
 ### [1.1.11](https://github.com/endojs/endo/compare/@endo/init@1.1.10...@endo/init@1.1.11) (2025-06-17)
 
 **Note:** Version bump only for package @endo/init

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/init",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Prepare Endo environment on import",
   "type": "module",
   "main": "index.js",

--- a/packages/lockdown/CHANGELOG.md
+++ b/packages/lockdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.18](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.17...@endo/lockdown@1.0.18) (2025-07-12)
+
+**Note:** Version bump only for package @endo/lockdown
+
+
+
+
+
 ### [1.0.17](https://github.com/endojs/endo/compare/@endo/lockdown@1.0.16...@endo/lockdown@1.0.17) (2025-06-17)
 
 **Note:** Version bump only for package @endo/lockdown

--- a/packages/lockdown/package.json
+++ b/packages/lockdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lockdown",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Wrappers for hardening JavaScript for Endo",
   "type": "module",
   "main": "pre.js",

--- a/packages/lp32/CHANGELOG.md
+++ b/packages/lp32/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.13](https://github.com/endojs/endo/compare/@endo/lp32@1.1.12...@endo/lp32@1.1.13) (2025-07-12)
+
+**Note:** Version bump only for package @endo/lp32
+
+
+
+
+
 ### [1.1.12](https://github.com/endojs/endo/compare/@endo/lp32@1.1.11...@endo/lp32@1.1.12) (2025-06-17)
 
 **Note:** Version bump only for package @endo/lp32

--- a/packages/lp32/package.json
+++ b/packages/lp32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/lp32",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "32 bit unsigned host byte order length prefix message streams as async iterators",
   "keywords": [
     "stream",

--- a/packages/marshal/CHANGELOG.md
+++ b/packages/marshal/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.8.0](https://github.com/endojs/endo/compare/@endo/marshal@1.7.1...@endo/marshal@1.8.0) (2025-07-12)
+
+
+### Features
+
+* **marshal,patterns:** env-option to config string order ([#2873](https://github.com/endojs/endo/issues/2873)) ([94d844f](https://github.com/endojs/endo/commit/94d844fb63a7c9499972a45f3fc5d31fe4ead1da)), closes [#2113](https://github.com/endojs/endo/issues/2113) [#2002](https://github.com/endojs/endo/issues/2002) [/github.com/Agoric/agoric-sdk/pull/10165/files#diff-b51392c299617fe43392dd0bcf11b9ed89b619cd4e5051fcffc9bfedef1c4d15](https://github.com/endojs//github.com/Agoric/agoric-sdk/pull/10165/files/issues/diff-b51392c299617fe43392dd0bcf11b9ed89b619cd4e5051fcffc9bfedef1c4d15) [#2875](https://github.com/endojs/endo/issues/2875) [#2008](https://github.com/endojs/endo/issues/2008) [#2008](https://github.com/endojs/endo/issues/2008) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875)
+
+
+
 ### [1.7.1](https://github.com/endojs/endo/compare/@endo/marshal@1.7.0...@endo/marshal@1.7.1) (2025-06-17)
 
 

--- a/packages/marshal/NEWS.md
+++ b/packages/marshal/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/marshal`:
 
-# Next release
+# 1.8.0 (2025-07-11)
 
 - Introduces an environment variable config option `ENDO_RANK_STRINGS` to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN-conformant) ordering by Unicode code point. It currently defaults to "utf16-code-unit-order", matching the previously-unconditional behavior.
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/marshal",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "marshal: encoding and deconding of Passable subgraphs",
   "type": "module",
   "main": "index.js",

--- a/packages/memoize/CHANGELOG.md
+++ b/packages/memoize/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.13](https://github.com/endojs/endo/compare/@endo/memoize@1.1.12...@endo/memoize@1.1.13) (2025-07-12)
+
+**Note:** Version bump only for package @endo/memoize
+
+
+
+
+
 ### [1.1.12](https://github.com/endojs/endo/compare/@endo/memoize@1.1.11...@endo/memoize@1.1.12) (2025-06-17)
 
 **Note:** Version bump only for package @endo/memoize

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/memoize",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Safe function memoization",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/module-source/CHANGELOG.md
+++ b/packages/module-source/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.3](https://github.com/endojs/endo/compare/@endo/module-source@1.3.2...@endo/module-source@1.3.3) (2025-07-12)
+
+**Note:** Version bump only for package @endo/module-source
+
+
+
+
+
 ### [1.3.2](https://github.com/endojs/endo/compare/@endo/module-source@1.3.1...@endo/module-source@1.3.2) (2025-06-17)
 
 **Note:** Version bump only for package @endo/module-source

--- a/packages/module-source/package.json
+++ b/packages/module-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/module-source",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Ponyfill for the SES ModuleSource and module-to-program transformer",
   "keywords": [
     "ses",

--- a/packages/nat/CHANGELOG.md
+++ b/packages/nat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.1.3](https://github.com/endojs/endo/compare/@endo/nat@5.1.2...@endo/nat@5.1.3) (2025-07-12)
+
+**Note:** Version bump only for package @endo/nat
+
+
+
+
+
 ### [5.1.2](https://github.com/endojs/endo/compare/@endo/nat@5.1.1...@endo/nat@5.1.2) (2025-06-17)
 
 **Note:** Version bump only for package @endo/nat

--- a/packages/nat/package.json
+++ b/packages/nat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/nat",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
   "main": "./src/index.js",
   "type": "module",

--- a/packages/netstring/CHANGELOG.md
+++ b/packages/netstring/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.18](https://github.com/endojs/endo/compare/@endo/netstring@1.0.17...@endo/netstring@1.0.18) (2025-07-12)
+
+**Note:** Version bump only for package @endo/netstring
+
+
+
+
+
 ### [1.0.17](https://github.com/endojs/endo/compare/@endo/netstring@1.0.16...@endo/netstring@1.0.17) (2025-06-17)
 
 **Note:** Version bump only for package @endo/netstring

--- a/packages/netstring/package.json
+++ b/packages/netstring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/netstring",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Implements a JavaScript async iterator protocol for consuming and producing binary netstrings.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/ocapn/CHANGELOG.md
+++ b/packages/ocapn/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/endojs/endo/compare/@endo/ocapn@0.2.1...@endo/ocapn@0.2.2) (2025-07-12)
+
+**Note:** Version bump only for package @endo/ocapn
+
+
+
+
+
 ### [0.2.1](https://github.com/endojs/endo/compare/@endo/ocapn@0.2.0...@endo/ocapn@0.2.1) (2025-06-17)
 
 **Note:** Version bump only for package @endo/ocapn

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ocapn",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": null,
   "keywords": [],

--- a/packages/pass-style/CHANGELOG.md
+++ b/packages/pass-style/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.6.3](https://github.com/endojs/endo/compare/@endo/pass-style@1.6.2...@endo/pass-style@1.6.3) (2025-07-12)
+
+**Note:** Version bump only for package @endo/pass-style
+
+
+
+
+
 ### [1.6.2](https://github.com/endojs/endo/compare/@endo/pass-style@1.6.1...@endo/pass-style@1.6.2) (2025-06-17)
 
 

--- a/packages/pass-style/NEWS.md
+++ b/packages/pass-style/NEWS.md
@@ -1,8 +1,12 @@
 User-visible changes in `@endo/pass-style`:
 
-# Next release
+# 1.6.3 (2025-07-11)
 
-The exported function name `isObject` is ambiguous. It is unclear whether it includes functions or not. (It does.) To avoid this confusion, we're deprecating `isObject` and suggesting to use the new export `isPrimitive` instead, that has the opposite answer. IOW, for all `x`, `isObject(x) === !isPrimitive(x)`
+- The exported function name `isObject` is ambiguous. It is unclear whether it
+  includes functions or not. (It does.) To avoid this confusion, we're
+  deprecating `isObject` and suggesting to use the new export `isPrimitive`
+  instead, that has the opposite answer. IOW, for all `x`, `isObject(x) ===
+  !isPrimitive(x)`
 
 # v1.6.2 (2024-06-17)
 

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/patterns/CHANGELOG.md
+++ b/packages/patterns/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.7.0](https://github.com/endojs/endo/compare/@endo/patterns@1.6.1...@endo/patterns@1.7.0) (2025-07-12)
+
+
+### Features
+
+* **marshal,patterns:** env-option to config string order ([#2873](https://github.com/endojs/endo/issues/2873)) ([94d844f](https://github.com/endojs/endo/commit/94d844fb63a7c9499972a45f3fc5d31fe4ead1da)), closes [#2113](https://github.com/endojs/endo/issues/2113) [#2002](https://github.com/endojs/endo/issues/2002) [/github.com/Agoric/agoric-sdk/pull/10165/files#diff-b51392c299617fe43392dd0bcf11b9ed89b619cd4e5051fcffc9bfedef1c4d15](https://github.com/endojs//github.com/Agoric/agoric-sdk/pull/10165/files/issues/diff-b51392c299617fe43392dd0bcf11b9ed89b619cd4e5051fcffc9bfedef1c4d15) [#2875](https://github.com/endojs/endo/issues/2875) [#2008](https://github.com/endojs/endo/issues/2008) [#2008](https://github.com/endojs/endo/issues/2008) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875) [#2875](https://github.com/endojs/endo/issues/2875)
+
+
+### Bug Fixes
+
+* **patterns:** use `qp` for nested pattern error messages ([#2868](https://github.com/endojs/endo/issues/2868)) ([ec4e4c0](https://github.com/endojs/endo/commit/ec4e4c0d00894cfab59094ce8c75e692a7bf369c)), closes [#2799](https://github.com/endojs/endo/issues/2799) [#2799](https://github.com/endojs/endo/issues/2799) [/github.com/endojs/endo/pull/2868#pullrequestreview-2955029970](https://github.com/endojs//github.com/endojs/endo/pull/2868/issues/pullrequestreview-2955029970)
+
+
+
 ### [1.6.1](https://github.com/endojs/endo/compare/@endo/patterns@1.6.0...@endo/patterns@1.6.1) (2025-06-17)
 
 

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -1,6 +1,6 @@
 User-visible changes in `@endo/patterns`:
 
-# Next release
+# 1.7.0 (2025-07-11)
 
 - `@endo/marshal` introduces an environment variable config option `ENDO_RANK_STRINGS` to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN-conformant) ordering by Unicode code point. It currently defaults to "utf16-code-unit-order", matching the previously-unconditional behavior.
   - `@endo/patterns` provides a `compareKeys` partial order that delegates some ordering, including strings, to the rank ordering provided by `@endo/marshal`. So when the `ENDO_RANK_STRINGS` default is not overridden, then `compareKeys` also follows the (incorrect) UTF-16 code unit order. But when it is overridden, then `compareKeys` also follows the (correct) Unicode code-point order.

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Pattern matching for Passable objects, expressed as Passable data",
   "keywords": [],
   "author": "Endo contributors",

--- a/packages/promise-kit/CHANGELOG.md
+++ b/packages/promise-kit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.13](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.12...@endo/promise-kit@1.1.13) (2025-07-12)
+
+**Note:** Version bump only for package @endo/promise-kit
+
+
+
+
+
 ### [1.1.12](https://github.com/endojs/endo/compare/@endo/promise-kit@1.1.11...@endo/promise-kit@1.1.12) (2025-06-17)
 
 **Note:** Version bump only for package @endo/promise-kit

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/promise-kit",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Helper for making promises",
   "keywords": [
     "promise"

--- a/packages/ses-ava/CHANGELOG.md
+++ b/packages/ses-ava/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.3.2](https://github.com/endojs/endo/compare/@endo/ses-ava@1.3.1...@endo/ses-ava@1.3.2) (2025-07-12)
+
+**Note:** Version bump only for package @endo/ses-ava
+
+
+
+
+
 ### [1.3.1](https://github.com/endojs/endo/compare/@endo/ses-ava@1.3.0...@endo/ses-ava@1.3.1) (2025-06-17)
 
 **Note:** Version bump only for package @endo/ses-ava

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/ses-ava",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Virtualize Ava's test to work better under SES.",
   "keywords": [
     "ses",

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.14.0](https://github.com/endojs/endo/compare/ses@1.13.1...ses@1.14.0) (2025-07-12)
+
+
+### Features
+
+* **cache-map:** Promote makeLRUCacheMap into a new package ([a39db9e](https://github.com/endojs/endo/commit/a39db9e03dd9bdcc20e25bb857351ca5bfe314ef))
+* **cache-map:** Return a kit for exposing metrics ([f513ebd](https://github.com/endojs/endo/commit/f513ebd36c01ce45eb2684d5f9db4db57a4ac526))
+* **ses:** add noAggregateLoadErrors flag ([#2832](https://github.com/endojs/endo/issues/2832)) ([b222f9f](https://github.com/endojs/endo/commit/b222f9f5c68ef373c31a68b091452b7789a6621b))
+
+
+### Bug Fixes
+
+* **immutable-arraybuffer:** unify shim to work on more platforms ([#2855](https://github.com/endojs/endo/issues/2855)) ([25039f5](https://github.com/endojs/endo/commit/25039f561d5e0c1bac48260adcf7e1a26d661659)), closes [#2785](https://github.com/endojs/endo/issues/2785) [#2399](https://github.com/endojs/endo/issues/2399) [#2785](https://github.com/endojs/endo/issues/2785) [#2785](https://github.com/endojs/endo/issues/2785)
+
+
+
 ### [1.13.1](https://github.com/endojs/endo/compare/ses@1.13.0...ses@1.13.1) (2025-06-17)
 
 

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ses",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Hardened JavaScript for Fearless Cooperation",
   "keywords": [
     "lockdown",

--- a/packages/skel/CHANGELOG.md
+++ b/packages/skel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.13](https://github.com/endojs/endo/compare/@endo/skel@1.1.12...@endo/skel@1.1.13) (2025-07-12)
+
+**Note:** Version bump only for package @endo/skel
+
+
+
+
+
 ### [1.1.12](https://github.com/endojs/endo/compare/@endo/skel@1.1.11...@endo/skel@1.1.12) (2025-06-17)
 
 **Note:** Version bump only for package @endo/skel

--- a/packages/skel/package.json
+++ b/packages/skel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/skel",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "private": true,
   "description": null,
   "keywords": [],

--- a/packages/stream-node/CHANGELOG.md
+++ b/packages/stream-node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.13](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.12...@endo/stream-node@1.1.13) (2025-07-12)
+
+**Note:** Version bump only for package @endo/stream-node
+
+
+
+
+
 ### [1.1.12](https://github.com/endojs/endo/compare/@endo/stream-node@1.1.11...@endo/stream-node@1.1.12) (2025-06-17)
 
 **Note:** Version bump only for package @endo/stream-node

--- a/packages/stream-node/package.json
+++ b/packages/stream-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-node",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Uint8Array async iterator adapters for Node.js streams",
   "keywords": [
     "stream",

--- a/packages/stream-types-test/CHANGELOG.md
+++ b/packages/stream-types-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.18](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.17...@endo/stream-types-test@1.0.18) (2025-07-12)
+
+**Note:** Version bump only for package @endo/stream-types-test
+
+
+
+
+
 ### [1.0.17](https://github.com/endojs/endo/compare/@endo/stream-types-test@1.0.16...@endo/stream-types-test@1.0.17) (2025-06-17)
 
 **Note:** Version bump only for package @endo/stream-types-test

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream-types-test",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": true,
   "description": "TypeScript validation for Endo stream types.",
   "keywords": [],

--- a/packages/stream/CHANGELOG.md
+++ b/packages/stream/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.13](https://github.com/endojs/endo/compare/@endo/stream@1.2.12...@endo/stream@1.2.13) (2025-07-12)
+
+**Note:** Version bump only for package @endo/stream
+
+
+
+
+
 ### [1.2.12](https://github.com/endojs/endo/compare/@endo/stream@1.2.11...@endo/stream@1.2.12) (2025-06-17)
 
 **Note:** Version bump only for package @endo/stream

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/stream",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Foundation for async iterators as streams",
   "keywords": [
     "endo",

--- a/packages/test262-runner/CHANGELOG.md
+++ b/packages/test262-runner/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.48](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.47...@endo/test262-runner@0.1.48) (2025-07-12)
+
+**Note:** Version bump only for package @endo/test262-runner
+
+
+
+
+
 ### [0.1.47](https://github.com/endojs/endo/compare/@endo/test262-runner@0.1.46...@endo/test262-runner@0.1.47) (2025-06-17)
 
 **Note:** Version bump only for package @endo/test262-runner

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/test262-runner",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "private": true,
   "description": "Hardened JavaScript Test262 Runner",
   "keywords": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,8 +314,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/cache-map@workspace:packages/cache-map"
   dependencies:
-    "@endo/lockdown": "workspace:^"
-    "@endo/ses-ava": "workspace:^"
     ava: "npm:^6.1.3"
     c8: "npm:^7.14.0"
     eslint: "npm:^8.57.0"


### PR DESCRIPTION

# `@endo/immutable-arraybuffer` 1.1.2

- Removes `@endo/immutable-arraybufer/shim-hermes.js` and absorbs the necessary features into `@endo/immutable-arraybuffer/shim.js`. We are not qualifying this as a breaking change since the feature did not exist long enough to become relied upon.

# `@endo/marshal` 1.8.0

- Introduces an environment variable config option `ENDO_RANK_STRINGS` to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN-conformant) ordering by Unicode code point. It currently defaults to "utf16-code-unit-order", matching the previously-unconditional behavior.

# `@endo/pass-style` 1.6.3

- The exported function name `isObject` is ambiguous. It is unclear whether it includes functions or not. (It does.) To avoid this confusion, we're deprecating `isObject` and suggesting to use the new export `isPrimitive` instead, that has the opposite answer. IOW, for all `x`, `isObject(x) === !isPrimitive(x)`

# `@endo/patterns` 1.7.0

- `@endo/marshal` introduces an environment variable config option `ENDO_RANK_STRINGS` to change the rank ordering of strings from the current (incorrect) ordering by UTF-16 code unit used by JavaScript's `<` and `.sort()` operations to (correct and OCapN-conformant) ordering by Unicode code point. It currently defaults to "utf16-code-unit-order", matching the previously-unconditional behavior.
  - `@endo/patterns` provides a `compareKeys` partial order that delegates some ordering, including strings, to the rank ordering provided by `@endo/marshal`. So when the `ENDO_RANK_STRINGS` default is not overridden, then `compareKeys` also follows the (incorrect) UTF-16 code unit order. But when it is overridden, then `compareKeys` also follows the (correct) Unicode code-point order.
- In errors explaining why a specimen does not match a pattern, sometimes the error message contains a quoted form of a nested pattern. This quoting was done with `q`, producing an uninformative rendering of these nested patterns. Now this quoting is done with `qp`, which renders these nested patterns into readable [Justin](https://github.com/endojs/Jessie/blob/main/packages/parse/src/quasi-justin.js) source code.
