### PR TITLE
fix(pass-style): unblock downstream decl-emit; obviate agoric-sdk patch

### DIFF
--- a/.changeset/pass-style-decl-emit.md
+++ b/.changeset/pass-style-decl-emit.md
@@ -1,0 +1,13 @@
+---
+'@endo/pass-style': minor
+---
+
+Unblock TypeScript declaration emit in downstream packages that structurally expose `PassStyled`/`Container` types. Compile-time type changes only; no runtime behavior changes.
+
+- `PASS_STYLE` is now typed as the string-literal `'Symbol(passStyle)'` rather than `unique symbol`. The runtime value is unchanged (still `Symbol.for('passStyle')`), and computed-key indexing like `obj[PASS_STYLE]` continues to work because JS computed keys accept any value. This removes TS4023 / TS9006 errors in consumers whose inferred types structurally contain `[PASS_STYLE]` (via `PassStyled`, `ExtractStyle`, object spread of a `PassStyled`, etc.). A `unique symbol` is only nameable via its original declaration module, which consumers have no reason to import; a string-literal type has no such nameability requirement.
+- `CopyArrayInterface`, `CopyRecordInterface`, and `CopyTaggedInterface` are now exported, so downstream `.d.ts` emit can name them when they appear through structural expansion of `Passable`/`Container`.
+- The `PassStyleOf` array overload is widened from `(p: any[]) => 'copyArray'` to `(p: readonly any[]) => 'copyArray'`, so `as const` tuples and `readonly T[]` values classify as `'copyArray'`. This aligns the classifier with `CopyArray<T>`, which is already `readonly T[]`. Backward-compatible because `T[]` still extends `readonly T[]`.
+
+Obviates the `@endo/pass-style` patch that agoric-sdk has been carrying in `.yarn/patches/`.
+
+TypeScript consumers that relied on `typeof PASS_STYLE` being `unique symbol` (e.g. annotating a value as `symbol` from `PASS_STYLE`) will need minor adjustments — widen the annotation to `symbol | string`, or cast via `unknown`.

