### PR TITLE
chore(ses-ava): Replace dynamic CLI options with static ones

### DIFF
--- a/packages/ses-ava/README.md
+++ b/packages/ses-ava/README.md
@@ -36,9 +36,9 @@ SES-AVA also provides a command line tool, `ses-ava`, that can run AVA with
 multiple configurations in a single command, intercepting flags to filter
 for interesting configurations.
 The `ses-ava` command consumes the `"ava"` and (new) `"sesAvaConfigs"` properties
-in `package.json` to discover and name the supported configurations and infer
-flags like `--only-config-configname` and `--no-config-configname` for each,
-where the `"ava"` configuration is the `default`, if present.
+in `package.json` to discover and name the supported configurations which can be
+referenced by `--only` and `--exclude` options (and their respective `-o` and
+`-x` shorthands), where the `"ava"` configuration is the `default`, if present.
 
 With appropriate configurations, packages can run many of the same tests
 with or without an initialized Endo environment.
@@ -93,8 +93,8 @@ Then, in `package.json`, we can use `ses-ava` instead of `ava`.
 }
 ```
 
-With this configuration, `ses-ava ...args --no-config-lockdown` and `ses-ava
-...args --only-config-unsafe` would both just run the `unsafe` configuration.
+With this configuration, `ses-ava ...args --exclude lockdown` and `ses-ava
+...args --only unsafe` would both just run the `unsafe` configuration.
 Using `ses-ava` under `c8` allows all configurations to cover used code.
 
 # Compatibility

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -40,7 +40,7 @@
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",
     "lint:types": "tsc",
-    "test": "ava && bin/ses-ava --only-config-env --only-config-raw"
+    "test": "ava && bin/ses-ava --only env --only raw"
   },
   "dependencies": {
     "@endo/env-options": "workspace:^",

--- a/packages/ses-ava/test/ses-ava.env-test.js
+++ b/packages/ses-ava/test/ses-ava.env-test.js
@@ -3,6 +3,6 @@
 import test from 'ava';
 
 test('ses-ava env', t => {
-  // ses-ava --only-config-* flag sees this test and the corresponding config
+  // ses-ava `--only env` flag sees this test and the corresponding config
   t.is(process.env.SES_AVA, '1');
 });

--- a/packages/ses-ava/test/ses-ava.must-not-test.js
+++ b/packages/ses-ava/test/ses-ava.must-not-test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
 
-test('ses-ava --no-config-* prevents this test from being discovered', t => {
-  t.fail('should not be reachable because --no-config-two');
+test('ses-ava --exclude prevents this test from being discovered', t => {
+  t.fail('should not be reachable because --exclude two');
 });


### PR DESCRIPTION
Fixes #2998

## Description

Replace `--no-config-$name` and `--only-config-$name` with `--exclude $name` and `--only $name` (and respective shorthands `-x $name` and `-o $name`).

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Updated unit tests but chose not to cover all spellings of the options.

### Compatibility Considerations

ses-ava just landed; we're still in the window where breakage is acceptable.

### Upgrade Considerations

Likewise.