### PR TITLE
chore(ci): run tests on macOS Sequoia

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18.x, 20.x, 22.x]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, macos-15]
         # windows-latest exhibited flakey tests that are not yet worth the
         # trouble to investigate, and blocked us from upgrading yarn from 1 to
         # 4.


### PR DESCRIPTION
This adds `macos-15` (macOS Sequoia) to the CI matrix for the `test` job in the `ci.yml` workflow.

I have reason to suspect something is amiss in `@endo/module-source`, but this may be a bug in the VM image.
