### PR TITLE
Libp2p internet connectivity

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -44,6 +44,8 @@
     "test:clean": "rm -rf tmp && yarn test"
   },
   "dependencies": {
+    "@chainsafe/libp2p-noise": "^17.0.0",
+    "@chainsafe/libp2p-yamux": "^8.0.1",
     "@endo/base64": "workspace:^",
     "@endo/captp": "workspace:^",
     "@endo/compartment-mapper": "workspace:^",
@@ -62,6 +64,17 @@
     "@endo/stream": "workspace:^",
     "@endo/stream-node": "workspace:^",
     "@endo/where": "workspace:^",
+    "@libp2p/autonat": "^3.0.12",
+    "@libp2p/bootstrap": "^12.0.13",
+    "@libp2p/circuit-relay-v2": "^4.1.5",
+    "@libp2p/dcutr": "^3.0.12",
+    "@libp2p/identify": "^4.0.12",
+    "@libp2p/kad-dht": "^16.1.5",
+    "@libp2p/tcp": "^11.0.12",
+    "@libp2p/webrtc": "^6.0.13",
+    "@libp2p/websockets": "^10.1.5",
+    "@multiformats/multiaddr": "^13.0.1",
+    "libp2p": "^3.1.5",
     "ses": "workspace:^",
     "ws": "^8.13.0"
   },

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -375,11 +375,17 @@ const makeDaemonCore = async (
       cancelConnection,
       connectionCancelled,
     ) => {
+      console.log(
+        `[endo-greeter] hello received from remote node ${remoteNodeId.slice(0, 16)}... at ${new Date().toISOString()}`,
+      );
       assertNodeNumber(remoteNodeId);
       const remoteControl = provideRemoteControl(remoteNodeId);
       /** @param {Error} error */
       const wrappedCancel = error => E(cancelConnection)(error);
       remoteControl.accept(remoteGateway, wrappedCancel, connectionCancelled);
+      console.log(
+        `[endo-greeter] accepted connection from remote node ${remoteNodeId.slice(0, 16)}...`,
+      );
       return localGateway;
     },
   });
@@ -1320,11 +1326,27 @@ const makeDaemonCore = async (
         reviveNetworks: async () => {
           const networksDirectory = await provide(networksId, 'directory');
           const networkIds = await networksDirectory.listIdentifiers();
-          await Promise.allSettled(
+          console.log(
+            `[endo-networks] reviving ${networkIds.length} network(s)`,
+          );
+          const results = await Promise.allSettled(
             networkIds.map(id =>
               provide(/** @type {FormulaIdentifier} */ (id)),
             ),
           );
+          for (let i = 0; i < results.length; i += 1) {
+            const result = results[i];
+            if (result.status === 'rejected') {
+              console.error(
+                `[endo-networks] failed to revive network ${networkIds[i]}:`,
+                result.reason,
+              );
+            } else {
+              console.log(
+                `[endo-networks] revived network ${networkIds[i]}`,
+              );
+            }
+          }
         },
         revivePins: async () => {
           const pinsDirectory = await provide(pinsId, 'directory');
@@ -1338,16 +1360,23 @@ const makeDaemonCore = async (
             /** @type {unknown} */ (await provide(peersId, 'pet-store'))
           );
           const { node: nodeNumber, addresses } = peerInfo;
+          console.log(
+            `[endo-peers] addPeerInfo: node=${nodeNumber.slice(0, 16)}... addresses=[${addresses.join(', ')}]`,
+          );
           assertNodeNumber(nodeNumber);
           if (knownPeers.has(nodeNumber)) {
-            // We already have this peer.
-            // TODO: merge connection info
+            console.log(
+              `[endo-peers] peer already known: node=${nodeNumber.slice(0, 16)}...`,
+            );
             return;
           }
           const { id: peerId } =
             // eslint-disable-next-line no-use-before-define
             await formulatePeer(networksId, nodeNumber, addresses);
           await knownPeers.write(nodeNumber, peerId);
+          console.log(
+            `[endo-peers] peer registered: node=${nodeNumber.slice(0, 16)}... peerId=${peerId}`,
+          );
         },
       });
       return endoBootstrap;
