### PR TITLE
Gateway remote access configuration

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -21,3 +21,56 @@ Set the `ENDO_ADDR` environment variable before running `endo start` to control 
 ```sh
 ENDO_ADDR=127.0.0.1:9000 endo start
 ```
+
+### Remote access
+
+By default the gateway only accepts WebSocket connections from localhost
+(`127.0.0.1`, `::1`, `::ffff:127.0.0.1`).  Connections from any other
+client IP are closed with `"Only local connections allowed"`.
+
+To accept connections from non-localhost clients (for example, over a VPN or
+LAN), you must both **bind to a reachable interface** via `ENDO_ADDR` and
+**opt in** with one of the two environment variables below.
+
+#### Allow all remote connections
+
+Set `ENDO_GATEWAY_ALLOW_REMOTE=1` to disable the client-IP check entirely.
+Every address that can reach the gateway port will be allowed through.
+
+```sh
+ENDO_ADDR=0.0.0.0:8920 ENDO_GATEWAY_ALLOW_REMOTE=1 endo start
+```
+
+#### Allow specific IP ranges (CIDR allowlist)
+
+Set `ENDO_GATEWAY_ALLOWED_CIDRS` to a comma-separated list of CIDRs.
+Localhost is always allowed in addition to the listed ranges.
+
+```sh
+ENDO_ADDR=0.0.0.0:8920 \
+  ENDO_GATEWAY_ALLOWED_CIDRS="10.0.0.0/8,100.64.0.0/10" \
+  endo start
+```
+
+Both IPv4 and IPv6 CIDRs are supported.  A bare address without a `/prefix`
+is treated as a host route (`/32` for IPv4, `/128` for IPv6).  Invalid
+entries are silently ignored.
+
+IPv4-mapped IPv6 addresses (`::ffff:10.1.2.3`) are normalized before
+matching, so an IPv4 CIDR like `10.0.0.0/8` will match connections that
+arrive as `::ffff:10.x.x.x`.
+
+#### Common CIDR examples
+
+| Range | Description |
+|---|---|
+| `10.0.0.0/8` | RFC 1918 private (Class A) |
+| `172.16.0.0/12` | RFC 1918 private (Class B) |
+| `192.168.0.0/16` | RFC 1918 private (Class C) |
+| `100.64.0.0/10` | CGNAT / Tailscale |
+| `fd00::/8` | IPv6 unique local addresses |
+
+> **Security note:** These options control which client IPs may establish a
+> WebSocket connection to the gateway.  They do not add authentication or
+> encryption.  Use a VPN or other transport-layer protection when exposing
+> the gateway beyond localhost.

