### PR TITLE
feat(ses): handle iterator override

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -106,6 +106,10 @@ export const moderateEnablements = {
     [iteratorSymbol]: true, // set by mobx generated code (old TS compiler?)
   },
 
+  '%IteratorPrototype%': {
+    [iteratorSymbol]: true, // is sometimes used in custom iterators and generators implementations eg. @rive-app/canvas
+  },
+
   // Function.prototype has no 'prototype' property to enable.
   // Function instances have their own 'name' and 'length' properties
   // which are configurable and non-writable. Thus, they are already

--- a/packages/ses/test/_override-tester.js
+++ b/packages/ses/test/_override-tester.js
@@ -1,7 +1,7 @@
 import {
   getPrototypeOf,
   getOwnPropertyDescriptor,
-  getOwnPropertyNames,
+  ownKeys,
 } from '../src/commons.js';
 
 function getValue(obj, name) {
@@ -11,37 +11,43 @@ function getValue(obj, name) {
 
 export function overrideTester(t, type, obj, allowed = []) {
   const proto = getPrototypeOf(obj);
-  for (const name of getOwnPropertyNames(proto)) {
-    if (name === '__proto__') {
-      t.notThrows(() => {
-        obj[name] = 1;
-      }, `Should not throw when setting property ${name} of ${type} instance`);
-      t.not(
-        getValue(obj, name),
-        1,
-        `Should not allow setting property ${name} of ${type} instance`,
+  for (const key of ownKeys(proto)) {
+    if (key === '__proto__') {
+      t.notThrows(
+        () => {
+          obj[key] = 1;
+        },
+        `Should not throw when setting property ${String(key)} of ${type} instance`,
       );
-    } else if (allowed.includes(name)) {
-      t.notThrows(() => {
-        obj[name] = 1;
-      }, `Should not throw when setting property ${name} of ${type} instance`);
-      t.is(
-        getValue(obj, name),
+      t.not(
+        getValue(obj, key),
         1,
-        `Should allow setting property ${name} of ${type} instance`,
+        `Should not allow setting property ${String(key)} of ${type} instance`,
+      );
+    } else if (allowed.includes(key)) {
+      t.notThrows(
+        () => {
+          obj[key] = 1;
+        },
+        `Should not throw when setting property ${String(key)} of ${type} instance`,
+      );
+      t.is(
+        getValue(obj, key),
+        1,
+        `Should allow setting property ${String(key)} of ${type} instance`,
       );
     } else {
       t.throws(
         () => {
-          obj[name] = 1;
+          obj[key] = 1;
         },
         undefined,
-        `Should throw when setting property ${name} of ${type} instance`,
+        `Should throw when setting property ${String(key)} of ${type} instance`,
       );
       t.not(
-        getValue(obj, name),
+        getValue(obj, key),
         1,
-        `Should not allow setting property ${name} of ${type} instance`,
+        `Should not allow setting property ${String(key)} of ${type} instance`,
       );
     }
   }

--- a/packages/ses/test/enable-default-overrides-default.test.js
+++ b/packages/ses/test/enable-default-overrides-default.test.js
@@ -30,3 +30,34 @@ test('enable default overrides of Uint8Array in evaluation', t => {
     ),
   );
 });
+
+if (typeof Iterator !== 'undefined') {
+  test('enable default overrides of Iterator', t => {
+    t.notThrows(() => {
+      const somethingToOverrideWith = () => {};
+      // someone's idea of a generator implementation, partially sourced from @rive-app/canvas npm package
+      const g = Object.create(Iterator.prototype);
+      g.next = somethingToOverrideWith;
+      g.throw = somethingToOverrideWith;
+      g.return = somethingToOverrideWith;
+      g[Symbol.iterator] = somethingToOverrideWith;
+    });
+  });
+
+  test('enable default overrides of Iterator in evaluation', t => {
+    const c = new Compartment();
+    t.notThrows(() =>
+      c.evaluate(
+        `(${function foo() {
+          const somethingToOverrideWith = () => {};
+          // someone's idea of a generator implementation, partially sourced from @rive-app/canvas npm package
+          const g = Object.create(Iterator.prototype);
+          g.next = somethingToOverrideWith;
+          g.throw = somethingToOverrideWith;
+          g.return = somethingToOverrideWith;
+          g[Symbol.iterator] = somethingToOverrideWith;
+        }})()`,
+      ),
+    );
+  });
+}

--- a/packages/ses/test/enable-property-overrides-default.test.js
+++ b/packages/ses/test/enable-property-overrides-default.test.js
@@ -12,7 +12,12 @@ test('enablePropertyOverrides - on', t => {
   overrideTester(t, 'Object', {}, ['toString', 'valueOf']);
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
-  overrideTester(t, 'Array', [], ['toString', 'length', 'push', 'concat']);
+  overrideTester(
+    t,
+    'Array',
+    [],
+    ['toString', 'length', 'push', 'concat', Symbol.iterator],
+  );
   // eslint-disable-next-line func-names, prefer-arrow-callback
   overrideTester(t, 'Function', function () {}, [
     'constructor',
@@ -34,4 +39,9 @@ test('enablePropertyOverrides - on', t => {
   // eslint-disable-next-line func-names, prefer-arrow-callback
   overrideTester(t, 'Promise', new Promise(function () {}), ['constructor']);
   overrideTester(t, 'JSON', JSON);
+  if (typeof Iterator !== 'undefined') {
+    overrideTester(t, 'Iterator', Object.create(Iterator.prototype), [
+      Symbol.iterator,
+    ]);
+  }
 });

--- a/packages/ses/test/enable-property-overrides-severe-debug.test.js
+++ b/packages/ses/test/enable-property-overrides-severe-debug.test.js
@@ -16,7 +16,12 @@ test('enablePropertyOverrides - on, with debug', t => {
 
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
-  overrideTester(t, 'Array', [], ['toString', 'length', 'push', 'concat']);
+  overrideTester(
+    t,
+    'Array',
+    [],
+    ['toString', 'length', 'push', 'concat', Symbol.iterator],
+  );
 
   const TypedArray = getPrototypeOf(Uint8Array);
   overrideTester(

--- a/packages/ses/test/enable-property-overrides-severe.test.js
+++ b/packages/ses/test/enable-property-overrides-severe.test.js
@@ -12,7 +12,12 @@ test('enablePropertyOverrides - on', t => {
 
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
-  overrideTester(t, 'Array', [], ['toString', 'length', 'push', 'concat']);
+  overrideTester(
+    t,
+    'Array',
+    [],
+    ['toString', 'length', 'push', 'concat', Symbol.iterator],
+  );
 
   const TypedArray = getPrototypeOf(Uint8Array);
   overrideTester(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

> Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one):

Closes: #2992

## Description

Adds an enablement to cover for override mistake on Iterator's `Symbol.iterator` key.

Additionally, added symbols to override test setup in general.

### Security Considerations

None I'm aware of

### Scaling Considerations

no

### Documentation Considerations

### Testing Considerations

tests added

### Compatibility Considerations

compatibility improved

### Upgrade Considerations

Not a breaking change