### PR TITLE
support dynamic imports in CJS

### DIFF
--- a/packages/cjs-module-analyzer/LICENSE-MIT
+++ b/packages/cjs-module-analyzer/LICENSE-MIT
@@ -1,0 +1,10 @@
+MIT License
+-----------
+
+Copyright (C) 2018-2020 Guy Bedford
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/cjs-module-analyzer/README.md
+++ b/packages/cjs-module-analyzer/README.md
@@ -1,0 +1,12 @@
+# @endo/cjs-module-analyzer
+
+This is a fork of an older version of [cjs-module-lexer](https://github.com/nodejs/cjs-module-lexer) with the following changes:
+
+- Reports specifiers imported via `import()` statements.
+- Reports specifiers required via `require()` statements.
+
+## License
+
+Original author: Guy Bedford / MIT
+
+Modifications licensed: Apache-2.0

--- a/packages/cjs-module-analyzer/index.js
+++ b/packages/cjs-module-analyzer/index.js
@@ -27,6 +27,8 @@ let myexports;
 let unsafeGetters;
 let reexports;
 let requires;
+let imports;
+let importCallPositions;
 
 function resetState() {
   openTokenDepth = 0;
@@ -45,6 +47,8 @@ function resetState() {
   unsafeGetters = new Set();
   reexports = new Set();
   requires = [];
+  imports = [];
+  importCallPositions = [];
 }
 
 /** @typedef {0 | 1 | 2} RequireType */
@@ -66,10 +70,29 @@ const strictReserved = new Set([
 ]);
 
 /**
+ * Result of {@link analyzeCommonJS}
+ *
+ * @typedef {object} CJSModuleAnalysis
+ * @property {string[]} exports List of export names.
+ * @property {string[]} reexports List of reexported names; always empty.
+ * @property {string[]} requires List of specifiers found in `require()` calls.
+ * @property {string[]} imports List of specifiers found in `import()` calls.
+ * @property {string} source The source code with `import()` calls replaced with `$h_import`.
+ */
+
+/**
+ * Analyzes a CommonJS module source code and returns a record of the module's
+ * exports, reexports, requires, imports, and source code.
+ *
  * @param {string} cjsSource
  * @param {string} [name]
+ * @returns {CJSModuleAnalysis}
  */
 export function analyzeCommonJS(cjsSource, name = '<unknown>') {
+  if (cjsSource.includes('$h_import')) {
+    throw Error('Source contains reserved identifier "$h_import"');
+  }
+
   resetState();
   try {
     parseSource(cjsSource);
@@ -81,10 +104,25 @@ export function analyzeCommonJS(cjsSource, name = '<unknown>') {
     err.loc = pos;
     throw err;
   }
+
+  let transformedSource = cjsSource;
+  if (importCallPositions.length > 0) {
+    let built = '';
+    let lastPos = 0;
+    for (const importPos of importCallPositions) {
+      built += `${cjsSource.slice(lastPos, importPos)}$h_import`;
+      lastPos = importPos + 6;
+    }
+    built += cjsSource.slice(lastPos);
+    transformedSource = built;
+  }
+
   const result = {
     exports: [...myexports].filter(expt => !unsafeGetters.has(expt)),
     reexports: [...reexports],
     requires,
+    imports,
+    source: transformedSource,
   };
   resetState();
   return result;
@@ -127,8 +165,9 @@ function parseSource(cjsSource) {
     if (openTokenDepth === 0) {
       switch (ch) {
         case 105 /* i */:
-          if (source.startsWith('mport', pos + 1) && keywordStart(pos))
-            throwIfImportStatement();
+          if (source.startsWith('mport', pos + 1) && keywordStart(pos)) {
+            if (!tryParseImportCall()) throwIfImportStatement();
+          }
           lastTokenPos = pos;
           continue;
         case 114 /* r */: {
@@ -177,6 +216,10 @@ function parseSource(cjsSource) {
         lastTokenPos = pos;
         continue;
       }
+      case 105 /* i */:
+        if (source.startsWith('mport', pos + 1) && keywordStart(pos))
+          tryParseImportCall();
+        break;
       case 101 /* e */:
         if (source.startsWith('xport', pos + 1) && keywordStart(pos)) {
           if (source.charCodeAt(pos + 6) === 115 /* s */)
@@ -1077,6 +1120,38 @@ function tryParseRequire(requireType) {
     }
     pos = revertPos;
   }
+  return false;
+}
+
+function tryParseImportCall() {
+  const revertPos = pos;
+  pos += 6;
+  let ch = commentWhitespace();
+  if (ch === 40 /* ( */) {
+    pos++;
+    ch = commentWhitespace();
+    const specifierStart = pos + 1;
+    if (ch === 39 /* ' */) {
+      const simple = singleQuoteString();
+      const specifierEnd = pos++;
+      ch = commentWhitespace();
+      if (ch === 41 /* ) */ && simple) {
+        imports.push(source.slice(specifierStart, specifierEnd));
+        importCallPositions.push(revertPos);
+        return true;
+      }
+    } else if (ch === 34 /* " */) {
+      const simple = doubleQuoteString();
+      const specifierEnd = pos++;
+      ch = commentWhitespace();
+      if (ch === 41 /* ) */ && simple) {
+        imports.push(source.slice(specifierStart, specifierEnd));
+        importCallPositions.push(revertPos);
+        return true;
+      }
+    }
+  }
+  pos = revertPos;
   return false;
 }
 

--- a/packages/cjs-module-analyzer/test/cjs-module-analyzer.test.js
+++ b/packages/cjs-module-analyzer/test/cjs-module-analyzer.test.js
@@ -841,6 +841,36 @@ test('dynamic import method', t => {
   t.assert(analyzeCommonJS(source));
 });
 
+test('dynamic import()', t => {
+  const input = `
+    import('a').then(m => m.default);
+  `;
+  const { imports, source } = analyzeCommonJS(input);
+  t.deepEqual(imports, ['a']);
+  t.assert(source.includes("$h_import('a')"));
+  t.regex(source, /\$h_import\('a'\)/);
+});
+
+test('dynamic import() nested in function', t => {
+  const input = `
+    module.exports.load = async () => {
+      return import("dep");
+    };
+  `;
+  const { imports, source } = analyzeCommonJS(input);
+  t.deepEqual(imports, ['dep']);
+  t.assert(source.includes('$h_import("dep")'));
+});
+
+test('$h_import in source throws', t => {
+  const input = `
+    const $h_import = require('foo');
+  `;
+  t.throws(() => analyzeCommonJS(input), {
+    message: /reserved identifier "\$h_import"/,
+  });
+});
+
 test('Comments', t => {
   const source = `/*
   VERSION

--- a/packages/compartment-mapper/src/parse-cjs-shared-export-wrapper.js
+++ b/packages/compartment-mapper/src/parse-cjs-shared-export-wrapper.js
@@ -83,10 +83,11 @@ export const getModulePaths = (readPowers, location) => {
  * @param {string} in.location
  * @param {ReadFn | ReadPowers | undefined} in.readPowers
  * @returns {{
- *   module: { exports: any },
- *   moduleExports: any,
- *   afterExecute: Function,
- *   require: Function,
+ *   module: { exports: unknown },
+ *   moduleExports: unknown,
+ *   afterExecute: () => void,
+ *   require: (specifier: string) => unknown,
+ *   importFn: (specifier: string) => Promise<unknown>,
  * }}
  */
 export const wrap = ({
@@ -204,6 +205,15 @@ export const wrap = ({
 
   freeze(require);
 
+  /** @param {string} importSpecifier */
+  const importFn = async importSpecifier => {
+    const specifier = has(resolvedImports, importSpecifier)
+      ? resolvedImports[importSpecifier]
+      : importSpecifier;
+    return compartment.import(specifier);
+  };
+  freeze(importFn);
+
   const afterExecute = () => {
     const finalExports = module.exports; // in case it's a getter, only call it once
     const exportsHaveBeenOverwritten = finalExports !== originalExports;
@@ -231,5 +241,6 @@ export const wrap = ({
     moduleExports: originalExports,
     afterExecute,
     require,
+    importFn,
   };
 };

--- a/packages/compartment-mapper/src/parse-cjs.js
+++ b/packages/compartment-mapper/src/parse-cjs.js
@@ -11,6 +11,7 @@ import { analyzeCommonJS } from '@endo/cjs-module-analyzer';
 import { wrap, getModulePaths } from './parse-cjs-shared-export-wrapper.js';
 
 const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
 
 const { freeze } = Object;
 
@@ -22,13 +23,18 @@ export const parseCjs = (
   _packageLocation,
   { readPowers } = {},
 ) => {
-  const source = textDecoder.decode(bytes);
+  const originalSource = textDecoder.decode(bytes);
 
   const {
-    requires: imports,
+    requires: requires_,
+    imports,
     exports,
     reexports,
-  } = analyzeCommonJS(source, location);
+    source,
+  } = analyzeCommonJS(originalSource, location);
+
+  const requires =
+    imports.length > 0 ? [...new Set([...requires_, ...imports])] : requires_;
 
   if (!exports.includes('default')) {
     exports.push('default');
@@ -43,10 +49,10 @@ export const parseCjs = (
    */
   const execute = (moduleEnvironmentRecord, compartment, resolvedImports) => {
     const functor = compartment.evaluate(
-      `(function (require, exports, module, __filename, __dirname) { 'use strict'; ${source} })\n`,
+      `(function (require, exports, module, __filename, __dirname, $h_import) { 'use strict'; ${source} })\n`,
     );
 
-    const { require, moduleExports, module, afterExecute } = wrap({
+    const { require, moduleExports, module, afterExecute, importFn } = wrap({
       moduleEnvironmentRecord,
       compartment,
       resolvedImports,
@@ -62,15 +68,18 @@ export const parseCjs = (
       module,
       filename,
       dirname,
+      importFn,
     );
 
     afterExecute();
   };
 
+  const transformedBytes = textEncoder.encode(source);
+
   return {
     parser: 'cjs',
-    bytes,
-    record: freeze({ imports, exports, reexports, execute }),
+    bytes: transformedBytes,
+    record: freeze({ imports: requires, exports, reexports, execute }),
   };
 };
 

--- a/packages/compartment-mapper/test/cjs-compat.test.js
+++ b/packages/compartment-mapper/test/cjs-compat.test.js
@@ -9,6 +9,7 @@ import { scaffold } from './scaffold.js';
 
 /**
  * @import {FixtureAssertionFn} from './test.types.js';
+ * @import {ThirdPartyStaticModuleInterface} from 'ses'
  */
 
 const fixture = new URL(
@@ -19,9 +20,13 @@ const fixtureDirname = new URL(
   'fixtures-cjs-compat/node_modules/app/dirname.js',
   import.meta.url,
 ).toString();
+const fixtureDynamicImport = new URL(
+  'fixtures-cjs-compat/node_modules/dynamic-import/index.js',
+  import.meta.url,
+).toString();
 
 const q = JSON.stringify;
-
+const { freeze } = Object;
 /**
  * @type {FixtureAssertionFn<{requireResolvePaths: string[]}>}
  */
@@ -116,4 +121,31 @@ scaffold(
     }
   },
   3,
+);
+
+scaffold(
+  'fixtures-cjs-compat-dynamic-import',
+  test,
+  fixtureDynamicImport,
+  async (t, { namespace }) => {
+    // @ts-expect-error - untyped
+    const { namespace: dynamicNamespace } = await namespace.dynamicImport('a');
+    t.is(dynamicNamespace.foo, 'foo');
+  },
+  1,
+  {
+    knownArchiveFailure: true,
+    additionalOptions: {
+      importHook: async () => {
+        /** @type {ThirdPartyStaticModuleInterface} */
+        return freeze({
+          imports: [],
+          exports: ['foo'],
+          execute: moduleExports => {
+            moduleExports.foo = 'foo';
+          },
+        });
+      },
+    },
+  },
 );

--- a/packages/compartment-mapper/test/dynamic-import-esm.test.js
+++ b/packages/compartment-mapper/test/dynamic-import-esm.test.js
@@ -1,0 +1,24 @@
+import 'ses';
+
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+
+const fixture = new URL(
+  'fixtures-dynamic-import-esm/node_modules/app/index.js',
+  import.meta.url,
+).toString();
+
+scaffold(
+  'fixtures-dynamic-import-esm',
+  test,
+  fixture,
+  async (t, { namespace }) => {
+    // @ts-expect-error - untyped
+    const foo = await namespace.getFoo();
+    t.is(foo, 'foo');
+  },
+  1,
+  {
+    knownArchiveFailure: true,
+  },
+);

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/dynamic-import/index.js
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/dynamic-import/index.js
@@ -1,0 +1,3 @@
+module.exports.dynamicImport = async () => {
+  return import('node:fs');
+};

--- a/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/dynamic-import/package.json
+++ b/packages/compartment-mapper/test/fixtures-cjs-compat/node_modules/dynamic-import/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dynamic-import",
+  "main": "./index.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/foo.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/foo.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/index.js
@@ -1,0 +1,4 @@
+export const getFoo = async () => {
+  const foo = await import('./foo.js');
+  return foo.default;
+};

--- a/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./index.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}


### PR DESCRIPTION
## REVIEWERS

I acknowledge mauling the CJS lexer to transform `import()` calls on-the-fly is an egregious violation of the single-responsibility principle and is thus a _bad idea._  That said, I want to replace the lexer with an AST parser (done similarly to ESM sources), perhaps soon.  

### feat(compartment-mapper): support dynamic import() in CommonJS

This change enables use of (`await`) `import(specifier)` in CommonJS sources.

To make this work, `parse-cjs-shared-export-wrapper.js` provides an `importFn` to the functor, which invokes `compartment.import()`.  The CJS module source is transformed on-the-fly by `@endo/cjs-module-analyzer` which evades SES.

Note that dynamically-imported _non-exit_ modules are still unsupported by `loadLocation`/`importLocation` due a lack of support for pre-loaded compartments (`_preload`). Currently, only `captureForMap()` supports this option. Without it, dynamically-imported modules will be unknown to Endo unless they were statically loaded via other means.  Exit modules can be loaded dynamically _if_ the caller provides an `importHook`.

Added tests covering dynamic imports in _both_ ESM and CJS.

### feat(cjs-module-analyzer): detect dynamic imports; add on-the-fly evasion

This modifies the `analyzeCommonJS` function to return an object with two new properties:

1. `imports`: list of specifiers imported via `import()` calls
2. `source`: transformed source for SES evasion, replacing `import()` with `$h_import()`

If `$h_import` is detected in the original source, it will throw an exception. There are better ways to handle this, of course.

Updated `README.md` and added missing MIT license / attribution.