--- a/packages/daemon/src/cidr.js
+++ b/packages/daemon/src/cidr.js
@@ -1,0 +1,217 @@
+// @ts-check
+
+/** @import { AddressChecker, ParsedCIDR } from './types.js' */
+
+const localhostAddresses = harden(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+/**
+ * Strip the IPv4-mapped IPv6 prefix so `::ffff:10.1.2.3` becomes `10.1.2.3`.
+ *
+ * @param {string} addr
+ * @returns {string}
+ */
+const normalizeAddress = addr => {
+  const v4Prefix = '::ffff:';
+  if (addr.startsWith(v4Prefix)) {
+    return addr.slice(v4Prefix.length);
+  }
+  return addr;
+};
+
+/**
+ * @param {string} addr
+ * @returns {number[] | undefined} 4-element array of octets, or undefined
+ */
+const parseIPv4 = addr => {
+  const parts = addr.split('.');
+  if (parts.length !== 4) return undefined;
+  /** @type {number[]} */
+  const octets = [];
+  for (const part of parts) {
+    const n = Number(part);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return undefined;
+    octets.push(n);
+  }
+  return octets;
+};
+
+/**
+ * Expand `::` shorthand and parse to 8 x 16-bit groups.
+ *
+ * @param {string} addr
+ * @returns {number[] | undefined} 8-element array of 16-bit groups, or undefined
+ */
+const parseIPv6 = addr => {
+  const halves = addr.split('::');
+  if (halves.length > 2) return undefined;
+
+  /** @type {string[]} */
+  let groups;
+  if (halves.length === 2) {
+    const left = halves[0] ? halves[0].split(':') : [];
+    const right = halves[1] ? halves[1].split(':') : [];
+    const missing = 8 - left.length - right.length;
+    if (missing < 0) return undefined;
+    const zeros = [];
+    for (let i = 0; i < missing; i += 1) {
+      zeros.push('0');
+    }
+    groups = [...left, ...zeros, ...right];
+  } else {
+    groups = addr.split(':');
+  }
+
+  if (groups.length !== 8) return undefined;
+
+  /** @type {number[]} */
+  const result = [];
+  for (const group of groups) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(group)) return undefined;
+    result.push(parseInt(group, 16));
+  }
+  return result;
+};
+
+/**
+ * Compare the leading `prefixLen` bits of two addresses represented as
+ * equal-length arrays of integer groups (octets for IPv4, 16-bit groups for
+ * IPv6).
+ *
+ * @param {number[]} addr
+ * @param {number[]} network
+ * @param {number} prefixLen
+ * @param {number} groupBits - 8 for IPv4 octets, 16 for IPv6 groups
+ * @returns {boolean}
+ */
+const matchesPrefix = (addr, network, prefixLen, groupBits) => {
+  let remaining = prefixLen;
+  for (let i = 0; i < addr.length; i += 1) {
+    if (remaining <= 0) return true;
+    if (remaining >= groupBits) {
+      if (addr[i] !== network[i]) return false;
+      remaining -= groupBits;
+    } else {
+      const divisor = 2 ** (groupBits - remaining);
+      return (
+        Math.floor(addr[i] / divisor) === Math.floor(network[i] / divisor)
+      );
+    }
+  }
+  return true;
+};
+
+/**
+ * Parse a CIDR string like `10.0.0.0/8` or `fd00::/8` into a structured
+ * representation.  A bare address without `/` is treated as a host route
+ * (`/32` for IPv4, `/128` for IPv6).
+ *
+ * @param {string} cidr
+ * @returns {ParsedCIDR | undefined}
+ */
+export const parseCIDR = cidr => {
+  const slashIdx = cidr.lastIndexOf('/');
+
+  if (slashIdx === -1) {
+    const v4 = parseIPv4(cidr);
+    if (v4 !== undefined) {
+      return harden({ type: 'ipv4', network: v4, prefixLen: 32 });
+    }
+    const v6 = parseIPv6(cidr);
+    if (v6 !== undefined) {
+      return harden({ type: 'ipv6', network: v6, prefixLen: 128 });
+    }
+    return undefined;
+  }
+
+  const addrPart = cidr.slice(0, slashIdx);
+  const prefixStr = cidr.slice(slashIdx + 1);
+  const prefixLen = Number(prefixStr);
+  if (!Number.isInteger(prefixLen) || prefixLen < 0) return undefined;
+
+  const v4 = parseIPv4(addrPart);
+  if (v4 !== undefined) {
+    if (prefixLen > 32) return undefined;
+    return harden({ type: 'ipv4', network: v4, prefixLen });
+  }
+
+  const v6 = parseIPv6(addrPart);
+  if (v6 !== undefined) {
+    if (prefixLen > 128) return undefined;
+    return harden({ type: 'ipv6', network: v6, prefixLen });
+  }
+
+  return undefined;
+};
+harden(parseCIDR);
+
+/**
+ * Test whether `addr` falls within the given parsed CIDR.
+ *
+ * @param {string} addr - normalized IP address
+ * @param {ParsedCIDR} cidr
+ * @returns {boolean}
+ */
+export const addressMatchesCIDR = (addr, cidr) => {
+  if (cidr.type === 'ipv4') {
+    const parsed = parseIPv4(addr);
+    if (parsed === undefined) return false;
+    return matchesPrefix(parsed, cidr.network, cidr.prefixLen, 8);
+  }
+  const parsed = parseIPv6(addr);
+  if (parsed === undefined) return false;
+  return matchesPrefix(parsed, cidr.network, cidr.prefixLen, 16);
+};
+harden(addressMatchesCIDR);
+
+/**
+ * Build a predicate that returns `true` when a given `remoteAddress` should be
+ * allowed through the gateway.
+ *
+ * - No options / empty options: only localhost addresses pass.
+ * - `allowRemote: true`: every address passes.
+ * - `allowedCIDRs` (comma-separated): localhost plus any address in the listed
+ *   CIDRs passes.
+ *
+ * @param {{ allowRemote?: boolean, allowedCIDRs?: string }} [options]
+ * @returns {AddressChecker}
+ */
+export const makeAddressChecker = (options = {}) => {
+  const { allowRemote = false, allowedCIDRs = '' } = options;
+
+  if (allowRemote) {
+    /** @type {AddressChecker} */
+    const allowAll = _addr => true;
+    return harden(allowAll);
+  }
+
+  if (!allowedCIDRs) {
+    /** @type {AddressChecker} */
+    const localhostOnly = addr => localhostAddresses.includes(addr);
+    return harden(localhostOnly);
+  }
+
+  /** @type {ParsedCIDR[]} */
+  const cidrs = [];
+  for (const entry of allowedCIDRs.split(',')) {
+    const trimmed = entry.trim();
+    if (trimmed.length > 0) {
+      const parsed = parseCIDR(trimmed);
+      if (parsed !== undefined) {
+        cidrs.push(parsed);
+      }
+    }
+  }
+  harden(cidrs);
+
+  /** @type {AddressChecker} */
+  const cidrChecker = addr => {
+    if (localhostAddresses.includes(addr)) return true;
+    const normalized = normalizeAddress(addr);
+    for (const cidr of cidrs) {
+      if (addressMatchesCIDR(normalized, cidr)) return true;
+    }
+    return false;
+  };
+  return harden(cidrChecker);
+};
+harden(makeAddressChecker);

