### PR TITLE
chore(ci): optimize CI job concurrency

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -11,6 +11,11 @@ permissions:
   contents: read
   actions: write
 
+# Cancel in-progress runs for the same branch when a new run is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   browser-tests:
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ permissions:
   contents: read
   actions: write
 
+# Cancel in-progress runs for the same branch when a new run is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # This file has necessary redundancies since of github actions aren't supporting:
 # - the definition of macros, which could be called from each job.
 # - reporting the status of steps in the PR (only jobs and workflows are reported).

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -11,6 +11,11 @@ on:
 permissions:
   contents: read
 
+# Cancel in-progress runs for the same branch when a new run is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This updates the `browser-test`, `ci` and `depcheck` workflows to cancel the current run if a new run is triggered on the same branch.

Practically speaking, if you push to a PR branch and then push again soon thereafter, resources will be freed for CI to run on the latest push.
