### PR TITLE
feat(patterns): helper for interface guard inheritance

### DIFF
--- a/packages/exo/src/exo-tools.js
+++ b/packages/exo/src/exo-tools.js
@@ -384,7 +384,7 @@ export const defendPrototype = (
       methodGuards: mg,
       symbolMethodGuards,
       sloppy,
-      defaultGuards: dg = sloppy ? 'passable' : defaultGuards,
+      defaultGuards: dg = sloppy ? 'passable' : undefined,
     } = getInterfaceGuardPayload(interfaceGuard);
     methodGuards = harden({
       ...mg,

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -3,7 +3,7 @@ User-visible changes in `@endo/patterns`:
 # Next release
 
 - The `sloppy` option for `@endo/patterns` interface guards is deprecated. Use `defaultGuards` instead.
-- `@endo/patterns` now exports a new `getNamedMethodGuards(interfaceGuards)` that returns that interface guard's record of method guards. The motivation is to support interface inheritance expressed by patterns like
+- `@endo/patterns` now exports a new `getNamedMethodGuards(interfaceGuard)` that returns that interface guard's record of method guards. The motivation is to support interface inheritance expressed by patterns like
    ```js
    const I2 = M.interface('I2', {
      ...getNamedMethodGuards(I1),

--- a/packages/patterns/NEWS.md
+++ b/packages/patterns/NEWS.md
@@ -3,6 +3,15 @@ User-visible changes in `@endo/patterns`:
 # Next release
 
 - The `sloppy` option for `@endo/patterns` interface guards is deprecated. Use `defaultGuards` instead.
+- `@endo/patterns` now exports a new `getNamedMethodGuards(interfaceGuards)` that returns that interface guard's record of method guards. The motivation is to support interface inheritance expressed by patterns like
+   ```js
+   const I2 = M.interface('I2', {
+     ...getNamedMethodGuards(I1),
+     doMore: M.call().returns(M.any()),
+   });
+   ```
+   See `@endo/exo`'s `exo-wobbly-point.test.js` to see it in action together
+   with an experiment in class inheritance.
 
 # 1.7.0 (2025-07-11)
 

--- a/packages/patterns/index.js
+++ b/packages/patterns/index.js
@@ -73,6 +73,7 @@ export {
   getMethodGuardPayload,
   getInterfaceGuardPayload,
   getInterfaceMethodKeys,
+  getNamedMethodGuards,
 } from './src/patterns/getGuardPayloads.js';
 
 // eslint-disable-next-line import/export

--- a/packages/patterns/src/patterns/getGuardPayloads.js
+++ b/packages/patterns/src/patterns/getGuardPayloads.js
@@ -234,7 +234,7 @@ const adaptMethodGuard = methodGuard => {
  * we smooth the transition to https://github.com/endojs/endo/pull/1712,
  * tolerating both the legacy and current guard shapes.
  *
- * Unlike LegacyAwaitArgGuardShape, tolerating LegacyInterfaceGuardShape
+ * Unlike `LegacyAwaitArgGuardShape`, tolerating `LegacyInterfaceGuardShape`
  * does not seem like a currently exploitable bug, because there is not
  * currently any context where either an interfaceGuard or a copyRecord would
  * both be meaningful.
@@ -284,3 +284,28 @@ export const getInterfaceMethodKeys = interfaceGuard => {
   ]);
 };
 harden(getInterfaceMethodKeys);
+
+// Tested in @endo/exo by exo-wobbly-point.test.js since that's already
+// about class inheritance, which naturally goes with interface
+// inheritance.
+/**
+ * This ignores symbol-named method guards (which cannot be represented
+ * directly in a `CopyRecord` anyway). It returns only a `CopyRecord` of
+ * the string-named method guards. This is useful for interface guard
+ * inheritance patterns like
+ * ```js
+ * const I2 = M.interface('I2', {
+ *   ...getNamedMethodGuards(I1),
+ *   doMore: M.call().returns(M.any()),
+ * });
+ * ```
+ * While we could do more to support symbol-named method guards,
+ * this feature is deprecated, and hopefully will disappear soon.
+ * (TODO link to PRs removing symbol-named methods and method guards.)
+ *
+ * @template {Record<RemotableMethodName, MethodGuard>} [T=Record<RemotableMethodName, MethodGuard>]
+ * @param {InterfaceGuard<T>} interfaceGuard
+ */
+export const getNamedMethodGuards = interfaceGuard =>
+  getInterfaceGuardPayload(interfaceGuard).methodGuards;
+harden(getNamedMethodGuards);


### PR DESCRIPTION
Closes: #XXXX
Refs: https://hackmd.io/@rekmarks/H1X6VtP5eg#

## Description

https://hackmd.io/@rekmarks/H1X6VtP5eg# @rekmarks explains the need to express that one interface guard effectively extends another. In a slack thread, @michaelfig explains how all we need is a helper that can extract the method guards from an super/base interface guard which can then be used with `...` when defining a sub/derived interface guard. Revising the name to fit this PR, @michaelfig 's pattern is

```js
const I2 = M.interface('I2', {
  ...getNamedMethodGuards(I1),
  doMore: M.call().returns(M.any()),
});
```

By putting the `...` first, the sub/derived interface guard can override "inherited" interface guards as well as adding new ones.

Note that this ignores symbol-named method guards. This feature is deprecated anyway, and will hopefully disappear soon. (TODO links to PRs that will make symbol-named methods and method guards disappear.)

### Security Considerations

By making it easier to express interface guards, programmers are more likely to use non-vacuous interface guards, i.e., with method guards. Without explicit method guards or patterns, our experience is that ad-hoc input validation is *hard*. Interface guards with method guards with patterns expresses the type-like portion of interface validation in a declarative, readable, reviewable, and sound manner. The remaining input validation burden on the manually written "raw" exo methods then is more like it would be in a soundly-statically-typed ocap language. In our before/after experience, this is typically much smaller and more reliably reviewable.

Thus, this change is good for security.

### Scaling Considerations

none
### Documentation Considerations

@michaelfig 's inheritance pattern is nice and should be explained somewhere. Where?

### Testing Considerations

Tested in @endo/exo by exo-wobbly-point.test.js since that's already about class inheritance, which naturally goes with interface inheritance.

### Compatibility Considerations

It ignores symbol-named methods. This is unlikely to cause any problems now, and will help prevent new problems when we withdraw that "feature".

By internally using `getInterfaceGuardPayload`, we remain tolerant of the old deprecated `klass`-based interface-guard representation. Unfortunately, this compat is still needed by agoric-sdk.

### Upgrade Considerations

none. Unless I'm missing something?