### PR TITLE
chore(ci): changeset commits credited to github-actions bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Set up Git user
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
       - name: Process Changesets
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -42,4 +47,3 @@ jobs:
         with:
           publish: yarn changeset tag
           createGithubReleases: true
-          setupGitUser: false


### PR DESCRIPTION
This fixes the "Release" workflow to assign the commit generated to `github-actions[bot]`. A proper Git user/email seems to be required.

(See current failures of "Release" workflow on `master`)