### PR TITLE
refactor(ses-ava): Remove use of ambient process from main

### DIFF
--- a/packages/ses-ava/bin/ses-ava.cjs
+++ b/packages/ses-ava/bin/ses-ava.cjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 (async () => {
   const { main } = await import('../src/command.js');
-  await main(process.argv.slice(2));
-})().catch(error => {
-  console.error(error);
-  process.exitCode = 1;
-});
+  return main(process.argv.slice(2));
+})().then(
+  exitCode => {
+    process.exitCode ||= exitCode;
+  },
+  error => {
+    console.error(error);
+    process.exitCode ||= 1;
+  },
+);


### PR DESCRIPTION
Refs: #2987

## Description

Update the signature of `main` to (args: string[]) => Promise\<ExitCode>, removing access to ambient `process.argv` and `process.exit`.