### PR TITLE
refactor(ocapn): Use new tsdoc imports instead

### DIFF
--- a/packages/ocapn/src/captp/captp-engine.js
+++ b/packages/ocapn/src/captp/captp-engine.js
@@ -1,7 +1,9 @@
 /** @import {RemoteKit, Settler} from '@endo/eventual-send' */
 /** @import {CapTPSlot} from './types.js' */
 
-/** @typedef {import('../client/types.js').Logger} Logger */
+/**
+ * @import { Logger } from '../client/types.js'
+ */
 
 // Your app may need to `import '@endo/eventual-send/shim.js'` to get HandledPromise
 

--- a/packages/ocapn/src/client/index.js
+++ b/packages/ocapn/src/client/index.js
@@ -1,23 +1,12 @@
 // @ts-check
 
 /**
- * @typedef {import('../cryptography.js').OcapnPublicKey} OcapnPublicKey
- * @typedef {import('../cryptography.js').OcapnKeyPair} OcapnKeyPair
- * @typedef {import('../codecs/components.js').OcapnPublicKeyData} OcapnPublicKeyData
- * @typedef {import('../codecs/components.js').OcapnLocation} OcapnLocation
- * @typedef {import('../codecs/components.js').OcapnSignature} OcapnSignature
- * @typedef {import('./types.js').Session} Session
- * @typedef {import('./types.js').Connection} Connection
- * @typedef {import('./types.js').Client} Client
- * @typedef {import('./types.js').NetLayer} NetLayer
- * @typedef {import('./types.js').SelfIdentity} SelfIdentity
- * @typedef {import('./types.js').Logger} Logger
- * @typedef {import('./types.js').LocationId} LocationId
- * @typedef {import('./types.js').PendingSession} PendingSession
- * @typedef {import('./types.js').SessionManager} SessionManager
- * @typedef {import('./ocapn.js').GrantTracker} GrantTracker
- * @typedef {import('./ocapn.js').Ocapn} Ocapn
+ * @import { OcapnLocation, OcapnPublicKeyData, OcapnSignature } from '../codecs/components.js'
+ * @import { OcapnKeyPair, OcapnPublicKey } from '../cryptography.js'
+ * @import { GrantTracker, Ocapn } from './ocapn.js'
+ * @import { Client, Connection, LocationId, Logger, NetLayer, PendingSession, SelfIdentity, Session, SessionManager } from './types.js'
  */
