### PR TITLE
feat(compartment-mapper): new option additionalLocations for mapNodeModules

### DIFF
--- a/.changeset/wet-brooms-press.md
+++ b/.changeset/wet-brooms-press.md
@@ -1,0 +1,5 @@
+---
+'@endo/compartment-mapper': minor
+---
+
+This adds a new option, `additionalLocations`, to `mapNodeModules`. This option enables addition of arbitrary packages to the resulting Compartment Map. It enables execution of packages which need to dynamically load files from Compartments which would otherwise not appear in the map. Specific use-cases include tooling like Webpack and ESLint.

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -718,7 +718,7 @@ const gatherDependency = async (
  * @param {boolean} strict
  * @param {LogicalPathGraph} logicalPathGraph
  * @param {GraphPackagesOptions} options
- * @returns {Promise<Graph>}
+ * @returns {Promise<{graph: Graph, readDescriptor: MaybeReadDescriptorFn}>}
  */
 const graphPackages = async (
   maybeRead,
@@ -801,7 +801,7 @@ const graphPackages = async (
       policy,
     },
   );
-  return graph;
+  return { graph, readDescriptor };
 };
 
 /**
@@ -1316,7 +1316,18 @@ export const compartmentMapForNodeModules_ = async (
     unknownCanonicalNameHook,
     packageDataHook,
     packageDependenciesHook,
+    additionalLocations = [],
   } = options;
+
+  for (const { location: additionalLocation } of additionalLocations) {
+    try {
+      assertFileUrlString(additionalLocation);
+    } catch (error) {
+      throw new TypeError(
+        `Invalid additional location: ${q(additionalLocation)}; must be a file URL string`,
+      );
+    }
+  }
   const { maybeRead, canonical } = unpackReadPowers(readPowers);
   const languageOptions = makeLanguageOptions(options);
 
@@ -1326,8 +1337,6 @@ export const compartmentMapForNodeModules_ = async (
    * This graph will contain nodes for each package location (a
    * {@link FileUrlString}) and edges representing dependencies between packages.
    *
-   * The edges are weighted by {@link calculatePackageWeight}.
-   *
    * @type {LogicalPathGraph}
    */
   const logicalPathGraph = new GenericGraph();
