### PR TITLE
feat(ses): Synchronize error stack repair mechanism

### DIFF
--- a/packages/pass-style/src/error.js
+++ b/packages/pass-style/src/error.js
@@ -28,6 +28,9 @@ const hardenIsFake = () => {
   return desc?.writable === true;
 };
 
+// The error repair mechanism is very similar to code in ses/src/commons.js
+// and these implementations should be kept in sync.
+
 /**
  * Pass-style must defend its own integrity under a number of configurations.
  *


### PR DESCRIPTION

Refs: #2990

## Description

This change synchronizes the error repair mechanism in SES with changes made in #2990 to pass-style to gratutiously improve the resilience of that mechanism in the face of scripts that ran before SES.

### Security Considerations

This reduces SES vulnerability to corruption from code that runs before SES. Replacing the TypeError constructor cannot confuse SES with regard to whether the platform produces type errors with own stack properties.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

We cover versions of Node.js with and without own stack properties in CI and existing tests should be sufficient.

### Compatibility Considerations

Programs that previously deceived SES may now fail when initializing SES. We consider such programs compromised and that incompatibility is a feature.

### Upgrade Considerations

None.
