### PR TITLE
fix: resolve #3025 — Pet Dæmon: Guest code evaluation requests

### DIFF
--- a/packages/pet-daemon/src/guest-evaluate.js
+++ b/packages/pet-daemon/src/guest-evaluate.js
@@ -1,0 +1,48 @@
+let nextRequestId = 0;
+
+const makeRequestId = () => {
+ nextRequestId += 1;
+ return `${Date.now()}-${nextRequestId}`;
+};
+
+export const makeGuestEvaluator = mailbox => {
+ if (!mailbox || typeof mailbox.send !== 'function' || typeof mailbox.receive !== 'function') {
+    throw new TypeError('mailbox must have send and receive functions');
+ }
+
+ const evaluate = async program => {
+    if (typeof program !== 'string') {
+      throw new TypeError('program must be a string');
+    }
+
+    const requestId = makeRequestId();
+    const message = {
+      type: 'evaluation-request',
+      requestId,
+      source: program,
+      location: {
+        source: 'guest',
+        line: 1,
+        column: 0,
+      },
+    };
+
+    await mailbox.send(message);
+
+    for (;;) {
+      const response = await mailbox.receive();
+      if (!response) {
+        throw new Error('No response from host');
+      }
+      if (response.type === 'evaluation-response' && response.requestId === requestId) {
+        if (response.allow === true || response.decision === 'allow' || response.ok === true) {
+          return response;
+        }
+        const reason = response.reason || response.error || 'Evaluation denied';
+        throw new Error(reason);
+      }
+    }
+ };
+
+ return evaluate;
+};

--- a/packages/pet-daemon/src/host-evaluate-handler.js
+++ b/packages/pet-daemon/src/host-evaluate-handler.js
@@ -1,0 +1,45 @@
+import { makePromiseKit } from '@endo/promise-kit';
+
+export const makeHostEvaluateHandler = (mailbox, endo, presenter) => {
+  const { promise, resolve } = makePromiseKit();
+
+  const handler = async message => {
+    if (message.type !== 'evaluation-request') {
+      return;
+    }
+
+    const { code, requestID } = message;
+
+    const decision = await presenter.presentEvaluationRequest(code);
+
+    if (!decision.approved) {
+      await mailbox.send({
+        type: 'evaluation-response',
+        requestID,
+        approved: false,
+        reason: decision.reason,
+      });
+      return;
+    }
+
+    let result;
+    let error;
+    try {
+      result = await endo.evaluate(code);
+    } catch (err) {
+      error = String(err);
+    }
+
+    await mailbox.send({
+      type: 'evaluation-response',
+      requestID,
+      approved: true,
+      result,
+      error,
+    });
+  };
+
+  mailbox.addHandler(handler);
+
+  return promise;
+};


### PR DESCRIPTION
## Summary

fix: resolve #3025 — Pet Dæmon: Guest code evaluation requests

## Problem

**Severity**: `High` | **File**: `packages/pet-daemon/src/guest-evaluate.js`

Create a new module that provides the `evaluate` function to guest code. This function should accept a program string and package it as an evaluation request message to be sent to the host via the mail system. The function should return a promise that resolves or rejects based on the host's response (allow/deny).

## Solution

Export a `makeGuestEvaluator(mailbox)` function that returns an `evaluate(program)` async function. The `evaluate` function should construct a structured mail message of type 'evaluation-request' containing the source code, send it through the mailbox, and await a response message of type 'evaluation-response'. Include source location metadata and a unique request ID for correlation.

## Changes

- `packages/pet-daemon/src/guest-evaluate.js` (new)
- `packages/pet-daemon/src/host-evaluate-handler.js` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.15.0*