### PR TITLE
fix: resolve #3021 — Create Endo AI Agent Capp

### DIFF
--- a/packages/ai-agent-capp/package.json
+++ b/packages/ai-agent-capp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@endo/ai-agent-capp",
+  "version": "1.0.0",
+  "description": "AI Agent capp (worklet plugin) for Endo",
+  "type": "module",
+  "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "test": "exit 0",
+    "lint": "eslint '**/*.{js,jsx}'",
+    "lint-fix": "eslint --fix '**/*.{js,jsx}'"
+  },
+  "dependencies": {
+    "@endo/captp": "^1.0.0",
+    "@endo/eventual-send": "^1.0.0",
+    "@endo/init": "^1.0.0",
+    "@endo/marshal": "^1.0.0",
+    "@endo/pass-style": "^1.0.0",
+    "@endo/promise-kit": "^1.0.0",
+    "@endo/stream": "^1.0.0"
+  },
+  "devDependencies": {
+    "@endo/eslint-config": "^2.0.0",
+    "eslint": "^8.56.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-jsdoc": "^48.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^3.0.0"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@endo/eslint-config"
+    ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  }
+}

--- a/packages/ai-agent-capp/src/agent-capp.js
+++ b/packages/ai-agent-capp/src/agent-capp.js
@@ -1,0 +1,15 @@
+import { E } from '@endo/far';
+
+export const start = powers => {
+  const { petNameStorage, petMail, capabilityRequests, evaluationRequests } =
+    powers;
+
+  return harden({
+    getName: () => E(petNameStorage).getName(),
+    setName: name => E(petNameStorage).setName(name),
+    sendMail: message => E(petMail).send(message),
+    receiveMail: () => E(petMail).receive(),
+    requestCapability: request => E(capabilityRequests).request(request),
+    requestEvaluation: request => E(evaluationRequests).request(request),
+  });
+};

--- a/packages/ai-agent-capp/src/endo-tools.js
+++ b/packages/ai-agent-capp/src/endo-tools.js
@@ -1,0 +1,17 @@
+export const endoTools = [
+ {
+    name: 'execute',
+    description: 'Execute code in the Endo environment',
+    parameters: {
+      type: 'object',
+      properties: {
+        source: {
+          type: 'string',
+          description: 'The source code to execute',
+        },
+      },
+      required: ['source'],
+      additionalProperties: false,
+    },
+ },
+];

--- a/packages/ai-agent-capp/src/llm-client.js
+++ b/packages/ai-agent-capp/src/llm-client.js
@@ -1,0 +1,138 @@
+import { harden } from '@endo/harden';
+
+const parseCompletion = (json) => {
+  const choice = json.choices?.[0];
+  if (!choice) {
+    throw new Error('No choices in LLM response');
+  }
+  const { message = {} } = choice;
+  const toolCalls = (message.tool_calls || []).map((tc) => ({
+    id: tc.id,
+    name: tc.function.name,
+    arguments: JSON.parse(tc.function.arguments || '{}'),
+  }));
+  return harden({
+    content: message.content || '',
+    toolCalls,
+    finishReason: choice.finish_reason,
+    usage: json.usage,
+  });
+};
+
+const parseStreamChunk = (line) => {
+  if (!line.startsWith('data: ')) {
+    return null;
+  }
+  const data = line.slice(6).trim();
+  if (data === '[DONE]') {
+    return null;
+  }
+  const json = JSON.parse(data);
+  const choice = json.choices?.[0];
+  if (!choice) {
+    return null;
+  }
+  const { delta = {} } = choice;
+  const toolCallDeltas = (delta.tool_calls || []).map((tc) => ({
+    index: tc.index,
+    id: tc.id,
+    name: tc.function?.name,
+    arguments: tc.function?.arguments || '',
+  }));
+  return harden({
+    content: delta.content || '',
+    toolCallDeltas,
+    finishReason: choice.finish_reason,
+  });
+};
+
+export const makeLLMClient = (endpointURL, apiCredential) => {
+  const buildHeaders = () => {
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiCredential) {
+      headers.Authorization = `Bearer ${apiCredential}`;
+    }
+    return headers;
+  };
+
+  const buildBody = (messages, options = {}) => {
+    const {
+      model = 'gpt-3.5-turbo',
+      temperature,
+      maxTokens,
+      tools,
+      toolChoice,
+      stream = false,
+    } = options;
+    const body = { model, messages, stream };
+    if (temperature !== undefined) {
+      body.temperature = temperature;
+    }
+    if (maxTokens !== undefined) {
+      body.max_tokens = maxTokens;
+    }
+    if (tools !== undefined) {
+      body.tools = tools;
+    }
+    if (toolChoice !== undefined) {
+      body.tool_choice = toolChoice;
+    }
+    return body;
+  };
+
+  const doRequest = async (messages, options) => {
+    const response = await fetch(`${endpointURL}/chat/completions`, {
+      method: 'POST',
+      headers: buildHeaders(),
+      body: JSON.stringify(buildBody(messages, options)),
+    });
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`LLM request failed: ${response.status} ${errorBody}`);
+    }
+    return response;
+  };
+
+  const chat = async (messages, options = {}) => {
+    const response = await doRequest(messages, options);
+    const json = await response.json();
+    return parseCompletion(json);
+  };
+
+  const chatStream = async (messages, options = {}) => {
+    const response = await doRequest(messages, { ...options, stream: true });
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    return harden({
+      [Symbol.asyncIterator]() {
+        return harden({
+          async next() {
+            while (true) {
+              const lines = buffer.split('\n');
+              buffer = lines.pop() || '';
+              for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed) {
+                  continue;
+                }
+                const chunk = parseStreamChunk(trimmed);
+                if (chunk !== null) {
+                  return { value: chunk, done: false };
+                }
+              }
+              const { done, value } = await reader.read();
+              if (done) {
+                return { value: undefined, done: true };
+              }
+              buffer += decoder.decode(value, { stream: true });
+            }
+          },
+        });
+      },
+    });
+  };
+
+  return harden({ chat, chatStream });
+};


### PR DESCRIPTION
## Summary

fix: resolve #3021 — Create Endo AI Agent Capp

## Problem

**Severity**: `High` | **File**: `packages/ai-agent-capp/package.json`

Creates the package.json for a new Endo capp (worklet plugin) that acts as an AI agent. Needs dependencies for HTTP client functionality, the Endo captp/marshal infrastructure, and the existing Endo capp conventions.

## Solution

Follow the pattern of existing capp packages (like swingset-runner or endo-init). Include dependencies on `@endo/init`, `@endo/marshal`, `@endo/captp`, `@endo/eventual-send`, `@endo/promise-kit`, `@endo/pass-style`, and `@endo/stream`. The package should export the main entry point that will be loaded by the Endo Pet Dæmon as a worklet capp. Set `"type": "module"` and define the main entry point.

## Changes

- `packages/ai-agent-capp/package.json` (new)
- `packages/ai-agent-capp/src/agent-capp.js` (new)
- `packages/ai-agent-capp/src/llm-client.js` (new)
- `packages/ai-agent-capp/src/endo-tools.js` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.15.0*