### PR TITLE
fix(compartment-mapper): correct broken type; remove unused types

### DIFF
--- a/.changeset/blue-kids-smoke.md
+++ b/.changeset/blue-kids-smoke.md
@@ -1,0 +1,5 @@
+---
+'@endo/compartment-mapper': patch
+---
+
+Fix type of `PackageDataHook.packageData` which now correctly allows `$root$` as a key.

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -25,6 +25,11 @@ import type { SomePolicy } from './policy-schema.js';
 import type { HashFn, ReadFn, ReadPowers } from './powers.js';
 import type { CanonicalName } from './canonical-name.js';
 import type { PackageDescriptor } from './node-modules.js';
+import type {
+  ATTENUATORS_COMPARTMENT,
+  ENTRY_COMPARTMENT,
+} from '../policy-format.js';
+import type { LiteralUnion } from './typescript.js';
 
 export type { CanonicalName };
 export type { PackageDescriptor };
@@ -59,7 +64,15 @@ export type PackageData = {
  * Called once before `translateGraph`.
  */
 export type PackageDataHook = (params: {
-  packageData: Readonly<Map<PackageCompartmentDescriptorName, PackageData>>;
+  packageData: Readonly<
+    Map<
+      LiteralUnion<
+        typeof ATTENUATORS_COMPARTMENT | typeof ENTRY_COMPARTMENT,
+        FileUrlString
+      >,
+      PackageData
+    >
+  >;
   log: LogFn;
 }) => void;
 

--- a/packages/compartment-mapper/src/types/node-modules.ts
+++ b/packages/compartment-mapper/src/types/node-modules.ts
@@ -1,19 +1,12 @@
 import type { GenericGraph } from '../generic-graph.js';
 import type {
-  ATTENUATORS_COMPARTMENT,
-  ENTRY_COMPARTMENT,
-} from '../policy-format.js';
-import type {
   CanonicalName,
-  CompartmentMapDescriptor,
   PackageCompartmentDescriptorName,
   PolicyOption,
-  SomePolicy,
 } from '../types.js';
 import type {
   Language,
   LanguageForExtension,
-  PackageCompartmentMapDescriptor,
 } from './compartment-map-schema.js';
 import type {
   FileUrlString,
@@ -21,6 +14,7 @@ import type {
   PackageDependenciesHook,
 } from './external.js';
 import type { LiteralUnion } from './typescript.js';
+import { ATTENUATORS_COMPARTMENT } from '../policy-format.js';
 
 export type CommonDependencyDescriptors = Record<
   string,
@@ -164,7 +158,10 @@ export interface FinalNode extends Node {
  * Keys may either be a file URL string to a package or the special
  * `<ATTENUATORS>` string.
  */
-export type Graph = Record<LiteralUnion<'<ATTENUATORS>', FileUrlString>, Node>;
+export type Graph = Record<
+  LiteralUnion<typeof ATTENUATORS_COMPARTMENT, FileUrlString>,
+  Node
+>;
 
 /**
  * A graph, but contains {@link FinalNode}s instead of {@link Node}s.


### PR DESCRIPTION
- Corrects the `PackageDataHook` type so that the `packageData` property's keys are of the correct type (which includes `$root$`).
- Remove hardcoded `<ATTENUATORS>` string in `Graph` type
- Remove unused types from `node-modules.ts`
