### PR TITLE
fix(daemon)!: Detect truncation of Unix domain socket paths

### DIFF
--- a/.changeset/lucky-views-train.md
+++ b/.changeset/lucky-views-train.md
@@ -1,0 +1,5 @@
+---
+'@endo/daemon': major
+---
+
+Detect truncation of Unix domain socket paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,16 +87,36 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 
+      # Some tests (e.g., in package "daemon") create Unix domain sockets, and
+      # their full absolute paths MUST remain short.
+      - name: Move working directory
+        id: move-wd
+        run: |
+          ORIGINAL_WORKDIR="$(pwd)"
+          echo "ORIGINAL_WORKDIR=$ORIGINAL_WORKDIR" >> $GITHUB_ENV
+          cd "$RUNNER_TEMP"
+          WORKDIR="$(mktemp --tmpdir="$(pwd)" --dry-run checkout-XXXXXX)"
+          mv -fv "$ORIGINAL_WORKDIR" "$WORKDIR"
+          echo "WORKDIR=$WORKDIR" >> $GITHUB_ENV
+
       - name: Install dependencies
+        working-directory: ${{ env.WORKDIR }}
         run: yarn install --immutable
 
       # end macro
 
       - name: Run yarn build
+        working-directory: ${{ env.WORKDIR }}
         run: yarn build
 
       - name: Run yarn test
+        working-directory: ${{ env.WORKDIR }}
         run: yarn test
+
+      - name: Restore working directory
+        if: ${{ steps.move-wd.outcome == 'success' }}
+        working-directory: ${{ runner.temp }}
+        run: mv -fv "$WORKDIR" "$ORIGINAL_WORKDIR"
 
   test-async-hooks:
     name: test-async-hooks

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -21,9 +21,10 @@ const textEncoder = new TextEncoder();
 /**
  * @param {object} modules
  * @param {typeof import('net')} modules.net
+ * @param {Pick<typeof import('fs/promises'), 'access'>} modules.fsp
  * @returns {SocketPowers}
  */