+
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeSyrupWriter } from '../syrup/encode.js';
 import {

--- a/packages/ocapn/src/client/ocapn.js
+++ b/packages/ocapn/src/client/ocapn.js
@@ -5,19 +5,14 @@
 /** @import {CapTPSlot} from '../captp/types.js' */
 
 /**
- * @typedef {import('./types.js').Client} Client
- * @typedef {import('./types.js').Connection} Connection
- * @typedef {import('./types.js').Logger} Logger
- * @typedef {import('./types.js').LocationId} LocationId
- * @typedef {import('./types.js').OcapnPublicKey} OcapnPublicKey
- * @typedef {import('./types.js').Session} Session
- * @typedef {import('../captp/captp-engine.js').CapTPEngine} CapTPEngine
- * @typedef {import('../syrup/decode.js').SyrupReader} SyrupReader
- * @typedef {import('../codecs/components.js').OcapnLocation} OcapnLocation
- * @typedef {import('../codecs/descriptors.js').HandoffGiveSigEnvelope} HandoffGiveSigEnvelope
- * @typedef {import('../codecs/descriptors.js').HandoffReceiveSigEnvelope} HandoffReceiveSigEnvelope
- * @typedef {import('../codecs/descriptors.js').HandoffGive} HandoffGive
+ * @import { CapTPEngine } from '../captp/captp-engine.js'
+ * @import { OcapnLocation } from '../codecs/components.js'
+ * @import { HandoffGive, HandoffGiveSigEnvelope, HandoffReceiveSigEnvelope } from '../codecs/descriptors.js'
+ * @import { SyrupReader } from '../syrup/decode.js'
+ * @import { Client, Connection, LocationId, Logger, Session } from './types.js'
  */
+
+/** @typedef {import('../cryptography.js').OcapnPublicKey} OcapnPublicKey */
 
 import { E, HandledPromise } from '@endo/eventual-send';
 import { Far, Remotable } from '@endo/marshal';

--- a/packages/ocapn/src/client/types.js
+++ b/packages/ocapn/src/client/types.js
@@ -1,12 +1,11 @@
 // @ts-check
 
 /**
- * @typedef {import('../codecs/components.js').OcapnLocation} OcapnLocation
- * @typedef {import('../cryptography.js').OcapnPublicKey} OcapnPublicKey
- * @typedef {import('../cryptography.js').OcapnSignature} OcapnSignature
- * @typedef {import('../cryptography.js').OcapnKeyPair} OcapnKeyPair
- * @typedef {import('./ocapn.js').Ocapn} Ocapn
- * @typedef {import('./ocapn.js').GrantTracker} GrantTracker
+ * @import { OcapnLocation, OcapnSignature } from '../codecs/components.js'
+ * @import { OcapnKeyPair, OcapnPublicKey } from '../cryptography.js'
+ * @import { GrantTracker, Ocapn } from './ocapn.js'
+ */
+
 /**
  * @typedef {string} LocationId
  */

--- a/packages/ocapn/src/client/util.js
+++ b/packages/ocapn/src/client/util.js
@@ -1,8 +1,8 @@
 // @ts-check
 
 /**
- * @typedef {import('../codecs/components.js').OcapnLocation} OcapnLocation
- * @typedef {import('./types.js').LocationId} LocationId
+ * @import { OcapnLocation } from '../codecs/components.js'
+ * @import { LocationId } from './types.js'
  */
 
 import { Buffer } from 'buffer';

--- a/packages/ocapn/src/codecs/descriptors.js
+++ b/packages/ocapn/src/codecs/descriptors.js
@@ -1,18 +1,13 @@
 // @ts-check
 
-/** @typedef {import('../syrup/decode.js').SyrupReader} SyrupReader */
-/** @typedef {import('../syrup/encode.js').SyrupWriter} SyrupWriter */
-/** @typedef {import('../syrup/codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('../syrup/codec.js').SyrupRecordCodec} SyrupRecordCodec */
-/** @typedef {import('../syrup/codec.js').SyrupRecordUnionCodec} SyrupRecordUnionCodec */
-/** @typedef {import('../client/ocapn.js').TableKit} TableKit */
-/** @typedef {import('../client/types.js').OcapnPublicKey} OcapnPublicKey */
-/** @typedef {import('../client/types.js').OcapnKeyPair} OcapnKeyPair */
-/** @typedef {import('./components.js').OcapnLocation} OcapnLocation */
-/** @typedef {import('./components.js').OcapnPublicKeyData} OcapnPublicKeyData */
-/** @typedef {import('../client/ocapn.js').GrantDetails} GrantDetails */
-/** @typedef {import('../client/ocapn.js').HandoffGiveDetails} HandoffGiveDetails */
-/** @typedef {import('../cryptography.js').OcapnSignature} OcapnSignature */
+/**
+ * @import { GrantDetails, HandoffGiveDetails, TableKit } from '../client/ocapn.js'
+ * @import { SyrupCodec, SyrupRecordCodec, SyrupRecordUnionCodec } from '../syrup/codec.js'
+ * @import { SyrupReader } from '../syrup/decode.js'
+ * @import { SyrupWriter } from '../syrup/encode.js'
+ * @import { OcapnLocation, OcapnPublicKeyData, OcapnSignature } from './components.js'
+ * @import { OcapnPublicKey, OcapnKeyPair } from '../cryptography.js'
+ */
 
 import { makeCodec, makeRecordUnionCodec } from '../syrup/codec.js';
 import {

--- a/packages/ocapn/src/codecs/operations.js
+++ b/packages/ocapn/src/codecs/operations.js
@@ -1,10 +1,12 @@
 // @ts-check
 
-/** @typedef {import('../syrup/decode.js').SyrupReader} SyrupReader */
-/** @typedef {import('../syrup/encode.js').SyrupWriter} SyrupWriter */
-/** @typedef {import('../syrup/codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('./descriptors.js').DescCodecs} DescCodecs */
-/** @typedef {import('./passable.js').PassableCodecs} PassableCodecs */
+/**
+ * @import { SyrupCodec } from '../syrup/codec.js'
+ * @import { SyrupReader } from '../syrup/decode.js'
+ * @import { SyrupWriter } from '../syrup/encode.js'
+ * @import { DescCodecs } from './descriptors.js'
+ * @import { PassableCodecs } from './passable.js'
+ */
 
 import {
   makeCodec,

--- a/packages/ocapn/src/codecs/passable.js
+++ b/packages/ocapn/src/codecs/passable.js
@@ -1,8 +1,9 @@
 // @ts-check
 
-/** @typedef {import('../syrup/codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('../syrup/codec.js').SyrupRecordCodec} SyrupRecordCodec */
-/** @typedef {import('./descriptors.js').DescCodecs} DescCodecs */
+/**
+ * @import { SyrupCodec, SyrupRecordCodec } from '../syrup/codec.js'
+ * @import { DescCodecs } from './descriptors.js'
+ */
 
 import { passStyleOf as realPassStyleOf } from '@endo/pass-style';
 import {

--- a/packages/ocapn/src/codecs/subtypes.js
+++ b/packages/ocapn/src/codecs/subtypes.js
@@ -1,6 +1,6 @@
 import { makeCodec } from '../syrup/codec.js';
 
-/** @typedef {import('../syrup/codec.js').SyrupCodec} SyrupCodec */
+/** @import { SyrupCodec } from '../syrup/codec.js' */
 
 /** @type {SyrupCodec} */
 export const NonNegativeIntegerCodec = makeCodec('NonNegativeInteger', {

--- a/packages/ocapn/src/codecs/util.js
+++ b/packages/ocapn/src/codecs/util.js
@@ -1,12 +1,9 @@
-/** @typedef {import('../syrup/decode.js').SyrupReader} SyrupReader */
-/** @typedef {import('../syrup/encode.js').SyrupWriter} SyrupWriter */
-/** @typedef {import('../syrup/codec.js').SyrupType} SyrupType */
-/** @typedef {import('../syrup/codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('../syrup/codec.js').SyrupRecordCodec} SyrupRecordCodec */
-/** @typedef {import('../syrup/codec.js').SyrupRecordDefinition} SyrupRecordDefinition */
-/** @typedef {import('../syrup/codec.js').SyrupRecordUnionCodec} SyrupRecordUnionCodec */
-/** @typedef {import('../client/ocapn.js').TableKit} TableKit */
-/** @typedef {import('../client/ocapn.js').HandoffGiveDetails} HandoffGiveDetails */
+/**
+ * @import { HandoffGiveDetails, TableKit } from '../client/ocapn.js'
+ * @import { SyrupCodec, SyrupRecordCodec, SyrupRecordDefinition, SyrupRecordUnionCodec, SyrupType } from '../syrup/codec.js'
+ * @import { SyrupReader } from '../syrup/decode.js'
+ * @import { SyrupWriter } from '../syrup/encode.js'
+ */
 
 import {
   makeCodec,

--- a/packages/ocapn/src/cryptography.js
+++ b/packages/ocapn/src/cryptography.js
@@ -8,8 +8,9 @@ import { makeSyrupWriter } from './syrup/encode.js';
 import { OcapnPublicKeyCodec } from './codecs/components.js';
 import { compareByteArrays } from './syrup/compare.js';
 
-/** @typedef {import('./codecs/components.js').OcapnSignature} OcapnSignature */
-/** @typedef {import('./codecs/components.js').OcapnPublicKeyData} OcapnPublicKeyData */
+/**
+ * @import { OcapnPublicKeyData, OcapnSignature } from './codecs/components.js'
+ */
 
 const textEncoder = new TextEncoder();
 

--- a/packages/ocapn/src/netlayers/tcp-test-only.js
+++ b/packages/ocapn/src/netlayers/tcp-test-only.js
@@ -4,6 +4,11 @@ import net from 'net';
 
 import { makeSelfIdentity, sendHello } from '../client/index.js';
 
+/**
+ * @import { Connection, NetLayer, Session, Client } from '../client/types.js'
+ * @import { OcapnLocation } from '../codecs/components.js'
+ */
+
 const { isNaN } = Number;
 
 /**
@@ -13,14 +18,6 @@ const { isNaN } = Number;
 const bufferToBytes = buffer => {
   return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 };
-
-/**
- * @typedef {import('../codecs/components.js').OcapnLocation} OcapnLocation
- * @typedef {import('../client/types.js').NetLayer} NetLayer
- * @typedef {import('../client/index.js').Client} Client
- * @typedef {import('../client/types.js').Connection} Connection
- * @typedef {import('../client/types.js').Session} Session
- */
 
 /**
  * @param {NetLayer} netlayer

--- a/packages/ocapn/src/syrup/codec.js
+++ b/packages/ocapn/src/syrup/codec.js
@@ -1,16 +1,16 @@
-const { freeze } = Object;
-const quote = JSON.stringify;
-
-/** @typedef {import('./decode.js').SyrupReader} SyrupReader */
-/** @typedef {import('./encode.js').SyrupWriter} SyrupWriter */
-/** @typedef {import('./decode.js').SyrupType} SyrupType */
-/** @typedef {import('./decode.js').TypeHintTypes} TypeHintTypes */
+/**
+ * @import { SyrupReader, SyrupType, TypeHintTypes } from './decode.js'
+ * @import { SyrupWriter } from './encode.js'
+ */
 
 /**
  * @typedef {object} SyrupCodec
  * @property {function(SyrupReader): any} read
  * @property {function(any, SyrupWriter): void} write
  */
+
+const { freeze } = Object;
+const quote = JSON.stringify;
 
 const textDecoder = new TextDecoder('utf-8', { fatal: true });
 const textEncoder = new TextEncoder();

--- a/packages/ocapn/src/syrup/js-representation.js
+++ b/packages/ocapn/src/syrup/js-representation.js
@@ -16,13 +16,11 @@ import { compareByteArrays } from './compare.js';
 import { makeSyrupReader } from './decode.js';
 import { makeSyrupWriter } from './encode.js';
 
-/** @typedef {import('./decode.js').SyrupReader} SyrupReader */
-/** @typedef {import('./encode.js').SyrupWriter} SyrupWriter */
-/** @typedef {import('./codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('./codec.js').SyrupRecordCodec} SyrupRecordCodec */
-/** @typedef {import('./decode.js').SyrupType} SyrupType */
-/** @typedef {import('./decode.js').TypeHintTypes} TypeHintTypes */
-/** @typedef {import('./codec.js').SyrupRecordLabelType} SyrupRecordLabelType */
+/**
+ * @import { SyrupCodec, SyrupRecordCodec, SyrupRecordLabelType } from './codec.js'
+ * @import { SyrupReader, SyrupType, TypeHintTypes } from './decode.js'
+ * @import { SyrupWriter } from './encode.js'
+ */
 
 /*
  * This is a set of codecs that are used to represent Syrup values as JavaScript values.

--- a/packages/ocapn/test/client.test.js
+++ b/packages/ocapn/test/client.test.js
@@ -1,7 +1,9 @@
 // @ts-check
 
-/** @typedef {import('../src/codecs/components.js').OcapnLocation} OcapnLocation */
-/** @typedef {import('../src/client/types.js').Client} Client */
+/**
+ * @import { Client } from '../src/client/types.js'
+ * @import { OcapnLocation } from '../src/codecs/components.js'
+ */
 
 import test from '@endo/ses-ava/prepare-endo.js';
 import { E } from '@endo/eventual-send';

--- a/packages/ocapn/test/codecs/_codecs_util.js
+++ b/packages/ocapn/test/codecs/_codecs_util.js
@@ -1,15 +1,13 @@
 // @ts-check
 
-/** @typedef {import('@endo/eventual-send').Settler} Settler */
-/** @typedef {import('../../src/syrup/codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('../../src/captp/captp-engine.js').CapTPEngine} CapTPEngine */
-/** @typedef {import('../../src/client/ocapn.js').TableKit} TableKit */
-/** @typedef {import('../../src/client/ocapn.js').MakeRemoteResolver} MakeRemoteResolver */
-/** @typedef {import('../../src/client/ocapn.js').MakeRemoteSturdyRef} MakeRemoteSturdyRef */
-/** @typedef {import('../../src/client/ocapn.js').MakeHandoff} MakeHandoff */
-/** @typedef {import('../../src/codecs/components.js').OcapnLocation} OcapnLocation */
-/** @typedef {import('../../src/codecs/descriptors.js').HandoffGiveSigEnvelope} HandoffGiveSigEnvelope */
-/** @typedef {import('../../src/codecs/descriptors.js').HandoffReceiveSigEnvelope} HandoffReceiveSigEnvelope */
+/**
+ * @import { CapTPEngine } from '../../src/captp/captp-engine.js'
+ * @import { MakeHandoff, MakeRemoteResolver, MakeRemoteSturdyRef, TableKit } from '../../src/client/ocapn.js'
+ * @import { OcapnLocation } from '../../src/codecs/components.js'
+ * @import { HandoffGiveSigEnvelope, HandoffReceiveSigEnvelope } from '../../src/codecs/descriptors.js'
+ * @import { SyrupCodec } from '../../src/syrup/codec.js'
+ * @import { Settler } from '@endo/eventual-send'
+ */
 
 import { Buffer } from 'buffer';
 import { Far, Remotable } from '@endo/marshal';

--- a/packages/ocapn/test/codecs/components.test.js
+++ b/packages/ocapn/test/codecs/components.test.js
@@ -1,10 +1,12 @@
 // @ts-check
 
-/** @typedef {import('@endo/eventual-send').Settler} Settler */
-/** @typedef {import('../../src/syrup/decode.js').SyrupReader} SyrupReader */
-/** @typedef {import('../../src/syrup/encode.js').SyrupWriter} SyrupWriter */
-/** @typedef {import('../../src/syrup/codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('./_codecs_util.js').CodecTestEntry} CodecTestEntry */
+/**
+ * @import { SyrupCodec } from '../../src/syrup/codec.js'
+ * @import { SyrupReader } from '../../src/syrup/decode.js'
+ * @import { SyrupWriter } from '../../src/syrup/encode.js'
+ * @import { CodecTestEntry } from './_codecs_util.js'
+ * @import { Settler } from '@endo/eventual-send'
+ */
 
 import test from '@endo/ses-ava/prepare-endo.js';
 

--- a/packages/ocapn/test/codecs/descriptors.test.js
+++ b/packages/ocapn/test/codecs/descriptors.test.js
@@ -1,6 +1,8 @@
 // @ts-check
 
-/** @typedef {import('./_codecs_util.js').CodecTestEntry} CodecTestEntry */
+/**
+ * @import { CodecTestEntry } from './_codecs_util.js'
+ */
 
 import test from '@endo/ses-ava/prepare-endo.js';
 

--- a/packages/ocapn/test/codecs/operations.test.js
+++ b/packages/ocapn/test/codecs/operations.test.js
@@ -1,10 +1,12 @@
 // @ts-check
 
-/** @typedef {import('../../src/syrup/decode.js').SyrupReader} SyrupReader */
-/** @typedef {import('../../src/syrup/encode.js').SyrupWriter} SyrupWriter */
-/** @typedef {import('../../src/syrup/codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('@endo/eventual-send').Settler} Settler */
-/** @typedef {import('./_codecs_util.js').CodecTestEntry} CodecTestEntry */
+/**
+ * @import { SyrupCodec } from '../../src/syrup/codec.js'
+ * @import { SyrupReader } from '../../src/syrup/decode.js'
+ * @import { SyrupWriter } from '../../src/syrup/encode.js'
+ * @import { CodecTestEntry } from './_codecs_util.js'
+ * @import { Settler } from '@endo/eventual-send'
+ */
 
 import test from '@endo/ses-ava/prepare-endo.js';
 

--- a/packages/ocapn/test/codecs/passable.test.js
+++ b/packages/ocapn/test/codecs/passable.test.js
@@ -1,10 +1,12 @@
 // @ts-check
 
-/** @typedef {import('@endo/eventual-send').Settler} Settler */
-/** @typedef {import('../../src/syrup/decode.js').SyrupReader} SyrupReader */
-/** @typedef {import('../../src/syrup/encode.js').SyrupWriter} SyrupWriter */
-/** @typedef {import('../../src/syrup/codec.js').SyrupCodec} SyrupCodec */
-/** @typedef {import('./_codecs_util.js').CodecTestEntry} CodecTestEntry */
+/**
+ * @import { SyrupCodec } from '../../src/syrup/codec.js'
+ * @import { SyrupReader } from '../../src/syrup/decode.js'
+ * @import { SyrupWriter } from '../../src/syrup/encode.js'
+ * @import { CodecTestEntry } from './_codecs_util.js'
+ * @import { Settler } from '@endo/eventual-send'
+ */
 
 import test from '@endo/ses-ava/prepare-endo.js';
 

--- a/packages/ocapn/test/cryptography.test.js
+++ b/packages/ocapn/test/cryptography.test.js
@@ -1,8 +1,8 @@
 // @ts-check
 
-/** @typedef {import('../src/codecs/descriptors.js').HandoffGive} HandoffGive */
-/** @typedef {import('../src/codecs/descriptors.js').HandoffGiveSigEnvelope} HandoffGiveSigEnvelope */
-/** @typedef {import('../src/codecs/descriptors.js').HandoffReceive} HandoffReceive */
+/**
+ * @import { HandoffGive, HandoffGiveSigEnvelope, HandoffReceive } from '../src/codecs/descriptors.js'
+ */
 
 import test from '@endo/ses-ava/prepare-endo.js';
 import { Buffer } from 'buffer';

--- a/packages/ocapn/test/handoffs.test.js
+++ b/packages/ocapn/test/handoffs.test.js
@@ -1,7 +1,9 @@
 // @ts-check
 
-/** @typedef {import('../src/codecs/components.js').OcapnLocation} OcapnLocation */
-/** @typedef {import('../src/client/types.js').Client} Client */
+/**
+ * @import { Client } from '../src/client/types.js'
+ * @import { OcapnLocation } from '../src/codecs/components.js'
+ */
 
 import '@endo/ses-ava/prepare-endo.js';
 

--- a/packages/ocapn/test/syrup/codec.test.js
+++ b/packages/ocapn/test/syrup/codec.test.js
@@ -12,7 +12,9 @@ import {
   makeListCodecFromEntryCodec,
 } from '../../src/syrup/codec.js';
 
-/** @typedef {import('../../src/syrup/codec.js').SyrupCodec} SyrupCodec */
+/**
+ * @import { SyrupCodec } from '../../src/syrup/codec.js'
+ */
 
 const textDecoder = new TextDecoder('utf-8', { fatal: true });
 const textEncoder = new TextEncoder();


### PR DESCRIPTION
A minor refactor to streamline types.