### PR TITLE
fix(compartment-mapper): skip self-referential wildcard pattern redirects in moduleMapHook

### DIFF
--- a/.changeset/spotty-hands-help.md
+++ b/.changeset/spotty-hands-help.md
@@ -1,0 +1,5 @@
+---
+'@endo/compartment-mapper': patch
+---
+
+Compatibility fix for passthrough-style wildcards in subpath exports.

--- a/packages/compartment-mapper/src/link.js
+++ b/packages/compartment-mapper/src/link.js
@@ -190,6 +190,20 @@ const makeModuleMapHook = (
           /** @type {FileUrlString} */
           (foreignCompartmentName || compartmentName);
 
+        // A passthrough wildcard like "./*": "./*" produces a pattern where
+        // the resolved path equals the original specifier in the same
+        // compartment — a self-referential no-op.  Returning it as a redirect
+        // would cause SES's memoized loader to await the in-flight Promise for
+        // this specifier from within that same Promise's resolution chain,
+        // deadlocking permanently.  Skip it and let importHook load the module
+        // directly from the filesystem instead.
+        if (
+          targetCompartmentName === compartmentName &&
+          resolvedPath === moduleSpecifier
+        ) {
+          return undefined;
+        }
+
         // Write back to moduleDescriptors for caching, archival, and
         // policy enforcement. The write-back must precede the policy
         // check because enforcePolicyByModule verifies the specifier

--- a/packages/compartment-mapper/test/export-patterns.test.js
+++ b/packages/compartment-mapper/test/export-patterns.test.js
@@ -2,7 +2,8 @@
 
 import 'ses';
 import test from 'ava';
-import { scaffold } from './scaffold.js';
+import { scaffold, readPowers } from './scaffold.js';
+import { importLocation } from '../index.js';
 
 const fixture = new URL(
   'fixtures-export-patterns/node_modules/app/main.js',
@@ -29,3 +30,25 @@ scaffold(
   assertFixture,
   fixtureAssertionCount,
 );
+
+// Regression test for: packages whose exports include a passthrough wildcard
+// like "./*": "./*" cause a promise deadlock in the memoized module loader.
+// The wildcard produces a within-compartment pattern whose resolved path is
+// identical to the input specifier.  When the moduleMapHook returns that
+// self-referential redirect, SES's memoized loader ends up awaiting the
+// in-flight Promise for the specifier from within that same Promise's
+// resolution chain — a deadlock that silently empties the event loop.
+// The pattern is present in tslib >=2.x, which is a transitive dependency
+// of many popular packages.
+test('loading dual-format package with ./* wildcard export does not stall (tslib pattern)', async t => {
+  t.timeout(5000);
+  const tslibMockConsumer = new URL(
+    'fixtures-export-patterns/node_modules/tslib-mock-consumer/main.js',
+    import.meta.url,
+  ).toString();
+
+  const { namespace } = await importLocation(readPowers, tslibMockConsumer);
+
+  t.is(namespace.theAnswer, 42);
+  t.is(namespace.double(21), 42);
+});

--- a/packages/compartment-mapper/test/fixtures-export-patterns/node_modules/tslib-mock-consumer/main.js
+++ b/packages/compartment-mapper/test/fixtures-export-patterns/node_modules/tslib-mock-consumer/main.js
@@ -1,0 +1,2 @@
+import { theAnswer, double } from 'tslib-mock';
+export { theAnswer, double };

--- a/packages/compartment-mapper/test/fixtures-export-patterns/node_modules/tslib-mock-consumer/package.json
+++ b/packages/compartment-mapper/test/fixtures-export-patterns/node_modules/tslib-mock-consumer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "tslib-mock-consumer",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "tslib-mock": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-export-patterns/node_modules/tslib-mock/index.js
+++ b/packages/compartment-mapper/test/fixtures-export-patterns/node_modules/tslib-mock/index.js
@@ -1,0 +1,2 @@
+exports.theAnswer = 42;
+exports.double = x => x * 2;

--- a/packages/compartment-mapper/test/fixtures-export-patterns/node_modules/tslib-mock/package.json
+++ b/packages/compartment-mapper/test/fixtures-export-patterns/node_modules/tslib-mock/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "tslib-mock",
+  "version": "1.0.0",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}


### PR DESCRIPTION
Fixes #3200.

In `makeModuleMapHook`, after resolving the target compartment and specifier from a matched pattern, short-circuit and return `undefined` (fall through to `importHook`) when the redirect is a self-referential no-op: same compartment name *and* same resolved path as the input specifier.  The write-back to `moduleDescriptors` is intentionally skipped in this case; writing the self-referential descriptor would re-trigger the deadlock via the cached `isCompartmentModuleConfiguration` branch on subsequent lookups.

The guard is narrow and does not affect legitimate same-compartment redirects (e.g. `"./x/*.js": "./src/x/*.js"`, package self-references via bare name, or `#imports` maps) because those always produce a `resolvedPath` different from the input `moduleSpecifier`.

Included test case and minimal fixture.