### PR TITLE
fix(ocapn): harden Guile goblin-chat interop workflow

### DIFF
--- a/.github/workflows/ocapn-guile-interop.yml
+++ b/.github/workflows/ocapn-guile-interop.yml
@@ -6,9 +6,8 @@ name: OCapN Guile interop
 #
 # This is scaffolding: it stands up the pieces (Guix toolchain, Spritely
 # goblin-chat, Endo chatroom server) and runs a minimal Guile interop
-# client. Expect to iterate on the Guile module paths and manifest the first
-# few runs; that's why it's a standalone workflow with `continue-on-error`
-# and `workflow_dispatch` rather than a required job in the main CI graph.
+# client. It remains a standalone workflow (`workflow_dispatch`) but should
+# fail normally so regressions are visible in PR checks.
 
 on:
   pull_request:
@@ -28,7 +27,6 @@ jobs:
   test-ocapn-guile-interop:
     name: test-ocapn-guile-interop
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/ocapn-guile-interop.yml
+++ b/.github/workflows/ocapn-guile-interop.yml
@@ -19,7 +19,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ocapn-guile-interop.yml
+++ b/.github/workflows/ocapn-guile-interop.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Start Endo goblin-chat host
         working-directory: endo
+        env:
+          OCAPN_CAPTP_VERSION: goblins-0.16
         run: |
           node ./packages/ocapn/test/goblin-chat/index.js interop-room \
             > /tmp/endo-chat.log 2>&1 &

--- a/.github/workflows/ocapn-guile-interop.yml
+++ b/.github/workflows/ocapn-guile-interop.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,31 +63,12 @@ jobs:
         working-directory: endo
         run: yarn build
 
-      - name: Cache Guix store
-        id: cache-guix
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        with:
-          path: |
-            /gnu
-            /var/guix
-          key: guix-${{ runner.os }}-v2-interop-manifest
-          # Fall back to older caches if the interop manifest key misses,
-          # so we still populate /gnu and just rebuild what's missing.
-          restore-keys: |
-            guix-${{ runner.os }}-v2-
-            guix-${{ runner.os }}-v1
-
       - name: Install GNU Guix
-        if: steps.cache-guix.outputs.cache-hit != 'true'
         uses: PromyLOPh/guix-install-action@40615e98e5c16a451aec10fe01c214ed07cbaa77 # v1
-
-      - name: Put guix on PATH (cache hit path)
-        if: steps.cache-guix.outputs.cache-hit == 'true'
-        run: |
-          # The install-action already puts guix on PATH; on a cache hit we
-          # skipped it, so wire the same paths ourselves.
-          echo "/var/guix/profiles/per-user/root/current-guix/bin" >> $GITHUB_PATH
-          echo "GUIX_PROFILE=/var/guix/profiles/per-user/root/current-guix" >> $GITHUB_ENV
+        with:
+          # Skip `guix pull`: the default action behavior updates channels to
+          # bleeding edge and costs most of the runtime in this workflow.
+          pullAfterInstall: false
 
       - name: Report Guix version
         run: guix describe || guix --version
@@ -110,22 +92,12 @@ jobs:
           fi
           echo "STURDYREF=$STURDYREF" >> $GITHUB_ENV
 
-      - name: List installed goblins ocapn modules
-        env:
-          INTEROP_MANIFEST: ${{ github.workspace }}/endo/packages/ocapn/test/goblin-chat/interop-manifest.scm
-        run: |
-          # One-shot diagnostic so we don't have to keep guessing module
-          # names. Prints every .scm under goblins/ocapn/ in the resolved
-          # profile, which is the source of truth for `use-modules` paths.
-          # No --pure here: we need the host's `find` + shell utilities.
-          guix shell --no-grafts --manifest="$INTEROP_MANIFEST" -- \
-            bash -c 'find "$GUIX_ENVIRONMENT/share" -path "*goblins/ocapn*" -name "*.scm" | sort'
-
       - name: Run Guile interop client
         working-directory: goblin-chat
         env:
           INTEROP_CLIENT: ${{ github.workspace }}/endo/packages/ocapn/test/goblin-chat/interop-client.scm
           INTEROP_MANIFEST: ${{ github.workspace }}/endo/packages/ocapn/test/goblin-chat/interop-manifest.scm
+          GUILE_AUTO_COMPILE: 0
         run: |
           # Slim manifest: only guile + guile-goblins + guile-fibers.
           # Spritely's goblin-chat/manifest.scm also pulls gtk/g-golf/mesa

