### PR TITLE
OCapN Demo: Capricorn Server

### DIFF
--- a/packages/capricorn/.gitignore
+++ b/packages/capricorn/.gitignore
@@ -1,0 +1,1 @@
+route-payload.js

--- a/packages/capricorn/CHANGELOG.md
+++ b/packages/capricorn/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/capricorn/LICENSE
+++ b/packages/capricorn/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/capricorn/NEWS.md
+++ b/packages/capricorn/NEWS.md
@@ -1,0 +1,1 @@
+User-visible changes in `@endo/capricorn`:

--- a/packages/capricorn/README.md
+++ b/packages/capricorn/README.md
@@ -2,3 +2,4 @@
 
 This `@endo/capricorn` package is an OCapN server for making OCapN functions that perform web requests.
 
+See the `register.js` and `fn-caller.js` examples for how to interact with the server as a client.

--- a/packages/capricorn/README.md
+++ b/packages/capricorn/README.md
@@ -1,0 +1,4 @@
+# Capricorn
+
+This `@endo/capricorn` package is an OCapN server for making OCapN functions that perform web requests.
+

--- a/packages/capricorn/SECURITY.md
+++ b/packages/capricorn/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+The SES package and associated Endo packages are still undergoing development and security review, and all
+users are encouraged to use the latest version available. Security fixes will
+be made for the most recent branch only.
+
+## Coordinated Vulnerability Disclosure of Security Bugs
+
+SES stands for fearless cooperation, and strong security requires strong collaboration with security researchers. If you believe that you have found a security sensitive bug that should not be disclosed until a fix has been made available, we encourage you to report it. To report a bug in HardenedJS, you have several options that include:
+
+* Reporting the issue to the [Agoric HackerOne vulnerability rewards program](https://hackerone.com/agoric).
+
+* Sending an email to security at (@) agoric.com., encrypted or unencrypted. To encrypt, please use  @Warner’s personal GPG key  [A476E2E6 11880C98 5B3C3A39 0386E81B 11CAA07A](http://www.lothar.com/warner-gpg.html)  .
+
+* Sending a message on Keybase to `@agoric_security`, or sharing code and other log files via Keybase’s encrypted file system. ((_keybase_private/agoric_security,$YOURNAME).
+
+* It is important to be able to provide steps that reproduce the issue and demonstrate its impact with a Proof of Concept example in an initial bug report. Before reporting a bug, a reporter may want to have another trusted individual reproduce the issue.
+
+* A bug reporter can expect acknowledgment of a potential vulnerability reported through  [security@agoric.com](mailto:security@agoric.com)  within one business day of submitting a report. If an acknowledgement of an issue is not received within this time frame, especially during a weekend or holiday period, please reach out again. Any issues reported to the HackerOne program will be acknowledged within the time frames posted on the program page.
+	* The bug triage team and Agoric code maintainers are primarily located in the San Francisco Bay Area with business hours in  [Pacific Time](https://www.timeanddate.com/worldclock/usa/san-francisco) .
+
+* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public Github issues during the coordination process.
+
+* Once a vulnerability report has been received and triaged:
+	* Agoric code maintainers will confirm whether it is valid, and will provide updates to the reporter on validity of the report.
+	* It may take up to 72 hours for an issue to be validated, especially if reported during holidays or on weekends.
+
+* When the Agoric team has verified an issue, remediation steps and patch release timeline information will be shared with the reporter.
+	* Complexity, severity, impact, and likelihood of exploitation are all vital factors that determine the amount of time required to remediate an issue and distribute a software patch.
+	* If an issue is Critical or High Severity, Agoric code maintainers will release a security advisory to notify impacted parties to prepare for an emergency patch.
+	* While the current industry standard for vulnerability coordination resolution is 90 days, Agoric code maintainers will strive to release a patch as quickly as possible.
+
+When a bug patch is included in a software release, the Agoric code maintainers will:
+	* Confirm the version and date of the software release with the reporter.
+	* Provide information about the security issue that the software release resolves.
+	* Credit the bug reporter for discovery by adding thanks in release notes, securing a CVE designation, or adding the researcher’s name to a Hall of Fame.

--- a/packages/capricorn/fn-caller.js
+++ b/packages/capricorn/fn-caller.js
@@ -1,0 +1,55 @@
+// @ts-check
+
+import '@endo/init';
+import process from 'node:process';
+import { E, makeClient, makeTcpNetLayer, encodeSwissnum } from '@endo/ocapn';
+
+/** @returns {string} */
+const getFnSwissnumFromEnv = () => {
+  const swissnum = process.env.CAPRICORN_FN_SWISSNUM || '2w91spfxd66';
+  if (!swissnum) {
+    throw new Error('CAPRICORN_FN_SWISSNUM env var is required');
+  }
+  return swissnum;
+};
+
+/** @returns {import('@endo/ocapn').OcapnLocation} */
+const getLocationFromEnv = () => {
+  const address = process.env.CAPRICORN_LOCATION || '127.0.0.1:64187';
+  if (!address) {
+    throw new Error('CAPRICORN_LOCATION env var is required (e.g., 127.0.0.1:64187)');
+  }
+  /** @type {import('@endo/ocapn').OcapnLocation} */
+  const loc = {
+    type: 'ocapn-node',
+    transport: 'tcp-testing-only',
+    address,
+    hints: false,
+  };
+  return loc;
+};
+
+const main = async () => {
+  const location = getLocationFromEnv();
+  const fnSwissnum = getFnSwissnumFromEnv();
+
+  const client = makeClient({ debugLabel: 'LightbulbManipulator' });
+  const tcpNetlayer = await makeTcpNetLayer({ client });
+  client.registerNetlayer(tcpNetlayer);
+
+  const { ocapn } = await client.provideSession(location);
+  const bootstrap = await ocapn.getBootstrap();
+  const routeFn = await E(bootstrap).fetch(encodeSwissnum(fnSwissnum));
+
+  console.log('calling routeFn', routeFn);
+  await E(routeFn)();
+  console.log('routeFn called');
+
+  client.shutdown();
+  process.exit(0);
+};
+
+// eslint-disable-next-line no-console
+main().catch(err => console.error(err));
+
+

--- a/packages/capricorn/index.js
+++ b/packages/capricorn/index.js
@@ -17,11 +17,11 @@ const storageFilePath =
 const startCapricornServer = async () => {
   const storageProvider = makeFileStorageProvider(storageFilePath);
   const debugLabel = 'Capricorn';
-  const { location, adminFacetSwissnum } = await makeCapricornServer(
+  const { tcpLocation, webSocketLocation, adminFacetSwissnum } = await makeCapricornServer(
     debugLabel,
     storageProvider,
   );
-  console.log('Capricorn server started:', location);
+  console.log('Capricorn server started:', tcpLocation, webSocketLocation);
   console.log('Admin facet swissnum:', adminFacetSwissnum);
 };
 

--- a/packages/capricorn/index.js
+++ b/packages/capricorn/index.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+/** @typedef {import('./src/server.js').makeCapricornServer} makeCapricornServer */
+
+import '@endo/init';
+
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { makeCapricornServer } from './src/server.js';
+import { makeFileStorageProvider } from './src/storage.js';
+
+const storageFilePath =
+  process.env.CAPRICORN_STORAGE_FILE ||
+  path.join(os.homedir(), '.capricorn', 'capricorn-storage.json');
+
+const startCapricornServer = async () => {
+  const storageProvider = makeFileStorageProvider(storageFilePath);
+  const debugLabel = 'Capricorn';
+  const { location, adminFacetSwissnum } = await makeCapricornServer(
+    debugLabel,
+    storageProvider,
+  );
+  console.log('Capricorn server started:', location);
+  console.log('Admin facet swissnum:', adminFacetSwissnum);
+};
+
+startCapricornServer();

--- a/packages/capricorn/package.json
+++ b/packages/capricorn/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@endo/capricorn",
+  "version": "1.1.10",
+  "private": true,
+  "description": null,
+  "keywords": [],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/capricorn#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/capricorn"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "module": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
+    "lint:eslint": "eslint '**/*.js'",
+    "lint:types": "tsc",
+    "prepack": "tsc --build tsconfig.build.json",
+    "postpack": "git clean -f '*.d.ts*' '*.tsbuildinfo'",
+    "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
+    "test:xs": "exit 0"
+  },
+  "devDependencies": {
+    "@endo/lockdown": "workspace:^",
+    "@endo/ses-ava": "workspace:^",
+    "ava": "^6.1.3",
+    "c8": "^7.14.0",
+    "eslint": "^8.57.0",
+    "tsd": "^0.31.2",
+    "typescript": "~5.6.3"
+  },
+  "files": [
+    "./*.d.ts",
+    "./*.js",
+    "./*.map",
+    "LICENSE*",
+    "SECURITY*",
+    "dist",
+    "lib",
+    "src",
+    "tools"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "plugin:@endo/internal"
+    ]
+  },
+  "ava": {
+    "files": [
+      "test/**/*.test.*"
+    ],
+    "timeout": "2m"
+  },
+  "dependencies": {
+    "@endo/init": "workspace:^",
+    "@endo/ocapn": "workspace:^"
+  }
+}

--- a/packages/capricorn/package.json
+++ b/packages/capricorn/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@endo/lockdown": "workspace:^",
     "@endo/ses-ava": "workspace:^",
+    "@types/ws": "^8",
     "ava": "^6.1.3",
     "c8": "^7.14.0",
     "eslint": "^8.57.0",
@@ -70,6 +71,7 @@
   },
   "dependencies": {
     "@endo/init": "workspace:^",
-    "@endo/ocapn": "workspace:^"
+    "@endo/ocapn": "workspace:^",
+    "ws": "^8.18.3"
   }
 }

