### PR TITLE
refactor: Linting dependencies

### DIFF
--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -54,6 +54,11 @@
     "@endo/ses-ava": "workspace:^",
     "ava": "catalog:testing",
     "c8": "catalog:testing",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.29.1",
     "typescript": "~5.9.2"
   },
   "dependencies": {

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -41,6 +41,11 @@
     "@endo/lockdown": "workspace:^",
     "ava": "catalog:testing",
     "c8": "catalog:testing",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.29.1",
     "tsd": "catalog:testing",
     "typescript": "~5.9.2"
   },

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -51,6 +51,11 @@
     "@endo/ses-ava": "workspace:^",
     "ava": "catalog:testing",
     "c8": "catalog:testing",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.29.1",
     "typescript": "~5.9.2"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,6 +230,11 @@ __metadata:
     "@endo/ses-ava": "workspace:^"
     ava: "catalog:testing"
     c8: "catalog:testing"
+    eslint: "npm:^8.57.0"
+    eslint-config-airbnb-base: "npm:^15.0.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-eslint-comments: "npm:^3.2.0"
+    eslint-plugin-import: "npm:^2.29.1"
     typescript: "npm:~5.9.2"
   languageName: unknown
   linkType: soft
@@ -460,6 +465,11 @@ __metadata:
     "@endo/lockdown": "workspace:^"
     ava: "catalog:testing"
     c8: "catalog:testing"
+    eslint: "npm:^8.57.0"
+    eslint-config-airbnb-base: "npm:^15.0.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-eslint-comments: "npm:^3.2.0"
+    eslint-plugin-import: "npm:^2.29.1"
     tsd: "catalog:testing"
     typescript: "npm:~5.9.2"
   languageName: unknown
@@ -536,6 +546,11 @@ __metadata:
     "@endo/where": "workspace:^"
     ava: "catalog:testing"
     c8: "catalog:testing"
+    eslint: "npm:^8.57.0"
+    eslint-config-airbnb-base: "npm:^15.0.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-eslint-comments: "npm:^3.2.0"
+    eslint-plugin-import: "npm:^2.29.1"
     ses: "workspace:^"
     typescript: "npm:~5.9.2"
   languageName: unknown


### PR DESCRIPTION
This is a minor refactor that restores linting dependencies to three packages, such that `yarn lint` will function again in each workspace.