### PR TITLE
fix(exo): Correct the typing for `makeExo` methods

### DIFF
--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -32,6 +32,7 @@ const makeSelf = (proto, instanceCount) => {
   return harden(self);
 };
 
+/** @type {Record<PropertyKey, never>} */
 const emptyRecord = harden({});
 
 /**
@@ -40,8 +41,6 @@ const emptyRecord = harden({});
  * state record of the (virtual/durable) instances of the kind/exoClass
  * should be empty, and that the returned maker function should have zero
  * parameters.
- *
- * @returns {{}}
  */
 export const initEmpty = () => emptyRecord;
 
@@ -218,12 +217,14 @@ export const defineExoClassKit = (
 harden(defineExoClassKit);
 
 /**
+ * Return a singleton instance of an internal ExoClass with no state fields.
+ *
  * @template {Methods} M
  * @param {string} tag
  * @param {import('@endo/patterns').InterfaceGuard<{
  *   [K in keyof M]: import('@endo/patterns').MethodGuard
  * }> | undefined} interfaceGuard CAVEAT: static typing does not yet support `callWhen` transformation
- * @param {ExoClassMethods<M, () => Record<PropertyKey, never>>} methods
+ * @param {ExoClassMethods<M, typeof initEmpty>} methods
  * @param {FarClassOptions<import('./types.js').ClassContext<{}, M>>} [options]
  * @returns {Guarded<M>}
  */

--- a/packages/exo/src/exo-makers.js
+++ b/packages/exo/src/exo-makers.js
@@ -218,14 +218,14 @@ export const defineExoClassKit = (
 harden(defineExoClassKit);
 
 /**
- * @template {Methods} T
+ * @template {Methods} M
  * @param {string} tag
  * @param {import('@endo/patterns').InterfaceGuard<{
- *   [M in keyof T]: import('@endo/patterns').MethodGuard
+ *   [K in keyof M]: import('@endo/patterns').MethodGuard
  * }> | undefined} interfaceGuard CAVEAT: static typing does not yet support `callWhen` transformation
- * @param {T} methods
- * @param {FarClassOptions<import('./types.js').ClassContext<{},T>>} [options]
- * @returns {Guarded<T>}
+ * @param {ExoClassMethods<M, () => Record<PropertyKey, never>>} methods
+ * @param {FarClassOptions<import('./types.js').ClassContext<{}, M>>} [options]
+ * @returns {Guarded<M>}
  */
 export const makeExo = (tag, interfaceGuard, methods, options = undefined) => {
   const makeInstance = defineExoClass(


### PR DESCRIPTION
Fixes: #2937
agoric-sdk integration PR: https://github.com/Agoric/agoric-sdk/pull/11756

## Description

Use `ExoClassMethods` for `makeExo`, in alignment with the implementation internally leveraging `defineExoClass`.

### Security Considerations

None known.

### Scaling Considerations

n/a

### Documentation Considerations

Nothing specific.

### Testing Considerations

Should be covered by existing tests, but I'm open to ideas for more coverage.

### Compatibility and Upgrade Considerations

I suspect that internal method calls for non-class exos are probably rare, which is why this went undetected. But if anything is affected, it will probably invalidate undesirable `@ts-expect-error` comments.