@@ -2306,6 +2335,9 @@ const makeDaemonCore = async (
 
   /** @type {DaemonCore['formulatePeer']} */
   const formulatePeer = async (networksDirectoryId, nodeNumber, addresses) => {
+    console.log(
+      `[endo-peer] formulatePeer: node=${nodeNumber.slice(0, 16)}... addresses=[${addresses.join(', ')}]`,
+    );
     const formulaNumber = /** @type {FormulaNumber} */ (await randomHex512());
     // TODO: validate addresses
     // TODO: mutable state like addresses should not be stored in formula
@@ -2399,6 +2431,9 @@ const makeDaemonCore = async (
   const getAllNetworks = async networksDirectoryId => {
     const networksDirectory = await provide(networksDirectoryId, 'directory');
     const networkIds = await networksDirectory.listIdentifiers();
+    console.log(
+      `[endo-networks] getAllNetworks: ${networkIds.length} network(s) registered`,
+    );
     const networks = await Promise.all(
       networkIds.map(id =>
         provide(/** @type {FormulaIdentifier} */ (id), 'network'),
@@ -2417,6 +2452,9 @@ const makeDaemonCore = async (
         }),
       )
     ).flat();
+    console.log(
+      `[endo-networks] getAllNetworkAddresses: ${addresses.length} address(es): [${addresses.join(', ')}]`,
+    );
     return addresses;
   };
 
@@ -2427,6 +2465,9 @@ const makeDaemonCore = async (
    * @param {Context} context
    */
   const makePeer = async (networksDirectoryId, nodeId, addresses, context) => {
+    console.log(
+      `[endo-peer] makePeer: node=${nodeId.slice(0, 16)}... addresses=[${addresses.join(', ')}]`,
+    );
     const remoteControl = provideRemoteControl(nodeId);
     return remoteControl.connect(
       async () => {
@@ -2436,17 +2477,52 @@ const makeDaemonCore = async (
         // connection loss and invalidate the connection formula and its transitive
         // dependees when this occurs.
         const networks = await getAllNetworks(networksDirectoryId);
+        console.log(
+          `[endo-peer] connecting to node=${nodeId.slice(0, 16)}..., ${networks.length} network(s) available, ${addresses.length} address(es) to try`,
+        );
         // Connect on first support address.
         for (const address of addresses) {
           const { protocol } = new URL(address);
+          console.log(
+            `[endo-peer] trying address=${address} protocol=${protocol}`,
+          );
+          let supported = false;
           for (const network of networks) {
             // eslint-disable-next-line no-await-in-loop
             if (await E(network).supports(protocol)) {
-              return E(network).connect(address, makeFarContext(context));
+              supported = true;
+              console.log(
+                `[endo-peer] found supporting network for protocol=${protocol}, dialing address=${address}`,
+              );
+              try {
+                const result = await E(network).connect(
+                  address,
+                  makeFarContext(context),
+                );
+                console.log(
+                  `[endo-peer] connected to node=${nodeId.slice(0, 16)}... via address=${address}`,
+                );
+                return result;
+              } catch (dialErr) {
+                console.error(
+                  `[endo-peer] dial failed: address=${address} error=${dialErr.message}`,
+                );
+                throw dialErr;
+              }
             }
           }
+          if (!supported) {
+            console.warn(
+              `[endo-peer] no network supports protocol=${protocol} for address=${address}`,
+            );
+          }
         }
-        throw new Error('Cannot connect to peer: no supported addresses');
+        const err = new Error('Cannot connect to peer: no supported addresses');
+        console.error(
+          `[endo-peer] all addresses exhausted for node=${nodeId.slice(0, 16)}...:`,
+          err.message,
+        );
+        throw err;
       },
       context.cancel,
       context.cancelled,
@@ -2464,6 +2540,9 @@ const makeDaemonCore = async (
 
     const locate = async () => {
       const { node, addresses } = await hostAgent.getPeerInfo();
+      console.log(
+        `[endo-invitation] locate: node=${node.slice(0, 16)}... addresses=[${addresses.join(', ')}]`,
+      );
       const { number: hostHandleNumber } = parseId(hostHandleId);
       const { number } = parseId(id);
       const url = new URL('endo://');
@@ -2473,6 +2552,9 @@ const makeDaemonCore = async (
       for (const address of addresses) {
         url.searchParams.append('at', address);
       }
+      console.log(
+        `[endo-invitation] locator=${url.href}`,
+      );
       return url.href;
     };
 
@@ -2480,10 +2562,17 @@ const makeDaemonCore = async (
      * @param {string} guestHandleLocator
      */
     const accept = async guestHandleLocator => {
+      console.log(
+        `[endo-invitation] accept: locator=${guestHandleLocator}`,
+      );
       const url = new URL(guestHandleLocator);
       const guestHandleNumber = url.searchParams.get('id');
       const addresses = url.searchParams.getAll('at');
       const guestNodeNumber = url.hostname;
+
+      console.log(
+        `[endo-invitation] accept: guestNode=${(guestNodeNumber || '').slice(0, 16)}... addresses=[${addresses.join(', ')}]`,
+      );
 
       if (!guestHandleNumber) {
         throw makeError('Handle locator must have an "id" parameter');

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -664,6 +664,9 @@ export const makeHostMaker = ({
     /** @type {EndoHost['getPeerInfo']} */
     const getPeerInfo = async () => {
       const addresses = await getAllNetworkAddresses(networksDirectoryId);
+      console.log(
+        `[endo-host] getPeerInfo: node=${localNodeNumber.slice(0, 16)}... addresses=[${addresses.join(', ')}]`,
+      );
       const peerInfo = {
         node: localNodeNumber,
         addresses,

--- a/packages/daemon/src/networks/libp2p-webrtc.js
+++ b/packages/daemon/src/networks/libp2p-webrtc.js
@@ -1,0 +1,705 @@
+// @ts-check
+/* global setTimeout, clearTimeout */
+
+import { createLibp2p } from 'libp2p';
+import { webRTC } from '@libp2p/webrtc';
+import { webSockets } from '@libp2p/websockets';
+import { tcp } from '@libp2p/tcp';
+import { circuitRelayTransport, circuitRelayServer } from '@libp2p/circuit-relay-v2';
+import { identify } from '@libp2p/identify';
+import { kadDHT, removePrivateAddressesMapper } from '@libp2p/kad-dht';
+import { bootstrap } from '@libp2p/bootstrap';
+import { dcutr } from '@libp2p/dcutr';
+import { autoNAT } from '@libp2p/autonat';
+import { noise } from '@chainsafe/libp2p-noise';
+import { yamux } from '@chainsafe/libp2p-yamux';
+import { multiaddr } from '@multiformats/multiaddr';
+
+import harden from '@endo/harden';
+import { E, Far } from '@endo/far';
+import { makePipe } from '@endo/stream';
+import { mapWriter, mapReader } from '@endo/stream';
+import { makeNetstringReader, makeNetstringWriter } from '@endo/netstring';
+import {
+  makeMessageCapTP,
+  bytesToMessage,
+  messageToBytes,
+} from '../connection.js';
+
+const protocol = 'libp2p+webrtc+json+captp0';
+
+const timestamp = () => new Date().toISOString();
+
+const log = (...args) =>
+  console.log(`[libp2p-net ${timestamp()}]`, ...args);
+const warn = (...args) =>
+  console.warn(`[libp2p-net ${timestamp()}]`, ...args);
+const error = (...args) =>
+  console.error(`[libp2p-net ${timestamp()}]`, ...args);
+
+const ENDO_PROTOCOL_ID = '/endo/captp/1.0.0';
+
+const DEFAULT_BOOTSTRAP_PEERS = [
+  '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+  '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+  '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+  '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt',
+];
+
+/**
+ * Wraps a libp2p stream into the reader/writer pair expected by endo's
+ * netstring/captp framing. The libp2p stream is a duplex with source
+ * (AsyncIterable<Uint8ArrayList>) and sink (takes AsyncIterable<Uint8Array>).
+ *
+ * @param {import('libp2p').Stream} stream
+ * @returns {{ reader: import('@endo/stream').Reader<Uint8Array>, writer: import('@endo/stream').Writer<Uint8Array>, closed: Promise<void> }}
+ */
+const wrapLibp2pStream = (stream) => {
+  const [readFrom, writeTo] = makePipe();
+
+  const sinkClosed = stream.sink(
+    (async function* generate() {
+      for await (const chunk of readFrom) {
+        yield chunk;
+      }
+    })(),
+  );
+
+  const [sourceReadFrom, sourceWriteTo] = makePipe();
+
+  const sourceConsumed = (async () => {
+    try {
+      for await (const data of stream.source) {
+        const bytes =
+          data instanceof Uint8Array ? data : new Uint8Array(data.subarray());
+        await sourceWriteTo.next(bytes);
+      }
+    } catch (err) {
+      await sourceWriteTo.throw(err);
+      return;
+    }
+    await sourceWriteTo.return(undefined);
+  })();
+
+  const closed = Promise.all([sinkClosed, sourceConsumed]).then(() => {});
+
+  return {
+    reader: sourceReadFrom,
+    writer: writeTo,
+    closed,
+  };
+};
+
+/**
+ * @param {object} powers - EndoHost powers (getPeerInfo, greeter, gateway, request)
+ * @param {object} context - Endo disposal context (whenCancelled, cancel, addDisposalHook)
+ */
+export const make = async (powers, context) => {
+  const cancelled = /** @type {Promise<never>} */ (E(context).whenCancelled());
+  const cancelServer = (err) => E(context).cancel(err);
+
+  /** @type {Array<string>} */
+  const addresses = [];
+
+  const { node: localNodeId } = await E(powers).getPeerInfo();
+  const localGreeter = E(powers).greeter();
+  const localGateway = E(powers).gateway();
+
+  log('Initializing libp2p network for endo node', localNodeId);
+
+  const connectionNumbers = (function* generateNumbers() {
+    let n = 0;
+    for (;;) {
+      yield n;
+      n += 1;
+    }
+  })();
+
+  /** @type {Set<Promise<void>>} */
+  const connectionClosedPromises = new Set();
+
+  let bootstrapPeers;
+  try {
+    const bootstrapConfig = await E(powers).request(
+      'SELF',
+      'Bootstrap peers (comma-separated multiaddrs, or "default" for public IPFS bootstrap)',
+      'libp2p-bootstrap-peers',
+    );
+    if (bootstrapConfig && bootstrapConfig !== 'default') {
+      bootstrapPeers = bootstrapConfig.split(',').map((s) => s.trim());
+      log('Using custom bootstrap peers:', bootstrapPeers);
+    } else {
+      bootstrapPeers = DEFAULT_BOOTSTRAP_PEERS;
+      log('Using default IPFS bootstrap peers');
+    }
+  } catch {
+    bootstrapPeers = DEFAULT_BOOTSTRAP_PEERS;
+    log('Defaulting to IPFS bootstrap peers (request failed or timed out)');
+  }
+
+  log('Creating libp2p node with transports: WebRTC, WebSocket, TCP, CircuitRelay');
+  log('Services: identify, kad-dht, dcutr, autonat');
+
+  const node = await createLibp2p({
+    addresses: {
+      listen: [
+        '/ip4/0.0.0.0/tcp/0/ws',
+        '/ip4/0.0.0.0/tcp/0',
+        '/webrtc',
+      ],
+    },
+    transports: [
+      webSockets(),
+      tcp(),
+      webRTC(),
+      circuitRelayTransport({ discoverRelays: 2 }),
+    ],
+    connectionEncrypters: [noise()],
+    streamMuxers: [yamux()],
+    peerDiscovery: [
+      bootstrap({ list: bootstrapPeers }),
+    ],
+    services: {
+      identify: identify(),
+      dht: kadDHT({
+        clientMode: false,
+        validators: {},
+        selectors: {},
+      }),
+      dcutr: dcutr(),
+      autonat: autonat(),
+      relay: circuitRelayServer({
+        reservations: {
+          maxReservations: 128,
+          defaultDurationLimit: 120000,
+          defaultDataLimit: BigInt(1 << 24),
+        },
+      }),
+    },
+  });
+
+  const localPeerId = node.peerId.toString();
+  log(`libp2p node created with PeerId: ${localPeerId}`);
+
+  // === Comprehensive event logging ===
+
+  node.addEventListener('peer:discovery', (evt) => {
+    const peer = evt.detail;
+    log(
+      `PEER DISCOVERED: ${peer.id.toString()}`,
+      `multiaddrs: [${peer.multiaddrs.map((ma) => ma.toString()).join(', ')}]`,
+    );
+  });
+
+  node.addEventListener('peer:connect', (evt) => {
+    const peerId = evt.detail;
+    log(`PEER CONNECTED: ${peerId.toString()}`);
+    const conns = node.getConnections(peerId);
+    for (const conn of conns) {
+      log(
+        `  Connection detail:`,
+        `remoteAddr=${conn.remoteAddr.toString()}`,
+        `direction=${conn.direction}`,
+        `multiplexer=${conn.multiplexer || 'none'}`,
+        `encryption=${conn.encryption || 'none'}`,
+        `status=${conn.status}`,
+        `transient=${conn.transient}`,
+      );
+    }
+  });
+
+  node.addEventListener('peer:disconnect', (evt) => {
+    const peerId = evt.detail;
+    warn(`PEER DISCONNECTED: ${peerId.toString()}`);
+  });
+
+  node.addEventListener('peer:identify', (evt) => {
+    const result = evt.detail;
+    log(
+      `PEER IDENTIFIED: ${result.peerId.toString()}`,
+      `protocols: [${(result.protocols || []).join(', ')}]`,
+      `listenAddrs: [${(result.listenAddrs || []).map((a) => a.toString()).join(', ')}]`,
+      `observedAddr: ${result.observedAddr ? result.observedAddr.toString() : 'none'}`,
+      `agentVersion: ${result.agentVersion || 'unknown'}`,
+    );
+  });
+
+  node.addEventListener('connection:open', (evt) => {
+    const conn = evt.detail;
+    log(
+      `CONNECTION OPENED:`,
+      `remote=${conn.remoteAddr.toString()}`,
+      `remotePeer=${conn.remotePeer.toString()}`,
+      `direction=${conn.direction}`,
+      `transient=${conn.transient}`,
+    );
+  });
+
+  node.addEventListener('connection:close', (evt) => {
+    const conn = evt.detail;
+    log(
+      `CONNECTION CLOSED:`,
+      `remote=${conn.remoteAddr.toString()}`,
+      `remotePeer=${conn.remotePeer.toString()}`,
+      `direction=${conn.direction}`,
+    );
+  });
+
+  node.addEventListener('self:peer:update', (evt) => {
+    const addrs = node.getMultiaddrs();
+    log(
+      `SELF PEER UPDATE: multiaddrs now: [${addrs.map((a) => a.toString()).join(', ')}]`,
+    );
+  });
+
+  node.addEventListener('transport:listening', (evt) => {
+    log(`TRANSPORT LISTENING:`, evt.detail);
+  });
+
+  node.addEventListener('transport:close', (evt) => {
+    log(`TRANSPORT CLOSED:`, evt.detail);
+  });
+
+  // === DHT event logging ===
+
+  /**
+   * Publishes this endo node's connection info (endo node id + peer id mapping)
+   * to the DHT so other endo nodes can find us.
+   *
+   * @param {string} endoNodeId
+   */
+  const publishToDHT = async (endoNodeId) => {
+    const dhtKey = `/endo/node/${endoNodeId}`;
+    const dhtValue = new TextEncoder().encode(
+      JSON.stringify({
+        endoNodeId,
+        libp2pPeerId: localPeerId,
+        multiaddrs: node.getMultiaddrs().map((ma) => ma.toString()),
+        timestamp: Date.now(),
+      }),
+    );
+    log(`DHT WRITE: key=${dhtKey} peerId=${localPeerId} addrs=[${node.getMultiaddrs().map((a) => a.toString()).join(', ')}]`);
+    try {
+      const dht = node.services.dht;
+      for await (const event of dht.put(
+        new TextEncoder().encode(dhtKey),
+        dhtValue,
+      )) {
+        log(`DHT WRITE EVENT: type=${event.name}`, JSON.stringify(event));
+      }
+      log(`DHT WRITE COMPLETE: key=${dhtKey}`);
+    } catch (err) {
+      error(`DHT WRITE FAILED: key=${dhtKey}`, err.message, err.stack);
+    }
+  };
+
+  /**
+   * Looks up an endo node's libp2p connection info from the DHT.
+   *
+   * @param {string} endoNodeId
+   * @returns {Promise<{ libp2pPeerId: string, multiaddrs: string[] } | null>}
+   */
+  const lookupFromDHT = async (endoNodeId) => {
+    const dhtKey = `/endo/node/${endoNodeId}`;
+    log(`DHT READ: looking up key=${dhtKey}`);
+    try {
+      const dht = node.services.dht;
+      for await (const event of dht.get(new TextEncoder().encode(dhtKey))) {
+        log(`DHT READ EVENT: type=${event.name}`, JSON.stringify(event));
+        if (event.name === 'VALUE') {
+          const decoded = JSON.parse(new TextDecoder().decode(event.value));
+          log(
+            `DHT READ SUCCESS: key=${dhtKey}`,
+            `peerId=${decoded.libp2pPeerId}`,
+            `addrs=[${(decoded.multiaddrs || []).join(', ')}]`,
+            `age=${Date.now() - decoded.timestamp}ms`,
+          );
+          return decoded;
+        }
+      }
+      warn(`DHT READ: no VALUE event found for key=${dhtKey}`);
+      return null;
+    } catch (err) {
+      error(`DHT READ FAILED: key=${dhtKey}`, err.message, err.stack);
+      return null;
+    }
+  };
+
+  // Start the libp2p node
+  await node.start();
+  log('libp2p node started');
+
+  const multiaddrs = node.getMultiaddrs();
+  log(`Listening on ${multiaddrs.length} multiaddrs:`);
+  for (const ma of multiaddrs) {
+    log(`  ${ma.toString()}`);
+  }
+
+  // Classify addresses for debugging
+  const webrtcAddrs = multiaddrs.filter((ma) =>
+    ma.toString().includes('/webrtc'),
+  );
+  const wsAddrs = multiaddrs.filter(
+    (ma) => ma.toString().includes('/ws') && !ma.toString().includes('/webrtc'),
+  );
+  const tcpAddrs = multiaddrs.filter(
+    (ma) =>
+      ma.toString().includes('/tcp') &&
+      !ma.toString().includes('/ws') &&
+      !ma.toString().includes('/webrtc'),
+  );
+  const relayAddrs = multiaddrs.filter((ma) =>
+    ma.toString().includes('/p2p-circuit'),
+  );
+  log(
+    `Address breakdown: ${tcpAddrs.length} TCP, ${wsAddrs.length} WS, ${webrtcAddrs.length} WebRTC, ${relayAddrs.length} relay`,
+  );
+
+  // Build endo-style addresses for peer discovery
+  for (const ma of multiaddrs) {
+    const endoAddr = `${protocol}://${localPeerId}?ma=${encodeURIComponent(ma.toString())}`;
+    addresses.push(endoAddr);
+  }
+  log(`Publishing ${addresses.length} endo addresses`);
+
+  // Publish our endo node ID -> libp2p peer ID mapping to the DHT
+  // Retry periodically so the record stays fresh
+  let dhtPublishTimer;
+  const publishLoop = async () => {
+    await publishToDHT(localNodeId);
+    dhtPublishTimer = setTimeout(publishLoop, 60000);
+  };
+  // Kick off initial publish after a short delay to let DHT bootstrap
+  dhtPublishTimer = setTimeout(publishLoop, 5000);
+
+  // Handle incoming streams on the endo protocol
+  const handleIncoming = async () => {
+    try {
+      await node.handle(ENDO_PROTOCOL_ID, async ({ stream, connection }) => {
+        const { value: connectionNumber } = connectionNumbers.next();
+        const remotePeerId = connection.remotePeer.toString();
+        log(
+          `INBOUND STREAM #${connectionNumber}: remotePeer=${remotePeerId}`,
+          `remoteAddr=${connection.remoteAddr.toString()}`,
+          `direction=${connection.direction}`,
+          `transient=${connection.transient}`,
+        );
+
+        try {
+          const {
+            reader: bytesReader,
+            writer: bytesWriter,
+            closed: connectionClosed,
+          } = wrapLibp2pStream(stream);
+
+          const messageWriter = mapWriter(
+            makeNetstringWriter(bytesWriter, { chunked: true }),
+            messageToBytes,
+          );
+          const messageReader = mapReader(
+            makeNetstringReader(bytesReader),
+            bytesToMessage,
+          );
+
+          const { closed: capTpClosed } = makeMessageCapTP(
+            `Endo-libp2p-in-${connectionNumber}`,
+            messageWriter,
+            messageReader,
+            cancelled,
+            localGreeter,
+          );
+
+          const closed = Promise.race([connectionClosed, capTpClosed]);
+          connectionClosedPromises.add(closed);
+          closed.finally(() => {
+            connectionClosedPromises.delete(closed);
+            log(
+              `INBOUND STREAM #${connectionNumber} CLOSED: remotePeer=${remotePeerId}`,
+            );
+          });
+        } catch (err) {
+          error(
+            `INBOUND STREAM #${connectionNumber} ERROR: remotePeer=${remotePeerId}`,
+            err.message,
+            err.stack,
+          );
+          cancelServer(err);
+        }
+      });
+      log(`Registered protocol handler for ${ENDO_PROTOCOL_ID}`);
+    } catch (err) {
+      error('Failed to register protocol handler:', err.message);
+      cancelServer(err);
+    }
+  };
+  await handleIncoming();
+
+  // Cleanup on cancellation
+  cancelled.catch(async (err) => {
+    log('Shutting down libp2p network:', err.message);
+    clearTimeout(dhtPublishTimer);
+    try {
+      await node.stop();
+      log('libp2p node stopped');
+    } catch (stopErr) {
+      error('Error stopping libp2p node:', stopErr.message);
+    }
+  });
+
+  const stopped = cancelled
+    .catch(() => {})
+    .then(() => Promise.all(Array.from(connectionClosedPromises)))
+    .then(() => {});
+  E.sendOnly(context).addDisposalHook(() => stopped);
+
+  /**
+   * Dial a remote endo peer over libp2p.
+   *
+   * The address format is:
+   *   libp2p+webrtc+json+captp0://<peerIdOrEndoNodeId>?ma=<multiaddr>&ma=<multiaddr>
+   *
+   * If only an endo node ID is provided (no multiaddrs), the DHT is consulted.
+   *
+   * @param {string} address
+   * @param {object} connectionContext
+   * @returns {Promise<object>}
+   */
+  const connect = async (address, connectionContext) => {
+    const { value: connectionNumber } = connectionNumbers.next();
+
+    const connectionCancelled = /** @type {Promise<never>} */ (
+      E(connectionContext).whenCancelled()
+    );
+    const cancelConnection = () => E(connectionContext).cancel();
+
+    const url = new URL(address);
+    const remoteIdentifier = url.hostname || url.pathname.replace(/^\/\//, '');
+    const explicitMultiaddrs = url.searchParams.getAll('ma');
+
+    log(
+      `DIAL #${connectionNumber} INITIATED:`,
+      `address=${address}`,
+      `remoteId=${remoteIdentifier}`,
+      `explicitMultiaddrs=[${explicitMultiaddrs.join(', ')}]`,
+    );
+
+    let targetPeerId = remoteIdentifier;
+    let targetMultiaddrs = explicitMultiaddrs;
+
+    // If the identifier looks like an endo node ID (128 hex chars) rather than
+    // a libp2p PeerId, look it up in the DHT.
+    if (/^[0-9a-f]{128}$/i.test(remoteIdentifier)) {
+      log(`DIAL #${connectionNumber}: identifier looks like endo node ID, consulting DHT`);
+      const dhtInfo = await lookupFromDHT(remoteIdentifier);
+      if (dhtInfo) {
+        targetPeerId = dhtInfo.libp2pPeerId;
+        if (targetMultiaddrs.length === 0) {
+          targetMultiaddrs = dhtInfo.multiaddrs;
+        }
+        log(
+          `DIAL #${connectionNumber}: DHT resolved endo node ${remoteIdentifier}`,
+          `-> peerId=${targetPeerId}`,
+          `-> addrs=[${targetMultiaddrs.join(', ')}]`,
+        );
+      } else {
+        error(
+          `DIAL #${connectionNumber}: DHT lookup failed for endo node ${remoteIdentifier}, no peer info found`,
+        );
+        throw new Error(
+          `Cannot resolve endo node ${remoteIdentifier} via DHT`,
+        );
+      }
+    }
+
+    // Try each multiaddr, with detailed logging on each attempt
+    let lastError;
+    const triedAddrs = [];
+
+    for (const maStr of targetMultiaddrs) {
+      const ma = multiaddr(maStr);
+      log(
+        `DIAL #${connectionNumber} ATTEMPT:`,
+        `multiaddr=${ma.toString()}`,
+        `targetPeer=${targetPeerId}`,
+      );
+      triedAddrs.push(maStr);
+
+      try {
+        const startTime = Date.now();
+        const stream = await node.dialProtocol(ma, ENDO_PROTOCOL_ID);
+        const elapsed = Date.now() - startTime;
+        log(
+          `DIAL #${connectionNumber} SUCCESS:`,
+          `multiaddr=${ma.toString()}`,
+          `elapsed=${elapsed}ms`,
+          `remotePeer=${stream.protocol}`,
+        );
+
+        const {
+          reader: bytesReader,
+          writer: bytesWriter,
+          closed: connectionClosed,
+        } = wrapLibp2pStream(stream);
+
+        const messageWriter = mapWriter(
+          makeNetstringWriter(bytesWriter, { chunked: true }),
+          messageToBytes,
+        );
+        const messageReader = mapReader(
+          makeNetstringReader(bytesReader),
+          bytesToMessage,
+        );
+
+        const { closed: capTpClosed, getBootstrap } = makeMessageCapTP(
+          `Endo-libp2p-out-${connectionNumber}`,
+          messageWriter,
+          messageReader,
+          connectionCancelled,
+          localGateway,
+        );
+
+        const closed = Promise.race([connectionClosed, capTpClosed]);
+        connectionClosedPromises.add(closed);
+        closed.finally(() => {
+          connectionClosedPromises.delete(closed);
+          log(
+            `OUTBOUND STREAM #${connectionNumber} CLOSED: remotePeer=${targetPeerId}`,
+          );
+        });
+
+        const remoteGreeter = getBootstrap();
+        return E(remoteGreeter).hello(
+          localNodeId,
+          localGateway,
+          Far('Canceller', cancelConnection),
+          connectionCancelled,
+        );
+      } catch (dialErr) {
+        warn(
+          `DIAL #${connectionNumber} FAILED:`,
+          `multiaddr=${ma.toString()}`,
+          `error=${dialErr.message}`,
+        );
+        lastError = dialErr;
+      }
+    }
+
+    // If explicit multiaddrs all failed, try dialing by PeerId directly
+    // (libp2p may find the peer through DHT/routing).
+    if (targetPeerId) {
+      log(
+        `DIAL #${connectionNumber}: all explicit multiaddrs failed, trying direct PeerId dial`,
+        `peerId=${targetPeerId}`,
+      );
+      try {
+        const peerMa = multiaddr(`/p2p/${targetPeerId}`);
+        const startTime = Date.now();
+        const stream = await node.dialProtocol(peerMa, ENDO_PROTOCOL_ID);
+        const elapsed = Date.now() - startTime;
+        log(
+          `DIAL #${connectionNumber} SUCCESS via PeerId:`,
+          `peerId=${targetPeerId}`,
+          `elapsed=${elapsed}ms`,
+        );
+
+        const {
+          reader: bytesReader,
+          writer: bytesWriter,
+          closed: connectionClosed,
+        } = wrapLibp2pStream(stream);
+
+        const messageWriter = mapWriter(
+          makeNetstringWriter(bytesWriter, { chunked: true }),
+          messageToBytes,
+        );
+        const messageReader = mapReader(
+          makeNetstringReader(bytesReader),
+          bytesToMessage,
+        );
+
+        const { closed: capTpClosed, getBootstrap } = makeMessageCapTP(
+          `Endo-libp2p-out-${connectionNumber}`,
+          messageWriter,
+          messageReader,
+          connectionCancelled,
+          localGateway,
+        );
+
+        const closed = Promise.race([connectionClosed, capTpClosed]);
+        connectionClosedPromises.add(closed);
+        closed.finally(() => {
+          connectionClosedPromises.delete(closed);
+          log(
+            `OUTBOUND STREAM #${connectionNumber} CLOSED (PeerId dial): remotePeer=${targetPeerId}`,
+          );
+        });
+
+        const remoteGreeter = getBootstrap();
+        return E(remoteGreeter).hello(
+          localNodeId,
+          localGateway,
+          Far('Canceller', cancelConnection),
+          connectionCancelled,
+        );
+      } catch (peerDialErr) {
+        error(
+          `DIAL #${connectionNumber} FAILED via PeerId:`,
+          `peerId=${targetPeerId}`,
+          `error=${peerDialErr.message}`,
+          peerDialErr.stack,
+        );
+        lastError = peerDialErr;
+      }
+    }
+
+    error(
+      `DIAL #${connectionNumber} ALL ATTEMPTS EXHAUSTED:`,
+      `target=${remoteIdentifier}`,
+      `tried=[${triedAddrs.join(', ')}]`,
+      `lastError=${lastError?.message}`,
+    );
+    throw lastError || new Error(`Cannot connect to peer ${remoteIdentifier}`);
+  };
+
+  /**
+   * Prints a comprehensive connectivity diagnostic snapshot.
+   */
+  const logDiagnostics = () => {
+    const peers = node.getPeers();
+    const conns = node.getConnections();
+    log('=== LIBP2P DIAGNOSTICS ===');
+    log(`PeerId: ${localPeerId}`);
+    log(`Multiaddrs: [${node.getMultiaddrs().map((a) => a.toString()).join(', ')}]`);
+    log(`Known peers: ${peers.length}`);
+    log(`Active connections: ${conns.length}`);
+    for (const conn of conns) {
+      log(
+        `  Conn: peer=${conn.remotePeer.toString()}`,
+        `addr=${conn.remoteAddr.toString()}`,
+        `dir=${conn.direction}`,
+        `transient=${conn.transient}`,
+        `status=${conn.status}`,
+      );
+    }
+    log('=== END DIAGNOSTICS ===');
+  };
+
+  // Periodic diagnostics every 30 seconds
+  const diagInterval = setInterval(logDiagnostics, 30000);
+  cancelled.catch(() => clearInterval(diagInterval));
+
+  // Initial diagnostics after bootstrap
+  setTimeout(logDiagnostics, 10000);
+
+  return Far('Libp2pWebRTCService', {
+    addresses: () => harden(addresses),
+    supports: (address) => {
+      try {
+        return new URL(address).protocol === `${protocol}:`;
+      } catch {
+        return false;
+      }
+    },
+    connect,
+  });
+};

--- a/packages/daemon/src/networks/tcp-netstring.js
+++ b/packages/daemon/src/networks/tcp-netstring.js
@@ -62,8 +62,9 @@ export const make = async (powers, context) => {
       cancelled,
     });
 
-    // TODO log assigned port
-    console.log(`Endo daemon started local ${protocol} network device`);
+    console.log(
+      `[tcp-net] started ${protocol} network device on ${host}:${assignedPort}`,
+    );
     addresses.push(`${protocol}://${host}:${assignedPort}`);
 
     return connections;
@@ -79,9 +80,8 @@ export const make = async (powers, context) => {
       (async () => {
         const { value: connectionNumber } = connectionNumbers.next();
 
-        // TODO listen and connect addresses should be logged
         console.log(
-          `Endo daemon accepted connection ${connectionNumber} over ${protocol} at ${new Date().toISOString()}`,
+          `[tcp-net] accepted inbound connection #${connectionNumber} over ${protocol} at ${new Date().toISOString()}`,
         );
 
         const messageWriter = mapWriter(
@@ -138,9 +138,8 @@ export const make = async (powers, context) => {
       cancelled: connectionCancelled,
     });
 
-    // TODO listen and connect addresses should be logged
     console.log(
-      `Endo daemon connected ${connectionNumber} over ${protocol} at ${new Date().toISOString()}`,
+      `[tcp-net] outbound connection #${connectionNumber} to ${host}:${port} over ${protocol} at ${new Date().toISOString()}`,
     );
 
     const messageWriter = mapWriter(

--- a/packages/daemon/src/remote-control.js
+++ b/packages/daemon/src/remote-control.js
@@ -260,11 +260,16 @@ export const makeRemoteControlProvider = localNodeId => {
       connectionCancelled,
       connectionDispose,
     ) => {
+      const prevStateName = state.name || 'start';
       state = state.accept(
         proposedRemoteGateway,
         cancelConnection,
         connectionCancelled,
         connectionDispose || (() => {}),
+      );
+      const nextStateName = state.name || 'accepted';
+      console.log(
+        `[remote-control] accept: remote=${remoteNodeId.slice(0, 16)}... state=${prevStateName}->${nextStateName}`,
       );
     };
     /**
@@ -279,6 +284,10 @@ export const makeRemoteControlProvider = localNodeId => {
       incarnationCancelled,
       disposeIncarnation,
     ) => {
+      const prevStateName = state.name || 'start';
+      console.log(
+        `[remote-control] connect: remote=${remoteNodeId.slice(0, 16)}... currentState=${prevStateName}`,
+      );
       const { state: nextState, remoteGateway } = state.connect(
         getRemoteGateway,
         cancelIncarnation,
@@ -286,6 +295,10 @@ export const makeRemoteControlProvider = localNodeId => {
         disposeIncarnation,
       );
       state = nextState;
+      const nextStateName = state.name || 'connected';
+      console.log(
+        `[remote-control] connect: remote=${remoteNodeId.slice(0, 16)}... newState=${nextStateName}`,
+      );
       return remoteGateway;
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,69 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainsafe/as-chacha20poly1305@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@chainsafe/as-chacha20poly1305@npm:0.1.0"
+  checksum: 10c0/a537dce48829484488c8e55678dec55f8d47b40bf27f0909dfd8d3b49d5a8e154a4a8433e76c787f9a60ef74524137b7f3fbf2bac10a20e698b30cfd6fe22257
+  languageName: node
+  linkType: hard
+
+"@chainsafe/as-sha256@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@chainsafe/as-sha256@npm:1.2.0"
+  checksum: 10c0/277589bfbdfc692f669a19b87110f4eda033f94d2774cb6d8fc0f745bff3b9e895add862684dbf09ff19102ae79639fdfbc758ecafbbee1cb8e033c679c82aef
+  languageName: node
+  linkType: hard
+
+"@chainsafe/is-ip@npm:^2.0.1, @chainsafe/is-ip@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@chainsafe/is-ip@npm:2.1.0"
+  checksum: 10c0/a6c64cfa845979101e808a4398cc7e45ba8ea0a8e30097cdf12306dd084bcc6d92e008221386ae0819f1b53c78bcc634a415537ec970d6ff65cdb62d8445e1d5
+  languageName: node
+  linkType: hard
+
+"@chainsafe/libp2p-noise@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@chainsafe/libp2p-noise@npm:17.0.0"
+  dependencies:
+    "@chainsafe/as-chacha20poly1305": "npm:^0.1.0"
+    "@chainsafe/as-sha256": "npm:^1.2.0"
+    "@libp2p/crypto": "npm:^5.1.9"
+    "@libp2p/interface": "npm:^3.0.0"
+    "@libp2p/peer-id": "npm:^6.0.0"
+    "@libp2p/utils": "npm:^7.0.0"
+    "@noble/ciphers": "npm:^2.0.1"
+    "@noble/curves": "npm:^2.0.1"
+    "@noble/hashes": "npm:^2.0.1"
+    protons-runtime: "npm:^5.6.0"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+    wherearewe: "npm:^2.0.1"
+  checksum: 10c0/7a11df5254336fffbe5ad346b3bcb186e600d74bd59813c6a52e4e72db034dea353452d093497623e5a92203d57df29063544f18f8e7d264a4646bcc739643c2
+  languageName: node
+  linkType: hard
+
+"@chainsafe/libp2p-yamux@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@chainsafe/libp2p-yamux@npm:8.0.1"
+  dependencies:
+    "@libp2p/interface": "npm:^3.0.0"
+    "@libp2p/utils": "npm:^7.0.0"
+    race-signal: "npm:^2.0.0"
+    uint8arraylist: "npm:^2.4.8"
+  checksum: 10c0/af225414d080ec313baa4ef3d591acfa757368574bd13e69708497ada3394639a99183c22628d7daa1bddf931b4557139a1e851a69a325dec04b618e10d76b36
+  languageName: node
+  linkType: hard
+
+"@chainsafe/netmask@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@chainsafe/netmask@npm:2.0.0"
+  dependencies:
+    "@chainsafe/is-ip": "npm:^2.0.1"
+  checksum: 10c0/a9069e52b0a1470b00c88d3fb16ff4fe14274e5055770faab974b29f7bc69ebf76172775461da1e88b7fe73539a9228f6af0406253d46e987193ddf21a073da1
+  languageName: node
+  linkType: hard
+
 "@changesets/apply-release-plan@npm:^7.0.14":
   version: 7.0.14
   resolution: "@changesets/apply-release-plan@npm:7.0.14"
@@ -373,6 +436,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dnsquery/dns-packet@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "@dnsquery/dns-packet@npm:6.1.1"
+  dependencies:
+    "@leichtgewicht/ip-codec": "npm:^2.0.4"
+    utf8-codec: "npm:^1.0.0"
+  checksum: 10c0/6df09a06e148ad5869b9b3ca49746f8bda886f70e3959421bc4850a7c27fb856f0f3f7cbe315652a3c5d78060a49748263a49eb64816f524434e1296bf6166fb
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.1.0":
   version: 1.2.0
   resolution: "@emnapi/core@npm:1.2.0"
@@ -618,6 +691,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/daemon@workspace:packages/daemon"
   dependencies:
+    "@chainsafe/libp2p-noise": "npm:^17.0.0"
+    "@chainsafe/libp2p-yamux": "npm:^8.0.1"
     "@endo/base64": "workspace:^"
     "@endo/bundle-source": "workspace:^"
     "@endo/captp": "workspace:^"
@@ -639,9 +714,20 @@ __metadata:
     "@endo/stream": "workspace:^"
     "@endo/stream-node": "workspace:^"
     "@endo/where": "workspace:^"
+    "@libp2p/autonat": "npm:^3.0.12"
+    "@libp2p/bootstrap": "npm:^12.0.13"
+    "@libp2p/circuit-relay-v2": "npm:^4.1.5"
+    "@libp2p/dcutr": "npm:^3.0.12"
+    "@libp2p/identify": "npm:^4.0.12"
+    "@libp2p/kad-dht": "npm:^16.1.5"
+    "@libp2p/tcp": "npm:^11.0.12"
+    "@libp2p/webrtc": "npm:^6.0.13"
+    "@libp2p/websockets": "npm:^10.1.5"
+    "@multiformats/multiaddr": "npm:^13.0.1"
     ava: "catalog:dev"
     c8: "catalog:dev"
     eslint: "catalog:dev"
+    libp2p: "npm:^3.1.5"
     ses: "workspace:^"
     typescript: "npm:~5.9.2"
     ws: "npm:^8.13.0"
@@ -1498,6 +1584,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@leichtgewicht/ip-codec@npm:^2.0.4":
+  version: 2.0.5
+  resolution: "@leichtgewicht/ip-codec@npm:2.0.5"
+  checksum: 10c0/14a0112bd59615eef9e3446fea018045720cd3da85a98f801a685a818b0d96ef2a1f7227e8d271def546b2e2a0fe91ef915ba9dc912ab7967d2317b1a051d66b
+  languageName: node
+  linkType: hard
+
 "@lerna/create@npm:8.2.3":
   version: 8.2.3
   resolution: "@lerna/create@npm:8.2.3"
@@ -1576,6 +1669,423 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@libp2p/autonat@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "@libp2p/autonat@npm:3.0.12"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@libp2p/peer-collections": "npm:^7.0.12"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    any-signal: "npm:^4.1.1"
+    main-event: "npm:^1.0.1"
+    multiformats: "npm:^13.4.0"
+    protons-runtime: "npm:^5.6.0"
+    uint8arraylist: "npm:^2.4.8"
+  checksum: 10c0/8b0cec6cc81a41799d42e56682132d652dab7c760890c0d5b43457c0f7571fd7c5c2a4c970f7328bd03e3d601d508c918b96b7e1f5d91462caf712e0ec2837b3
+  languageName: node
+  linkType: hard
+
+"@libp2p/bootstrap@npm:^12.0.13":
+  version: 12.0.13
+  resolution: "@libp2p/bootstrap@npm:12.0.13"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    main-event: "npm:^1.0.1"
+  checksum: 10c0/d5be797149c1fc3055d5ed5660d57fb102b9c0f812492170e3f82ffc582dbe1a0868bc9b83267abcd76d9eedddf24d4285e364e368848e5f9f1d57a552cfbe7a
+  languageName: node
+  linkType: hard
+
+"@libp2p/circuit-relay-v2@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "@libp2p/circuit-relay-v2@npm:4.1.5"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@libp2p/peer-collections": "npm:^7.0.12"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@libp2p/peer-record": "npm:^9.0.5"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    any-signal: "npm:^4.1.1"
+    main-event: "npm:^1.0.1"
+    multiformats: "npm:^13.4.0"
+    nanoid: "npm:^5.1.5"
+    progress-events: "npm:^1.0.1"
+    protons-runtime: "npm:^5.6.0"
+    retimeable-signal: "npm:^1.0.1"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/9726658ebfaf698de7cd5c13e36fe5e62dc0d5c9d2647c5426d96a78830c132cb9a6851cbfe372b500f82ca552695151732a936dac65ff2dc22a6485948b8ef0
+  languageName: node
+  linkType: hard
+
+"@libp2p/crypto@npm:^5.1.13, @libp2p/crypto@npm:^5.1.9":
+  version: 5.1.13
+  resolution: "@libp2p/crypto@npm:5.1.13"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@noble/curves": "npm:^2.0.1"
+    "@noble/hashes": "npm:^2.0.1"
+    multiformats: "npm:^13.4.0"
+    protons-runtime: "npm:^5.6.0"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/18a3b5ec62e435b21fd3ff446e50e2f8711c43d9e5ffb4ca36b77da8de22e3a30a5cc914728b33f7f117bfe9af4c9a1fe74d32a7f6d85f91a241fea506a04992
+  languageName: node
+  linkType: hard
+
+"@libp2p/dcutr@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "@libp2p/dcutr@npm:3.0.12"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    delay: "npm:^7.0.0"
+    protons-runtime: "npm:^5.6.0"
+    uint8arraylist: "npm:^2.4.8"
+  checksum: 10c0/9f710ad191dcc6b617488d26e92829743f8cd3b205addfed2fad67d61f1bbc4ec569ce060d4ef5499fa7a614b23c88dae665a2b63d2e13590f6c18f65382cba3
+  languageName: node
+  linkType: hard
+
+"@libp2p/identify@npm:^4.0.12":
+  version: 4.0.12
+  resolution: "@libp2p/identify@npm:4.0.12"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@libp2p/peer-record": "npm:^9.0.5"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    it-drain: "npm:^3.0.10"
+    it-parallel: "npm:^3.0.13"
+    main-event: "npm:^1.0.1"
+    protons-runtime: "npm:^5.6.0"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/71f189ae7268f7b73b6da4f4fd87728b4a59d6c65ea9c60125d5d61ea1e2bd9deebe6b28273f5b8b00f26dfac18c2caae64eb3f4165e206749bc9dd6e0038208
+  languageName: node
+  linkType: hard
+
+"@libp2p/interface-internal@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "@libp2p/interface-internal@npm:3.0.12"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/peer-collections": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    progress-events: "npm:^1.0.1"
+  checksum: 10c0/6fcc9973609aa45221e35649298aefa9887a4e9511f2a4b6669952d2cc50361466fd1d2acc17caf60f186fc9da80dcd5778ef315416fd7db6d276ea6648f96e3
+  languageName: node
+  linkType: hard
+
+"@libp2p/interface@npm:^3.0.0, @libp2p/interface@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@libp2p/interface@npm:3.1.0"
+  dependencies:
+    "@multiformats/dns": "npm:^1.0.6"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    main-event: "npm:^1.0.1"
+    multiformats: "npm:^13.4.0"
+    progress-events: "npm:^1.0.1"
+    uint8arraylist: "npm:^2.4.8"
+  checksum: 10c0/b0c922bca5b8676d3d6edae3335850aaea9a76d5d9520d5e46109d94aa2bb998f63b0e9e1378e896f0a5e379eede29a96752e114bea8dd7e42277068cbd46071
+  languageName: node
+  linkType: hard
+
+"@libp2p/kad-dht@npm:^16.1.5":
+  version: 16.1.5
+  resolution: "@libp2p/kad-dht@npm:16.1.5"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@libp2p/peer-collections": "npm:^7.0.12"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@libp2p/ping": "npm:^3.0.12"
+    "@libp2p/record": "npm:^4.0.9"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    any-signal: "npm:^4.1.1"
+    interface-datastore: "npm:^9.0.1"
+    it-all: "npm:^3.0.9"
+    it-drain: "npm:^3.0.10"
+    it-length: "npm:^3.0.9"
+    it-map: "npm:^3.1.4"
+    it-merge: "npm:^3.0.12"
+    it-parallel: "npm:^3.0.13"
+    it-pipe: "npm:^3.0.1"
+    it-pushable: "npm:^3.2.3"
+    it-take: "npm:^3.0.9"
+    main-event: "npm:^1.0.1"
+    multiformats: "npm:^13.4.0"
+    p-defer: "npm:^4.0.1"
+    p-event: "npm:^7.0.0"
+    progress-events: "npm:^1.0.1"
+    protons-runtime: "npm:^5.6.0"
+    race-signal: "npm:^2.0.0"
+    uint8-varint: "npm:^2.0.4"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/ba37b3695ed5c6377a7bbf2ada545f1845736887457f813be22929637745be95456be23cf0cf98aa9e9de7f124759a3adb7284bf4b3289ba456a4458954f31df
+  languageName: node
+  linkType: hard
+
+"@libp2p/keychain@npm:^6.0.10":
+  version: 6.0.10
+  resolution: "@libp2p/keychain@npm:6.0.10"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@noble/hashes": "npm:^2.0.1"
+    asn1js: "npm:^3.0.6"
+    interface-datastore: "npm:^9.0.1"
+    multiformats: "npm:^13.4.0"
+    sanitize-filename: "npm:^1.6.3"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/caacc02e29de75d523314648c1a708acd278fb98757f9b879c910b53440471ddf1c0737c8100e0bcdfc52486557432122150f18ce7fea3f8c6c2e08fffe7671d
+  languageName: node
+  linkType: hard
+
+"@libp2p/logger@npm:^6.0.0, @libp2p/logger@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "@libp2p/logger@npm:6.2.2"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    interface-datastore: "npm:^9.0.1"
+    multiformats: "npm:^13.4.0"
+    weald: "npm:^1.1.0"
+  checksum: 10c0/bb78cd0afc82c3f6a66dbe3a77553dba88e6d1951e9003c473866317894e99c3a46bf50ac21aadd174d749f8c894badc65fcb1cf18c7e936f22c4e32fca2a7bc
+  languageName: node
+  linkType: hard
+
+"@libp2p/multistream-select@npm:^7.0.12":
+  version: 7.0.12
+  resolution: "@libp2p/multistream-select@npm:7.0.12"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/utils": "npm:^7.0.12"
+    it-length-prefixed: "npm:^10.0.1"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/87eac666a621cff31f30000902f55771b3e5b3b5baf965024e90ec44940e26ab4f3d12be41a606151f97deca2b428d3f5aca8af9d097a0d571801f568087ec7c
+  languageName: node
+  linkType: hard
+
+"@libp2p/peer-collections@npm:^7.0.12":
+  version: 7.0.12
+  resolution: "@libp2p/peer-collections@npm:7.0.12"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@libp2p/utils": "npm:^7.0.12"
+    multiformats: "npm:^13.4.0"
+  checksum: 10c0/2be277a5d858b4990f36cfa2054281488b70fd3d4cbe3e23cad866c4f8d312f69cf94f490d66b97b8c5165139029ad19e55483570fbb67a5fbde4a8bff330434
+  languageName: node
+  linkType: hard
+
+"@libp2p/peer-id@npm:^6.0.0, @libp2p/peer-id@npm:^6.0.4":
+  version: 6.0.4
+  resolution: "@libp2p/peer-id@npm:6.0.4"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    multiformats: "npm:^13.4.0"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/21b300349e8277baf85c0d1fa28ea63864498e0bd5676338aafb7955a554b6d7f273d29927b8685a2adc48436c2e6f53eb40571b9766eefde9d54bd157e03443
+  languageName: node
+  linkType: hard
+
+"@libp2p/peer-record@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "@libp2p/peer-record@npm:9.0.5"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    multiformats: "npm:^13.4.0"
+    protons-runtime: "npm:^5.6.0"
+    uint8-varint: "npm:^2.0.4"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/6cde12e0a8e6cd46ea7a91c444fe3cf315ea5426490b3058cff1547cfa8e917ab0300a7bd0f3b4abbbdd18714b36efd275d6198119ba6a0ba58029abb234bb15
+  languageName: node
+  linkType: hard
+
+"@libp2p/peer-store@npm:^12.0.12":
+  version: 12.0.12
+  resolution: "@libp2p/peer-store@npm:12.0.12"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/peer-collections": "npm:^7.0.12"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@libp2p/peer-record": "npm:^9.0.5"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    interface-datastore: "npm:^9.0.1"
+    it-all: "npm:^3.0.9"
+    main-event: "npm:^1.0.1"
+    mortice: "npm:^3.3.1"
+    multiformats: "npm:^13.4.0"
+    protons-runtime: "npm:^5.6.0"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/07561b8de830c259f2e5a389b46d22c5ccb329fc52fbb3956391c57d0d65c0193f03173cbb5271b5b17f81a8b7d20ed8fa66e807c2ddc574a6c604f079ccd4a9
+  languageName: node
+  linkType: hard
+
+"@libp2p/ping@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "@libp2p/ping@npm:3.0.12"
+  dependencies:
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    p-event: "npm:^7.0.0"
+    race-signal: "npm:^2.0.0"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/6a8844182391136b8f5bbbc3990937340d159e203c3ce9080d327d9cfef65b19f8b6fd83d2919bdb3057869bb8dbd5706a018b831d8e9b5dc80cfb8b96f60a40
+  languageName: node
+  linkType: hard
+
+"@libp2p/record@npm:^4.0.9":
+  version: 4.0.9
+  resolution: "@libp2p/record@npm:4.0.9"
+  dependencies:
+    protons-runtime: "npm:^5.6.0"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/7479cf8b7023c4769f1b12fba175f7e7225f14f3abace047079a12461ae7d5b274ff4712cc76efcdea79184f789b871f4440a56f2935390af84eff2cec09ea51
+  languageName: node
+  linkType: hard
+
+"@libp2p/tcp@npm:^11.0.12":
+  version: 11.0.12
+  resolution: "@libp2p/tcp@npm:11.0.12"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    "@types/sinon": "npm:^20.0.0"
+    main-event: "npm:^1.0.1"
+    p-event: "npm:^7.0.0"
+    progress-events: "npm:^1.0.1"
+    uint8arraylist: "npm:^2.4.8"
+  checksum: 10c0/27eedc788961b6e68d851dc570fcd789c5a8130289d3945572abe0a57aca6022332c83b38c5ad17ed6fd64d8a3d593b3195dca7ddf851191b7286fc22c6fc43f
+  languageName: node
+  linkType: hard
+
+"@libp2p/utils@npm:^7.0.0, @libp2p/utils@npm:^7.0.12":
+  version: 7.0.12
+  resolution: "@libp2p/utils@npm:7.0.12"
+  dependencies:
+    "@chainsafe/is-ip": "npm:^2.1.0"
+    "@chainsafe/netmask": "npm:^2.0.0"
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/logger": "npm:^6.2.2"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@sindresorhus/fnv1a": "npm:^3.1.0"
+    any-signal: "npm:^4.1.1"
+    cborg: "npm:^4.2.14"
+    delay: "npm:^7.0.0"
+    is-loopback-addr: "npm:^2.0.2"
+    it-length-prefixed: "npm:^10.0.1"
+    it-pipe: "npm:^3.0.1"
+    it-pushable: "npm:^3.2.3"
+    it-stream-types: "npm:^2.0.2"
+    main-event: "npm:^1.0.1"
+    netmask: "npm:^2.0.2"
+    p-defer: "npm:^4.0.1"
+    p-event: "npm:^7.0.0"
+    race-signal: "npm:^2.0.0"
+    uint8-varint: "npm:^2.0.4"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/e5f76a392746ee02229c8a9467d1ff36e16d75676c76bef6c928e2222e7ad4e2f11593aa476c2c45c0df48df5decdc96ac5088d1d073f0493dbf5b20710c41e1
+  languageName: node
+  linkType: hard
+
+"@libp2p/webrtc@npm:^6.0.13":
+  version: 6.0.13
+  resolution: "@libp2p/webrtc@npm:6.0.13"
+  dependencies:
+    "@chainsafe/is-ip": "npm:^2.1.0"
+    "@chainsafe/libp2p-noise": "npm:^17.0.0"
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@libp2p/keychain": "npm:^6.0.10"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    "@peculiar/webcrypto": "npm:^1.5.0"
+    "@peculiar/x509": "npm:^1.13.0"
+    detect-browser: "npm:^5.3.0"
+    get-port: "npm:^7.1.0"
+    interface-datastore: "npm:^9.0.1"
+    it-length-prefixed: "npm:^10.0.1"
+    it-protobuf-stream: "npm:^2.0.3"
+    it-pushable: "npm:^3.2.3"
+    it-stream-types: "npm:^2.0.2"
+    main-event: "npm:^1.0.1"
+    multiformats: "npm:^13.4.0"
+    node-datachannel: "npm:^0.29.0"
+    p-defer: "npm:^4.0.1"
+    p-event: "npm:^7.0.0"
+    p-timeout: "npm:^7.0.0"
+    p-wait-for: "npm:^6.0.0"
+    progress-events: "npm:^1.0.1"
+    protons-runtime: "npm:^5.6.0"
+    race-signal: "npm:^2.0.0"
+    react-native-webrtc: "npm:^124.0.6"
+    uint8-varint: "npm:^2.0.4"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/763d964b227aa46ac5ea3fac79e49b7259f5e39e14ffcdde78a0aff1e2ece0bb549aebd8952a852ba8eed9e58db77486d60a952d17c86a7eb9b77cf94f3293a0
+  languageName: node
+  linkType: hard
+
+"@libp2p/websockets@npm:^10.1.5":
+  version: 10.1.5
+  resolution: "@libp2p/websockets@npm:10.1.5"
+  dependencies:
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    "@multiformats/multiaddr-to-uri": "npm:^12.0.0"
+    main-event: "npm:^1.0.1"
+    p-event: "npm:^7.0.0"
+    progress-events: "npm:^1.0.1"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+    ws: "npm:^8.18.3"
+  checksum: 10c0/2f6fb7d27fc9428ecfc72ae7f0cd65f4e8a1ca518cad5757b1b6929ce9912a44d1622d10a02af25093e9893cf9b5ecc22bc6eb290c7b58af50bb30829d8e4bbc
+  languageName: node
+  linkType: hard
+
 "@manypkg/find-root@npm:^1.1.0":
   version: 1.1.0
   resolution: "@manypkg/find-root@npm:1.1.0"
@@ -1619,6 +2129,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@multiformats/dns@npm:^1.0.6":
+  version: 1.0.13
+  resolution: "@multiformats/dns@npm:1.0.13"
+  dependencies:
+    "@dnsquery/dns-packet": "npm:^6.1.1"
+    "@libp2p/interface": "npm:^3.1.0"
+    hashlru: "npm:^2.3.0"
+    p-queue: "npm:^9.0.0"
+    progress-events: "npm:^1.0.0"
+    uint8arrays: "npm:^5.0.2"
+  checksum: 10c0/fb849af8a8a6e8bc6c035514476d6677befea96595f6847bfffc0612ad3a19e3678ebd893e6a1f4f4e19f1e3a4e3e19576f98fcc5bc64da6eafe65b8c7e5eb9a
+  languageName: node
+  linkType: hard
+
+"@multiformats/multiaddr-matcher@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@multiformats/multiaddr-matcher@npm:3.0.1"
+  dependencies:
+    "@multiformats/multiaddr": "npm:^13.0.0"
+  checksum: 10c0/f1d18bbb61d0f424a3f4c565d5f3ca80fbed362ea9c834f0b273f3ff63cfbd3798fd3c13bc0e63e8561ee9e7452abc18ebcf7c8f34c343f17070ce4f6d7f6ea8
+  languageName: node
+  linkType: hard
+
+"@multiformats/multiaddr-to-uri@npm:^12.0.0":
+  version: 12.0.0
+  resolution: "@multiformats/multiaddr-to-uri@npm:12.0.0"
+  dependencies:
+    "@multiformats/multiaddr": "npm:^13.0.0"
+  checksum: 10c0/78ff27861e6a9de5619b2fefe22b959a935aed011800621f40749494ada24d492eeaaf26afeb894f7b5de3a3083053f53051f4284366724a81dedb9faedcc74b
+  languageName: node
+  linkType: hard
+
+"@multiformats/multiaddr@npm:^13.0.0, @multiformats/multiaddr@npm:^13.0.1":
+  version: 13.0.1
+  resolution: "@multiformats/multiaddr@npm:13.0.1"
+  dependencies:
+    "@chainsafe/is-ip": "npm:^2.0.1"
+    multiformats: "npm:^13.0.0"
+    uint8-varint: "npm:^2.0.1"
+    uint8arrays: "npm:^5.0.0"
+  checksum: 10c0/e5f360c6674cf96010fe7c6875e62c4bf35639e8a8a75e6fad9384a23f1abf35ca689b90446341ba47c242c83a9d529c25d2610bee46fe2ff68f44d19321c138
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:0.2.4":
   version: 0.2.4
   resolution: "@napi-rs/wasm-runtime@npm:0.2.4"
@@ -1627,6 +2181,13 @@ __metadata:
     "@emnapi/runtime": "npm:^1.1.0"
     "@tybys/wasm-util": "npm:^0.9.0"
   checksum: 10c0/1040de49b2ef509db207e2517465dbf7fb3474f20e8ec32897672a962ff4f59872385666dac61dc9dbeae3cae5dad265d8dc3865da756adeb07d1634c67b03a1
+  languageName: node
+  linkType: hard
+
+"@noble/ciphers@npm:^2.0.1":
+  version: 2.1.1
+  resolution: "@noble/ciphers@npm:2.1.1"
+  checksum: 10c0/f02662723475a9785a2f7bcd6e8e12d4b5f77537154f5e21edb0fed398051fb1ae5057eb444987e1c65342f8632474f0143ea612a2dad49593d3358eb730a079
   languageName: node
   linkType: hard
 
@@ -1639,10 +2200,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@noble/curves@npm:2.0.1"
+  dependencies:
+    "@noble/hashes": "npm:2.0.1"
+  checksum: 10c0/e0b329eb9229e862d3b7203e0444bd479e9ecf2d5990181908dad416aab69106717ca696fc7b12ad0eb19d710f58c454646b27ce517a4298ab9abc89a9bdb6ee
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1.8.0":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:2.0.1, @noble/hashes@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@noble/hashes@npm:2.0.1"
+  checksum: 10c0/e81769ce21c3b1c80141a3b99bd001f17edea09879aa936692ae39525477386d696101cd573928a304806efb2b9fa751e1dd83241c67d0c84d30091e85c79bdb
   languageName: node
   linkType: hard
 
@@ -2169,6 +2746,173 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@peculiar/asn1-cms@npm:^2.6.0, @peculiar/asn1-cms@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-cms@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.1"
+    "@peculiar/asn1-x509-attr": "npm:^2.6.1"
+    asn1js: "npm:^3.0.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/682e952fb35dec229bf54ecaff58bdf56281c1d718b5bcc2da103d67b5be302452c6275300c9f9fce1ed02f03792dab3ebe98c903117e0a5b0d9e5d861356280
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-csr@npm:^2.6.0":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-csr@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.1"
+    asn1js: "npm:^3.0.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/5ea1ef27bf3879c793acb0b370b9fc1cb45df244b4706cecf075e45b58d19d65e612f4777eb12aa37f2037c1c725e96543ab9caf41d5a92378c5069071deae1f
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-ecc@npm:^2.6.0":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-ecc@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.1"
+    asn1js: "npm:^3.0.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/7804600f12a8993085232839ea020f51a329a195ce991ebbce077668d9ee1e57301bf97d5ef9657bd81717888f36f51f7aed3a9eee59fe4345c55d04eff89927
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-pfx@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-pfx@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-cms": "npm:^2.6.1"
+    "@peculiar/asn1-pkcs8": "npm:^2.6.1"
+    "@peculiar/asn1-rsa": "npm:^2.6.1"
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    asn1js: "npm:^3.0.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/69c86ed339b945f7c77173da06207af71553a5b033cc1f2bde262085e7b5870543f358a29efd8981ca7247ec7f1c5d722a014cc0979679045909cb13e2ca527e
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-pkcs8@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-pkcs8@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.1"
+    asn1js: "npm:^3.0.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/d712dc79ab877152f20c1772cbe065f5beb2a20e3dcae7892cc72f3227a1d3f7ae8eecba8bc29cf2b77cfdd8a01b0660f5390a416ca78ca7147f0e3c13d4d755
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-pkcs9@npm:^2.6.0":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-pkcs9@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-cms": "npm:^2.6.1"
+    "@peculiar/asn1-pfx": "npm:^2.6.1"
+    "@peculiar/asn1-pkcs8": "npm:^2.6.1"
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.1"
+    "@peculiar/asn1-x509-attr": "npm:^2.6.1"
+    asn1js: "npm:^3.0.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/4a2f815bbeee3f65aea391d5e2287a19701d757d2781b3ecfd908a67028f2752796bd22f8ba3eb486911fcc34b52b0f7c1ff3e3b7d7f04ef58767be9ddbc851d
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-rsa@npm:^2.6.0, @peculiar/asn1-rsa@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-rsa@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.1"
+    asn1js: "npm:^3.0.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/4d7c71c5bddf7be3b0270c4d95b8274a392185cad4939a7a837d9c4c612601fee1a1ccabe414383b26629fb2013608e60a58ecd665c371617c1f177431a88ff2
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-schema@npm:^2.3.13, @peculiar/asn1-schema@npm:^2.3.8, @peculiar/asn1-schema@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "@peculiar/asn1-schema@npm:2.6.0"
+  dependencies:
+    asn1js: "npm:^3.0.6"
+    pvtsutils: "npm:^1.3.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/8c283b10a2e4aca4cb20d242cde773c9a798ea15a6c221d1474ef483e182d48195aeb5dde3f7b518f236eceb7808ae4438539d41a3aa9ed6d20aa4d36a21a0c2
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-x509-attr@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-x509-attr@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.1"
+    asn1js: "npm:^3.0.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/de8634ec12ef34b430e5a458151e856f954e15fe9e08d056dca51db6962e849a951820ab66d291e2452799576c44221b40087b9350dc3728d3770a46fcdeffc5
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-x509@npm:^2.6.0, @peculiar/asn1-x509@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "@peculiar/asn1-x509@npm:2.6.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    asn1js: "npm:^3.0.6"
+    pvtsutils: "npm:^1.3.6"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/2e73a0ce6521eeb2d876e0b52e9fae2de4e2d183be5fba77d5fae9b7724de446d02c0b4e5fb04d4fedb50eed0de842f29f4d7cf2e998eaed6a2d2952f5c52d2c
+  languageName: node
+  linkType: hard
+
+"@peculiar/json-schema@npm:^1.1.12":
+  version: 1.1.12
+  resolution: "@peculiar/json-schema@npm:1.1.12"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  checksum: 10c0/202132c66dcc6b6aca5d0af971c015be2e163da2f7f992910783c5d39c8a7db59b6ec4f4ce419459a1f954b7e1d17b6b253f0e60072c1b3d254079f4eaebc311
+  languageName: node
+  linkType: hard
+
+"@peculiar/webcrypto@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@peculiar/webcrypto@npm:1.5.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.3.8"
+    "@peculiar/json-schema": "npm:^1.1.12"
+    pvtsutils: "npm:^1.3.5"
+    tslib: "npm:^2.6.2"
+    webcrypto-core: "npm:^1.8.0"
+  checksum: 10c0/4f6f24b2c52c2155b9c569b6eb1d57954cb5f7bd2764a50cdaed7aea17a6dcf304b75b87b57ba318756ffec8179a07d9a76534aaf77855912b838543e5ff8983
+  languageName: node
+  linkType: hard
+
+"@peculiar/x509@npm:^1.13.0":
+  version: 1.14.3
+  resolution: "@peculiar/x509@npm:1.14.3"
+  dependencies:
+    "@peculiar/asn1-cms": "npm:^2.6.0"
+    "@peculiar/asn1-csr": "npm:^2.6.0"
+    "@peculiar/asn1-ecc": "npm:^2.6.0"
+    "@peculiar/asn1-pkcs9": "npm:^2.6.0"
+    "@peculiar/asn1-rsa": "npm:^2.6.0"
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.0"
+    pvtsutils: "npm:^1.3.6"
+    reflect-metadata: "npm:^0.2.2"
+    tslib: "npm:^2.8.1"
+    tsyringe: "npm:^4.10.0"
+  checksum: 10c0/949231ca9daf84534bfe255f28a856df497302fed294d227c6a28e50f5cfb67ed1d91afe6db787b88294ce042295243dbcb44455fe2efa5ed07428a74392eec9
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -2501,6 +3245,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sindresorhus/fnv1a@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@sindresorhus/fnv1a@npm:3.1.0"
+  checksum: 10c0/75b31084b4d886eb774266c546ecd06744758d26e1b89c9a2ee11d5f8f84541c1e1befa4b37d8548fd78c03a617dcfe92730a65178510369a73ecf4cda4c341b
+  languageName: node
+  linkType: hard
+
 "@sindresorhus/merge-streams@npm:^2.1.0":
   version: 2.3.0
   resolution: "@sindresorhus/merge-streams@npm:2.3.0"
@@ -2668,6 +3419,22 @@ __metadata:
   dependencies:
     rollup: "npm:*"
   checksum: 10c0/a7311e2178136e0e3b9105c8687c95d6c825bc7d5966b95c5bcc5db2aa173b61292ea31dbd062948a808182a5b2dd91f296d357c972c68437b146b7b1ba2cdb4
+  languageName: node
+  linkType: hard
+
+"@types/sinon@npm:^20.0.0":
+  version: 20.0.0
+  resolution: "@types/sinon@npm:20.0.0"
+  dependencies:
+    "@types/sinonjs__fake-timers": "npm:*"
+  checksum: 10c0/0a3d9761be5bf2f7bf79fb91da2f4462726ec27ed8bc14adb50a9ce68efbcdb71436447ae923e5df297c3023c7c39447b63c98be49b4954e0ed3fd01e8917de2
+  languageName: node
+  linkType: hard
+
+"@types/sinonjs__fake-timers@npm:*":
+  version: 15.0.1
+  resolution: "@types/sinonjs__fake-timers@npm:15.0.1"
+  checksum: 10c0/be8daa4e19746f4c249ce4926b83676bb2e5500a8c33b61d81cd303495b56697c28c910f7c57c0ecfd1d7c8ead87449570586d9568b0b5c6fd94c45f116197f4
   languageName: node
   linkType: hard
 
@@ -2907,6 +3674,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abort-error@npm:^1.0.0, abort-error@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "abort-error@npm:1.0.1"
+  checksum: 10c0/7b071226ca13408b26e994d1b1f6700ac17305a6c5d4588c0b5ded254211424c7eff356c2c3d936ade4d5b72c537270484c653b40cdf6bc4cfc176633befe359
+  languageName: node
+  linkType: hard
+
 "accepts@npm:~1.3.4":
   version: 1.3.8
   resolution: "accepts@npm:1.3.8"
@@ -3069,6 +3843,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
+  languageName: node
+  linkType: hard
+
+"any-signal@npm:^4.1.1":
+  version: 4.2.0
+  resolution: "any-signal@npm:4.2.0"
+  checksum: 10c0/765b8fd5270320bb1fd612cc9890cecb58ab044adc6d20e5ed35a2fc0d63fc09ec50abf513a2b75ef5fb9a81666dcdf60eb2b28f281d09859c06f8d10c9d3b34
   languageName: node
   linkType: hard
 
@@ -3255,6 +4036,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asn1js@npm:^3.0.5, asn1js@npm:^3.0.6":
+  version: 3.0.7
+  resolution: "asn1js@npm:3.0.7"
+  dependencies:
+    pvtsutils: "npm:^1.3.6"
+    pvutils: "npm:^1.1.3"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/7e79795edf1bcc86532c4084aa7c8c0ebc57f7dd6f964ad6de956abf617329722f6964b7af3a5d1c4554dd61b4b148ae1580e63e3ec2e70e7fba34f6df072b29
+  languageName: node
+  linkType: hard
+
 "ast-types@npm:0.12.4":
   version: 0.12.4
   resolution: "ast-types@npm:0.12.4"
@@ -3402,7 +4194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:1.5.1, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
@@ -3715,6 +4507,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cborg@npm:^4.2.14":
+  version: 4.5.8
+  resolution: "cborg@npm:4.5.8"
+  bin:
+    cborg: lib/bin.js
+  checksum: 10c0/9703fc3201aeb9814c6f27358f079f63bd2361bb946aae4fc82db3ea389418516251a2ea85a728839af887ff43fd67f9900353aae6daa0c0d8b1bc6f20addeb4
+  languageName: node
+  linkType: hard
+
 "chalk@npm:4.1.0":
   version: 4.1.0
   resolution: "chalk@npm:4.1.0"
@@ -3796,7 +4597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chownr@npm:^1.1.4":
+"chownr@npm:^1.1.1, chownr@npm:^1.1.4":
   version: 1.1.4
   resolution: "chownr@npm:1.1.4"
   checksum: 10c0/ed57952a84cc0c802af900cf7136de643d3aba2eecb59d29344bc2f3f9bf703a301b9d84cdc71f82c3ffc9ccde831b0d92f5b45f91727d6c9da62f23aef9d9db
@@ -4459,6 +5260,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"datastore-core@npm:^11.0.1":
+  version: 11.0.2
+  resolution: "datastore-core@npm:11.0.2"
+  dependencies:
+    "@libp2p/logger": "npm:^6.0.0"
+    interface-datastore: "npm:^9.0.0"
+    interface-store: "npm:^7.0.0"
+    it-drain: "npm:^3.0.9"
+    it-filter: "npm:^3.1.3"
+    it-map: "npm:^3.1.3"
+    it-merge: "npm:^3.0.11"
+    it-pipe: "npm:^3.0.1"
+    it-sort: "npm:^3.0.8"
+    it-take: "npm:^3.0.8"
+  checksum: 10c0/d3a6db7fa86cd8f5d14df1cb64b4e822f3fd89dce185b9c0e22fdc231cdd5ff897465ca5ccc32aef2635cb49f7e66dc6a5bce195ab85109228f6c4f75eff7e00
+  languageName: node
+  linkType: hard
+
 "date-time@npm:^3.1.0":
   version: 3.1.0
   resolution: "date-time@npm:3.1.0"
@@ -4484,6 +5303,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/d2b44bc1afd912b49bb7ebb0d50a860dc93a4dd7d946e8de94abc957bb63726b7dd5aa48c18c2386c379ec024c46692e15ed3ed97d481729f929201e671fcd55
+  languageName: node
+  linkType: hard
+
+"debug@npm:4.3.4":
+  version: 4.3.4
+  resolution: "debug@npm:4.3.4"
+  dependencies:
+    ms: "npm:2.1.2"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/cedbec45298dd5c501d01b92b119cd3faebe5438c3917ff11ae1bff86a6c722930ac9c8659792824013168ba6db7c4668225d845c633fbdafbbf902a6389f736
   languageName: node
   linkType: hard
 
@@ -4538,6 +5369,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decompress-response@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "decompress-response@npm:6.0.0"
+  dependencies:
+    mimic-response: "npm:^3.1.0"
+  checksum: 10c0/bd89d23141b96d80577e70c54fb226b2f40e74a6817652b80a116d7befb8758261ad073a8895648a29cc0a5947021ab66705cb542fa9c143c82022b27c5b175e
+  languageName: node
+  linkType: hard
+
 "dedent@npm:1.5.3":
   version: 1.5.3
   resolution: "dedent@npm:1.5.3"
@@ -4547,6 +5387,13 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 10c0/d94bde6e6f780be4da4fd760288fcf755ec368872f4ac5218197200d86430aeb8d90a003a840bff1c20221188e3f23adced0119cb811c6873c70d0ac66d12832
+  languageName: node
+  linkType: hard
+
+"deep-extend@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "deep-extend@npm:0.6.0"
+  checksum: 10c0/1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
   languageName: node
   linkType: hard
 
@@ -4631,6 +5478,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"delay@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "delay@npm:7.0.0"
+  dependencies:
+    random-int: "npm:^3.1.0"
+    unlimited-timeout: "npm:^0.1.0"
+  checksum: 10c0/714811a891e76ad402355899d264867034231492b4606a5a4c137dca6015c766370d9fe082bfaa2c8fc992b1072ec9e32522f9ac1e98121995f303b86a4d9a02
+  languageName: node
+  linkType: hard
+
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
@@ -4642,6 +5499,13 @@ __metadata:
   version: 2.3.1
   resolution: "deprecation@npm:2.3.1"
   checksum: 10c0/23d688ba66b74d09b908c40a76179418acbeeb0bfdf218c8075c58ad8d0c315130cb91aa3dffb623aa3a411a3569ce56c6460de6c8d69071c17fe6dd2442f032
+  languageName: node
+  linkType: hard
+
+"detect-browser@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "detect-browser@npm:5.3.0"
+  checksum: 10c0/88d49b70ce3836e7971345b2ebdd486ad0d457d1e4f066540d0c12f9210c8f731ccbed955fcc9af2f048f5d4629702a8e46bedf5bcad42ad49a3a0927bfd5a76
   languageName: node
   linkType: hard
 
@@ -5442,10 +6306,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-target-shim@npm:6.0.2":
+  version: 6.0.2
+  resolution: "event-target-shim@npm:6.0.2"
+  checksum: 10c0/e40b89effb1bd0fdd44dd198e3b61669c2bff89b680a8156c50480b5df8d4364208d1db09fbe823211005651558415691cb3ff72c22618eb154e55282b8b0481
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "eventemitter3@npm:5.0.4"
+  checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
   languageName: node
   linkType: hard
 
@@ -5534,6 +6412,13 @@ __metadata:
     strip-final-newline: "npm:^4.0.0"
     yoctocolors: "npm:^2.1.1"
   checksum: 10c0/2c44a33142f77d3a6a590a3b769b49b27029a76768593bac1f26fed4dd1330e9c189ee61eba6a8c990fb77e37286c68c7445472ebf24c22b31e9ff320e73d7ac
+  languageName: node
+  linkType: hard
+
+"expand-template@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "expand-template@npm:2.0.3"
+  checksum: 10c0/1c9e7afe9acadf9d373301d27f6a47b34e89b3391b1ef38b7471d381812537ef2457e620ae7f819d2642ce9c43b189b3583813ec395e2938319abe356a9b2f51
   languageName: node
   linkType: hard
 
@@ -6006,6 +6891,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-port@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "get-port@npm:7.1.0"
+  checksum: 10c0/896051fea0fd3df58c050566754ab91f46406e898ce0c708414739d908a5ac03ffef3eca7a494ea9cc1914439e8caccd2218010d1eeabdde914b9ff920fa28fc
+  languageName: node
+  linkType: hard
+
 "get-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "get-proto@npm:1.0.1"
@@ -6120,6 +7012,13 @@ __metadata:
   dependencies:
     ini: "npm:^1.3.2"
   checksum: 10c0/cfcb16344834113199f209f2758ced778dc30e075ddb49b5dde659b4dd2deadee824db0a1b77e1303cb594d9e8b2240da18c67705f657aa76affb444aa349005
+  languageName: node
+  linkType: hard
+
+"github-from-package@npm:0.0.0":
+  version: 0.0.0
+  resolution: "github-from-package@npm:0.0.0"
+  checksum: 10c0/737ee3f52d0a27e26332cde85b533c21fcdc0b09fb716c3f8e522cfaa9c600d4a631dec9fcde179ec9d47cca89017b7848ed4d6ae6b6b78f936c06825b1fcc12
   languageName: node
   linkType: hard
 
@@ -6364,6 +7263,13 @@ __metadata:
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: 10c0/ebdb2f4895c26bb08a8a100b62d362e49b2190bcfd84b76bc4be1a3bd4d254ec52d0dd9f2fbcc093fc5eb878b20c52146f9dfd33e2686ed28982187be593b47c
+  languageName: node
+  linkType: hard
+
+"hashlru@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "hashlru@npm:2.3.0"
+  checksum: 10c0/90f351db1a320c43aeb681c7e806f35af6877a86d3fa9b970636ea21f111d0f0b819e046dc9b5fe6a8ab211a3d98178eb37aacbad29ea4f6f53554a4541a6f0d
   languageName: node
   linkType: hard
 
@@ -6633,7 +7539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.0, ini@npm:^1.3.2, ini@npm:^1.3.8":
+"ini@npm:^1.3.0, ini@npm:^1.3.2, ini@npm:^1.3.8, ini@npm:~1.3.0":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
@@ -6703,6 +7609,23 @@ __metadata:
     through: "npm:^2.3.6"
     wrap-ansi: "npm:^7.0.0"
   checksum: 10c0/e3e64e10f5daeeb8f770f1310acceb4aab593c10d693e7676ecd4a5b023d5b865b484fec7ead516e5e394db70eff687ef85459f75890f11a99ceadc0f4adce18
+  languageName: node
+  linkType: hard
+
+"interface-datastore@npm:^9.0.0, interface-datastore@npm:^9.0.1":
+  version: 9.0.2
+  resolution: "interface-datastore@npm:9.0.2"
+  dependencies:
+    interface-store: "npm:^7.0.0"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/dbddf752de35ba97696190c63db4920a130db7bf41ba8fb1930c00c58cd9e6b0266e5b17535cb54e6242c432ca67c56d198b7890af1660cd2b71d986759b48d0
+  languageName: node
+  linkType: hard
+
+"interface-store@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "interface-store@npm:7.0.1"
+  checksum: 10c0/91a509ea1e495812f759f48a3cae4e15ad11d6751b2d8eba61814d88414c65e370c370803937b1481198812a3cdd8e1417a950b6275fa9ed93cd8649b92021e3
   languageName: node
   linkType: hard
 
@@ -6862,6 +7785,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-electron@npm:^2.2.0":
+  version: 2.2.2
+  resolution: "is-electron@npm:2.2.2"
+  checksum: 10c0/327bb373f7be01b16cdff3998b5ddaa87d28f576092affaa7fe0659571b3306fdd458afbf0683a66841e7999af13f46ad0e1b51647b469526cd05a4dd736438a
+  languageName: node
+  linkType: hard
+
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -6951,6 +7881,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-loopback-addr@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-loopback-addr@npm:2.0.2"
+  checksum: 10c0/574ce2f8f9c9f4543295a6e1979c4f9dcc96e353c48e8bcd4f1089b05a88ad9e87e3e6131c977fcd1dab0a775d8bf9e456284dda119317b9b901cd7d6a995494
+  languageName: node
+  linkType: hard
+
 "is-map@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
@@ -6969,6 +7906,13 @@ __metadata:
   version: 2.0.3
   resolution: "is-negative-zero@npm:2.0.3"
   checksum: 10c0/bcdcf6b8b9714063ffcfa9929c575ac69bfdabb8f4574ff557dfc086df2836cf07e3906f5bbc4f2a5c12f8f3ba56af640c843cdfc74da8caed86c7c7d66fd08e
+  languageName: node
+  linkType: hard
+
+"is-network-error@npm:^1.1.0":
+  version: 1.3.1
+  resolution: "is-network-error@npm:1.3.1"
+  checksum: 10c0/389b4a4cc6838bc5764c1d4ab8af11ec68c63825d53f7ce9f5a31aa4d2c9e5d33896c052f4c44100911e8db47bcf854c4aae6c03d6b1d84700f7c6aa72d16693
   languageName: node
   linkType: hard
 
@@ -7299,6 +8243,198 @@ __metadata:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
   checksum: 10c0/3a147171bffdbd3034856410b6ec81637871d17d10986513328fec23df6b666f66bd08ea480f5b7a5b9f7e8abc30f3e3c2e7d1b661fc57cdc479aaaa677b1011
+  languageName: node
+  linkType: hard
+
+"it-all@npm:^3.0.0, it-all@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "it-all@npm:3.0.9"
+  checksum: 10c0/811bd0889b3b293ef921c700b58dd82e1281c21d15655f2c00c910a461c1b16c68e9ac84e856cb7b03df790a6819c941fbd91c25f77910a3bb1652eb40ff48ef
+  languageName: node
+  linkType: hard
+
+"it-byte-stream@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "it-byte-stream@npm:2.0.4"
+  dependencies:
+    abort-error: "npm:^1.0.1"
+    it-queueless-pushable: "npm:^2.0.0"
+    it-stream-types: "npm:^2.0.2"
+    race-signal: "npm:^2.0.0"
+    uint8arraylist: "npm:^2.4.8"
+  checksum: 10c0/d1a64737b82b8a85eaf02219ef79c78c8a8a303dfcea39f49f07ef56b1c652c086b248895bb306c2e1e2b90ab19397524e141330d5d1750439d68973c4fdd2a3
+  languageName: node
+  linkType: hard
+
+"it-drain@npm:^3.0.10, it-drain@npm:^3.0.9":
+  version: 3.0.10
+  resolution: "it-drain@npm:3.0.10"
+  checksum: 10c0/ec0535ee95be34bbf5f0e3a0f55b0e11e6178130e633e66d75264648a1b35726d49685533508e587be5f0868a03ee07ed8a6c56e4d3ca8cbed9686b98781fce1
+  languageName: node
+  linkType: hard
+
+"it-filter@npm:^3.1.3":
+  version: 3.1.4
+  resolution: "it-filter@npm:3.1.4"
+  dependencies:
+    it-peekable: "npm:^3.0.0"
+  checksum: 10c0/aed568df69e91052531ea813cd49f6bccf286bee74c788a6d836c3da63e06ba76b595c7b72200e878f45c91070b6520a3e0b54ffc5de43a339cb562e04c9198c
+  languageName: node
+  linkType: hard
+
+"it-length-prefixed-stream@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "it-length-prefixed-stream@npm:2.0.4"
+  dependencies:
+    abort-error: "npm:^1.0.1"
+    it-byte-stream: "npm:^2.0.0"
+    it-stream-types: "npm:^2.0.2"
+    uint8-varint: "npm:^2.0.4"
+    uint8arraylist: "npm:^2.4.8"
+  checksum: 10c0/8098a63029865f1969b25c28d6f7b0ba3ebe38f3c89fe856ba8969e8e1aeb41f3d0851bd183ed74383b72bf72d9968fc74e4b419a031364b349a9455079b3c4c
+  languageName: node
+  linkType: hard
+
+"it-length-prefixed@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "it-length-prefixed@npm:10.0.1"
+  dependencies:
+    it-reader: "npm:^6.0.1"
+    it-stream-types: "npm:^2.0.1"
+    uint8-varint: "npm:^2.0.1"
+    uint8arraylist: "npm:^2.0.0"
+    uint8arrays: "npm:^5.0.1"
+  checksum: 10c0/9b32946eee33296f77718423a183ad09654d3dfc9b1a06efe91bd650c83285dd7201268ad40dc1040cd25f5a0c5e28349c1a5ca121ca3fc9dd52ab4e272a0711
+  languageName: node
+  linkType: hard
+
+"it-length@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "it-length@npm:3.0.9"
+  checksum: 10c0/6dd7e9a064befdbe3e8dc229335fdb5b27f37af08fbb97bfbcac0a2e75d667aef27c72cd40fa0dcbbc0675aededc533d354cf046d4f402b5d80697d4b18d3df4
+  languageName: node
+  linkType: hard
+
+"it-map@npm:^3.1.3, it-map@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "it-map@npm:3.1.4"
+  dependencies:
+    it-peekable: "npm:^3.0.0"
+  checksum: 10c0/05b35de0a0a531f4756f55977f89e17bd44fd5d19dc2223cd03860f8a07736b001a80e9cb7a2ed2826dabf6afb0244661da1fa51f18c3efe36718e5d099d026a
+  languageName: node
+  linkType: hard
+
+"it-merge@npm:^3.0.0, it-merge@npm:^3.0.11, it-merge@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "it-merge@npm:3.0.12"
+  dependencies:
+    it-queueless-pushable: "npm:^2.0.0"
+  checksum: 10c0/358fc9f4e8b982012443306cc8cbdf971fa1d333b17659ed0b7b933f04e9f701a27155eb9cd51f60bc0d91cd13ad8f63409f060d675698bece83c7cdfde8d4e1
+  languageName: node
+  linkType: hard
+
+"it-parallel@npm:^3.0.13":
+  version: 3.0.13
+  resolution: "it-parallel@npm:3.0.13"
+  dependencies:
+    p-defer: "npm:^4.0.1"
+  checksum: 10c0/acfba9f9e18d67815a655d937c0449447bd438a113c614b8d11afe0b5d11eb280a496379c6837621d17c785262c9dcd48c2947f4757ca1770ccb3263c8cd116b
+  languageName: node
+  linkType: hard
+
+"it-peekable@npm:^3.0.0":
+  version: 3.0.8
+  resolution: "it-peekable@npm:3.0.8"
+  checksum: 10c0/f7690d0dd90cfe83f2121d2a7880f0da050094df48d8fa4b61d73d327ee1e7caaea3ebdf6a46895c0504b8183ec90b9847b54aa09abba647bfa8b70cf276a3e2
+  languageName: node
+  linkType: hard
+
+"it-pipe@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "it-pipe@npm:3.0.1"
+  dependencies:
+    it-merge: "npm:^3.0.0"
+    it-pushable: "npm:^3.1.2"
+    it-stream-types: "npm:^2.0.1"
+  checksum: 10c0/342b7dec98fb3a7247f576091cbf3c3b121eb32ceb0480ca39b5a757f56658aba852d35d78a59472ce3d6502af1b6b43a19b2311134f67800404d74da7cf4e43
+  languageName: node
+  linkType: hard
+
+"it-protobuf-stream@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "it-protobuf-stream@npm:2.0.3"
+  dependencies:
+    abort-error: "npm:^1.0.1"
+    it-length-prefixed-stream: "npm:^2.0.0"
+    it-stream-types: "npm:^2.0.2"
+    uint8arraylist: "npm:^2.4.8"
+  checksum: 10c0/7f7e24e133ee893ab98cd5e67ab8b5d93273281abff3a8336a586fc4c59a47b0603f84680f35eaad236a8e5a816a2b8e22dc0c9dc4aebed8c9fcffdd302d3413
+  languageName: node
+  linkType: hard
+
+"it-pushable@npm:^3.1.2, it-pushable@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "it-pushable@npm:3.2.3"
+  dependencies:
+    p-defer: "npm:^4.0.0"
+  checksum: 10c0/ba99744f0a6fe9e555bdde76ce2144a3e35c37a33830c69d65f5512129fb5a58272f1bbb4b9741fca69be868c301109fc910b26629c8eb0961f0503dd80a4830
+  languageName: node
+  linkType: hard
+
+"it-queue@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "it-queue@npm:1.1.1"
+  dependencies:
+    abort-error: "npm:^1.0.1"
+    it-pushable: "npm:^3.2.3"
+    main-event: "npm:^1.0.0"
+    race-event: "npm:^1.3.0"
+    race-signal: "npm:^2.0.0"
+  checksum: 10c0/b8aea7e6c98a0b2ad96a4b3bc45aa8ba608dc1df213a639a893b1e9382021657041e9e01242980e21c673805c83d8b677a1c8b397699213007f2210f50b8b400
+  languageName: node
+  linkType: hard
+
+"it-queueless-pushable@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "it-queueless-pushable@npm:2.0.3"
+  dependencies:
+    abort-error: "npm:^1.0.1"
+    p-defer: "npm:^4.0.1"
+    race-signal: "npm:^2.0.0"
+  checksum: 10c0/e41907a5c8838419f46f255c08c3b770c4c62e965d5f9fd57405e63931a63e400bc9b118a257dce5639b71a0b6586e40a40987d214304af2c128ba7e50979a85
+  languageName: node
+  linkType: hard
+
+"it-reader@npm:^6.0.1":
+  version: 6.0.4
+  resolution: "it-reader@npm:6.0.4"
+  dependencies:
+    it-stream-types: "npm:^2.0.1"
+    uint8arraylist: "npm:^2.0.0"
+  checksum: 10c0/7c87be7df0d573fa2fc3bd29ec7b5c34e3ec722bb65d7f19a25c52f3bfd2e0170073850f2ebde2c8b48156c4fd9cc684583f63ca601c6dad53c31859f6b1c275
+  languageName: node
+  linkType: hard
+
+"it-sort@npm:^3.0.8":
+  version: 3.0.9
+  resolution: "it-sort@npm:3.0.9"
+  dependencies:
+    it-all: "npm:^3.0.0"
+  checksum: 10c0/fdc184d14115b9d2c19ee0ae2685b92b9fb6dfcf01e601e4f70d3c77b64189821b3dd2e547319e9263cff79682d027ccc713229b04c9eae81e365f05c1d6cab6
+  languageName: node
+  linkType: hard
+
+"it-stream-types@npm:^2.0.1, it-stream-types@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "it-stream-types@npm:2.0.2"
+  checksum: 10c0/da2a035234b3a914c12cfbfc38cbae201c8464b917db1e6dadd88aaa87d4ca6c52c35827b9c3405fe0c55862bdc63d5cefca33a219394d0b4c2f22987e838807
+  languageName: node
+  linkType: hard
+
+"it-take@npm:^3.0.8, it-take@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "it-take@npm:3.0.9"
+  checksum: 10c0/39812440e0831ac75aaf3373d9d48fd2769b4e80c69270616998a59f4b49e9caeb245251f3bad908161c0cdc324d05866586a6996c8e260709b9ad2c9098cc94
   languageName: node
   linkType: hard
 
@@ -7704,6 +8840,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"libp2p@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "libp2p@npm:3.1.5"
+  dependencies:
+    "@chainsafe/is-ip": "npm:^2.1.0"
+    "@chainsafe/netmask": "npm:^2.0.0"
+    "@libp2p/crypto": "npm:^5.1.13"
+    "@libp2p/interface": "npm:^3.1.0"
+    "@libp2p/interface-internal": "npm:^3.0.12"
+    "@libp2p/logger": "npm:^6.2.2"
+    "@libp2p/multistream-select": "npm:^7.0.12"
+    "@libp2p/peer-collections": "npm:^7.0.12"
+    "@libp2p/peer-id": "npm:^6.0.4"
+    "@libp2p/peer-store": "npm:^12.0.12"
+    "@libp2p/utils": "npm:^7.0.12"
+    "@multiformats/dns": "npm:^1.0.6"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    any-signal: "npm:^4.1.1"
+    datastore-core: "npm:^11.0.1"
+    interface-datastore: "npm:^9.0.1"
+    it-merge: "npm:^3.0.12"
+    it-parallel: "npm:^3.0.13"
+    main-event: "npm:^1.0.1"
+    multiformats: "npm:^13.4.0"
+    p-defer: "npm:^4.0.1"
+    p-event: "npm:^7.0.0"
+    p-retry: "npm:^7.0.0"
+    progress-events: "npm:^1.0.1"
+    race-signal: "npm:^2.0.0"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/8d77769bb0d9bb8000fc239f8348b3704c627a4dc689326cc55cf2e1eb5be580aacf22a894ea05d18ec10b24e86815f5f2dec485106b3254e000473065b68bc4
+  languageName: node
+  linkType: hard
+
 "lie@npm:~3.3.0":
   version: 3.3.0
   resolution: "lie@npm:3.3.0"
@@ -7888,6 +9059,13 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
   checksum: 10c0/16826e415d04b88378f200fe022b53e638e3838b9e496edda6c0e086d7753a44a6ed187adc72d19f3623810589bf139af1a315541cd6a26ae0771a0193eaf7b8
+  languageName: node
+  linkType: hard
+
+"main-event@npm:^1.0.0, main-event@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "main-event@npm:1.0.1"
+  checksum: 10c0/c71f0d2974bdb3204141b39af90236235143f8734d2c9b5415c0f6ed4f08099e83c1d9d827581654d3add3e0137d0b4d338ca5c2e14d07b71a61f3164716d98b
   languageName: node
   linkType: hard
 
@@ -8110,6 +9288,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-response@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "mimic-response@npm:3.1.0"
+  checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
+  languageName: node
+  linkType: hard
+
 "min-indent@npm:^1.0.0":
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
@@ -8191,7 +9376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:1, minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
+"minimist@npm:1, minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -8298,6 +9483,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "mkdirp-classic@npm:0.5.3"
+  checksum: 10c0/95371d831d196960ddc3833cc6907e6b8f67ac5501a6582f47dfae5eb0f092e9f8ce88e0d83afcae95d6e2b61a01741ba03714eeafb6f7a6e9dcc158ac85b168
+  languageName: node
+  linkType: hard
+
 "mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.5":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
@@ -8365,6 +9557,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mortice@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "mortice@npm:3.3.1"
+  dependencies:
+    abort-error: "npm:^1.0.0"
+    it-queue: "npm:^1.1.0"
+    main-event: "npm:^1.0.0"
+  checksum: 10c0/1a10dab1874a84c6a3d8eebbda8df8063deed3dad6f3680686a8af46d38c5f6f55b8a73f0a4f858be89bf2fcb7c4a2915bd8747a43a616cf1690d9467e6bcb75
+  languageName: node
+  linkType: hard
+
 "mri@npm:^1.2.0":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
@@ -8379,10 +9582,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ms@npm:2.1.2":
+  version: 2.1.2
+  resolution: "ms@npm:2.1.2"
+  checksum: 10c0/a437714e2f90dbf881b5191d35a6db792efbca5badf112f87b9e1c712aace4b4b9b742dd6537f3edf90fd6f684de897cec230abde57e87883766712ddda297cc
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"ms@npm:^3.0.0-canary.1":
+  version: 3.0.0-canary.202508261828
+  resolution: "ms@npm:3.0.0-canary.202508261828"
+  checksum: 10c0/d4921b3e2c46daa0a4119efcf7cfd6b0d75ab1d572314bc026c2403aa3e4a7f1e35f0db06979eaa2700f80494469e72587b25b7083d1d9386af30c4130fc1a2d
+  languageName: node
+  linkType: hard
+
+"multiformats@npm:^13.0.0, multiformats@npm:^13.4.0":
+  version: 13.4.2
+  resolution: "multiformats@npm:13.4.2"
+  checksum: 10c0/b7be09b8bf8198d601c8f8c9a358b9a6aca5a14d61239a84f88d8266322e4e7c3015fe7bdf88b589b9993a4abb752defabb932719d1b457a53277e264c4cee11
   languageName: node
   linkType: hard
 
@@ -8410,6 +9634,22 @@ __metadata:
   version: 1.0.0
   resolution: "mute-stream@npm:1.0.0"
   checksum: 10c0/dce2a9ccda171ec979a3b4f869a102b1343dee35e920146776780de182f16eae459644d187e38d59a3d37adf85685e1c17c38cf7bfda7e39a9880f7a1d10a74c
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^5.1.5":
+  version: 5.1.6
+  resolution: "nanoid@npm:5.1.6"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: 10c0/27b5b055ad8332cf4f0f9f6e2a494aa7e5ded89df4cab8c8490d4eabefe72c4423971d2745d22002868b1d50576a5e42b7b05214733b19f576382323282dd26e
+  languageName: node
+  linkType: hard
+
+"napi-build-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "napi-build-utils@npm:2.0.0"
+  checksum: 10c0/5833aaeb5cc5c173da47a102efa4680a95842c13e0d9cc70428bd3ee8d96bb2172f8860d2811799b5daa5cbeda779933601492a2028a6a5351c6d0fcf6de83db
   languageName: node
   linkType: hard
 
@@ -8443,6 +9683,32 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
+  languageName: node
+  linkType: hard
+
+"netmask@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "netmask@npm:2.0.2"
+  checksum: 10c0/cafd28388e698e1138ace947929f842944d0f1c0b87d3fa2601a61b38dc89397d33c0ce2c8e7b99e968584b91d15f6810b91bef3f3826adf71b1833b61d4bf4f
+  languageName: node
+  linkType: hard
+
+"node-abi@npm:^3.3.0":
+  version: 3.87.0
+  resolution: "node-abi@npm:3.87.0"
+  dependencies:
+    semver: "npm:^7.3.5"
+  checksum: 10c0/41cfc361edd1b0711d412ca9e1a475180c5b897868bd5583df7ff73e30e6044cc7de307df36c2257203320f17fadf7e82dfdf5a9f6fd510a8578e3fe3ed67ebb
+  languageName: node
+  linkType: hard
+
+"node-datachannel@npm:^0.29.0":
+  version: 0.29.0
+  resolution: "node-datachannel@npm:0.29.0"
+  dependencies:
+    node-gyp: "npm:latest"
+    prebuild-install: "npm:^7.1.3"
+  checksum: 10c0/e877ae55bbff1efe24b206ce65f309eb105084626069980dcadf56da4e0dc9e92a7fb208808895375b12cb263b035e4ea6d9738fe5b99d778cfbec1d5039dd4d
   languageName: node
   linkType: hard
 
@@ -9053,6 +10319,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-defer@npm:^4.0.0, p-defer@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "p-defer@npm:4.0.1"
+  checksum: 10c0/592f5bd32f8c6a57f892b00976e5272b3bbbd792b503f4cf3bc22094d08d7a973413c59c15deccff4759d860b38467a08b5b3363e865da6f00f44a031777118c
+  languageName: node
+  linkType: hard
+
+"p-event@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "p-event@npm:7.1.0"
+  dependencies:
+    p-timeout: "npm:^7.0.1"
+  checksum: 10c0/933d8ff228522e330a48b5d69baa4725ca2af54b8a07ba1ade220d851aa4384eba96cbdd19c7974310baa0167bd2f26e3067f4673ca7131ec97089118409109d
+  languageName: node
+  linkType: hard
+
 "p-filter@npm:^2.1.0":
   version: 2.1.0
   resolution: "p-filter@npm:2.1.0"
@@ -9179,10 +10461,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-queue@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "p-queue@npm:9.1.0"
+  dependencies:
+    eventemitter3: "npm:^5.0.1"
+    p-timeout: "npm:^7.0.0"
+  checksum: 10c0/f6bb4644997c20cbbf68c0c88208283697c6c9b1e1879f2073791b1ffcb2d2eb0a9fe35c9631e0c74bd6562ef159b87b418d48df7e7b30e5ddb4d99055bb5c92
+  languageName: node
+  linkType: hard
+
 "p-reduce@npm:2.1.0, p-reduce@npm:^2.0.0, p-reduce@npm:^2.1.0":
   version: 2.1.0
   resolution: "p-reduce@npm:2.1.0"
   checksum: 10c0/27b8ff0fb044995507a06cd6357dffba0f2b98862864745972562a21885d7906ce5c794036d2aaa63ef6303158e41e19aed9f19651dfdafb38548ecec7d0de15
+  languageName: node
+  linkType: hard
+
+"p-retry@npm:^7.0.0":
+  version: 7.1.1
+  resolution: "p-retry@npm:7.1.1"
+  dependencies:
+    is-network-error: "npm:^1.1.0"
+  checksum: 10c0/d72fb15dace25b8bf72c97a13c8a630ad1deb4667e708955e8806ee38f1d70e9611598ebe57bd9677349256e024a5599292f99aabb203143e0e13f1735e30818
   languageName: node
   linkType: hard
 
@@ -9192,6 +10493,13 @@ __metadata:
   dependencies:
     p-finally: "npm:^1.0.0"
   checksum: 10c0/524b393711a6ba8e1d48137c5924749f29c93d70b671e6db761afa784726572ca06149c715632da8f70c090073afb2af1c05730303f915604fd38ee207b70a61
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^7.0.0, p-timeout@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "p-timeout@npm:7.0.1"
+  checksum: 10c0/87d96529d1096d506607218dba6f9ec077c6dbedd0c2e2788c748e33bcd05faae8a81009fd9d22ec0b3c95fc83f4717306baba223f6e464737d8b99294c3e863
   languageName: node
   linkType: hard
 
@@ -9206,6 +10514,13 @@ __metadata:
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: 10c0/c36c19907734c904b16994e6535b02c36c2224d433e01a2f1ab777237f4d86e6289fd5fd464850491e940379d4606ed850c03e0f9ab600b0ebddb511312e177f
+  languageName: node
+  linkType: hard
+
+"p-wait-for@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "p-wait-for@npm:6.0.0"
+  checksum: 10c0/c3bb3c16e3bea6ee9764d8b62570ee6bfadc7b1b408bbdcdd1e6b9a7431d3596bd6463a179af85ad87bdaf1e6f1a385fb78fc865e92357023a8fc5fa57533d78
   languageName: node
   linkType: hard
 
@@ -9551,6 +10866,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prebuild-install@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "prebuild-install@npm:7.1.3"
+  dependencies:
+    detect-libc: "npm:^2.0.0"
+    expand-template: "npm:^2.0.3"
+    github-from-package: "npm:0.0.0"
+    minimist: "npm:^1.2.3"
+    mkdirp-classic: "npm:^0.5.3"
+    napi-build-utils: "npm:^2.0.0"
+    node-abi: "npm:^3.3.0"
+    pump: "npm:^3.0.0"
+    rc: "npm:^1.2.7"
+    simple-get: "npm:^4.0.0"
+    tar-fs: "npm:^2.0.0"
+    tunnel-agent: "npm:^0.6.0"
+  bin:
+    prebuild-install: bin.js
+  checksum: 10c0/25919a42b52734606a4036ab492d37cfe8b601273d8dfb1fa3c84e141a0a475e7bad3ab848c741d2f810cef892fcf6059b8c7fe5b29f98d30e0c29ad009bedff
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -9631,6 +10968,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"progress-events@npm:^1.0.0, progress-events@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "progress-events@npm:1.0.1"
+  checksum: 10c0/27d998de678ca91ea8fdfba4c39c1e393144e658663fcdab344aacc4a3c7d420d2007eaba9e981c1b0894d4b1df05facfc90f5844e1c6518dcf95330fd09473d
+  languageName: node
+  linkType: hard
+
 "promise-all-reject-late@npm:^1.0.0":
   version: 1.0.1
   resolution: "promise-all-reject-late@npm:1.0.1"
@@ -9678,6 +11022,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protons-runtime@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "protons-runtime@npm:5.6.0"
+  dependencies:
+    uint8-varint: "npm:^2.0.2"
+    uint8arraylist: "npm:^2.4.3"
+    uint8arrays: "npm:^5.0.1"
+  checksum: 10c0/f6961e0ce30d7018b6bf35183384fdf540e58db4b3051342d616bb6a5ffefec0aaca168c5356ce6cf0d6b92cb736149c30f42a7558a76cbb8da9a5ba90827892
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
@@ -9716,6 +11071,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pvtsutils@npm:^1.3.5, pvtsutils@npm:^1.3.6":
+  version: 1.3.6
+  resolution: "pvtsutils@npm:1.3.6"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/b1b42646370505ccae536dcffa662303b2c553995211330c8e39dec9ab8c197585d7751c2c5b9ab2f186feda0219d9bb23c34ee1e565573be96450f79d89a13c
+  languageName: node
+  linkType: hard
+
+"pvutils@npm:^1.1.3":
+  version: 1.1.5
+  resolution: "pvutils@npm:1.1.5"
+  checksum: 10c0/e968b07b78a58fec9377fe7aa6342c8cfa21c8fb4afc4e51e1489bd42bec6dc71b8a52541d0aede0aea17adec7ca3f89f29f56efdc31d0083cc02e9bb5721bcf
+  languageName: node
+  linkType: hard
+
 "q@npm:^1.5.1":
   version: 1.5.1
   resolution: "q@npm:1.5.1"
@@ -9744,6 +11115,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"race-event@npm:^1.3.0":
+  version: 1.6.1
+  resolution: "race-event@npm:1.6.1"
+  dependencies:
+    abort-error: "npm:^1.0.1"
+  checksum: 10c0/06521bdbfd41a1e847688959e662aa44fc16af4fb5a3dda724b31e5e796bd537273e2baf4c6275e40798e52ef4a3d4dd6cfe97ab479e75a942c982e233638a9a
+  languageName: node
+  linkType: hard
+
+"race-signal@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "race-signal@npm:2.0.0"
+  checksum: 10c0/120a4d7562ee238cd5e2bfb732ae1ca8d3657910287a28cb0bb77c19f6fbf7080d289eb4ef12842dca17045815aa7185f6b8d1481eb30f8c867d4434e2d2a531
+  languageName: node
+  linkType: hard
+
+"random-int@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "random-int@npm:3.1.0"
+  checksum: 10c0/c8a8cd324bc6aeefdf4f6e1f88cf373da1acf63c3ee3992b1d4b267e13425a3d2aced531c7bb684a53670d139b4a710f7ac5cb3bf8d47b91e73bc777c3c86129
+  languageName: node
+  linkType: hard
+
 "randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
@@ -9753,10 +11147,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rc@npm:^1.2.7":
+  version: 1.2.8
+  resolution: "rc@npm:1.2.8"
+  dependencies:
+    deep-extend: "npm:^0.6.0"
+    ini: "npm:~1.3.0"
+    minimist: "npm:^1.2.0"
+    strip-json-comments: "npm:~2.0.1"
+  bin:
+    rc: ./cli.js
+  checksum: 10c0/24a07653150f0d9ac7168e52943cc3cb4b7a22c0e43c7dff3219977c2fdca5a2760a304a029c20811a0e79d351f57d46c9bde216193a0f73978496afc2b85b15
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.0.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: 10c0/6eb5e4b28028c23e2bfcf73371e72cd4162e4ac7ab445ddae2afe24e347a37d6dc22fae6e1748632cd43c6d4f9b8f86dcf26bf9275e1874f436d129952528ae0
+  languageName: node
+  linkType: hard
+
+"react-native-webrtc@npm:^124.0.6":
+  version: 124.0.7
+  resolution: "react-native-webrtc@npm:124.0.7"
+  dependencies:
+    base64-js: "npm:1.5.1"
+    debug: "npm:4.3.4"
+    event-target-shim: "npm:6.0.2"
+  peerDependencies:
+    react-native: ">=0.60.0"
+  checksum: 10c0/8947299ec2d86d0baa44dbab76169cd4fe204de20cf27187f9181fd7bcf6a742313aba7b8352c05afb0eba24edfa74eac6b0f9ef75b088380e945b7abb49c40a
   languageName: node
   linkType: hard
 
@@ -9899,6 +11320,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reflect-metadata@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "reflect-metadata@npm:0.2.2"
+  checksum: 10c0/1cd93a15ea291e420204955544637c264c216e7aac527470e393d54b4bb075f10a17e60d8168ec96600c7e0b9fcc0cb0bb6e91c3fbf5b0d8c9056f04e6ac1ec2
+  languageName: node
+  linkType: hard
+
 "reflect.getprototypeof@npm:^1.0.6, reflect.getprototypeof@npm:^1.0.9":
   version: 1.0.9
   resolution: "reflect.getprototypeof@npm:1.0.9"
@@ -10020,6 +11448,13 @@ __metadata:
     onetime: "npm:^5.1.0"
     signal-exit: "npm:^3.0.2"
   checksum: 10c0/8051a371d6aa67ff21625fa94e2357bd81ffdc96267f3fb0fc4aaf4534028343836548ef34c240ffa8c25b280ca35eb36be00b3cb2133fa4f51896d7e73c6b4f
+  languageName: node
+  linkType: hard
+
+"retimeable-signal@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "retimeable-signal@npm:1.0.1"
+  checksum: 10c0/65662c5453f7a53c7b2ea9b7b52b7831d9dbba83dd0e74db68eefd28376fd15c218b45ee27bdf4dec097488feb6a0ed5a09014e6287104682691a690d03c4bb7
   languageName: node
   linkType: hard
 
@@ -10242,7 +11677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.1.0":
+"safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
@@ -10281,6 +11716,15 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
+  languageName: node
+  linkType: hard
+
+"sanitize-filename@npm:^1.6.3":
+  version: 1.6.3
+  resolution: "sanitize-filename@npm:1.6.3"
+  dependencies:
+    truncate-utf8-bytes: "npm:^1.0.0"
+  checksum: 10c0/16ff47556a6e54e228c28db096bedd303da67b030d4bea4925fd71324932d6b02c7b0446f00ad33987b25b6414f24ae968e01a1a1679ce599542e82c4b07eb1f
   languageName: node
   linkType: hard
 
@@ -10535,6 +11979,24 @@ __metadata:
     "@sigstore/tuf": "npm:^2.3.4"
     "@sigstore/verify": "npm:^1.2.1"
   checksum: 10c0/8906b1074130d430d707e46f15c66eb6996891dc0d068705f1884fb1251a4a367f437267d44102cdebcee34f1768b3f30131a2ec8fb7aac74ba250903a459aa7
+  languageName: node
+  linkType: hard
+
+"simple-concat@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "simple-concat@npm:1.0.1"
+  checksum: 10c0/62f7508e674414008910b5397c1811941d457dfa0db4fd5aa7fa0409eb02c3609608dfcd7508cace75b3a0bf67a2a77990711e32cd213d2c76f4fd12ee86d776
+  languageName: node
+  linkType: hard
+
+"simple-get@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "simple-get@npm:4.0.1"
+  dependencies:
+    decompress-response: "npm:^6.0.0"
+    once: "npm:^1.3.1"
+    simple-concat: "npm:^1.0.0"
+  checksum: 10c0/b0649a581dbca741babb960423248899203165769747142033479a7dc5e77d7b0fced0253c731cd57cf21e31e4d77c9157c3069f4448d558ebc96cf9e1eebcf0
   languageName: node
   linkType: hard
 
@@ -11009,6 +12471,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-json-comments@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "strip-json-comments@npm:2.0.1"
+  checksum: 10c0/b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
+  languageName: node
+  linkType: hard
+
 "supertap@npm:^3.0.1":
   version: 3.0.1
   resolution: "supertap@npm:3.0.1"
@@ -11018,6 +12487,13 @@ __metadata:
     serialize-error: "npm:^7.0.1"
     strip-ansi: "npm:^7.0.1"
   checksum: 10c0/8164674f2e280cab875f0fef5bb36c15553c13e29697ff92f4e0d6bc62149f0303a89eee47535413ed145ea72e14a24d065bab233059d48a499ec5ebb4566b0f
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^10.0.0":
+  version: 10.2.2
+  resolution: "supports-color@npm:10.2.2"
+  checksum: 10c0/fb28dd7e0cdf80afb3f2a41df5e068d60c8b4f97f7140de2eaed5b42e075d82a0e980b20a2c0efd2b6d73cfacb55555285d8cc719fa0472220715aefeaa1da7c
   languageName: node
   linkType: hard
 
@@ -11075,7 +12551,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:~2.2.0":
+"tar-fs@npm:^2.0.0":
+  version: 2.1.4
+  resolution: "tar-fs@npm:2.1.4"
+  dependencies:
+    chownr: "npm:^1.1.1"
+    mkdirp-classic: "npm:^0.5.2"
+    pump: "npm:^3.0.0"
+    tar-stream: "npm:^2.1.4"
+  checksum: 10c0/decb25acdc6839182c06ec83cba6136205bda1db984e120c8ffd0d80182bc5baa1d916f9b6c5c663ea3f9975b4dd49e3c6bb7b1707cbcdaba4e76042f43ec84c
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^2.1.4, tar-stream@npm:~2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
   dependencies:
@@ -11320,6 +12808,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"truncate-utf8-bytes@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "truncate-utf8-bytes@npm:1.0.2"
+  dependencies:
+    utf8-byte-length: "npm:^1.0.1"
+  checksum: 10c0/af2b431fc4314f119b551e5fccfad49d4c0ef82e13ba9ca61be6567801195b08e732ce9643542e8ad1b3df44f3df2d7345b3dd34f723954b6bb43a14584d6b3c
+  languageName: node
+  linkType: hard
+
 "ts-api-utils@npm:^2.1.0":
   version: 2.1.0
   resolution: "ts-api-utils@npm:2.1.0"
@@ -11402,10 +12899,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1, tslib@npm:^1.9.0":
+"tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10c0/69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.0.0, tslib@npm:^2.7.0, tslib@npm:^2.8.1":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 
@@ -11420,6 +12924,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsyringe@npm:^4.10.0":
+  version: 4.10.0
+  resolution: "tsyringe@npm:4.10.0"
+  dependencies:
+    tslib: "npm:^1.9.3"
+  checksum: 10c0/918594b4dfac97beb8be2c041c6ec45f078ef3768ed4edfe35ae2c709ab503e2e6b454b2b37e692c658572d1972a428fbfdbc0a2b42fee727a83c1c685fbe5e1
+  languageName: node
+  linkType: hard
+
 "tuf-js@npm:^2.2.1":
   version: 2.2.1
   resolution: "tuf-js@npm:2.2.1"
@@ -11428,6 +12941,15 @@ __metadata:
     debug: "npm:^4.3.4"
     make-fetch-happen: "npm:^13.0.1"
   checksum: 10c0/7c17b097571f001730d7be0aeaec6bec46ed2f25bf73990b1133c383d511a1ce65f831e5d6d78770940a85b67664576ff0e4c98e5421bab6d33ff36e4be500c8
+  languageName: node
+  linkType: hard
+
+"tunnel-agent@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "tunnel-agent@npm:0.6.0"
+  dependencies:
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/4c7a1b813e7beae66fdbf567a65ec6d46313643753d0beefb3c7973d66fcec3a1e7f39759f0a0b4465883499c6dc8b0750ab8b287399af2e583823e40410a17a
   languageName: node
   linkType: hard
 
@@ -11690,6 +13212,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uint8-varint@npm:^2.0.1, uint8-varint@npm:^2.0.2, uint8-varint@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "uint8-varint@npm:2.0.4"
+  dependencies:
+    uint8arraylist: "npm:^2.0.0"
+    uint8arrays: "npm:^5.0.0"
+  checksum: 10c0/850bce72c2b639d317db6af2c30544f7f8c6451fa328d674aca74d7e263a9510acd3af555ed04ffbc20b9ff68fd5d2e06b91a5c9ffde781cf6ee6233606f34dc
+  languageName: node
+  linkType: hard
+
+"uint8arraylist@npm:^2.0.0, uint8arraylist@npm:^2.4.3, uint8arraylist@npm:^2.4.8":
+  version: 2.4.8
+  resolution: "uint8arraylist@npm:2.4.8"
+  dependencies:
+    uint8arrays: "npm:^5.0.1"
+  checksum: 10c0/a997289ad66d4ffff24d85524b70af9fb6914ef1657400907a792afbff4c4600e7dde7ab3de83da8309c7b22c093c93bc8a95b3d288eeac4c935133bfb925bac
+  languageName: node
+  linkType: hard
+
+"uint8arrays@npm:^5.0.0, uint8arrays@npm:^5.0.1, uint8arrays@npm:^5.0.2, uint8arrays@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "uint8arrays@npm:5.1.0"
+  dependencies:
+    multiformats: "npm:^13.0.0"
+  checksum: 10c0/e7587f97d03a17a608becd01b3ca52aa6db43e7ee6156c18b278c715a62f4f9e62ef2fe9432a3cd02791b6222a17578476a20b8e3ea37dd3b5ce454c6a8782a9
+  languageName: node
+  linkType: hard
+
 "unbox-primitive@npm:^1.1.0":
   version: 1.1.0
   resolution: "unbox-primitive@npm:1.1.0"
@@ -11766,6 +13316,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unlimited-timeout@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "unlimited-timeout@npm:0.1.0"
+  checksum: 10c0/07b61f3ab7771254f3b742edde177b7d22439ac193025d6fa36d7f4b2064809886f37a9bcef4859d302d1bf3a18e17ca07d16032dc463e959e70cde18f288eb8
+  languageName: node
+  linkType: hard
+
 "untildify@npm:^4.0.0":
   version: 4.0.0
   resolution: "untildify@npm:4.0.0"
@@ -11786,6 +13343,20 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"utf8-byte-length@npm:^1.0.1":
+  version: 1.0.5
+  resolution: "utf8-byte-length@npm:1.0.5"
+  checksum: 10c0/e69bda3299608f4cc75976da9fb74ac94801a58b9ca29fdad03a20ec952e7477d7f226c12716b5f36bd4cff8151d1d152d02ee1df3752f017d4b2c725ce3e47a
+  languageName: node
+  linkType: hard
+
+"utf8-codec@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "utf8-codec@npm:1.0.0"
+  checksum: 10c0/14261909eb757e7c3d896748cc0de4c25a76588edeaaa9072dd1ccabeefbc449ffb62244fbc3f428f9cf1f8104f2021e1d63f50841ec203efe9ac1451e8aae17
   languageName: node
   linkType: hard
 
@@ -11856,6 +13427,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"weald@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "weald@npm:1.1.1"
+  dependencies:
+    ms: "npm:^3.0.0-canary.1"
+    supports-color: "npm:^10.0.0"
+  checksum: 10c0/9186b5d4b2315763b9d71dcfb27318227a25426c6788c2d488a18fae1e2e5d11176bbc0750662056908d8467d4ff680ee78c3fdfd5ecf67dba0a9257b72d2a1b
+  languageName: node
+  linkType: hard
+
+"webcrypto-core@npm:^1.8.0":
+  version: 1.8.1
+  resolution: "webcrypto-core@npm:1.8.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.3.13"
+    "@peculiar/json-schema": "npm:^1.1.12"
+    asn1js: "npm:^3.0.5"
+    pvtsutils: "npm:^1.3.5"
+    tslib: "npm:^2.7.0"
+  checksum: 10c0/b85a986b4f73e8505ec5eaafe8e4f1ff02574a3b655793aca91f913d02822c8b79168ad6961eaab86ae00fec00bf780ec4cef7535f64879fb866649bc2a723fa
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^3.0.0":
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
@@ -11877,6 +13471,15 @@ __metadata:
     tr46: "npm:~0.0.3"
     webidl-conversions: "npm:^3.0.0"
   checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
+  languageName: node
+  linkType: hard
+
+"wherearewe@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "wherearewe@npm:2.0.1"
+  dependencies:
+    is-electron: "npm:^2.2.0"
+  checksum: 10c0/a6193319688972890597342108b083fe35505ad0501a9c6c56926b6897f478f66d76436951005e24637265df717f81bc70ea511bd684972be5a966310581b872
   languageName: node
   linkType: hard
 
@@ -12142,6 +13745,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.19.0
+  resolution: "ws@npm:8.19.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/4741d9b9bc3f9c791880882414f96e36b8b254e34d4b503279d6400d9a4b87a033834856dbdd94ee4b637944df17ea8afc4bce0ff4a1560d2166be8855da5b04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR introduces a new `libp2p-webrtc` network plugin to enable cross-internet connectivity for Endo daemons, addressing the previous limitation where only local or LAN connections were supported. It integrates WebRTC, WebSocket, TCP, and Circuit Relay v2 transports, along with DCUtR (hole punching), AutoNAT, and Kad-DHT for NAT traversal and peer discovery.

Additionally, this PR adds comprehensive debug logging across the entire Endo daemon's connection lifecycle, including `libp2p-net`, `endo-peer`, `endo-peers`, `endo-networks`, `endo-greeter`, `endo-invitation`, `endo-host`, `remote-control`, and `tcp-net` components. This logging is crucial for diagnosing connectivity issues and understanding the flow of peer discovery and connection attempts.

The most critical files to review are:
*   `packages/daemon/src/networks/libp2p-webrtc.js`: The new libp2p network plugin implementation.
*   `packages/daemon/src/daemon.js`, `packages/daemon/src/host.js`, `packages/daemon/src/remote-control.js`, `packages/daemon/src/networks/tcp-netstring.js`: Files with added debug logging.

### Security Considerations

This change introduces new network dependencies (`libp2p` and its sub-modules) and exposes the Endo daemon to the public internet via WebRTC, WebSockets, and TCP. While libp2p handles many security aspects (e.g., noise protocol for encryption), it's important to ensure that the integration properly isolates and validates incoming connections. The new network plugin adheres to the existing `EndoNetwork` interface, maintaining the current trust boundaries for CapTP messages. New authorities are introduced by the ability to connect to arbitrary libp2p peers.

### Scaling Considerations

The `libp2p` stack, especially Kad-DHT, can consume more CPU, RAM, and network bandwidth compared to simple TCP. DHT operations involve message exchanges for peer discovery and record storage. WebRTC connections can also be resource-intensive. The current implementation uses default libp2p configurations; future tuning might be necessary if resource consumption becomes an issue with a large number of peers.

### Documentation Considerations

Downstream users will need documentation on:
*   How to enable and configure the `libp2p-webrtc` network plugin (e.g., via `makeUnconfined` and `move` into `NETS`).
*   How to interpret the new debug logs for diagnosing connectivity issues.
*   Instructions for setting up bootstrap peers or relay servers if custom configurations are desired.
*   Explanation of the different network addresses (multiaddrs) and their implications for connectivity.

This change is additive; existing data or deployments using only the loopback or TCP-netstring networks will continue to function as before. There is no upgrade path for existing saved data, as the new network is a new capability.

### Testing Considerations

All existing unit and integration tests pass with these changes.
Additional tests are needed for:
*   **Cross-internet connectivity**: End-to-end tests demonstrating two daemons connecting over the internet using the `libp2p-webrtc` plugin, including scenarios with NAT traversal.
*   **Relay functionality**: Tests to ensure connections can be established via circuit relays when direct connections are not possible.
*   **DHT peer discovery**: Tests verifying that peers can discover each other through the DHT.
*   **Performance and stability**: Long-running tests under various network conditions.

### Compatibility Considerations

This change is fully backward-compatible. The new `libp2p-webrtc` network plugin is an additive feature and does not alter the behavior of existing network plugins (loopback, tcp-netstring). Existing usage patterns remain unchanged, but new patterns for internet-based peer-to-peer communication are now enabled.

### Upgrade Considerations

No breaking changes are introduced. To leverage the new cross-internet connectivity, live production systems will need to:
1.  Update their `Endo` daemon to include this PR's changes.
2.  Explicitly enable the `libp2p-webrtc` network plugin in their daemon configuration.
3.  Optionally configure `libp2p` bootstrap peers or relay servers if default public ones are not suitable.

---
<p><a href="https://cursor.com/agents/bc-86d7d892-adc7-48e2-b940-4379c109fa2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86d7d892-adc7-48e2-b940-4379c109fa2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->