### PR TITLE
fix(module-source): fix re-exported names in ModuleSource

### DIFF
--- a/packages/module-source/src/module-source.js
+++ b/packages/module-source/src/module-source.js
@@ -90,7 +90,9 @@ export function ModuleSource(source, opts = {}) {
     [
       ...keys(liveExportMap),
       ...keys(fixedExportMap),
-      ...values(reexportMap).flatMap(([_, exportName]) => exportName),
+      ...values(reexportMap)
+        .flat()
+        .map(([_, exportName]) => exportName),
     ].sort(),
   );
   this.reexports = freeze([...exportAlls].sort());

--- a/packages/module-source/test/module-source.test.js
+++ b/packages/module-source/test/module-source.test.js
@@ -713,7 +713,9 @@ test('export name as default from', t => {
     __fixedExportMap__,
     __liveExportMap__,
     __reexportMap__,
+    exports,
   } = new ModuleSource(`
+    export { less, more } from './meaningless.js';
     export { meaning as default } from './meaning.js';
   `);
   // t.log(__syncModuleProgram__);
@@ -721,7 +723,12 @@ test('export name as default from', t => {
   t.deepEqual(__liveExportMap__, {});
   t.deepEqual(__reexportMap__, {
     './meaning.js': [['meaning', 'default']],
+    './meaningless.js': [
+      ['less', 'less'],
+      ['more', 'more'],
+    ],
   });
+  t.deepEqual(exports, ['default', 'less', 'more'].sort());
 });
 
 test('source map generation', t => {


### PR DESCRIPTION
## Description

This seems very subtly wrong. `Array.prototype.flatMap()` wants its callback to return an array. The values returned by this operation will return different values depending on the count of exported items (mod 2, in fact):

```js
const reexports = {
  foo: [['bar', 'bar'], ['baz', 'baz']],
  spam: [['quux', 'quux']]
};

// current
const a = Object.values(reexports).flatMap(([_, exportName]) => exportName); // ['baz', 'baz', undefined]

// fixed
const b = Object.values(reexports).flat().map(([_, exportName]) => exportName); // ['bar', 'baz', 'quux']
```

### Security Considerations

n/a

### Scaling Considerations

This notices many more re-exports, which may cause more memory pressure.

### Documentation Considerations

I'm not sure.

### Testing Considerations

I added a test which demonstrates the correct value of `ModuleSource.exports`.

### Compatibility Considerations

It's a bugfix, but it might surface other problems!

### Upgrade Considerations

Should probably update `NEWS.md`.
