### PR TITLE
feat(nat,marshal,ocapn): help support apps script limitations

### DIFF
--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-bitwise */
+import { b, q, Fail } from '@endo/errors';
+import { ZERO_N } from '@endo/nat';
 import {
   getTag,
   makeTagged,
@@ -12,8 +14,6 @@ import {
 /**
  * @import {CopyRecord, PassStyle, Passable, RemotableObject, ByteArray} from '@endo/pass-style'
  */
-
-import { b, q, Fail } from '@endo/errors';
 
 const { isArray } = Array;
 const { fromEntries, is } = Object;
@@ -165,10 +165,10 @@ const decodeBinary64 = (encoded, skip = 0) => {
  * @returns {string}
  */
 const encodeBigInt = n => {
-  const abs = n < 0n ? -n : n;
+  const abs = n < ZERO_N ? -n : n;
   const nDigits = abs.toString().length;
   const lDigits = nDigits.toString().length;
-  if (n < 0n) {
+  if (n < ZERO_N) {
     return `n${
       // A "#" for each digit beyond the first
       // in the decimal *count* of decimal digits.

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -7,6 +7,8 @@
 // encodes to Smallcaps, a JSON-representable data structure, and leaves it to
 // the caller (`marshal.js`) to stringify it.
 
+import { X, Fail, q } from '@endo/errors';
+import { ZERO_N } from '@endo/nat';
 import {
   passStyleOf,
   isErrorLike,
@@ -16,7 +18,6 @@ import {
   nameForPassableSymbol,
   passableSymbolForName,
 } from '@endo/pass-style';
-import { X, Fail, q } from '@endo/errors';
 
 /** @import {Passable, RemotableObject} from '@endo/pass-style' */
 // FIXME define actual types
@@ -206,7 +207,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
       }
       case 'bigint': {
         const str = String(passable);
-        return /** @type {bigint} */ (passable) < 0n ? str : `+${str}`;
+        return /** @type {bigint} */ (passable) < ZERO_N ? str : `+${str}`;
       }
       case 'symbol': {
         assertPassableSymbol(passable);

--- a/packages/nat/src/index.js
+++ b/packages/nat/src/index.js
@@ -16,6 +16,46 @@
 // @ts-check
 
 /**
+ * Regarding Google Apps Script limitations,
+ * https://www.google.com/search?q=what+version+of+ecmascript+does+apps+script+support&oq=what+version+of+ecmascript+does+apps+script+support&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQRRg7MgYIAhBFGDsyBggDEEUYOzIGCAQQLhhA0gEHODg4ajBqMagCALACAA&sourceid=chrome&ie=UTF-8
+ * at one point said
+ * > Literal syntax limitation: The shortcut syntax for `BigInt` literals
+ * > (e.g., `10n`) is not supported by the script editor’s parser,
+ * > and will cause a syntax error. You must use the `BigInt()` constructor
+ * > with a string argument instead (e.g., `BigInt("10"))`.
+ * Actually, when a number is accurate, we can use that instead of a string.
+ *
+ * Endo is not in general trying for compat with Apps Script. But packages that
+ * will have minimal dependencies after adapting to
+ * https://github.com/endojs/endo/pull/3008
+ * might, such as `@endo/marshal` and `@endo/ocapn`.
+ */
+export const ZERO_N = BigInt(0);
+/**
+ * Regarding Google Apps Script limitations,
+ * https://www.google.com/search?q=what+version+of+ecmascript+does+apps+script+support&oq=what+version+of+ecmascript+does+apps+script+support&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQRRg7MgYIAhBFGDsyBggDEEUYOzIGCAQQLhhA0gEHODg4ajBqMagCALACAA&sourceid=chrome&ie=UTF-8
+ * at one point said
+ * > Literal syntax limitation: The shortcut syntax for `BigInt` literals
+ * > (e.g., `10n`) is not supported by the script editor’s parser,
+ * > and will cause a syntax error. You must use the `BigInt()` constructor
+ * > with a string argument instead (e.g., `BigInt("10"))`.
+ * Actually, when a number is accurate, we can use that instead of a string.
+ *
+ * Endo is not in general trying for compat with Apps Script. But packages that
+ * will have minimal dependencies after adapting to
+ * https://github.com/endojs/endo/pull/3008
+ * might, such as `@endo/marshal` and `@endo/ocapn`.
+ */
+export const ONE_N = BigInt(1);
+
+/**
+ * Use as a standin for `harden` until https://github.com/endojs/endo/pull/3008
+ * Since we're only using it on unadorned arrow functions, `freeze` in this
+ * case is actually equivalent to `harden`.
+ */
+const { freeze } = Object;
+
+/**
  * Is `allegedNum` a number in the [contiguous range of exactly and
  * unambiguously
  * representable](https://esdiscuss.org/topic/more-numeric-constants-please-especially-epsilon#content-14)
@@ -29,7 +69,7 @@
  * @param {unknown} allegedNum
  * @returns {boolean}
  */
-function isNat(allegedNum) {
+export const isNat = allegedNum => {
   if (typeof allegedNum === 'bigint') {
     return allegedNum >= 0;
   }
@@ -38,7 +78,8 @@ function isNat(allegedNum) {
   }
 
   return Number.isSafeInteger(allegedNum) && allegedNum >= 0;
-}
+};
+freeze(isNat);
 
 /**
  * If `allegedNumber` passes the `isNat` test, then return it as a bigint.
@@ -53,9 +94,9 @@ function isNat(allegedNum) {
  * @param {unknown} allegedNum
  * @returns {bigint}
  */
-function Nat(allegedNum) {
+export const Nat = allegedNum => {
   if (typeof allegedNum === 'bigint') {
-    if (allegedNum < 0n) {
+    if (allegedNum < ZERO_N) {
       throw RangeError(`${allegedNum} is negative`);
     }
     return allegedNum;
@@ -74,6 +115,5 @@ function Nat(allegedNum) {
   throw TypeError(
     `${allegedNum} is a ${typeof allegedNum} but must be a bigint or a number`,
   );
-}
-
-export { isNat, Nat };
+};
+freeze(Nat);

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -42,6 +42,7 @@
     "@endo/immutable-arraybuffer": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/marshal": "workspace:^",
+    "@endo/nat": "workspace:^",
     "@endo/pass-style": "workspace:^",
     "@endo/promise-kit": "workspace:^",
     "@noble/curves": "^1.9.0",

--- a/packages/ocapn/src/client/index.js
+++ b/packages/ocapn/src/client/index.js
@@ -9,6 +9,7 @@
  * @import { Client, Connection, LocationId, Logger, NetLayer, PendingSession, SelfIdentity, Session, SessionManager } from './types.js'
  */
 
+import { ONE_N, ZERO_N } from '@endo/nat';
 import { makePromiseKit } from '@endo/promise-kit';
 import {
   readOcapnHandshakeMessage,
@@ -64,7 +65,7 @@ const makeSession = ({
   connection,
 }) => {
   const { keyPair, location, locationSignature } = selfIdentity;
-  let nextHandoffCount = 0n;
+  let nextHandoffCount = ZERO_N;
   return harden({
     id,
     connection,
@@ -84,7 +85,7 @@ const makeSession = ({
     },
     takeNextHandoffCount: () => {
       const current = nextHandoffCount;
-      nextHandoffCount += 1n;
+      nextHandoffCount += ONE_N;
       return current;
     },
   });

--- a/packages/ocapn/src/client/ocapn.js
+++ b/packages/ocapn/src/client/ocapn.js
@@ -14,6 +14,7 @@
  * @import { OcapnPublicKey } from '../cryptography.js'
  */
 
+import { ZERO_N } from '@endo/nat';
 import { E, HandledPromise } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
@@ -826,7 +827,7 @@ export const makeOcapn = (
         }
 
         // Check if the index is within bounds
-        if (index < 0n || index >= resolved.length) {
+        if (index < ZERO_N || index >= resolved.length) {
           throw Error(
             `Index ${index} out of bounds for array of length ${resolved.length}`,
           );
@@ -1189,7 +1190,7 @@ export const makeOcapn = (
     }
   };
 
-  const localBootstrapSlot = makeSlot('o', true, 0n);
+  const localBootstrapSlot = makeSlot('o', true, ZERO_N);
   const bootstrapObj = makeBootstrapObject(
     ourIdLabel,
     logger,

--- a/packages/ocapn/src/client/ref-kit.js
+++ b/packages/ocapn/src/client/ref-kit.js
@@ -15,6 +15,7 @@
 
 /** @typedef {import('../cryptography.js').OcapnPublicKey} OcapnPublicKey */
 
+import { ONE_N, ZERO_N } from '@endo/nat';
 import { Far, Remotable } from '@endo/marshal';
 import { makeSlot, parseSlot } from '../captp/pairwise.js';
 
@@ -114,13 +115,13 @@ export const makeReferenceKit = (
   makeHandoff,
   sendHandoff,
 ) => {
-  let nextExportPosition = 1n;
+  let nextExportPosition = ONE_N;
   const provideSlotForValue = value => {
     let slot = ocapnTable.getSlotForValue(value);
     if (slot === undefined) {
       // If there is no slot for this value, its our own export.
       const position = nextExportPosition;
-      nextExportPosition += 1n;
+      nextExportPosition += ONE_N;
       const type = value instanceof Promise ? 'p' : 'o';
       slot = makeSlot(type, true, position);
       ocapnTable.registerSlot(slot, value);
@@ -208,7 +209,7 @@ export const makeReferenceKit = (
   };
 
   const makeRemoteBootstrap = () => {
-    return makeRemoteObject(0n, 'Remote Bootstrap');
+    return makeRemoteObject(ZERO_N, 'Remote Bootstrap');
   };
 
   const makeLocalResolver = (slot, settler) => {
@@ -226,7 +227,7 @@ export const makeReferenceKit = (
   };
 
   // Track the next answer position.
-  let nextAnswerPosition = 0n;
+  let nextAnswerPosition = ZERO_N;
 
   /** @type {ReferenceKit} */
   const referenceKit = harden({
@@ -281,7 +282,7 @@ export const makeReferenceKit = (
       return value;
     },
     provideRemoteBootstrapValue: () => {
-      const slot = makeSlot('o', false, 0n);
+      const slot = makeSlot('o', false, ZERO_N);
       let value = ocapnTable.getValueForSlot(slot);
       if (value === undefined) {
         value = makeRemoteBootstrap();
@@ -347,7 +348,7 @@ export const makeReferenceKit = (
        *   The resolver is used to resolve the internal promise (which should resolve the external answer promise).
        */
       const answerPosition = nextAnswerPosition;
-      nextAnswerPosition += 1n;
+      nextAnswerPosition += ONE_N;
 
       // Create a promise + settler pair with an optional externalAnswerPromise.
       // The settler is needed to resolve the promise when the answer comes back.

--- a/packages/ocapn/src/codecs/subtypes.js
+++ b/packages/ocapn/src/codecs/subtypes.js
@@ -1,3 +1,4 @@
+import { ZERO_N } from '@endo/nat';
 import { makeCodec } from '../syrup/codec.js';
 
 /** @import { SyrupCodec } from '../syrup/codec.js' */
@@ -10,14 +11,14 @@ export const PositiveIntegerCodec = makeCodec('PositiveInteger', {
     if (typeof value !== 'bigint') {
       throw Error('value must be a bigint');
     }
-    if (value <= 0n) {
+    if (value <= ZERO_N) {
       throw Error('value must be positive');
     }
     syrupWriter.writeInteger(value);
   },
   read: syrupReader => {
     const value = syrupReader.readInteger();
-    if (value <= 0n) {
+    if (value <= ZERO_N) {
       throw Error('value must be positive');
     }
     return value;
@@ -30,14 +31,14 @@ export const NonNegativeIntegerCodec = makeCodec('NonNegativeInteger', {
     if (typeof value !== 'bigint') {
       throw Error('value must be a bigint');
     }
-    if (value < 0n) {
+    if (value < ZERO_N) {
       throw Error('value must be non-negative');
     }
     syrupWriter.writeInteger(value);
   },
   read: syrupReader => {
     const value = syrupReader.readInteger();
-    if (value < 0n) {
+    if (value < ZERO_N) {
       throw Error('value must be non-negative');
     }
     return value;

--- a/packages/ocapn/src/syrup/encode.js
+++ b/packages/ocapn/src/syrup/encode.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { ZERO_N } from '@endo/nat';
 import { BufferWriter } from './buffer-writer.js';
 
 const quote = JSON.stringify;
@@ -118,7 +119,7 @@ function writeInteger(bufferWriter, value) {
   if (typeof value !== 'bigint') {
     throw Error(`writeInteger: Expected bigint, got ${typeof value}`);
   }
-  const string = value >= 0n ? `${value}+` : `${-value}-`;
+  const string = value >= ZERO_N ? `${value}+` : `${-value}-`;
   bufferWriter.writeString(string);
 }
 

--- a/packages/pass-style/src/types.test-d.ts
+++ b/packages/pass-style/src/types.test-d.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { ONE_N } from '@endo/nat';
 import { expectAssignable, expectType, expectNotType } from 'tsd';
 import { Far } from './make-far.js';
 import { passStyleOf } from './passStyleOf.js';
@@ -18,7 +19,7 @@ expectType<'undefined'>(passStyleOf(undefined));
 expectType<'string'>(passStyleOf('str'));
 expectType<'boolean'>(passStyleOf(true));
 expectType<'number'>(passStyleOf(1));
-expectType<'bigint'>(passStyleOf(1n));
+expectType<'bigint'>(passStyleOf(ONE_N));
 expectType<'symbol'>(passStyleOf(passableSymbolForName('foo')));
 expectType<'null'>(passStyleOf(null));
 expectType<'promise'>(passStyleOf(Promise.resolve()));

--- a/packages/stream-types-test/package.json
+++ b/packages/stream-types-test/package.json
@@ -26,6 +26,7 @@
     "test": "yarn lint:types"
   },
   "dependencies": {
+    "@endo/nat": "workspace:^",
     "@endo/stream": "workspace:^",
     "ses": "workspace:^"
   },

--- a/packages/stream-types-test/validation.ts
+++ b/packages/stream-types-test/validation.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle, no-empty */
 /// <reference types="ses"/>
 
+import { ONE_N } from '@endo/nat';
 import {
   makeQueue,
   makeStream,
@@ -92,7 +93,7 @@ async () => {
   const s: Stream<string, number, bigint, bigint> = prime(
     (async function* generator() {
       const n: number = yield 'A';
-      return 1n;
+      return ONE_N;
     })(),
     1,
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,6 +643,7 @@ __metadata:
     "@endo/init": "workspace:^"
     "@endo/lockdown": "workspace:^"
     "@endo/marshal": "workspace:^"
+    "@endo/nat": "workspace:^"
     "@endo/pass-style": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"
@@ -784,6 +785,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/stream-types-test@workspace:packages/stream-types-test"
   dependencies:
+    "@endo/nat": "workspace:^"
     "@endo/stream": "workspace:^"
     eslint: "catalog:dev"
     ses: "workspace:^"


### PR DESCRIPTION
Closes: #XXXX
Refs: #3008  , #1686 , #1582
Refs: https://github.com/dckc/inter-fun/blob/main/gapp/unmarshal.js
Refs: https://www.google.com/search?q=what+version+of+ecmascript+does+apps+script+support&oq=what+version+of+ecmascript+does+apps+script+support&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQRRg7MgYIAhBFGDsyBggDEEUYOzIGCAQQLhhA0gEHODg4ajBqMagCALACAA&sourceid=chrome&ie=UTF-8 


## Description

One of the reasons @dckc reimplemented marshal as https://github.com/dckc/inter-fun/blob/main/gapp/unmarshal.js is to be able to use it in Apps Script. After marshal adapts to #3008 , it should be much easier to create a marshal with far fewer dependencies that should be adequate for these purposes. However, at least one annoying problem would prevent that.

 https://www.google.com/search?q=what+version+of+ecmascript+does+apps+script+support&oq=what+version+of+ecmascript+does+apps+script+support&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIGCAEQRRg7MgYIAhBFGDsyBggDEEUYOzIGCAQQLhhA0gEHODg4ajBqMagCALACAA&sourceid=chrome&ie=UTF-8
 
at one point said 

> Literal syntax limitation: The shortcut syntax for `BigInt` literals (e.g., `10n`) is not supported by the script editor’s parser, and will cause a syntax error. You must use the `BigInt()` constructor with a string argument instead (e.g., `BigInt("10"))`.

Actually, when a number is accurate, we can use that instead of a string.

Endo is not in general trying for compat with Apps Script. But packages that will have minimal dependencies after adapting to https://github.com/endojs/endo/pull/3008 might, such as `@endo/marshal` and `@endo/ocapn`. This PR readies such packages for that by avoiding the bigint literals that would prevent that.

### Security Considerations
none
### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

none
### Compatibility Considerations

the point. After we adapt to #3008, this PR will help enable some packages (marshal, ocapn) to run under Apps Script despite the limitations quoted above. There may be other problems, but at least this PR eliminates one known problem.

### Upgrade Considerations
none.