### PR TITLE
feat(ses): add support for "code" prop in SES-managed Errors

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -295,7 +295,7 @@ const tagError = (err, optErrorName = err.name) => {
  *     such as `stack` on v8 (Chrome, Brave, Edge?)
  *   - `sanitizeError` will freeze the error, preventing any correct engine from
  *     adding or
- *     altering any of the error's own properties `sanitizeError` is done.
+ *     altering any of the error's own properties once `sanitizeError` is done.
  *
  * However, `sanitizeError` will not, for example, `harden`
  * (i.e., deeply freeze)
@@ -315,10 +315,16 @@ export const sanitizeError = error => {
     errors: _errorsDesc = undefined,
     cause: _causeDesc = undefined,
     stack: _stackDesc = undefined,
+    code: codeDesc = undefined,
     ...restDescs
   } = descs;
 
   const restNames = ownKeys(restDescs);
+
+  // the spec allows any value, but we drop 'code' if it's not a string
+  if (codeDesc?.value !== undefined && typeof codeDesc.value !== 'string') {
+    arrayPush(restNames, 'code');
+  }
   if (restNames.length >= 1) {
     for (const name of restNames) {
       delete error[name];
@@ -350,6 +356,7 @@ const makeError = (
     cause = undefined,
     errors = undefined,
     sanitize = true,
+    code = undefined,
   } = {},
 ) => {
   // The first two parameters above cannot be inferred unless this is rewritten
@@ -357,7 +364,8 @@ const makeError = (
   // that we at least have type-safety within the function body.
   //
   // Note that due to the overload of AssertionUtilities['makeError'], strict
-  // mode will complain if default parameters are provided in the method
+  // Note that due to the overload of AssertionUtilities['makeError'], Typescript's so-called "strict
+  // mode" will complain if default parameters are provided in the method
   // signature. The below workaround (optDetails -> details; errConstructor ->
   // errCtor) is functionally equivalent but allows us to use type assertions to
   // workaround the strict mode issue.
@@ -397,6 +405,14 @@ const makeError = (
         configurable: true,
       });
     }
+  }
+  if (code !== undefined) {
+    defineProperty(error, 'code', {
+      value: code,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
   }
   weakmapSet(hiddenMessageLogArgs, error, getLogArgs(hiddenDetails));
   if (errorName !== undefined) {

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -368,7 +368,7 @@ const makeError = (
   // mode" will complain if default parameters are provided in the method
   // signature. The below workaround (optDetails -> details; errConstructor ->
   // errCtor) is functionally equivalent but allows us to use type assertions to
-  // workaround the strict mode issue.
+  // workaround the issue with TypeScript's so-called "strict mode".
   let details = /** @type {Details} */ (
     optDetails ?? redactedDetails`Assert failed`
   );

--- a/packages/ses/test/error/assert-log.test.js
+++ b/packages/ses/test/error/assert-log.test.js
@@ -339,6 +339,21 @@ test('makeError named', t => {
   );
 });
 
+test('makeError code', t => {
+  const err = makeError(X`<${'bar'},${q('baz')}>`, URIError, {
+    code: 'FOO_ERR',
+  });
+  t.is(/** @type {Error & {code: string}} */ (err).code, 'FOO_ERR');
+});
+
+test('makeError code dropped (non-string)', t => {
+  const err = makeError(X`<${'bar'},${q('baz')}>`, URIError, {
+    // @ts-expect-error intentional bad input
+    code: 123,
+  });
+  t.is(/** @type {Error & {code?: unknown}} */ (err).code, undefined);
+});
+
 test('assert.quote', t => {
   throwsAndLogs(t, () => Fail`<${'bar'},${q('baz')}>`, /<\(a string\),"baz">/, [
     ['log', 'Caught', Error],

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -242,6 +242,11 @@ export interface AssertMakeErrorOptions {
    * {@link sanitizeError}.
    */
   sanitize?: boolean;
+
+  /**
+   * The error code to assign to the error.
+   */
+  code?: string;
 }
 
 // TODO inline overloading

--- a/packages/ses/types.test-d.ts
+++ b/packages/ses/types.test-d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @endo/no-polymorphic-call, import/no-extraneous-dependencies, no-restricted-globals, no-underscore-dangle */
-import { expectType } from 'tsd';
 import type { Assert } from 'ses';
+import { expectAssignable, expectType } from 'tsd';
 
 // Lockdown
 
@@ -221,6 +221,18 @@ expectType<Error>(makeError(X`details are ${stringable}`, TypeError));
 expectType<Error>(
   makeError(X`details are ${stringable}`, TypeError, {
     errorName: 'Nom de plum',
+  }),
+);
+
+expectType<AggregateError>(
+  makeError(X`details are ${stringable}`, AggregateError, {
+    errors: [new Error('error 1'), new Error('error 2')],
+  }),
+);
+
+expectAssignable<Error & { code?: string }>(
+  makeError(X`details are ${stringable}`, Error, {
+    code: '123',
   }),
 );
 


### PR DESCRIPTION
- Adds a new `string` option to `AssertMakeErrorOptions`, `code`
- If a `string`, will be an non-enumerable property of the `Error` instance returned by `makeError`.
- To avoid mutating global types, a new type `SesError` is introduced which is simply `Error & {code?: string}`.

Note that `code` is expected to be a `string` here, but only by convention; the language will not enforce this (as per the below proposal).

Ref: https://github.com/tc39-transfer/proposal-error-code-property
