### PR TITLE
feat(ses):  add `toTemporalInstant` method to DatePrototype permits

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -847,6 +847,7 @@ export const permitted = {
     toLocaleString: fn,
     toLocaleTimeString: fn,
     toString: fn,
+    toTemporalInstant: fn,
     toTimeString: fn,
     toUTCString: fn,
     valueOf: fn,


### PR DESCRIPTION
## Description

Add `toTemporalInstant` method to DatePrototype permits. This method has been included in the latest browser APIs.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toTemporalInstant
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal

### Security Considerations

> No

### Scaling Considerations

> No

### Documentation Considerations

> No

### Testing Considerations

> No

### Compatibility Considerations

> No

### Upgrade Considerations

> No
