### PR TITLE
fix(ses): (assert-shim): No error redaction without lockdown

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -4,6 +4,14 @@ User-visible changes in `ses`
 
 - Adds `assert.makeError` and deprecates `assert.error` as an alias, matching
   the API already exported from `@endo/errors`.
+- Before this version, the `assert` left in global scope before `lockdown`
+  would redact errors and would be replaced by `lockdown` with a version that
+  did *not* redact errors if the caller opted-in with `errorTaming`
+  set to one of the `unsafe` variants.
+  After this version, the reverse is true: the `assert` left in global scope
+  before `lockdown` does not redact.
+  Then, `lockdown` replaces `assert` with a redacting `assert` unless the
+  caller opted-out with `errorTaming` set to one of the `unsafe` variants.
 
 # v1.13.0 (2025-06-02)
 

--- a/packages/ses/src/assert-shim.js
+++ b/packages/ses/src/assert-shim.js
@@ -1,4 +1,4 @@
 import { globalThis } from './commons.js';
-import { assert } from './error/assert.js';
+import { makeAssert } from './error/assert.js';
 
-globalThis.assert = assert;
+globalThis.assert = makeAssert(undefined, true);

--- a/packages/ses/src/lockdown.js
+++ b/packages/ses/src/lockdown.js
@@ -404,19 +404,16 @@ export const repairIntrinsics = (options = {}) => {
     );
   }
 
+  // The default `assert` installed by `assert-shim.js` does not redact errors,
+  // leaving `lockdown` or `repairIntrinsics` with the obligation to replace it
+  // with a redacting version, unless the caller opts-out with errorTaming set
+  // to `unsafe` or `unsafe-debug`.
+  // The inverse was true through version 1.13.0, except the configuration
+  // was disregarded and the redacting `assert` left in place if lexical
+  // `assert` differed from `globalThis.assert`.
   // @ts-ignore assert is absent on globalThis type def.
-  if (
-    (errorTaming === 'unsafe' || errorTaming === 'unsafe-debug') &&
-    globalThis.assert === assert
-  ) {
-    // If errorTaming is 'unsafe' or 'unsafe-debug' we replace the
-    // global assert with
-    // one whose `details` template literal tag does not redact
-    // unmarked substitution values. IOW, it blabs information that
-    // was supposed to be secret from callers, as an aid to debugging
-    // at a further cost in safety.
-    // @ts-ignore assert is absent on globalThis type def.
-    globalThis.assert = makeAssert(undefined, true);
+  if (errorTaming !== 'unsafe' && errorTaming !== 'unsafe-debug') {
+    globalThis.assert = makeAssert();
   }
 
   // Replace *Locale* methods with their non-locale equivalents

--- a/packages/ses/test/error/assert-before-lockdown.test.js
+++ b/packages/ses/test/error/assert-before-lockdown.test.js
@@ -1,0 +1,49 @@
+/**
+ * Tests that assert errors are NOT redacted before lockdown.
+ *
+ * Before lockdown, the assert shim installs an unredacted assert on
+ * globalThis. This allows developers to see full error details during
+ * the startup phase before lockdown is called.
+ *
+ * After lockdown (with default safe errorTaming), assert becomes redacting.
+ */
+
+// Import only the shims, but do NOT call lockdown yet
+import '../../index.js';
+
+import test from 'ava';
+
+// Capture the pre-lockdown Fail function
+const { Fail: preLockdownFail, quote: q, bare: b } = assert;
+
+test('assert errors are not redacted before lockdown', t => {
+  // Before lockdown, unquoted substitution values should appear directly
+  // in the error message, not be redacted to type placeholders.
+  t.throws(
+    () =>
+      preLockdownFail`Incorrect luggage combination: ${12345}, consider ${q('abc123')} or ${b('invalid')}`,
+    {
+      message:
+        /Incorrect luggage combination: 12345, consider "abc123" or invalid/,
+    },
+  );
+});
+
+test('assert errors are redacted after lockdown with default errorTaming', t => {
+  // Call lockdown with default (safe) error taming
+  lockdown();
+
+  // Capture the post-lockdown Fail function
+  const { Fail: postLockdownFail } = assert;
+
+  // After lockdown with default settings, unquoted substitution values
+  // should be redacted to type placeholders like "(a number)".
+  t.throws(
+    () =>
+      postLockdownFail`Incorrect luggage combination: ${12345}, consider ${q('abc123')} or ${b('invalid')}`,
+    {
+      message:
+        /Incorrect luggage combination: \(a number\), consider "abc123" or invalid/,
+    },
+  );
+});


### PR DESCRIPTION

## Description

In preparation to introduce a new `@endo/harden` package, toward #2983 decoupling harden from lockdown, it became evident that redacting errors without lockdown left a system in an undebuggable state, since lockdown is necessary to install an unredacter. This was an oversight easily fixed. The default `assert` introduced by initialization of `ses` should not redact, and `lockdown` should replace this `assert` with one that does redact along with its paired unredacting `console` and platform hooks for unredacting uncaught errors and unhandled rejections.

This is important because it will allow multiplexed tests to see the same exception messages before and after lockdown when using `ses-ava`.

### Security Considerations

This relaxation pertains only to systems that run without lockdown and for which SES provides no security claims.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

None.

### Compatibility Considerations

None.

### Upgrade Considerations

None.