### PR TITLE
Libp2p internet connectivity

### DIFF
--- a/packages/daemon/test/channel.test.js
+++ b/packages/daemon/test/channel.test.js
@@ -358,6 +358,37 @@ test.serial('channel - sub-invitations carry full pedigree chain', async t => {
   );
 });
 
+test.serial('channel - messages include pedigreeMemberIds for ancestor chain', async t => {
+  const { host } = await prepareHost(t);
+
+  await E(host).makeChannel('my-channel', 'Alice');
+  const channel = await E(host).lookup('my-channel');
+
+  const adminMemberId = await E(channel).getMemberId();
+
+  // Alice invites Bob, Bob invites Carol.
+  const [bobInvite] = await E(channel).createInvitation('Bob');
+  const bobMember = await E(bobInvite).join('Bob');
+  const bobMemberId = await E(bobMember).getMemberId();
+  const [carolInvite] = await E(bobMember).createInvitation('Carol');
+  const carolMember = await E(carolInvite).join('Carol');
+
+  // Admin and Carol both post.
+  await E(channel).post(['Admin message'], [], []);
+  await E(carolMember).post(['Carol message'], [], []);
+
+  const messages = await E(channel).listMessages();
+  t.is(messages.length, 2);
+
+  // Admin has no ancestors.
+  t.deepEqual(messages[0].pedigree, []);
+  t.deepEqual(messages[0].pedigreeMemberIds, []);
+
+  // Carol's invitation chain is Alice -> Bob, and IDs align to those members.
+  t.deepEqual(messages[1].pedigree, ['Alice', 'Bob']);
+  t.deepEqual(messages[1].pedigreeMemberIds, [adminMemberId, bobMemberId]);
+});
+
 // ---------- Implicit threading ----------
 
 test.serial('channel - implicit threading with replyTo', async t => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: #XXXX
Refs: #XXXX

## Description

This PR adds a regression test to verify the correct inclusion of `pedigreeMemberIds` in channel messages. Specifically, it ensures that admin messages have an empty `pedigreeMemberIds` array and that descendant messages correctly map pedigree names to ancestor `memberId`s in the expected order.

The most critical file to review is `packages/daemon/test/channel.test.js`.

### Security Considerations

None. This change only adds a test.

### Scaling Considerations

None. This change only adds a test.

### Documentation Considerations

None. This change only adds a test.

### Testing Considerations

This PR introduces a new regression test for the `pedigreeMemberIds` field in channel messages. No additional tests are needed beyond this.

### Compatibility Considerations

None. This change only adds a test and does not alter existing usage patterns.

### Upgrade Considerations

None. This change only adds a test.

---
<p><a href="https://cursor.com/agents/bc-45ae8f4b-65e1-4354-b9b7-8af6bc9d0647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45ae8f4b-65e1-4354-b9b7-8af6bc9d0647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->