### PR TITLE
Revert "fix(pass-style): retype PASS_STYLE as string literal for decl-emit

### DIFF
--- a/.changeset/pass-style-decl-emit-2.md
+++ b/.changeset/pass-style-decl-emit-2.md
@@ -1,5 +1,5 @@
 ---
-'@endo/pass-style': minor
+'@endo/pass-style': patch
 ---
 
 Revert the TypeScript declaration for `PASS_STYLE` back to a unique symbol. Compile-time type changes only; no runtime behavior changes.

--- a/.changeset/pass-style-decl-emit-2.md
+++ b/.changeset/pass-style-decl-emit-2.md
@@ -1,0 +1,7 @@
+---
+'@endo/pass-style': minor
+---
+
+Revert the TypeScript declaration for `PASS_STYLE` back to a unique symbol. Compile-time type changes only; no runtime behavior changes.
+
+`PASS_STYLE` is once again typed as a `unique symbol` instead of a string-literal `'Symbol(passStyle)'`. We are working to narrow down the issue and have a more targeted type fix.

--- a/packages/pass-style/src/passStyle-helpers.js
+++ b/packages/pass-style/src/passStyle-helpers.js
@@ -69,22 +69,13 @@ export const isTypedArray = object => {
 hideAndHardenFunction(isTypedArray);
 
 /**
- * The well-known symbol used to tag passable objects with their pass style.
+ * The registered symbol used to tag passable objects with their pass style.
  *
- * Typed as the string literal `'Symbol(passStyle)'` rather than as
- * `unique symbol`, to keep the type nameable across module boundaries.
- * The runtime value is still `Symbol.for('passStyle')` — JS computed property
- * keys accept any value, so `obj[PASS_STYLE]` indexing is unchanged.
- *
- * Without this, declaration emit in downstream packages whose inferred types
- * structurally contain `[PASS_STYLE]` (via `PassStyled`, `ExtractStyle`, etc.)
- * fails with TS4023 / TS9006, because `unique symbol` bindings are only
- * nameable via their original declaration module — which consumers have no
- * reason to import directly.
+ * Caveat: typed as a `unique symbol` because of TypeScript limitations around
+ * registered symbols. This may cause typing issues in consumers that do not
+ * import the original declaration in this module.
  */
-export const PASS_STYLE = /** @type {'Symbol(passStyle)'} */ (
-  /** @type {unknown} */ (Symbol.for('passStyle'))
-);
+export const PASS_STYLE = Symbol.for('passStyle');
 
 /**
  * Below we have a series of predicate functions and their (curried) assertion


### PR DESCRIPTION
This partially reverts commit c05c9a884fd6f2f0888bd954ea8295af7020146f.

Refs: #3184

## Description

It's unclear to me whether this is an agoric-sdk bug, or a TS bug, but let's not propagate a hack to the world just yet
