### PR TITLE
fix(compartment-mapper): remove unused type from ModuleSourceHookModuleSource

### DIFF
--- a/.changeset/whole-schools-rescue.md
+++ b/.changeset/whole-schools-rescue.md
@@ -1,0 +1,5 @@
+---
+'@endo/compartment-mapper': patch
+---
+
+Remove unused "error" `ModuleSourceHookModuleSource` type.

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -41,7 +41,8 @@
  *   CompartmentModuleConfiguration,
  *   LogOptions,
  *   CanonicalName,
- *   LocalModuleSource
+ *   LocalModuleSource,
+ *   ModuleSourceHook,
  * } from './types.js'
  */
 
@@ -262,7 +263,7 @@ const nominateCandidates = (moduleSpecifier, searchSuffixes) => {
  *
  * Preprocesses the fields for the hook.
  *
- * @param {import('./types.js').ModuleSourceHook | undefined} moduleSourceHook Hook function
+ * @param {ModuleSourceHook | undefined} moduleSourceHook Hook function
  * @param {LocalModuleSource} moduleSource Original `LocalModuleSource` object
  * @param {CanonicalName} canonicalName Canonical name of the compartment/package
  * @param {LogOptions} options Options

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -98,17 +98,30 @@ export type PackageDependenciesHook = (params: {
  * The `moduleSource` property value for {@link ModuleSourceHook}
  */
 export type ModuleSourceHookModuleSource =
-  | {
-      location: FileUrlString;
-      language: Language;
-      bytes: Uint8Array;
-      imports?: string[] | undefined;
-      exports?: string[] | undefined;
-      reexports?: string[] | undefined;
-      sha512?: string | undefined;
-    }
-  | { error: string }
-  | { exit: string };
+  | ModuleSourceHookFileModuleSource
+  | ModuleSourceHookExitModuleSource;
+
+/**
+ * The `moduleSource` property value for {@link ModuleSourceHook} for a module
+ * on disk
+ */
+export type ModuleSourceHookFileModuleSource = {
+  location: FileUrlString;
+  language: Language;
+  bytes: Uint8Array;
+  imports?: string[] | undefined;
+  exports?: string[] | undefined;
+  reexports?: string[] | undefined;
+  sha512?: string | undefined;
+};
+
+/**
+ * The `moduleSource` property value for {@link ModuleSourceHook} for an exit
+ * module (virtual)
+ */
+export type ModuleSourceHookExitModuleSource = {
+  exit: string;
+};
 
 /**
  * Hook executed when processing a module source.

--- a/packages/compartment-mapper/test/fixtures-module-source-hook/README.md
+++ b/packages/compartment-mapper/test/fixtures-module-source-hook/README.md
@@ -1,0 +1,18 @@
+# fixtures-module-source-hook
+
+Fixtures for testing the behavior of `moduleSourceHook` when called against various project configurations.
+
+## `app-implicit` — Implicit (Transitive) Dependency
+
+Tests what happens when a package imports a dependency it does _not_ directly declare in its own `package.json`—a transitive dependency that's only reachable through an intermediary.
+
+```mermaid
+graph TD
+    app-implicit -- "declares dependency" --> dependency-a
+    dependency-a -- "declares dependency" --> dependency-b
+    app-implicit -. "imports (implicit)" .-> dependency-b
+```
+
+`app-implicit` declares `dependency-a` as a direct dependency, and `dependency-a` in turn declares `dependency-b`. However, `app-implicit`'s `index.js` imports from `dependency-b` directly—a package it does not list in its own `dependencies`. In a flat `node_modules` layout (as used by these fixtures), `dependency-b` is resolvable despite not being a direct dependency.
+
+The expectation is that `dependency-b` is loaded as an exit module from `app-implicit`.

--- a/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/app-implicit/index.js
+++ b/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/app-implicit/index.js
@@ -1,0 +1,1 @@
+export { value } from 'dependency-b';

--- a/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/app-implicit/package.json
+++ b/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/app-implicit/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app-implicit",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "dependency-a": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/dependency-a/index.js
+++ b/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/dependency-a/index.js
@@ -1,0 +1,2 @@
+export const value = 'dependency-a';
+export default value;

--- a/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/dependency-a/package.json
+++ b/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/dependency-a/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dependency-a",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "dependency-b": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/dependency-b/index.js
+++ b/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/dependency-b/index.js
@@ -1,0 +1,2 @@
+export const value = 'dependency-b';
+export default value;

--- a/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/dependency-b/package.json
+++ b/packages/compartment-mapper/test/fixtures-module-source-hook/node_modules/dependency-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dependency-b",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/make-import-hook-maker.test.js
+++ b/packages/compartment-mapper/test/make-import-hook-maker.test.js
@@ -1,12 +1,16 @@
 /* eslint-disable no-shadow */
 import './ses-lockdown.js';
 import test from 'ava';
+import fs from 'node:fs';
+import url from 'node:url';
 import { mapNodeModules } from '../src/node-modules.js';
 import { makeProjectFixtureReadPowers } from './project-fixture.js';
 import { defaultParserForLanguage } from '../src/import-parsers.js';
 import { captureFromMap } from '../capture-lite.js';
 import { loadFromMap } from '../import-lite.js';
 import { loadLocation } from '../import.js';
+import { makeReadPowers } from '../src/node-powers.js';
+import { ENTRY_COMPARTMENT } from '../src/policy-format.js';
 
 /**
  * @import {
@@ -153,4 +157,69 @@ test(
     callImport: true,
   },
 );
+
+test('captureFromMap - moduleSourceHook - receives correct parameters w/ implicit dependency', async t => {
+  t.plan(5);
+  const readPowers = makeReadPowers({ fs, url });
+  const moduleLocation = new URL(
+    'fixtures-module-source-hook/node_modules/app-implicit/index.js',
+    import.meta.url,
+  ).href;
+
+  /**
+   * Track hook call arguments for verification
+   * @type {Array<{moduleSource: object, canonicalName: string}>}
+   */
+  const hookCallArgs = [];
+
+  /** @type {ModuleSourceHook} */
+  const moduleSourceHook = ({ moduleSource, canonicalName }) => {
+    hookCallArgs.push({ moduleSource, canonicalName });
+  };
+
+  const compartmentMap = await mapNodeModules(readPowers, moduleLocation);
+  t.falsy(
+    compartmentMap.compartments[compartmentMap.entry.compartment].modules[
+      'dependency-a>dependency-b'
+    ],
+    'app-implicit should not have a module reference to dependency-b',
+  );
+  t.truthy(
+    Object.values(compartmentMap.compartments).find(
+      compartment => compartment.label === 'dependency-a>dependency-b',
+    ),
+    'dependency-b should be in the compartment map',
+  );
+
+  await captureFromMap(readPowers, compartmentMap, {
+    moduleSourceHook,
+    parserForLanguage: defaultParserForLanguage,
+    importHook: async (_moduleSpecifier, _compartmentName) => {
+      return {
+        imports: [],
+        exports: [],
+        execute() {},
+      };
+    },
+  });
+
+  t.is(
+    hookCallArgs.length,
+    2,
+    'moduleSource hook should have been called twice',
+  );
+  t.like(
+    hookCallArgs[0],
+    { canonicalName: ENTRY_COMPARTMENT },
+    'entry compartment should be the first hook call',
+  );
+  t.deepEqual(
+    hookCallArgs[1],
+    {
+      canonicalName: ENTRY_COMPARTMENT,
+      moduleSource: { exit: 'dependency-b' },
+    },
+    'dependency-b should be the second hook call',
+  );
+});
 // #endregion


### PR DESCRIPTION
- Removes unused `ModuleSourceHook`'s "error" module source type.
- Adds tests for specific behavior around exit modules
- Fix a JSDoc import