### PR TITLE
fix(ses-ava): Pass raw arguments (test file names) without modification

### DIFF
--- a/packages/ses-ava/src/command.js
+++ b/packages/ses-ava/src/command.js
@@ -97,7 +97,7 @@ export const main = async () => {
         `Unknown flag ${arg}. If this is an ava flag, pass through after --.`,
       );
     } else {
-      passThroughArgs.push(arg);
+      passThroughArgs.push(rawArg);
     }
     firstArg = false;
   }


### PR DESCRIPTION
Minor defect affecting the behavior of `yarn test test/file-name.test.js`, where it passed `te` instead of the entire test file name.