### PR TITLE
refactor(daemon): Use branded types for validated strings

### DIFF
--- a/packages/daemon/src/context.js
+++ b/packages/daemon/src/context.js
@@ -3,11 +3,11 @@
 import { makePromiseKit } from '@endo/promise-kit';
 
 /** @import { PromiseKit } from '@endo/promise-kit' */
-/** @import { Context } from './types.js' */
+/** @import { Context, FormulaIdentifier } from './types.js' */
 
 export const makeContextMaker = ({ controllerForId, provideController }) => {
   /**
-   * @param {string} id
+   * @param {FormulaIdentifier} id
    */
   const makeContext = id => {
     let done = false;
@@ -16,7 +16,7 @@ export const makeContextMaker = ({ controllerForId, provideController }) => {
     const { promise: disposed, resolve: resolveDisposed } =
       /** @type {PromiseKit<void>} */ (makePromiseKit());
 
-    /** @type {Map<string, Context>} */
+    /** @type {Map<FormulaIdentifier, Context>} */
     const dependents = new Map();
     /** @type {Array<() => void>} */
     const hooks = [];
@@ -45,7 +45,7 @@ export const makeContextMaker = ({ controllerForId, provideController }) => {
     };
 
     /**
-     * @param {string} dependentId
+     * @param {FormulaIdentifier} dependentId
      */
     const thatDiesIfThisDies = dependentId => {
       assert(!done);
@@ -54,7 +54,7 @@ export const makeContextMaker = ({ controllerForId, provideController }) => {
     };
 
     /**
-     * @param {string} dependencyId
+     * @param {FormulaIdentifier} dependencyId
      */
     const thisDiesIfThatDies = dependencyId => {
       const dependencyController = provideController(dependencyId);

--- a/packages/daemon/src/formula-identifier.js
+++ b/packages/daemon/src/formula-identifier.js
@@ -1,7 +1,7 @@
 // @ts-check
 /// <ref types="ses">
 
-/** @import { IdRecord } from './types.js' */
+/** @import { IdRecord, ParseIdRecord, FormulaNumber, NodeNumber, FormulaIdentifier } from './types.js' */
 
 import { makeError, q } from '@endo/errors';
 
@@ -24,9 +24,29 @@ export const assertValidNumber = allegedNumber => {
 };
 
 /**
+ * @param {string} allegedFormulaNumber
+ * @returns {asserts allegedFormulaNumber is FormulaNumber}
+ */
+export const assertFormulaNumber = allegedFormulaNumber => {
+  if (!isValidNumber(allegedFormulaNumber)) {
+    throw makeError(`Invalid formula number ${q(allegedFormulaNumber)}`);
+  }
+};
+
+/**
+ * @param {string} allegedNodeNumber
+ * @returns {asserts allegedNodeNumber is NodeNumber}
+ */
+export const assertNodeNumber = allegedNodeNumber => {
+  if (!isValidNumber(allegedNodeNumber)) {
+    throw makeError(`Invalid node number ${q(allegedNodeNumber)}`);
+  }
+};
+
+/**
  * @param {string} id
  * @param {string} [petName]
- * @returns {void}
+ * @returns {asserts id is FormulaIdentifier}
  */
 export const assertValidId = (id, petName) => {
   if (typeof id !== 'string' || !idPattern.test(id)) {
@@ -40,7 +60,7 @@ export const assertValidId = (id, petName) => {
 
 /**
  * @param {string} id
- * @returns {IdRecord}
+ * @returns {ParseIdRecord}
  */
 export const parseId = id => {
   const match = idPattern.exec(id);
@@ -57,15 +77,18 @@ export const parseId = id => {
   }
 
   const { number, node } = groups;
-  return { number, node };
+  const formulaId = /** @type {FormulaIdentifier} */ (id);
+  const formulaNumber = /** @type {FormulaNumber} */ (number);
+  const nodeNumber = /** @type {NodeNumber} */ (node);
+  return { id: formulaId, number: formulaNumber, node: nodeNumber };
 };
 
 /**
  * @param {IdRecord} formulaRecord
- * @returns {string}
+ * @returns {FormulaIdentifier}
  */
 export const formatId = ({ number, node }) => {
-  const id = `${number}:${node}`;
+  const id = `${String(number)}:${String(node)}`;
   assertValidId(id);
-  return id;
+  return /** @type {FormulaIdentifier} */ (id);
 };

--- a/packages/daemon/src/guest.js
+++ b/packages/daemon/src/guest.js
@@ -4,7 +4,7 @@ import { makeExo } from '@endo/exo';
 import { makeIteratorRef } from './reader-ref.js';
 import { makePetSitter } from './pet-sitter.js';
 
-/** @import { Context, EndoGuest, MakeDirectoryNode, MakeMailbox, Provide } from './types.js' */
+/** @import { Context, EndoGuest, FormulaIdentifier, MakeDirectoryNode, MakeMailbox, Provide } from './types.js' */
 import { GuestInterface } from './interfaces.js';
 
 /**
@@ -15,12 +15,12 @@ import { GuestInterface } from './interfaces.js';
  */
 export const makeGuestMaker = ({ provide, makeMailbox, makeDirectoryNode }) => {
   /**
-   * @param {string} guestId
-   * @param {string} handleId
-   * @param {string} hostAgentId
-   * @param {string} hostHandleId
-   * @param {string} petStoreId
-   * @param {string} mainWorkerId
+   * @param {FormulaIdentifier} guestId
+   * @param {FormulaIdentifier} handleId
+   * @param {FormulaIdentifier} hostAgentId
+   * @param {FormulaIdentifier} hostHandleId
+   * @param {FormulaIdentifier} petStoreId
+   * @param {FormulaIdentifier} mainWorkerId
    * @param {Context} context
    */
   const makeGuest = async (

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 /** @import { ERef } from '@endo/eventual-send' */
-/** @import { AgentDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EvalDeferredTaskParams, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, PeerInfo, ReadableBlobDeferredTaskParams, MarshalDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
+/** @import { AgentDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, MarshalDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
 
 import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
@@ -11,15 +11,25 @@ import { makeIteratorRef } from './reader-ref.js';
 import {
   assertPetName,
   assertPetNamePath,
-  petNamePathFrom,
+  assertName,
+  assertNamePath,
+  namePathFrom,
 } from './pet-name.js';
-import { parseId, formatId } from './formula-identifier.js';
+import {
+  assertFormulaNumber,
+  assertNodeNumber,
+  parseId,
+  formatId,
+} from './formula-identifier.js';
 import { makePetSitter } from './pet-sitter.js';
 import { makeDeferredTasks } from './deferred-tasks.js';
 
 import { HostInterface } from './interfaces.js';
 
-/** @param {string} name */
+/**
+ * @param {string} name
+ * @returns {asserts name is Name}
+ */
 const assertPowersName = name => {
   ['NONE', 'AGENT', 'ENDO'].includes(name) || assertPetName(name);
 };
@@ -41,7 +51,7 @@ const assertPowersName = name => {
  * @param {DaemonCore['getAllNetworkAddresses']} args.getAllNetworkAddresses
  * @param {MakeMailbox} args.makeMailbox
  * @param {MakeDirectoryNode} args.makeDirectoryNode
- * @param {string} args.localNodeId
+ * @param {NodeNumber} args.localNodeNumber
  */
 export const makeHostMaker = ({
   provide,
@@ -59,19 +69,19 @@ export const makeHostMaker = ({
   getAllNetworkAddresses,
   makeMailbox,
   makeDirectoryNode,
-  localNodeId,
+  localNodeNumber,
 }) => {
   /**
-   * @param {string} hostId
-   * @param {string} handleId
-   * @param {string} storeId
-   * @param {string} inspectorId
-   * @param {string} mainWorkerId
-   * @param {string} endoId
-   * @param {string} networksDirectoryId
-   * @param {string} pinsDirectoryId
-   * @param {string} leastAuthorityId
-   * @param {{[name: string]: string}} platformNames
+   * @param {FormulaIdentifier} hostId
+   * @param {FormulaIdentifier} handleId
+   * @param {FormulaIdentifier} storeId
+   * @param {FormulaIdentifier} inspectorId
+   * @param {FormulaIdentifier} mainWorkerId
+   * @param {FormulaIdentifier} endoId
+   * @param {FormulaIdentifier} networksDirectoryId
+   * @param {FormulaIdentifier} pinsDirectoryId
+   * @param {FormulaIdentifier} leastAuthorityId
+   * @param {{[name: string]: FormulaIdentifier}} platformNames
    * @param {Context} context
    */
   const makeHost = async (
@@ -111,22 +121,46 @@ export const makeHostMaker = ({
       context,
     });
     const { petStore, handle } = mailbox;
-
     const getEndoBootstrap = async () => provide(endoId, 'endo');
 
     /**
+     * @param {MakeHostOrGuestOptions | undefined} opts
+     * @returns {{ introducedNames: Record<Name, PetName>, agentName?: PetName }}
+     */
+    const normalizeHostOrGuestOptions = opts => {
+      const { introducedNames: introducedNamesRecord, agentName } = opts ?? {};
+      /** @type {Record<Name, PetName>} */
+      const introducedNames = Object.create(null);
+      if (introducedNamesRecord !== undefined) {
+        for (const [edgeName, introducedPetName] of Object.entries(
+          introducedNamesRecord,
+        )) {
+          assertName(edgeName);
+          assertPetName(introducedPetName);
+          introducedNames[edgeName] = introducedPetName;
+        }
+      }
+      if (agentName !== undefined) {
+        assertPetName(agentName);
+      }
+      return {
+        introducedNames,
+        agentName,
+      };
+    };
+
+    /**
      * @param {ERef<AsyncIterableIterator<string>>} readerRef
-     * @param {string | string[]} [petName]
+     * @param {string | string[]} petName
      */
     const storeBlob = async (readerRef, petName) => {
+      const { namePath } = assertPetNamePath(namePathFrom(petName));
+
       /** @type {DeferredTasks<ReadableBlobDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
-
-      if (petName !== undefined) {
-        tasks.push(identifiers =>
-          E(directory).write(petName, identifiers.readableBlobId),
-        );
-      }
+      tasks.push(identifiers =>
+        E(directory).write(namePath, identifiers.readableBlobId),
+      );
 
       const { value } = await formulateReadableBlob(readerRef, tasks);
       return value;
@@ -134,58 +168,65 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['storeValue']} */
     const storeValue = async (value, petName) => {
+      const namePath = namePathFrom(petName);
+      assertNamePath(namePath);
       /** @type {DeferredTasks<MarshalDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
 
-      if (petName !== undefined) {
-        tasks.push(identifiers =>
-          E(directory).write(petName, identifiers.marshalId),
-        );
-      }
+      tasks.push(identifiers =>
+        E(directory).write(namePath, identifiers.marshalId),
+      );
 
       await formulateMarshalValue(value, tasks);
     };
 
     /**
-     * @param {string[]} workerNamePath
+     * @param {string | string[]} workerNamePath
      */
     const provideWorker = async workerNamePath => {
-      const workerId = await E(directory).identify(...workerNamePath);
+      const namePath = namePathFrom(workerNamePath);
+      assertNamePath(namePath);
+      const workerId = await E(directory).identify(...namePath);
 
       if (workerId !== undefined) {
-        return provide(workerId, 'worker');
+        return provide(/** @type {FormulaIdentifier} */ (workerId), 'worker');
       }
 
       /** @type {DeferredTasks<WorkerDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       const { value, id } = await formulateWorker(tasks);
-      await E(directory).write(workerNamePath, id);
+      await E(directory).write(namePath, id);
       return value;
     };
 
     /**
-     * @param {string | undefined} workerName
-     * @param {DeferredTasks<{ workerId: string }>['push']} deferTask
+     * @param {Name | undefined} workerName
+     * @param {DeferredTasks<WorkerDeferredTaskParams>['push']} deferTask
      */
     const prepareWorkerFormulation = (workerName, deferTask) => {
       if (workerName === undefined) {
         return undefined;
       }
-      const workerId = petStore.identifyLocal(workerName);
+      const workerId = /** @type {FormulaIdentifier | undefined} */ (
+        petStore.identifyLocal(workerName)
+      );
       if (workerId === undefined) {
-        deferTask(identifiers =>
-          petStore.write(workerName, identifiers.workerId),
-        );
+        assertPetName(workerName);
+        const petName = workerName;
+        deferTask(identifiers => {
+          return petStore.write(petName, identifiers.workerId);
+        });
+        return undefined;
       }
       return workerId;
     };
 
     /**
-     * @param {string | 'MAIN' | undefined} workerName
+     * @param {string | undefined} workerName
      * @param {string} source
-     * @param {string[]} codeNames
+     * @param {Array<string>} codeNames
      * @param {(string | string[])[]} petNamePaths
-     * @param {string[]} resultName
+     * @param {string | string[] | undefined} resultName
      */
     const evaluate = async (
       workerName,
@@ -194,8 +235,20 @@ export const makeHostMaker = ({
       petNamePaths,
       resultName,
     ) => {
+      if (workerName !== undefined) {
+        assertName(workerName);
+      }
+      if (!Array.isArray(codeNames)) {
+        throw new Error('Evaluator requires an array of code names');
+      }
+      for (const codeName of codeNames) {
+        if (typeof codeName !== 'string') {
+          throw new Error(`Invalid endowment name: ${q(codeName)}`);
+        }
+      }
       if (resultName !== undefined) {
-        assertPetNamePath(resultName);
+        const resultNamePath = namePathFrom(resultName);
+        assertNamePath(resultNamePath);
       }
       if (petNamePaths.length !== codeNames.length) {
         throw new Error('Evaluator requires one pet name for each code name');
@@ -206,29 +259,24 @@ export const makeHostMaker = ({
 
       const workerId = prepareWorkerFormulation(workerName, tasks.push);
 
-      /** @type {(string | string[])[]} */
-      const endowmentFormulaIdsOrPaths = petNamePaths.map(
-        (petNameOrPath, index) => {
-          if (typeof codeNames[index] !== 'string') {
-            throw new Error(`Invalid endowment name: ${q(codeNames[index])}`);
+      /** @type {(FormulaIdentifier | NamePath)[]} */
+      const endowmentFormulaIdsOrPaths = petNamePaths.map(petNameOrPath => {
+        const petNamePath = namePathFrom(petNameOrPath);
+        if (petNamePath.length === 1) {
+          const id = petStore.identifyLocal(petNamePath[0]);
+          if (id === undefined) {
+            throw new Error(`Unknown pet name ${q(petNamePath[0])}`);
           }
+          return /** @type {FormulaIdentifier} */ (id);
+        }
 
-          const petNamePath = petNamePathFrom(petNameOrPath);
-          if (petNamePath.length === 1) {
-            const id = petStore.identifyLocal(petNamePath[0]);
-            if (id === undefined) {
-              throw new Error(`Unknown pet name ${q(petNamePath[0])}`);
-            }
-            return id;
-          }
-
-          return petNamePath;
-        },
-      );
+        return petNamePath;
+      });
 
       if (resultName !== undefined) {
+        const resultNamePath = namePathFrom(resultName);
         tasks.push(identifiers =>
-          E(directory).write(resultName, identifiers.evalId),
+          E(directory).write(resultNamePath, identifiers.evalId),
         );
       }
 
@@ -246,7 +294,7 @@ export const makeHostMaker = ({
     /**
      * Helper function for makeUnconfined and makeBundle.
      * @param {string} powersName
-     * @param {string | undefined} workerName
+     * @param {Name | undefined} workerName
      * @param {string | string[]} [resultName]
      */
     const prepareMakeCaplet = (powersName, workerName, resultName) => {
@@ -257,16 +305,20 @@ export const makeHostMaker = ({
 
       const workerId = prepareWorkerFormulation(workerName, tasks.push);
 
-      const powersId = petStore.identifyLocal(powersName);
+      const powersId = /** @type {FormulaIdentifier | undefined} */ (
+        petStore.identifyLocal(powersName)
+      );
       if (powersId === undefined) {
-        tasks.push(identifiers =>
-          petStore.write(powersName, identifiers.powersId),
-        );
+        assertPetName(powersName);
+        const powersPetName = powersName;
+        tasks.push(identifiers => {
+          return petStore.write(powersPetName, identifiers.powersId);
+        });
       }
 
       if (resultName !== undefined) {
         tasks.push(identifiers =>
-          E(directory).write(resultName, identifiers.capletId),
+          E(directory).write(namePathFrom(resultName), identifiers.capletId),
         );
       }
 
@@ -280,6 +332,10 @@ export const makeHostMaker = ({
       powersName,
       resultName,
     ) => {
+      if (workerName !== undefined) {
+        assertName(workerName);
+      }
+      assertPowersName(powersName);
       const { tasks, workerId, powersId } = prepareMakeCaplet(
         powersName,
         workerName,
@@ -300,10 +356,10 @@ export const makeHostMaker = ({
     };
 
     /**
-     * @param {string | 'MAIN' | undefined} workerName
+     * @param {string | undefined} workerName
      * @param {string} bundleName
-     * @param {string | 'NONE' | 'SELF' | 'ENDO'} powersName
-     * @param {string} resultName
+     * @param {string} powersName
+     * @param {string | string[] | undefined} resultName
      */
     const makeBundle = async (
       workerName,
@@ -311,7 +367,14 @@ export const makeHostMaker = ({
       powersName,
       resultName,
     ) => {
-      const bundleId = petStore.identifyLocal(bundleName);
+      if (workerName !== undefined) {
+        assertName(workerName);
+      }
+      assertName(bundleName);
+      assertPowersName(powersName);
+      const bundleId = /** @type {FormulaIdentifier | undefined} */ (
+        petStore.identifyLocal(bundleName)
+      );
       if (bundleId === undefined) {
         throw new TypeError(`Unknown pet name for bundle: ${q(bundleName)}`);
       }
@@ -339,15 +402,17 @@ export const makeHostMaker = ({
      * Attempts to introduce the given names to the specified agent. The agent in question
      * must be formulated before this function is called.
      *
-     * @param {string} agentId - The agent's formula identifier.
-     * @param {Record<string,string>} introducedNames - The names to introduce.
+     * @param {FormulaIdentifier} agentId - The agent's formula identifier.
+     * @param {Record<Name, PetName>} introducedNames - The names to introduce.
      * @returns {Promise<void>}
      */
     const introduceNamesToAgent = async (agentId, introducedNames) => {
       const agent = await provide(agentId, 'agent');
       await Promise.all(
         Object.entries(introducedNames).map(async ([parentName, childName]) => {
-          const introducedId = petStore.identifyLocal(parentName);
+          const introducedId = petStore.identifyLocal(
+            /** @type {Name} */ (parentName),
+          );
           if (introducedId === undefined) {
             return;
           }
@@ -358,16 +423,17 @@ export const makeHostMaker = ({
 
     /**
      * @template {'host' | 'guest' | 'agent'} T
-     * @param {string} [petName] - The agent's potential pet name.
+     * @param {Name} [petName] - The agent's potential pet name.
      * @param {T} [type]
      */
     const getNamedAgent = (petName, type) => {
       if (petName !== undefined) {
         const id = petStore.identifyLocal(petName);
         if (id !== undefined) {
+          const formulaId = /** @type {FormulaIdentifier} */ (id);
           return {
-            id,
-            value: provide(id, type),
+            id: formulaId,
+            value: provide(formulaId, type),
           };
         }
       }
@@ -382,26 +448,30 @@ export const makeHostMaker = ({
       /** @type {DeferredTasks<AgentDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
       if (handleName !== undefined) {
-        tasks.push(identifiers =>
-          petStore.write(handleName, identifiers.handleId),
-        );
+        assertPetName(handleName);
+        const handlePetName = handleName;
+        tasks.push(identifiers => {
+          return petStore.write(handlePetName, identifiers.handleId);
+        });
       }
       if (agentName !== undefined) {
-        tasks.push(identifiers =>
-          petStore.write(agentName, identifiers.agentId),
-        );
+        assertPetName(agentName);
+        const agentPetName = agentName;
+        tasks.push(identifiers => {
+          return petStore.write(agentPetName, identifiers.agentId);
+        });
       }
       return tasks;
     };
 
     /**
-     * @param {string} [petName]
-     * @param {MakeHostOrGuestOptions} [opts]
-     * @returns {Promise<{id: string, value: Promise<EndoHost>}>}
+     * @param {Name} [petName]
+     * @param {{ introducedNames?: Record<Name, PetName>, agentName?: PetName }} [opts]
+     * @returns {Promise<{id: FormulaIdentifier, value: Promise<EndoHost>}>}
      */
     const makeChildHost = async (
       petName,
-      { introducedNames = {}, agentName = undefined } = {},
+      { introducedNames = Object.create(null), agentName = undefined } = {},
     ) => {
       let host = getNamedAgent(petName, 'host');
       await null;
@@ -419,24 +489,28 @@ export const makeHostMaker = ({
 
       await introduceNamesToAgent(host.id, introducedNames);
 
-      /** @type {{ id: string, value: Promise<EndoHost> }} */
+      /** @type {{ id: FormulaIdentifier, value: Promise<EndoHost> }} */
       return host;
     };
 
     /** @type {EndoHost['provideHost']} */
     const provideHost = async (petName, opts) => {
-      const { value } = await makeChildHost(petName, opts);
+      if (petName !== undefined) {
+        assertName(petName);
+      }
+      const normalizedOpts = normalizeHostOrGuestOptions(opts);
+      const { value } = await makeChildHost(petName, normalizedOpts);
       return value;
     };
 
     /**
-     * @param {string} [handleName]
-     * @param {MakeHostOrGuestOptions} [opts]
-     * @returns {Promise<{id: string, value: Promise<EndoGuest>}>}
+     * @param {Name} [handleName]
+     * @param {{ introducedNames?: Record<Name, PetName>, agentName?: PetName }} [opts]
+     * @returns {Promise<{id: FormulaIdentifier, value: Promise<EndoGuest>}>}
      */
     const makeGuest = async (
       handleName,
-      { introducedNames = {}, agentName = undefined } = {},
+      { introducedNames = Object.create(null), agentName = undefined } = {},
     ) => {
       let guest = getNamedAgent(handleName, 'guest');
       await null;
@@ -453,13 +527,17 @@ export const makeHostMaker = ({
 
       await introduceNamesToAgent(guest.id, introducedNames);
 
-      /** @type {{ id: string, value: Promise<EndoGuest> }} */
+      /** @type {{ id: FormulaIdentifier, value: Promise<EndoGuest> }} */
       return guest;
     };
 
     /** @type {EndoHost['provideGuest']} */
     const provideGuest = async (petName, opts) => {
-      const { value } = await makeGuest(petName, opts);
+      if (petName !== undefined) {
+        assertName(petName);
+      }
+      const normalizedOpts = normalizeHostOrGuestOptions(opts);
+      const { value } = await makeGuest(petName, normalizedOpts);
       return value;
     };
 
@@ -467,6 +545,7 @@ export const makeHostMaker = ({
      * @param {string} guestName
      */
     const invite = async guestName => {
+      assertPetName(guestName);
       // We must immediately retain a formula under guestName so that we
       // preserve the invitation across restarts, but we must replace the
       // guestName with the handle of the guest that accepts the invitation.
@@ -494,6 +573,7 @@ export const makeHostMaker = ({
      * @param {string} guestName
      */
     const accept = async (invitationLocator, guestName) => {
+      assertPetName(guestName);
       const url = new URL(invitationLocator);
       const nodeNumber = url.hostname;
       const invitationNumber = url.searchParams.get('id');
@@ -507,6 +587,9 @@ export const makeHostMaker = ({
       if (invitationNumber === null) {
         throw makeError(`Invitation must have an "id" parameter`);
       }
+      assertNodeNumber(nodeNumber);
+      assertFormulaNumber(remoteHandleNumber);
+      assertFormulaNumber(invitationNumber);
 
       /** @type {PeerInfo} */
       const peerInfo = {
@@ -529,7 +612,7 @@ export const makeHostMaker = ({
       // eslint-disable-next-line no-use-before-define
       const { addresses: hostAddresses } = await getPeerInfo();
       const handleUrl = new URL('endo://');
-      handleUrl.hostname = localNodeId;
+      handleUrl.hostname = localNodeNumber;
       handleUrl.searchParams.set('id', handleNumber);
       for (const address of hostAddresses) {
         handleUrl.searchParams.append('at', address);
@@ -543,11 +626,12 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['cancel']} */
     const cancel = async (petName, reason = new Error('Cancelled')) => {
+      assertPetName(petName);
       const id = petStore.identifyLocal(petName);
       if (id === undefined) {
         throw new TypeError(`Unknown pet name: ${q(petName)}`);
       }
-      return cancelValue(id, reason);
+      return cancelValue(/** @type {FormulaIdentifier} */ (id), reason);
     };
 
     /** @type {EndoHost['gateway']} */
@@ -572,7 +656,7 @@ export const makeHostMaker = ({
     const getPeerInfo = async () => {
       const addresses = await getAllNetworkAddresses(networksDirectoryId);
       const peerInfo = {
-        node: localNodeId,
+        node: localNodeNumber,
         addresses,
       };
       return peerInfo;

--- a/packages/daemon/src/locator.js
+++ b/packages/daemon/src/locator.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+/** @import { FormulaNumber, NodeNumber } from './types.js' */
+
 import { makeError, q } from '@endo/errors';
 import { formatId, isValidNumber, parseId } from './formula-identifier.js';
 import { isValidFormulaType } from './formula-type.js';
@@ -33,7 +35,7 @@ const assertValidLocatorType = allegedType => {
 
 /**
  * @param {string} allegedLocator
- * @returns {{ formulaType: string, node: string, number: string }}
+ * @returns {{ formulaType: string, node: NodeNumber, number: FormulaNumber }}
  */
 export const parseLocator = allegedLocator => {
   const errorPrefix = `Invalid locator ${q(allegedLocator)}:`;
@@ -70,7 +72,9 @@ export const parseLocator = allegedLocator => {
     throw makeError(`${errorPrefix} Invalid type.`);
   }
 
-  return { formulaType, node, number };
+  const nodeNumber = /** @type {NodeNumber} */ (node);
+  const formulaNumber = /** @type {FormulaNumber} */ (number);
+  return { formulaType, node: nodeNumber, number: formulaNumber };
 };
 
 /** @param {string} allegedLocator */

--- a/packages/daemon/src/pet-name.js
+++ b/packages/daemon/src/pet-name.js
@@ -1,16 +1,35 @@
 // @ts-check
 
+/// <reference types="./types.d.ts" />
+
+/** @import { Name, NamePath, PetName, SpecialName } from './types.js' */
+
 import { q } from '@endo/errors';
 
-const validNamePattern = /^[a-z][a-z0-9-]{0,127}$/;
+const validPetNamePattern = /^[a-z][a-z0-9-]{0,127}$/;
+const validSpecialNamePattern = /^[A-Z][A-Z0-9-]{0,127}$/;
 
 /**
  * @param {string} petName
+ * @returns {petName is PetName}
  */
-export const isPetName = petName => validNamePattern.test(petName);
+export const isPetName = petName => validPetNamePattern.test(petName);
+
+/**
+ * @param {string} name
+ * @returns {name is SpecialName}
+ */
+export const isSpecialName = name => validSpecialNamePattern.test(name);
+
+/**
+ * @param {string} name
+ * @returns {name is Name}
+ */
+export const isName = name => isPetName(name) || isSpecialName(name);
 
 /**
  * @param {string} petName
+ * @returns {asserts petName is PetName}
  */
 export const assertPetName = petName => {
   if (typeof petName !== 'string' || !isPetName(petName)) {
@@ -19,21 +38,89 @@ export const assertPetName = petName => {
 };
 
 /**
- * @param {string[]} petNamePath
+ * @param {string} name
+ * @returns {asserts name is SpecialName}
  */
-export const assertPetNamePath = petNamePath => {
-  if (!Array.isArray(petNamePath) || petNamePath.length < 1) {
-    throw new Error(`Invalid pet name path`);
+export const assertSpecialName = name => {
+  if (typeof name !== 'string' || !isSpecialName(name)) {
+    throw new Error(`Invalid special name ${q(name)}`);
   }
-  for (const petName of petNamePath) {
+};
+
+/**
+ * @param {string} name
+ * @returns {asserts name is Name}
+ */
+export const assertName = name => {
+  if (typeof name !== 'string' || !isName(name)) {
+    throw new Error(`Invalid name ${q(name)}`);
+  }
+};
+
+/**
+ * @param {string[]} names
+ * @returns {asserts names is Name[]}
+ */
+export const assertNames = names => {
+  for (const name of names) {
+    assertName(name);
+  }
+};
+
+/**
+ * @param {string[]} petNames
+ * @returns {asserts petNames is PetName[]}
+ */
+export const assertPetNames = petNames => {
+  for (const petName of petNames) {
     assertPetName(petName);
   }
 };
 
 /**
- * @param {string | string[]} petNameOrPetNamePath
+ * @param {string[]} namePath
+ * @returns {asserts namePath is NamePath}
  */
-export const petNamePathFrom = petNameOrPetNamePath =>
-  typeof petNameOrPetNamePath === 'string'
-    ? [petNameOrPetNamePath]
-    : petNameOrPetNamePath;
+export const assertNamePath = namePath => {
+  if (!Array.isArray(namePath) || namePath.length < 1) {
+    throw new Error(`Invalid name path`);
+  }
+  for (const name of namePath) {
+    assertName(name);
+  }
+};
+
+/**
+ * Asserts that the path is a valid name path ending in a pet name.
+ * Returns the validated path, the prefix path (all but the last element),
+ * and the final pet name.
+ * @param {string[]} path
+ * @returns {{ namePath: NamePath, prefixPath: NamePath, petName: PetName }}
+ */
+export const assertPetNamePath = path => {
+  if (!Array.isArray(path) || path.length < 1) {
+    throw new Error(`Invalid name path`);
+  }
+  const lastIndex = path.length - 1;
+  for (let i = 0; i < lastIndex; i += 1) {
+    assertName(path[i]);
+  }
+  const petName = path[lastIndex];
+  assertPetName(petName);
+  return {
+    namePath: /** @type {NamePath} */ (path),
+    prefixPath: /** @type {NamePath} */ (path.slice(0, -1)),
+    petName,
+  };
+};
+
+/**
+ * Normalizes a name or path to a path and validates it.
+ * @param {string | string[]} nameOrPath
+ * @returns {NamePath}
+ */
+export const namePathFrom = nameOrPath => {
+  const path = typeof nameOrPath === 'string' ? [nameOrPath] : nameOrPath;
+  assertNamePath(path);
+  return /** @type {NamePath} */ (path);
+};

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -3,6 +3,40 @@ import type { ERef } from '@endo/eventual-send';
 import type { FarRef } from '@endo/far';
 import type { Reader, Writer, Stream } from '@endo/stream';
 
+// Branded string types for pet names and special names
+declare const PetNameBrand: unique symbol;
+declare const SpecialNameBrand: unique symbol;
+declare const FormulaNumberBrand: unique symbol;
+declare const NodeNumberBrand: unique symbol;
+declare const FormulaIdentifierBrand: unique symbol;
+
+/** A validated pet name (lowercase, e.g., 'worker', 'my-app') */
+export type PetName = string & { [PetNameBrand]: true };
+
+/** A validated special name (uppercase, e.g., 'SELF', 'HOST', 'ENDO') */
+export type SpecialName = string & { [SpecialNameBrand]: true };
+
+/** A 128-character hex string identifying a formula within a node */
+export type FormulaNumber = string & { [FormulaNumberBrand]: true };
+
+/** A 128-character hex string identifying a node */
+export type NodeNumber = string & { [NodeNumberBrand]: true };
+
+/** A full formula identifier in the format {FormulaNumber}:{NodeNumber} */
+export type FormulaIdentifier = string & { [FormulaIdentifierBrand]: true };
+
+/** Either a pet name or a special name */
+export type Name = PetName | SpecialName;
+
+/** A validated path of names (array of at least one name) */
+export type NamePath = Name[];
+
+/** Either a single name or a path of names */
+export type NameOrPath = Name | NamePath;
+
+/** An array of names or paths */
+export type NamesOrPaths = NameOrPath[];
+
 export type SomehowAsyncIterable<T> =
   | AsyncIterable<T>
   | Iterable<T>
@@ -53,17 +87,21 @@ export type MignonicPowers = {
 };
 
 type IdRecord = {
-  number: string;
-  node: string;
+  number: FormulaNumber;
+  node: NodeNumber;
+};
+
+type ParseIdRecord = IdRecord & {
+  id: FormulaIdentifier;
 };
 
 type EndoFormula = {
   type: 'endo';
-  networks: string;
-  pins: string;
-  peers: string;
-  host: string;
-  leastAuthority: string;
+  networks: FormulaIdentifier;
+  pins: FormulaIdentifier;
+  peers: FormulaIdentifier;
+  host: FormulaIdentifier;
+  leastAuthority: FormulaIdentifier;
 };
 
 type LoopbackNetworkFormula = {
@@ -75,35 +113,35 @@ type WorkerFormula = {
 };
 
 export type WorkerDeferredTaskParams = {
-  workerId: string;
+  workerId: FormulaIdentifier;
 };
 
 /**
  * Deferred tasks parameters for `host` and `guest` formulas.
  */
 export type AgentDeferredTaskParams = {
-  agentId: string;
-  handleId: string;
+  agentId: FormulaIdentifier;
+  handleId: FormulaIdentifier;
 };
 
 type HostFormula = {
   type: 'host';
-  handle: string;
-  worker: string;
-  inspector: string;
-  petStore: string;
-  endo: string;
-  networks: string;
-  pins: string;
+  handle: FormulaIdentifier;
+  worker: FormulaIdentifier;
+  inspector: FormulaIdentifier;
+  petStore: FormulaIdentifier;
+  endo: FormulaIdentifier;
+  networks: FormulaIdentifier;
+  pins: FormulaIdentifier;
 };
 
 type GuestFormula = {
   type: 'guest';
-  handle: string;
-  hostHandle: string;
-  hostAgent: string;
-  petStore: string;
-  worker: string;
+  handle: FormulaIdentifier;
+  hostHandle: FormulaIdentifier;
+  hostAgent: FormulaIdentifier;
+  petStore: FormulaIdentifier;
+  worker: FormulaIdentifier;
 };
 
 type LeastAuthorityFormula = {
@@ -113,27 +151,27 @@ type LeastAuthorityFormula = {
 type MarshalFormula = {
   type: 'marshal';
   body: any;
-  slots: Array<string>;
+  slots: Array<FormulaIdentifier>;
 };
 
 type EvalFormula = {
   type: 'eval';
-  worker: string;
+  worker: FormulaIdentifier;
   source: string;
   names: Array<string>; // lexical names
-  values: Array<string>; // formula identifiers
+  values: Array<FormulaIdentifier>; // formula identifiers
   // TODO formula slots
 };
 
 export type MarshalDeferredTaskParams = {
-  marshalFormulaNumber: string;
-  marshalId: string;
+  marshalFormulaNumber: FormulaNumber;
+  marshalId: FormulaIdentifier;
 };
 
 export type EvalDeferredTaskParams = {
-  endowmentIds: string[];
-  evalId: string;
-  workerId: string;
+  endowmentIds: FormulaIdentifier[];
+  evalId: FormulaIdentifier;
+  workerId: FormulaIdentifier;
 };
 
 type ReadableBlobFormula = {
@@ -142,7 +180,7 @@ type ReadableBlobFormula = {
 };
 
 export type ReadableBlobDeferredTaskParams = {
-  readableBlobId: string;
+  readableBlobId: FormulaIdentifier;
 };
 
 type LookupFormula = {
@@ -152,46 +190,46 @@ type LookupFormula = {
    * The formula identifier of the naming hub to call lookup on.
    * A "naming hub" is an object with a variadic `lookup()` method.
    */
-  hub: string;
+  hub: FormulaIdentifier;
 
   /**
    * The pet name path.
    */
-  path: Array<string>;
+  path: NamePath;
 };
 
 type MakeUnconfinedFormula = {
   type: 'make-unconfined';
-  worker: string;
-  powers: string;
+  worker: FormulaIdentifier;
+  powers: FormulaIdentifier;
   specifier: string;
   // TODO formula slots
 };
 
 type MakeBundleFormula = {
   type: 'make-bundle';
-  worker: string;
-  powers: string;
-  bundle: string;
+  worker: FormulaIdentifier;
+  powers: FormulaIdentifier;
+  bundle: FormulaIdentifier;
   // TODO formula slots
 };
 
 export type MakeCapletDeferredTaskParams = {
-  capletId: string;
-  powersId: string;
-  workerId: string;
+  capletId: FormulaIdentifier;
+  powersId: FormulaIdentifier;
+  workerId: FormulaIdentifier;
 };
 
 type PeerFormula = {
   type: 'peer';
-  networks: string;
-  node: string;
+  networks: FormulaIdentifier;
+  node: NodeNumber;
   addresses: Array<string>;
 };
 
 type HandleFormula = {
   type: 'handle';
-  agent: string;
+  agent: FormulaIdentifier;
 };
 
 type KnownPeersStoreFormula = {
@@ -204,23 +242,23 @@ type PetStoreFormula = {
 
 type PetInspectorFormula = {
   type: 'pet-inspector';
-  petStore: string;
+  petStore: FormulaIdentifier;
 };
 
 type DirectoryFormula = {
   type: 'directory';
-  petStore: string;
+  petStore: FormulaIdentifier;
 };
 
 type InvitationFormula = {
   type: 'invitation';
-  hostAgent: string; // identifier
-  hostHandle: string; // identifier
-  guestName: string;
+  hostAgent: FormulaIdentifier;
+  hostHandle: FormulaIdentifier;
+  guestName: PetName;
 };
 
 export type InvitationDeferredTaskParams = {
-  invitationId: string;
+  invitationId: FormulaIdentifier;
 };
 
 export type Formula =
@@ -245,8 +283,8 @@ export type Formula =
   | InvitationFormula;
 
 export type Builtins = {
-  NONE: string;
-  MAIN: string;
+  NONE: FormulaIdentifier;
+  MAIN: FormulaIdentifier;
 };
 
 export type Specials = {
@@ -267,7 +305,7 @@ export type Request = {
 export type Package = {
   type: 'package';
   strings: Array<string>; // text that appears before, between, and after named formulas.
-  names: Array<string>; // edge names
+  names: Array<Name>; // edge names
   ids: Array<string>; // formula identifiers
 };
 
@@ -290,7 +328,7 @@ export type StampedMessage = EnvelopedMessage & {
 };
 
 export interface Invitation {
-  accept(guestHandleId: string): Promise<void>;
+  accept(guestHandleLocator: string): Promise<void>;
 }
 
 export interface Topic<
@@ -310,7 +348,7 @@ export interface Context {
   /**
    * The identifier for the associated formula.
    */
-  id: string;
+  id: FormulaIdentifier;
   /**
    * Cancel the value, preparing it for garbage collection. Cancellation
    * propagates to all values that depend on this value.
@@ -355,7 +393,7 @@ export interface Context {
 }
 
 export interface FarContext {
-  id: () => string;
+  id: () => FormulaIdentifier;
   cancel: (reason: Error) => Promise<void>;
   whenCancelled: () => Promise<never>;
   whenDisposed: () => Promise<void>;
@@ -370,8 +408,8 @@ export interface Controller<Value = unknown> {
 export type FormulaMaker<F extends Formula> = (
   formula: F,
   context: Context,
-  id: string,
-  number: string,
+  id: FormulaIdentifier,
+  number: FormulaNumber,
 ) => unknown;
 
 export type FormulaMakerTable = {
@@ -388,21 +426,21 @@ export interface Handle {
 export type MakeSha512 = () => Sha512;
 
 export type PetStoreNameChange =
-  | { add: string; value: IdRecord }
-  | { remove: string };
+  | { add: Name; value: IdRecord }
+  | { remove: Name };
 
 export type PetStoreIdNameChange =
-  | { add: IdRecord; names: string[] }
-  | { remove: IdRecord; names?: string[] };
+  | { add: IdRecord; names: Name[] }
+  | { remove: IdRecord; names?: Name[] };
 
 export type NameChangesTopic = Topic<PetStoreNameChange>;
 
 export type IdChangesTopic = Topic<PetStoreIdNameChange>;
 
 export interface PetStore {
-  has(petName: string): boolean;
-  identifyLocal(petName: string): string | undefined;
-  list(): Array<string>;
+  has(petName: Name): boolean;
+  identifyLocal(petName: Name): string | undefined;
+  list(): Array<Name>;
   /**
    * Subscribe to all name changes. First publishes all existing names in alphabetical order.
    * Then publishes diffs as names are added and removed.
@@ -416,38 +454,47 @@ export interface PetStore {
   followIdNameChanges(
     id: string,
   ): AsyncGenerator<PetStoreIdNameChange, undefined, undefined>;
-  write(petName: string, id: string): Promise<void>;
-  remove(petName: string): Promise<void>;
-  rename(fromPetName: string, toPetName: string): Promise<void>;
+  write(petName: PetName, id: string): Promise<void>;
+  remove(petName: PetName): Promise<void>;
+  rename(fromPetName: PetName, toPetName: PetName): Promise<void>;
   /**
    * @param id The formula identifier to look up.
    * @returns The formula identifier for the given pet name, or `undefined` if the pet name is not found.
    */
-  reverseIdentify(id: string): Array<string>;
+  reverseIdentify(id: string): Array<Name>;
 }
+
+export type KnownPeersStore = Omit<
+  PetStore,
+  'has' | 'identifyLocal' | 'write'
+> & {
+  has(nodeNumber: NodeNumber): boolean;
+  identifyLocal(nodeNumber: NodeNumber): string | undefined;
+  write(nodeNumber: NodeNumber, id: string): Promise<void>;
+};
 
 /**
  * `add` and `remove` are locators.
  */
 export type LocatorNameChange =
-  | { add: string; names: string[] }
-  | { remove: string; names?: string[] };
+  | { add: string; names: Name[] }
+  | { remove: string; names?: Name[] };
 
 export interface NameHub {
   has(...petNamePath: string[]): Promise<boolean>;
   identify(...petNamePath: string[]): Promise<string | undefined>;
   locate(...petNamePath: string[]): Promise<string | undefined>;
-  reverseLocate(locator: string): Promise<string[]>;
+  reverseLocate(locator: string): Promise<Name[]>;
   followLocatorNameChanges(
     locator: string,
   ): AsyncGenerator<LocatorNameChange, undefined, undefined>;
-  list(...petNamePath: string[]): Promise<Array<string>>;
+  list(...petNamePath: string[]): Promise<Array<Name>>;
   listIdentifiers(...petNamePath: string[]): Promise<Array<string>>;
   followNameChanges(
     ...petNamePath: string[]
   ): AsyncGenerator<PetStoreNameChange, undefined, undefined>;
   lookup(petNamePath: string | string[]): Promise<unknown>;
-  reverseLookup(value: unknown): Array<string>;
+  reverseLookup(value: unknown): Array<Name>;
   write(petNamePath: string | string[], id: string): Promise<void>;
   remove(...petNamePath: string[]): Promise<void>;
   move(fromPetName: string[], toPetName: string[]): Promise<void>;
@@ -455,7 +502,7 @@ export interface NameHub {
 }
 
 export interface EndoDirectory extends NameHub {
-  makeDirectory(petNamePath: string[]): Promise<EndoDirectory>;
+  makeDirectory(petNamePath: string | string[]): Promise<EndoDirectory>;
 }
 
 export type MakeDirectoryNode = (petStore: PetStore) => EndoDirectory;
@@ -534,7 +581,7 @@ export interface EndoGreeter {
 }
 
 export interface PeerInfo {
-  node: string;
+  node: NodeNumber;
   addresses: string[];
 }
 
@@ -557,9 +604,9 @@ export interface EndoAgent extends EndoDirectory {
   deliver: Mail['deliver'];
   /**
    * @param id The formula identifier to look up.
-   * @returns The formula identifier for the given pet name, or `undefined` if the pet name is not found.
+   * @returns The pet names for the given formula identifier.
    */
-  reverseIdentify(id: string): Array<string>;
+  reverseIdentify(id: string): Array<Name>;
 }
 
 export interface EndoGuest extends EndoAgent {}
@@ -569,7 +616,7 @@ export type FarEndoGuest = FarRef<EndoGuest>;
 export interface EndoHost extends EndoAgent {
   storeBlob(
     readerRef: ERef<AsyncIterableIterator<string>>,
-    petName: string,
+    petName: string | string[],
   ): Promise<FarRef<EndoReadable>>;
   storeValue<T extends Passable>(
     value: T,
@@ -583,26 +630,26 @@ export interface EndoHost extends EndoAgent {
     petName?: string,
     opts?: MakeHostOrGuestOptions,
   ): Promise<EndoHost>;
-  makeDirectory(petNamePath: string[]): Promise<EndoDirectory>;
-  provideWorker(petNamePath: string[]): Promise<EndoWorker>;
+  makeDirectory(petNamePath: string | string[]): Promise<EndoDirectory>;
+  provideWorker(petNamePath: string | string[]): Promise<EndoWorker>;
   evaluate(
     workerPetName: string | undefined,
     source: string,
     codeNames: Array<string>,
     petNames: Array<string>,
-    resultName?: string[],
+    resultName?: string | string[],
   ): Promise<unknown>;
   makeUnconfined(
-    workerName: string | undefined | 'MAIN',
+    workerName: string | undefined,
     specifier: string,
-    powersName: string | 'NONE' | 'SELF' | 'ENDO',
-    resultName?: string,
+    powersName: string,
+    resultName?: string | string[],
   ): Promise<unknown>;
   makeBundle(
     workerPetName: string | undefined,
     bundleName: string,
     powersName: string,
-    resultName?: string,
+    resultName?: string | string[],
   ): Promise<unknown>;
   cancel(petName: string, reason: Error): Promise<void>;
   greeter(): Promise<EndoGreeter>;
@@ -610,17 +657,13 @@ export interface EndoHost extends EndoAgent {
   getPeerInfo(): Promise<PeerInfo>;
   addPeerInfo(peerInfo: PeerInfo): Promise<void>;
   invite(guestName: string): Promise<Invitation>;
-  accept(
-    invitationId: string,
-    guestHandleId: string,
-    guestName: string,
-  ): Promise<void>;
+  accept(invitationLocator: string, guestName: string): Promise<void>;
 }
 
 export interface EndoHostController extends Controller<FarRef<EndoHost>> {}
 
 export type EndoInspector<Record = string> = {
-  lookup: (petName: Record) => Promise<unknown>;
+  lookup: (petNameOrPath: Record | NameOrPath) => Promise<unknown>;
   list: () => Record[];
 };
 
@@ -702,18 +745,23 @@ export type NetworkPowers = SocketPowers & {
   ) => { started: Promise<void>; stopped: Promise<void> };
 };
 
+export type RootNonceDescriptor = {
+  rootNonce: FormulaNumber;
+  isNewlyCreated: boolean;
+};
+
 export type DaemonicPersistencePowers = {
   initializePersistence: () => Promise<void>;
-  provideRootNonce: () => Promise<{
-    rootNonce: string;
-    isNewlyCreated: boolean;
-  }>;
+  provideRootNonce: () => Promise<RootNonceDescriptor>;
   makeContentSha512Store: () => {
     store: (readable: AsyncIterable<Uint8Array>) => Promise<string>;
     fetch: (sha512: string) => EndoReadable;
   };
-  readFormula: (formulaNumber: string) => Promise<Formula>;
-  writeFormula: (formulaNumber: string, formula: Formula) => Promise<void>;
+  readFormula: (formulaNumber: FormulaNumber) => Promise<Formula>;
+  writeFormula: (
+    formulaNumber: FormulaNumber,
+    formula: Formula,
+  ) => Promise<void>;
 };
 
 export interface DaemonWorkerFacet {}
@@ -724,7 +772,7 @@ export interface WorkerDaemonFacet {
     source: string,
     names: Array<string>,
     values: Array<unknown>,
-    id: string,
+    id: FormulaIdentifier,
     cancelled: Promise<never>,
   ): Promise<unknown>;
   makeBundle(
@@ -758,7 +806,7 @@ export type DaemonicPowers = {
 };
 
 type FormulateResult<T> = Promise<{
-  id: string;
+  id: FormulaIdentifier;
   value: T;
 }>;
 
@@ -776,32 +824,32 @@ export type DeferredTasks<T extends Record<string, string | string[]>> = {
 };
 
 type FormulateNumberedGuestParams = {
-  guestFormulaNumber: string;
-  handleId: string;
-  guestId: string;
-  hostAgentId: string;
-  hostHandleId: string;
-  storeId: string;
-  workerId: string;
+  guestFormulaNumber: FormulaNumber;
+  handleId: FormulaIdentifier;
+  guestId: FormulaIdentifier;
+  hostAgentId: FormulaIdentifier;
+  hostHandleId: FormulaIdentifier;
+  storeId: FormulaIdentifier;
+  workerId: FormulaIdentifier;
 };
 
 type FormulateHostDependenciesParams = {
-  endoId: string;
-  networksDirectoryId: string;
-  pinsDirectoryId: string;
-  specifiedWorkerId?: string;
+  endoId: FormulaIdentifier;
+  networksDirectoryId: FormulaIdentifier;
+  pinsDirectoryId: FormulaIdentifier;
+  specifiedWorkerId?: FormulaIdentifier;
 };
 
 type FormulateNumberedHostParams = {
-  hostFormulaNumber: string;
-  hostId: string;
-  handleId: string;
-  workerId: string;
-  storeId: string;
-  inspectorId: string;
-  endoId: string;
-  networksDirectoryId: string;
-  pinsDirectoryId: string;
+  hostFormulaNumber: FormulaNumber;
+  hostId: FormulaIdentifier;
+  handleId: FormulaIdentifier;
+  workerId: FormulaIdentifier;
+  storeId: FormulaIdentifier;
+  inspectorId: FormulaIdentifier;
+  endoId: FormulaIdentifier;
+  networksDirectoryId: FormulaIdentifier;
+  pinsDirectoryId: FormulaIdentifier;
 };
 
 export type FormulaValueTypes = {
@@ -824,34 +872,34 @@ export type ProvideTypes = FormulaValueTypes & {
 };
 
 export type Provide = <T extends keyof ProvideTypes, U extends ProvideTypes[T]>(
-  id: string,
+  id: FormulaIdentifier,
   expectedType?: T,
 ) => Promise<U>;
 
 export interface DaemonCore {
-  cancelValue: (id: string, reason: Error) => Promise<void>;
+  cancelValue: (id: FormulaIdentifier, reason: Error) => Promise<void>;
 
   formulate: (
-    formulaNumber: string,
+    formulaNumber: FormulaNumber,
     formula: Formula,
   ) => Promise<{
-    id: string;
+    id: FormulaIdentifier;
     value: unknown;
   }>;
 
   formulateBundle: (
-    hostAgentId: string,
-    hostHandleId: string,
-    bundleId: string,
+    hostAgentId: FormulaIdentifier,
+    hostHandleId: FormulaIdentifier,
+    bundleId: FormulaIdentifier,
     deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
-    specifiedWorkerId?: string,
-    specifiedPowersId?: string,
+    specifiedWorkerId?: FormulaIdentifier,
+    specifiedPowersId?: FormulaIdentifier,
   ) => FormulateResult<unknown>;
 
   formulateDirectory: () => FormulateResult<EndoDirectory>;
 
   formulateEndo: (
-    specifiedFormulaNumber: string,
+    specifiedFormulaNumber?: FormulaNumber,
   ) => FormulateResult<FarRef<EndoBootstrap>>;
 
   formulateMarshalValue: (
@@ -860,17 +908,17 @@ export interface DaemonCore {
   ) => FormulateResult<void>;
 
   formulateEval: (
-    nameHubId: string,
+    nameHubId: FormulaIdentifier,
     source: string,
-    codeNames: string[],
-    endowmentIdsOrPaths: (string | string[])[],
+    codeNames: Array<string>,
+    endowmentIdsOrPaths: (FormulaIdentifier | NamePath)[],
     deferredTasks: DeferredTasks<EvalDeferredTaskParams>,
-    specifiedWorkerId?: string,
+    specifiedWorkerId?: FormulaIdentifier,
   ) => FormulateResult<unknown>;
 
   formulateGuest: (
-    hostId: string,
-    hostHandleId: string,
+    hostId: FormulaIdentifier,
+    hostHandleId: FormulaIdentifier,
     deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
   ) => FormulateResult<EndoGuest>;
 
@@ -880,16 +928,16 @@ export interface DaemonCore {
    * @returns The formula identifiers for the guest formulation's dependencies.
    */
   formulateGuestDependencies: (
-    hostAgentId: string,
-    hostHandleId: string,
+    hostAgentId: FormulaIdentifier,
+    hostHandleId: FormulaIdentifier,
   ) => Promise<Readonly<FormulateNumberedGuestParams>>;
 
   formulateHost: (
-    endoId: string,
-    networksDirectoryId: string,
-    pinsDirectoryId: string,
+    endoId: FormulaIdentifier,
+    networksDirectoryId: FormulaIdentifier,
+    pinsDirectoryId: FormulaIdentifier,
     deferredTasks: DeferredTasks<AgentDeferredTaskParams>,
-    specifiedWorkerId?: string | undefined,
+    specifiedWorkerId?: FormulaIdentifier | undefined,
   ) => FormulateResult<EndoHost>;
 
   /**
@@ -914,8 +962,8 @@ export interface DaemonCore {
   ) => FormulateResult<EndoHost>;
 
   formulatePeer: (
-    networksId: string,
-    nodeId: string,
+    networksId: FormulaIdentifier,
+    nodeNumber: NodeNumber,
     addresses: Array<string>,
   ) => FormulateResult<EndoPeer>;
 
@@ -925,30 +973,32 @@ export interface DaemonCore {
   ) => FormulateResult<FarRef<EndoReadable>>;
 
   formulateInvitation: (
-    hostAgentId: string,
-    hostHandleId: string,
-    guestName: string,
+    hostAgentId: FormulaIdentifier,
+    hostHandleId: FormulaIdentifier,
+    guestName: PetName,
     deferredTasks: DeferredTasks<InvitationDeferredTaskParams>,
   ) => FormulateResult<Invitation>;
 
   formulateUnconfined: (
-    hostAgentId: string,
-    hostHandleId: string,
+    hostAgentId: FormulaIdentifier,
+    hostHandleId: FormulaIdentifier,
     specifier: string,
     deferredTasks: DeferredTasks<MakeCapletDeferredTaskParams>,
-    specifiedWorkerId?: string,
-    specifiedPowersId?: string,
+    specifiedWorkerId?: FormulaIdentifier,
+    specifiedPowersId?: FormulaIdentifier,
   ) => FormulateResult<unknown>;
 
   formulateWorker: (
     deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
   ) => FormulateResult<EndoWorker>;
 
-  getAllNetworkAddresses: (networksDirectoryId: string) => Promise<string[]>;
+  getAllNetworkAddresses: (
+    networksDirectoryId: FormulaIdentifier,
+  ) => Promise<string[]>;
 
-  getIdForRef: (ref: unknown) => string | undefined;
+  getIdForRef: (ref: unknown) => FormulaIdentifier | undefined;
 
-  getTypeForId: (id: string) => Promise<string>;
+  getTypeForId: (id: FormulaIdentifier) => Promise<string>;
 
   makeDirectoryNode: MakeDirectoryNode;
 
@@ -956,14 +1006,14 @@ export interface DaemonCore {
 
   provide: Provide;
 
-  provideController: (id: string) => Controller;
+  provideController: (id: FormulaIdentifier) => Controller;
 
   provideAgentForHandle: (id: string) => Promise<ERef<EndoAgent>>;
 }
 
 export interface DaemonCoreExternal {
   formulateEndo: DaemonCore['formulateEndo'];
-  nodeId: string;
+  nodeNumber: NodeNumber;
   provide: DaemonCore['provide'];
 }
 

--- a/packages/daemon/test/move-hub.js
+++ b/packages/daemon/test/move-hub.js
@@ -5,13 +5,13 @@ import { M } from '@endo/patterns';
 
 import { q } from '@endo/errors';
 
-/** @import {NameHub} from '../src/types.js' */
+/** @import {FormulaIdentifier, Name, NameHub} from '../src/types.js' */
 
 // This caplet is a mock name hub for testing NameHub.move().
 export const make = () => {
-  /** @type {Map<string, string>} */
+  /** @type {Map<FormulaIdentifier, string>} */
   const idToName = new Map();
-  /** @type {Map<string, string>} */
+  /** @type {Map<string, FormulaIdentifier>} */
   const nameToId = new Map();
 
   /**
@@ -38,7 +38,7 @@ export const make = () => {
 
   /**
    * @param {string[]} petNamePath
-   * @param {string} id
+   * @param {FormulaIdentifier} id
    */
   const write = async (petNamePath, id) => {
     const petName = parsePetNamePath(petNamePath);
@@ -81,7 +81,7 @@ export const make = () => {
 
         const toName = parsePetNamePath(toPath);
 
-        await remove(fromName);
+        await remove(/** @type {Name} */ (fromName));
         await write([toName], id);
       },
 


### PR DESCRIPTION
## Description

This PR introduces branded string types for identifiers and names in the `@endo/daemon` package, clarifying that some strings have been pre-validated and can be relied upon to be in the valid range of pet names, special names, or either.

### Security Considerations

No new security considerations. The branded types improve type safety but don't change runtime behavior beyond ensuring that validation has occurred. Some care needed to ensure string types are cast only after runtime validation.

### Scaling Considerations

None.

### Documentation Considerations

The branded types make the codebase more self-documenting. Parameter types now clearly indicate what kind of string is expected (e.g., `FormulaNumber` vs `NodeNumber` vs `PetName`).

### Testing Considerations

Existing tests pass. New tests added for:
- `storeBlob` with subdirectory paths
- `storeBlob` requiring a name parameter
- `storeBlob` with empty path rejection

### Compatibility Considerations

No breaking changes to the public API. Internal type changes are transparent to callers since public methods accept `string` and validate internally.

### Upgrade Considerations

None.