### PR TITLE
vibe(daemon): replace synced store with synced export tables under peer formula

### DIFF
--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -516,7 +516,12 @@ const makeDaemonCore = async (
           ['bundle', formula.bundle],
         ];
       case 'peer':
-        return [['networks', formula.networks]];
+        return [
+          ['networks', formula.networks],
+          ...(formula.syncedStore === undefined
+            ? []
+            : [['syncedStore', formula.syncedStore]]),
+        ];
       case 'handle':
         return [['agent', formula.agent]];
       case 'mail-hub':
@@ -2951,6 +2956,28 @@ const makeDaemonCore = async (
     return /** @type {FormulaIdentifier} */ (peerId);
   };
 
+  /** @type {DaemonCore['setPeerSyncedStore']} */
+  const setPeerSyncedStore = async (peerId, syncedStoreId) => {
+    const peerFormula = await getFormulaForId(peerId);
+    if (peerFormula.type !== 'peer') {
+      throw makeError(X`Formula ${q(peerId)} is not a peer`);
+    }
+    if (peerFormula.syncedStore === syncedStoreId) {
+      return;
+    }
+    /** @type {PeerFormula} */
+    const updatedFormula = harden({
+      ...peerFormula,
+      syncedStore: syncedStoreId,
+    });
+    const { number: peerNumber } = parseId(peerId);
+    await persistencePowers.writeFormula(peerNumber, updatedFormula);
+    await withFormulaGraphLock(async () => {
+      formulaForId.set(peerId, updatedFormula);
+      formulaGraph.onFormulaAdded(peerId, updatedFormula);
+    });
+  };
+
   /** @type {DaemonCore['cancelValue']} */
   const cancelValue = async (id, reason) => {
     // Wait for any in-flight graph operation (formulation, collection)
@@ -4483,6 +4510,7 @@ const makeDaemonCore = async (
           /** @type {FormulaNumber} */ ('0'.repeat(64)),
           peerId, // store dependency (peer keeps alive)
         );
+      await setPeerSyncedStore(peerId, syncedStoreId);
 
       // Write the guest handle locator into a hidden synced-store entry.
       // Hidden entries use special-name keys and are filtered from ordinary
@@ -4515,22 +4543,12 @@ const makeDaemonCore = async (
       // Create a local guest backed by the synced store.
       /** @type {DeferredTasks<AgentDeferredTaskParams>} */
       const guestTasks = makeDeferredTasks();
-      const { id: localGuestId } = await formulateGuest(
+      await formulateGuest(
         hostAgentId,
         hostHandleId,
         guestTasks,
         `guest:${guestName}`,
         syncedStoreId,
-      );
-
-      // Name the local guest handle inside @pins so that incarnating
-      // it transitively incarnates the guest and its synced pet store.
-      const localGuestFormula = /** @type {GuestFormula} */ (
-        await getFormulaForId(localGuestId)
-      );
-      await E(hostAgent).storeIdentifier(
-        /** @type {NamePath} */ (['@pins', `guest-${guestName}`]),
-        localGuestFormula.handle,
       );
 
       // Store the remote guest handle under guestName for mail delivery.
@@ -4691,6 +4709,7 @@ const makeDaemonCore = async (
     formulateScratchMount,
     formulateInvitation,
     formulateSyncedPetStore,
+    setPeerSyncedStore,
     formulateDirectoryForStore,
     getPeerIdForNodeIdentifier,
     getAllNetworkAddresses,
@@ -4814,6 +4833,9 @@ const makeDaemonCore = async (
           harden({
             NODE: formula.node,
             ADDRESSES: formula.addresses,
+            ...(formula.syncedStore === undefined
+              ? {}
+              : { SYNCED_STORE: formula.syncedStore }),
           }),
         );
       }

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -4484,10 +4484,13 @@ const makeDaemonCore = async (
           peerId, // store dependency (peer keeps alive)
         );
 
-      // Write the guest handle locator into the synced store.
+      // Write the guest handle locator into a hidden synced-store entry.
+      // Hidden entries use special-name keys and are filtered from ordinary
+      // user-facing listing operations.
+      const peerHandleEntry = /** @type {PetName} */ ('@peer-handle');
       const guestHandleLocatorStr = formatLocator(guestHandleId, 'remote');
       await E(syncedStoreValue).storeLocator(
-        /** @type {PetName} */ (guestName),
+        peerHandleEntry,
         guestHandleLocatorStr,
       );
 
@@ -4505,10 +4508,8 @@ const makeDaemonCore = async (
           hostHandleExternalId,
           'handle',
         );
-        await E(syncedStoreValue).storeLocator(
-          /** @type {PetName} */ (hostNameFromGuest),
-          hostHandleLocatorStr,
-        );
+        const selfHandleEntry = /** @type {PetName} */ ('@self-handle');
+        await E(syncedStoreValue).storeLocator(selfHandleEntry, hostHandleLocatorStr);
       }
 
       // Create a local guest backed by the synced store.

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -516,12 +516,12 @@ const makeDaemonCore = async (
           ['bundle', formula.bundle],
         ];
       case 'peer':
-        return [
+        return /** @type {Array<[string, FormulaIdentifier]>} */ ([
           ['networks', formula.networks],
           ...(formula.syncedStore === undefined
             ? []
             : [['syncedStore', formula.syncedStore]]),
-        ];
+        ]);
       case 'handle':
         return [['agent', formula.agent]];
       case 'mail-hub':

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -201,10 +201,20 @@ export const makeHostMaker = ({
       isLocalKey,
       getNetworkAddresses,
     );
-    let exportRetentionCounter = 0;
-    const makeExportRetentionName = () => {
-      exportRetentionCounter += 1;
-      return `@export-${exportRetentionCounter.toString(16)}`;
+    /**
+     * Derive an objective, deterministic hidden export-table key.
+     * Use the externalized identifier (node:number) so the key is
+     * stable across process restarts and independent of local formula
+     * identifier normalization.
+     *
+     * @param {FormulaIdentifier} externalizedId
+     * @returns {Name}
+     */
+    const makeExportRetentionNameForId = externalizedId => {
+      const { node, number } = parseId(externalizedId);
+      return /** @type {Name} */ (
+        `@export-${node.slice(0, 16)}-${number.slice(0, 16)}`
+      );
     };
 
     /**
@@ -245,7 +255,7 @@ export const makeHostMaker = ({
           });
           const locator = formatLocator(externalizedId, formulaType);
           await E(syncedStore).storeLocator(
-            /** @type {Name} */ (makeExportRetentionName()),
+            makeExportRetentionNameForId(id),
             locator,
           );
         }

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -13,6 +13,7 @@ import {
   assertPetNamePath,
   assertName,
   assertNamePath,
+  isPetName,
   namePathFrom,
 } from './pet-name.js';
 import {
@@ -21,7 +22,7 @@ import {
   parseId,
   formatId,
 } from './formula-identifier.js';
-import { addressesFromLocator, formatLocator } from './locator.js';
+import { addressesFromLocator, formatLocator, LOCAL_NODE } from './locator.js';
 import { toHex, fromHex } from './hex.js';
 import { makePetSitter } from './pet-sitter.js';
 
@@ -198,6 +199,55 @@ export const makeHostMaker = ({
       isLocalKey,
       getNetworkAddresses,
     );
+    let exportRetentionCounter = 0;
+    const makeExportRetentionName = () => {
+      exportRetentionCounter += 1;
+      return `@export-${exportRetentionCounter.toString(16)}`;
+    };
+
+    /**
+     * Track formulas sent to a remote peer in that peer's hidden synced table.
+     * These entries retain formulas even if the exporter never names them
+     * in their own local pet store.
+     *
+     * @param {FormulaIdentifier} recipientId
+     * @param {FormulaIdentifier[]} ids
+     */
+    const trackSentIdentifiers = async (recipientId, ids) => {
+      const { node: recipientNode } = parseId(recipientId);
+      if (recipientNode === LOCAL_NODE || isLocalKey(recipientNode)) {
+        return;
+      }
+
+      const peerNames = specialStore
+        .reverseIdentify(recipientId)
+        .filter(name => isPetName(name));
+
+      for (const peerName of peerNames) {
+        let syncedStore;
+        try {
+          syncedStore = await getSyncedStore(peerName);
+        } catch {
+          continue;
+        }
+        for (const id of ids) {
+          const { node } = parseId(id);
+          if (node !== LOCAL_NODE && !isLocalKey(node)) {
+            continue;
+          }
+          const formulaType = await getTypeForId(id);
+          const { number } = parseId(id);
+          const externalizedId = formatId({
+            number,
+            node: agentNodeNumber,
+          });
+          const locator = formatLocator(externalizedId, formulaType);
+          await E(syncedStore).storeLocator(makeExportRetentionName(), locator);
+        }
+        return;
+      }
+    };
+
     const mailbox = await makeMailbox({
       petStore: specialStore,
       agentNodeNumber,
@@ -205,6 +255,7 @@ export const makeHostMaker = ({
       directory,
       selfId: handleId,
       context,
+      trackSentIdentifiers,
     });
     const { petStore, handle } = mailbox;
     const getEndoBootstrap = async () => provide(endoId, 'endo');

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -244,7 +244,10 @@ export const makeHostMaker = ({
             node: agentNodeNumber,
           });
           const locator = formatLocator(externalizedId, formulaType);
-          await E(syncedStore).storeLocator(makeExportRetentionName(), locator);
+          await E(syncedStore).storeLocator(
+            /** @type {Name} */ (makeExportRetentionName()),
+            locator,
+          );
         }
         return;
       }

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -72,6 +72,7 @@ const normalizeHostOrGuestOptions = opts => {
  * @param {DaemonCore['formulateScratchMount']} args.formulateScratchMount
  * @param {DaemonCore['formulateInvitation']} args.formulateInvitation
  * @param {DaemonCore['formulateSyncedPetStore']} args.formulateSyncedPetStore
+ * @param {DaemonCore['setPeerSyncedStore']} args.setPeerSyncedStore
  * @param {DaemonCore['formulateDirectoryForStore']} args.formulateDirectoryForStore
  * @param {DaemonCore['getPeerIdForNodeIdentifier']} args.getPeerIdForNodeIdentifier
  * @param {DaemonCore['formulateChannel']} args.formulateChannel
@@ -106,6 +107,7 @@ export const makeHostMaker = ({
   formulateScratchMount,
   formulateInvitation,
   formulateSyncedPetStore,
+  setPeerSyncedStore,
   formulateDirectoryForStore,
   getPeerIdForNodeIdentifier,
   formulateChannel,
@@ -932,28 +934,17 @@ export const makeHostMaker = ({
         /** @type {import('./types.js').FormulaNumber} */ (syncedStoreNumber),
         peerId, // store dependency
       );
+      await setPeerSyncedStore(peerId, syncedStoreId);
 
       // Create a local guest backed by the synced store.
       /** @type {import('./types.js').DeferredTasks<import('./types.js').AgentDeferredTaskParams>} */
       const guestTasks = makeDeferredTasks();
-      const { id: localGuestId } = await formulateGuest(
+      await formulateGuest(
         hostId,
         handleId,
         guestTasks,
         `guest:${guestName}`,
         syncedStoreId,
-      );
-
-      // Look up the local guest's handle from its formula so we can
-      // name it.  Incarnating the handle transitively incarnates the
-      // guest and its synced pet store, starting synchronisation.
-      const localGuestFormula =
-        /** @type {import('./types.js').GuestFormula} */ (
-          await getFormulaForId(localGuestId)
-        );
-      await E(directory).storeIdentifier(
-        ['@pins', `guest-${guestName}`],
-        localGuestFormula.handle,
       );
 
       // Store the remote handle under guestName for mail delivery.
@@ -969,31 +960,30 @@ export const makeHostMaker = ({
 
     /** @type {EndoHost['registerSyncedStore']} */
     const registerSyncedStore = async (_petName, _syncedStoreId) => {
-      // No-op: the synced store is now discovered via the formula
-      // graph (guest handle → guest → petStore).  Retained for
-      // interface compatibility.
+      // No-op: synced stores are attached to peer formulas.
+      // Retained for interface compatibility.
     };
 
     /** @type {EndoHost['getSyncedStore']} */
     const getSyncedStore = async petName => {
-      // Traverse the formula graph:
-      // @pins/guest-<name> → local guest handle
-      //   → handle formula.agent → guest formula
-      //     → guest formula.petStore → synced store
-      const localHandleId = await E(directory).identify(
-        '@pins',
-        `guest-${petName}`,
-      );
-      if (localHandleId === undefined) {
+      const remoteHandleId = await E(directory).identify(petName);
+      if (remoteHandleId === undefined) {
         throw new Error(`No synced store for ${q(petName)}`);
       }
-      const handleFormula = /** @type {import('./types.js').HandleFormula} */ (
-        await getFormulaForId(/** @type {FormulaIdentifier} */ (localHandleId))
+      const { node: remoteNode } = parseId(
+        /** @type {FormulaIdentifier} */ (remoteHandleId),
       );
-      const guestFormula = /** @type {import('./types.js').GuestFormula} */ (
-        await getFormulaForId(handleFormula.agent)
+      if (remoteNode === LOCAL_NODE || isLocalKey(remoteNode)) {
+        throw new Error(`No synced store for non-peer ${q(petName)}`);
+      }
+      const peerId = await getPeerIdForNodeIdentifier(
+        /** @type {NodeNumber} */ (remoteNode),
       );
-      return provide(guestFormula.petStore, 'synced-pet-store');
+      const peerFormula = await getFormulaForId(peerId);
+      if (peerFormula.type !== 'peer' || peerFormula.syncedStore === undefined) {
+        throw new Error(`No synced store for ${q(petName)}`);
+      }
+      return provide(peerFormula.syncedStore, 'synced-pet-store');
     };
 
     /** @type {EndoHost['cancel']} */

--- a/packages/daemon/src/mail.js
+++ b/packages/daemon/src/mail.js
@@ -148,6 +148,7 @@ export const makeMailboxMaker = ({
     mailboxStore,
     directory,
     context,
+    trackSentIdentifiers = async (_recipientId, _ids) => {},
   }) => {
     const { number: selfNumber } = parseId(localSelfId);
     const selfId = formatId({
@@ -862,6 +863,7 @@ export const makeMailboxMaker = ({
           return /** @type {FormulaIdentifier} */ (id);
         }),
       );
+      await trackSentIdentifiers(/** @type {FormulaIdentifier} */ (toId), ids);
 
       /** @type {import('./types.js').FormulaNumber | undefined} */
       let replyTo;
@@ -939,6 +941,10 @@ export const makeMailboxMaker = ({
           assertValidId(id);
           return /** @type {FormulaIdentifier} */ (id);
         }),
+      );
+      await trackSentIdentifiers(
+        /** @type {FormulaIdentifier} */ (otherId),
+        ids,
       );
 
       const message = harden({
@@ -1314,6 +1320,10 @@ export const makeMailboxMaker = ({
         throw new Error(`Unknown pet name ${q(petNameOrPath)}`);
       }
       assertValidId(valueId);
+      await trackSentIdentifiers(
+        /** @type {FormulaIdentifier} */ (otherId),
+        [/** @type {FormulaIdentifier} */ (valueId)],
+      );
 
       const messageId = /** @type {import('./types.js').FormulaNumber} */ (
         await randomHex256()

--- a/packages/daemon/src/store-controller.js
+++ b/packages/daemon/src/store-controller.js
@@ -4,6 +4,7 @@ import harden from '@endo/harden';
 
 import { formatId, parseId } from './formula-identifier.js';
 import { LOCAL_NODE } from './locator.js';
+import { isPetName } from './pet-name.js';
 
 /** @import { FormulaIdentifier, GcHooks, Name, PetName, PetStore, StoreController, StoreConverters, SyncedPetStore } from './types.js' */
 
@@ -198,6 +199,9 @@ export const makeSyncedStoreController = (
     const names = [];
     const state = syncedStore.getState();
     for (const [key, entry] of Object.entries(state)) {
+      if (!isPetName(key)) {
+        continue;
+      }
       if (entry.locator !== null) {
         try {
           const { id: entryId } = converters.internalizeLocator(
@@ -318,6 +322,9 @@ export const makeSyncedStoreController = (
   /** @type {StoreController['followNameChanges']} */
   const followNameChanges = async function* syncedFollowNameChanges() {
     for await (const { key, entry } of syncedStore.followChanges()) {
+      if (!isPetName(key)) {
+        continue;
+      }
       if (entry.locator !== null) {
         const entryId = safeIdFromLocator(entry.locator);
         if (entryId !== undefined) {
@@ -349,6 +356,9 @@ export const makeSyncedStoreController = (
     });
     // Then deltas.
     for await (const { key, entry } of syncedStore.followChanges()) {
+      if (!isPetName(key)) {
+        continue;
+      }
       const entryId =
         entry.locator !== null ? safeIdFromLocator(entry.locator) : undefined;
       let normalizedEntryId;
@@ -376,16 +386,16 @@ export const makeSyncedStoreController = (
   /** @type {StoreController['seedGcEdges']} */
   const seedGcEdges = async () => {
     await null;
-    const names = syncedStore.list();
     /** @type {FormulaIdentifier[]} */
     const ids = [];
-    for (const name of names) {
-      const locator = syncedStore.lookup(name);
-      if (locator !== undefined) {
-        const id = safeIdFromLocator(locator);
-        if (id !== undefined) {
-          ids.push(id);
-        }
+    const state = syncedStore.getState();
+    for (const entry of Object.values(state)) {
+      if (entry.locator === null) {
+        continue;
+      }
+      const id = safeIdFromLocator(entry.locator);
+      if (id !== undefined) {
+        ids.push(id);
       }
     }
     if (ids.length > 0) {

--- a/packages/daemon/src/synced-pet-store.js
+++ b/packages/daemon/src/synced-pet-store.js
@@ -11,7 +11,7 @@ import { M } from '@endo/patterns';
 import { q } from '@endo/errors';
 
 import { makeChangeTopic } from './pubsub.js';
-import { assertPetName } from './pet-name.js';
+import { assertName, isPetName } from './pet-name.js';
 import { makeSerialJobs } from './serial-jobs.js';
 import { makeIteratorRef } from './reader-ref.js';
 
@@ -231,8 +231,9 @@ export const makeSyncedPetStore = async ({
 
   /** @type {SyncedPetStore['storeLocator']} */
   const storeLocator = async (petName, locator) => {
-    assertPetName(petName);
-    if (role === 'grantee') {
+    assertName(petName);
+    const isInternalEntry = !isPetName(petName);
+    if (role === 'grantee' && !isInternalEntry) {
       throw new Error('Grantee cannot write new entries');
     }
     meta.localClock += 1;
@@ -250,7 +251,7 @@ export const makeSyncedPetStore = async ({
 
   /** @type {SyncedPetStore['remove']} */
   const remove = async petName => {
-    assertPetName(petName);
+    assertName(petName);
     if (!state.has(petName)) {
       throw new Error(`No entry for pet name ${q(petName)}`);
     }
@@ -292,7 +293,7 @@ export const makeSyncedPetStore = async ({
     /** @type {PetName[]} */
     const names = [];
     for (const [key, entry] of state) {
-      if (entry.locator !== null) {
+      if (entry.locator !== null && isPetName(key)) {
         names.push(/** @type {PetName} */ (key));
       }
     }

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -282,6 +282,7 @@ type PeerFormula = {
   networks: FormulaIdentifier;
   node: NodeNumber;
   addresses: Array<string>;
+  syncedStore?: FormulaIdentifier;
 };
 
 type HandleFormula = {
@@ -1567,6 +1568,11 @@ export interface DaemonCore {
   getPeerIdForNodeIdentifier: (
     nodeNumber: NodeNumber,
   ) => Promise<FormulaIdentifier>;
+
+  setPeerSyncedStore: (
+    peerId: FormulaIdentifier,
+    syncedStoreId: FormulaIdentifier,
+  ) => Promise<void>;
 
   formulateEndo: (
     specifiedFormulaNumber?: FormulaNumber,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -699,15 +699,18 @@ export type SyncedPetStoreChange = {
 };
 
 export interface SyncedPetStore {
-  /** Store a name->locator entry (grantor only). */
-  storeLocator(petName: PetName, locator: string): Promise<void>;
+  /**
+   * Store a name->locator entry.
+   * Grantees may only write special-name internal entries.
+   */
+  storeLocator(petName: Name, locator: string): Promise<void>;
   /** Delete a name (tombstone). Either party can delete. */
-  remove(petName: PetName): Promise<void>;
+  remove(petName: Name): Promise<void>;
   /** Check if a non-tombstoned entry exists for the name. */
   has(petName: string): boolean;
   /** Look up the locator for a name, or undefined if absent/tombstoned. */
   lookup(petName: string): string | undefined;
-  /** List all non-tombstoned pet names, sorted. */
+  /** List all non-tombstoned regular pet names, sorted. */
   list(): PetName[];
   /** Return a serializable snapshot of the full CRDT state (including tombstones). */
   getState(): Record<string, SyncedEntry>;
@@ -908,6 +911,13 @@ export type MakeMailbox = (args: {
   mailboxStore: StoreController;
   directory: EndoDirectory;
   context: Context;
+  /**
+   * Optional hook for host mailboxes to retain formulas sent to remote peers.
+   */
+  trackSentIdentifiers?: (
+    recipientId: FormulaIdentifier,
+    ids: FormulaIdentifier[],
+  ) => Promise<void>;
 }) => Promise<Mail>;
 
 export type RequestFn = (

--- a/packages/daemon/test/synced-pet-store-integration.test.js
+++ b/packages/daemon/test/synced-pet-store-integration.test.js
@@ -428,7 +428,7 @@ test.serial('synced stores converge after offline changes', async t => {
   await E(hostA2).move(['test-network-2'], ['@nets', 'tcp']);
 
   // After restart, the synced store should still be accessible via
-  // getSyncedStore because the mapping is persisted in the @pins directory.
+  // getSyncedStore because the peer formula stores the synced-store ID.
   const aliceStore2 = await E(hostA2).getSyncedStore('bob');
   t.truthy(aliceStore2, 'Alice synced store should survive restart');
 

--- a/packages/daemon/test/synced-pet-store-integration.test.js
+++ b/packages/daemon/test/synced-pet-store-integration.test.js
@@ -154,18 +154,14 @@ test.serial(
     // The synced store should have a 'list' method.
     const aliceNames = await E(aliceSyncedStore).list();
     t.true(Array.isArray(aliceNames), 'Alice synced store should be listable');
-    // Alice's grantor store wrote the guest handle under "bob" pet name
-    // during acceptance.
-    t.true(
-      aliceNames.length !== 0,
-      'Alice store should have at least one entry',
-    );
+    // Peer bootstrap entries are hidden from the user-facing list.
+    t.deepEqual(aliceNames, []);
 
     // Bob should have a synced-pet-store under 'alice'.
     const bobSyncedStore = await E(hostB).getSyncedStore('alice');
     t.truthy(bobSyncedStore, 'Bob should have a synced store under "alice"');
     const bobNames = await E(bobSyncedStore).list();
-    t.true(Array.isArray(bobNames), 'Bob synced store should be listable');
+    t.deepEqual(bobNames, []);
   },
 );
 
@@ -208,6 +204,7 @@ test.serial(
     t.is(aliceLocator, bobLocator, 'Both stores should agree on the locator');
   },
 );
+
 
 test.serial('synced stores converge via manual sync', async t => {
   const { host: hostA } = await prepareHostWithTestNetwork(t);
@@ -460,3 +457,61 @@ test.serial('synced stores converge after offline changes', async t => {
     'Bob should have post-restart entry after sync with restarted daemon',
   );
 });
+
+test.serial(
+  'sending to peer records hidden export retention entries',
+  async t => {
+    const { host: hostA } = await prepareHostWithTestNetwork(t);
+    const { host: hostB } = await prepareHostWithTestNetwork(t);
+
+    const invitation = await E(hostA).invite('bob');
+    const invitationLocator = await E(invitation).locate();
+    await E(hostB).accept(invitationLocator, 'alice');
+
+    const aliceStore = await E(hostA).getSyncedStore('bob');
+    const bobStore = await E(hostB).getSyncedStore('alice');
+
+    await E(hostA).storeValue('tracked-export-value', 'tracked-export-value');
+    await E(hostA).send(
+      'bob',
+      ['tracked @value'],
+      ['value'],
+      ['tracked-export-value'],
+    );
+
+    const deadline = Date.now() + 15_000;
+    /** @type {[string, import('../src/types.js').SyncedEntry] | undefined} */
+    let retained;
+    while (Date.now() < deadline) {
+      const state = await E(aliceStore).getState();
+      retained = Object.entries(state).find(
+        ([name, entry]) => name.startsWith('@export-') && entry.locator !== null,
+      );
+      if (retained !== undefined) {
+        break;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, 500));
+    }
+
+    t.truthy(retained, 'Alice should track exports in hidden synced-store rows');
+    const [hiddenName, hiddenEntry] = /** @type {[string, any]} */ (retained);
+    const listedNames = await E(aliceStore).list();
+    t.false(
+      listedNames.includes(hiddenName),
+      'Hidden export entries must not appear in list()',
+    );
+
+    let mirrored = false;
+    while (Date.now() < deadline) {
+      const state = await E(bobStore).getState();
+      if (state[hiddenName]?.locator === hiddenEntry.locator) {
+        mirrored = true;
+        break;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, 500));
+    }
+    t.true(mirrored, 'Hidden export entries should synchronize to the peer');
+  },
+);

--- a/packages/daemon/test/synced-pet-store.test.js
+++ b/packages/daemon/test/synced-pet-store.test.js
@@ -189,6 +189,24 @@ test('synced store: grantee cannot write', async t => {
   }
 });
 
+test('synced store: grantee can write hidden internal entries', async t => {
+  const dir = await makeTmpDir('grantee-internal-write');
+  try {
+    const store = await makeSyncedPetStore({
+      storePath: dir,
+      filePowers,
+      localNodeId: 'node-bob',
+      role: 'grantee',
+    });
+    await store.storeLocator('@export-1', 'endo://node-alice/handle:xyz');
+    t.is(store.lookup('@export-1'), 'endo://node-alice/handle:xyz');
+    // Hidden entries do not appear in user-facing list().
+    t.deepEqual(store.list(), []);
+  } finally {
+    await removeTmpDir(dir);
+  }
+});
+
 test('synced store: remove creates tombstone', async t => {
   const dir = await makeTmpDir('remove');
   try {
@@ -529,6 +547,24 @@ test('synced store: overwrite updates entry', async t => {
     await store.storeLocator('name', 'loc-new');
     t.is(store.lookup('name'), 'loc-new');
     t.is(store.getLocalClock(), 2);
+  } finally {
+    await removeTmpDir(dir);
+  }
+});
+
+test('synced store: internal entries are hidden from list', async t => {
+  const dir = await makeTmpDir('hidden-list');
+  try {
+    const store = await makeSyncedPetStore({
+      storePath: dir,
+      filePowers,
+      localNodeId: 'node-alice',
+      role: 'grantor',
+    });
+    await store.storeLocator('@export-1', 'loc-hidden');
+    await store.storeLocator('visible', 'loc-visible');
+    t.deepEqual(store.list(), ['visible']);
+    t.is(store.lookup('@export-1'), 'loc-hidden');
   } finally {
     await removeTmpDir(dir);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs: (no linked issue)

## Description

This PR changes cross-peer retention bookkeeping so it is attached to each
`peer` formula and no longer modeled as user-visible inventory data.

The goal is to retain formulas for objects exported to a peer (including when
that object is not saved in the local pet store), while keeping retention rows
out of normal user-facing name APIs.

## What changed

- Peer formulas can now record their synced-store dependency via an optional
  `syncedStore` field.
- Invitation setup records the synced-store on the peer formula and stores
  bootstrap handles under hidden internal names (`@peer-handle`,
  `@self-handle`).
- Mail send/reply/sendValue paths now call a host hook
  (`trackSentIdentifiers`) so locally sourced identifiers sent to a peer are
  retained in that peer's synced store.
- Hidden export-retention rows use objective, deterministic names derived from
  the exported identifier (`@export-...`) instead of subjective counters.
- `synced-pet-store` supports internal (non-pet) names for writes/removals, but
  `list()` remains user-facing and returns only pet names.
- Synced-store controller user APIs filter internal names, while GC seeding uses
  full synced-store state (including hidden rows).

## Files touched

- `packages/daemon/src/daemon.js`
- `packages/daemon/src/host.js`
- `packages/daemon/src/mail.js`
- `packages/daemon/src/store-controller.js`
- `packages/daemon/src/synced-pet-store.js`
- `packages/daemon/src/types.d.ts`
- `packages/daemon/test/synced-pet-store.test.js`
- `packages/daemon/test/synced-pet-store-integration.test.js`

## Testing

Executed:

- `npx corepack yarn workspace @endo/daemon ava test/synced-pet-store.test.js test/synced-pet-store-integration.test.js --timeout=120s`

Added/updated coverage for:

- grantee writes to hidden internal synced-store entries
- hidden entries excluded from `list()`
- send path retention rows being created and synchronized as hidden entries

## Compatibility notes

- `SyncedPetStore.list()` intentionally exposes only regular pet names.
- Internal retention/bootstrap rows remain replicated and GC-relevant, but are
  not surfaced in user inventory listings.
- Type signatures for synced-store write/remove accept `Name` so internal rows
  can be represented explicitly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3462eb3c-2a02-4130-ae3b-9dec25854c06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3462eb3c-2a02-4130-ae3b-9dec25854c06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

