### PR TITLE
feat(errors): Rejectors (as suggested by #2285)

### DIFF
--- a/packages/common/apply-labeling-error.js
+++ b/packages/common/apply-labeling-error.js
@@ -26,6 +26,7 @@ import { throwLabeled } from './throw-labeled.js';
  * If the promise rejects with an error, then the returned promise is
  * rejected with a similar promise, prefixed with the label in that same way.
  *
+ * @deprecated Use `nestReject` in the confirm/reject pattern instead
  * @template A,R
  * @param {(...args: A[]) => R} func
  * @param {A[]} args

--- a/packages/common/ident-checker.js
+++ b/packages/common/ident-checker.js
@@ -1,7 +1,5 @@
-// TODO Complete migration of Checker type from @endo/pass-style to @endo/common
-// by having @endo/pass-style, and everyone else who needs it, import it from
-// `@endo/common/ident-checker.js`.
 /**
+ * @deprecated Use `Rejector` in the confirm/reject pattern instead
  * @callback Checker
  * Internal to a useful pattern for writing checking logic
  * (a "checkFoo" function) that can be used to implement a predicate
@@ -30,6 +28,7 @@
  * identity function, but is typed as a `Checker` to indicate its
  * intended use.
  *
+ * @deprecated use `false` in the confirm/reject pattern instead
  * @type {Checker}
  */
 export const identChecker = (cond, _details) => cond;

--- a/packages/common/throw-labeled.js
+++ b/packages/common/throw-labeled.js
@@ -5,6 +5,7 @@ import { X, makeError, annotateError } from '@endo/errors';
  * error whose message string is `${label}: ${innerErr.message}`.
  * See `applyLabelingError` for the motivating use.
  *
+ * @deprecated Use `nestReject` in the confirm/reject pattern instead
  * @param {Error} innerErr
  * @param {string|number} label
  * @param {import('ses').GenericErrorConstructor} [errConstructor]

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -19,6 +19,7 @@
   "module": "./index.js",
   "exports": {
     ".": "./index.js",
+    "./rejector.js": "./rejector.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/errors/rejector.js
+++ b/packages/errors/rejector.js
@@ -1,0 +1,111 @@
+import { Fail } from './index.js';
+
+// TODO `RejectOptPrefixPair` should be a circular type, which TS, surprisingly
+// to me, seems unhappy about. The `any` within it should be another
+// `RejectOptPrefixPair`
+/**
+ * @typedef {string|number|bigint} RejectPrefix
+ * @typedef {RejectPrefix|undefined} RejectOptPrefix
+ * @typedef {undefined | [any, RejectPrefix]} RejectOptPrefixPair
+ */
+
+/**
+ * @param {RejectOptPrefixPair} prePre
+ * @param {RejectPrefix} postPre
+ */
+const makeReject = (prePre, postPre) => {
+  /**
+   * @param {TemplateStringsArray | string[]} template
+   * @param {...any} args
+   * @returns {never}
+   */
+  const reject = ([...template], ...args) => {
+    let [pre, post] = [prePre, postPre];
+    for (;;) {
+      switch (typeof post) {
+        case 'string': {
+          break;
+        }
+        case 'number':
+        case 'bigint': {
+          // based on throw-labeled.js
+          post = `[${post}]`;
+          break;
+        }
+        default: {
+          post = `${post}`;
+          break;
+        }
+      }
+      template[0] = `${post}: ${template[0]}`;
+      if (pre === undefined) {
+        break;
+      }
+      [pre, post] = pre;
+    }
+    throw Fail(template, ...args);
+  };
+  /**
+   * @param {RejectPrefix} prefix
+   * @returns {typeof reject}
+   */
+  reject.nestRejectMethod = prefix => makeReject([prePre, postPre], prefix);
+  return harden(reject);
+};
+
+/**
+ * Given a Rejector `reject`, returns a Rejector just like it, except that
+ * if the returned Rejector is invoked to create and throw an error,
+ * the error message will begin with all the prefixes already accumulated by
+ * the paren `reject`, followed by `prefix` and `': '` (colon space),
+ * followed by the normal `Fail` formulated error message.
+ *
+ * This is recursive of course, so it the returned Rejector is used as an
+ * argument in another call to `nestReject`, then that prefix
+ * (with its own `': '`) would appear between this prefix and `Fail`
+ * formulated error message.
+ *
+ * As a convenience, if the prefix is a number or a bigint, it is first
+ * converted to a string within square brackets, to be suggestive of an index.
+ * If this is not your intention, then convert it to a string first
+ * yourself.
+ *
+ * @param {RejectOptPrefix} prefix
+ * @param {Rejector} reject
+ * @returns {Rejector}
+ */
+export const nestReject = (prefix, reject) => {
+  if (reject === false) {
+    return false;
+  }
+  if (prefix === undefined) {
+    return reject;
+  }
+  if (reject === Fail) {
+    return makeReject(undefined, prefix);
+  }
+  // @ts-expect-error purposely omitted nestRejectMethod from type
+  return reject.nestRejectMethod(prefix);
+};
+harden(nestReject);
+
+/**
+ * Either
+ * - `false`
+ * - or an object like `Fail`
+ *
+ * A `Rejector` should be used as
+ * ```js
+ * cond || reject && reject`...`
+ * ```
+ * If `cond` is truthy, that is the value of the expression.
+ * Else if `reject` is false, it is the value
+ * Otherwise, invoke `reject` just like you would invoke `Fail`, with the
+ * same template arguments. This throws the same kind of Error object that
+ * `Fail` would throw, except the prefixes accumulated by `nestReject` are
+ * preprended to the error message.
+ *
+ * See rejector.test.js for illustrative examples.
+ *
+ * @typedef {false | typeof Fail} Rejector
+ */


### PR DESCRIPTION
Closes: #2285
Refs: #2851 #2917 #2918

## Description

Follows approximately @gibson042 's suggestions at #2285, with some minor differences I'd like @gibson042 's feedback on:

- I changed the template type in the `Rejector` type to end with `=> never` rather than `=> false`.
- I added a `{false}` type disjunct to `Rejector`
- made the `reject` parameter to the `confirmFoo` functions non-optional, since it would also be supplied by the `isFoo` or `assertFoo` functions. Typically, only the latter two would be exported. The only reason I can see to make `confirmFoo`'s `reject` parameter optional is to be able to export and use it directly as the predicate, which would be an abstraction leak.

As stated in #2285, the purpose is to migrate existing uses of `Checker` to use `Rejector` instead. The first real test for that will be to redo #2851 to use Rejectors instead of Checkers, while also giving `passStyleOf` a variant which can avoid erroring on non-passables. And then to see how it compares with the old ones on speed. Likewise to see if @endo/patterns speeds up.

### Security Considerations

Since this PR itself is only additive, if it is correct, none. If so, then the redo of #2851 hopefully should improve security since code using Rejectors should overall be simpler and easier to review for correctness that code using Checkers.

### Scaling Considerations

Most of the point. We hope that code using Rejectors will be faster than current code using Checkers. We should measure the redo of #2851 to find out.

### Documentation Considerations

Most code uses only `isFoo` or `assertFoo` functions, whose behavior should be identical. Only users of definers of the old `checkFoo` or the new `confirmFoo` functions need to understand the difference. Not sure where these are or should be documented.

### Testing Considerations

The test included in this PR also demonstrate the `confirm/is/assert` pattern that Rejectors are designed to support.

### Compatibility Considerations

For this PR by itself, since it is only additive, none. Further, the design of Rejectors is intended to enable code to switch over without causing external compat considerations. The redo of #2851 will be a good first test.

For any old `checkFoo` code using Checkers rather than Rejectors, if those `checkFoo` functions were exported, we can deprecate and continue to export them during the transition to further avoid compat issues.

### Upgrade Considerations

None of this causes any change to data that is communicated or stored. Given that the `isFoo` and `assertFoo` functions are behaviorally identical and that any exported `checkFoo` functions continue to be exported (as deprecated), there should be no upgrade concerns.

- [ ] NEWS.md