### PR TITLE
chore(ocapn): initial publish 1.0.0-rc.spec-2026-01-06.0

### DIFF
--- a/.changeset/ocapn-initial-publish.md
+++ b/.changeset/ocapn-initial-publish.md
@@ -1,0 +1,7 @@
+---
+'@endo/ocapn': major
+---
+
+Initial public release of `@endo/ocapn`. The package is no longer private and is now published to npm.
+
+Tested against the python test suite from 2026-01-06 https://github.com/ocapn/ocapn-test-suite/commits/f0273f21c5ee05a28785b51c231535124f28bca9

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@endo/ocapn",
-  "version": "0.2.2",
-  "private": true,
+  "version": "1.0.0-rc.spec-2026-01-06.0",
   "description": null,
   "keywords": [],
   "author": "Endo contributors",


### PR DESCRIPTION
First publish for `@endo/ocapn`, a prerelease trailing the spec but passing the python test suite as of 2026-01-06 https://github.com/ocapn/ocapn-test-suite/commits/f0273f21c5ee05a28785b51c231535124f28bca9