### PR TITLE
test(compartment-mapper): Verify implicit reexport propagation

### DIFF
--- a/packages/compartment-mapper/test/fixtures-implicit-reexport/direct.js
+++ b/packages/compartment-mapper/test/fixtures-implicit-reexport/direct.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/no-mutable-exports
+export let value;
+export const set = newValue => {
+  value = newValue;
+};

--- a/packages/compartment-mapper/test/fixtures-implicit-reexport/index.js
+++ b/packages/compartment-mapper/test/fixtures-implicit-reexport/index.js
@@ -1,0 +1,8 @@
+import { value } from './indirect.js';
+import { set } from './direct.js';
+
+const secret = {};
+set(secret);
+if (value !== secret) {
+  throw new Error('Implicit reexport did not propagate change');
+}

--- a/packages/compartment-mapper/test/fixtures-implicit-reexport/indirect.js
+++ b/packages/compartment-mapper/test/fixtures-implicit-reexport/indirect.js
@@ -1,0 +1,3 @@
+import { value } from './direct.js';
+
+export { value };

--- a/packages/compartment-mapper/test/fixtures-implicit-reexport/package.json
+++ b/packages/compartment-mapper/test/fixtures-implicit-reexport/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fixtures-implicit-reexport",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}
+

--- a/packages/compartment-mapper/test/implicit-reexport.test.js
+++ b/packages/compartment-mapper/test/implicit-reexport.test.js
@@ -1,0 +1,14 @@
+// @ts-nocheck
+
+import 'ses';
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+
+const fixture = new URL(
+  'fixtures-implicit-reexport/index.js',
+  import.meta.url,
+).toString();
+
+const assertFixture = () => {};
+
+scaffold('fixtures-implicit-reexport', test, fixture, assertFixture, 0);


### PR DESCRIPTION
This is an additional test that verifies that we have already taken into due consideration the case of importing and exporting a mutable binding.