### PR TITLE
fix(compartment-mapper): mapNodeModules should not crawl ESM modules from CJS entrypoints

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -10,6 +10,8 @@ User-visible changes to `@endo/compartment-mapper`:
   occur _if and only if_ dynamic requires are enabled _and_ a policy is
   provided.
 - Improved error messaging for policy enforcement failures.
+- Fixed a bug where `mapNodeModules()` would traverse ESM exports even when
+  provided a CJS entrypoint.
 
 # v1.6.2 (2025-06-17)
 

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -704,7 +704,6 @@ const graphPackages = async (
   const packageDescriptor = allegedPackageDescriptor;
 
   conditions = new Set(conditions || []);
-  conditions.add('import');
   conditions.add('default');
   conditions.add('endo');
 
@@ -1098,13 +1097,20 @@ export const mapNodeModules = async (
     packageDescriptorLocation,
     moduleSpecifier,
   } = await search(readPowers, moduleLocation, { log });
-
+  conditions = conditions ?? new Set();
+  
   const packageDescriptor = /** @type {typeof parseLocatedJson<unknown>} */ (
     parseLocatedJson
   )(packageDescriptorText, packageDescriptorLocation);
 
   assertPackageDescriptor(packageDescriptor);
   assertFileUrlString(packageLocation);
+
+  if (packageDescriptor.type === 'module') {
+    conditions.add('import');
+  } else {
+    conditions.add('require');
+  }
 
   return compartmentMapForNodeModules(
     readPowers,

--- a/packages/compartment-mapper/test/fixtures-dual-module/node_modules/app-esm/index.js
+++ b/packages/compartment-mapper/test/fixtures-dual-module/node_modules/app-esm/index.js
@@ -1,0 +1,2 @@
+export * from 'dual';
+

--- a/packages/compartment-mapper/test/fixtures-dual-module/node_modules/app-esm/package.json
+++ b/packages/compartment-mapper/test/fixtures-dual-module/node_modules/app-esm/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "app-esm",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "module",
+  "dependencies": {
+    "dual": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}
+

--- a/packages/compartment-mapper/test/fixtures-dual-module/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dual-module/node_modules/app/index.js
@@ -1,0 +1,2 @@
+module.exports = require('dual');
+

--- a/packages/compartment-mapper/test/fixtures-dual-module/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dual-module/node_modules/app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "commonjs",
+  "dependencies": {
+    "dual": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}
+

--- a/packages/compartment-mapper/test/fixtures-dual-module/node_modules/dual/index.cjs
+++ b/packages/compartment-mapper/test/fixtures-dual-module/node_modules/dual/index.cjs
@@ -1,0 +1,2 @@
+module.exports = { value: 'dual-esm' };
+

--- a/packages/compartment-mapper/test/fixtures-dual-module/node_modules/dual/index.js
+++ b/packages/compartment-mapper/test/fixtures-dual-module/node_modules/dual/index.js
@@ -1,0 +1,2 @@
+export const value = 'dual-esm';
+

--- a/packages/compartment-mapper/test/fixtures-dual-module/node_modules/dual/package.json
+++ b/packages/compartment-mapper/test/fixtures-dual-module/node_modules/dual/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dual",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "require": "./index.cjs",
+      "default": "./index.js"
+    }
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}
+

--- a/packages/compartment-mapper/test/map-node-modules.test.js
+++ b/packages/compartment-mapper/test/map-node-modules.test.js
@@ -158,3 +158,35 @@ test('mapNodeModules() should not consider peerDependenciesMeta without correspo
     }
   });
 }
+
+test('mapNodeModules() should not traverse ESM exports for CJS entrypoints', async t => {
+  const moduleLocation = new URL(
+    'fixtures-dual-module/node_modules/app/index.js',
+    import.meta.url,
+  ).href;
+  const readPowers = makeReadPowers({ fs, url });
+  const compartmentMap = await mapNodeModules(readPowers, moduleLocation);
+
+  t.is(
+    Object.values(compartmentMap.compartments).find(
+      compartment => compartment.name === 'dual',
+    )?.modules?.dual?.module,
+    './index.cjs',
+  );
+});
+
+test('mapNodeModules() should prefer ESM exports for ESM entrypoints', async t => {
+  const moduleLocation = new URL(
+    'fixtures-dual-module/node_modules/app-esm/index.js',
+    import.meta.url,
+  ).href;
+  const readPowers = makeReadPowers({ fs, url });
+  const compartmentMap = await mapNodeModules(readPowers, moduleLocation);
+
+  t.is(
+    Object.values(compartmentMap.compartments).find(
+      compartment => compartment.name === 'dual',
+    )?.modules?.dual?.module,
+    './index.js',
+  );
+});


### PR DESCRIPTION

## Description

This changes the logic in `mapNodeModules()` so that when it reads the `package.json` of the entrypoint, it checks for `type === 'module'`. If this is set, then `import` is added to the `conditions`. If it is not set, then `require` is added to the conditions. The conditions always contain `default`; this has not changed.

This prevents CJS modules from referencing modules in the `CompartmentMapDescriptor` which they would not otherwise load (and in fact _cannot_ load for some value of "_cannot_").

### Security Considerations

n/a

### Scaling Considerations

n/a

### Documentation Considerations

This may impact users, but it is a bug fix.

### Testing Considerations

The tests verify this is working for both module systems.

### Compatibility Considerations

n/a

### Upgrade Considerations

Updated `NEWS.md`.
