### PR TITLE
feat(daemon): HTTP and WebSocket gateway

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -12,3 +12,12 @@ Over that channel, the daemon communicates in CapTP over netstring message
 envelopes.
 The bootstrap provides the user agent API from which one can derive facets for
 other agents.
+
+## Gateway
+
+The daemon runs a unified HTTP/WebSocket gateway server.
+Set the `ENDO_ADDR` environment variable before running `endo start` to control the listen address and port (default `127.0.0.1:8920`).
+
+```sh
+ENDO_ADDR=127.0.0.1:9000 endo start
+```

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -69,6 +69,7 @@
     "@endo/bundle-source": "workspace:^",
     "@endo/pass-style": "workspace:^",
     "@endo/ses-ava": "workspace:^",
+    "@types/ws": "^8.18.1",
     "ava": "catalog:dev",
     "c8": "catalog:dev",
     "eslint": "catalog:dev",

--- a/packages/daemon/src/daemon-node.js
+++ b/packages/daemon/src/daemon-node.js
@@ -102,11 +102,14 @@ const main = async () => {
     cancelled,
     {
       /** @param {Builtins} builtins */
-      APPS: ({ MAIN, NONE }) => ({
+      APPS: ({ MAIN, ENDO }) => ({
         type: /** @type {const} */ ('make-unconfined'),
         worker: MAIN,
-        powers: NONE,
+        powers: ENDO,
         specifier: new URL('web-server-node.js', import.meta.url).href,
+        env: {
+          ENDO_ADDR: process.env.ENDO_ADDR || '127.0.0.1:8920',
+        },
       }),
     },
   );

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -232,10 +232,16 @@ const makeDaemonCore = async (
   });
   const { id: mainWorkerId } = await preformulate('main', { type: 'worker' });
 
+  const endoFormulaId = formatId({
+    number: /** @type {FormulaNumber} */ (rootEntropy),
+    node: localNodeNumber,
+  });
+
   /** @type {Builtins} */
   const builtins = {
     NONE: leastAuthorityId,
     MAIN: mainWorkerId,
+    ENDO: endoFormulaId,
   };
 
   // Prepare platform formulas

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -328,6 +328,7 @@ export type Formula =
 export type Builtins = {
   NONE: FormulaIdentifier;
   MAIN: FormulaIdentifier;
+  ENDO: FormulaIdentifier;
 };
 
 export type Specials = {

--- a/packages/daemon/src/web-server-node.js
+++ b/packages/daemon/src/web-server-node.js
@@ -3,16 +3,17 @@ import fs from 'node:fs';
 import http from 'node:http';
 import { fileURLToPath } from 'url';
 
-/** @import { HttpRespond, FarContext } from './types.js' */
+/** @import { HttpRespond, HttpConnect, FarContext, EndoBootstrap } from './types.js' */
 
-// @ts-ignore We cannot use a synthetic default export in practice here (circa Node.js 16)
 import * as ws from 'ws';
 
-import { mapWriter, mapReader } from '@endo/stream';
+import { makePromiseKit } from '@endo/promise-kit';
+import { makePipe, mapWriter, mapReader } from '@endo/stream';
 import { E, Far } from '@endo/far';
 import { makeBundle } from '@endo/compartment-mapper/bundle.js';
+import { makeExo } from '@endo/exo';
+import { M } from '@endo/patterns';
 
-import { q } from '@endo/errors';
 import { makeHttpPowers } from './web-server-node-powers.js';
 
 import {
@@ -23,17 +24,29 @@ import {
 
 const { servePortHttp } = makeHttpPowers({ ws, http });
 
+const { WebSocketServer } = ws;
+
+const GatewayBootstrapInterface = M.interface('GatewayBootstrap', {
+  fetch: M.call(M.string()).returns(M.promise()),
+});
+
 const read = async location => fs.promises.readFile(fileURLToPath(location));
 
 /**
- * @param {unknown} _powers
+ * @param {EndoBootstrap} powers
  * @param {FarContext} context
+ * @param {{ env?: Record<string, string> }} [options]
  */
-export const make = async (_powers, context) => {
+export const make = async (powers, context, { env = {} } = {}) => {
+  const addrUrl = new URL(`http://${env.ENDO_ADDR || '127.0.0.1:8920'}`);
+  const gatewayHost = addrUrl.hostname;
+  const gatewayPort = Number(addrUrl.port) || 8920;
   const script = await makeBundle(
     read,
     new URL('web-page.js', import.meta.url).href,
   );
+
+  const gateway = await E(powers).gateway();
 
   const exitWithError = error => {
     E(context).cancel(error);
@@ -53,9 +66,258 @@ export const make = async (_powers, context) => {
   const connectionClosedPromises = new Set();
 
   /**
+   * @param {Promise<void>} closed
+   * @param {string} logMessage
+   */
+  const trackConnection = (closed, logMessage) => {
+    connectionClosedPromises.add(closed);
+    closed.finally(() => {
+      connectionClosedPromises.delete(closed);
+      console.log(logMessage);
+    });
+  };
+
+  /**
+   * @param {string} name
+   * @param {import('@endo/stream').Writer<Uint8Array>} frameWriter
+   * @param {import('@endo/stream').Reader<Uint8Array>} frameReader
+   * @param {Promise<never>} sessionCancelled
+   * @param {object} [bootstrap]
+   */
+  const openCapTPSession = (
+    name,
+    frameWriter,
+    frameReader,
+    sessionCancelled,
+    bootstrap,
+  ) => {
+    const { value: connectionNumber } = connectionNumbers.next();
+    const messageWriter = mapWriter(frameWriter, messageToBytes);
+    const messageReader = mapReader(frameReader, bytesToMessage);
+    const { closed: capTpClosed, getBootstrap } = makeMessageCapTP(
+      name,
+      messageWriter,
+      messageReader,
+      sessionCancelled,
+      bootstrap,
+    );
+    const remoteBootstrap = getBootstrap();
+    E.sendOnly(remoteBootstrap).ping();
+    return { connectionNumber, capTpClosed, remoteBootstrap };
+  };
+
+  /**
+   * Per-weblet HTTP/WebSocket handlers, keyed by hostname.
+   * @type {Map<string, { respond: HttpRespond, connect: HttpConnect }>}
+   */
+  const webletHandlers = new Map();
+
+  // --- Unified HTTP server ---
+
+  const server = http.createServer();
+
+  server.on('error', error => {
+    console.error(error);
+  });
+
+  server.on('request', (req, res) => {
+    (async () => {
+      await null;
+      if (req.method === undefined || req.url === undefined) {
+        return;
+      }
+
+      const { host } = req.headers;
+      const hostname = host && new URL(`http://${host}`).hostname;
+      const handlers = hostname ? webletHandlers.get(hostname) : undefined;
+
+      if (handlers) {
+        // Delegate to weblet HTTP handler
+        try {
+          const response = await handlers.respond(
+            harden({
+              method: req.method,
+              url: req.url,
+              headers: harden(
+                /** @type {Record<string, string | Array<string> | undefined>} */ (
+                  req.headers
+                ),
+              ),
+            }),
+          );
+          res.writeHead(response.status, response.headers);
+          if (response.content === undefined) {
+            res.end();
+          } else if (
+            typeof response.content === 'string' ||
+            response.content instanceof Uint8Array
+          ) {
+            res.end(response.content);
+          } else {
+            for await (const chunk of response.content) {
+              res.write(chunk);
+            }
+            res.end();
+          }
+        } catch (_error) {
+          try {
+            res.writeHead(500, { 'Content-Type': 'text/plain' });
+            res.end('Internal Server Error');
+          } catch (error) {
+            console.error(error);
+          }
+        }
+      } else {
+        // Default: gateway info page
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('Endo Gateway');
+      }
+    })();
+  });
+
+  const wss = new WebSocketServer({ server });
+
+  wss.on('connection', (socket, req) => {
+    const remoteAddress = req.socket.remoteAddress;
+    // XXX: When the gateway migrates from CapTP to OCapN with a Noise
+    // Protocol network layer, accept connections from non-local remote
+    // addresses.
+    if (
+      remoteAddress !== '127.0.0.1' &&
+      remoteAddress !== '::1' &&
+      remoteAddress !== '::ffff:127.0.0.1'
+    ) {
+      console.error(
+        `[Gateway] Rejected non-local connection from ${remoteAddress}`,
+      );
+      socket.close(1008, 'Only local connections allowed');
+      return;
+    }
+
+    const { host } = req.headers;
+    const hostname = host && new URL(`http://${host}`).hostname;
+    const handlers = hostname ? webletHandlers.get(hostname) : undefined;
+
+    const { promise: closed, resolve: close, reject: abort } = makePromiseKit();
+
+    closed.finally(() => socket.close());
+
+    const [reader, sink] = makePipe();
+
+    socket.on('message', (bytes, isBinary) => {
+      if (!isBinary) {
+        abort(new Error('expected binary WebSocket frames'));
+        return;
+      }
+      sink.next(bytes);
+    });
+
+    socket.on('close', () => {
+      sink.return(undefined);
+      close(undefined);
+    });
+
+    socket.on('error', error => {
+      console.error(`[Gateway] WebSocket error:`, error.message);
+      abort(error);
+    });
+
+    const writer = harden({
+      /** @param {Uint8Array} bytes */
+      async next(bytes) {
+        socket.send(bytes, { binary: true });
+        return harden({ done: false, value: undefined });
+      },
+      async return() {
+        socket.close();
+        return harden({ done: true, value: undefined });
+      },
+      /** @param {Error} error */
+      async throw(error) {
+        socket.close();
+        abort(error);
+        return harden({ done: true, value: undefined });
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    });
+
+    if (handlers) {
+      // Delegate to weblet WebSocket handler
+      handlers.connect(
+        harden({
+          reader,
+          writer,
+          closed: closed.then(() => {}),
+        }),
+        harden({
+          method: /** @type {string} */ (req.method),
+          url: /** @type {string} */ (req.url),
+          headers: req.headers,
+        }),
+      );
+    } else {
+      // Gateway CapTP connection
+      const clientBootstrap = makeExo(
+        'GatewayBootstrap',
+        GatewayBootstrapInterface,
+        {
+          /** @param {string} token */
+          async fetch(token) {
+            return E(gateway).provide(token);
+          },
+        },
+      );
+
+      const { connectionNumber, capTpClosed } = openCapTPSession(
+        'Gateway',
+        writer,
+        reader,
+        serverCancelled,
+        clientBootstrap,
+      );
+      console.log(
+        `[Gateway] Connection ${connectionNumber} from ${remoteAddress}`,
+      );
+
+      trackConnection(
+        Promise.race([closed.then(() => {}), capTpClosed]),
+        `[Gateway] Closed connection ${connectionNumber}`,
+      );
+    }
+  });
+
+  // Start the unified server
+  /** @type {Promise<string>} */
+  const started = new Promise((resolve, reject) => {
+    server.listen(gatewayPort, gatewayHost, error => {
+      if (error) {
+        reject(error);
+      } else {
+        serverCancelled.catch(() => server.close());
+        const address = server.address();
+        if (address === null || typeof address === 'string') {
+          reject(new Error('expected listener to be assigned a port'));
+        } else {
+          resolve(`http://${gatewayHost}:${address.port}`);
+        }
+      }
+    });
+  });
+
+  started.then(address => {
+    console.log(
+      `Endo unified server listening on ${address} at ${new Date().toISOString()}`,
+    );
+  });
+
+  // --- Weblet registration ---
+
+  /**
    * @param {unknown} webletBundle
    * @param {unknown} webletPowers
-   * @param {number} requestedPort
+   * @param {number | undefined} requestedPort
    * @param {string} webletId
    * @param {Promise<never>} webletCancelled
    */
@@ -70,10 +332,16 @@ export const make = async (_powers, context) => {
 
     const cancelled = Promise.race([webletCancelled, serverCancelled]);
 
+    // When a dedicated port is requested, the weblet uses access-token-in-path
+    // isolation on its own HTTP server. Otherwise it registers on the unified
+    // server with hostname-based isolation.
+    const dedicatedPort = requestedPort !== undefined;
+    const pathPrefix = dedicatedPort ? `/${accessToken}` : '';
+
     /** @type {HttpRespond} */
     const respond = async request => {
       if (request.method === 'GET') {
-        if (request.url === `/${accessToken}/`) {
+        if (request.url === `${pathPrefix}/`) {
           return {
             status: 200,
             headers: { 'Content-Type': 'text/html', Charset: 'utf-8' },
@@ -85,10 +353,7 @@ export const make = async (_powers, context) => {
     <script src="bootstrap.js"></script>
   </body>`,
           };
-        } else if (request.url === `/${accessToken}/bootstrap.js`) {
-          // TODO readable mutable file formula (with watcher?)
-          // Behold, recursion:
-          // eslint-disable-next-line no-use-before-define
+        } else if (request.url === `${pathPrefix}/bootstrap.js`) {
           return {
             status: 200,
             headers: { 'Content-Type': 'application/javascript' },
@@ -103,8 +368,9 @@ export const make = async (_powers, context) => {
       };
     };
 
+    /** @type {HttpConnect} */
     const connect = (connection, request) => {
-      if (request.url !== `/${accessToken}/`) {
+      if (dedicatedPort && request.url !== `/${accessToken}/`) {
         connection.writer.throw(new Error(`Invalid access token.`));
         return;
       }
@@ -117,26 +383,20 @@ export const make = async (_powers, context) => {
           closed: connectionClosed,
         } = connection;
 
-        const { value: connectionNumber } = connectionNumbers.next();
-        console.log(
-          `Endo daemon received local web socket connection ${connectionNumber} at ${new Date().toISOString()}`,
-        );
-
-        const messageWriter = mapWriter(frameWriter, messageToBytes);
-        const messageReader = mapReader(frameReader, bytesToMessage);
-
-        const { closed: capTpClosed, getBootstrap } = makeMessageCapTP(
+        const {
+          connectionNumber,
+          capTpClosed,
+          remoteBootstrap: webletBootstrap,
+        } = openCapTPSession(
           'Endo',
-          messageWriter,
-          messageReader,
+          frameWriter,
+          frameReader,
           cancelled,
           undefined, // bootstrap
         );
-
-        const webletBootstrap = getBootstrap();
-
-        // TODO set up heart monitor
-        E.sendOnly(webletBootstrap).ping();
+        console.log(
+          `Endo daemon received weblet web socket connection ${connectionNumber} at ${new Date().toISOString()}`,
+        );
 
         E(webletBootstrap)
           .makeBundle(
@@ -150,45 +410,62 @@ export const make = async (_powers, context) => {
             console.log(error);
           });
 
-        const closed = Promise.race([connectionClosed, capTpClosed]);
-        connectionClosedPromises.add(closed);
-        closed.finally(() => {
-          connectionClosedPromises.delete(closed);
-          console.log(
-            `Endo daemon closed local web socket connection ${connectionNumber} at ${new Date().toISOString()}`,
-          );
-        });
+        trackConnection(
+          Promise.race([connectionClosed, capTpClosed]),
+          `Endo daemon closed weblet web socket connection ${connectionNumber} at ${new Date().toISOString()}`,
+        );
       })().catch(exitWithError);
     };
-
-    const started = servePortHttp({
-      port: requestedPort,
-      host: '127.0.0.1',
-      respond,
-      connect,
-      cancelled,
-    });
-
-    started.then(assignedPort => {
-      console.log(
-        `Endo daemon listening for HTTP on ${q(
-          assignedPort,
-        )} ${new Date().toISOString()}`,
-      );
-    });
 
     const stopped = cancelled.catch(() =>
       Promise.all(Array.from(connectionClosedPromises)),
     );
 
-    return Far('Weblet', {
-      async getLocation() {
-        const assignedPort = await started;
+    /** @param {() => Promise<string>} getLocation */
+    const makeWebletFar = getLocation =>
+      Far('Weblet', { getLocation, stopped: () => stopped });
+
+    if (dedicatedPort) {
+      // Dedicated HTTP server on the requested port (legacy path-based isolation)
+      const portStarted = servePortHttp({
+        port: requestedPort,
+        host: '127.0.0.1',
+        respond,
+        connect,
+        cancelled,
+      });
+
+      portStarted.then(assignedPort => {
+        console.log(
+          `Endo daemon listening for weblet HTTP on ${assignedPort} at ${new Date().toISOString()}`,
+        );
+      });
+
+      return makeWebletFar(async () => {
+        const assignedPort = await portStarted;
         return `http://127.0.0.1:${assignedPort}/${accessToken}/`;
-      },
-      stopped: () => stopped,
+      });
+    }
+
+    // Register on the unified server.
+    // Electron's custom protocol handler sends the bare access token as the
+    // Host header, so we key on accessToken directly.
+    webletHandlers.set(accessToken, { respond, connect });
+
+    cancelled.catch(() => {
+      webletHandlers.delete(accessToken);
+    });
+
+    return makeWebletFar(async () => {
+      await started;
+      return `localhttp://${accessToken}`;
     });
   };
 
-  return Far('WebletService', { makeWeblet });
+  return Far('WebletService', {
+    makeWeblet,
+    async getAddress() {
+      return started;
+    },
+  });
 };

--- a/packages/daemon/src/web-server-node.js
+++ b/packages/daemon/src/web-server-node.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import 'ses';
 import fs from 'node:fs';
 import http from 'node:http';
@@ -25,6 +27,11 @@ import {
 const { servePortHttp } = makeHttpPowers({ ws, http });
 
 const { WebSocketServer } = ws;
+
+// `1008` is the WebSocket Close Status Code for **"Policy Violation"** (RFC
+// 6455, Section 7.4.1). It's used to indicate that the server is terminating
+// the connection because it encountered a violation of its policy.
+const POLICY_VIOLATION = 1008;
 
 const GatewayBootstrapInterface = M.interface('GatewayBootstrap', {
   fetch: M.call(M.string()).returns(M.promise()),
@@ -56,7 +63,7 @@ export const make = async (powers, context, { env = {} } = {}) => {
 
   const connectionNumbers = (function* generateNumbers() {
     let n = 0;
-    for (;;) {
+    for (; ;) {
       yield n;
       n += 1;
     }
@@ -117,7 +124,7 @@ export const make = async (powers, context, { env = {} } = {}) => {
   const server = http.createServer();
 
   server.on('error', error => {
-    console.error(error);
+    console.error(`[Gateway] server error: ${error}`);
   });
 
   server.on('request', (req, res) => {
@@ -133,18 +140,21 @@ export const make = async (powers, context, { env = {} } = {}) => {
 
       if (handlers) {
         // Delegate to weblet HTTP handler
+        let headSent = false;
         try {
           const response = await handlers.respond(
             harden({
               method: req.method,
               url: req.url,
               headers: harden(
-                /** @type {Record<string, string | Array<string> | undefined>} */ (
+                /** @type {Record<string, string | Array<string> | undefined>} */(
                   req.headers
                 ),
               ),
             }),
           );
+
+          headSent = true;
           res.writeHead(response.status, response.headers);
           if (response.content === undefined) {
             res.end();
@@ -159,12 +169,21 @@ export const make = async (powers, context, { env = {} } = {}) => {
             }
             res.end();
           }
-        } catch (_error) {
+        } catch (error) {
+          console.error(`[Gateway] weblet error: ${error}`);
           try {
-            res.writeHead(500, { 'Content-Type': 'text/plain' });
-            res.end('Internal Server Error');
-          } catch (error) {
-            console.error(error);
+            if (!headSent) {
+              res.writeHead(500, { 'Content-Type': 'text/plain' });
+              res.end('Internal Server Error');
+            } else {
+              res.end();
+            }
+          } catch (error2) {
+            if (headSent) {
+              console.error(`[Gateway] weblet error while ending failed response: ${error2}`);
+            } else {
+              console.error(`[Gateway] weblet error while sending 500 response: ${error2}`);
+            }
           }
         }
       } else {
@@ -190,7 +209,7 @@ export const make = async (powers, context, { env = {} } = {}) => {
       console.error(
         `[Gateway] Rejected non-local connection from ${remoteAddress}`,
       );
-      socket.close(1008, 'Only local connections allowed');
+      socket.close(POLICY_VIOLATION, 'Only local connections allowed');
       return;
     }
 
@@ -249,7 +268,7 @@ export const make = async (powers, context, { env = {} } = {}) => {
         harden({
           reader,
           writer,
-          closed: closed.then(() => {}),
+          closed: closed.then(() => { }),
         }),
         harden({
           method: /** @type {string} */ (req.method),
@@ -282,33 +301,55 @@ export const make = async (powers, context, { env = {} } = {}) => {
       );
 
       trackConnection(
-        Promise.race([closed.then(() => {}), capTpClosed]),
+        Promise.race([closed.then(() => { }), capTpClosed]),
         `[Gateway] Closed connection ${connectionNumber}`,
       );
     }
   });
 
+  /**
+   * @typedef {{address: string, port: number}} AddrPort
+   */
+  /**
+   * @typedef {object} StartedRes
+   * @property {AddrPort} config - requested gateway listen spec
+   * @property {AddrPort} actual - actual address and port given by OS
+   */
+
   // Start the unified server
-  /** @type {Promise<string>} */
+  /** @type {Promise<StartedRes>} */
   const started = new Promise((resolve, reject) => {
     server.listen(gatewayPort, gatewayHost, error => {
       if (error) {
         reject(error);
-      } else {
-        serverCancelled.catch(() => server.close());
-        const address = server.address();
-        if (address === null || typeof address === 'string') {
-          reject(new Error('expected listener to be assigned a port'));
-        } else {
-          resolve(`http://${gatewayHost}:${address.port}`);
-        }
+        return;
       }
+
+      serverCancelled.catch(() => server.close());
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('expected listener to be assigned a port'));
+        return;
+      }
+
+      resolve({
+        config: {
+          address: gatewayHost,
+          port: gatewayPort,
+        },
+        actual: {
+          address: address.address,
+          port: address.port,
+        },
+      });
     });
   });
 
-  started.then(address => {
+  started.then(addr => {
+    const actual = `http://${addr.actual.address}:${addr.actual.port}`;
+    const spec = `${addr.config.address}:${addr.config.port}`;
     console.log(
-      `Endo unified server listening on ${address} at ${new Date().toISOString()}`,
+      `Endo unified server listening on ${actual} at ${new Date().toISOString()} (config wanted ${spec})`,
     );
   });
 
@@ -400,7 +441,7 @@ export const make = async (powers, context, { env = {} } = {}) => {
 
         E(webletBootstrap)
           .makeBundle(
-            await E(/** @type {any} */ (webletBundle)).json(),
+            await E(/** @type {any} */(webletBundle)).json(),
             webletPowers,
           )
           .catch(error => {
@@ -465,7 +506,10 @@ export const make = async (powers, context, { env = {} } = {}) => {
   return Far('WebletService', {
     makeWeblet,
     async getAddress() {
-      return started;
+      const addr = await started;
+      // NOTE this was prior behavior, but we may want to consider passing `actual.address` out, since config might be `0.0.0.0`?
+      const actual = `http://${addr.config.address}:${addr.actual.port}`;
+      return actual;
     },
   });
 };

--- a/packages/daemon/test/gateway.test.js
+++ b/packages/daemon/test/gateway.test.js
@@ -1,0 +1,326 @@
+// @ts-check
+/* global Buffer, process */
+
+// Establish a perimeter:
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import url from 'url';
+import path from 'path';
+import http from 'http';
+
+import { E } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+import { makePipe, mapWriter, mapReader } from '@endo/stream';
+
+import * as ws from 'ws';
+
+import { start, stop, purge, makeEndoClient } from '../index.js';
+import {
+  makeMessageCapTP,
+  messageToBytes,
+  bytesToMessage,
+} from '../src/connection.js';
+
+const { raw } = String;
+const dirname = url.fileURLToPath(new URL('..', import.meta.url)).toString();
+
+/**
+ * @param {string[]} root
+ */
+const makeConfig = (...root) => {
+  return {
+    statePath: path.join(dirname, ...root, 'state'),
+    ephemeralStatePath: path.join(dirname, ...root, 'run'),
+    cachePath: path.join(dirname, ...root, 'cache'),
+    sockPath:
+      process.platform === 'win32'
+        ? raw`\\?\pipe\endo-${root.join('-')}-test.sock`
+        : path.join(dirname, ...root, 'endo.sock'),
+    pets: new Map(),
+    values: new Map(),
+  };
+};
+
+let configPathId = 0;
+const MAX_UNIX_SOCKET_PATH = 90;
+const SOCKET_PATH_OVERHEAD =
+  path.join(dirname, 'tmp').length + 1 + 'endo.sock'.length + 8;
+const MAX_CONFIG_DIR_LENGTH = Math.max(
+  8,
+  MAX_UNIX_SOCKET_PATH - SOCKET_PATH_OVERHEAD,
+);
+
+/**
+ * @param {string} testTitle
+ * @param {number} configNumber
+ */
+const getConfigDirectoryName = (testTitle, configNumber) => {
+  const defaultPath = testTitle.replace(/\s/giu, '-').replace(/[^\w-]/giu, '');
+  const basePath =
+    defaultPath.length <= MAX_CONFIG_DIR_LENGTH
+      ? defaultPath
+      : defaultPath.slice(0, MAX_CONFIG_DIR_LENGTH);
+  const testId = String(configPathId).padStart(4, '0');
+  const configId = String(configNumber).padStart(2, '0');
+  const configSubDirectory = `${basePath}#${testId}-${configId}`;
+  configPathId += 1;
+  return configSubDirectory;
+};
+
+/** @param {import('ava').ExecutionContext<any>} t */
+const prepareConfig = async t => {
+  const { reject: cancel, promise: cancelled } = makePromiseKit();
+  const config = makeConfig(
+    'tmp',
+    getConfigDirectoryName(t.title, t.context.length),
+  );
+
+  // Set port to 0 so the OS assigns a free port.
+  process.env.ENDO_ADDR = '127.0.0.1:0';
+
+  await purge(config);
+  await start(config);
+
+  const contextObj = { cancel, cancelled, config };
+  t.context.push(contextObj);
+  return { ...contextObj };
+};
+
+/**
+ * @param {ReturnType<typeof makeConfig>} config
+ * @param {Promise<void>} cancelled
+ */
+const makeHost = async (config, cancelled) => {
+  const { getBootstrap } = await makeEndoClient(
+    'client',
+    config.sockPath,
+    cancelled,
+  );
+  const bootstrap = getBootstrap();
+  return { host: E(bootstrap).host() };
+};
+
+/** @param {import('ava').ExecutionContext<any>} t */
+const prepareHost = async t => {
+  const { cancel, cancelled, config } = await prepareConfig(t);
+  const { host } = await makeHost(config, cancelled);
+  return { cancel, cancelled, config, host };
+};
+
+/**
+ * Make an HTTP GET request.
+ * @param {string} urlStr
+ * @param {Record<string, string>} [headers]
+ * @returns {Promise<{ status: number, body: string }>}
+ */
+const httpGet = (urlStr, headers = {}) =>
+  new Promise((resolve, reject) => {
+    const reqUrl = new URL(urlStr);
+    const req = http.get(
+      {
+        hostname: reqUrl.hostname,
+        port: reqUrl.port,
+        path: reqUrl.pathname + reqUrl.search,
+        headers,
+      },
+      res => {
+        /** @type {Buffer[]} */
+        const chunks = [];
+        res.on('data', chunk => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            status: /** @type {number} */ (res.statusCode),
+            body: Buffer.concat(chunks).toString('utf-8'),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+  });
+
+test.beforeEach(t => {
+  t.context = [];
+});
+
+test.afterEach.always(async t => {
+  delete process.env.ENDO_ADDR;
+  await Promise.allSettled(
+    /** @type {Array<{cancel: Function, cancelled: Promise<void>, config: ReturnType<typeof makeConfig>}>} */ (
+      t.context
+    ).flatMap(({ cancel, cancelled, config }) => {
+      cancel(Error('teardown'));
+      return [cancelled, stop(config)];
+    }),
+  );
+});
+
+// Tests are serial because each forks a full daemon process (SES lockdown,
+// CapTP, HTTP server). Running them concurrently in a single ava worker
+// causes resource contention that leads to timeouts.
+
+test.serial('gateway HTTP returns info page', async t => {
+  const { host } = await prepareHost(t);
+
+  const apps = E(host).lookup('APPS');
+  const address = await E(apps).getAddress();
+  t.is(typeof address, 'string');
+  t.regex(address, /^http:\/\//);
+
+  const { status, body } = await httpGet(`${address}/`);
+  t.is(status, 200);
+  t.is(body, 'Endo Gateway');
+});
+
+test.serial('gateway WebSocket fetch(token)', async t => {
+  const { host } = await prepareHost(t);
+
+  // Store a value and get its formula identifier.
+  await E(host).evaluate('MAIN', '42', [], [], ['answer']);
+  const formulaId = await E(host).identify('answer');
+  t.truthy(formulaId);
+
+  // Discover the gateway address.
+  const apps = E(host).lookup('APPS');
+  const address = await E(apps).getAddress();
+
+  // Connect WebSocket.
+  const socket = new ws.WebSocket(`${address.replace(/^http/, 'ws')}/`);
+  await new Promise((resolve, reject) => {
+    socket.on('open', resolve);
+    socket.on('error', reject);
+  });
+
+  t.teardown(() => socket.close());
+
+  const [reader, sink] = makePipe();
+
+  socket.on(
+    'message',
+    (/** @type {Uint8Array} */ bytes, /** @type {boolean} */ isBinary) => {
+      if (isBinary) {
+        sink.next(bytes);
+      }
+    },
+  );
+  socket.on('close', () => {
+    sink.return(undefined);
+  });
+
+  const writer = harden({
+    /** @param {Uint8Array} bytes */
+    async next(bytes) {
+      socket.send(bytes, { binary: true });
+      return harden({ done: false, value: undefined });
+    },
+    async return() {
+      socket.close();
+      return harden({ done: true, value: undefined });
+    },
+    /** @param {Error} error */
+    async throw(error) {
+      socket.close();
+      return harden({ done: true, value: error });
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  });
+
+  const messageWriter = mapWriter(writer, messageToBytes);
+  const messageReader = mapReader(reader, bytesToMessage);
+
+  const { promise: cancelled, reject: cancelCapTP } = makePromiseKit();
+  t.teardown(() => cancelCapTP(Error('test done')));
+
+  const { getBootstrap } = makeMessageCapTP(
+    'Test',
+    messageWriter,
+    messageReader,
+    cancelled,
+    undefined,
+  );
+
+  const bootstrap = getBootstrap();
+  const result = await E(bootstrap).fetch(/** @type {string} */ (formulaId));
+  t.is(result, 42);
+});
+
+test.serial('weblet on unified server', async t => {
+  const { host } = await prepareHost(t);
+
+  // Discover the gateway address.
+  const apps = E(host).lookup('APPS');
+  const address = await E(apps).getAddress();
+
+  // Create a weblet on the unified server (no dedicated port).
+  // makeWeblet(bundle, powers, requestedPort, webletId, webletCancelled)
+  // The webletId must be >= 32 chars; the first 32 chars become the access token.
+  const webletId = 'abcdef01234567890abcdef012345678extra';
+  const accessToken = webletId.slice(0, 32);
+  const { promise: webletCancelled, reject: cancelWeblet } = makePromiseKit();
+  t.teardown(() => cancelWeblet(Error('test done')));
+
+  const weblet = E(apps).makeWeblet(
+    undefined,
+    undefined,
+    undefined,
+    webletId,
+    webletCancelled,
+  );
+
+  const location = await E(weblet).getLocation();
+  t.true(location.startsWith('localhttp://'));
+  t.true(location.includes(accessToken));
+
+  // HTTP GET with Host header set to the access token.
+  const { status, body } = await httpGet(`${address}/`, {
+    Host: accessToken,
+  });
+  t.is(status, 200);
+  t.true(body.includes('<body>'));
+
+  // HTTP GET for bootstrap.js.
+  const { status: jsStatus, body: jsBody } = await httpGet(
+    `${address}/bootstrap.js`,
+    { Host: accessToken },
+  );
+  t.is(jsStatus, 200);
+  t.true(jsBody.length > 0);
+});
+
+test.serial('weblet on dedicated port', async t => {
+  const { host } = await prepareHost(t);
+
+  const apps = E(host).lookup('APPS');
+
+  // Create a weblet with a dedicated port (port 0 = OS-assigned).
+  const webletId = 'fedcba98765432100fedcba987654321extra';
+  const accessToken = webletId.slice(0, 32);
+  const { promise: webletCancelled, reject: cancelWeblet } = makePromiseKit();
+  t.teardown(() => cancelWeblet(Error('test done')));
+
+  const weblet = E(apps).makeWeblet(
+    undefined,
+    undefined,
+    0,
+    webletId,
+    webletCancelled,
+  );
+
+  const location = await E(weblet).getLocation();
+  // Dedicated-port weblets use http://127.0.0.1:PORT/TOKEN/ format.
+  t.regex(location, /^http:\/\/127\.0\.0\.1:\d+\//);
+  t.true(location.includes(accessToken));
+
+  // HTTP GET to the weblet location.
+  const { status, body } = await httpGet(location);
+  t.is(status, 200);
+  t.true(body.includes('<body>'));
+
+  // HTTP GET for bootstrap.js via the dedicated port.
+  const bsUrl = location.replace(/\/$/, '/bootstrap.js');
+  const { status: jsStatus, body: jsBody } = await httpGet(bsUrl);
+  t.is(jsStatus, 200);
+  t.true(jsBody.length > 0);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,6 +639,7 @@ __metadata:
     "@endo/stream": "workspace:^"
     "@endo/stream-node": "workspace:^"
     "@endo/where": "workspace:^"
+    "@types/ws": "npm:^8.18.1"
     ava: "catalog:dev"
     c8: "catalog:dev"
     eslint: "catalog:dev"
@@ -2675,6 +2676,15 @@ __metadata:
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Description

This sets the stage for Endo Familiar, an Electron app that manages the daemon and serves local HTTP web applications through a custom `localhttp://` protocol handler. The unified gateway eliminates the need for each weblet to claim a dedicated port, allowing Electron to route requests to weblets by hostname instead.

Adds a unified HTTP/WebSocket gateway server to the Endo daemon, listening on `ENDO_ADDR` (default `127.0.0.1:8920`). Weblets can register on the shared server using hostname-based isolation or opt into a dedicated port with path-based isolation. Gateway clients connect over WebSocket and call `fetch(token)` to retrieve formula values via CapTP.

Extracts `trackConnection`, `openCapTPSession`, and `makeWebletFar` helpers to deduplicate the gateway and weblet connection paths. Installs `@types/ws` to replace `@ts-ignore` directives.

### Security Considerations

Only loopback connections (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`) are accepted. Non-local connections are rejected with a 1008 close code. This restriction will be revisited when CapTP is replaced with OCapN over Noise Protocol.

### Scaling Considerations

None. One HTTP server replaces per-weblet servers when no dedicated port is requested.

### Documentation Considerations

The daemon README now documents the `ENDO_ADDR` environment variable and its usage with `endo start`.

### Testing Considerations

New `gateway.test.js` covers: gateway info page, WebSocket `fetch(token)`, weblet on the unified server, and weblet on a dedicated port.

### Compatibility Considerations

`getPort()` is renamed to `getAddress()` and now returns a URL string instead of a port number. Callers must be updated.

### Upgrade Considerations

None.