--- a/packages/ocapn/src/client/handshake.js
+++ b/packages/ocapn/src/client/handshake.js
@@ -24,6 +24,26 @@ import { decodeSyrup } from '../syrup/js-representation.js';
 import { locationToLocationId } from './util.js';
 
 /**
+ * @param {any} err
+ * @returns {boolean}
+ */
+const isIncompleteSyrupError = err => {
+  let cursor = err;
+  while (cursor) {
+    if (
+      typeof cursor === 'object' &&
+      cursor !== null &&
+      typeof cursor.message === 'string' &&
+      cursor.message.includes('End of data reached')
+    ) {
+      return true;
+    }
+    cursor = cursor.cause;
+  }
+  return false;
+};
+
+/**
  * @param {Connection} connection
  * @param {SelfIdentity} selfIdentity
  * @param {string} captpVersion
@@ -148,6 +168,13 @@ const handleSessionHandshakeMessage = (
       } = message;
       // Handle invalid version
       if (messageCaptpVersion !== captpVersion) {
+        logger.info(
+          'Handshake CapTP version mismatch',
+          JSON.stringify({
+            received: messageCaptpVersion,
+            expected: captpVersion,
+          }),
+        );
         // send op abort
         logger.info(`Abort during start-session message with invalid version`);
         sendAbortAndClose(connection, 'invalid-version');
@@ -256,6 +283,7 @@ const handleSessionHandshakeMessage = (
  * @param {Uint8Array} data
  * @param {string} captpVersion
  * @param {(connection: Connection, sessionId: SessionId, peerLocation: OcapnLocation) => Ocapn} prepareOcapn
+ * @returns {Uint8Array}
  */
 export const handleHandshakeMessageData = (
   logger,
@@ -269,14 +297,25 @@ export const handleHandshakeMessageData = (
 ) => {
   try {
     const syrupReader = makeSyrupReader(data);
+    let priorSession = sessionManager.getSessionForConnection(connection);
     while (syrupReader.index < data.length) {
       const start = syrupReader.index;
       let message;
       try {
         message = readOcapnHandshakeMessage(syrupReader);
       } catch (err) {
+        // Stream transport can split a Syrup message across packets.
+        // Keep the remaining bytes and wait for more data.
+        if (isIncompleteSyrupError(err)) {
+          return data.slice(start);
+        }
         const problematicBytes = data.slice(start);
-        const syrupMessage = decodeSyrup(problematicBytes);
+        let syrupMessage;
+        try {
+          syrupMessage = decodeSyrup(problematicBytes);
+        } catch {
+          syrupMessage = '<un-decodable>';
+        }
         logger.error(
           `Message decode error:`,
           err,
@@ -302,10 +341,20 @@ export const handleHandshakeMessageData = (
           message,
         );
       }
+
+      const nextSession = sessionManager.getSessionForConnection(connection);
+      if (!priorSession && nextSession) {
+        // Session handshake completed; leave any remaining bytes to be decoded
+        // by the normal post-handshake OCapN message decoder.
+        return data.slice(syrupReader.index);
+      }
+      priorSession = nextSession;
     }
+    return new Uint8Array(0);
   } catch (err) {
     logger.error(`Unexpected error while processing handshake message:`, err);
     sendAbortAndClose(connection, 'internal error');
     sessionManager.deleteConnection(connection);
+    return new Uint8Array(0);
   }
 };

--- a/packages/ocapn/src/client/index.js
+++ b/packages/ocapn/src/client/index.js
@@ -200,6 +200,8 @@ export const makeClient = ({
   });
 
   const sessionManager = makeSessionManager();
+  /** @type {WeakMap<Connection, Uint8Array>} */
+  const pendingHandshakeBytes = new WeakMap();
 
   /** @type {WeakMap<Connection, SelfIdentity>} */
   const connectionSelfIdentityMap = new WeakMap();
@@ -322,6 +324,11 @@ export const makeClient = ({
    */
   const handleMessageData = (connection, data) => {
     logger.info(`handleMessageData called`);
+    const buffered = pendingHandshakeBytes.get(connection);
+    const incoming =
+      buffered && buffered.length > 0
+        ? new Uint8Array([...buffered, ...data])
+        : data;
     const session = sessionManager.getSessionForConnection(connection);
     if (session) {
       handleActiveSessionMessageData(
@@ -329,19 +336,37 @@ export const makeClient = ({
         sessionManager,
         connection,
         session,
-        data,
+        incoming,
       );
+      pendingHandshakeBytes.delete(connection);
     } else {
-      handleHandshakeMessageData(
+      const remaining = handleHandshakeMessageData(
         logger,
         sessionManager,
         connection,
         getSelfIdentityForConnection,
         sendAbortAndClose,
-        data,
+        incoming,
         captpVersion,
         prepareOcapn,
       );
+      const postHandshakeSession = sessionManager.getSessionForConnection(connection);
+      if (postHandshakeSession) {
+        pendingHandshakeBytes.delete(connection);
+        if (remaining.length > 0) {
+          handleActiveSessionMessageData(
+            logger,
+            sessionManager,
+            connection,
+            postHandshakeSession,
+            remaining,
+          );
+        }
+      } else if (remaining.length > 0) {
+        pendingHandshakeBytes.set(connection, remaining);
+      } else {
+        pendingHandshakeBytes.delete(connection);
+      }
     }
   };
 
@@ -362,6 +387,7 @@ export const makeClient = ({
       // If no session exists, check if there's a pending session for this connection
       sessionManager.rejectPendingSessionForConnection(connection);
     }
+    pendingHandshakeBytes.delete(connection);
     sessionManager.deleteConnection(connection);
   };
 

--- a/packages/ocapn/src/client/ocapn.js
+++ b/packages/ocapn/src/client/ocapn.js
@@ -59,6 +59,26 @@ import { makeGrantDetails } from './grant-tracker.js';
 const sink = harden(() => {});
 
 /**
+ * @param {any} err
+ * @returns {boolean}
+ */
+const isIncompleteSyrupError = err => {
+  let cursor = err;
+  while (cursor) {
+    if (
+      typeof cursor === 'object' &&
+      cursor !== null &&
+      typeof cursor.message === 'string' &&
+      cursor.message.includes('End of data reached')
+    ) {
+      return true;
+    }
+    cursor = cursor.cause;
+  }
+  return false;
+};
+
+/**
  * @callback MessageObserver
  * @param {'send' | 'receive'} direction - Whether the message was sent or received
  * @param {object} message - The message object
@@ -1188,12 +1208,19 @@ export const makeOcapn = (
     }
   }
 
+  /** @type {Uint8Array} */
+  let pendingMessageBytes = new Uint8Array(0);
+
   /**
    * @param {Uint8Array} data
    */
   const dispatchMessageData = data => {
-    const syrupReader = makeSyrupReader(data);
-    while (syrupReader.index < data.length) {
+    const incoming =
+      pendingMessageBytes.length > 0
+        ? new Uint8Array([...pendingMessageBytes, ...data])
+        : data;
+    const syrupReader = makeSyrupReader(incoming);
+    while (syrupReader.index < incoming.length) {
       let message;
       const start = syrupReader.index;
       try {
@@ -1202,10 +1229,19 @@ export const makeOcapn = (
         // Tell the engine message deserialization has completed.
         ocapnTable.commitReceivedRefCounts();
       } catch (err) {
+        if (isIncompleteSyrupError(err)) {
+          pendingMessageBytes = incoming.slice(start);
+          return;
+        }
         // Tell the engine message deserialization has failed.
         ocapnTable.clearPendingRefCounts();
-        const problematicBytes = data.slice(start);
-        const syrupMessage = decodeSyrup(problematicBytes);
+        const problematicBytes = incoming.slice(start);
+        let syrupMessage;
+        try {
+          syrupMessage = decodeSyrup(problematicBytes);
+        } catch {
+          syrupMessage = '<un-decodable>';
+        }
         logger.error(`Message decode error:`);
         logger.error(
           JSON.stringify(
@@ -1219,6 +1255,7 @@ export const makeOcapn = (
       }
       dispatch(message);
     }
+    pendingMessageBytes = new Uint8Array(0);
   };
 
   const localBootstrapSlot = makeSlot('o', true, ZERO_N);

--- a/packages/ocapn/test/client.test.js
+++ b/packages/ocapn/test/client.test.js
@@ -370,6 +370,106 @@ test('provideSession throws and cleans up pending session on handshake abort', a
   }
 });
 
+test('fragmented post-handshake message is buffered and decoded', async t => {
+  const { establishSession, shutdownBoth } = await makeTestClientPair();
+
+  try {
+    const { sessionA, sessionB } = await establishSession();
+
+    const msg = {
+      type: 'op:gc-answer',
+      answerPosition: 0n,
+    };
+    const bytes = sessionB.ocapn.writeOcapnMessage(msg);
+    const splitAt = 1;
+    const chunk1 = bytes.slice(0, splitAt);
+    const chunk2 = bytes.slice(splitAt);
+
+    // First fragment should not be parseable by itself, but must not tear down session.
+    sessionA.ocapn.dispatchMessageData(chunk1);
+    t.false(
+      sessionA.connection.isDestroyed,
+      'session should remain alive after first partial fragment',
+    );
+
+    // Second fragment completes message and should be processed.
+    sessionA.ocapn.dispatchMessageData(chunk2);
+    t.false(
+      sessionA.connection.isDestroyed,
+      'session should remain alive after full fragmented message is reassembled',
+    );
+
+    // If buffering failed, connection would be torn down by decode abort.
+    t.false(
+      sessionB.connection.isDestroyed,
+      'sender side should also remain connected after fragmented message handling',
+    );
+  } finally {
+    shutdownBoth();
+  }
+});
+
+test('fragmented handshake message is buffered and establishes session', async t => {
+  const { clientKitA, clientKitB } = await makeTestClientPair();
+
+  try {
+    const connectionAtoB = clientKitA.netlayer.connect(clientKitB.location);
+    // Force handshake bytes ourselves so we can fragment them.
+    const keyPairA = makeOcapnKeyPair();
+    const locationSignatureA = signLocation(clientKitA.location, keyPairA);
+    const startSessionA = {
+      type: 'op:start-session',
+      captpVersion: '1.0',
+      sessionPublicKey: keyPairA.publicKey.descriptor,
+      location: clientKitA.location,
+      locationSignature: locationSignatureA,
+    };
+    const bytes = writeOcapnHandshakeMessage(startSessionA);
+    const splitAt = 1;
+    const chunk1 = bytes.slice(0, splitAt);
+    const chunk2 = bytes.slice(splitAt);
+
+    // Send first partial chunk directly on the wire.
+    connectionAtoB.write(chunk1);
+    await waitUntilTrue(
+      () => !connectionAtoB.isDestroyed,
+      200,
+      20,
+    );
+    t.false(
+      connectionAtoB.isDestroyed,
+      'connection should remain alive after partial handshake fragment',
+    );
+
+    // Send second chunk and ensure session becomes active.
+    connectionAtoB.write(chunk2);
+    await waitUntilTrue(
+      () =>
+        !!clientKitA.debug.sessionManager.getActiveSession(clientKitB.locationId),
+      1000,
+      20,
+    );
+    await waitUntilTrue(
+      () =>
+        !!clientKitB.debug.sessionManager.getActiveSession(clientKitA.locationId),
+      1000,
+      20,
+    );
+
+    t.truthy(
+      clientKitA.debug.sessionManager.getActiveSession(clientKitB.locationId),
+      'A should have active session after fragmented handshake',
+    );
+    t.truthy(
+      clientKitB.debug.sessionManager.getActiveSession(clientKitA.locationId),
+      'B should have active session after fragmented handshake',
+    );
+  } finally {
+    clientKitA.client.shutdown();
+    clientKitB.client.shutdown();
+  }
+});
+
 test('session can be re-established after normal abort', async t => {
   const {
     establishSession,

--- a/packages/ocapn/test/goblin-chat/index.js
+++ b/packages/ocapn/test/goblin-chat/index.js
@@ -16,12 +16,14 @@ import { makeChatroom } from './backend.js';
 const CHATROOM_SWISS = 'goblinChatRoomSwissnumForInteropTests0001';
 const DEFAULT_PORT = 22047;
 const DEFAULT_NAME = 'endo-interop';
+const DEFAULT_CAPTP_VERSION = 'goblins-0.16';
 
 const main = async () => {
   const roomName = process.argv[2] || DEFAULT_NAME;
   const port = Number(process.env.OCAPN_TEST_PORT) || DEFAULT_PORT;
 
-  const client = makeClient({ verbose: true });
+  const captpVersion = process.env.OCAPN_CAPTP_VERSION || DEFAULT_CAPTP_VERSION;
+  const client = makeClient({ verbose: true, captpVersion });
   const chatroom = makeChatroom(roomName);
   client.registerSturdyRef(CHATROOM_SWISS, chatroom);
 

--- a/packages/ocapn/test/goblin-chat/interop-client.scm
+++ b/packages/ocapn/test/goblin-chat/interop-client.scm
@@ -10,21 +10,85 @@
 ;;;
 ;;; Exit 0 on a successful `send-message` ack, non-zero otherwise.
 ;;;
-;;; Module paths for the tcp-testing-only netlayer in guile-goblins: the
-;;; published TCP+TLS doc uses singular `netlayer`
-;;;   (goblins ocapn netlayer tcp-tls)
-;;; so the testing variant is assumed to live alongside it as
-;;;   (goblins ocapn netlayer tcp-testing)
-;;; Adjust if that's off — at least the `netlayer` vs `netlayers` pluralisation
-;;; is verified.
+;;; Guix's packaged guile-goblins may not include a dedicated
+;;; `(goblins ocapn netlayer tcp-testing)` module. To keep this script runnable
+;;; against those builds, we define a small tcp-testing netlayer actor locally,
+;;; following Goblins' own OCapN test-suite implementation.
 
 (use-modules (goblins)
              (goblins actor-lib common)
+             (goblins actor-lib io)
              (goblins ocapn captp)
              (goblins ocapn ids)
-             (goblins ocapn netlayer tcp-testing)
+             (goblins ocapn netlayer base-port)
+             (goblins utils hashmap)
              (goblin-chat backend)
              (ice-9 match))
+
+;; Copied from Goblins' OCapN test-suite pattern:
+;; this gives us a tcp-testing-only netlayer without depending on a module that
+;; might be absent from packaged guile-goblins.
+(define (use-nonblocking-i/o port)
+  (fcntl port F_SETFL (logior O_NONBLOCK (fcntl port F_GETFL))))
+
+(define (make-server-socket+port port max-connections)
+  (let ((sock (socket AF_INET SOCK_STREAM IPPROTO_TCP)))
+    (bind sock AF_INET INADDR_ANY (or port 0))
+    (setsockopt sock SOL_SOCKET SO_REUSEADDR 1)
+    (fcntl sock F_SETFD FD_CLOEXEC)
+    (use-nonblocking-i/o sock)
+    (listen sock max-connections)
+    (values sock (vector-ref (getsockname sock) 2))))
+
+(define (make-client-socket host port)
+  ;; Resolve hostname to get IP address.
+  (match (getaddrinfo host (number->string port)
+                      AI_NUMERICSERV AF_INET SOCK_STREAM IPPROTO_TCP)
+    ((info _ ...)
+     (let* ((family (addrinfo:fam info))
+            (socktype (addrinfo:socktype info))
+            (address (sockaddr:addr (addrinfo:addr info)))
+            (sock (socket family socktype IPPROTO_TCP)))
+       (use-nonblocking-i/o sock)
+       (connect sock family address port)
+       sock))))
+
+(define-actor (^tcp-testing-netlayer bcom host #:optional [port 0])
+  (define-values (sock assigned-port)
+    (make-server-socket+port port 32))
+  (define socket-io
+    (spawn ^io sock #:cleanup close-port))
+
+  (define our-location
+    (make-ocapn-peer 'tcp-testing-only
+                     "guile-goblins"
+                     (hashmap ("host" host)
+                              ("port" (number->string assigned-port)))))
+
+  (define (incoming-accept)
+    (on-match (<- socket-io
+                  (lambda (resource)
+                    (accept resource O_NONBLOCK)))
+        ((client-socket . _)
+         (setvbuf client-socket 'block)
+         (use-nonblocking-i/o client-socket)
+         client-socket)))
+
+  (define (outgoing-connect-to-loc loc)
+    (unless (eq? (ocapn-peer-transport loc) 'tcp-testing-only)
+      (error "Wrong netlayer! Expected `tcp-testing-only'" loc))
+    (let*-values (((hints) (ocapn-peer-hints loc))
+                  ((host) (hashmap-ref hints "host"))
+                  ((port) (hashmap-ref hints "port")))
+      (make-client-socket host (string->number port))))
+
+  (define main-beh
+    (^base-port-netlayer bcom our-location incoming-accept
+                         outgoing-connect-to-loc))
+
+  (extend-methods main-beh
+   ((halt)
+    ($ socket-io 'halt))))
 
 (define args (cdr (command-line)))
 (define uri (list-ref args 0))
@@ -37,7 +101,7 @@
 (define (user-run thunk) (with-vat user-vat (thunk)))
 
 (define netlayer
-  (machine-run (lambda () (spawn ^tcp-testing-netlayer))))
+  (machine-run (lambda () (spawn ^tcp-testing-netlayer "127.0.0.1"))))
 
 (define mycapn
   (machine-run (lambda () (spawn-mycapn netlayer))))

--- a/packages/ocapn/test/goblin-chat/interop-client.scm
+++ b/packages/ocapn/test/goblin-chat/interop-client.scm
@@ -1,8 +1,6 @@
 ;;; Minimal tcp-testing-only interop client for the Endo goblin-chat host.
 ;;;
-;;; Intended to run inside `guix shell --manifest=manifest.scm` against
-;;; spritely/goblin-chat checked out at $GOBLIN_CHAT_SRC, so it can reuse
-;;; that repository's (goblin-chat backend) for the user-controller side.
+;;; Intended to run inside `guix shell --manifest=manifest.scm`.
 ;;;
 ;;; Expected env/args:
 ;;;   $1  sturdyref URI printed by `test/goblin-chat/index.js`
@@ -13,17 +11,22 @@
 ;;; Guix's packaged guile-goblins may not include a dedicated
 ;;; `(goblins ocapn netlayer tcp-testing)` module. To keep this script runnable
 ;;; against those builds, we define a small tcp-testing netlayer actor locally,
-;;; following Goblins' own OCapN test-suite implementation.
+;;; following Goblins' own OCapN test-suite implementation. We also define a
+;;; minimal user-controller pair locally so this client doesn't depend on
+;;; `(goblin-chat backend)`, whose extra module dependencies vary by package
+;;; build.
 
 (use-modules (goblins)
              (goblins actor-lib common)
              (goblins actor-lib io)
+             (goblins actor-lib methods)
+             (goblins actor-lib sealers)
              (goblins ocapn captp)
              (goblins ocapn ids)
              (goblins ocapn netlayer base-port)
              (goblins utils hashmap)
-             (goblin-chat backend)
-             (ice-9 match))
+             (ice-9 match)
+             (fibers conditions))
 
 ;; Copied from Goblins' OCapN test-suite pattern:
 ;; this gives us a tcp-testing-only netlayer without depending on a module that
@@ -66,13 +69,15 @@
                               ("port" (number->string assigned-port)))))
 
   (define (incoming-accept)
-    (on-match (<- socket-io
-                  (lambda (resource)
-                    (accept resource O_NONBLOCK)))
-        ((client-socket . _)
-         (setvbuf client-socket 'block)
-         (use-nonblocking-i/o client-socket)
-         client-socket)))
+    (on (<- socket-io
+            (lambda (resource)
+              (accept resource O_NONBLOCK)))
+        (match-lambda
+          ((client-socket . _)
+           (setvbuf client-socket 'block)
+           (use-nonblocking-i/o client-socket)
+           client-socket))
+        #:promise? #t))
 
   (define (outgoing-connect-to-loc loc)
     (unless (eq? (ocapn-peer-transport loc) 'tcp-testing-only)
@@ -89,6 +94,70 @@
   (extend-methods main-beh
    ((halt)
     ($ socket-io 'halt))))
+
+;; Minimal subset of goblin-chat backend needed for CI:
+;; - create a user with the expected methods
+;; - join a room via `subscribe`
+;; - return an authenticated channel that seals chat messages
+(define (spawn-user-controller-pair self-proposed-name)
+  (define-values (chat-msg-sealer chat-msg-unsealer chat-msg-sealed?)
+    (spawn-sealer-triplet))
+  (define-values (subscription-sealer subscription-unsealer _subscription-sealed?)
+    (spawn-sealer-triplet))
+
+  (define (^user _bcom)
+    (methods
+     ((self-proposed-name) self-proposed-name)
+     ((get-chat-sealed?) chat-msg-sealed?)
+     ((get-chat-unsealer) chat-msg-unsealer)
+     ((get-subscription-sealer) subscription-sealer)))
+  (define user (spawn ^user))
+
+  (define (^user-inbox _bcom context)
+    (methods
+     ((new-message from-user sealed-msg)
+      ;; Decode messages to exercise the same app-layer path as Goblins.
+      (on (<- from-user 'get-chat-unsealer)
+          (lambda (chat-unsealer)
+            (on (<- chat-unsealer sealed-msg)
+                (lambda (_message)
+                  #t)
+                #:promise? #t))
+          #:promise? #t)
+      #t)
+     ((user-joined _user) #t)
+     ((user-left _user) #t)
+     ((context) context)))
+
+  (define (^authenticated-channel _bcom room-channel)
+    (methods
+     ((send-message contents)
+      (on (<- chat-msg-sealer contents)
+          (lambda (sealed-msg)
+            (<- room-channel 'send-message sealed-msg))
+          #:promise? #t))
+     ((leave)
+      (<- room-channel 'leave))
+     ((list-users)
+      (<- room-channel 'list-users))))
+
+  (define (^user-controller _bcom)
+    (methods
+     ((whoami) user)
+     ((join-room room)
+      (define inbox (spawn ^user-inbox room))
+      (define sealed-finalizer-vow
+        (<- room 'subscribe user))
+      (define subscription-finalizer-vow
+        (<- subscription-unsealer sealed-finalizer-vow))
+      (on (<- subscription-finalizer-vow inbox)
+          (lambda (room-channel)
+            (spawn ^authenticated-channel room-channel))
+          #:promise? #t))))
+
+  (define user-controller
+    (spawn ^user-controller))
+  (values user user-controller))
 
 (define args (cdr (command-line)))
 (define uri (list-ref args 0))
@@ -150,4 +219,5 @@
       (exit 4))
     #:promise? #t)
 
+(define forever (make-condition))
 (wait forever)

--- a/packages/ocapn/test/goblin-chat/interop-client.scm
+++ b/packages/ocapn/test/goblin-chat/interop-client.scm
@@ -25,6 +25,7 @@
              (goblins ocapn ids)
              (goblins ocapn netlayer base-port)
              (goblins utils hashmap)
+             (ice-9 iconv)
              (ice-9 match)
              (fibers conditions))
 
@@ -82,9 +83,9 @@
   (define (outgoing-connect-to-loc loc)
     (unless (eq? (ocapn-peer-transport loc) 'tcp-testing-only)
       (error "Wrong netlayer! Expected `tcp-testing-only'" loc))
-    (let*-values (((hints) (ocapn-peer-hints loc))
-                  ((host) (hashmap-ref hints "host"))
-                  ((port) (hashmap-ref hints "port")))
+    (let* ((hints (ocapn-peer-hints loc))
+           (host (hashmap-ref hints "host"))
+           (port (hashmap-ref hints "port")))
       (make-client-socket host (string->number port))))
 
   (define main-beh
@@ -159,9 +160,31 @@
     (spawn ^user-controller))
   (values user user-controller))
 
+(define done?
+  (make-condition))
+
 (define args (cdr (command-line)))
 (define uri (list-ref args 0))
 (define message (list-ref args 1))
+
+;; Endo's interop host currently prints a peer-style URI where the designator is
+;; the swiss number. Goblins `enliven` expects an actual sturdyref object.
+;; Accept both forms:
+;;   - ocapn://<peer>.<transport>/s/<base64swiss>?...
+;;   - ocapn://<swiss-as-designator>.<transport>?...
+(define (uri->chat-sturdyref uri-string)
+  (define ocapn-id
+    (string->ocapn-id uri-string))
+  (cond
+   ((ocapn-sturdyref? ocapn-id)
+    ocapn-id)
+   ((ocapn-peer? ocapn-id)
+    (make-ocapn-sturdyref ocapn-id
+                          (string->bytevector
+                           (ocapn-peer-designator ocapn-id)
+                           "ascii")))
+   (else
+    (error "Expected OCapN sturdyref/peer URI" uri-string))))
 
 (define machine-vat (spawn-vat))
 (define user-vat (spawn-vat))
@@ -175,7 +198,7 @@
 (define mycapn
   (machine-run (lambda () (spawn-mycapn netlayer))))
 
-(define chat-sref (string->ocapn-id uri))
+(define chat-sref (uri->chat-sturdyref uri))
 
 (define-values (user user-controller)
   (user-run (lambda () (spawn-user-controller-pair "endo-interop-ci"))))
@@ -183,41 +206,45 @@
 (define chatroom-vow
   (user-run (lambda () (<- mycapn 'enliven chat-sref))))
 
-(on chatroom-vow
-    (lambda (chatroom)
-      (define channel-vow
-        (user-run (lambda () (<- user-controller 'join-room chatroom))))
-      (on channel-vow
-          (lambda (channel)
-            (define ack-vow
-              (user-run (lambda () (<- channel 'send-message message))))
-            (on ack-vow
-                (lambda (ack)
-                  (display "interop-client: sent message, ack = ")
-                  (write ack)
-                  (newline)
-                  (exit 0))
-                #:catch
-                (lambda (err)
-                  (display "interop-client: send failed: ")
-                  (write err)
-                  (newline)
-                  (exit 2))
-                #:promise? #t))
-          #:catch
-          (lambda (err)
-            (display "interop-client: join-room failed: ")
-            (write err)
-            (newline)
-            (exit 3))
-          #:promise? #t))
-    #:catch
-    (lambda (err)
-      (display "interop-client: enliven failed: ")
-      (write err)
-      (newline)
-      (exit 4))
-    #:promise? #t)
-
-(define forever (make-condition))
-(wait forever)
+(user-run
+ (lambda ()
+   (on chatroom-vow
+       (lambda (chatroom)
+         (define channel-vow
+           (<- user-controller 'join-room chatroom))
+         (on channel-vow
+             (lambda (channel)
+               (define ack-vow
+                 (<- channel 'send-message message))
+               (on ack-vow
+                   (lambda (ack)
+                     (display "interop-client: sent message, ack = ")
+                     (write ack)
+                     (newline)
+                  (signal-condition! done?))
+                   #:catch
+                   (lambda (err)
+                     (display "interop-client: send failed: ")
+                     (write err)
+                     (newline)
+                  (signal-condition! done?)
+                  (primitive-exit 2))
+                   #:promise? #t))
+             #:catch
+             (lambda (err)
+               (display "interop-client: join-room failed: ")
+               (write err)
+               (newline)
+              (signal-condition! done?)
+              (primitive-exit 3))
+             #:promise? #t))
+       #:catch
+       (lambda (err)
+         (display "interop-client: enliven failed: ")
+         (write err)
+         (newline)
+         (signal-condition! done?)
+         (primitive-exit 4))
+       #:promise? #t)))
+(wait done?)
+(primitive-exit 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: #XXXX
Refs: #XXXX

## Description

This PR now fixes the full runtime path for Guile goblin-chat interop against Endo, in addition to making the workflow fail properly on regressions.

### What was fixed

#### 1) Workflow should not ignore failure

- Removed `continue-on-error` from `.github/workflows/ocapn-guile-interop.yml`.

#### 2) Runtime compatibility fixes for Guile interop client

- `packages/ocapn/test/goblin-chat/interop-client.scm`
  - No longer depends on `(goblin-chat backend)` (avoids `(goblins ghash)` packaging mismatch).
  - Adds a minimal local user-controller path for the interop scenario.
  - Keeps local tcp-testing netlayer support and fixes the earlier `on-match` pattern issue.
  - Normalizes Endo’s peer-style room URI into a proper Goblins sturdyref before `enliven`.
  - Exits cleanly with `primitive-exit` + condition signaling (avoids hanging processes).

#### 3) CapTP version alignment for Guile interop host

- `packages/ocapn/test/goblin-chat/index.js`
  - Adds configurable CapTP version with env override.
  - Sets default to `goblins-0.16` for current Guix/Guile Goblins interop path.
- `.github/workflows/ocapn-guile-interop.yml`
  - Starts host with `OCAPN_CAPTP_VERSION: goblins-0.16`.

#### 4) Robust stream-fragment handling in Endo client handshake/message path

- `packages/ocapn/src/client/handshake.js`
  - Treats incomplete Syrup decode as partial TCP frame (buffer and wait for next bytes), instead of aborting.
  - Returns unconsumed bytes when handshake completes so post-handshake bytes can be dispatched by normal OCapN decoding.
- `packages/ocapn/src/client/index.js`
  - Adds per-connection handshake byte buffering and carries post-handshake remainder into active-session processing.
- `packages/ocapn/src/client/ocapn.js`
  - Adds post-handshake message buffering for fragmented OCapN messages.
  - Incomplete-message decode now buffers instead of disconnecting.

### Tiny focused tests added (as requested)

- `packages/ocapn/test/client.test.js`
  - `fragmented post-handshake message is buffered and decoded`
  - `fragmented handshake message is buffered and establishes session`

These provide quick regression coverage for the exact streaming-fragment class of bugs encountered during interop debugging.

## Local validation

### Targeted tests

- `yarn test -- ./test/client.test.js` (in `packages/ocapn`) ✅
  - includes the two new tiny fragmentation tests

### Lint

- `yarn lint` (in `packages/ocapn`) ✅

### Local CI-equivalent interop run

Executed a local equivalent of `.github/workflows/ocapn-guile-interop.yml`:

- build Endo
- start Endo goblin-chat host
- run Guile client via `guix shell --manifest=interop-manifest.scm`

Result:

- `interop-client: sent message, ack = "OK"`
- `Local CI-equivalent interop run passed.`

## Security Considerations

No new trust boundaries are introduced. Changes are constrained to test/interop harness behavior and robustness in message decoding for stream fragmentation.

## Scaling Considerations

No significant runtime cost increase in normal operation. Buffering only retains incomplete message tails and prevents needless disconnect/reconnect churn.

## Documentation Considerations

No user-facing API docs changes required. This is CI/test harness and protocol-robustness hardening.

## Testing Considerations

The added tiny tests specifically guard against fragmented-message regressions in both handshake and post-handshake phases.

## Compatibility Considerations

Improves compatibility with Guix-packaged Goblins and real TCP stream behavior where message boundaries are not preserved.

## Upgrade Considerations

No production upgrade impact; this is interop/test-path hardening.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ae350af-9d24-4eb0-83b4-f9c2c636b09c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ae350af-9d24-4eb0-83b4-f9c2c636b09c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

