### PR TITLE
feat(compartment-mapper): add retainAll flag to captureFromMap

### DIFF
--- a/packages/compartment-mapper/src/capture-lite.js
+++ b/packages/compartment-mapper/src/capture-lite.js
@@ -38,6 +38,7 @@
  *   CompartmentMapDescriptor,
  *   ReadFn,
  *   ReadPowers,
+ *   RetainAllOptions,
  *   Sources,
  * } from './types.js'
  */
@@ -59,16 +60,21 @@ const defaultCompartment = Compartment;
 /**
  * @param {CompartmentMapDescriptor} compartmentMap
  * @param {Sources} sources
+ * @param {RetainAllOptions} [options]
  * @returns {CaptureResult}
  */
-const captureCompartmentMap = (compartmentMap, sources) => {
+const captureCompartmentMap = (
+  compartmentMap,
+  sources,
+  { retainAll = false } = {},
+) => {
   const {
     compartmentMap: captureCompartmentMap,
     sources: captureSources,
     newToOldCompartmentNames,
     compartmentRenames,
     oldToNewCompartmentNames,
-  } = digestCompartmentMap(compartmentMap, sources);
+  } = digestCompartmentMap(compartmentMap, sources, { retainAll });
   return {
     captureCompartmentMap,
     captureSources,
@@ -84,8 +90,10 @@ const captureCompartmentMap = (compartmentMap, sources) => {
  * @param {CaptureLiteOptions} [options]
  * @returns {Promise<CaptureResult>}
  */
-export const captureFromMap = async (powers, compartmentMap, options = {}) => {
-  const {
+export const captureFromMap = async (
+  powers,
+  compartmentMap,
+  {
     moduleTransforms,
     syncModuleTransforms,
     modules: exitModules = {},
@@ -95,8 +103,9 @@ export const captureFromMap = async (powers, compartmentMap, options = {}) => {
     sourceMapHook = undefined,
     parserForLanguage: parserForLanguageOption = {},
     Compartment = defaultCompartment,
-  } = options;
-
+    retainAll = false,
+  } = {},
+) => {
   const parserForLanguage = freeze(
     assign(create(null), parserForLanguageOption),
   );
@@ -148,5 +157,5 @@ export const captureFromMap = async (powers, compartmentMap, options = {}) => {
     );
   }
 
-  return captureCompartmentMap(compartmentMap, sources);
+  return captureCompartmentMap(compartmentMap, sources, { retainAll });
 };

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -134,10 +134,24 @@ export type CompartmentMapForNodeModulesOptions = Omit<
   'conditions' | 'tags'
 >;
 
+/**
+ * Options containing a `retainAll` property
+ */
+export interface RetainAllOptions {
+  /**
+   * If `true`, all compartments will be retained during the digest phase
+   */
+  retainAll?: boolean;
+}
+
+/**
+ * Options for `captureFromMap()`
+ */
 export type CaptureLiteOptions = ImportingOptions &
   LinkingOptions &
   PolicyOption &
-  LogOptions;
+  LogOptions &
+  RetainAllOptions;
 
 export type ArchiveLiteOptions = SyncOrAsyncArchiveOptions &
   ModuleTransformsOption &

--- a/packages/compartment-mapper/test/fixtures-digest/README.md
+++ b/packages/compartment-mapper/test/fixtures-digest/README.md
@@ -1,0 +1,1 @@
+This fixture illustrates a case where `mapNodeModules()` should return a `CompartmentMapDescriptor` having more compartments than the result of passing it thru `captureFromMap()`.

--- a/packages/compartment-mapper/test/fixtures-digest/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-digest/node_modules/app/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  fjord: 'ria'
+};

--- a/packages/compartment-mapper/test/fixtures-digest/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-digest/node_modules/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "fjord": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-digest/node_modules/fjord/index.js
+++ b/packages/compartment-mapper/test/fixtures-digest/node_modules/fjord/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  fjord: 'firth'
+};

--- a/packages/compartment-mapper/test/fixtures-digest/node_modules/fjord/package.json
+++ b/packages/compartment-mapper/test/fixtures-digest/node_modules/fjord/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fjord",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/README.md
+++ b/packages/compartment-mapper/test/fixtures-optional-peer-dependencies/README.md
@@ -1,9 +1,9 @@
 This fixture is for testing the behavior of `mapNodeModules()` when a package has no declared `peerDependencies` _but_ has a `peerDependenciesMeta` field listing an _optional_ dependency.
 
-The _intent_ of this configuration is to declare _optional_ peer dependencies.  
+The _intent_ of this configuration is to declare _optional_ peer dependencies.
 
 `npm@7+` requires all dependencies mentioned in `peerDependenciesMeta` must to be declared in `peerDependencies`. This enables automatic installation of the peer dependencies (which is then allowed to fail).
 
-Prior to `npm@7`, there was no way to declare a peer dependency as optional, leading packages to _omit_ optional `peerDependencies` from `package.json`.  
+Prior to `npm@7`, there was no way to declare a peer dependency as optional, leading packages to _omit_ optional `peerDependencies` from `package.json`.
 
 I do not know if `yarn` or `pnpm` (any version) do anything with a lone `peerDependenciesMeta` field. Assuming they don't, `peerDependenciesMeta` w/o a `peerDependencies` is little more than a _hint_ to a human reader.


### PR DESCRIPTION
Closes: #2886
Ref: #2894 (future implementation may make _this_ PR unnecessary)

## Description

This adds a boolean flag to `captureFromMap()` which instructs `digestCompartmentMap()` to ignore the `retained` flag on `CompartmentDescriptor`s and `ModuleDescriptor`s, which ensures no "unused" `CompartmentDescriptor` is dropped from the mapping.

Considered creating a new public function for this, but it did not seem worth the bother. Still, it would be feasible to:

1. Create a new function `captureAllFromMap()`
2. Extract common logic from `captureFromMap()` into a new module-scoped function
3. Call that function from both `captureFromMap()` and `captureAllFromMap()`
4. `captureAllFromMap()` would pass `retainAll: true` to the common function which would hand it off to `digestCompartmentMap()`

### Security Considerations

n/a

### Scaling Considerations

Use of this will result in a large compartment map, which may bloat whatever you're using it for.

### Documentation Considerations

n/a

### Testing Considerations

Added fixture and tests for the specific behavior with and without the flag.

### Compatibility Considerations

This is backwards-compatible.

### Upgrade Considerations

Update `NEWS.md`
