### PR TITLE
fix(compartment-mapper): fix handling of module field in package.json

### DIFF
--- a/packages/compartment-mapper/src/infer-exports.js
+++ b/packages/compartment-mapper/src/infer-exports.js
@@ -181,7 +181,7 @@ export const inferExportsAndAliases = (
   conditions,
   types,
 ) => {
-  const { name, type, main, module, exports, browser } = descriptor;
+  const { name, type, module, main = module, exports, browser } = descriptor;
 
   // collect externalAliases from exports and main/module
   assign(
@@ -192,7 +192,7 @@ export const inferExportsAndAliases = (
   // expose default module as package root
   // may be overwritten by browser field
   // see https://github.com/endojs/endo/issues/1363
-  if (module === undefined && exports === undefined) {
+  if (exports === undefined) {
     const defaultModule = main !== undefined ? relativize(main) : './index.js';
     externalAliases['.'] = defaultModule;
     // in commonjs, expose package root as default module


### PR DESCRIPTION
## Description

This changes how package exports are inferred from within `mapNodeModules`, such that a `.` external alias is always present for `package.json`s without an `exports` field.

### Testing Considerations

Needs tests!

### Compatibility Considerations

Improves ecosystem compatibility.
