### PR TITLE
fix: create-package.sh had NEWS detritus

### DIFF
--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -69,5 +69,5 @@ function sedi() {
 sedi -ne '/###/ { x; q; }; p' CHANGELOG.md
 # LICENSE: current year
 sedi -e "s/\[yyyy\]\ \[name\ of\ copyright\ owner\]/$(date '+%Y') Endo Contributors/g" LICENSE
-# NEWS.md and README.md: package name
-sedi -e "s#\[package\]#@endo/$NAME#g; s#\[name\]#$NAME#g" NEWS.md README.md
+# README.md: package name
+sedi -e "s#\[package\]#@endo/$NAME#g; s#\[name\]#$NAME#g" README.md


### PR DESCRIPTION

Closes: #XXXX
Refs: #XXXX

## Description

create-package.sh had NEWS detritus that broke in our new changesets world.

### Security Considerations

none

### Scaling Considerations

none

### Documentation Considerations

none

### Testing Considerations

I desk checked that it worked by rerunning a package creation that failed. Beyond that, I'm not inclined to add automated tests of create-package.sh .

### Compatibility Considerations

The point. This makes create-package.sh compatible with our new status quo.

### Upgrade Considerations

none