### PR TITLE
Formula graph seeding race

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -405,6 +405,36 @@ const makeDaemonCore = async (
   for (const id of Object.values(platformNames)) {
     formulaGraph.addRoot(/** @type {FormulaIdentifier} */ (id));
   }
+  const startupBootFormulaIds = new Set([
+    knownPeersId,
+    leastAuthorityId,
+    mainWorkerId,
+    endoFormulaId,
+    ...Object.values(platformNames),
+  ]);
+  let startupSeedingComplete = false;
+  const {
+    promise: startupReady,
+    resolve: resolveStartupReady,
+    reject: rejectStartupReady,
+  } = /** @type {PromiseKit<void>} */ (makePromiseKit());
+  startupReady.catch(() => {});
+
+  /**
+   * Defer startup reincarnation of non-boot formulas until persistence seeding
+   * has loaded all formula and pet-store edges into the in-memory graph.
+   *
+   * @param {FormulaIdentifier} id
+   */
+  const waitForStartupSeeding = async id => {
+    if (startupSeedingComplete || !isLocalId(id)) {
+      return;
+    }
+    if (startupBootFormulaIds.has(id)) {
+      return;
+    }
+    await startupReady;
+  };
 
   // Transient roots protect formulas from collection for the duration of
   // a command. Without this, a formula created by a command could be
@@ -591,7 +621,7 @@ const makeDaemonCore = async (
   };
 
   const collectIfDirty = async () => {
-    if (!enableFormulaCollection) {
+    if (!enableFormulaCollection || !startupSeedingComplete) {
       return;
     }
     // collectIfDirty is never called re-entrantly (only from
@@ -2197,6 +2227,7 @@ const makeDaemonCore = async (
       return E(peer).provide(id);
     }
 
+    await waitForStartupSeeding(id);
     const formula = await getFormulaForId(id);
     console.log(`Reincarnating ${formula.type} ${id}`);
     assertValidFormulaType(formula.type);
@@ -3630,7 +3661,14 @@ const makeDaemonCore = async (
   };
 
   /** @type {DaemonCoreExternal} */
-  await seedFormulaGraphFromPersistence();
+  try {
+    await seedFormulaGraphFromPersistence();
+    startupSeedingComplete = true;
+    resolveStartupReady(undefined);
+  } catch (error) {
+    rejectStartupReady(error);
+    throw error;
+  }
   return {
     formulateEndo,
     provide,

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -823,6 +823,36 @@ test('closure state lost by restart', async t => {
   }
 });
 
+test('makeUnconfined with guest powers reincarnates after restart', async t => {
+  const { cancelled, config } = await prepareConfig(t);
+  const counterPath = path.join(dirname, 'test', 'counter.js');
+  const counterLocation = url.pathToFileURL(counterPath).href;
+
+  {
+    const { host } = await makeHost(config, cancelled);
+    await E(host).provideGuest('fae', {
+      introducedNames: harden({ AGENT: 'host-agent' }),
+      agentName: 'profile-for-fae',
+    });
+
+    const controller = await E(host).makeUnconfined('MAIN', counterLocation, {
+      powersName: 'profile-for-fae',
+      resultName: 'controller-for-fae',
+    });
+    t.is(await E(controller).incr(), 1);
+    t.is(await E(controller).incr(), 2);
+  }
+
+  await restart(config, { env: { ENDO_ADDR: '127.0.0.1:0' } });
+
+  {
+    const { host } = await makeHost(config, cancelled);
+    const reincarnatedController = await E(host).lookup('controller-for-fae');
+    t.is(await E(reincarnatedController).incr(), 1);
+    t.is(await E(reincarnatedController).incr(), 2);
+  }
+});
+
 test('persist unconfined services and their requests', async t => {
   const { cancelled, config } = await prepareConfig(t);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXXX (No specific issue provided, please update if available)

## Description

This PR resolves a race condition during daemon startup that could lead to Fae manager crashes after `endo restart`. The issue occurred because formula evaluation and garbage collection (`collectIfDirty`) could run before the formula graph was fully seeded from persistence. This created a window where dependencies appeared unreachable, triggering premature cancellation of formulas (e.g., the Fae manager's worker) and causing the worker process to exit immediately.

The fix introduces a startup barrier in `packages/daemon/src/daemon.js` that:
1.  Blocks the reincarnation of non-boot formulas until `seedFormulaGraphFromPersistence` has completed.
2.  Suppresses `collectIfDirty` from running until the seeding process is finished.

This ensures that all formula dependencies are correctly loaded and known before any evaluation or garbage collection can occur, preventing spurious cancellations and improving daemon stability.

### Files critical to review:
*   `packages/daemon/src/daemon.js`: Contains the core startup barrier logic.
*   `packages/daemon/test/endo.test.js`: Adds a new regression test for `makeUnconfined` with guest powers after restart.

### Security Considerations

This change improves daemon stability by preventing a race condition during startup. It does not introduce new security assumptions, dependencies, or authorities.

### Scaling Considerations

The startup barrier might introduce a minor, one-time delay during daemon initialization while waiting for persistence seeding. This delay is negligible and is a necessary trade-off for preventing crashes and ensuring correct daemon operation.

### Documentation Considerations

No new user-facing features or breaking changes are introduced. Therefore, no specific documentation updates or upgrade instructions are needed for downstream users or existing deployments.

### Testing Considerations

A new regression test, `makeUnconfined with guest powers reincarnates after restart`, has been added to `packages/daemon/test/endo.test.js`. This test specifically covers the scenario addressed by this fix, verifying that controllers with guest powers can be successfully reincarnated and invoked after a daemon restart.

### Compatibility Considerations

This change is fully backward compatible and improves the reliability of daemon startup. It does not break any prior usage patterns.

### Upgrade Considerations

This is a stability fix and does not introduce any breaking changes or require special upgrade procedures for live production systems.

---
<p><a href="https://cursor.com/agents/bc-99c9076e-ebf8-4d91-8293-5e6145485f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99c9076e-ebf8-4d91-8293-5e6145485f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->