@@ -1335,7 +1344,7 @@ export const compartmentMapForNodeModules_ = async (
   // dev is only set for the entry package, and implied by the development
   // condition.
 
-  const graph = await graphPackages(
+  const { graph, readDescriptor } = await graphPackages(
     maybeRead,
     canonical,
     entryPackageLocation,
@@ -1348,6 +1357,57 @@ export const compartmentMapForNodeModules_ = async (
     logicalPathGraph,
     { log, policy, packageDependenciesHook },
   );
+
+  // Graph additional package locations that are not reachable from the entry's
+  // dependency tree (e.g., a project root package when the entry is a tool
+  // binary in node_modules).
+
+  // NOTE: This operation could theoretically be run safely in parallel, but the
+  // performance benefits are minimal given the expected number of additional
+  // locations.
+  for (const {
+    location: additionalLocation,
+    modules: additionalModules,
+  } of additionalLocations) {
+    // eslint-disable-next-line no-await-in-loop
+    const additionalDescriptor = await readDescriptor(`${additionalLocation}/`);
+    if (additionalDescriptor === undefined) {
+      log(
+        `WARNING: additionalLocations entry at ${q(additionalLocation)} has no package.json; skipping`,
+      );
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    assertPackageDescriptor(additionalDescriptor);
+
+    logicalPathGraph.addNode(additionalLocation);
+    logicalPathGraph.addEdge(entryPackageLocation, additionalLocation);
+
+    // eslint-disable-next-line no-await-in-loop
+    await graphPackage(
+      additionalDescriptor.name,
+      readDescriptor,
+      canonical,
+      graph,
+      {
+        packageLocation: additionalLocation,
+        packageDescriptor: additionalDescriptor,
+      },
+      conditions,
+      true,
+      languageOptions,
+      strict,
+      logicalPathGraph,
+      { commonDependencyDescriptors: {}, log, packageDependenciesHook, policy },
+    );
+
+    if (additionalModules && graph[additionalLocation]) {
+      const node = graph[additionalLocation];
+      for (const modulePath of additionalModules) {
+        node.externalAliases[modulePath] = modulePath;
+      }
+    }
+  }
 
   makeAttenuatorsNode(graph, graph[entryPackageLocation], policy);
 

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -256,7 +256,41 @@ type MapNodeModulesOptionsOmitPolicy = Partial<{
    * from the `parserForLanguage` option.
    */
   languages: Array<Language> | undefined;
+  /**
+   * Additional package locations to graph alongside the entry package. Each
+   * entry is graphed into the same compartment map, with an edge from the entry
+   * package. If `modules` is specified, those paths are injected into the
+   * package's external aliases.
+   *
+   * These can be thought of as "additional entry points" insofar as building
+   * the compartment map.
+   */
+  additionalLocations: Array<AdditionalLocation>;
 }>;
+
+/**
+ * An additional package location to include in the compartment map graph.
+ *
+ * This allows packages that are not reachable through the entry package's
+ * dependency graph to appear in the compartment map. A common use case is
+ * including a project root package when the entry point is a tool binary
+ * (e.g., webpack) inside `node_modules`.
+ */
+export interface AdditionalLocation {
+  /**
+   * File URL of the package root directory (must contain a `package.json`).
+   */
+  location: FileUrlString;
+
+  /**
+   * Specific relative module paths to expose as external aliases. These paths
+   * are relative to {@link location}.
+   *
+   * If omitted, only modules discovered by standard inference (see
+   * `infer-exports.js`) are externally visible.
+   */
+  modules?: Array<string>;
+}
 
 /**
  * Hook options for `mapNodeModules()`

--- a/packages/compartment-mapper/test/fixtures-dynamic-ancestor/node_modules/webpackish-app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic-ancestor/node_modules/webpackish-app/index.js
@@ -1,0 +1,1 @@
+module.exports = 'webpackish-app';

--- a/packages/compartment-mapper/test/fixtures-dynamic-ancestor/node_modules/webpackish-app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic-ancestor/node_modules/webpackish-app/package.json
@@ -5,6 +5,7 @@
     "jorts-folder": "^1.0.0",
     "pantspack": "^1.0.0"
   },
+  "main": "index.js",
   "scripts": {
     "build": "node ../pantspack/pantspack.js --config pantspack.config.js",
     "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"

--- a/packages/compartment-mapper/test/map-node-modules.test.js
+++ b/packages/compartment-mapper/test/map-node-modules.test.js
@@ -22,7 +22,16 @@ const dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * @import {ProjectFixture} from './test.types.js'
- * @import {FileUrlString, MapNodeModulesOptions, MaybeReadPowers, PackageCompartmentMapDescriptor, CanonicalName, SomePolicy, PackageDescriptor, UnknownCanonicalNameHook, PackageDependenciesHook, LogFn} from '../src/types.js'
+ * @import {MapNodeModulesOptions,
+ *   MaybeReadPowers,
+ *   PackageCompartmentMapDescriptor,
+ *   CanonicalName,
+ *   SomePolicy,
+ *   UnknownCanonicalNameHook,
+ *   PackageDependenciesHook,
+ *   LogFn,
+ FileUrlString,
+ * } from '../src/types.js'
  */
 
 const { keys, values } = Object;
@@ -955,5 +964,94 @@ test('mapNodeModules - packageDataHook provides all package data', async t => {
     receivedCanonicalNames,
     expectedCanonicalNames,
     'should receive exactly the expected canonical names from the project fixture',
+  );
+});
+
+test('additionalLocations - adds package to compartment map', async t => {
+  t.plan(3);
+
+  const fixtureDir = new URL(
+    'fixtures-dynamic-ancestor/node_modules/pantspack/pantspack.js',
+    import.meta.url,
+  ).href;
+  const projectLocation = new URL(
+    'fixtures-dynamic-ancestor/node_modules/webpackish-app/',
+    import.meta.url,
+  ).href;
+
+  const compartmentMap = await mapNodeModules(readPowers, fixtureDir, {
+    dev: true,
+    additionalLocations: [
+      {
+        location: /** @type {FileUrlString} */ (projectLocation),
+        modules: ['./pantspack.config.js'],
+      },
+    ],
+  });
+
+  const projectCompartment = values(compartmentMap.compartments).find(
+    c => c.name === 'webpackish-app',
+  );
+
+  t.truthy(
+    projectCompartment,
+    'webpackish-app should appear in the compartment map when added via additionalLocations',
+  );
+  t.truthy(
+    projectCompartment?.modules?.['webpackish-app/pantspack.config.js'],
+    'should contain pantspack.config.js',
+  );
+  t.truthy(
+    projectCompartment?.modules?.pantspack,
+    'should contain reference to pantspack compartment',
+  );
+});
+
+test('additionalLocations - project package absent without the option', async t => {
+  const fixtureDir = new URL(
+    'fixtures-dynamic-ancestor/node_modules/pantspack/pantspack.js',
+    import.meta.url,
+  ).href;
+
+  const compartmentMap = await mapNodeModules(readPowers, fixtureDir, {
+    dev: true,
+  });
+
+  const projectCompartment = values(compartmentMap.compartments).find(
+    c => c.name === 'webpackish-app',
+  );
+
+  t.falsy(
+    projectCompartment,
+    'webpackish-app should NOT appear when additionalLocations is not provided',
+  );
+});
+
+test('additionalLocations - empty "modules" prop graphs the package using inferred main entry point', async t => {
+  const fixtureDir = new URL(
+    'fixtures-dynamic-ancestor/node_modules/pantspack/pantspack.js',
+    import.meta.url,
+  ).href;
+  const projectLocation = new URL(
+    'fixtures-dynamic-ancestor/node_modules/webpackish-app/',
+    import.meta.url,
+  ).href;
+
+  const compartmentMap = await mapNodeModules(readPowers, fixtureDir, {
+    dev: true,
+    additionalLocations: [
+      {
+        location: /** @type {FileUrlString} */ (projectLocation),
+      },
+    ],
+  });
+
+  const projectCompartment = values(compartmentMap.compartments).find(
+    c => c.name === 'webpackish-app',
+  );
+
+  t.truthy(
+    projectCompartment,
+    'webpackish-app should appear even without explicit modules',
   );
 });


### PR DESCRIPTION
This adds a new option, `additionalLocations`, to `mapNodeModules`.

This value is an array of `AdditionalLocation` objects:

```ts
/**
 * An additional package location to include in the compartment map graph.
 *
 * This allows packages that are not reachable through the entry package's
 * dependency graph to appear in the compartment map. A common use case is
 * including a project root package when the entry point is a tool binary
 * (e.g., webpack) inside `node_modules`.
 */
export interface AdditionalLocation {
  /**
   * File URL of the package root directory (must contain a `package.json`).
   */
  location: FileUrlString;

  /**
   * Specific relative module paths to expose as external aliases. These paths
   * are relative to {@link location}.
   *
   * If omitted, only modules discovered by standard inference (see
   * `infer-exports.js`) are externally visible.
   */
  modules?: Array<string>;
}
```

This enables graphing of packages unreachable from the entry location.  This is necessary, for example, when the entry module is a command-line tool, and that tool must reach into another directory to read a file. The most common concrete examples of this are ESLint and Webpack.  We can run these tools directly (e.g., using `@lavamoat/node`), but the actual "app" won't be a member of the compartment map, and thus the tool will be unable to read its config file (e.g., `webpack.config.js` / `eslint.config.js`).

We can provide an `additionalLocations` value such as `[{location: '.', modules: ['./webpack.config.js']}]` to cause the package at `.` (presumably, the "app") to be graphed and included in the compartment map. The canonical name of the package at `.` will be its package name (as if it was imported by `webpack`).

For a tool like Webpack or ESLint to actually reach the "app", it will still need permissions in policy to do so. So, if the "app" was `@foo/bar`, the `webpack` resource in policy would need to include a `packages: {"@foo/bar": true}` policy.  This presumes that the entry compartment does not have unrestricted permissions, which is not recommended for a third-party package.