### PR TITLE
docs(ses): Cleanup guide.md

### DIFF
--- a/packages/ses/docs/guide.md
+++ b/packages/ses/docs/guide.md
@@ -482,9 +482,11 @@ down or delete one.
 
 ## `lockdown()`
 
-`lockdown()` freezes all JavaScript defined objects accessible to any
-program in the execution environment. Calling `lockdown()` turns a JavaScript
-system into a hardened system, with enforced OCap (object-capability) security. It
+`lockdown()` freezes all objects that are accessible to every program
+in the execution environment, as well as some others that are likely to be shared
+such as `TextDecoder`, `TextEncoder`, and (if present) `Buffer`.
+Calling `lockdown()` turns a JavaScript system into a hardened system,
+with enforced OCap (object-capability) security. It
 alters the surrounding execution environment (realm) such that no two
 programs running in the same realm can observe or interfere with each other
 until they have been introduced.


### PR DESCRIPTION
## Description

* Add some references (WHATWG, tc39/how-we-work, etc.).
* Consistently spell "I/O".
* Remove the claim that `lockdown()` hardens the global object.
* Mention the hardening of TextDecoder/TextEncoder/Buffer.

This is a start, but I think further cleanup is also warranted. For example, [What Lockdown removes from standard JavaScript](https://github.com/endojs/endo/blob/master/packages/ses/docs/guide.md#what-lockdown-removes-from-standard-javascript) claims unavailability of Node.js-specific global objects, but everything mentioned does in fact remain on the start compartment's global object (and some of them are even hardened). Perhaps that section is intended to be specific to code in a non-start compartment? If so, then it should probably be narrowed and moved to after the concept of "compartment" is explained.