### PR TITLE
chore(ci): downgrade changesets/action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
         run: yarn
 
       - name: Process Changesets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # This action will create/update Changesets' Release PR *or* create a
         # GitHub Release and tags if its Release PR was just merged
         uses: changesets/action@935fe876b0054dfc962ac86bcddf028460040d46 # v1


### PR DESCRIPTION
This forces `GITHUB_TOKEN` into the action env, since the newer version of `changesets/action` with the fix has not yet been properly published.