--- a/packages/daemon/src/daemon-node.js
+++ b/packages/daemon/src/daemon-node.js
@@ -141,6 +141,10 @@ const main = async () => {
           ENDO_ADDR: process.env.ENDO_ADDR || '127.0.0.1:8920',
           ENDO_WEB_PAGE_BUNDLE_PATH:
             process.env.ENDO_WEB_PAGE_BUNDLE_PATH || '',
+          ENDO_GATEWAY_ALLOW_REMOTE:
+            process.env.ENDO_GATEWAY_ALLOW_REMOTE || '',
+          ENDO_GATEWAY_ALLOWED_CIDRS:
+            process.env.ENDO_GATEWAY_ALLOWED_CIDRS || '',
         },
       }),
     });

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1653,6 +1653,12 @@ export type BidirectionalMultimap<K, V> = {
   getAllFor(key: K): V[];
 };
 
+export type ParsedCIDR =
+  | { type: 'ipv4'; network: number[]; prefixLen: number }
+  | { type: 'ipv6'; network: number[]; prefixLen: number };
+
+export type AddressChecker = (remoteAddress: string) => boolean;
+
 export interface RemoteControl {
   accept(
     remoteGateway: Promise<EndoGateway>,

--- a/packages/daemon/src/web-server-node.js
+++ b/packages/daemon/src/web-server-node.js
@@ -13,6 +13,7 @@ import { makeBundle } from '@endo/compartment-mapper/bundle.js';
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';
 
+import { makeAddressChecker } from './cidr.js';
 import { makeHttpPowers } from './web-server-node-powers.js';
 
 import {
@@ -40,6 +41,11 @@ export const make = async (powers, context, { env = {} } = {}) => {
   const addrUrl = new URL(`http://${env.ENDO_ADDR || '127.0.0.1:8920'}`);
   const gatewayHost = addrUrl.hostname;
   const gatewayPort = addrUrl.port !== '' ? Number(addrUrl.port) : 8920;
+
+  const isAllowed = makeAddressChecker({
+    allowRemote: env.ENDO_GATEWAY_ALLOW_REMOTE === '1',
+    allowedCIDRs: env.ENDO_GATEWAY_ALLOWED_CIDRS || '',
+  });
   let script;
   if (env.ENDO_WEB_PAGE_BUNDLE_PATH) {
     script = await fs.promises.readFile(env.ENDO_WEB_PAGE_BUNDLE_PATH, 'utf-8');
@@ -183,16 +189,9 @@ export const make = async (powers, context, { env = {} } = {}) => {
 
   wss.on('connection', (socket, req) => {
     const remoteAddress = req.socket.remoteAddress;
-    // XXX: When the gateway migrates from CapTP to OCapN with a Noise
-    // Protocol network layer, accept connections from non-local remote
-    // addresses.
-    if (
-      remoteAddress !== '127.0.0.1' &&
-      remoteAddress !== '::1' &&
-      remoteAddress !== '::ffff:127.0.0.1'
-    ) {
+    if (!isAllowed(remoteAddress || '')) {
       console.error(
-        `[Gateway] Rejected non-local connection from ${remoteAddress}`,
+        `[Gateway] Rejected connection from ${remoteAddress}`,
       );
       socket.close(1008, 'Only local connections allowed');
       return;

--- a/packages/daemon/test/cidr.test.js
+++ b/packages/daemon/test/cidr.test.js
@@ -1,0 +1,160 @@
+// @ts-check
+
+import '@endo/init/debug.js';
+
+import test from 'ava';
+
+import {
+  parseCIDR,
+  addressMatchesCIDR,
+  makeAddressChecker,
+} from '../src/cidr.js';
+
+// --- parseCIDR ---
+
+test('parseCIDR parses IPv4 CIDR', t => {
+  const result = parseCIDR('10.0.0.0/8');
+  t.deepEqual(result, { type: 'ipv4', network: [10, 0, 0, 0], prefixLen: 8 });
+});
+
+test('parseCIDR parses IPv4 host address', t => {
+  const result = parseCIDR('192.168.1.5');
+  t.deepEqual(result, {
+    type: 'ipv4',
+    network: [192, 168, 1, 5],
+    prefixLen: 32,
+  });
+});
+
+test('parseCIDR parses IPv6 CIDR', t => {
+  const result = parseCIDR('fd00::/8');
+  t.not(result, undefined);
+  t.is(/** @type {NonNullable<typeof result>} */ (result).type, 'ipv6');
+  t.is(/** @type {NonNullable<typeof result>} */ (result).prefixLen, 8);
+});
+
+test('parseCIDR parses IPv6 loopback', t => {
+  const result = parseCIDR('::1');
+  t.not(result, undefined);
+  t.is(/** @type {NonNullable<typeof result>} */ (result).type, 'ipv6');
+  t.is(/** @type {NonNullable<typeof result>} */ (result).prefixLen, 128);
+});
+
+test('parseCIDR rejects invalid input', t => {
+  t.is(parseCIDR('not-an-ip'), undefined);
+  t.is(parseCIDR('10.0.0.0/33'), undefined);
+  t.is(parseCIDR(''), undefined);
+  t.is(parseCIDR('10.0.0.256/8'), undefined);
+});
+
+// --- addressMatchesCIDR ---
+
+test('addressMatchesCIDR matches IPv4 within /8', t => {
+  const cidr = /** @type {NonNullable<ReturnType<typeof parseCIDR>>} */ (
+    parseCIDR('10.0.0.0/8')
+  );
+  t.true(addressMatchesCIDR('10.0.0.1', cidr));
+  t.true(addressMatchesCIDR('10.255.255.255', cidr));
+  t.false(addressMatchesCIDR('11.0.0.1', cidr));
+  t.false(addressMatchesCIDR('192.168.1.1', cidr));
+});
+
+test('addressMatchesCIDR matches IPv4 within /16', t => {
+  const cidr = /** @type {NonNullable<ReturnType<typeof parseCIDR>>} */ (
+    parseCIDR('172.16.0.0/12')
+  );
+  t.true(addressMatchesCIDR('172.16.0.1', cidr));
+  t.true(addressMatchesCIDR('172.31.255.255', cidr));
+  t.false(addressMatchesCIDR('172.32.0.1', cidr));
+});
+
+test('addressMatchesCIDR matches exact IPv4 host', t => {
+  const cidr = /** @type {NonNullable<ReturnType<typeof parseCIDR>>} */ (
+    parseCIDR('192.168.1.100/32')
+  );
+  t.true(addressMatchesCIDR('192.168.1.100', cidr));
+  t.false(addressMatchesCIDR('192.168.1.101', cidr));
+});
+
+test('addressMatchesCIDR matches Tailscale CGNAT range', t => {
+  const cidr = /** @type {NonNullable<ReturnType<typeof parseCIDR>>} */ (
+    parseCIDR('100.64.0.0/10')
+  );
+  t.true(addressMatchesCIDR('100.64.0.1', cidr));
+  t.true(addressMatchesCIDR('100.127.255.255', cidr));
+  t.false(addressMatchesCIDR('100.128.0.1', cidr));
+  t.false(addressMatchesCIDR('100.63.255.255', cidr));
+});
+
+test('addressMatchesCIDR matches /0 (all IPs)', t => {
+  const cidr = /** @type {NonNullable<ReturnType<typeof parseCIDR>>} */ (
+    parseCIDR('0.0.0.0/0')
+  );
+  t.true(addressMatchesCIDR('1.2.3.4', cidr));
+  t.true(addressMatchesCIDR('255.255.255.255', cidr));
+});
+
+test('addressMatchesCIDR does not match IPv6 addr against IPv4 CIDR', t => {
+  const cidr = /** @type {NonNullable<ReturnType<typeof parseCIDR>>} */ (
+    parseCIDR('10.0.0.0/8')
+  );
+  t.false(addressMatchesCIDR('::1', cidr));
+});
+
+test('addressMatchesCIDR matches IPv6 within prefix', t => {
+  const cidr = /** @type {NonNullable<ReturnType<typeof parseCIDR>>} */ (
+    parseCIDR('fd00::/8')
+  );
+  t.true(addressMatchesCIDR('fd12:3456:789a::', cidr));
+  t.false(addressMatchesCIDR('fe80::1', cidr));
+});
+
+// --- makeAddressChecker ---
+
+test('makeAddressChecker default allows only localhost', t => {
+  const check = makeAddressChecker();
+  t.true(check('127.0.0.1'));
+  t.true(check('::1'));
+  t.true(check('::ffff:127.0.0.1'));
+  t.false(check('10.0.0.1'));
+  t.false(check('192.168.1.1'));
+});
+
+test('makeAddressChecker allowRemote allows everything', t => {
+  const check = makeAddressChecker({ allowRemote: true });
+  t.true(check('127.0.0.1'));
+  t.true(check('10.0.0.1'));
+  t.true(check('203.0.113.5'));
+  t.true(check('::1'));
+});
+
+test('makeAddressChecker with CIDRs allows localhost plus listed ranges', t => {
+  const check = makeAddressChecker({
+    allowedCIDRs: '10.0.0.0/8, 100.64.0.0/10',
+  });
+  t.true(check('127.0.0.1'));
+  t.true(check('::1'));
+  t.true(check('10.1.2.3'));
+  t.true(check('100.100.50.25'));
+  t.false(check('192.168.1.1'));
+  t.false(check('203.0.113.5'));
+});
+
+test('makeAddressChecker normalizes IPv4-mapped IPv6 for CIDR match', t => {
+  const check = makeAddressChecker({ allowedCIDRs: '10.0.0.0/8' });
+  t.true(check('::ffff:10.1.2.3'));
+  t.false(check('::ffff:192.168.1.1'));
+});
+
+test('makeAddressChecker ignores invalid CIDRs gracefully', t => {
+  const check = makeAddressChecker({ allowedCIDRs: 'not-a-cidr, 10.0.0.0/8' });
+  t.true(check('10.1.2.3'));
+  t.true(check('127.0.0.1'));
+  t.false(check('192.168.1.1'));
+});
+
+test('makeAddressChecker with empty CIDRs string acts as localhost-only', t => {
+  const check = makeAddressChecker({ allowedCIDRs: '' });
+  t.true(check('127.0.0.1'));
+  t.false(check('10.0.0.1'));
+});

--- a/packages/daemon/test/gateway.test.js
+++ b/packages/daemon/test/gateway.test.js
@@ -146,6 +146,8 @@ test.beforeEach(t => {
 
 test.afterEach.always(async t => {
   delete process.env.ENDO_ADDR;
+  delete process.env.ENDO_GATEWAY_ALLOW_REMOTE;
+  delete process.env.ENDO_GATEWAY_ALLOWED_CIDRS;
   await Promise.allSettled(
     /** @type {Array<{cancel: Function, cancelled: Promise<void>, config: ReturnType<typeof makeConfig>}>} */ (
       t.context
@@ -436,6 +438,81 @@ test.serial('weblet on dedicated port', async t => {
   t.is(jsStatus, 200);
   t.true(jsBody.length > 0);
 });
+
+test.serial(
+  'gateway allows connection when ENDO_GATEWAY_ALLOW_REMOTE=1',
+  async t => {
+    process.env.ENDO_GATEWAY_ALLOW_REMOTE = '1';
+    const { host } = await prepareHost(t);
+
+    await E(host).evaluate('MAIN', '99', [], [], ['val']);
+    const formulaId = await E(host).identify('val');
+    t.truthy(formulaId);
+
+    const apps = E(host).lookup('APPS');
+    const address = await E(apps).getAddress();
+
+    const socket = new ws.WebSocket(`${address.replace(/^http/, 'ws')}/`);
+    await new Promise((resolve, reject) => {
+      socket.on('open', resolve);
+      socket.on('error', reject);
+    });
+    t.teardown(() => socket.close());
+
+    const [reader, sink] = makePipe();
+    socket.on(
+      'message',
+      (/** @type {Uint8Array} */ bytes, /** @type {boolean} */ isBinary) => {
+        if (isBinary) {
+          sink.next(bytes);
+        }
+      },
+    );
+    socket.on('close', () => {
+      sink.return(undefined);
+    });
+
+    const writer = harden({
+      /** @param {Uint8Array} bytes */
+      async next(bytes) {
+        socket.send(bytes, { binary: true });
+        return harden({ done: false, value: undefined });
+      },
+      async return() {
+        socket.close();
+        return harden({ done: true, value: undefined });
+      },
+      /** @param {Error} error */
+      async throw(error) {
+        socket.close();
+        return harden({ done: true, value: error });
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    });
+
+    const messageWriter = mapWriter(writer, messageToBytes);
+    const messageReader = mapReader(reader, bytesToMessage);
+
+    const { promise: cancelled, reject: cancelCapTP } = makePromiseKit();
+    t.teardown(() => cancelCapTP(Error('test done')));
+
+    const { getBootstrap } = makeMessageCapTP(
+      'Test',
+      messageWriter,
+      messageReader,
+      cancelled,
+      undefined,
+    );
+
+    const bootstrap = getBootstrap();
+    const result = await E(bootstrap).fetch(
+      /** @type {string} */ (formulaId),
+    );
+    t.is(result, 99);
+  },
+);
 
 test.serial('daemon writes root file matching AGENT identifier', async t => {
   const { config, host } = await prepareHost(t);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXXX
Refs: #XXXX

## Description

This PR implements configurable remote access for the Endo daemon's HTTP/WebSocket gateway (port 8920), which was previously restricted to localhost connections only.

Key changes include:
- **New Environment Variables**: Introduced `ENDO_GATEWAY_ALLOW_REMOTE` (to allow all remote connections) and `ENDO_GATEWAY_ALLOWED_CIDRS` (to allow connections from specified IP ranges/CIDRs).
- **IP Address Utilities**: Added `packages/daemon/src/cidr.js` for parsing CIDR strings and checking if an IP address falls within a given range.
- **Gateway Logic**: `packages/daemon/src/web-server-node.js` now uses these new environment variables to control remote access, replacing the hardcoded localhost check.
- **Daemon Configuration**: `packages/daemon/src/daemon-node.js` passes the new environment variables to the APPS formula.
- **Documentation**: `packages/daemon/README.md` has been updated to describe the new remote access options, including usage examples and security considerations.
- **Testing**: Added comprehensive unit tests for CIDR parsing and matching (`packages/daemon/test/cidr.test.js`) and an integration test for the `ENDO_GATEWAY_ALLOW_REMOTE` functionality (`packages/daemon/test/gateway.test.js`).

The default behavior remains localhost-only, ensuring backward compatibility.

## Security Considerations

This change introduces the ability to expose the Endo gateway to non-localhost clients.
- The default behavior remains secure (localhost-only).
- Users must explicitly opt-in to remote access by setting `ENDO_GATEWAY_ALLOW_REMOTE` or `ENDO_GATEWAY_ALLOWED_CIDRS`.
- This PR does *not* introduce authentication or TLS for the gateway, which remain out of scope as per the original plan. Users enabling remote access should ensure their network environment is secure.

## Scaling Considerations

The impact on scaling is minimal. CIDR parsing occurs once at daemon startup, and IP address checking is a fast, lightweight operation performed per connection.

## Documentation Considerations

The `packages/daemon/README.md` has been updated to:
- Clearly state that the gateway defaults to localhost-only.
- Explain how to enable remote access using `ENDO_GATEWAY_ALLOW_REMOTE` and `ENDO_GATEWAY_ALLOWED_CIDRS`.
- Provide examples of CIDR usage.
- Note that binding to `0.0.0.0` (via `ENDO_ADDR`) is required for remote reachability.
- No upgrade instructions are needed for existing data or deployments as the default behavior is unchanged.

## Testing Considerations

- **Unit Tests**: `packages/daemon/test/cidr.test.js` contains 18 unit tests covering various CIDR parsing and matching scenarios, including edge cases and IPv4-mapped IPv6 normalization.
- **Integration Tests**: `packages/daemon/test/gateway.test.js` includes a new test case to verify that `ENDO_GATEWAY_ALLOW_REMOTE=1` correctly allows connections.
- All existing tests pass with these changes.

## Compatibility Considerations

This change is fully backward compatible. The default behavior of restricting connections to localhost is preserved when the new environment variables are not set. It enables new usage patterns for users who require remote access.

## Upgrade Considerations

No specific upgrade steps are required for live production systems. Existing deployments will continue to function with localhost-only access. Users wishing to enable remote access can do so by setting the new environment variables.

---
<p><a href="https://cursor.com/agents/bc-ad4b1fc5-c8fc-462b-870f-3700edbd6b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad4b1fc5-c8fc-462b-870f-3700edbd6b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->