### PR TITLE
fix(compartment-mapper,bundle-source): async parser support

### DIFF
--- a/.changeset/fuzzy-hornets-shout.md
+++ b/.changeset/fuzzy-hornets-shout.md
@@ -1,0 +1,6 @@
+---
+'@endo/compartment-mapper': patch
+'@endo/bundle-source': patch
+---
+
+Fixes poorly-defined support for asynchronous parsers.

--- a/packages/bundle-source/src/endo.js
+++ b/packages/bundle-source/src/endo.js
@@ -9,6 +9,7 @@ import { defaultParserForLanguage as transparentParserForLanguage } from '@endo/
 import tsBlankSpace from 'ts-blank-space';
 
 /** @import {Language} from '@endo/compartment-mapper/node-powers.js' */
+/** @import {AsyncParserImplementation} from '@endo/compartment-mapper' */
 /** @import {BundlingKit, BundlingKitIO, BundlingKitOptions, ModuleTransformsLike, ParserForLanguageLike, SourceMapDescriptor} from './types.js' */
 
 const textEncoder = new TextEncoder();
@@ -189,8 +190,9 @@ export const makeBundlingKit = (
     };
   }
 
+  /** @type {AsyncParserImplementation} */
   const mtsParser = {
-    parse(
+    async parse(
       sourceBytes,
       specifier,
       moduleLocation,
@@ -212,8 +214,9 @@ export const makeBundlingKit = (
     synchronous: false,
   };
 
+  /** @type {AsyncParserImplementation} */
   const ctsParser = {
-    parse(
+    async parse(
       sourceBytes,
       specifier,
       moduleLocation,

--- a/packages/bundle-source/src/endo.js
+++ b/packages/bundle-source/src/endo.js
@@ -8,7 +8,8 @@ import { defaultParserForLanguage as transformingParserForLanguage } from '@endo
 import { defaultParserForLanguage as transparentParserForLanguage } from '@endo/compartment-mapper/import-parsers.js';
 import { transformSync } from 'amaro';
 
-/** @import {Language, ParserImplementation} from '@endo/compartment-mapper/node-powers.js' */
+/** @import {Language} from '@endo/compartment-mapper/node-powers.js' */
+/** @import {AsyncParserImplementation} from '@endo/compartment-mapper' */
 /** @import {BundlingKit, BundlingKitIO, BundlingKitOptions, ModuleTransformsLike, ParserForLanguageLike, SourceMapDescriptor} from './types.js' */
 
 const textEncoder = new TextEncoder();
@@ -189,9 +190,9 @@ export const makeBundlingKit = (
     };
   }
 
-  /** @type {ParserImplementation} */
+  /** @type {AsyncParserImplementation} */
   const mtsParser = {
-    parse(
+    async parse(
       sourceBytes,
       specifier,
       moduleLocation,
@@ -215,9 +216,9 @@ export const makeBundlingKit = (
     synchronous: false,
   };
 
-  /** @type {ParserImplementation} */
+  /** @type {AsyncParserImplementation} */
   const ctsParser = {
-    parse(
+    async parse(
       sourceBytes,
       specifier,
       moduleLocation,

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -9,7 +9,15 @@
  *
  * @module
  */
-
+import { asyncTrampoline, syncTrampoline } from '@endo/trampoline';
+import { resolve } from './node-module-specifier.js';
+import {
+  attenuateModuleHook,
+  enforcePolicyByModule,
+  enforcePackagePolicyByCanonicalName,
+} from './policy.js';
+import { ATTENUATORS_COMPARTMENT } from './policy-format.js';
+import { unpackReadPowers } from './powers.js';
 /**
  * @import {
  *   ImportHook,
@@ -43,18 +51,19 @@
  *   CanonicalName,
  *   LocalModuleSource,
  *   ModuleSourceHook,
+ *   ParseFn,
+ *   AsyncParseFn,
  * } from './types.js'
  */
 
-import { asyncTrampoline, syncTrampoline } from '@endo/trampoline';
-import { resolve } from './node-module-specifier.js';
-import {
-  attenuateModuleHook,
-  enforcePolicyByModule,
-  enforcePackagePolicyByCanonicalName,
-} from './policy.js';
-import { ATTENUATORS_COMPARTMENT } from './policy-format.js';
-import { unpackReadPowers } from './powers.js';
+/**
+ * Type guard that narrows a `ParseFn | AsyncParseFn` to `ParseFn` by checking
+ * for the `isSyncParser` flag.
+ *
+ * @param {ParseFn | AsyncParseFn} parse
+ * @returns {parse is ParseFn}
+ */
+const isSyncParseFn = parse => 'isSyncParser' in parse && !!parse.isSyncParser;
 
 // q, as in quote, for quoting strings in error messages.
 const { quote: q } = assert;
@@ -324,8 +333,7 @@ const executeLocalModuleSourceHook = (
  * {@link StaticModuleType} for a particular {@link CompartmentDescriptor} (or
  * `undefined`).
  *
- * Supports both {@link SyncChooseModuleDescriptorOperators sync} and
- * {@link AsyncChooseModuleDescriptorOperators async} operators.
+ * Supports both sync and async operators.
  *
  * Used by both {@link makeImportNowHookMaker} and {@link makeImportHookMaker}.
  *
@@ -839,13 +847,14 @@ export function makeImportNowHookMaker(
       }
     };
 
-    if (!('isSyncParser' in parse)) {
+    if (!isSyncParseFn(parse)) {
       return function impossibleTransformImportNowHook() {
         throw new Error(
           'Dynamic requires are only possible with synchronous parsers and no asynchronous module transforms in options',
         );
       };
     }
+    const /** @type {ParseFn} */ syncParse = parse;
 
     const compartmentDescriptor =
       compartmentDescriptors[packageLocation] || create(null);
@@ -924,7 +933,7 @@ export function makeImportNowHookMaker(
           },
           {
             maybeRead: maybeReadNow,
-            parse,
+            parse: syncParse,
             shouldDeferError,
           },
         );

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -390,8 +390,7 @@ export const link = (
     /** @type {ShouldDeferError} */
     const shouldDeferError = language => {
       if (language && has(parserForLanguage, language)) {
-        return /** @type {ParserImplementation} */ (parserForLanguage[language])
-          .heuristicImports;
+        return parserForLanguage[language].heuristicImports;
       } else {
         // If language is undefined or there's no parser, the error we could consider deferring is surely related to
         // that. Nothing to throw here.

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -404,8 +404,7 @@ export const link = (
     /** @type {ShouldDeferError} */
     const shouldDeferError = language => {
       if (language && has(parserForLanguage, language)) {
-        return /** @type {ParserImplementation} */ (parserForLanguage[language])
-          .heuristicImports;
+        return parserForLanguage[language].heuristicImports;
       } else {
         // If language is undefined or there's no parser, the error we could consider deferring is surely related to
         // that. Nothing to throw here.

--- a/packages/compartment-mapper/src/map-parser.js
+++ b/packages/compartment-mapper/src/map-parser.js
@@ -17,6 +17,9 @@
  *   AsyncParseFn,
  *   ParseResult,
  *   ParserForLanguage,
+ *   SyncParserForLanguage,
+ *   ParserImplementation,
+ *   AsyncParserImplementation,
  *   SyncModuleTransform,
  *   SyncModuleTransforms
  * } from './types.js';
@@ -49,87 +52,54 @@ const has = (object, key) => apply(hasOwnProperty, object, [key]);
 const extensionImpliesLanguage = extension => extension !== 'js';
 
 /**
- * Produces a `parser` that parses the content of a module according to the
- * corresponding module language, given the extension of the module specifier
- * and the configuration of the containing compartment. We do not yet support
- * import assertions and we do not have a mechanism for validating the MIME type
- * of the module content against the language implied by the extension or file
- * name.
+ * Resolves the module language from its specifier and location, then applies
+ * any matching transform. Shared logic between sync and async generators.
  *
- * @overload
- * @param {true} preferSynchronous
- * @param {Record<string, string>} languageForExtension - maps a file extension
- * to the corresponding language.
- * @param {Record<string, string>} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} moduleTransforms
- * @param {SyncModuleTransforms} syncModuleTransforms
- * @returns {ParseFn}
+ * @param {string} specifier
+ * @param {string} location
+ * @param {Record<string, string>} languageForExtension
+ * @param {Record<string, string>} languageForModuleSpecifier
+ * @returns {string} The resolved language.
  */
-
-/**
- * Produces a `parser` that parses the content of a module according to the
- * corresponding module language, given the extension of the module specifier
- * and the configuration of the containing compartment. We do not yet support
- * import assertions and we do not have a mechanism for validating the MIME type
- * of the module content against the language implied by the extension or file
- * name.
- *
- * @overload
- * @param {false} preferSynchronous
- * @param {Record<string, string>} languageForExtension - maps a file extension
- * to the corresponding language.
- * @param {Record<string, string>} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} moduleTransforms
- * @param {SyncModuleTransforms} syncModuleTransforms
- * @returns {AsyncParseFn}
- */
-
-/**
- * Produces a `parser` that parses the content of a module according to the
- * corresponding module language, given the extension of the module specifier
- * and the configuration of the containing compartment. We do not yet support
- * import assertions and we do not have a mechanism for validating the MIME type
- * of the module content against the language implied by the extension or file
- * name.
- *
- * @param {boolean} preferSynchronous
- * @param {Record<string, string>} languageForExtension - maps a file extension
- * to the corresponding language.
- * @param {Record<string, string>} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} moduleTransforms
- * @param {SyncModuleTransforms} syncModuleTransforms
- * @returns {AsyncParseFn|ParseFn}
- */
-const makeExtensionParser = (
-  preferSynchronous,
+const resolveLanguage = (
+  specifier,
+  location,
   languageForExtension,
   languageForModuleSpecifier,
-  parserForLanguage,
-  moduleTransforms,
-  syncModuleTransforms,
 ) => {
-  /** @type {Record<string, ModuleTransform | SyncModuleTransform>} */
-  let transforms;
+  const extension = parseExtension(location);
+  if (
+    !extensionImpliesLanguage(extension) &&
+    has(languageForModuleSpecifier, specifier)
+  ) {
+    return languageForModuleSpecifier[specifier];
+  }
+  return languageForExtension[extension] || extension;
+};
 
+/**
+ * Produces a sync `ParseFn` for use when all parsers and transforms are
+ * synchronous.
+ *
+ * @param {Record<string, string>} languageForExtension
+ * @param {Record<string, string>} languageForModuleSpecifier
+ * @param {SyncParserForLanguage} parsers
+ * @param {SyncModuleTransforms} transforms
+ * @returns {ParseFn}
+ */
+const makeSyncExtensionParser = (
+  languageForExtension,
+  languageForModuleSpecifier,
+  parsers,
+  transforms,
+) => {
   /**
-   * Function returning a generator which executes a parser for a module in
-   * either sync or async context.
-   *
    * @param {Uint8Array} bytes
    * @param {string} specifier
    * @param {string} location
    * @param {string} packageLocation
    * @param {*} options
-   * @returns {Generator<ReturnType<ModuleTransform>|ReturnType<SyncModuleTransform>, ParseResult, EReturn<ModuleTransform|SyncModuleTransform>>}
+   * @returns {Generator<ReturnType<SyncModuleTransform>, ParseResult, ReturnType<SyncModuleTransform>>}
    */
   function* getParserGenerator(
     bytes,
@@ -138,28 +108,14 @@ const makeExtensionParser = (
     packageLocation,
     options,
   ) {
-    /** @type {string} */
-    let language;
-    const extension = parseExtension(location);
+    let language = resolveLanguage(
+      specifier,
+      location,
+      languageForExtension,
+      languageForModuleSpecifier,
+    );
 
-    if (
-      !extensionImpliesLanguage(extension) &&
-      has(languageForModuleSpecifier, specifier)
-    ) {
-      language = languageForModuleSpecifier[specifier];
-    } else {
-      // We should revisit this design decision:
-      // Defaulting the language to the extension conflates those namespaces.
-      // So, a transform keyed by extension can be used to coerce a language
-      // (e.g., .mts to mjs) as a shorthand for configuring a parser for that
-      // extension that pre-processes the file before handing off to the
-      // parser.
-      // But, this forces us to support the case of using weird language
-      // names like pre-mjs-json as valid, unconfigured extensions.
-      language = languageForExtension[extension] || extension;
-    }
-
-    /** @type {string|undefined} */
+    /** @type {string | undefined} */
     let sourceMap;
 
     if (has(transforms, language)) {
@@ -174,9 +130,6 @@ const makeExtensionParser = (
           location,
           packageLocation,
           {
-            // At time of writing, sourceMap is always undefined, but keeping
-            // it here is more resilient if the surrounding if block becomes a
-            // loop for multi-step transforms.
             sourceMap,
           },
         ));
@@ -187,21 +140,19 @@ const makeExtensionParser = (
         );
       }
     }
-    if (!has(parserForLanguage, language)) {
+    if (!has(parsers, language)) {
       throw Error(
         `Cannot parse module ${specifier} at ${location}, no parser configured for the language ${language}`,
       );
     }
-    const { parse } = parserForLanguage[language];
+    const { parse } = parsers[language];
     return parse(bytes, specifier, location, packageLocation, {
       sourceMap,
       ...options,
     });
   }
 
-  /**
-   * @type {ParseFn}
-   */
+  /** @type {ParseFn} */
   const syncParser = (bytes, specifier, location, packageLocation, options) => {
     const result = syncTrampoline(
       getParserGenerator,
@@ -219,18 +170,101 @@ const makeExtensionParser = (
     return result;
   };
   syncParser.isSyncParser = true;
+  return syncParser;
+};
+
+/**
+ * Produces an async `AsyncParseFn` for use when any parser or transform may
+ * be asynchronous.
+ *
+ * @param {Record<string, string>} languageForExtension
+ * @param {Record<string, string>} languageForModuleSpecifier
+ * @param {ParserForLanguage} parsers
+ * @param {ModuleTransforms} moduleTransforms
+ * @param {SyncModuleTransforms} syncModuleTransforms
+ * @returns {AsyncParseFn}
+ */
+const makeAsyncExtensionParser = (
+  languageForExtension,
+  languageForModuleSpecifier,
+  parsers,
+  moduleTransforms,
+  syncModuleTransforms,
+) => {
+  /** @type {Record<string, ModuleTransform | SyncModuleTransform>} */
+  const transforms = {
+    ...syncModuleTransforms,
+    ...moduleTransforms,
+  };
 
   /**
-   * @type {AsyncParseFn}
+   * @param {Uint8Array} bytes
+   * @param {string} specifier
+   * @param {string} location
+   * @param {string} packageLocation
+   * @param {*} options
+   * @returns {Generator<ReturnType<ModuleTransform> | ReturnType<SyncModuleTransform>, ParseResult | Promise<ParseResult>, any>}
    */
+  function* getParserGenerator(
+    bytes,
+    specifier,
+    location,
+    packageLocation,
+    options,
+  ) {
+    let language = resolveLanguage(
+      specifier,
+      location,
+      languageForExtension,
+      languageForModuleSpecifier,
+    );
+
+    /** @type {string | undefined} */
+    let sourceMap;
+
+    if (has(transforms, language)) {
+      try {
+        ({
+          bytes,
+          parser: language,
+          sourceMap,
+        } = yield transforms[language](
+          bytes,
+          specifier,
+          location,
+          packageLocation,
+          {
+            sourceMap,
+          },
+        ));
+      } catch (err) {
+        throw Error(
+          `Error transforming ${q(language)} source in ${q(location)}: ${err.message}`,
+          { cause: err },
+        );
+      }
+    }
+    if (!has(parsers, language)) {
+      throw Error(
+        `Cannot parse module ${specifier} at ${location}, no parser configured for the language ${language}`,
+      );
+    }
+    const { parse } = parsers[language];
+    return parse(bytes, specifier, location, packageLocation, {
+      sourceMap,
+      ...options,
+    });
+  }
+
+  /** @type {AsyncParseFn} */
   const asyncParser = async (
     bytes,
     specifier,
     location,
     packageLocation,
     options,
-  ) => {
-    return asyncTrampoline(
+  ) =>
+    asyncTrampoline(
       getParserGenerator,
       bytes,
       specifier,
@@ -238,77 +272,21 @@ const makeExtensionParser = (
       packageLocation,
       options,
     );
-  };
-
-  // Unfortunately, typescript was not smart enough to figure out the return
-  // type depending on a boolean in arguments, so it has to be
-  // AsyncParseFn|ParseFn
-  if (preferSynchronous) {
-    transforms = syncModuleTransforms;
-    return syncParser;
-  } else {
-    // we can fold syncModuleTransforms into moduleTransforms because
-    // async supports sync, but not vice-versa
-    transforms = {
-      ...syncModuleTransforms,
-      ...moduleTransforms,
-    };
-
-    return asyncParser;
-  }
+  return asyncParser;
 };
 
 /**
- * Creates a synchronous parser
+ * Validates the language-for-extension mapping against the parser-for-language
+ * map, filtering to only valid entries.
  *
- * @overload
  * @param {LanguageForExtension} languageForExtension
- * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
  * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} [moduleTransforms]
- * @param {SyncModuleTransforms} [syncModuleTransforms]
- * @param {true} preferSynchronous If `true`, will create a `ParseFn`
- * @returns {ParseFn}
+ * @returns {Record<string, string>} Filtered extension-to-language mapping.
  */
-
-/**
- * Creates an asynchronous parser
- *
- * @overload
- * @param {LanguageForExtension} languageForExtension
- * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} [moduleTransforms]
- * @param {SyncModuleTransforms} [syncModuleTransforms]
- * @param {false} [preferSynchronous]
- * @returns {AsyncParseFn}
- */
-
-/**
- * @param {LanguageForExtension} languageForExtension
- * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} [moduleTransforms]
- * @param {SyncModuleTransforms} [syncModuleTransforms]
- * @param {boolean} [preferSynchronous] If `true`, will create a `ParseFn`
- * @returns {AsyncParseFn|ParseFn}
- */
-function mapParsers(
+const validateLanguageForExtension = (
   languageForExtension,
-  languageForModuleSpecifier,
   parserForLanguage,
-  moduleTransforms,
-  syncModuleTransforms,
-  preferSynchronous,
-) {
-  moduleTransforms = moduleTransforms || {};
-  syncModuleTransforms = syncModuleTransforms || {};
+) => {
   const languageForExtensionEntries = [];
   const problems = [];
   for (const [extension, language] of entries(languageForExtension)) {
@@ -321,26 +299,24 @@ function mapParsers(
   if (problems.length > 0) {
     throw Error(`No parser available for language: ${problems.join(', ')}`);
   }
-  return makeExtensionParser(
-    /** @type {any} */ (preferSynchronous),
-    fromEntries(languageForExtensionEntries),
-    languageForModuleSpecifier,
-    parserForLanguage,
-    moduleTransforms,
-    syncModuleTransforms,
-  );
-}
+  return fromEntries(languageForExtensionEntries);
+};
+
+/**
+ * Type guard that narrows {@link ParserForLanguage} to
+ * {@link SyncParserForLanguage} by checking that every parser has
+ * `synchronous: true`.
+ *
+ * @param {ParserForLanguage} pfl
+ * @returns {pfl is SyncParserForLanguage}
+ */
+const isSyncParserForLanguage = pfl =>
+  values(pfl).every(({ synchronous }) => synchronous);
 
 /**
  * Prepares a function to map parsers after verifying whether synchronous
  * behavior is preferred. Synchronous behavior is selected if all parsers are
  * synchronous and no async transforms are provided.
- *
- * _Note:_ The type argument for {@link MapParsersFn} _could_ be inferred from
- * the function arguments _if_ {@link ParserForLanguage} contained only values
- * of type `ParserImplementation & {synchronous: true}` (and also considering
- * the emptiness of `moduleTransforms`); may only be worth the effort if it was
- * causing issues in practice.
  *
  * @param {MakeMapParsersOptions} options
  * @returns {MapParsersFn}
@@ -350,44 +326,47 @@ export const makeMapParsers = ({
   moduleTransforms,
   syncModuleTransforms,
 }) => {
+  const hasAsyncTransforms =
+    moduleTransforms != null && keys(moduleTransforms).length > 0;
+
+  if (!hasAsyncTransforms && isSyncParserForLanguage(parserForLanguage)) {
+    /**
+     * Synchronous `mapParsers()` function; returned when all parsers are
+     * synchronous and `moduleTransforms` is empty.
+     *
+     * @type {MapParsersFn<ParseFn>}
+     */
+    return (languageForExtension, languageForModuleSpecifier) => {
+      const validExtensions = validateLanguageForExtension(
+        languageForExtension,
+        parserForLanguage,
+      );
+      return makeSyncExtensionParser(
+        validExtensions,
+        languageForModuleSpecifier,
+        parserForLanguage,
+        syncModuleTransforms || {},
+      );
+    };
+  }
+
   /**
    * Async `mapParsers()` function; returned when a non-synchronous parser is
    * present _or_ when `moduleTransforms` is non-empty.
    *
    * @type {MapParsersFn<AsyncParseFn>}
    */
-  const asyncParseFn = (languageForExtension, languageForModuleSpecifier) =>
-    mapParsers(
+  return (languageForExtension, languageForModuleSpecifier) => {
+    const validExtensions = validateLanguageForExtension(
       languageForExtension,
+      parserForLanguage,
+    );
+    return makeAsyncExtensionParser(
+      validExtensions,
       languageForModuleSpecifier,
       parserForLanguage,
-      moduleTransforms,
-      syncModuleTransforms,
+      moduleTransforms || {},
+      syncModuleTransforms || {},
     );
-
-  if (moduleTransforms && keys(moduleTransforms).length > 0) {
-    return asyncParseFn;
-  }
-
-  // all parsers must explicitly be flagged `synchronous` to return a
-  // `MapParsersFn<ParseFn>`
-  if (values(parserForLanguage).some(({ synchronous }) => !synchronous)) {
-    return asyncParseFn;
-  }
-
-  /**
-   * Synchronous `mapParsers()` function; returned when all parsers are
-   * synchronous and `moduleTransforms` is empty.
-   *
-   * @type {MapParsersFn<ParseFn>}
-   */
-  return (languageForExtension, languageForModuleSpecifier) =>
-    mapParsers(
-      languageForExtension,
-      languageForModuleSpecifier,
-      parserForLanguage,
-      moduleTransforms,
-      syncModuleTransforms,
-      true,
-    );
+  };
 };

--- a/packages/compartment-mapper/src/map-parser.js
+++ b/packages/compartment-mapper/src/map-parser.js
@@ -8,27 +8,25 @@
 /**
  * @import {
  *   LanguageForExtension,
- *   LanguageForModuleSpecifier,
  *   MakeMapParsersOptions,
  *   MapParsersFn,
  *   ModuleTransform,
- *   ModuleTransforms,
  *   ParseFn,
  *   AsyncParseFn,
  *   ParseResult,
  *   ParserForLanguage,
+ *   SyncParserForLanguage,
  *   SyncModuleTransform,
- *   SyncModuleTransforms
+ *   SyncModuleTransforms,
+ *   ParserGeneratorConfig
  * } from './types.js';
- * @import {
- *   EReturn
- * } from '@endo/eventual-send';
  */
 
 import { syncTrampoline, asyncTrampoline } from '@endo/trampoline';
 import { parseExtension } from './extension.js';
 
-const { entries, fromEntries, keys, hasOwnProperty, values } = Object;
+const { assign, create, entries, fromEntries, keys, hasOwnProperty, values } =
+  Object;
 const { apply } = Reflect;
 // q, as in quote, for strings in error messages.
 const q = JSON.stringify;
@@ -49,170 +47,170 @@ const has = (object, key) => apply(hasOwnProperty, object, [key]);
 const extensionImpliesLanguage = extension => extension !== 'js';
 
 /**
- * Produces a `parser` that parses the content of a module according to the
- * corresponding module language, given the extension of the module specifier
- * and the configuration of the containing compartment. We do not yet support
- * import assertions and we do not have a mechanism for validating the MIME type
- * of the module content against the language implied by the extension or file
- * name.
+ * Resolves the module language from its specifier and location.
  *
- * @overload
- * @param {true} preferSynchronous
- * @param {Record<string, string>} languageForExtension - maps a file extension
- * to the corresponding language.
- * @param {Record<string, string>} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} moduleTransforms
- * @param {SyncModuleTransforms} syncModuleTransforms
+ * Shared logic between sync and async generators.
+ *
+ * @param {string} specifier
+ * @param {string} location
+ * @param {Record<string, string>} languageForExtension
+ * @param {Record<string, string>} languageForModuleSpecifier
+ * @returns {string} The resolved language.
+ */
+const resolveLanguage = (
+  specifier,
+  location,
+  languageForExtension,
+  languageForModuleSpecifier,
+) => {
+  const extension = parseExtension(location);
+  if (
+    !extensionImpliesLanguage(extension) &&
+    has(languageForModuleSpecifier, specifier)
+  ) {
+    return languageForModuleSpecifier[specifier];
+  }
+  if (has(languageForExtension, extension)) {
+    return languageForExtension[extension];
+  }
+  return extension;
+};
+
+/**
+ * The single shared generator that drives the module parsing pipeline:
+ * resolve language, apply any matching transform, then delegate to the
+ * appropriate parser.
+ *
+ * Both the sync and async wrappers feed this exact function to their
+ * respective trampolines from {@link @endo/trampoline} — that is the entire
+ * point of using trampolines, and the reason this function takes its
+ * configuration as a parameter rather than closing over it.
+ *
+ * Yield/return types are intentionally permissive (async) so
+ * `asyncTrampoline` can `await` yielded values; `syncTrampoline` passes them
+ * through unchanged, which is safe as long as no async transforms or parsers
+ * are wired up for the sync path (the caller enforces this via the outer
+ * narrowing in {@link makeMapParsers}, plus a runtime thenable guard).
+ *
+ * @param {ParserGeneratorConfig} config
+ * @param {Uint8Array} bytes
+ * @param {string} specifier
+ * @param {string} location
+ * @param {string} packageLocation
+ * @param {*} options
+ * @returns {Generator<ReturnType<ModuleTransform> | ReturnType<SyncModuleTransform>, ParseResult | Promise<ParseResult>, any>}
+ */
+function* getParserGenerator(
+  config,
+  bytes,
+  specifier,
+  location,
+  packageLocation,
+  options,
+) {
+  const {
+    languageForExtension,
+    languageForModuleSpecifier,
+    parserForLanguage,
+    transforms,
+  } = config;
+
+  let language = resolveLanguage(
+    specifier,
+    location,
+    languageForExtension,
+    languageForModuleSpecifier,
+  );
+
+  /** @type {string | undefined} */
+  let sourceMap;
+
+  if (has(transforms, language)) {
+    try {
+      ({
+        bytes,
+        parser: language,
+        sourceMap,
+      } = yield transforms[language](
+        bytes,
+        specifier,
+        location,
+        packageLocation,
+        {
+          sourceMap,
+        },
+      ));
+    } catch (err) {
+      throw Error(
+        `Error transforming ${q(language)} source in ${q(location)}: ${/** @type {Error} */ (err).message}`,
+        { cause: err },
+      );
+    }
+  }
+  if (!has(parserForLanguage, language)) {
+    throw Error(
+      `Cannot parse module ${specifier} at ${location}, no parser configured for the language ${language}`,
+    );
+  }
+  const { parse } = parserForLanguage[language];
+  return parse(bytes, specifier, location, packageLocation, {
+    sourceMap,
+    ...options,
+  });
+}
+
+/**
+ * Type guard that narrows a `ParseResult | Promise<ParseResult>` to
+ * `Promise<ParseResult>` by checking that the result has a `then` method.
+ *
+ * @param {ParseResult | Promise<ParseResult>} result
+ * @returns {result is Promise<ParseResult>}
+ */
+const isAsyncParseResult = result =>
+  'then' in result && typeof result.then === 'function';
+
+/**
+ * Produces a sync `ParseFn` for use when all parsers and transforms are
+ * synchronous.
+ *
+ * The `ParseFn` parses the content of a module according to the corresponding
+ * module language, given the extension of the module specifier and the
+ * configuration of the containing compartment. We do not yet support import
+ * assertions and we do not have a mechanism for validating the MIME type of the
+ * module content against the language implied by the extension or file name.
+ *
+ * @param {Record<string, string>} languageForExtension
+ * @param {Record<string, string>} languageForModuleSpecifier
+ * @param {SyncParserForLanguage} parserForLanguage
+ * @param {SyncModuleTransforms} transforms
  * @returns {ParseFn}
  */
-
-/**
- * Produces a `parser` that parses the content of a module according to the
- * corresponding module language, given the extension of the module specifier
- * and the configuration of the containing compartment. We do not yet support
- * import assertions and we do not have a mechanism for validating the MIME type
- * of the module content against the language implied by the extension or file
- * name.
- *
- * @overload
- * @param {false} preferSynchronous
- * @param {Record<string, string>} languageForExtension - maps a file extension
- * to the corresponding language.
- * @param {Record<string, string>} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} moduleTransforms
- * @param {SyncModuleTransforms} syncModuleTransforms
- * @returns {AsyncParseFn}
- */
-
-/**
- * Produces a `parser` that parses the content of a module according to the
- * corresponding module language, given the extension of the module specifier
- * and the configuration of the containing compartment. We do not yet support
- * import assertions and we do not have a mechanism for validating the MIME type
- * of the module content against the language implied by the extension or file
- * name.
- *
- * @param {boolean} preferSynchronous
- * @param {Record<string, string>} languageForExtension - maps a file extension
- * to the corresponding language.
- * @param {Record<string, string>} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} moduleTransforms
- * @param {SyncModuleTransforms} syncModuleTransforms
- * @returns {AsyncParseFn|ParseFn}
- */
-const makeExtensionParser = (
-  preferSynchronous,
+const makeSyncParserForExtension = (
   languageForExtension,
   languageForModuleSpecifier,
   parserForLanguage,
-  moduleTransforms,
-  syncModuleTransforms,
+  transforms,
 ) => {
-  /** @type {Record<string, ModuleTransform | SyncModuleTransform>} */
-  let transforms;
+  /** @type {ParserGeneratorConfig} */
+  const config = {
+    languageForExtension,
+    languageForModuleSpecifier,
+    parserForLanguage,
+    transforms,
+  };
 
-  /**
-   * Function returning a generator which executes a parser for a module in
-   * either sync or async context.
-   *
-   * @param {Uint8Array} bytes
-   * @param {string} specifier
-   * @param {string} location
-   * @param {string} packageLocation
-   * @param {*} options
-   * @returns {Generator<ReturnType<ModuleTransform>|ReturnType<SyncModuleTransform>, ParseResult, EReturn<ModuleTransform|SyncModuleTransform>>}
-   */
-  function* getParserGenerator(
-    bytes,
-    specifier,
-    location,
-    packageLocation,
-    options,
-  ) {
-    /** @type {string} */
-    let language;
-    const extension = parseExtension(location);
-
-    if (
-      !extensionImpliesLanguage(extension) &&
-      has(languageForModuleSpecifier, specifier)
-    ) {
-      language = languageForModuleSpecifier[specifier];
-    } else {
-      // We should revisit this design decision:
-      // Defaulting the language to the extension conflates those namespaces.
-      // So, a transform keyed by extension can be used to coerce a language
-      // (e.g., .mts to mjs) as a shorthand for configuring a parser for that
-      // extension that pre-processes the file before handing off to the
-      // parser.
-      // But, this forces us to support the case of using weird language
-      // names like pre-mjs-json as valid, unconfigured extensions.
-      language = languageForExtension[extension] || extension;
-    }
-
-    /** @type {string|undefined} */
-    let sourceMap;
-
-    if (has(transforms, language)) {
-      try {
-        ({
-          bytes,
-          parser: language,
-          sourceMap,
-        } = yield transforms[language](
-          bytes,
-          specifier,
-          location,
-          packageLocation,
-          {
-            // At time of writing, sourceMap is always undefined, but keeping
-            // it here is more resilient if the surrounding if block becomes a
-            // loop for multi-step transforms.
-            sourceMap,
-          },
-        ));
-      } catch (err) {
-        const cause = /** @type {Error} */ (err);
-        throw Error(
-          `Error transforming ${q(language)} source in ${q(location)}: ${cause.message}`,
-          { cause },
-        );
-      }
-    }
-    if (!has(parserForLanguage, language)) {
-      throw Error(
-        `Cannot parse module ${specifier} at ${location}, no parser configured for the language ${language}`,
-      );
-    }
-    const { parse } = parserForLanguage[language];
-    return parse(bytes, specifier, location, packageLocation, {
-      sourceMap,
-      ...options,
-    });
-  }
-
-  /**
-   * @type {ParseFn}
-   */
+  /** @type {ParseFn} */
   const syncParser = (bytes, specifier, location, packageLocation, options) => {
     const result = syncTrampoline(
       getParserGenerator,
+      config,
       bytes,
       specifier,
       location,
       packageLocation,
       options,
     );
-    if ('then' in result && typeof result.then === 'function') {
+    if (isAsyncParseResult(result)) {
       throw new TypeError(
         'Sync parser cannot return a Thenable; ensure parser is actually synchronous',
       );
@@ -220,96 +218,76 @@ const makeExtensionParser = (
     return result;
   };
   syncParser.isSyncParser = true;
+  return syncParser;
+};
 
-  /**
-   * @type {AsyncParseFn}
-   */
+/**
+ * Produces an async `AsyncParseFn` for use when any parser or transform may
+ * be asynchronous.
+ *
+ * The `AsyncParseFn` parses the content of a module according to the corresponding
+ * module language, given the extension of the module specifier and the
+ * configuration of the containing compartment. We do not yet support import
+ * assertions and we do not have a mechanism for validating the MIME type of the
+ * module content against the language implied by the extension or file name.
+ *
+ * @param {Record<string, string>} languageForExtension
+ * @param {Record<string, string>} languageForModuleSpecifier
+ * @param {ParserForLanguage} parserForLanguage
+ * @param {Record<string, ModuleTransform>} moduleTransforms
+ * @param {Record<string, SyncModuleTransform>} syncModuleTransforms
+ * @returns {AsyncParseFn}
+ */
+const makeAsyncParserForExtension = (
+  languageForExtension,
+  languageForModuleSpecifier,
+  parserForLanguage,
+  moduleTransforms,
+  syncModuleTransforms,
+) => {
+  /** @type {ParserGeneratorConfig} */
+  const config = {
+    languageForExtension,
+    languageForModuleSpecifier,
+    parserForLanguage,
+    transforms: {
+      ...syncModuleTransforms,
+      ...moduleTransforms,
+    },
+  };
+
+  /** @type {AsyncParseFn} */
   const asyncParser = async (
     bytes,
     specifier,
     location,
     packageLocation,
     options,
-  ) => {
-    return asyncTrampoline(
+  ) =>
+    asyncTrampoline(
       getParserGenerator,
+      config,
       bytes,
       specifier,
       location,
       packageLocation,
       options,
     );
-  };
-
-  // Unfortunately, typescript was not smart enough to figure out the return
-  // type depending on a boolean in arguments, so it has to be
-  // AsyncParseFn|ParseFn
-  if (preferSynchronous) {
-    transforms = syncModuleTransforms;
-    return syncParser;
-  } else {
-    // we can fold syncModuleTransforms into moduleTransforms because
-    // async supports sync, but not vice-versa
-    transforms = {
-      ...syncModuleTransforms,
-      ...moduleTransforms,
-    };
-
-    return asyncParser;
-  }
+  return asyncParser;
 };
 
 /**
- * Creates a synchronous parser
+ * Validates the language-for-extension mapping against the parser-for-language
+ * map, filtering to only valid entries.
  *
- * @overload
  * @param {LanguageForExtension} languageForExtension
- * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
  * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} [moduleTransforms]
- * @param {SyncModuleTransforms} [syncModuleTransforms]
- * @param {true} preferSynchronous If `true`, will create a `ParseFn`
- * @returns {ParseFn}
+ * @returns {Record<string, string>} Filtered extension-to-language mapping.
  */
-
-/**
- * Creates an asynchronous parser
- *
- * @overload
- * @param {LanguageForExtension} languageForExtension
- * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} [moduleTransforms]
- * @param {SyncModuleTransforms} [syncModuleTransforms]
- * @param {false} [preferSynchronous]
- * @returns {AsyncParseFn}
- */
-
-/**
- * @param {LanguageForExtension} languageForExtension
- * @param {LanguageForModuleSpecifier} languageForModuleSpecifier - In a rare case,
- * the type of a module is implied by package.json and should not be inferred
- * from its extension.
- * @param {ParserForLanguage} parserForLanguage
- * @param {ModuleTransforms} [moduleTransforms]
- * @param {SyncModuleTransforms} [syncModuleTransforms]
- * @param {boolean} [preferSynchronous] If `true`, will create a `ParseFn`
- * @returns {AsyncParseFn|ParseFn}
- */
-function mapParsers(
+const validateLanguageForExtension = (
   languageForExtension,
-  languageForModuleSpecifier,
   parserForLanguage,
-  moduleTransforms,
-  syncModuleTransforms,
-  preferSynchronous,
-) {
-  moduleTransforms = moduleTransforms || {};
-  syncModuleTransforms = syncModuleTransforms || {};
+) => {
   const languageForExtensionEntries = [];
   const problems = [];
   for (const [extension, language] of entries(languageForExtension)) {
@@ -322,26 +300,24 @@ function mapParsers(
   if (problems.length > 0) {
     throw Error(`No parser available for language: ${problems.join(', ')}`);
   }
-  return makeExtensionParser(
-    /** @type {any} */ (preferSynchronous),
-    fromEntries(languageForExtensionEntries),
-    languageForModuleSpecifier,
-    parserForLanguage,
-    moduleTransforms,
-    syncModuleTransforms,
-  );
-}
+  return assign(create(null), fromEntries(languageForExtensionEntries));
+};
+
+/**
+ * Type guard that narrows {@link ParserForLanguage} to
+ * {@link SyncParserForLanguage} by checking that every parser has
+ * `synchronous: true`.
+ *
+ * @param {ParserForLanguage} pfl
+ * @returns {pfl is SyncParserForLanguage}
+ */
+const isSyncParserForLanguage = pfl =>
+  values(pfl).every(({ synchronous }) => synchronous);
 
 /**
  * Prepares a function to map parsers after verifying whether synchronous
  * behavior is preferred. Synchronous behavior is selected if all parsers are
  * synchronous and no async transforms are provided.
- *
- * _Note:_ The type argument for {@link MapParsersFn} _could_ be inferred from
- * the function arguments _if_ {@link ParserForLanguage} contained only values
- * of type `ParserImplementation & {synchronous: true}` (and also considering
- * the emptiness of `moduleTransforms`); may only be worth the effort if it was
- * causing issues in practice.
  *
  * @param {MakeMapParsersOptions} options
  * @returns {MapParsersFn}
@@ -351,44 +327,47 @@ export const makeMapParsers = ({
   moduleTransforms,
   syncModuleTransforms,
 }) => {
+  const hasAsyncTransforms =
+    moduleTransforms != null && keys(moduleTransforms).length > 0;
+
+  if (!hasAsyncTransforms && isSyncParserForLanguage(parserForLanguage)) {
+    /**
+     * Synchronous `mapParsers()` function; returned when all parsers are
+     * synchronous and `moduleTransforms` is empty.
+     *
+     * @type {MapParsersFn<ParseFn>}
+     */
+    return (languageForExtension, languageForModuleSpecifier) => {
+      const validExtensions = validateLanguageForExtension(
+        languageForExtension,
+        parserForLanguage,
+      );
+      return makeSyncParserForExtension(
+        validExtensions,
+        languageForModuleSpecifier,
+        parserForLanguage,
+        syncModuleTransforms || {},
+      );
+    };
+  }
+
   /**
    * Async `mapParsers()` function; returned when a non-synchronous parser is
    * present _or_ when `moduleTransforms` is non-empty.
    *
    * @type {MapParsersFn<AsyncParseFn>}
    */
-  const asyncParseFn = (languageForExtension, languageForModuleSpecifier) =>
-    mapParsers(
+  return (languageForExtension, languageForModuleSpecifier) => {
+    const validExtensions = validateLanguageForExtension(
       languageForExtension,
+      parserForLanguage,
+    );
+    return makeAsyncParserForExtension(
+      validExtensions,
       languageForModuleSpecifier,
       parserForLanguage,
-      moduleTransforms,
-      syncModuleTransforms,
+      moduleTransforms || {},
+      syncModuleTransforms || {},
     );
-
-  if (moduleTransforms && keys(moduleTransforms).length > 0) {
-    return asyncParseFn;
-  }
-
-  // all parsers must explicitly be flagged `synchronous` to return a
-  // `MapParsersFn<ParseFn>`
-  if (values(parserForLanguage).some(({ synchronous }) => !synchronous)) {
-    return asyncParseFn;
-  }
-
-  /**
-   * Synchronous `mapParsers()` function; returned when all parsers are
-   * synchronous and `moduleTransforms` is empty.
-   *
-   * @type {MapParsersFn<ParseFn>}
-   */
-  return (languageForExtension, languageForModuleSpecifier) =>
-    mapParsers(
-      languageForExtension,
-      languageForModuleSpecifier,
-      parserForLanguage,
-      moduleTransforms,
-      syncModuleTransforms,
-      true,
-    );
+  };
 };

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -13,6 +13,11 @@ import type {
   Transform,
 } from 'ses';
 import type {
+  ATTENUATORS_COMPARTMENT,
+  ENTRY_COMPARTMENT,
+} from '../policy-format.js';
+import type { CanonicalName } from './canonical-name.js';
+import type {
   CompartmentDescriptor,
   CompartmentMapDescriptor,
   DigestedCompartmentMapDescriptor,
@@ -21,18 +26,12 @@ import type {
   PackageCompartmentDescriptorName,
   PackageCompartmentDescriptors,
 } from './compartment-map-schema.js';
+import type { PackageDescriptor } from './node-modules.js';
 import type { SomePolicy } from './policy-schema.js';
 import type { HashFn, ReadFn, ReadPowers } from './powers.js';
-import type { CanonicalName } from './canonical-name.js';
-import type { PackageDescriptor } from './node-modules.js';
-import type {
-  ATTENUATORS_COMPARTMENT,
-  ENTRY_COMPARTMENT,
-} from '../policy-format.js';
 import type { LiteralUnion } from './typescript.js';
 
-export type { CanonicalName };
-export type { PackageDescriptor };
+export type { CanonicalName, PackageDescriptor };
 
 /**
  * Hook executed for each canonical name mentioned in policy but not found in the
@@ -718,15 +717,23 @@ export type ComputeSourceMapLocationHook = (
   details: ComputeSourceMapLocationDetails,
 ) => string;
 
-export type ParserImplementation = {
+interface BaseParserImplementation {
   /**
    * Whether a heuristic is used by parser to detect imports.
    * CommonJS uses a lexer to heuristically discover static require calls.
    */
   heuristicImports: boolean;
+}
+
+export interface ParserImplementation extends BaseParserImplementation {
   parse: ParseFn;
-  synchronous: boolean;
-};
+  synchronous: true;
+}
+
+export interface AsyncParserImplementation extends BaseParserImplementation {
+  parse: AsyncParseFn;
+  synchronous: false;
+}
 
 type ParseArguments = [
   bytes: Uint8Array,
@@ -753,17 +760,48 @@ export type ParseResult = {
   sourceMap?: string | undefined;
 };
 
-export type AsyncParseFn = (...args: ParseArguments) => Promise<ParseResult>;
-
+/**
+ * A synchronous module parsing function.
+ *
+ * @todo This and all parser-related types (including {@link ParseResult} should
+ * be moved into a separate package. `@endo/parser-pipeline` needs these types,
+ * and a package needing the types in `@endo/parser-pipeline` would then pull in
+ * `@endo/compartment-mapper` as a transitive dep and all _its_ transitive deps.
+ * Because {@link ParseResult} contains {@link FinalStaticModuleType} from
+ * `ses`, those types would want to be moved out of `ses` with it.
+ */
 export type ParseFn = { isSyncParser?: true } & ((
   ...args: ParseArguments
 ) => ParseResult);
 
 /**
- * Mapping of `Language` to {@link ParserImplementation
- * ParserImplementations}
+ * An asynchronous module parsing function.
  */
-export type ParserForLanguage = Record<Language | string, ParserImplementation>;
+export type AsyncParseFn = { isSyncParser?: false } & ((
+  ...args: ParseArguments
+) => Promise<ParseResult>);
+
+/**
+ * Mapping of `Language` to synchronous {@link ParserImplementation}s only.
+ *
+ * Used when all parsers are known to be synchronous.
+ */
+export type SyncParserForLanguage = Record<
+  Language | string,
+  ParserImplementation
+>;
+
+/**
+ * Mapping of `Language` to {@link ParserImplementation
+ * ParserImplementations} or {@link AsyncParserImplementation}s.
+ *
+ * When any entry has `synchronous: false`, the pipeline uses the async
+ * trampoline.
+ */
+export type ParserForLanguage = Record<
+  Language | string,
+  ParserImplementation | AsyncParserImplementation
+>;
 
 /**
  * Generic logging function accepted by various functions.

--- a/packages/compartment-mapper/src/types/external.ts
+++ b/packages/compartment-mapper/src/types/external.ts
@@ -13,6 +13,11 @@ import type {
   Transform,
 } from 'ses';
 import type {
+  ATTENUATORS_COMPARTMENT,
+  ENTRY_COMPARTMENT,
+} from '../policy-format.js';
+import type { CanonicalName } from './canonical-name.js';
+import type {
   CompartmentDescriptor,
   CompartmentMapDescriptor,
   DigestedCompartmentMapDescriptor,
@@ -21,18 +26,12 @@ import type {
   PackageCompartmentDescriptorName,
   PackageCompartmentDescriptors,
 } from './compartment-map-schema.js';
+import type { PackageDescriptor } from './node-modules.js';
 import type { SomePolicy } from './policy-schema.js';
 import type { HashFn, ReadFn, ReadPowers } from './powers.js';
-import type { CanonicalName } from './canonical-name.js';
-import type { PackageDescriptor } from './node-modules.js';
-import type {
-  ATTENUATORS_COMPARTMENT,
-  ENTRY_COMPARTMENT,
-} from '../policy-format.js';
 import type { LiteralUnion } from './typescript.js';
 
-export type { CanonicalName };
-export type { PackageDescriptor };
+export type { CanonicalName, PackageDescriptor };
 
 /**
  * Hook executed for each canonical name mentioned in policy but not found in the
@@ -752,15 +751,23 @@ export type ComputeSourceMapLocationHook = (
   details: ComputeSourceMapLocationDetails,
 ) => string;
 
-export type ParserImplementation = {
+interface BaseParserImplementation {
   /**
    * Whether a heuristic is used by parser to detect imports.
    * CommonJS uses a lexer to heuristically discover static require calls.
    */
   heuristicImports: boolean;
+}
+
+export interface ParserImplementation extends BaseParserImplementation {
   parse: ParseFn;
-  synchronous: boolean;
-};
+  synchronous: true;
+}
+
+export interface AsyncParserImplementation extends BaseParserImplementation {
+  parse: AsyncParseFn;
+  synchronous: false;
+}
 
 type ParseArguments = [
   bytes: Uint8Array,
@@ -787,17 +794,48 @@ export type ParseResult = {
   sourceMap?: string | undefined;
 };
 
-export type AsyncParseFn = (...args: ParseArguments) => Promise<ParseResult>;
-
+/**
+ * A synchronous module parsing function.
+ *
+ * @todo This and all parser-related types (including {@link ParseResult} should
+ * be moved into a separate package. `@endo/parser-pipeline` needs these types,
+ * and a package needing the types in `@endo/parser-pipeline` would then pull in
+ * `@endo/compartment-mapper` as a transitive dep and all _its_ transitive deps.
+ * Because {@link ParseResult} contains {@link FinalStaticModuleType} from
+ * `ses`, those types would want to be moved out of `ses` with it.
+ */
 export type ParseFn = { isSyncParser?: true } & ((
   ...args: ParseArguments
 ) => ParseResult);
 
 /**
- * Mapping of `Language` to {@link ParserImplementation
- * ParserImplementations}
+ * An asynchronous module parsing function.
  */
-export type ParserForLanguage = Record<Language | string, ParserImplementation>;
+export type AsyncParseFn = { isSyncParser?: false } & ((
+  ...args: ParseArguments
+) => Promise<ParseResult>);
+
+/**
+ * Mapping of `Language` to synchronous {@link ParserImplementation}s only.
+ *
+ * Used when all parsers are known to be synchronous.
+ */
+export type SyncParserForLanguage = Record<
+  Language | string,
+  ParserImplementation
+>;
+
+/**
+ * Mapping of `Language` to {@link ParserImplementation
+ * ParserImplementations} or {@link AsyncParserImplementation}s.
+ *
+ * When any entry has `synchronous: false`, the pipeline uses the async
+ * trampoline.
+ */
+export type ParserForLanguage = Record<
+  Language | string,
+  ParserImplementation | AsyncParserImplementation
+>;
 
 /**
  * Generic logging function accepted by various functions.

--- a/packages/compartment-mapper/src/types/internal.ts
+++ b/packages/compartment-mapper/src/types/internal.ts
@@ -182,7 +182,7 @@ type SyncChooseModuleDescriptorOperators = {
 /**
  * Operators for `chooseModuleDescriptor` representing asynchronous operation.
  */
-export type AsyncChooseModuleDescriptorOperators = {
+type AsyncChooseModuleDescriptorOperators = {
   /**
    * A function that reads a file, resolving with its binary contents _or_
    * `undefined` if the file is not found

--- a/packages/compartment-mapper/src/types/internal.ts
+++ b/packages/compartment-mapper/src/types/internal.ts
@@ -42,6 +42,8 @@ import type {
   SyncModuleTransforms,
   CompartmentsRenameFn,
   RedundantPreloadHook,
+  ModuleTransform,
+  SyncModuleTransform,
 } from './external.js';
 import type { PackageDescriptor } from './node-modules.js';
 import type { DeferredAttenuatorsProvider } from './policy.js';
@@ -182,7 +184,7 @@ type SyncChooseModuleDescriptorOperators = {
 /**
  * Operators for `chooseModuleDescriptor` representing asynchronous operation.
  */
-export type AsyncChooseModuleDescriptorOperators = {
+type AsyncChooseModuleDescriptorOperators = {
   /**
    * A function that reads a file, resolving with its binary contents _or_
    * `undefined` if the file is not found
@@ -331,3 +333,13 @@ export type DigestCompartmentMapOptions<
 };
 
 export type CaptureCompartmentMapOptions = DigestCompartmentMapOptions;
+
+/**
+ * Per-call configuration passed into {@link getParserGenerator}.
+ */
+export type ParserGeneratorConfig = {
+  languageForExtension: LanguageForExtension;
+  languageForModuleSpecifier: LanguageForModuleSpecifier;
+  parserForLanguage: ParserForLanguage;
+  transforms: Record<string, ModuleTransform | SyncModuleTransform>;
+};

--- a/packages/compartment-mapper/test/dynamic-import-esm.test.js
+++ b/packages/compartment-mapper/test/dynamic-import-esm.test.js
@@ -1,0 +1,24 @@
+import 'ses';
+
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+
+const fixture = new URL(
+  'fixtures-dynamic-import-esm/node_modules/app/index.js',
+  import.meta.url,
+).toString();
+
+scaffold(
+  'fixtures-dynamic-import-esm',
+  test,
+  fixture,
+  async (t, { namespace }) => {
+    // @ts-expect-error - untyped
+    const foo = await namespace.getFoo();
+    t.is(foo, 'foo');
+  },
+  1,
+  {
+    knownArchiveFailure: true,
+  },
+);

--- a/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/foo.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/foo.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/index.js
@@ -1,0 +1,4 @@
+export const getFoo = async () => {
+  const foo = await import('./foo.js');
+  return foo.default;
+};

--- a/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-dynamic-import-esm/node_modules/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./index.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}


### PR DESCRIPTION
This fixes the half-implemented type defs and support for async parsers by introducing `AsyncParserImplementation`.

We needed sync-and-async-specific parse-mappers in `map-parser.js` and some type guards.

A sync-parser-specific `SyncParserForLanguage` is introduced as well.

_Bonus: added some tests for `import()` in ESM to `@endo/compartment-mapper`._