--- a/packages/capricorn/register.js
+++ b/packages/capricorn/register.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+import '@endo/init';
+import process from 'node:process';
+import { E, makeClient, makeTcpNetLayer, encodeSwissnum } from '@endo/ocapn';
+
+/** @returns {string} */
+const getAdminSwissnumFromEnv = () => {
+  const swissnum = process.env.CAPRICORN_ADMIN_SWISSNUM || 'h5xwz4k41pk';
+  if (!swissnum) {
+    throw new Error('CAPRICORN_ADMIN_SWISSNUM env var is required');
+  }
+  return swissnum;
+};
+
+/** @returns {import('@endo/ocapn').OcapnLocation} */
+const getLocationFromEnv = () => {
+  const address = process.env.CAPRICORN_LOCATION || '127.0.0.1:64187';
+  if (!address) {
+    throw new Error('CAPRICORN_LOCATION env var is required (e.g., 127.0.0.1:64187)');
+  }
+  /** @type {import('@endo/ocapn').OcapnLocation} */
+  const loc = {
+    type: 'ocapn-node',
+    transport: 'tcp-testing-only',
+    address,
+    hints: false,
+  };
+  return loc;
+};
+
+const main = async () => {
+  const location = getLocationFromEnv();
+  const adminFacetSwissnum = getAdminSwissnumFromEnv();
+
+  const client = makeClient({ debugLabel: 'LightbulbManipulator' });
+  const tcpNetlayer = await makeTcpNetLayer({ client });
+  client.registerNetlayer(tcpNetlayer);
+
+  const { ocapn } = await client.provideSession(location);
+  const bootstrap = await ocapn.getBootstrap();
+  const adminFacet = await E(bootstrap).fetch(encodeSwissnum(adminFacetSwissnum));
+
+  // Install a simple route that toggles a light
+  const routeCode = `
+    async () => {
+      // code goes here...
+    }
+  `;
+
+  const routeSwissnum = await E(adminFacet).createRoute(routeCode);
+  // eslint-disable-next-line no-console
+  console.log('Installed route swissnum:', routeSwissnum);
+
+  client.shutdown();
+  process.exit(0);
+};
+
+// eslint-disable-next-line no-console
+main().catch(err => console.error(err));
+
+

