### PR TITLE
test(exo): sequential interleaving hazards

### DIFF
--- a/packages/exo/test/status-holder.test.js
+++ b/packages/exo/test/status-holder.test.js
@@ -1,0 +1,113 @@
+/* eslint-disable no-new */
+/* eslint-disable class-methods-use-this */
+/* eslint-disable @endo/restrict-comparison-operands */
+/* eslint-disable max-classes-per-file */
+
+/*
+ * Example transliterated from
+ * https://papers.agoric.com/papers/robust-composition/abstract/
+ * Section 13.1 "Sequential Interleaving Hazards"
+ * and Figures 13.1 and 13.2 .
+ * See Chapter 13 for context.
+ */
+
+import test from '@endo/ses-ava/prepare-endo.js';
+
+export class StatusHolder {
+  #myStatus;
+
+  #myListeners = [];
+
+  constructor(status) {
+    this.#myStatus = status;
+  }
+
+  addListener(newListener) {
+    this.#myListeners.push(newListener);
+  }
+
+  get status() {
+    return this.#myStatus;
+  }
+
+  set status(newStatus) {
+    this.#myStatus = newStatus;
+    for (const listener of this.#myListeners) {
+      listener.statusChanged(newStatus);
+    }
+  }
+}
+
+const Nat = n => {
+  if (typeof n === 'bigint' && n >= 0) {
+    return n;
+  }
+  throw new Error('something bad happened');
+};
+
+export class AcctMgr {
+  #statusHolder;
+
+  constructor() {
+    this.#statusHolder = new StatusHolder(0n);
+  }
+
+  get statusHolder() {
+    return this.#statusHolder;
+  }
+
+  withdraw(amount) {
+    this.#statusHolder.status = Nat(this.#statusHolder.status - Nat(amount));
+  }
+
+  deposit(amount) {
+    this.#statusHolder.status += Nat(amount);
+  }
+}
+
+export class FinanceListener {
+  #statusHolder;
+
+  constructor(acctMgr) {
+    this.#statusHolder = acctMgr.statusHolder;
+    this.#statusHolder.addListener(this);
+  }
+
+  statusChanged(newStatus) {
+    if (newStatus < 4000n) {
+      this.#statusHolder.status += 1000n;
+    }
+  }
+}
+
+const log = [];
+
+export class CellViewer {
+  constructor(acctMgr) {
+    const statusHolder = acctMgr.statusHolder;
+    log.push(statusHolder.status);
+    statusHolder.addListener(this);
+  }
+
+  statusChanged(newStatus) {
+    log.push(newStatus);
+  }
+}
+
+test('nested publication bug', t => {
+  const acctMgr = new AcctMgr();
+  const statusHolder = acctMgr.statusHolder;
+  t.is(statusHolder.status, 0n);
+  t.deepEqual(log, []);
+  new FinanceListener(acctMgr);
+  new CellViewer(acctMgr);
+  t.deepEqual(log, [0n]);
+
+  acctMgr.deposit(4000n);
+  t.is(statusHolder.status, 4000n);
+  t.deepEqual(log, [0n, 4000n]);
+
+  acctMgr.withdraw(100n);
+  t.is(statusHolder.status, 4900n);
+  t.deepEqual(log, [0n, 4000n, 4900n, 3900n]);
+});


### PR DESCRIPTION

Closes: #XXXX
Refs: https://github.com/jasnell/discussion-abort-protocol/issues/9 https://github.com/jasnell/discussion-abort-protocol/issues/10 https://papers.agoric.com/papers/robust-composition/abstract/

## Description

Demonstrates some sequential interleaving hazards from https://papers.agoric.com/papers/robust-composition/abstract/ Section 13.1 . Starts with the Nested Publication Hazard of Figures 13.1 and 13.2

not added to @endo/exo for any good reason. It could go anywhere we can have a devDependency on ses-ava. Or not. Little would lost, at least for this first example, it we used ava instead without any other dependencies. But where should it go? New repo seems too much. New gist seems too little.

### Security Considerations

just tests
### Scaling Considerations
just tests

### Documentation Considerations

just tests

### Testing Considerations

new tests
### Compatibility Considerations

just tests

### Upgrade Considerations

just tests
