### PR TITLE
chore(ses): fix vanilla build script output

### DIFF
--- a/packages/ses/scripts/bundle.js
+++ b/packages/ses/scripts/bundle.js
@@ -105,7 +105,7 @@ const writeBundle = async ({ buildType } = {}) => {
 };
 
 const main = async () => {
-  const buildType = process.argv[2];
+  const buildType = process.argv[2] || 'vanilla';
   await writeBundle({ buildType });
 };
 


### PR DESCRIPTION
Previously, running `yarn build:vanilla` would print something like:

```
❯ yarn build
-- Building 'undefined' version of SES --
Bundle size: 476660 bytes
Minified bundle size: 217577 bytes
Copied ./types.d.ts to ./dist/types.d.cts
-- Building 'hermes' version of SES --
Bundle size: 476693 bytes
Copied ./types.d.ts to ./dist/types.d.cts
```

Now it reads `vanilla` instead of `undefined`.
