### PR TITLE
fix(compartment-mapper): do not blast named default exports in CJS

### DIFF
--- a/packages/compartment-mapper/src/parse-cjs-shared-export-wrapper.js
+++ b/packages/compartment-mapper/src/parse-cjs-shared-export-wrapper.js
@@ -219,7 +219,9 @@ export const wrap = ({
       }
     } else {
       for (const prop of redefined) {
-        moduleEnvironmentRecord[prop] = moduleEnvironmentRecord.default[prop];
+        if (prop !== 'default') {
+          moduleEnvironmentRecord[prop] = moduleEnvironmentRecord.default[prop];
+        }
       }
     }
   };

--- a/packages/compartment-mapper/test/cjs-compat.test.js
+++ b/packages/compartment-mapper/test/cjs-compat.test.js
@@ -1,10 +1,15 @@
+/* eslint-disable jsdoc/check-param-names */
 /* eslint-disable no-underscore-dangle */
 // import "./ses-lockdown.js";
 import 'ses';
+
 import test from 'ava';
 import path from 'path';
-
 import { scaffold } from './scaffold.js';
+
+/**
+ * @import {FixtureAssertionFn} from './test.types.js';
+ */
 
 const fixture = new URL(
   'fixtures-cjs-compat/node_modules/app/index.js',
@@ -17,6 +22,9 @@ const fixtureDirname = new URL(
 
 const q = JSON.stringify;
 
+/**
+ * @type {FixtureAssertionFn<{requireResolvePaths: string[]}>}
+ */
 const assertFixture = (t, { namespace, testCategoryHint }) => {
   const { assertions, results } = namespace;
 
@@ -28,6 +36,7 @@ const assertFixture = (t, { namespace, testCategoryHint }) => {
   assertions.defaultChangesAfterExec();
   assertions.packageNestedFile();
   assertions.requireExtensions();
+  assertions.defaultExports();
 
   if (testCategoryHint === 'Location') {
     t.deepEqual(results.requireResolvePaths, [
@@ -90,8 +99,8 @@ scaffold(
   test,
   fixtureDirname,
   (t, { namespace, testCategoryHint }) => {
-    const { __dirname, __filename } = namespace;
     if (testCategoryHint === 'Location') {
+      const { __filename, __dirname } = namespace;
       t.is(__filename, path.join(__dirname, '/dirname.js'));
       t.assert(!__dirname.startsWith('file://'));
       t.notRegex(
@@ -100,6 +109,7 @@ scaffold(
         'Expected __dirname to NOT have a trailing slash',
       );
     } else {
+      const { __filename, __dirname } = namespace;
       t.is(__dirname, null);
       t.is(__filename, null);
       t.pass();

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/app/index.js
@@ -2,6 +2,7 @@ const exportsShenanigans = require('exports-shenanigans');
 const fromDebug = require('exports-shenanigans/from-debug');
 const exportsThis = require('exports-shenanigans/exports-this');
 const defineExports = require('exports-shenanigans/define-exports');
+const defaultExports = require('exports-shenanigans/default-exports');
 const interops = require('interops');
 const moduleinterops = require('./moduleinterops');
 const stableOrderJson = require('./assertion-generators/json.cjs');
@@ -115,6 +116,20 @@ module.exports.assertions = {
           {cause: err}
         );
       }
+    }
+  },
+  defaultExports() {
+    const a1 = defaultExports.a;
+    const a2 = defaultExports.default;
+    if (a2 === undefined) {
+      throw Error(
+        'default export should not be undefined',
+      );
+    }
+    if (a1 !== a2) {
+      throw Error(
+        'default export should be the same as the named export "a"',
+      );
     }
   }
 };

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/exports-shenanigans/default-exports.js
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/exports-shenanigans/default-exports.js
@@ -1,0 +1,7 @@
+
+const a = exports.a = {};
+
+Object.defineProperty(exports, 'default', {
+  get: () => a,
+  enumerable: true,
+});


### PR DESCRIPTION
## Description

This fixes a situation where a module which uses `Object.defineProperty` to define its own `default` property. Previously, the CJS parser wrapper erroneously overwrote the property with the value of `default.default` (which, practically, is often `undefined`).

Example:

```js
const a = (exports.a = {});

Object.defineProperty(exports, 'default', {
  get: () => a,
  enumerable: true,
});
```

In the above, `a` would be exported, but `default` would be lost.

This more accurately mimics Node.js' behavior.

The problem was originally detected in `@babel/core` which uses this pattern in its CJS distfiles.

* * *

- Also adds types for the scaffolding harness. 

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Test added.

### Compatibility Considerations

Improves ecosystem compat.

### Upgrade Considerations

n/a
