### PR TITLE
disable exactOptionalPropertyTypes

### DIFF
--- a/packages/cli/test/_daemon-context.js
+++ b/packages/cli/test/_daemon-context.js
@@ -1,4 +1,4 @@
-/** @import { Context } from './types' */
+/** @import { Context } from './_types.js' */
 
 /**
  * Provides test setup and teardown hooks that purge the local endo

--- a/packages/cli/test/_section.js
+++ b/packages/cli/test/_section.js
@@ -1,6 +1,6 @@
-/** @import {Execa} from 'execa' */
-/** @import {t} from 'ava' */
-/** @import {TestRoutine} from './types' */
+/** @import {ExecaMethod} from 'execa' */
+/** @import {ExecutionContext} from 'ava' */
+/** @import {TestRoutine} from './_types.js' */
 
 /**
  * Transforms a testRoutine into an ava test.
@@ -12,9 +12,9 @@
  * when run under a vscode JavaScript Debug Terminal
  * @see https://github.com/endojs/endo/issues/2702
  *
- * @param {Execa} execa - the command execution environment
+ * @param {ExecaMethod} execa - the command execution environment
  * @param {TestRoutine} testRoutine - the test logic implementation
- * @returns {(t: t) => Promise<void>}
+ * @returns {(t: ExecutionContext) => Promise<void>}
  */
 export function makeSectionTest(execa, testRoutine) {
   return async t => {

--- a/packages/cli/test/_types.d.ts
+++ b/packages/cli/test/_types.d.ts
@@ -1,13 +1,13 @@
 import type { ExecaMethod } from 'execa';
 
-export type Expectation = {
+type Expectation = {
   stdout: RegExp | string | undefined;
   stderr?: RegExp | string | undefined;
 };
-export type TestCommand = (
+type TestCommand = (
   command: ReturnType<ExecaMethod>,
-  expectation: Expectation,
-) => Promise<true>;
+  expectation?: Expectation,
+) => Promise<void>;
 export type TestRoutine = (
   execa: ExecaMethod,
   testCommnd: TestCommand,

--- a/packages/cli/test/_with-context.js
+++ b/packages/cli/test/_with-context.js
@@ -1,4 +1,4 @@
-/** @import {Context, TestRoutine} from '../types' */
+/** @import {Context, TestRoutine} from './_types.js' */
 /**
  * Creates a wrapper which wraps a test routine with an execa-curried setup and teardown routine.
  *

--- a/packages/compartment-mapper/test/make-import-hook-maker.test.js
+++ b/packages/compartment-mapper/test/make-import-hook-maker.test.js
@@ -111,7 +111,7 @@ const moduleSourceHookTest = async (
  * Computes title for macro
  *
  * @param {string} providedTitle
- * @param {{loaderFn: Function}} options
+ * @param {{loaderFn: Function, argsFn: (readPowers: MaybeReadPowers, entrypoint: string, options: object) => any, callImport: boolean}} options
  * @returns {string}
  */
 moduleSourceHookTest.title = (providedTitle, { loaderFn }) =>

--- a/packages/daemon/src/deferred-tasks.js
+++ b/packages/daemon/src/deferred-tasks.js
@@ -12,7 +12,9 @@ export const makeDeferredTasks = () => {
 
   return {
     execute: async param => {
-      await Promise.all(tasks.map(task => task(param)));
+      await Promise.all(
+        tasks.map(task => task(/** @type {Readonly<T>} */ (param))),
+      );
     },
     push: task => {
       tasks.push(task);

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -1083,7 +1083,7 @@ export interface DaemonCoreExternal {
 }
 
 export type SerialJobs = {
-  enqueue: <T>(asyncFn?: () => Promise<T>) => Promise<T>;
+  enqueue: <T>(fn?: () => T | Promise<T>) => Promise<T>;
 };
 
 export type Multimap<K, V> = {

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -864,7 +864,7 @@ export type DeferredTask<T extends Record<string, string | string[]>> = (
  * parallel.
  */
 export type DeferredTasks<T extends Record<string, string | string[]>> = {
-  execute(identifiers: Readonly<T>): Promise<void>;
+  execute(identifiers?: Readonly<T>): Promise<void>;
   push(value: DeferredTask<T>): void;
 };
 

--- a/packages/daemon/test/deferred-tasks.test.js
+++ b/packages/daemon/test/deferred-tasks.test.js
@@ -14,7 +14,7 @@ test('execute', async t => {
     results.push(3);
   });
 
-  await tasks.execute();
+  await tasks.execute({});
 
   t.deepEqual(results.sort(), [1, 2, 3]);
 });

--- a/packages/daemon/test/formula-type.test.js
+++ b/packages/daemon/test/formula-type.test.js
@@ -6,16 +6,18 @@ import {
 } from '../src/formula-type.js';
 
 test('isValidFormulaType', t => {
-  [
+  /** @type {Array<[any, boolean]>} */
+  const cases = [
     ['eval', true],
     ['make-unconfined', true],
     ['', false],
     [null, false],
     [undefined, false],
     [{}, false],
-  ].forEach(([value, expected]) => {
+  ];
+  for (const [value, expected] of cases) {
     t.is(isValidFormulaType(value), expected);
-  });
+  }
 });
 
 test('assertValidFormulaType - valid', t => {

--- a/packages/daemon/test/locator.test.js
+++ b/packages/daemon/test/locator.test.js
@@ -8,10 +8,14 @@ import {
 } from '../src/locator.js';
 import { formatId } from '../src/formula-identifier.js';
 
-const validNode =
-  'd5c98890be3d17ad375517464ec494068267de60bd4b3143ef0214cc895746f2892baca4fec19b6d4dfc1f683b7cf3d2a884dfcae568555dd89665c33dfdc4b3';
-const validId =
-  '5cf3d8b4d6e03fb51d71fbbb6fa6982edbff673cd193707c902b70a26b7b468017fbcfc5c2895f4379459badbe507a4ef00e1d3638f4a67e8a8c14fd1d85d9aa';
+/** @import { FormulaNumber, NodeNumber } from '../src/types.js' */
+
+const validNode = /** @type {NodeNumber} */ (
+  'd5c98890be3d17ad375517464ec494068267de60bd4b3143ef0214cc895746f2892baca4fec19b6d4dfc1f683b7cf3d2a884dfcae568555dd89665c33dfdc4b3'
+);
+const validId = /** @type {FormulaNumber} */ (
+  '5cf3d8b4d6e03fb51d71fbbb6fa6982edbff673cd193707c902b70a26b7b468017fbcfc5c2895f4379459badbe507a4ef00e1d3638f4a67e8a8c14fd1d85d9aa'
+);
 const validType = 'eval';
 
 const makeLocator = (components = {}) => {
@@ -39,7 +43,8 @@ test('assertValidLocator - valid', t => {
 });
 
 test('assertValidLocator - invalid', t => {
-  [
+  /** @type {Array<[any, RegExp]>} */
+  const cases = [
     ['foobar', /Invalid URL.$/u],
     ['', /Invalid URL.$/u],
     [null, /Invalid URL.$/u],
@@ -52,9 +57,10 @@ test('assertValidLocator - invalid', t => {
     [`${makeLocator()}&foo=bar`, /Invalid search params.$/u],
     [makeLocator({ param1: 'id=foobar' }), /Invalid id.$/u],
     [makeLocator({ param2: 'type=foobar' }), /Invalid type.$/u],
-  ].forEach(([locator, reason]) => {
+  ];
+  for (const [locator, reason] of cases) {
     t.throws(() => assertValidLocator(locator), { message: reason });
-  });
+  }
 });
 
 test('parseLocator', t => {

--- a/packages/daemon/test/multimap.test.js
+++ b/packages/daemon/test/multimap.test.js
@@ -6,10 +6,12 @@ import {
   makeWeakMultimap,
 } from '../src/multimap.js';
 
-[
+/** @type {Array<[() => import('../src/types.js').Multimap<any, any>, string]>} */
+const multimapCases = [
   [makeMultimap, 'multimap'],
   [makeWeakMultimap, 'weak multimap'],
-].forEach(([multimapConstructor, mapName]) => {
+];
+for (const [multimapConstructor, mapName] of multimapCases) {
   test(`${mapName}: add`, t => {
     const multimap = multimapConstructor();
     const key = {};
@@ -109,7 +111,7 @@ import {
     t.is(multimap.deleteAll(key), false);
     t.is(multimap.get(key), undefined);
   });
-});
+}
 
 test('multi-bimap: add', t => {
   const bimap = makeBidirectionalMultimap();

--- a/packages/daemon/test/remote-control.test.js
+++ b/packages/daemon/test/remote-control.test.js
@@ -2,9 +2,16 @@ import test from '@endo/ses-ava/prepare-endo.js';
 
 import { makeExo } from '@endo/exo';
 import { M } from '@endo/patterns';
-import { makePromiseKit } from '@endo/promise-kit';
+import { makePromiseKit as _makePromiseKit } from '@endo/promise-kit';
 import { makeRemoteControlProvider } from '../src/remote-control.js';
 
+/** @import { PromiseKit } from '@endo/promise-kit' */
+
+// The RemoteControl cancellation promises only reject and never fulfill.
+/** @type {<T = never>() => PromiseKit<T>} */
+const makePromiseKit = _makePromiseKit;
+
+/** @returns {any} */
 const makeFakeGateway = () =>
   makeExo(
     'FakeGateway',

--- a/packages/daemon/test/remote-control.test.js
+++ b/packages/daemon/test/remote-control.test.js
@@ -154,7 +154,7 @@ test('remote control establishes new connection when reconnecting after disconne
     () => makeFakeGateway(),
     cancelBob1,
     bob1Cancelled,
-    disposeBob1,
+    /** @type {() => void} */ (disposeBob1),
   );
   cancelBob1(new Error('Disconnect'));
   await t.throwsAsync(() => bob1Cancelled);

--- a/packages/ses/test/lockdown.test.js
+++ b/packages/ses/test/lockdown.test.js
@@ -4,8 +4,7 @@ import '../index.js';
 test('lockdown returns or throws', t => {
   t.plan(3);
 
-  // @ts-expect-error TS treats 'void' separate from undefined
-  t.is(undefined, lockdown(), 'return undefined');
+  t.is(lockdown(), undefined, 'return undefined');
 
   t.throws(lockdown, undefined, 'throw if called again, at all');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "./tsconfig.eslint-base.json",
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
-        "exactOptionalPropertyTypes": true,
     },
     "exclude": [
         "api-docs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
         "**/demo",
         "**/dist",
         "**/docs",
-        "**/test"
     ],
     "include": [
         "./**/*.ts",


### PR DESCRIPTION
_incidental_

## Description

Disables `exactOptionalPropertyTypes` introduced in,
- https://github.com/endojs/endo/pull/3165

It leads into other parts like typedoc build and agoric-sdk. Not worth the additional integration cost.

The leak wasn't caught because of TS config. So this also tightens that up a bit and fixes errors.


### Security Considerations

> Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls?

### Scaling Considerations

> Does this change require or encourage significant increase in consumption of CPU cycles, RAM, on-chain storage, message exchanges, or other scarce resources? If so, can that be prevented or mitigated?

### Documentation Considerations

> Give our docs folks some hints about what needs to be described to downstream users.  Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

### Testing Considerations

> Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?

### Compatibility Considerations

> Does this change break any prior usage patterns? Does this change allow usage patterns to evolve?

### Upgrade Considerations

> What aspects of this PR are relevant to upgrading live production systems, and how should they be addressed?

> Include `*BREAKING*:` in the commit message with migration instructions for any breaking change.

> Delete guidance from pull request description before merge (including this!)
