### PR TITLE
feat(ses): repair missing "hasOwn"

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -166,14 +166,25 @@ const { bind } = functionPrototype;
  */
 export const uncurryThis = bind.bind(bind.call); // eslint-disable-line @endo/no-polymorphic-call
 
+// See https://github.com/endojs/endo/issues/2930
 if (!('hasOwn' in Object)) {
+  const ObjectPrototypeHasOwnProperty = objectPrototype.hasOwnProperty;
+  const hasOwnShim = (obj, key) => {
+    if (obj === undefined || obj === null) {
+      // We need to add this extra test because of differences in
+      // the order in which `hasOwn` vs `hasOwnProperty` validates
+      // arguments.
+      throw TypeError('Cannot convert undefined or null to object');
+    }
+    return apply(ObjectPrototypeHasOwnProperty, obj, [key]);
+  };
   defineProperty(Object, 'hasOwn', {
-    value: uncurryThis(objectPrototype.hasOwnProperty),
+    value: hasOwnShim,
     writable: true,
     enumerable: false,
     configurable: true,
   });
-}
+};
 
 export const { hasOwn } = Object;
 

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -184,7 +184,7 @@ if (!('hasOwn' in Object)) {
     enumerable: false,
     configurable: true,
   });
-};
+}
 
 export const { hasOwn } = Object;
 

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -77,7 +77,6 @@ export const {
   setPrototypeOf,
   values,
   fromEntries,
-  hasOwn,
 } = Object;
 
 export const {
@@ -166,6 +165,17 @@ const { bind } = functionPrototype;
  * @type {<F extends (this: any, ...args: any[]) => any>(fn: F) => ((thisArg: ThisParameterType<F>, ...args: Parameters<F>) => ReturnType<F>)}
  */
 export const uncurryThis = bind.bind(bind.call); // eslint-disable-line @endo/no-polymorphic-call
+
+if (!('hasOwn' in Object)) {
+  defineProperty(Object, 'hasOwn', {
+    value: uncurryThis(objectPrototype.hasOwnProperty),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+export const { hasOwn } = Object;
 
 /**
  * @deprecated Use `hasOwn` instead

--- a/packages/ses/test/_delete_hasOwn.js
+++ b/packages/ses/test/_delete_hasOwn.js
@@ -1,8 +1,10 @@
+// See https://github.com/endojs/endo/issues/2930
+
 // Delete `Object.hasOwn` to emulate JS engines that still do not provide
-// an `Object.hasOwn` themselves. While technically ses and endo no longer
-// support such engines, it seems to be the only impediment to running on
-// some ancient version of Safari/JSC that we're not set up to use for
-// simply rerunning these local ava tests.
+// an `Object.hasOwn` themselves, such as the Safari/JSC that ships with
+// iOS 15.3 or earlier. While technically ses and endo no longer
+// support such engines, this absence seems to be the only impediment to
+// running on these particular ones.
 
 // @ts-ignore Purposeful violation
 delete Object.hasOwn;

--- a/packages/ses/test/_delete_hasOwn.js
+++ b/packages/ses/test/_delete_hasOwn.js
@@ -1,0 +1,8 @@
+// Delete `Object.hasOwn` to emulate JS engines that still do not provide
+// an `Object.hasOwn` themselves. While technically ses and endo no longer
+// support such engines, it seems to be the only impediment to running on
+// some ancient version of Safari/JSC that we're not set up to use for
+// simply rerunning these local ava tests.
+
+// @ts-ignore Purposeful violation
+delete Object.hasOwn;

--- a/packages/ses/test/hasOwn-shim.test.js
+++ b/packages/ses/test/hasOwn-shim.test.js
@@ -1,0 +1,14 @@
+import './_delete_hasOwn.js';
+import '../index.js';
+import './_lockdown-safe.js';
+import test from 'ava';
+
+const { hasOwn } = Object;
+
+test('missing hasOwn repaired', t => {
+  t.is(typeof hasOwn, 'function');
+  t.true('hasOwn' in Object);
+  t.true(hasOwn(Object, 'hasOwn'));
+  t.true('hasOwnProperty' in Object);
+  t.false(hasOwn(Object, 'hasOwnProperty'));
+});

--- a/packages/ses/test/hasOwn-shim.test.js
+++ b/packages/ses/test/hasOwn-shim.test.js
@@ -1,10 +1,11 @@
-import './_delete_hasOwn.js';
+import './_delete_hasOwn.js'; // emulate platforms without `Object.hasOwn`
 import '../index.js';
 import './_lockdown-safe.js';
 import test from 'ava';
 
 const { hasOwn } = Object;
 
+// See https://github.com/endojs/endo/issues/2930
 test('missing hasOwn repaired', t => {
   t.is(typeof hasOwn, 'function');
   t.true('hasOwn' in Object);


### PR DESCRIPTION

Closes: https://github.com/endojs/endo/issues/2930
Refs: #XXXX

## Description

`Object.hasOwn` is supported on all JS engine versions that Endo officially supports, such as Node 18. Thus, technically, Endo should not need to cope with the absence of `Object.hasOwn`. However, as https://github.com/endojs/endo/issues/2930 reports, this absence seems to be the only impediment to running on the version of Safari/JSC shipping on iOS 15.3 or earlier. Fortunately, `Object.hasOwn` is trivial to shim, so this PR trivially shims it when it is absent.

### Security Considerations

Supporting such ancient engines makes it more likely for people to run ses on such ancient engines, which is indeed the point of this PR. However, ancient engines are also more likely to violate conformance with modern JS in other ways that may violate the ses implementation's assumptions, which is a security hazard.

### Scaling Considerations

practically none
### Documentation Considerations

none
### Testing Considerations

Rather than arrange to test the Safari/JSC from iOS 15.3 under CI, the test cases added by this PR emulates those conditions by deleting `Object.hasOwn` before `commons.js` initializes.

### Compatibility Considerations

The point. The restores the compat of Endo with platforms lacking their own `Object.hasOwn`, assuming that was their only incompat with modern ses.

### Upgrade Considerations

None

- [ ] Update `NEWS.md` for user-facing changes.
