### PR TITLE
Investigation for Node v24 AsyncLocalStorage compatibility issue

### DIFF
--- a/packages/init/src/node-async-local-storage-patch.js
+++ b/packages/init/src/node-async-local-storage-patch.js
@@ -80,6 +80,15 @@ AsyncLocalStorage.prototype.run = function run(store, callback, ...args) {
 
   if (typeof this._enable === 'function') {
     this._enable();
+  } else {
+    console.error(
+      'WAT',
+      this,
+      this.__proto__,
+      this.constructor,
+      this.constructor.toString(),
+    );
+    throw new Error('inconceivable ALS internal');
   }
 
   const storeMap = getStoreMap(this);


### PR DESCRIPTION
I've managed to at least turn a couple of banal type programming bugs into a perhaps more diagnostic semantic failure of the test:
- looks like `_enable` is no longer a thing, but the new class code does have a `disable` method
- not sure how the `kResourceStore` property setter used to get called, but looks like it doesn't anymore...
- ...so all those `getStoreMap(this).get // or set or whatever` sites that were pledged a non-undefined blew up

This gets us to "at least now it's just our own expectation that's failing, rather than the test crashing" like:
```
  ✘ [fail]: async_hooks › AsyncLocalStorage patch
  ✔ async_hooks › async_hooks Promise patch (616ms)
  ✔ bundle › Can be bundled (594ms)
  ─

  async_hooks › AsyncLocalStorage patch

  Difference (- actual, + expected):

  - undefined
  + 1

  [object Object]
    at packages/init/test/async_hooks.test.js:103:7
    at async packages/init/test/async_hooks.test.js:88:3

  ─

  1 test failed
```