### PR TITLE
docs(lp32): Elaborate README

### DIFF
--- a/packages/lp32/README.md
+++ b/packages/lp32/README.md
@@ -1,10 +1,136 @@
 # `@endo/lp32`
 
-Also known as the web extension "Native Host Message" protocol, this package
-implements async iterator streams for reading and writing with 32-bit
-host-byte-order length-prefix message envelopes for binary data, represented
-with Uint8Arrays.
+Length-prefixed message streams using 32-bit host byte order framing,
+implemented as async iterators.
 
-These streams are "hardened" and depend on Hardened JavaScript.
-Most JavaScript environments can be locked down with the
-[SES shim](../ses/README.md).
+## Overview
+
+This package implements the binary message framing protocol used by
+[WebExtension Native Messaging][native-messaging].
+Each message is prefixed with a 32-bit unsigned integer indicating the message
+length in bytes, using host byte order.
+
+The protocol is simple:
+- A 4-byte length prefix (uint32, host byte order)
+- Followed by the message payload of that length
+
+For example, a 5-byte message `hello` is transmitted as:
+```
+[0x05, 0x00, 0x00, 0x00] [h, e, l, l, o]
+```
+
+This package provides hardened async iterator streams for reading and writing
+these length-prefixed messages, represented as `Uint8Array`s.
+
+[native-messaging]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging
+
+## Usage
+
+### Reading Messages
+
+Use `makeLp32Reader` to wrap an async iterable of byte chunks and produce
+an async iterable of complete messages:
+
+```js
+import { makeLp32Reader } from '@endo/lp32';
+
+const reader = makeLp32Reader(byteStream, {
+  name: '<my-stream>',        // optional, for error messages
+  maxMessageLength: 1024 * 1024, // optional, defaults to 1MB
+});
+
+for await (const message of reader) {
+  // message is a Uint8Array containing one complete message
+  console.log(new TextDecoder().decode(message));
+}
+```
+
+### Writing Messages
+
+Use `makeLp32Writer` to wrap an output stream and automatically frame
+messages with length prefixes:
+
+```js
+import { makeLp32Writer } from '@endo/lp32';
+
+const writer = makeLp32Writer(outputStream, {
+  name: '<my-writer>',
+  maxMessageLength: 1024 * 1024,
+});
+
+const encoder = new TextEncoder();
+await writer.next(encoder.encode('hello'));
+await writer.next(encoder.encode('world'));
+await writer.return();
+```
+
+### Round-Trip Example
+
+```js
+import { makePipe } from '@endo/stream';
+import { makeLp32Reader, makeLp32Writer } from '@endo/lp32';
+
+const [input, output] = makePipe();
+const writer = makeLp32Writer(output);
+const reader = makeLp32Reader(input);
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+// Producer
+await writer.next(encoder.encode('message 1'));
+await writer.next(encoder.encode('message 2'));
+await writer.return();
+
+// Consumer
+for await (const message of reader) {
+  console.log(decoder.decode(message));
+}
+```
+
+## API
+
+### `makeLp32Reader(reader, options?)`
+
+Creates a reader that decodes length-prefixed messages from a byte stream.
+
+**Parameters:**
+- `reader` - An `Iterable<Uint8Array>` or `AsyncIterable<Uint8Array>`
+- `options.name` - Optional name for error messages
+- `options.maxMessageLength` - Maximum allowed message size (default: 1MB)
+- `options.initialCapacity` - Initial buffer size (default: 1024)
+
+**Returns:** An async iterator yielding `Uint8Array` messages.
+
+### `makeLp32Writer(output, options?)`
+
+Creates a writer that encodes messages with length prefixes.
+
+**Parameters:**
+- `output` - A `Writer<Uint8Array, undefined>` from `@endo/stream`
+- `options.name` - Optional name for error messages
+- `options.maxMessageLength` - Maximum allowed message size (default: 1MB)
+
+**Returns:** A `Writer<Uint8Array, undefined>` that frames messages.
+
+## Hardened JavaScript
+
+This package depends on Hardened JavaScript.
+The environment must be locked down before use, typically via `@endo/init`.
+All exported functions and the streams they produce are hardened.
+
+## Install
+
+```sh
+npm install @endo/lp32
+```
+
+Or with yarn:
+
+```sh
+yarn add @endo/lp32
+```
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/packages/lp32/reader.js
+++ b/packages/lp32/reader.js
@@ -1,17 +1,16 @@
 // @ts-check
