### PR TITLE
chore(ci): tag & create GH releases upon release PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,6 @@ jobs:
         # This action will create/update Changesets' Release PR *or* create a
         # GitHub Release and tags if its Release PR was just merged
         uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1
+        with:
+          publish: yarn changeset tag
+          createGithubReleases: true


### PR DESCRIPTION
This fixes the `release.yml` workflow so that it will automatically tag & create GitHub releases when a release PR ("Version Packages") is merged.  Thanks to @naugtur for diagnosing.