-export const makeSocketPowers = ({ net }) => {
+export const makeSocketPowers = ({ net, fsp: { access } }) => {
   const serveListener = async (listen, cancelled) => {
     const [
       /** @type {Reader<Connection>} */ readFrom,
@@ -98,14 +99,24 @@ export const makeSocketPowers = ({ net }) => {
   const servePath = async ({ path, cancelled }) => {
     const { connections } = await serveListener(server => {
       return new Promise((resolve, reject) =>
-        server.listen({ path }, error => {
+        server.listen({ path }, async error => {
+          await null;
+          // In some environments, an overly-long Unix domain socket path
+          // (`sockaddr_un` `sun_path`) is silently truncated. This exposes the
+          // problem, but we may still leak the incorrectly-named file and
+          // thereby cause EADDRINUSE errors for future attempts to start.
+          error ||= await access(path).catch(err => err);
           if (error) {
             if (path.length >= 104) {
               console.warn(
                 `Warning: Length of path for domain socket or named path exceeeds common maximum (104, possibly 108) for some platforms (length: ${path.length}, path: ${path})`,
               );
             }
-            reject(error);
+            try {
+              server.close(_serverNotRunningErr => reject(error));
+            } catch (_serverCloseErr) {
+              reject(error);
+            }
           } else {
             resolve(undefined);
           }
@@ -121,10 +132,11 @@ export const makeSocketPowers = ({ net }) => {
 /**
  * @param {object} modules
  * @param {typeof import('net')} modules.net
+ * @param {Pick<typeof import('fs/promises'), 'access'>} modules.fsp
  * @returns {NetworkPowers}
  */
-export const makeNetworkPowers = ({ net }) => {
-  const { servePort, servePath, connectPort } = makeSocketPowers({ net });
+export const makeNetworkPowers = ({ net, fsp }) => {
+  const { servePort, servePath, connectPort } = makeSocketPowers({ net, fsp });
 
   const connectionNumbers = (function* generateNumbers() {
     let n = 0;

--- a/packages/daemon/src/daemon-node.js
+++ b/packages/daemon/src/daemon-node.js
@@ -20,6 +20,8 @@ import {
   makeCryptoPowers,
 } from './daemon-node-powers.js';
 
+const fsp = { access: fs.promises.access };
+
 /** @import { PromiseKit } from '@endo/promise-kit' */
 /** @import { Config, Builtins } from './types.js' */
 
@@ -44,7 +46,7 @@ const config = {
 
 const { pid, kill } = process;
 
-const networkPowers = makeNetworkPowers({ net });
+const networkPowers = makeNetworkPowers({ net, fsp });
 const filePowers = makeFilePowers({ fs, path });
 const cryptoPowers = makeCryptoPowers(crypto);
 const powers = makeDaemonicPowers({

--- a/packages/daemon/src/networks/tcp-netstring.js
+++ b/packages/daemon/src/networks/tcp-netstring.js
@@ -1,4 +1,5 @@
 // @ts-check
+import fs from 'fs';
 import net from 'net';
 
 import harden from '@endo/harden';
@@ -12,10 +13,12 @@ import {
 } from '../connection.js';
 import { makeSocketPowers } from '../daemon-node-powers.js';
 
+const fsp = { access: fs.promises.access };
+
 const protocol = 'tcp+netstring+json+captp0';
 
 export const make = async (powers, context) => {
-  const { servePort, connectPort } = makeSocketPowers({ net });
+  const { servePort, connectPort } = makeSocketPowers({ net, fsp });
 
   const cancelled = /** @type {Promise<never>} */ (E(context).whenCancelled());
   const cancelServer = error => E(context).cancel(error);

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -6,6 +6,7 @@ import '@endo/init/debug.js';
 
 import baseTest from 'ava';
 import url from 'url';
+import fsp from 'fs/promises';
 import path from 'path';
 import crypto from 'crypto';
 import { E } from '@endo/far';
@@ -261,6 +262,29 @@ test('lifecycle', async t => {
   await closed.catch(() => {});
 
   t.pass();
+});
+
+test('failure to start', async t => {
+  await null;
+  const cleanup = async () => {
+    const dirAccessErr = await fsp.access('tmp').catch(err => err);
+    if (dirAccessErr) return;
+    for (const entry of await fsp.readdir('tmp')) {
+      // eslint-disable-next-line no-continue
+      if (!entry.startsWith('failure-to-start~0')) continue;
+      // eslint-disable-next-line no-await-in-loop
+      await fsp.rm(path.join('tmp', entry), { force: true, recursive: true });
+    }
+  };
+  try {
+    await cleanup();
+    const configSubDirectory = `failure-to-start~${'0'.repeat(200)}`;
+    const config = makeConfig('tmp', configSubDirectory);
+    await purge(config);
+    await t.throwsAsync(() => start(config));
+  } finally {
+    await cleanup().catch(err => t.log('cleanup error', err));
+  }
 });
 
 test('store pass-copy values', async t => {

--- a/packages/daemon/test/endo.test.js
+++ b/packages/daemon/test/endo.test.js
@@ -187,27 +187,34 @@ const doMakeBundle = async (host, filePath, callback) => {
   return result;
 };
 
-let configPathId = 0;
+/** @type {Map<string, number>} */
+const testNumbers = new Map();
 
 /**
  * @param {string} testTitle - The title of the current test.
- * @param {number} configNumber - The number of the current config. If this
- * is the n:th config created for the current test, the config number is n.
+ * @param {number} testConfigIndex - The 0-based index of this config, scoped to
+ * the current test.
+ * @returns {string} A unique directory name based on the inputs, with a suffix
+ * like `~${numberForTest}${alphabeticCounter`, e.g. "test-title~0000a".
  */
-const getConfigDirectoryName = (testTitle, configNumber) => {
-  const defaultPath = testTitle.replace(/\s/giu, '-').replace(/[^\w-]/giu, '');
+const getConfigDirectoryName = (testTitle, testConfigIndex) => {
+  const munged = testTitle.match(/\w+/gu)?.join('-') || '';
 
   // We truncate the subdirectory name to 30 characters in an attempt to respect
-  // the maximum Unix domain socket path length.
+  // the maximum Unix domain socket path length (`sockaddr_un` `sun_path`).
   // With our apologies to John Jacob Jingleheimerschmidt, for whom this may
   // not be enough.
-  const basePath =
-    defaultPath.length <= 22 ? defaultPath : defaultPath.slice(0, 22);
-  const testId = String(configPathId).padStart(4, '0');
-  const configId = String(configNumber).padStart(2, '0');
-  const configSubDirectory = `${basePath}#${testId}-${configId}`;
-
-  configPathId += 1;
+  if (!testNumbers.has(testTitle)) testNumbers.set(testTitle, testNumbers.size);
+  const testNumber = testNumbers.get(testTitle);
+  const nnnn = String(testNumber).padStart(4, '0');
+  if (!nnnn.match(/^[0-9]{4}$/)) {
+    throw Error('meta: time for five-digit test numbers?');
+  }
+  const letter = (testConfigIndex + 10).toString(36);
+  if (!letter.match(/^[a-z]$/)) {
+    throw Error('meta: time for two-letter suffixes?');
+  }
+  const configSubDirectory = `${munged.slice(0, 24)}~${nnnn}${letter}`;
 
   return configSubDirectory;
 };


### PR DESCRIPTION
Fixes #3203

## Description

Use [`access`](https://nodejs.org/docs/latest/api/fs.html#fspromisesaccesspath-mode) to verify existence of a Unix domain socket at the requested path after it should have been created by [`server.listen`](https://nodejs.org/docs/latest/api/net.html#serverlisten), and reject the server-is-ready promise if such verification fails.

Also includes related improvements to test files and GitHub Actions CI.

### Security Considerations

None known.

### Scaling Considerations

n/a

### Documentation Considerations

Covered by an existing warning which is being extended to include path truncation.

### Testing Considerations

Just a new unit test.

### Compatibility Considerations

This is a breaking change because some functions now require an `access` power from node:fs/promises. We could preserve backwards compatibility by instead making the new power optional, but I'd rather maximize our ability to detect what is otherwise a silent failure.

### Upgrade Considerations

The daemon is not used in production AFAIK, but direct imports may need an update to provide the required `access` function.