--- a/packages/capricorn/register.js
+++ b/packages/capricorn/register.js
@@ -43,7 +43,7 @@ const main = async () => {
   const adminFacet = await E(bootstrap).fetch(encodeSwissnum(adminFacetSwissnum));
 
   // Install a simple route that toggles a light using the file contents
-  const routeCode = await fs.readFile(new URL('./toggle-light.js', import.meta.url), 'utf8');
+  const routeCode = await fs.readFile(new URL('./route-payload.js', import.meta.url), 'utf8');
 
   const routeSwissnum = await E(adminFacet).createRoute(routeCode);
   // eslint-disable-next-line no-console

--- a/packages/capricorn/register.js
+++ b/packages/capricorn/register.js
@@ -2,6 +2,7 @@
 
 import '@endo/init';
 import process from 'node:process';
+import fs from 'node:fs/promises';
 import { E, makeClient, makeTcpNetLayer, encodeSwissnum } from '@endo/ocapn';
 
 /** @returns {string} */
@@ -41,12 +42,8 @@ const main = async () => {
   const bootstrap = await ocapn.getBootstrap();
   const adminFacet = await E(bootstrap).fetch(encodeSwissnum(adminFacetSwissnum));
 
-  // Install a simple route that toggles a light
-  const routeCode = `
-    async () => {
-      // code goes here...
-    }
-  `;
+  // Install a simple route that toggles a light using the file contents
+  const routeCode = await fs.readFile(new URL('./toggle-light.js', import.meta.url), 'utf8');
 
   const routeSwissnum = await E(adminFacet).createRoute(routeCode);
   // eslint-disable-next-line no-console

--- a/packages/capricorn/src/server.js
+++ b/packages/capricorn/src/server.js
@@ -1,0 +1,89 @@
+// @ts-check
+/* eslint-env es2020 */
+
+/** @typedef {import('@endo/ocapn').OcapnLocation} OcapnLocation */
+/** @typedef {import('@endo/ocapn').Client} Client */
+
+import { makeClient, makeTcpNetLayer, Far } from '@endo/ocapn';
+
+const makeDefaultState = () => ({
+  routes: {},
+  admin: undefined,
+});
+
+/**
+ * @typedef {object} StorageProvider
+ * @property {() => Record<string, any> | undefined} get
+ * @property {(value: Record<string, any>) => void} set
+ */
+
+const randomSwissnum = () => {
+  return Math.random().toString(36).substring(2, 15);
+};
+
+/**
+ * @param {string} debugLabel
+ * @param {StorageProvider} storageProvider
+ * @returns {Promise<{ client: Client, location: OcapnLocation, adminFacetSwissnum: string }>}
+ */
+export const makeCapricornServer = async (debugLabel, storageProvider) => {
+  const initialState = storageProvider.get();
+  const isInitialized = initialState !== undefined;
+  const state = initialState || makeDefaultState();
+  const swissnumTable = new Map();
+
+  const exposeSturdyref = (swissnum, object) => {
+    console.log('Exposing Sturdyref:', swissnum, object);
+    swissnumTable.set(swissnum, object);
+  };
+
+  const createRoute = (codeString, fnContextObject = {}) => {
+    console.log('CreateRoute received a message:', codeString, fnContextObject);
+    // Expose platform fetch
+    const platformContextObject = {
+      fetch: globalThis.fetch,
+    };
+    const contextObject = {
+      ...fnContextObject,
+      ...platformContextObject,
+    };
+    const compartment = new Compartment(contextObject);
+    const routeFn = compartment.evaluate(codeString);
+    if (typeof routeFn !== 'function') {
+      throw new Error('Route function is not a function');
+    }
+    const routeFarFn = Far('routeFn', routeFn);
+    const routeSwissnum = randomSwissnum();
+    exposeSturdyref(routeSwissnum, routeFarFn);
+    return routeSwissnum;
+  };
+
+  if (isInitialized) {
+    // Reinitialize state
+    for (const [swissnum, object] of Object.entries(state.routes)) {
+      exposeSturdyref(swissnum, object);
+    }
+    if (state.admin) {
+      exposeSturdyref(state.admin, state.admin);
+    }
+  } else {
+    // Make admin object
+    const adminFacetSwissnum = randomSwissnum();
+    state.admin = adminFacetSwissnum;
+    storageProvider.set(state);
+    const adminFacet = Far('adminFacet', {
+      createRoute,
+    });
+    exposeSturdyref(adminFacetSwissnum, adminFacet);
+  }
+
+  const client = makeClient({
+    debugLabel,
+    swissnumTable,
+  });
+  const tcpNetlayer = await makeTcpNetLayer({ client });
+  client.registerNetlayer(tcpNetlayer);
+  const { location } = tcpNetlayer;
+
+  return { client, location, adminFacetSwissnum: state.admin };
+};

--- a/packages/capricorn/src/storage.js
+++ b/packages/capricorn/src/storage.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  unlinkSync,
+} from 'node:fs';
+import path from 'node:path';
+
+/**
+ * @typedef {object} StorageProvider
+ * @property {() => Record<string, any> | undefined} get
+ * @property {(value: Record<string, any>) => void} set
+ * @property {() => void} clear
+ */
+
+/**
+ * Create a synchronous JSON file-backed storage provider.
+ * Returns `undefined` if the file does not exist or is empty.
+ *
+ * @param {string} storageFilePath
+ * @returns {StorageProvider}
+ */
+export const makeFileStorageProvider = storageFilePath => {
+  return {
+    get: () => {
+      try {
+        if (!existsSync(storageFilePath)) {
+          return undefined;
+        }
+        const raw = readFileSync(storageFilePath, 'utf8');
+        if (raw.trim() === '') {
+          return undefined;
+        }
+        const data = JSON.parse(raw);
+        return data && typeof data === 'object' ? data : {};
+      } catch (error) {
+        console.error('Error reading storage file', error);
+        return undefined;
+      }
+    },
+    set: value => {
+      try {
+        mkdirSync(path.dirname(storageFilePath), { recursive: true });
+        writeFileSync(storageFilePath, JSON.stringify(value, null, 2), 'utf8');
+      } catch (error) {
+        console.error('Error writing storage file', error);
+        throw error;
+      }
+    },
+    clear: () => {
+      try {
+        unlinkSync(storageFilePath);
+      } catch (error) {
+        console.error('Error clearing storage file', error);
+        throw error;
+      }
+    },
+  };
+};

--- a/packages/capricorn/test/http-route.test.js
+++ b/packages/capricorn/test/http-route.test.js
@@ -6,7 +6,7 @@ import http from 'node:http';
 import { E, makeClient, makeTcpNetLayer, encodeSwissnum } from '@endo/ocapn';
 import { makeCapricornServer } from '../src/server.js';
 
-test('capricorn can create a route and fetch a scalar value from local server', async t => {
+test('capricorn can create a route and fetch a scalar value from local server, and still works after server restart', async t => {
   // Start a local HTTP server that returns JSON 42
   const server = http.createServer((_req, res) => {
     res.setHeader('content-type', 'application/json');
@@ -23,16 +23,20 @@ test('capricorn can create a route and fetch a scalar value from local server', 
   }
   const port = address.port;
 
-  // In-memory storage provider stub for test isolation
+  // Persistent in-memory storage provider across restarts for this test
+  /** @type {Record<string, any> | undefined} */
+  let persistedState;
   /** @type {import('../src/server.js').StorageProvider} */
   const storageProvider = {
-    get: () => undefined,
-    set: _value => {},
+    get: () => persistedState,
+    set: value => {
+      persistedState = value;
+    },
   };
 
   const {
-    client: serverClient,
-    location,
+    client: serverClient1,
+    location: location1,
     adminFacetSwissnum,
   } = await makeCapricornServer('TestCapricorn', storageProvider);
 
@@ -41,7 +45,7 @@ test('capricorn can create a route and fetch a scalar value from local server', 
   const tcpNetlayer = await makeTcpNetLayer({ client });
   client.registerNetlayer(tcpNetlayer);
 
-  const { ocapn } = await client.provideSession(location);
+  const { ocapn } = await client.provideSession(location1);
   const bootstrap = await ocapn.getBootstrap();
 
   // Fetch the admin facet using its swissnum
@@ -62,16 +66,47 @@ test('capricorn can create a route and fetch a scalar value from local server', 
 
   t.truthy(routeSwissnum, 'received a route swissnum');
 
-  // Fetch the newly created route and invoke it
-  const route = await E(bootstrap).fetch(encodeSwissnum(routeSwissnum));
-  console.log('Route:', route);
+  // Fetch the newly created route and invoke it (before restart)
+  const route1 = await E(bootstrap).fetch(encodeSwissnum(routeSwissnum));
+  console.log('Route before restart:', route1);
+
+  // First invocation should succeed
+  const result1 = await E(route1)();
+  t.is(result1, 42);
+
+  // Simulate server restart by shutting down and starting a new server with the same storage
+  serverClient1.shutdown();
+  client.shutdown();
+
+  const {
+    client: serverClient2,
+    location: location2,
+    adminFacetSwissnum: adminFacetSwissnum2,
+  } = await makeCapricornServer('TestCapricorn-Restart', storageProvider);
+
+  // Ensure admin swissnum persisted across restart
+  t.is(adminFacetSwissnum2, adminFacetSwissnum);
+
+  // New client/session to the restarted server
+  const client2 = makeClient({ debugLabel: 'TestClient-After-Restart' });
+  const tcpNetlayer2 = await makeTcpNetLayer({ client: client2 });
+  client2.registerNetlayer(tcpNetlayer2);
+
+  const { ocapn: ocapn2 } = await client2.provideSession(location2);
+  const bootstrap2 = await ocapn2.getBootstrap();
+
+  // Fetch the same route and invoke it after restart
+  const route2 = await E(bootstrap2).fetch(encodeSwissnum(routeSwissnum));
+  console.log('Route after restart:', route2);
   try {
-    const result = await E(route)();
-    t.is(result, 42);
+    const result2 = await E(route2)();
+    t.is(result2, 42);
   } finally {
     // Cleanup
-    serverClient.shutdown();
-    client.shutdown();
+    // Shut down restarted server and client
+    serverClient2.shutdown();
+    // Close HTTP origin server
     await new Promise(resolve => server.close(() => resolve(undefined)));
+    client2.shutdown();
   }
 });

--- a/packages/capricorn/test/http-route.test.js
+++ b/packages/capricorn/test/http-route.test.js
@@ -1,0 +1,77 @@
+// @ts-check
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+import http from 'node:http';
+import { E, makeClient, makeTcpNetLayer, encodeSwissnum } from '@endo/ocapn';
+import { makeCapricornServer } from '../src/server.js';
+
+test('capricorn can create a route and fetch a scalar value from local server', async t => {
+  // Start a local HTTP server that returns JSON 42
+  const server = http.createServer((_req, res) => {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify(42));
+  });
+  await new Promise(resolve => server.listen(0, () => resolve(undefined)));
+  const address = server.address();
+  if (
+    address === null ||
+    typeof address !== 'object' ||
+    typeof address.port !== 'number'
+  ) {
+    throw new Error('Server address is not an object with a port property');
+  }
+  const port = address.port;
+
+  // In-memory storage provider stub for test isolation
+  /** @type {import('../src/server.js').StorageProvider} */
+  const storageProvider = {
+    get: () => undefined,
+    set: _value => {},
+  };
+
+  const {
+    client: serverClient,
+    location,
+    adminFacetSwissnum,
+  } = await makeCapricornServer('TestCapricorn', storageProvider);
+
+  // Create a separate client to connect to the server's location
+  const client = makeClient({ debugLabel: 'TestClient' });
+  const tcpNetlayer = await makeTcpNetLayer({ client });
+  client.registerNetlayer(tcpNetlayer);
+
+  const { ocapn } = await client.provideSession(location);
+  const bootstrap = await ocapn.getBootstrap();
+
+  // Fetch the admin facet using its swissnum
+  const adminFacet = await E(bootstrap).fetch(
+    encodeSwissnum(adminFacetSwissnum),
+  );
+
+  // Route handler code: fetch from local server and return parsed JSON
+  const routeCode = `
+    async () => {
+      const res = await fetch('http://localhost:${port}/');
+      return await res.json();
+    }
+  `;
+
+  const routeSwissnum = await E(adminFacet).createRoute(routeCode);
+  console.log('Route swissnum:', routeSwissnum);
+
+  t.truthy(routeSwissnum, 'received a route swissnum');
+
+  // Fetch the newly created route and invoke it
+  const route = await E(bootstrap).fetch(encodeSwissnum(routeSwissnum));
+  console.log('Route:', route);
+  try {
+    const result = await E(route)();
+    t.is(result, 42);
+  } finally {
+    // Cleanup
+    serverClient.shutdown();
+    client.shutdown();
+    await new Promise(resolve => server.close(() => resolve(undefined)));
+  }
+});

--- a/packages/capricorn/tsconfig.build.json
+++ b/packages/capricorn/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../tsconfig-build-options.json"
+  ],
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "exclude": [
+    "test/"
+  ]
+}

--- a/packages/capricorn/tsconfig.json
+++ b/packages/capricorn/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.eslint-base.json",
+  "include": [
+    "*.js",
+    "*.ts",
+    "src/**/*.js",
+    "src/**/*.ts"
+  ]
+}

--- a/packages/ocapn/index.js
+++ b/packages/ocapn/index.js
@@ -10,3 +10,5 @@ import { OcapnFar as Far } from './src/client/ocapn.js';
 import { E } from '@endo/eventual-send';
 
 export { makeClient, makeTcpNetLayer, encodeSwissnum, Far, E };
+
+export { makeWebSocketServerNetLayer } from './src/netlayers/web-socket/server.js';

--- a/packages/ocapn/index.js
+++ b/packages/ocapn/index.js
@@ -1,0 +1,12 @@
+// @ts-check
+
+/** @typedef {import('./src/codecs/components.js').OcapnLocation} OcapnLocation */
+/** @typedef {import('./src/client/types.js').Client} Client */
+
+import { makeClient } from './src/client/index.js';
+import { makeTcpNetLayer } from './src/netlayers/tcp-test-only.js';
+import { encodeSwissnum } from './src/client/util.js';
+import { OcapnFar as Far } from './src/client/ocapn.js';
+import { E } from '@endo/eventual-send';
+
+export { makeClient, makeTcpNetLayer, encodeSwissnum, Far, E };

--- a/packages/ocapn/src/client/ocapn.js
+++ b/packages/ocapn/src/client/ocapn.js
@@ -666,6 +666,7 @@ const makeBootstrapObject = (
      */
     fetch: swissnum => {
       const swissnumString = decodeSwissnum(swissnum);
+      console.log('Bootstrap fetch:', swissnumString, swissnumTable);
       const object = swissnumTable.get(swissnumString);
       if (!object) {
         throw Error(

--- a/packages/ocapn/src/netlayers/web-socket/server.js
+++ b/packages/ocapn/src/netlayers/web-socket/server.js
@@ -1,0 +1,236 @@
+// @ts-check
+
+import { WebSocketServer, WebSocket } from 'ws';
+import { Buffer } from 'node:buffer';
+import { makeSelfIdentity, sendHello } from '../../client/index.js';
+
+/**
+ * @typedef {import('../../codecs/components.js').OcapnLocation} OcapnLocation
+ * @typedef {import('../../client/types.js').NetLayer} NetLayer
+ * @typedef {import('../../client/index.js').Client} Client
+ * @typedef {import('../../client/types.js').Connection} Connection
+ * @typedef {import('../../client/types.js').Session} Session
+ */
+
+/**
+ * @param {NetLayer} netlayer
+ * @param {import('ws').WebSocket} socket
+ * @param {boolean} isOutgoing
+ * @returns {Connection}
+ */
+const makeConnection = (netlayer, socket, isOutgoing) => {
+  let isDestroyed = false;
+  const selfIdentity = makeSelfIdentity(netlayer.location);
+  /** @type {Connection} */
+  const connection = harden({
+    netlayer,
+    isOutgoing,
+    selfIdentity,
+    get isDestroyed() {
+      return isDestroyed;
+    },
+    write(bytes) {
+      if (socket.readyState === socket.OPEN) {
+        socket.send(Buffer.from(bytes));
+      }
+    },
+    end() {
+      isDestroyed = true;
+      if (socket.readyState === socket.OPEN) {
+        socket.close();
+      }
+    },
+  });
+  return connection;
+};
+
+/**
+ * @param {object} options
+ * @param {Client} options.client
+ * @param {number} [options.port]
+ * @param {string} [options.hostname]
+ * @returns {Promise<NetLayer>}
+ */
+export const makeWebSocketServerNetLayer = async ({
+  client,
+  port = 8080,
+  hostname = 'localhost',
+}) => {
+  const { logger } = client;
+
+  // Create and start WebSocket server
+  const wss = new WebSocketServer({ port, host: hostname });
+
+  // const addressInfo = wss.address();
+  // console.log('addressInfo', addressInfo);
+  // if (typeof addressInfo !== 'object' || addressInfo === null) {
+  //   throw Error('Unexpected Server Address Info');
+  // }
+  // const { address, port: actualPort } = addressInfo;
+  // logger.log('WebSocket server listening on', `${address}:${actualPort}`);
+
+  /** @type {OcapnLocation} */
+  const localLocation = {
+    type: 'ocapn-node',
+    transport: 'websocket',
+    // TODO: wss://
+    address: `ws://${hostname}:${port}`,
+    hints: false,
+  };
+
+  /** @type {Map<string, Connection>} */
+  const connections = new Map();
+
+  /**
+   * @param {OcapnLocation} location
+   * @returns {Connection}
+   */
+  const connect = location => {
+    console.log('x: connect: ws server');
+    logger.info('Connecting to', location);
+
+    if (location.transport !== 'websocket') {
+      throw new Error(`Unsupported transport: ${location.transport}`);
+    }
+
+    // For server-side connections to other servers, we create a client connection
+    const socket = new WebSocket(location.address);
+    // eslint-disable-next-line no-use-before-define
+    const connection = makeConnection(netlayer, socket, true);
+
+    socket.on('open', () => {
+      logger.info('WebSocket client connection opened to', socket.url);
+      sendHello(connection, connection.selfIdentity);
+    });
+
+    socket.on('message', data => {
+      try {
+        // WebSocket server can receive Buffer, ArrayBuffer, or string
+        let bytes;
+        if (Buffer.isBuffer(data)) {
+          bytes = new Uint8Array(data);
+        } else if (data instanceof ArrayBuffer) {
+          bytes = new Uint8Array(data);
+        } else if (typeof data === 'string') {
+          // Convert string to Uint8Array (assuming UTF-8 encoding)
+          const encoder = new TextEncoder();
+          bytes = encoder.encode(data);
+        } else {
+          logger.error('Unknown data type received:', typeof data);
+          return;
+        }
+
+        if (!connection.isDestroyed) {
+          client.handleMessageData(connection, bytes);
+        } else {
+          logger.info(
+            'WebSocket received message after connection was destroyed',
+            bytes,
+          );
+        }
+      } catch (err) {
+        logger.error('WebSocket received error:', err);
+        socket.close();
+      }
+    });
+
+    socket.on('error', err => {
+      logger.error('WebSocket client error:', err);
+      connection.end();
+    });
+
+    socket.on('close', (code, reason) => {
+      logger.info('WebSocket client connection closed:', code, reason);
+      client.handleConnectionClose(connection);
+    });
+
+    return connection;
+  };
+
+  /**
+   * @param {OcapnLocation} location
+   * @returns {Connection}
+   */
+  const lookupOrConnect = location => {
+    if (location.transport !== localLocation.transport) {
+      throw Error(`Unsupported transport: ${location.transport}`);
+    }
+    const connection = connections.get(location.address);
+    if (connection) {
+      return connection;
+    }
+    const newConnection = connect(location);
+    connections.set(location.address, newConnection);
+    return newConnection;
+  };
+
+  const shutdown = () => {
+    wss.close();
+    for (const connection of connections.values()) {
+      connection.end();
+    }
+    connections.clear();
+    logger.info('WebSocket server shutdown');
+  };
+
+  /** @type {NetLayer} */
+  const netlayer = harden({
+    location: localLocation,
+    connect: lookupOrConnect,
+    shutdown,
+  });
+
+  // Handle incoming WebSocket connections
+  wss.on('connection', (socket, request) => {
+    const clientAddress = request.socket.remoteAddress;
+    const clientPort = request.socket.remotePort;
+    logger.info(
+      'WebSocket client connected to server',
+      `${clientAddress}:${clientPort}`,
+    );
+
+    const connection = makeConnection(netlayer, socket, false);
+
+    socket.on('message', data => {
+      try {
+        // WebSocket server can receive Buffer, ArrayBuffer, or string
+        let bytes;
+        if (Buffer.isBuffer(data)) {
+          bytes = new Uint8Array(data);
+        } else if (data instanceof ArrayBuffer) {
+          bytes = new Uint8Array(data);
+        } else if (typeof data === 'string') {
+          // Convert string to Uint8Array (assuming UTF-8 encoding)
+          const encoder = new TextEncoder();
+          bytes = encoder.encode(data);
+        } else {
+          logger.error('Unknown data type received:', typeof data);
+          return;
+        }
+
+        if (!connection.isDestroyed) {
+          client.handleMessageData(connection, bytes);
+        } else {
+          logger.info(
+            'WebSocket server received message after connection was destroyed',
+            bytes,
+          );
+        }
+      } catch (err) {
+        logger.error('WebSocket server received error:', err);
+        socket.close();
+      }
+    });
+
+    socket.on('error', err => {
+      logger.error('WebSocket server socket error:', err);
+    });
+
+    socket.on('close', (code, reason) => {
+      logger.info('WebSocket client disconnected from server:', code, reason);
+      client.handleConnectionClose(connection);
+    });
+  });
+
+  return netlayer;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,6 +310,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@endo/capricorn@workspace:packages/capricorn":
+  version: 0.0.0-use.local
+  resolution: "@endo/capricorn@workspace:packages/capricorn"
+  dependencies:
+    "@endo/init": "workspace:^"
+    "@endo/lockdown": "workspace:^"
+    "@endo/ocapn": "workspace:^"
+    "@endo/ses-ava": "workspace:^"
+    ava: "npm:^6.1.3"
+    c8: "npm:^7.14.0"
+    eslint: "npm:^8.57.0"
+    tsd: "npm:^0.31.2"
+    typescript: "npm:~5.6.3"
+  languageName: unknown
+  linkType: soft
+
 "@endo/captp@workspace:^, @endo/captp@workspace:packages/captp":
   version: 0.0.0-use.local
   resolution: "@endo/captp@workspace:packages/captp"
@@ -775,7 +791,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/ocapn@workspace:packages/ocapn":
+"@endo/ocapn@workspace:^, @endo/ocapn@workspace:packages/ocapn":
   version: 0.0.0-use.local
   resolution: "@endo/ocapn@workspace:packages/ocapn"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,11 +318,13 @@ __metadata:
     "@endo/lockdown": "workspace:^"
     "@endo/ocapn": "workspace:^"
     "@endo/ses-ava": "workspace:^"
+    "@types/ws": "npm:^8"
     ava: "npm:^6.1.3"
     c8: "npm:^7.14.0"
     eslint: "npm:^8.57.0"
     tsd: "npm:^0.31.2"
     typescript: "npm:~5.6.3"
+    ws: "npm:^8.18.3"
   languageName: unknown
   linkType: soft
 
@@ -2649,6 +2651,15 @@ __metadata:
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -11568,6 +11579,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/a7783bb421c648b1e622b423409cb2a58ac5839521d2f689e84bc9dc41d59379c692dd405b15a997ea1d4c0c2e5314ad707332d0c558f15232d2bc07c0b4618a
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# 🐐 

demo of "capricorn" OCapN server that facilitates turning http based APIs into OCapN functions.

Capricorn provides an admin facet exposed as a sturdyref that allows one to create new "routes". The routes are small javascript programs that get access to node.js `fetch`. The result of a route is an OCapN function that can be passed around without exposing the content of the route program. Routes can be used to expose a constrained subset of an http endpoint with an authenticating bearer token without exposing the token or rest of the api to the route.

this is a proof of concept. it proved useful in sourcing caps from non-capability systems.

the name comes from ocaps + [unicorn](https://en.wikipedia.org/wiki/Unicorn_(web_server)) (and obviously [capricorn](https://en.wikipedia.org/wiki/Capricorn_(astrology)))