### PR TITLE
refactor(compartment-mapper): use @endo/errors

### DIFF
--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@endo/cjs-module-analyzer": "workspace:^",
+    "@endo/errors": "workspace:^",
     "@endo/harden": "workspace:^",
     "@endo/hex": "workspace:^",
     "@endo/module-source": "workspace:^",

--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -1,5 +1,6 @@
 /* Validates a compartment map against its schema. */
 
+import { Fail, q, b } from '@endo/errors';
 import {
   assertPackagePolicy,
   ATTENUATORS_COMPARTMENT,
@@ -31,17 +32,13 @@ import {
  *   DigestedCompartmentDescriptor} from './types.js'
  */
 
-// TODO convert to the new `||` assert style.
-// Deferred because this file pervasively uses simple template strings rather than
-// template strings tagged with `assert.details` (aka `X`), and uses
-// this definition of `q` rather than `assert.quote`
-const q = JSON.stringify;
 const { keys, entries } = Object;
 const { isArray } = Array;
 
-/** @type {(a: string, b: string) => number} */
-// eslint-disable-next-line no-nested-ternary
-export const stringCompare = (a, b) => (a === b ? 0 : a < b ? -1 : 1);
+/** @type {(left: string, right: string) => number} */
+export const stringCompare = (left, right) =>
+  // eslint-disable-next-line no-nested-ternary
+  left === right ? 0 : left < right ? -1 : 1;
 
 /**
  * @template T
@@ -83,12 +80,8 @@ function* enumerate(iterable) {
  * @returns {asserts value is string}
  */
 const assertString = (value, pathOrMessage, url) => {
-  const keypath = pathOrMessage;
-  assert.typeof(
-    value,
-    'string',
-    `${keypath} in ${q(url)} must be a string; got ${q(value)}`,
-  );
+  typeof value === 'string' ||
+    Fail`${b(pathOrMessage)} in ${q(url)} must be a string; got ${q(value)}`;
 };
 
 /**
@@ -97,7 +90,7 @@ const assertString = (value, pathOrMessage, url) => {
  * @param {unknown} allegedLabel
  * @param {string} keypath
  * @param {string} url
- * @returns {asserts alleged is string}
+ * @returns {asserts allegedLabel is string}
  */
 const assertLabel = (allegedLabel, keypath, url) => {
   assertString(allegedLabel, keypath, url);
@@ -107,12 +100,10 @@ const assertLabel = (allegedLabel, keypath, url) => {
   if (allegedLabel === ENTRY_COMPARTMENT) {
     return;
   }
-  assert(
-    /^(?:@[a-z][a-z0-9-.]*\/)?[a-z][a-z0-9-.]*(?:>(?:@[a-z][a-z0-9-.]*\/)?[a-z][a-z0-9-.]*)*$/.test(
-      allegedLabel,
-    ),
-    `${keypath} must be a canonical name in ${q(url)}; got ${q(allegedLabel)}`,
-  );
+  /^(?:@[a-z][a-z0-9-.]*\/)?[a-z][a-z0-9-.]*(?:>(?:@[a-z][a-z0-9-.]*\/)?[a-z][a-z0-9-.]*)*$/.test(
+    allegedLabel,
+  ) ||
+    Fail`${b(keypath)} must be a canonical name in ${q(url)}; got ${q(allegedLabel)}`;
 };
 
 /**
@@ -123,12 +114,10 @@ const assertLabel = (allegedLabel, keypath, url) => {
  */
 const assertPlainObject = (allegedObject, keypath, url) => {
   const object = Object(allegedObject);
-  assert(
-    object === allegedObject &&
-      !isArray(object) &&
-      !(typeof object === 'function'),
-    `${keypath} must be an object; got ${q(allegedObject)} of type ${q(typeof allegedObject)} in ${q(url)}`,
-  );
+  (object === allegedObject &&
+    !isArray(object) &&
+    !(typeof object === 'function')) ||
+    Fail`${b(keypath)} must be an object; got ${q(allegedObject)} of type ${q(typeof allegedObject)} in ${q(url)}`;
 };
 
 /**
@@ -139,19 +128,8 @@ const assertPlainObject = (allegedObject, keypath, url) => {
  * @returns {asserts value is boolean}
  */
 const assertBoolean = (value, keypath, url) => {
-  assert.typeof(
-    value,
-    'boolean',
-    `${keypath} in ${q(url)} must be a boolean; got ${q(value)}`,
-  );
-};
-
-/**
- * @param {Record<string, unknown>} object
- * @param {string} message
- */
-const assertEmptyObject = (object, message) => {
-  assert(keys(object).length === 0, message);
+  typeof value === 'boolean' ||
+    Fail`${b(keypath)} in ${q(url)} must be a boolean; got ${q(value)}`;
 };
 
 /**
@@ -161,11 +139,11 @@ const assertEmptyObject = (object, message) => {
  */
 const assertConditions = (conditions, url) => {
   if (conditions === undefined) return;
-  assert(
-    isArray(conditions),
-    `conditions must be an array; got ${conditions} in ${q(url)}`,
-  );
-  for (const [index, value] of enumerate(conditions)) {
+  isArray(conditions) ||
+    Fail`conditions must be an array; got ${q(conditions)} in ${q(url)}`;
+  for (const [index, value] of enumerate(
+    /** @type {unknown[]} */ (conditions),
+  )) {
     assertString(value, `conditions[${index}]`, url);
   }
 };
@@ -221,10 +199,8 @@ const assertCompartmentModuleConfiguration = (
     getModuleConfigurationSpecificProperties(
       /** @type {CompartmentModuleConfiguration} */ (moduleDescriptor),
     );
-  assertEmptyObject(
-    extra,
-    `${keypath} must not have extra properties; got ${q(extra)} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`${b(keypath)} must not have extra properties; got ${q(extra)} in ${q(url)}`;
 
   assertString(compartment, `${keypath}.compartment`, url);
   assertString(module, `${keypath}.module`, url);
@@ -241,12 +217,8 @@ const assertFileModuleConfiguration = (moduleDescriptor, keypath, url) => {
     getModuleConfigurationSpecificProperties(
       /** @type {FileModuleConfiguration} */ (moduleDescriptor),
     );
-  assertEmptyObject(
-    extra,
-    `${keypath} must not have extra properties; got ${q(
-      keys(extra),
-    )} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`${b(keypath)} must not have extra properties; got ${q(keys(extra))} in ${q(url)}`;
   if (location !== undefined) {
     assertString(location, `${keypath}.location`, url);
   }
@@ -267,12 +239,8 @@ const assertExitModuleConfiguration = (moduleDescriptor, keypath, url) => {
   const { exit, ...extra } = getModuleConfigurationSpecificProperties(
     /** @type {ExitModuleConfiguration} */ (moduleDescriptor),
   );
-  assertEmptyObject(
-    extra,
-    `${keypath} must not have extra properties; got ${q(
-      keys(extra),
-    )} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`${b(keypath)} must not have extra properties; got ${q(keys(extra))} in ${q(url)}`;
   assertString(exit, `${keypath}.exit`, url);
 };
 
@@ -370,10 +338,8 @@ function assertModuleConfiguration(allegedModule, keypath, url, kinds) {
     }
   }
 
-  assert(
-    errors.length < finalKinds.length,
-    `invalid module descriptor in ${q(url)} at ${q(keypath)}; expected to match one of ${q(kinds)}: ${errors.map(err => err.message).join('; ')}`,
-  );
+  errors.length < finalKinds.length ||
+    Fail`invalid module descriptor in ${q(url)} at ${q(keypath)}; expected to match one of ${q(kinds)}: ${errors.map(err => err.message).join('; ')}`;
 }
 
 /**
@@ -477,12 +443,10 @@ const assertParsers = (allegedParsers, keypath, url) => {
  * @returns {asserts allegedTruthyValue is NonNullable<unknown>}
  */
 const assertTruthy = (allegedTruthyValue, keypath, url) => {
-  assert(
-    allegedTruthyValue,
-    url
-      ? `${keypath} in ${q(url)} must be truthy; got ${q(allegedTruthyValue)}`
-      : url,
-  );
+  allegedTruthyValue ||
+    (url
+      ? Fail`${b(keypath)} in ${q(url)} must be truthy; got ${q(allegedTruthyValue)}`
+      : Fail`${q(url)}`);
 };
 
 /**
@@ -502,12 +466,8 @@ const assertScope = (allegedScope, keypath, url, assertCompartmentValue) => {
   assertPlainObject(allegedScope, keypath, url);
 
   const { compartment, ...extra } = allegedScope;
-  assertEmptyObject(
-    extra,
-    `${keypath} must not have extra properties; got ${q(
-      keys(extra),
-    )} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`${b(keypath)} must not have extra properties; got ${q(keys(extra))} in ${q(url)}`;
 
   if (assertCompartmentValue) {
     assertCompartmentValue(compartment, `${keypath}.compartment`, url);
@@ -630,14 +590,10 @@ const assertCompartmentDescriptor = (
  */
 const assertFileUrlString = (allegedFileUrlString, keypath, url) => {
   assertString(allegedFileUrlString, keypath, url);
-  assert(
-    allegedFileUrlString.startsWith('file://'),
-    `${keypath} must be a file URL in ${q(url)}; got ${q(allegedFileUrlString)}`,
-  );
-  assert(
-    allegedFileUrlString.length > 7,
-    `${keypath} must contain a non-empty path in ${q(url)}; got ${q(allegedFileUrlString)}`,
-  );
+  allegedFileUrlString.startsWith('file://') ||
+    Fail`${b(keypath)} must be a file URL in ${q(url)}; got ${q(allegedFileUrlString)}`;
+  allegedFileUrlString.length > 7 ||
+    Fail`${b(keypath)} must contain a non-empty path in ${q(url)}; got ${q(allegedFileUrlString)}`;
 };
 
 /**
@@ -706,12 +662,8 @@ const assertPackageCompartmentDescriptor = (
     ...extra
   } = /** @type {PackageCompartmentDescriptor} */ (allegedCompartment);
 
-  assertEmptyObject(
-    extra,
-    `${keypath} must not have extra properties; got ${q(
-      keys(extra),
-    )} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`${b(keypath)} must not have extra properties; got ${q(keys(extra))} in ${q(url)}`;
 
   assertPackageLocation(location, `${keypath}.location`, url);
   assertLabel(label, `${keypath}.label`, url);
@@ -746,12 +698,8 @@ const assertDigestedCompartmentDescriptor = (
     ...extra
   } = allegedCompartment;
 
-  assertEmptyObject(
-    extra,
-    `${keypath} must not have extra properties; got ${q(
-      keys(extra),
-    )} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`${b(keypath)} must not have extra properties; got ${q(keys(extra))} in ${q(url)}`;
 };
 
 /**
@@ -777,12 +725,8 @@ const assertFileCompartmentDescriptor = (allegedCompartment, keypath, url) => {
     ...extra
   } = /** @type {FileCompartmentDescriptor} */ (allegedCompartment);
 
-  assertEmptyObject(
-    extra,
-    `${keypath} must not have extra properties; got ${q(
-      keys(extra),
-    )} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`${b(keypath)} must not have extra properties; got ${q(keys(extra))} in ${q(url)}`;
 
   assertString(label, `${keypath}.label`, url);
 };
@@ -795,20 +739,16 @@ const assertFileCompartmentDescriptor = (allegedCompartment, keypath, url) => {
 const assertCompartmentDescriptors = (allegedCompartments, url) => {
   assertPlainObject(allegedCompartments, 'compartments', url);
   const compartmentNames = keys(allegedCompartments);
-  assert(
-    compartmentNames.length > 0,
-    `compartments must not be empty in ${q(url)}`,
-  );
+  compartmentNames.length > 0 ||
+    Fail`compartments must not be empty in ${q(url)}`;
   for (const key of keys(allegedCompartments)) {
     assertString(
       key,
       `all keys of compartments must be strings; got ${key} in ${q(url)}`,
     );
   }
-  assert(
-    compartmentNames.every(name => typeof name === 'string'),
-    `all keys of compartments must be strings; got ${q(compartmentNames)} in ${q(url)}`,
-  );
+  compartmentNames.every(name => typeof name === 'string') ||
+    Fail`all keys of compartments must be strings; got ${q(compartmentNames)} in ${q(url)}`;
 };
 
 /**
@@ -842,12 +782,8 @@ const assertPackageCompartmentDescriptors = (allegedCompartments, url) => {
 const assertEntry = (allegedEntry, url) => {
   assertPlainObject(allegedEntry, 'entry', url);
   const { compartment, module, ...extra } = allegedEntry;
-  assertEmptyObject(
-    extra,
-    `"entry" must not have extra properties in compartment map; got ${q(
-      keys(extra),
-    )} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`"entry" must not have extra properties in compartment map; got ${q(keys(extra))} in ${q(url)}`;
   assertString(compartment, 'entry.compartment', url);
   assertString(module, 'entry.module', url);
 };
@@ -867,12 +803,8 @@ const assertCompartmentMap = (allegedCompartmentMap, url) => {
     compartments: _compartments,
     ...extra
   } = allegedCompartmentMap;
-  assertEmptyObject(
-    extra,
-    `Compartment map must not have extra properties; got ${q(
-      keys(extra),
-    )} in ${q(url)}`,
-  );
+  keys(extra).length === 0 ||
+    Fail`Compartment map must not have extra properties; got ${q(keys(extra))} in ${q(url)}`;
   assertConditions(conditions, url);
   assertEntry(entry, url);
   assertTruthy(

--- a/packages/compartment-mapper/test/compartment-map-validators.test.js
+++ b/packages/compartment-mapper/test/compartment-map-validators.test.js
@@ -1,0 +1,92 @@
+// Tests covering edge cases in `compartment-map.js` validators surfaced by
+// the saboteur review of the `assert` -> `Fail` refactor.
+//
+// These tests exercise the validators indirectly via the package's exported
+// `assertFileCompartmentMap`, which internally drives the file-internal
+// helpers (`assertConditions`, `assertString`, and the inlined empty-object
+// checks).
+
+import 'ses';
+import test from 'ava';
+
+import {
+  assertFileCompartmentMap,
+  stringCompare,
+} from '../src/compartment-map.js';
+
+const wrap = (extras = {}) => ({
+  tags: [],
+  entry: { compartment: 'app-v1.0.0', module: './main.js' },
+  compartments: {
+    'app-v1.0.0': {
+      name: 'app',
+      label: 'app',
+      location: 'file:///app/',
+      modules: {
+        './main.js': { compartment: 'app-v1.0.0', module: './main.js' },
+      },
+    },
+  },
+  ...extras,
+});
+
+test('assertConditions reports Symbol input via bestEffortStringify', t => {
+  const symbol = Symbol('forbidden');
+  const error = t.throws(() =>
+    assertFileCompartmentMap(
+      { ...wrap(), tags: symbol },
+      'file:///compartment-map.json',
+    ),
+  );
+  // The intended assertion failure must surface; the prior `String(conditions)`
+  // shape would have thrown a V8 TypeError before `Fail` ever ran.
+  t.regex(error.message, /conditions must be an array/);
+  t.notRegex(error.message, /Cannot convert a Symbol value to a string/);
+  t.true(error.message.includes('Symbol(forbidden)'));
+});
+
+test('assertString reports a value with a throwing toString cleanly', t => {
+  const evil = {
+    toString() {
+      throw new Error('boom');
+    },
+  };
+  const error = t.throws(() =>
+    assertFileCompartmentMap(
+      { ...wrap(), entry: { compartment: evil, module: './main.js' } },
+      'file:///compartment-map.json',
+    ),
+  );
+  // bestEffortStringify must not propagate the inner toString throw; the
+  // assertion message is well-formed and names the failed field.
+  t.regex(error.message, /must be a string/);
+  t.notRegex(error.message, /^Error: boom$/);
+});
+
+test('stringCompare orders strings and resists b shadowing', t => {
+  // Guards against accidentally re-introducing the `(a, b)` parameter
+  // names that shadowed the imported `b` from `@endo/errors`.
+  t.is(stringCompare('a', 'b'), -1);
+  t.is(stringCompare('b', 'a'), 1);
+  t.is(stringCompare('x', 'x'), 0);
+});
+
+test('extra-property validation redacts the offending value', t => {
+  // Inlining the per-call-site `keys(extra).length === 0 || Fail`...``
+  // pattern keeps the keypath in `b()` and the offending key list in `q()`,
+  // so a sensitive *value* hung off an extra property never reaches the
+  // error message text.
+  const error = t.throws(() =>
+    assertFileCompartmentMap(
+      {
+        ...wrap(),
+        potentiallySemanticButUnrecognized:
+          'behave-differently-when-recognized',
+      },
+      'file:///compartment-map.json',
+    ),
+  );
+  t.regex(error.message, /must not have extra properties/);
+  t.true(error.message.includes('potentiallySemanticButUnrecognized'));
+  t.false(error.message.includes('behave-differently-when-recognized'));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,6 +601,7 @@ __metadata:
   dependencies:
     "@endo/cjs-module-analyzer": "workspace:^"
     "@endo/env-options": "workspace:^"
+    "@endo/errors": "workspace:^"
     "@endo/evasive-transform": "workspace:^"
     "@endo/eventual-send": "workspace:^"
     "@endo/harden": "workspace:^"


### PR DESCRIPTION

Closes: #XXXX
Refs: https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4#diff-2ce5fb201c10cb24e075359132ab825315f08bdd168d4c8e9ff464b87d3e74ffR4-R7 , #3110 


## Description

@boneskull reminded me of https://github.com/endojs/endo/commit/3fcb5b117eccb326c6c81339ae6a293a6bcaa9d4#diff-2ce5fb201c10cb24e075359132ab825315f08bdd168d4c8e9ff464b87d3e74ffR4-R7

This PR moves from the `assert` style towards the 
```js
    expr || Fail`...`
```
style, which is more efficient in the typical non-erroneous case, and is more idiomatic for Endo. It does this at the price of introducing a new dependency from `@endo/compartment-mapper` to `@endo/error` . If it is important for `@endo/compartment-mapper` not to transitively depend on `ses`, then this PR should probably wait on #3110 or a successor that accomplishes the same goal.

### Security Considerations

None

### Scaling Considerations

If this PR waits for #3110 or equivalent, then none. Otherwise, the transitive dependency on `ses` may be significant. OTOH, `@endo/compartment-mapper`'s use of `ses`'s `assert` shows that it is already transitively dependent, so probably makes no difference either way.

### Documentation Considerations

We want to encourage the `... || Fail...` style over the `assert` style, so good to get rid of violations of our own style preferences in our own code.

### Testing Considerations

All existing tests pass without modification, which should be good enough for this refactoring PR.

### Compatibility Considerations

Some error messages that were formed with untagged template literals are now formed with `Fail`. Untagged template literals don't redact, which seems to be intentional here. To preserve that intention, this PR annotations all `Fail` interpolations that did not already have a `q(...)` with a `b(...)`.

### Upgrade Considerations

none