--- a/packages/marshal/test/marshal-far-obj.test.js
+++ b/packages/marshal/test/marshal-far-obj.test.js
@@ -75,6 +75,16 @@ test('Remotable/getInterfaceOf', t => {
 const GOOD_PASS_STYLE = PASS_STYLE;
 const BAD_PASS_STYLE = Symbol('passStyle');
 
+/**
+ * @param {object} [options]
+ * @param {symbol | string} [options.styleSymbol]
+ * @param {string} [options.styleString]
+ * @param {boolean} [options.styleEnumerable]
+ * @param {symbol | string} [options.tagSymbol]
+ * @param {string} [options.tagString]
+ * @param {boolean} [options.tagEnumerable]
+ * @param {Record<PropertyKey, PropertyDescriptor>} [options.extras]
+ */
 const testRecord = ({
   styleSymbol = GOOD_PASS_STYLE,
   styleString = 'remotable',

--- a/packages/pass-style/src/passStyle-helpers.js
+++ b/packages/pass-style/src/passStyle-helpers.js
@@ -68,7 +68,23 @@ export const isTypedArray = object => {
 };
 hideAndHardenFunction(isTypedArray);
 
-export const PASS_STYLE = Symbol.for('passStyle');
+/**
+ * The well-known symbol used to tag passable objects with their pass style.
+ *
+ * Typed as the string literal `'Symbol(passStyle)'` rather than as
+ * `unique symbol`, to keep the type nameable across module boundaries.
+ * The runtime value is still `Symbol.for('passStyle')` — JS computed property
+ * keys accept any value, so `obj[PASS_STYLE]` indexing is unchanged.
+ *
+ * Without this, declaration emit in downstream packages whose inferred types
+ * structurally contain `[PASS_STYLE]` (via `PassStyled`, `ExtractStyle`, etc.)
+ * fails with TS4023 / TS9006, because `unique symbol` bindings are only
+ * nameable via their original declaration module — which consumers have no
+ * reason to import directly.
+ */
+export const PASS_STYLE = /** @type {'Symbol(passStyle)'} */ (
+  /** @type {unknown} */ (Symbol.for('passStyle'))
+);
 
 /**
  * Below we have a series of predicate functions and their (curried) assertion

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -116,11 +116,11 @@ export type Container<PC extends PassableCap, E extends Error> =
   | CopyArrayInterface<PC, E>
   | CopyRecordInterface<PC, E>
   | CopyTaggedInterface<PC, E>;
-interface CopyArrayInterface<PC extends PassableCap, E extends Error>
+export interface CopyArrayInterface<PC extends PassableCap, E extends Error>
   extends CopyArray<Passable<PC, E>> {}
-interface CopyRecordInterface<PC extends PassableCap, E extends Error>
+export interface CopyRecordInterface<PC extends PassableCap, E extends Error>
   extends CopyRecord<Passable<PC, E>> {}
-interface CopyTaggedInterface<PC extends PassableCap, E extends Error>
+export interface CopyTaggedInterface<PC extends PassableCap, E extends Error>
   extends CopyTagged<string, Passable<PC, E>> {}
 
 export type PassStyleOf = {
@@ -134,7 +134,7 @@ export type PassStyleOf = {
   (p: Promise<any>): 'promise';
   (p: Error): 'error';
   (p: CopyTagged): 'tagged';
-  (p: any[]): 'copyArray';
+  (p: readonly any[]): 'copyArray';
   (p: Iterable<any>): 'remotable';
   (p: Iterator<any, any, undefined>): 'remotable';
   <T extends PassStyled<PassStyleMarker, any>>(p: T): ExtractStyle<T>;

--- a/packages/pass-style/src/types.test-d.ts
+++ b/packages/pass-style/src/types.test-d.ts
@@ -4,7 +4,16 @@ import { expectAssignable, expectType, expectNotType } from 'tsd';
 import { Far } from './make-far.js';
 import { passStyleOf } from './passStyleOf.js';
 import { makeTagged } from './makeTagged.js';
-import type { Checker, CopyTagged, Passable, PassStyle } from './types.js';
+import type {
+  Checker,
+  CopyArrayInterface,
+  CopyRecordInterface,
+  CopyTagged,
+  CopyTaggedInterface,
+  Passable,
+  PassableCap,
+  PassStyle,
+} from './types.js';
 import { PASS_STYLE } from './passStyle-helpers.js';
 import { passableSymbolForName } from './symbol.js';
 
@@ -26,6 +35,15 @@ expectType<'promise'>(passStyleOf(Promise.resolve()));
 expectType<'error'>(passStyleOf(new Error()));
 expectType<'tagged'>(passStyleOf(copyTagged));
 expectType<'copyArray'>(passStyleOf([]));
+// readonly / `as const` arrays classify as copyArray
+expectType<'copyArray'>(passStyleOf([1, 2, 3] as const));
+const roArr: readonly number[] = [1, 2, 3];
+expectType<'copyArray'>(passStyleOf(roArr));
+
+// The three container interfaces are exported and usable as types.
+expectAssignable<CopyArrayInterface<PassableCap, Error>>([1, 'two', null]);
+expectAssignable<CopyRecordInterface<PassableCap, Error>>({ a: 1, b: 'two' });
+expectAssignable<CopyTaggedInterface<PassableCap, Error>>(copyTagged);
 expectType<'copyRecord'>(passStyleOf({}));
 // though the object is specifying a PASS_STYLE, it doesn't match the case for extracting it
 expectType<'copyRecord'>(passStyleOf({ [PASS_STYLE]: 'arbitrary' } as const));


### PR DESCRIPTION
## Summary

Two changes that together eliminate the need for agoric-sdk's [@endo/pass-style patch](https://github.com/Agoric/agoric-sdk/blob/a6212a802544568e6e8bf38fa7f0f03845ef2c28/.yarn/patches/%40endo-pass-style-npm-1.7.0-7dc50195b4.patch):

1. **`feat(pass-style): export container interfaces and accept readonly arrays`** (f25606b61)
   - Export `CopyArrayInterface`, `CopyRecordInterface`, `CopyTaggedInterface` so downstream `.d.ts` emit can name them when they appear through structural expansion of `Passable`/`Container`.
   - Broaden the `PassStyleOf` array overload from `(p: any[])` to `(p: readonly any[])` so `as const` tuples and `readonly T[]` values classify as `'copyArray'`. `CopyArray<T>` is already `readonly T[]` upstream, so this aligns the classifier with the element type.
   - New regression coverage in `src/types.test-d.ts`.

2. **`fix(pass-style): retype PASS_STYLE as string literal for decl-emit`** (77513ac92)
   - Retype `PASS_STYLE` from `unique symbol` to the string-literal type `'Symbol(passStyle)'` via a double cast through `unknown`. Runtime value is unchanged — still `Symbol.for('passStyle')`.
   - Fixes TS4023 / TS9006 in downstream packages whose inferred types structurally contain `[PASS_STYLE]`.
   - Small collateral fix in `packages/marshal/test/marshal-far-obj.test.js`: annotate `testRecord`'s `styleSymbol`/`tagSymbol` params as `symbol | string` so bad-case symbol inputs still typecheck under the narrower inferred default.

## Relation to the agoric-sdk patch

The upstream patch contains four hunks. This PR upstreams the three that are still load-bearing:

| Patch hunk | Upstreamed here? |
|---|---|
| Export `CopyArrayInterface` / `CopyRecordInterface` / `CopyTaggedInterface` | ✅ commit 1 |
| Broaden `(p: any[])` → `(p: readonly any[])` in `PassStyleOf` | ✅ commit 1 |
| Retype `PASS_STYLE` as string literal | ✅ commit 2 |
| Add `CopyReadonlyArray` alias + `CopyReadonlyArrayInterface` | ❌ already unnecessary — upstream `CopyArray<T>` is already `readonly T[]` (src/types.d.ts:207) |

After this PR ships (and a release of `@endo/pass-style`), agoric-sdk can delete `.yarn/patches/@endo-pass-style-npm-1.7.0-*.patch` and the matching `resolutions` entry.

## Why the `PASS_STYLE` cast is needed

**Root cause, stated sharply:** TypeScript models `Symbol.for('x')` with the same nameability rules as `Symbol()`, even though registered symbols are fully recoverable from their string key at runtime. The string-literal cast restores the nameability that the global symbol registry already provides.

At the runtime layer, JavaScript has two categories:

- **Registered symbols** (`Symbol.for('passStyle')`) — keyed in a global registry. Every call anywhere returns the *same* symbol. Identity is fully recoverable from the string key, cross-realm.
- **Unique symbols** (`Symbol('passStyle')`) — freshly minted each call, no registry, no way to reconstruct identity from the outside.

TypeScript's type system collapses both into a single `unique symbol` type nominally bound to *the specific `const` declaration site*. The initializer is irrelevant. See [microsoft/TypeScript#56611 "`Symbol.for` returns a `unique symbol`"](https://github.com/microsoft/TypeScript/issues/56611) (closed as working-as-intended); related requests in [#20898](https://github.com/microsoft/TypeScript/issues/20898), [#37469](https://github.com/microsoft/TypeScript/issues/37469), and [#55691](https://github.com/microsoft/TypeScript/issues/55691) explore allowing unique symbols to be nameable as types.

That collapse is the direct cause of TS4023 / TS9006 here. When a consumer's inferred type structurally expands `[PASS_STYLE]` — e.g. via `...({} as PassStyled<'remotable', 'X'>)`, `Pick<PassStyled<...>, ...>`, or any factory whose return type embeds a `PassStyled` — TypeScript's declaration emit fails:

```
error TS4023 / TS9006: ... has or is using name 'PASS_STYLE' from external
module '.../pass-style/src/types' but cannot be named.
```

Semantically, `PASS_STYLE`'s identity *is* recoverable by anyone who knows the key `'passStyle'` — any consumer could write `Symbol.for('passStyle')` and get the exact same value — but the type system won't let them describe the resulting symbol structurally. They have to import the exact binding. TS's naming algorithm traces a `unique symbol` to its original declaration site, not to re-export aliases, and it refuses to auto-inject an import to unblock emit. Re-exporting `PASS_STYLE` from `types.d.ts` at a shorter path was tried during investigation and did not help.

**A principled TypeScript-side fix** would introduce a `SymbolFor<'passStyle'>` type — nominally distinct from other symbols but structurally nameable by its registry key, parallel to how string literal types work. Any module could spell it without importing the binding. Nothing has shipped on that front (see issues linked above).

**What this PR does instead** is essentially a manual version of that: pick a string-literal naming key (`'Symbol(passStyle)'`), smuggle the symbol's identity through it, and let TS emit the key structurally anywhere. Once `PASS_STYLE`'s type is a plain string-literal, `[PASS_STYLE]: S` becomes the ordinary property key `["Symbol(passStyle)"]: S`. No nominal `unique symbol` to name, no import required in consumers. JavaScript computed property keys accept any value, so `obj[PASS_STYLE]`, `PASS_STYLE in obj`, and all existing runtime patterns are unchanged. The security/uniqueness properties are preserved because the runtime symbol itself remains the gatekeeper — only the compile-time brand weakens.

If TS ever ships registered-symbol types, the clean migration is to retype `PASS_STYLE` as `SymbolFor<'passStyle'>` and drop the cast.

## Test plan

- [x] `packages/pass-style`: `yarn lint` (tsc + eslint) passes
- [x] `packages/pass-style`: `yarn test` — 24 tests pass
- [x] `packages/marshal`: `yarn lint:types` passes
- [x] `packages/marshal`: `yarn test` — 69 tests pass, 1 skipped
- [x] `packages/patterns`, `packages/exo`: `yarn lint:types` pass (primary consumers)
- [x] Minimal downstream repro built outside the repo: a consumer that spreads `PassStyled<...>` into an object literal previously failed with TS4023 / TS9006; now emits clean `.d.ts` with `"Symbol(passStyle)"` as the key
- [x] `src/types.test-d.ts` extended to cover the three newly-exported interfaces, `readonly` arrays, and `as const` tuples

🤖 Generated with [Claude Code](https://claude.com/claude-code)