### PR TITLE
fix: Gracefully handle informative compartment map properties

### DIFF
--- a/.changeset/cull-created-by.md
+++ b/.changeset/cull-created-by.md
@@ -1,0 +1,9 @@
+---
+'@endo/compartment-mapper': patch
+'@endo/check-bundle': patch
+---
+
+Cull underscore-prefixed internal properties (like `__createdBy`) from
+serialized compartment maps in archives. The compartment map validator
+now also ignores underscore-prefixed properties when checking for
+extraneous fields.

--- a/packages/check-bundle/test/check-bundle.test.js
+++ b/packages/check-bundle/test/check-bundle.test.js
@@ -7,8 +7,8 @@ import * as url from 'url';
 import * as crypto from 'crypto';
 import harden from '@endo/harden';
 import bundleSource from '@endo/bundle-source';
-import { ZipWriter } from '@endo/zip';
-import { encodeBase64 } from '@endo/base64';
+import { ZipReader, ZipWriter } from '@endo/zip';
+import { decodeBase64, encodeBase64 } from '@endo/base64';
 import { checkBundle } from '../lite.js';
 import {
   checkBundleBytes,
@@ -116,6 +116,19 @@ test('bundle and hash bogus package', async t => {
   await t.throwsAsync(checkBundle(bundle, computeSha512, 'fixture/main.js'), {
     message: `checkBundle cannot determine hash of bundle with unrecognized moduleFormat "bogus"`,
   });
+});
+
+test('freshly bundled source passes check', async t => {
+  const bundle = await bundleSource(fixture, 'endoZipBase64');
+  // Verify that underscore-prefixed internal properties like __createdBy
+  // do not appear in the serialized compartment map.
+  const bytes = decodeBase64(bundle.endoZipBase64);
+  const { files } = new ZipReader(bytes);
+  const compartmentMapBytes = files.get('compartment-map.json').content;
+  const compartmentMapText = new TextDecoder().decode(compartmentMapBytes);
+  t.notRegex(compartmentMapText, /__createdBy/);
+  // The bundle must also pass checkBundle validation.
+  await checkBundle(bundle, computeSha512, 'fixture/main.js');
 });
 
 test('empty bundle is invalid', async t => {

--- a/packages/compartment-mapper/src/archive-lite.js
+++ b/packages/compartment-mapper/src/archive-lite.js
@@ -255,7 +255,7 @@ const digestFromMap = async (powers, compartmentMap, options = {}) => {
 
   const archiveCompartmentMapText = JSON.stringify(
     archiveCompartmentMap,
-    null,
+    (key, value) => (key.startsWith('_') ? undefined : value),
     2,
   );
   const archiveCompartmentMapBytes = textEncoder.encode(

--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -182,9 +182,7 @@ const getModuleConfigurationSpecificProperties = allegedModule => {
     ...other
   } = allegedModule;
   return /** @type {Omit<T, keyof BaseModuleConfiguration>} */ (
-    Object.fromEntries(
-      entries(other).filter(([key]) => !key.startsWith('_')),
-    )
+    Object.fromEntries(entries(other).filter(([key]) => !key.startsWith('_')))
   );
 };
 

--- a/packages/compartment-mapper/src/compartment-map.js
+++ b/packages/compartment-mapper/src/compartment-map.js
@@ -177,12 +177,15 @@ const assertConditions = (conditions, url) => {
  */
 const getModuleConfigurationSpecificProperties = allegedModule => {
   const {
-    __createdBy: _createdBy,
     retained: _retained,
     deferredError: _deferredError,
     ...other
   } = allegedModule;
-  return other;
+  return /** @type {Omit<T, keyof BaseModuleConfiguration>} */ (
+    Object.fromEntries(
+      entries(other).filter(([key]) => !key.startsWith('_')),
+    )
+  );
 };
 
 /**

--- a/packages/compartment-mapper/test/created-by.test.js
+++ b/packages/compartment-mapper/test/created-by.test.js
@@ -1,0 +1,48 @@
+import 'ses';
+import test from 'ava';
+import { ZipReader } from '@endo/zip';
+import { makeArchive } from '../index.js';
+import { assertFileCompartmentMap } from '../src/compartment-map.js';
+import { readPowers } from './scaffold.js';
+
+const fixture = new URL(
+  'fixtures-retained/node_modules/app/app.js',
+  import.meta.url,
+).toString();
+
+test('archives do not contain underscore-prefixed properties', async t => {
+  const bytes = await makeArchive(readPowers, fixture);
+
+  const reader = new ZipReader(bytes);
+  const compartmentMapBytes = reader.files.get('compartment-map.json').content;
+  const compartmentMapText = new TextDecoder().decode(compartmentMapBytes);
+
+  t.notRegex(compartmentMapText, /__createdBy/);
+});
+
+test('compartment map validator ignores underscore-prefixed properties', t => {
+  const compartmentMap = {
+    tags: [],
+    entry: { compartment: 'app-v1.0.0', module: './main.js' },
+    compartments: {
+      'app-v1.0.0': {
+        name: 'app',
+        label: 'app',
+        location: 'app-v1.0.0',
+        modules: {
+          './main.js': {
+            location: 'main.js',
+            parser: 'mjs',
+            sha512: 'abc123',
+            __createdBy: 'digest',
+            __otherInternal: 'value',
+          },
+        },
+      },
+    },
+  };
+
+  t.notThrows(() =>
+    assertFileCompartmentMap(compartmentMap, 'test-compartment-map'),
+  );
+});


### PR DESCRIPTION
Refs: #2671

## Description

This change consists of two adjustments.

1. The compartment mapper will strip all informative compartment map properties, like `__createdBy`, on the basis that they have a prefix `_`.
2. The bundle checker will ignore informative compartment map properties, like `__createdBy`, on the basis that they have a prefix `_`.

The first change addresses a backward incompatibility in the introduction of the `__createdBy` property without removing this instrument entirely. We only remove it when generating bundles. This is analogous to many other properties left behind in this transformation.

The second change will, in the long run, obviate the first. When this change lands in a chain software update for all Agoric chains, new bundles will be able to entrain diagnostic properties, bearing the `_` prefix safely.

### Security Considerations

These changes create a normative invariant that no future property added to the `compartment-map.json` may use the `_` underscore prefix to designate an intended change in behavior. Otherwise, new bundles running on old chains will have different behavior.

### Scaling Considerations

None.

### Documentation Considerations

None.

### Testing Considerations

This introduces a test to ensure that we do not introduce new properties to bundled compartment-map.json, at least until we deliberately decide to, in which case the test will need to be deliberately removed.

### Compatibility Considerations

This restores compatibility with earlier versions of `@endo/check-bundle` as deployed on Agoric chains.

### Upgrade Considerations

None.