### PR TITLE
Fae sub-agent resumption

### DIFF
--- a/packages/fae/agent.js
+++ b/packages/fae/agent.js
@@ -430,6 +430,47 @@ export const make = (guestPowers, _context) => {
     const selfId = await E(powers).identify('SELF');
     const activeWorkers = new Map();
 
+    // Restore existing sub-agents from persisted config.
+    const configSuffix = '-config';
+    try {
+      const allNames = /** @type {string[]} */ (await E(powers).list());
+      for (const entryName of allNames) {
+        if (!entryName.endsWith(configSuffix)) continue;
+        const agentName = entryName.slice(0, -configSuffix.length);
+        if (activeWorkers.has(agentName)) continue;
+        try {
+          const config =
+            /** @type {{ host: string, model: string, authToken: string }} */ (
+              await E(powers).lookup(entryName)
+            );
+          const guest = await E(agent).provideGuest(agentName, {
+            agentName: `profile-for-${agentName}`,
+          });
+          const workerP = spawnWorkerLoop(guest, null, {
+            LAL_HOST: config.host,
+            LAL_MODEL: config.model,
+            LAL_AUTH_TOKEN: config.authToken,
+          });
+          activeWorkers.set(agentName, workerP);
+          workerP.catch(error => {
+            console.error(
+              `[fae] Restored worker "${agentName}" error:`,
+              error,
+            );
+            activeWorkers.delete(agentName);
+          });
+          console.log(`[fae] Restored sub-agent "${agentName}"`);
+        } catch (error) {
+          console.error(
+            `[fae] Failed to restore sub-agent "${agentName}":`,
+            error,
+          );
+        }
+      }
+    } catch (error) {
+      console.error('[fae] Failed to list names for restoration:', error);
+    }
+
     // Pre-scan existing messages to find our latest form messageId so that
     // old value messages (from prior sessions) that reply to an earlier form
     // are not accidentally matched when the iterator replays history.
@@ -486,6 +527,16 @@ export const make = (guestPowers, _context) => {
         const guest = await E(agent).provideGuest(name, {
           agentName: `profile-for-${name}`,
         });
+
+        // Persist the agent config so it survives restarts.
+        await E(powers).store(
+          `${name}${configSuffix}`,
+          harden({
+            host: config.host,
+            model: config.model,
+            authToken: config.authToken,
+          }),
+        );
 
         // Spawn a worker loop for this guest.
         const workerP = spawnWorkerLoop(guest, null, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: #XXXX

## Description

This PR addresses a bug where Fae sub-agents (e.g., "mola") would not resume after an `endo restart`. Previously, sub-agent configurations were not persisted, leading to an empty `activeWorkers` map on reboot and no mechanism to re-spawn existing agent loops.

The fix introduces two main changes in `packages/fae/agent.js`:

1.  **Persist Agent Configuration**: When a new sub-agent is successfully created via form submission, its configuration (host, model, authToken) is now persisted in the pet store under a key derived from the agent's name (e.g., `mola-config`).
2.  **Restore Agents on Startup**: At the beginning of `runManager()`, before entering the form submission loop, the system now scans the pet store for all entries ending in `-config`. For each found configuration, it re-creates the guest and spawns a new worker loop, effectively restoring previously configured sub-agents.

This ensures that all active sub-agents automatically resume their operation after an `endo restart` or daemon shutdown.

### Security Considerations

This change introduces persistence of agent configuration (host, model, authToken). While these are typically provided by the user, their storage in the pet store means they are now durable. Ensure that the pet store's security guarantees are sufficient for these potentially sensitive values.

### Scaling Considerations

On startup, the `runManager()` function now performs a `E(powers).list()` and potentially multiple `E(powers).lookup()` calls to restore agents. For a very large number of sub-agents, this could introduce a slight increase in startup time and resource consumption, but it is expected to be negligible for typical usage.

### Documentation Considerations

Users should be aware that sub-agent configurations are now persisted. No explicit upgrade instructions are needed for existing data, as the fix primarily affects behavior on restart. Existing agents will automatically benefit from the restoration logic on their next restart.

### Testing Considerations

*   **Unit Tests**: Add tests for the persistence of configurations when a new agent is added.
*   **Integration Tests**: Test the full `endo restart` flow to ensure sub-agents resume correctly. This would involve creating an agent, restarting endo, and verifying the agent is still responsive.
*   **Edge Cases**: Test scenarios like corrupted config entries, or agents that fail to restore.

### Compatibility Considerations

This change is fully backward compatible. It fixes a bug in existing usage patterns without altering the API or expected behavior for creating/managing agents. It allows usage patterns to evolve by making sub-agents more resilient to restarts.

### Upgrade Considerations

No specific upgrade steps are required. Existing Fae deployments will automatically gain the ability to persist and restore sub-agents upon the next `endo restart` after this code is deployed.

---
<p><a href="https://cursor.com/agents/bc-ef1c0852-c359-4793-8495-a30b54eff309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef1c0852-c359-4793-8495-a30b54eff309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->