### PR TITLE
support Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         platform: [ubuntu-latest, macos-15]
         # windows-latest exhibited flakey tests that are not yet worth the
         # trouble to investigate, and blocked us from upgrading yarn from 1 to
@@ -154,7 +154,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 24.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -190,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 24.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -294,7 +294,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 24.x]
         platform: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
[Node 24 is LTS as of 2026-02-24](https://nodejs.org/en/blog/release/v24.14.0). The "engines: >16" implies that Endo can be used with it. So we should test that.

## Summary
- Add `24.x` to the GitHub Actions test matrices that already cover `18.x` and `20.x`.
- Keep the existing `22.x` coverage where it already exists in the main CI matrix.
- Leave single-version jobs unchanged.

## Testing
- CI
- Once this is approved I'll add it as a required job. 