-// We use a DataView to give users choice over endianness.
-// But DataView does not default to host-byte-order like other typed arrays.
+// DataView does not default to host byte order like TypedArrays, so we must
+// pass an explicit endianness argument.
 
 import { Fail, q } from '@endo/errors';
 import { hostIsLittleEndian } from './src/host-endian.js';
 
 /**
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} reader
- * @param {object} opts
- * @param {string=} [opts.name]
- * @param {number} [opts.maxMessageLength] - defaults to 1MB
- * @param {boolean=} [opts.littleEndian]
- * @param {number=} [opts.initialCapacity]
+ * @param {object} options
+ * @param {string=} [options.name]
+ * @param {number} [options.maxMessageLength] - defaults to 1MB
+ * @param {number=} [options.initialCapacity]
  * @returns {import('@endo/stream').Reader<Uint8Array, void>}
  */
 async function* makeLp32Iterator(
@@ -20,7 +19,6 @@ async function* makeLp32Iterator(
     name = '<unknown>',
     initialCapacity = 1024,
     maxMessageLength = 1024 * 1024, // 1MB
-    littleEndian = hostIsLittleEndian,
   } = {},
 ) {
   let capacity = Math.max(4, initialCapacity);
@@ -44,7 +42,7 @@ async function* makeLp32Iterator(
 
     let drained = false;
     while (!drained && length >= 4) {
-      const messageLength = data.getUint32(0, littleEndian);
+      const messageLength = data.getUint32(0, hostIsLittleEndian);
       messageLength <= maxMessageLength ||
         Fail`Messages on ${q(name)} must not exceed ${q(
           maxMessageLength,
@@ -72,12 +70,12 @@ harden(makeLp32Iterator);
 
 /**
  * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} reader
- * @param {object} [opts]
- * @param {string=} [opts.name]
- * @param {number=} [opts.capacity]
+ * @param {object} [options]
+ * @param {string=} [options.name]
+ * @param {number=} [options.capacity]
  * @returns {import('@endo/stream').Reader<Uint8Array, void>} reader
  */
-export const makeLp32Reader = (reader, opts) => {
-  return harden(makeLp32Iterator(reader, opts));
+export const makeLp32Reader = (reader, options) => {
+  return harden(makeLp32Iterator(reader, options));
 };
 harden(makeLp32Reader);

--- a/packages/lp32/writer.js
+++ b/packages/lp32/writer.js
@@ -1,13 +1,15 @@
 // @ts-check
+// DataView does not default to host byte order like TypedArrays, so we must
+// pass an explicit endianness argument.
+
 import { Fail, q } from '@endo/errors';
 import { hostIsLittleEndian } from './src/host-endian.js';
 
 /**
  * @param {import('@endo/stream').Writer<Uint8Array, undefined>} output
- * @param {object} opts
- * @param {number} [opts.maxMessageLength] - defaults to 1MB
- * @param {string} [opts.name]
- * @param {boolean} [opts.littleEndian] - defaults to host byte order
+ * @param {object} options
+ * @param {number} [options.maxMessageLength] - defaults to 1MB
+ * @param {string} [options.name]
  * @returns {import('@endo/stream').Writer<Uint8Array, undefined>}
  */
 export const makeLp32Writer = (
@@ -15,7 +17,6 @@ export const makeLp32Writer = (
   {
     name = '<unknown-lp32-writer>',
     maxMessageLength = 1024 * 1024, // 1MB
-    littleEndian = hostIsLittleEndian,
   } = {},
 ) => {
   const writer = harden({
@@ -27,7 +28,7 @@ export const makeLp32Writer = (
         )} must not exceed ${maxMessageLength} bytes in length`;
       const array8 = new Uint8Array(4 + message.byteLength);
       const data = new DataView(array8.buffer);
-      data.setUint32(0, message.byteLength, littleEndian);
+      data.setUint32(0, message.byteLength, hostIsLittleEndian);
       array8.set(message, 4);
       return output.next(array8);
     },


### PR DESCRIPTION
This change documents the lp32 package. It also addresses some minor inconsistencies in the implementation. The byte order for native messages is not configurable.