### PR TITLE
feat(daemon): xsnap-worker and xsnap-formula

### DIFF
--- a/packages/daemon/docs/xsnap-durability-boundary-exploration.md
+++ b/packages/daemon/docs/xsnap-durability-boundary-exploration.md
@@ -220,13 +220,47 @@ Creating a boundary facade should feel like existing host operations that materi
 4. Add host API:
    - `makeXsnapRef(targetNameOrPath, resultName?, retry?)`
    - resolve target formula identifier from host naming graph
+   - persist both target id and original host/path binding metadata for rebinding
    - formulate and optionally store resulting facade by pet name
+5. Add facade diagnostics:
+   - `E.get(facade).diagnostics` returns
+     - `targetId`
+     - `retry`
+     - `callCount`
+     - `retryCount`
+     - `lastRebindMs`
+     - `lastFailure`
 
 ### Concrete tests
 
 1. **Ergonomics parity**: worker code can call `E(facade).method()` with no extra protocol.
 2. **Durable formula continuity**: `xsnap-ref` formula persists across daemon restart and still forwards to target formula ID.
 3. **Rebinding behavior**: when target formula is cancelled/reincarnated, facade calls continue to work and hit fresh incarnation state.
+4. **Diagnostics behavior**: stats reflect retries/rebinds/failures for observability.
+
+### Option B continuation (current iteration)
+
+This iteration expands Option B to better expose and control behavior at the
+durability boundary without changing worker-call ergonomics.
+
+#### Richer retry policy
+
+- Add `retry: 'none' | 'once' | 'twice'`.
+- Keep retries bounded and local to each call attempt.
+- Preserve explicit error surfacing after retry budget exhaustion.
+
+#### Naming-graph rebinding
+
+- Persist `hub` + `path` alongside `target`.
+- On each forwarded call, attempt to re-identify through the host naming graph.
+- Fall back to original `target` when rebinding path no longer resolves.
+- Update rebind diagnostics when identity changes are observed.
+
+#### Diagnostics as first-class ergonomics
+
+- Expose `diagnostics` as an ordinary property reachable with `E.get(facade)`.
+- Designed for operational introspection and UI/CLI tooling.
+- Keeps call path unchanged (`E(facade).method()` still primary API).
 
 ## Exploratory tests added in this branch
 

--- a/packages/daemon/docs/xsnap-durability-boundary-exploration.md
+++ b/packages/daemon/docs/xsnap-durability-boundary-exploration.md
@@ -1,0 +1,201 @@
+# Endo daemon xsnap durability-boundary exploration
+
+## Problem statement
+
+We want a new Endo daemon worker/formula flavor that can use xsnap-style heap snapshots (orthogonal persistence) while still fitting the daemon's current formula graph and CapTP session model.
+
+Target outcomes:
+
+- formulas should feel close to existing `worker` + `eval` usage
+- formulas should be able to exchange values with other formulas/workers (including non-xsnap workers)
+- formula references should remain meaningful across daemon restart
+- avoid requiring app code to adopt vat-data-style durable baggage patterns
+
+The core difficulty is the durability regime boundary:
+
+- **daemon/client side**: ephemeral CapTP sessions
+- **xsnap side**: durable heap snapshots and incarnation continuity
+
+## Current daemon behavior relevant to the boundary
+
+From the existing code and tests:
+
+1. `worker` formulas are revived after restart, but worker heap state is re-created (closure state resets).
+2. Formula identity persists through stored formula records; values are re-incarnated on demand.
+3. Host-side marshaling uses `@endo/marshal` with `serializeBodyFormat: 'smallcaps'` for persisted marshal formulas.
+4. CapTP transport currently uses `@endo/captp` with `serializeBodyFormat: 'capdata'` (TODO in captp source notes smallcaps compatibility work remains).
+5. A client-held remote presence from an old daemon session does not survive restart as a live connection; recovery requires reacquiring through a fresh session and formula reference.
+
+This means today we already have a durable **identifier graph**, but only ephemeral **session bindings**.
+
+## Boundary hazards to design around
+
+### 1. Session-disconnect visibility
+
+An xsnap worker might continue to exist (or be recoverable by snapshot) even when a specific daemon/client CapTP session ends. A client that only has old presences learns about breakage only when sending.
+
+### 2. Identity continuity versus transport continuity
+
+Formula IDs can remain stable while transport endpoints rotate. Durable identity must not be conflated with connection liveness.
+
+### 3. Promise semantics across reincarnation
+
+In Agoric/SwingSet, promises are intentionally not durable across upgrade boundaries. Endo daemon should similarly avoid pretending in-flight promise pipelines survive a full boundary crossing unless explicitly modeled.
+
+### 4. Cross-regime sharing
+
+Non-xsnap worker values may be intrinsically ephemeral. xsnap formulas must tolerate peer formulas being reincarnated and references being rebound.
+
+## Architecture options
+
+## Option A: Epoch-gated direct presence model (minimal change)
+
+Keep existing CapTP object semantics. Add explicit worker/session epoch metadata to xsnap-origin references.
+
+- New worker formula: `xsnap-worker`
+- Existing formulas (`eval`, `make-bundle`, `make-unconfined`) optionally target `xsnap-worker`
+- Every exported xsnap reference carries `{ formulaId, workerEpoch }` in its recovery metadata
+- Method sends reject fast on epoch mismatch, with an error that includes a rebinding hint
+
+Pros:
+
+- Smallest implementation delta
+- Fits current cancellation and dependency graphs
+
+Cons:
+
+- Clients must handle rebinding manually
+- No transparent continuity for old presences
+
+Best when:
+
+- we prioritize explicit failure over transparent reconnection
+
+## Option B: Durable reference facade formula (recommended incremental direction)
+
+Introduce a new formula type that acts as a stable rebinding facade.
+
+- Example formula: `xsnap-ref`
+- Stores stable target formula ID plus rebinding strategy
+- Client receives facade object, not raw xsnap export
+- Facade internally resolves latest incarnation before each call
+- If peer formula restarted, facade re-provides and retries (policy-controlled)
+
+Pros:
+
+- Strong alignment with daemon formula model (IDs are already durable)
+- Can communicate with non-xsnap formulas while insulating clients from session churn
+- Compatible with smallcaps persisted marshal records (`body + slots`)
+
+Cons:
+
+- Added call indirection and policy complexity (retry idempotence, timeout, backoff)
+
+Best when:
+
+- we want "normal Endo formula feel" with durable backing
+
+## Option C: Durable mailbox endpoint between regimes
+
+Convert boundary crossing into explicit queued messages.
+
+- xsnap side exposes durable inbox/outbox formula(s)
+- ephemeral UI session subscribes to stream but protocol truth is durable queue state
+- disconnection means missed live updates, not lost protocol state
+
+Pros:
+
+- Clear semantics under disconnection/restart
+- Natural place for replay and deduplication
+
+Cons:
+
+- More like actor messaging than direct object call ergonomics
+- Higher latency/complexity for request/response patterns
+
+Best when:
+
+- correctness under churn is more important than object-call ergonomics
+
+## Option D: Dual-channel model (fast ephemeral + durable control plane)
+
+Combine direct object calls with durable reattachment metadata.
+
+- fast path: direct CapTP calls while session alive
+- durable path: checkpointed formula references + sequence/ack state in durable records
+- on disconnect, client library transparently flips to reattach flow
+
+Pros:
+
+- Good latency in normal path
+- Better continuity without forcing full queue protocol
+
+Cons:
+
+- Most subtle invariants; hardest to test
+
+Best when:
+
+- high-throughput interactive UX is required
+
+## Option E: Fully durable protocol endpoint (persistent CapTP-like layer)
+
+Define a protocol where object references are always mediated by durable endpoint records instead of transport session object tables.
+
+Pros:
+
+- maximal continuity
+
+Cons:
+
+- effectively a new protocol stack
+- significant risk and implementation scope
+
+Best when:
+
+- long-term platform rewrite is acceptable
+
+## Serialization implications
+
+For this repository state today:
+
+- Persisted formula values should continue to use smallcaps (`@endo/marshal`) for `marshal` formulas.
+- Worker link transport remains capdata until `@endo/captp` smallcaps support is completed.
+
+Practical interpretation:
+
+- "smallcaps at the durability boundary" is already feasible for formula persistence and rebinding metadata.
+- "smallcaps over live worker RPC" is not yet drop-in with current captp.
+
+## Suggested concrete shape for first implementation
+
+1. Add `xsnap-worker` formula type (parallel to `worker`).
+2. Add worker power implementation for xsnap process lifecycle and snapshot management.
+3. Add `xsnap-ref` formula type for stable client-facing references.
+4. Keep daemon dependency graph semantics (`thisDiesIfThatDies`) but define rebinding policies for `xsnap-ref`:
+   - no retry
+   - retry once on epoch mismatch
+   - bounded retry with backoff
+5. Expose explicit diagnostics on references:
+   - current epoch
+   - last rebind time
+   - last rebind failure reason
+
+This gives durable state benefits without forcing user code into vat-data durable object APIs.
+
+## Exploratory tests added in this branch
+
+The tests in `test/xsnap-boundary-exploration.test.js` probe key invariants:
+
+1. Persisted marshal formulas use smallcaps body and slot references for formula values.
+2. Cross-worker references survive restart by formula identity, while worker heap state still resets (current baseline behavior).
+
+These tests do not implement xsnap workers; they establish baseline facts the xsnap design must preserve or intentionally change.
+
+## Open questions to settle before implementation
+
+1. Should `xsnap-ref` auto-retry calls by default, or fail fast with explicit rebinding?
+2. What methods are safe to replay after rebind (idempotence policy)?
+3. Should old-epoch references expose a specific error class for client tooling?
+4. Do we allow mixed graphs where xsnap durable references point to purely ephemeral non-xsnap exports, and if so with what downgrade behavior?
+5. Is a daemon-level "session ended" notification stream needed, or is call-time failure sufficient?

--- a/packages/daemon/docs/xsnap-durability-boundary-exploration.md
+++ b/packages/daemon/docs/xsnap-durability-boundary-exploration.md
@@ -183,6 +183,51 @@ Practical interpretation:
 
 This gives durable state benefits without forcing user code into vat-data durable object APIs.
 
+## Option B implementation plan (ergonomics-first)
+
+This section refines Option B into concrete repository changes.
+
+### Ergonomics goals
+
+#### Formula author ergonomics (inside workers)
+
+Code that receives a boundary value should be able to keep using ordinary eventual-send style:
+
+- preferred: `E(counterLike).incr()`
+- avoid requiring a bespoke wrapper call style like `E(ref).dispatch('incr', [])`
+
+To preserve this, the facade value should behave like a generic eventual-send target and forward arbitrary method/property operations to the latest target incarnation.
+
+#### Host ergonomics (outside workers)
+
+Creating a boundary facade should feel like existing host operations that materialize formulas and optionally name them:
+
+- new host helper: `makeXsnapRef(targetNameOrPath, resultName?, retryPolicy?)`
+- this creates a durable formula and (optionally) writes a pet name
+- hosts/workers can then pass the named value exactly like other formula-backed values
+
+### Concrete daemon changes
+
+1. Add formula type `xsnap-ref` with persisted payload:
+   - `target: FormulaIdentifier`
+   - `retry: 'none' | 'once'`
+2. Add daemon maker for `xsnap-ref`:
+   - produce a handled facade that forwards `get` / `applyMethod` / `applyFunction`
+   - resolve target using `provide(targetId)` on every interaction (rebind-ready)
+   - apply retry policy (`once` retries one time after failure with fresh provide)
+3. Add core formulation helper:
+   - `formulateXsnapRef(targetId, deferredTasks, retry?)`
+4. Add host API:
+   - `makeXsnapRef(targetNameOrPath, resultName?, retry?)`
+   - resolve target formula identifier from host naming graph
+   - formulate and optionally store resulting facade by pet name
+
+### Concrete tests
+
+1. **Ergonomics parity**: worker code can call `E(facade).method()` with no extra protocol.
+2. **Durable formula continuity**: `xsnap-ref` formula persists across daemon restart and still forwards to target formula ID.
+3. **Rebinding behavior**: when target formula is cancelled/reincarnated, facade calls continue to work and hit fresh incarnation state.
+
 ## Exploratory tests added in this branch
 
 The tests in `test/xsnap-boundary-exploration.test.js` probe key invariants:

--- a/packages/daemon/docs/xsnap-durability-boundary-exploration.md
+++ b/packages/daemon/docs/xsnap-durability-boundary-exploration.md
@@ -89,7 +89,7 @@ Pros:
 
 Cons:
 
-- Added call indirection and policy complexity (retry idempotence, timeout, backoff)
+- Added call indirection and policy complexity (error propagation, timeout, observability)
 
 Best when:
 
@@ -172,10 +172,7 @@ Practical interpretation:
 1. Add `xsnap-worker` formula type (parallel to `worker`).
 2. Add worker power implementation for xsnap process lifecycle and snapshot management.
 3. Add `xsnap-ref` formula type for stable client-facing references.
-4. Keep daemon dependency graph semantics (`thisDiesIfThatDies`) but define rebinding policies for `xsnap-ref`:
-   - no retry
-   - retry once on epoch mismatch
-   - bounded retry with backoff
+4. Keep daemon dependency graph semantics (`thisDiesIfThatDies`) and fail-fast call behavior for `xsnap-ref`, while relying on formula/id rebinding through persisted naming metadata.
 5. Expose explicit diagnostics on references:
    - current epoch
    - last rebind time
@@ -202,7 +199,7 @@ To preserve this, the facade value should behave like a generic eventual-send ta
 
 Creating a boundary facade should feel like existing host operations that materialize formulas and optionally name them:
 
-- new host helper: `makeXsnapRef(targetNameOrPath, resultName?, retryPolicy?)`
+- new host helper: `makeXsnapRef(workerName, targetNameOrPath, resultName?)`
 - this creates a durable formula and (optionally) writes a pet name
 - hosts/workers can then pass the named value exactly like other formula-backed values
 
@@ -210,24 +207,26 @@ Creating a boundary facade should feel like existing host operations that materi
 
 1. Add formula type `xsnap-ref` with persisted payload:
    - `target: FormulaIdentifier`
-   - `retry: 'none' | 'once'`
+   - `worker: FormulaIdentifier`
 2. Add daemon maker for `xsnap-ref`:
    - produce a handled facade that forwards `get` / `applyMethod` / `applyFunction`
    - resolve target using `provide(targetId)` on every interaction (rebind-ready)
-   - apply retry policy (`once` retries one time after failure with fresh provide)
+   - enforce configured worker formula is of type `xsnap-worker`
 3. Add core formulation helper:
-   - `formulateXsnapRef(targetId, deferredTasks, retry?)`
+   - `formulateXsnapRef(targetId, workerId, deferredTasks)`
+4. Add `xsnap-worker` formula support:
+   - `formulateXsnapWorker(deferredTasks)`
+   - host caller can request by name, and daemon formulates `xsnap-worker`
 4. Add host API:
-   - `makeXsnapRef(targetNameOrPath, resultName?, retry?)`
+   - `makeXsnapRef(workerName, targetNameOrPath, resultName?)`
    - resolve target formula identifier from host naming graph
-   - persist both target id and original host/path binding metadata for rebinding
+   - resolve/provide configured xsnap worker formula identifier
+   - persist target id, worker id, and original host/path binding metadata
    - formulate and optionally store resulting facade by pet name
 5. Add facade diagnostics:
    - `E.get(facade).diagnostics` returns
      - `targetId`
-     - `retry`
      - `callCount`
-     - `retryCount`
      - `lastRebindMs`
      - `lastFailure`
 
@@ -236,22 +235,24 @@ Creating a boundary facade should feel like existing host operations that materi
 1. **Ergonomics parity**: worker code can call `E(facade).method()` with no extra protocol.
 2. **Durable formula continuity**: `xsnap-ref` formula persists across daemon restart and still forwards to target formula ID.
 3. **Rebinding behavior**: when target formula is cancelled/reincarnated, facade calls continue to work and hit fresh incarnation state.
-4. **Diagnostics behavior**: stats reflect retries/rebinds/failures for observability.
+4. **Diagnostics behavior**: stats reflect rebinds/failures for observability.
+5. **Worker regime enforcement**: using a non-`xsnap-worker` formula fails at call time.
 
 ### Option B continuation (current iteration)
 
 This iteration expands Option B to better expose and control behavior at the
 durability boundary without changing worker-call ergonomics.
 
-#### Richer retry policy
+#### Worker regime alignment
 
-- Add `retry: 'none' | 'once' | 'twice'`.
-- Keep retries bounded and local to each call attempt.
-- Preserve explicit error surfacing after retry budget exhaustion.
+- `xsnap-ref` now carries explicit `worker` formula identity.
+- Host API requires a worker argument (`workerName`) so formulation stays close to
+  other daemon APIs that are worker-scoped.
+- Daemon enforces that configured worker formula type is `xsnap-worker`.
 
 #### Naming-graph rebinding
 
-- Persist `hub` + `path` alongside `target`.
+- Persist `hub` + `path` alongside `target` and `worker`.
 - On each forwarded call, attempt to re-identify through the host naming graph.
 - Fall back to original `target` when rebinding path no longer resolves.
 - Update rebind diagnostics when identity changes are observed.
@@ -273,8 +274,6 @@ These tests do not implement xsnap workers; they establish baseline facts the xs
 
 ## Open questions to settle before implementation
 
-1. Should `xsnap-ref` auto-retry calls by default, or fail fast with explicit rebinding?
-2. What methods are safe to replay after rebind (idempotence policy)?
-3. Should old-epoch references expose a specific error class for client tooling?
-4. Do we allow mixed graphs where xsnap durable references point to purely ephemeral non-xsnap exports, and if so with what downgrade behavior?
-5. Is a daemon-level "session ended" notification stream needed, or is call-time failure sufficient?
+1. Should old-epoch references expose a specific error class for client tooling?
+2. Do we allow mixed graphs where xsnap durable references point to purely ephemeral non-xsnap exports, and if so with what downgrade behavior?
+3. Is a daemon-level "session ended" notification stream needed, or is call-time failure sufficient?

--- a/packages/daemon/docs/xsnap-durability-boundary-exploration.md
+++ b/packages/daemon/docs/xsnap-durability-boundary-exploration.md
@@ -203,6 +203,13 @@ Creating a boundary facade should feel like existing host operations that materi
 - this creates a durable formula and (optionally) writes a pet name
 - hosts/workers can then pass the named value exactly like other formula-backed values
 
+Creating new formulas directly in an xsnap worker should mirror ordinary `evaluate`:
+
+- new host helper: `xsnapEvaluate(workerName, source, codeNames, petNames, resultName?)`
+- semantics intentionally parallel `evaluate`
+- the daemon resolves/formulates `workerName` as an `xsnap-worker`
+- resulting formula records still use normal `eval` type, but are pinned to the xsnap worker
+
 ### Concrete daemon changes
 
 1. Add formula type `xsnap-ref` with persisted payload:
@@ -217,13 +224,16 @@ Creating a boundary facade should feel like existing host operations that materi
 4. Add `xsnap-worker` formula support:
    - `formulateXsnapWorker(deferredTasks)`
    - host caller can request by name, and daemon formulates `xsnap-worker`
-4. Add host API:
+5. Add host APIs:
+   - `xsnapEvaluate(workerName, source, codeNames, petNames, resultName?)`
+   - ensure specified worker is an `xsnap-worker`
+   - persist resulting `eval` formulas against that worker
    - `makeXsnapRef(workerName, targetNameOrPath, resultName?)`
    - resolve target formula identifier from host naming graph
    - resolve/provide configured xsnap worker formula identifier
    - persist target id, worker id, and original host/path binding metadata
    - formulate and optionally store resulting facade by pet name
-5. Add facade diagnostics:
+6. Add facade diagnostics:
    - `E.get(facade).diagnostics` returns
      - `targetId`
      - `callCount`
@@ -237,6 +247,7 @@ Creating a boundary facade should feel like existing host operations that materi
 3. **Rebinding behavior**: when target formula is cancelled/reincarnated, facade calls continue to work and hit fresh incarnation state.
 4. **Diagnostics behavior**: stats reflect rebinds/failures for observability.
 5. **Worker regime enforcement**: using a non-`xsnap-worker` formula fails at call time.
+6. **Xsnap evaluate ergonomics**: `xsnapEvaluate` mirrors `evaluate` and produces `eval` formulas attached to an `xsnap-worker`.
 
 ### Option B continuation (current iteration)
 

--- a/packages/daemon/docs/xsnap-durability-boundary-exploration.md
+++ b/packages/daemon/docs/xsnap-durability-boundary-exploration.md
@@ -71,29 +71,30 @@ Best when:
 
 - we prioritize explicit failure over transparent reconnection
 
-## Option B: Durable reference facade formula (recommended incremental direction)
+## Option B: Direct `xsnapEvaluate` worker model (implemented direction)
 
-Introduce a new formula type that acts as a stable rebinding facade.
+Keep formulas explicit and worker-scoped, and formulate directly in an
+`xsnap-worker` instead of introducing an extra facade formula type.
 
-- Example formula: `xsnap-ref`
-- Stores stable target formula ID plus rebinding strategy
-- Client receives facade object, not raw xsnap export
-- Facade internally resolves latest incarnation before each call
-- If peer formula restarted, facade re-provides and retries (policy-controlled)
+- New worker formula: `xsnap-worker`
+- New host helper: `xsnapEvaluate(workerName, source, codeNames, petNames, resultName?)`
+- Resulting formulas remain normal `eval` formulas, pinned to an `xsnap-worker`
+- Heap continuity comes from xsnap snapshots plus formula-id keyed value reuse inside the xsnap worker
 
 Pros:
 
-- Strong alignment with daemon formula model (IDs are already durable)
-- Can communicate with non-xsnap formulas while insulating clients from session churn
-- Compatible with smallcaps persisted marshal records (`body + slots`)
+- Calling conventions stay aligned with existing daemon APIs (`evaluate`, `provideWorker`)
+- No extra forwarding layer; cross-boundary calls are direct capability passing
+- Explicit worker selection allows daemon enforcement of xsnap regime boundaries
 
 Cons:
 
-- Added call indirection and policy complexity (error propagation, timeout, observability)
+- Clients still reacquire values through formula identities after daemon/session restart
+- No transparent "old presence revival" for stale sessions (same as existing daemon model)
 
 Best when:
 
-- we want "normal Endo formula feel" with durable backing
+- we want durable xsnap heap behavior with minimal API novelty
 
 ## Option C: Durable mailbox endpoint between regimes
 
@@ -171,39 +172,30 @@ Practical interpretation:
 
 1. Add `xsnap-worker` formula type (parallel to `worker`).
 2. Add worker power implementation for xsnap process lifecycle and snapshot management.
-3. Add `xsnap-ref` formula type for stable client-facing references.
-4. Keep daemon dependency graph semantics (`thisDiesIfThatDies`) and fail-fast call behavior for `xsnap-ref`, while relying on formula/id rebinding through persisted naming metadata.
-5. Expose explicit diagnostics on references:
-   - current epoch
-   - last rebind time
-   - last rebind failure reason
+3. Add `xsnapEvaluate(...)` host API that mirrors `evaluate(...)` but provisions/uses `xsnap-worker`.
+4. Ensure daemon enforcement that formulas intended for xsnap execution are bound to `xsnap-worker`.
+5. Validate cross-boundary capability traffic (xsnap <-> non-xsnap) before and after full restart.
 
 This gives durable state benefits without forcing user code into vat-data durable object APIs.
 
-## Option B implementation plan (ergonomics-first)
+## `xsnapEvaluate` implementation plan (ergonomics-first)
 
-This section refines Option B into concrete repository changes.
+This section refines the direct `xsnapEvaluate` model into concrete repository changes.
 
 ### Ergonomics goals
 
 #### Formula author ergonomics (inside workers)
 
-Code that receives a boundary value should be able to keep using ordinary eventual-send style:
+Code that receives a boundary value should use ordinary eventual-send style:
 
 - preferred: `E(counterLike).incr()`
-- avoid requiring a bespoke wrapper call style like `E(ref).dispatch('incr', [])`
+- avoid requiring a bespoke wrapper call style
 
-To preserve this, the facade value should behave like a generic eventual-send target and forward arbitrary method/property operations to the latest target incarnation.
+This is preserved by passing ordinary capabilities across the boundary; no facade type is required.
 
 #### Host ergonomics (outside workers)
 
-Creating a boundary facade should feel like existing host operations that materialize formulas and optionally name them:
-
-- new host helper: `makeXsnapRef(workerName, targetNameOrPath, resultName?)`
-- this creates a durable formula and (optionally) writes a pet name
-- hosts/workers can then pass the named value exactly like other formula-backed values
-
-Creating new formulas directly in an xsnap worker should mirror ordinary `evaluate`:
+Creating formulas in an xsnap worker should mirror ordinary `evaluate`:
 
 - new host helper: `xsnapEvaluate(workerName, source, codeNames, petNames, resultName?)`
 - semantics intentionally parallel `evaluate`
@@ -212,78 +204,41 @@ Creating new formulas directly in an xsnap worker should mirror ordinary `evalua
 
 ### Concrete daemon changes
 
-1. Add formula type `xsnap-ref` with persisted payload:
-   - `target: FormulaIdentifier`
-   - `worker: FormulaIdentifier`
-2. Add daemon maker for `xsnap-ref`:
-   - produce a handled facade that forwards `get` / `applyMethod` / `applyFunction`
-   - resolve target using `provide(targetId)` on every interaction (rebind-ready)
-   - enforce configured worker formula is of type `xsnap-worker`
-3. Add core formulation helper:
-   - `formulateXsnapRef(targetId, workerId, deferredTasks)`
-4. Add `xsnap-worker` formula support:
+1. Add `xsnap-worker` formula support:
    - `formulateXsnapWorker(deferredTasks)`
    - host caller can request by name, and daemon formulates `xsnap-worker`
-5. Add host APIs:
+2. Add host APIs:
    - `xsnapEvaluate(workerName, source, codeNames, petNames, resultName?)`
    - ensure specified worker is an `xsnap-worker`
    - persist resulting `eval` formulas against that worker
-   - `makeXsnapRef(workerName, targetNameOrPath, resultName?)`
-   - resolve target formula identifier from host naming graph
-   - resolve/provide configured xsnap worker formula identifier
-   - persist target id, worker id, and original host/path binding metadata
-   - formulate and optionally store resulting facade by pet name
-6. Add facade diagnostics:
-   - `E.get(facade).diagnostics` returns
-     - `targetId`
-     - `callCount`
-     - `lastRebindMs`
-     - `lastFailure`
+3. Add xsnap runtime support in node powers:
+   - use real `@agoric/xsnap` worker process
+   - load snapshot on worker startup
+   - persist snapshot after evaluate/call operations and termination
+4. Add capability wire protocol for host/xsnap method calls and slot identity.
 
 ### Concrete tests
 
-1. **Ergonomics parity**: worker code can call `E(facade).method()` with no extra protocol.
-2. **Durable formula continuity**: `xsnap-ref` formula persists across daemon restart and still forwards to target formula ID.
-3. **Rebinding behavior**: when target formula is cancelled/reincarnated, facade calls continue to work and hit fresh incarnation state.
-4. **Diagnostics behavior**: stats reflect rebinds/failures for observability.
-5. **Worker regime enforcement**: using a non-`xsnap-worker` formula fails at call time.
-6. **Xsnap evaluate ergonomics**: `xsnapEvaluate` mirrors `evaluate` and produces `eval` formulas attached to an `xsnap-worker`.
-
-### Option B continuation (current iteration)
-
-This iteration expands Option B to better expose and control behavior at the
-durability boundary without changing worker-call ergonomics.
-
-#### Worker regime alignment
-
-- `xsnap-ref` now carries explicit `worker` formula identity.
-- Host API requires a worker argument (`workerName`) so formulation stays close to
-  other daemon APIs that are worker-scoped.
-- Daemon enforces that configured worker formula type is `xsnap-worker`.
-
-#### Naming-graph rebinding
-
-- Persist `hub` + `path` alongside `target` and `worker`.
-- On each forwarded call, attempt to re-identify through the host naming graph.
-- Fall back to original `target` when rebinding path no longer resolves.
-- Update rebind diagnostics when identity changes are observed.
-
-#### Diagnostics as first-class ergonomics
-
-- Expose `diagnostics` as an ordinary property reachable with `E.get(facade)`.
-- Designed for operational introspection and UI/CLI tooling.
-- Keeps call path unchanged (`E(facade).method()` still primary API).
+1. **Worker regime enforcement**: `xsnapEvaluate` formulas are attached to `xsnap-worker`.
+2. **Global heap continuity**: `globalThis` values survive full daemon restart via snapshots.
+3. **Ordinary closure heap continuity**: exo closure/object state survives restart.
+4. **Cross-boundary non-xsnap -> xsnap**: non-xsnap callers invoke xsnap values before and after restart.
+5. **Cross-boundary xsnap -> non-xsnap**: xsnap callers invoke non-xsnap values before and after restart.
 
 ## Exploratory tests added in this branch
 
 The tests in `test/xsnap-boundary-exploration.test.js` probe key invariants:
 
 1. Persisted marshal formulas use smallcaps body and slot references for formula values.
-2. `xsnapEvaluate` creates formulas tied to `xsnap-worker` and recovers
-   `globalThis` heap state across daemon restart via snapshots.
+2. `xsnapEvaluate` creates formulas tied to `xsnap-worker`.
+3. `xsnapEvaluate` recovers `globalThis` heap state across daemon restart via snapshots.
+4. `xsnapEvaluate` recovers ordinary closure/object heap state across restart.
+5. Cross-boundary calls are covered in both directions across restart:
+   - non-xsnap caller -> xsnap value
+   - xsnap caller -> non-xsnap value
 
 ## Open questions to settle before implementation
 
-1. Should old-epoch references expose a specific error class for client tooling?
-2. Do we allow mixed graphs where xsnap durable references point to purely ephemeral non-xsnap exports, and if so with what downgrade behavior?
-3. Is a daemon-level "session ended" notification stream needed, or is call-time failure sufficient?
+1. Should daemon expose explicit worker regime metadata in inspector output for tooling/UX?
+2. Is a daemon-level "session ended" notification stream needed, or is call-time failure sufficient?
+3. Should we add an explicit conformance test around formula-id stability of repeated `xsnapEvaluate` on named results?

--- a/packages/daemon/docs/xsnap-durability-boundary-exploration.md
+++ b/packages/daemon/docs/xsnap-durability-boundary-exploration.md
@@ -279,9 +279,8 @@ durability boundary without changing worker-call ergonomics.
 The tests in `test/xsnap-boundary-exploration.test.js` probe key invariants:
 
 1. Persisted marshal formulas use smallcaps body and slot references for formula values.
-2. Cross-worker references survive restart by formula identity, while worker heap state still resets (current baseline behavior).
-
-These tests do not implement xsnap workers; they establish baseline facts the xsnap design must preserve or intentionally change.
+2. `xsnapEvaluate` creates formulas tied to `xsnap-worker` and recovers
+   `globalThis` heap state across daemon restart via snapshots.
 
 ## Open questions to settle before implementation
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -44,6 +44,7 @@
     "test:clean": "rm -rf tmp && yarn test"
   },
   "dependencies": {
+    "@agoric/xsnap": "^0.15.0",
     "@endo/base64": "workspace:^",
     "@endo/captp": "workspace:^",
     "@endo/compartment-mapper": "workspace:^",

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -844,7 +844,9 @@ export const makeDaemonicControlPowers = (
       globalThis.E.get = target => target;
 
       const issueHost = payload => {
-        const response = issueCommand(encoder.encode(JSON.stringify(payload)));
+        const response = issueCommand(
+          encoder.encode(JSON.stringify(payload)).buffer,
+        );
         const parsed = JSON.parse(decoder.decode(response));
         if (!parsed || parsed.ok !== true) {
           throw new Error(parsed && parsed.message || 'Host command failed');

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -814,7 +814,7 @@ export const makeDaemonicControlPowers = (
         return result;
       };
 
-      const methodTable = Object.create(null);
+      const methodTable = {};
       for (const method of methods) {
         methodTable[method] = (...args) => invoke(method, args);
       }
@@ -826,13 +826,18 @@ export const makeDaemonicControlPowers = (
     await worker.evaluate(`
       const encoder = new TextEncoder();
       const decoder = new TextDecoder();
-      const formulas = new Map();
-      const xsSlots = new Map();
-      let nextXsSlot = 1;
+      const state = globalThis.__endoXsnapState || {
+        formulas: new Map(),
+        xsSlots: new Map(),
+        nextXsSlot: 1,
+      };
+      globalThis.__endoXsnapState = state;
+      const { formulas, xsSlots } = state;
 
       const M = { interface: () => ({}) };
       globalThis.M = M;
-      globalThis.makeExo = (_name, _iface, methods) => methods;
+      globalThis.makeExo = (_name, _iface, methods) =>
+        Object.assign(Object.create(null), methods);
       globalThis.E = target => new Proxy({}, {
         get: (_obj, prop) => (...args) => target[prop](...args),
       });
@@ -903,7 +908,8 @@ export const makeDaemonicControlPowers = (
               return { xsSlot: slot, methods: stored.__methodNames__ || [] };
             }
           }
-          const slot = nextXsSlot++;
+          const slot = state.nextXsSlot;
+          state.nextXsSlot += 1;
           const methodNames = Object.getOwnPropertyNames(value).filter(name =>
             typeof value[name] === 'function',
           );

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -5,6 +5,7 @@ import harden from '@endo/harden';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makePipe } from '@endo/stream';
 import { makeNodeReader, makeNodeWriter } from '@endo/stream-node';
+import { E, Far } from '@endo/far';
 import { q } from '@endo/errors';
 import { makeNetstringCapTP } from './connection.js';
 import { makeReaderRef } from './reader-ref.js';
@@ -470,6 +471,8 @@ export const makeDaemonicControlPowers = (
   const endoWorkerPath = fileURLToPath(
     new URL('worker-node.js', import.meta.url),
   );
+  const wireDecoder = new TextDecoder();
+  const wireEncoder = new TextEncoder();
 
   /**
    * @param {string} workerId
@@ -553,8 +556,455 @@ export const makeDaemonicControlPowers = (
     return { workerTerminated, workerDaemonFacet };
   };
 
+  /**
+   * @param {string} workerId
+   * @param {DaemonWorkerFacet} _daemonWorkerFacet
+   * @param {Promise<never>} cancelled
+   */
+  const makeXsnapWorker = async (workerId, _daemonWorkerFacet, cancelled) => {
+    const { statePath, ephemeralStatePath } = config;
+    const workerStatePath = filePowers.joinPath(statePath, 'worker', workerId);
+    const workerEphemeralStatePath = filePowers.joinPath(
+      ephemeralStatePath,
+      'worker',
+      workerId,
+    );
+    await Promise.all([
+      filePowers.makePath(workerStatePath),
+      filePowers.makePath(workerEphemeralStatePath),
+    ]);
+
+    const snapshotPath = filePowers.joinPath(workerStatePath, 'worker.xss');
+    const pidPath = filePowers.joinPath(workerEphemeralStatePath, 'worker.pid');
+    const workerName = `endo-xsnap-${workerId.slice(0, 16)}`;
+    const os = await import('os');
+    const path = await import('path');
+    const { createRequire } = await import('module');
+    const require = createRequire(import.meta.url);
+    const { xsnap } = await import('@agoric/xsnap');
+
+    /** @type {Map<number, unknown>} */
+    const hostSlots = new Map();
+    /** @type {WeakMap<object, number>} */
+    const hostValuesToSlots = new WeakMap();
+    let nextHostSlot = 1;
+
+    /** @type {Map<number, unknown>} */
+    const xsSlots = new Map();
+
+    /**
+     * @param {number} slot
+     */
+    const provideHostSlot = slot => {
+      const target = hostSlots.get(slot);
+      if (target === undefined) {
+        throw new Error(`Unknown host slot ${q(slot)}`);
+      }
+      return target;
+    };
+
+    /** @type {(slot: number, methods?: string[]) => unknown} */
+    let provideXsnapSlot = (slot, _methods = []) => {
+      throw new Error(`Unknown xs slot ${q(slot)}`);
+    };
+
+    /**
+     * @param {unknown} value
+     * @returns {unknown}
+     */
+    const decodeWireData = value => {
+      if (Array.isArray(value)) {
+        return value.map(decodeWireData);
+      }
+      if (value && typeof value === 'object') {
+        if ('xsSlot' in value) {
+          const slot = Reflect.get(value, 'xsSlot');
+          const methods = Reflect.get(value, 'methods');
+          const normalizedMethods = Array.isArray(methods)
+            ? methods.filter(method => typeof method === 'string')
+            : [];
+          return provideXsnapSlot(/** @type {number} */ (slot), normalizedMethods);
+        }
+        if ('hostSlot' in value) {
+          const slot = Reflect.get(value, 'hostSlot');
+          return provideHostSlot(/** @type {number} */ (slot));
+        }
+        return Object.fromEntries(
+          Object.entries(value).map(([key, inner]) => [key, decodeWireData(inner)]),
+        );
+      }
+      return value;
+    };
+
+    /**
+     * @param {unknown} value
+     * @returns {unknown}
+     */
+    const encodeWireData = value => {
+      if (value === null || value === undefined) {
+        return value;
+      }
+      const valueType = typeof value;
+      if (
+        valueType === 'boolean' ||
+        valueType === 'number' ||
+        valueType === 'string'
+      ) {
+        return value;
+      }
+      if (Array.isArray(value)) {
+        return value.map(encodeWireData);
+      }
+      if (valueType === 'object') {
+        if (Object.getPrototypeOf(value) === Object.prototype) {
+          return Object.fromEntries(
+            Object.entries(value).map(([key, inner]) => [key, encodeWireData(inner)]),
+          );
+        }
+        const knownSlot = hostValuesToSlots.get(/** @type {object} */ (value));
+        if (knownSlot !== undefined) {
+          return harden({ hostSlot: knownSlot });
+        }
+        const newSlot = nextHostSlot;
+        nextHostSlot += 1;
+        hostValuesToSlots.set(/** @type {object} */ (value), newSlot);
+        hostSlots.set(newSlot, value);
+        return harden({ hostSlot: newSlot });
+      }
+      throw new TypeError(`Cannot pass unsupported value into xsnap worker`);
+    };
+
+    const maybeBuildXsnapBinary = () => {
+      const xsnapPackageJsonPath = require.resolve('@agoric/xsnap/package.json');
+      const xsnapPackagePath = path.dirname(xsnapPackageJsonPath);
+      const binaryPath = path.join(
+        xsnapPackagePath,
+        'xsnap-native/xsnap/build/bin/lin/release/xsnap-worker',
+      );
+      if (fs.existsSync(binaryPath)) {
+        return;
+      }
+      const result = popen.spawnSync('npm', ['run', 'build:from-env'], {
+        cwd: xsnapPackagePath,
+        stdio: 'pipe',
+      });
+      if (result.status !== 0 || !fs.existsSync(binaryPath)) {
+        const stderr = result.stderr?.toString() ?? '';
+        throw new Error(
+          `Failed to build xsnap worker binary for ${workerName}: ${stderr}`,
+        );
+      }
+    };
+
+    const snapshotStream = fs.existsSync(snapshotPath)
+      ? fs.createReadStream(snapshotPath)
+      : undefined;
+
+    /** @type {Awaited<ReturnType<typeof xsnap>> | undefined} */
+    let worker;
+
+    const spawnXsnap = async () => {
+      await null;
+      return xsnap({
+        os: os.type(),
+        spawn: popen.spawn,
+        fs,
+        name: workerName,
+        snapshotStream,
+        snapshotDescription: workerId,
+        stdout: 'ignore',
+        stderr: 'ignore',
+        handleCommand: async request => {
+          await null;
+          const command = JSON.parse(wireDecoder.decode(request));
+          if (command.type !== 'host-call') {
+            const failure = harden({
+              ok: false,
+              message: `Unknown host command ${q(command.type)}`,
+            });
+            return wireEncoder.encode(JSON.stringify(failure));
+          }
+          const { slot, method, args } = command;
+          if (typeof method !== 'string') {
+            const failure = harden({
+              ok: false,
+              message: `Invalid host method ${q(method)}`,
+            });
+            return wireEncoder.encode(JSON.stringify(failure));
+          }
+          const target = hostSlots.get(slot);
+          if (target === undefined) {
+            const failure = harden({
+              ok: false,
+              message: `Unknown host slot ${q(slot)}`,
+            });
+            return wireEncoder.encode(JSON.stringify(failure));
+          }
+          try {
+            const decodedArgs = decodeWireData(args);
+            if (!Array.isArray(decodedArgs)) {
+              throw new Error('Host call arguments must be an array');
+            }
+            const targetAny = /** @type {any} */ (target);
+            const result = await /** @type {any} */ (E(targetAny)[method])(
+              ...decodedArgs,
+            );
+            const success = harden({
+              ok: true,
+              value: encodeWireData(result),
+            });
+            return wireEncoder.encode(JSON.stringify(success));
+          } catch (error) {
+            const failure = harden({
+              ok: false,
+              message: error instanceof Error ? error.message : String(error),
+            });
+            return wireEncoder.encode(JSON.stringify(failure));
+          }
+        },
+      });
+    };
+
+    try {
+      worker = await spawnXsnap();
+    } catch {
+      maybeBuildXsnapBinary();
+      worker = await spawnXsnap();
+    }
+
+    const persistSnapshot = async reason => {
+      await null;
+      if (worker === undefined) {
+        throw new Error('xsnap worker not initialized');
+      }
+      const stream = worker.makeSnapshotStream(reason);
+      await fs.promises.writeFile(snapshotPath, stream);
+    };
+
+    await filePowers.writeFileText(pidPath, `xsnap:${workerName}\n`);
+
+    /**
+     * @param {Record<string, unknown>} command
+     */
+    const callWorker = async command => {
+      await null;
+      const { reply } = await worker.issueCommand(
+        wireEncoder.encode(JSON.stringify(command)),
+      );
+      const response = JSON.parse(wireDecoder.decode(reply));
+      if (!response || response.ok !== true) {
+        throw new Error(response?.message ?? 'Unknown xsnap worker error');
+      }
+      return decodeWireData(response.value);
+    };
+
+    provideXsnapSlot = (slot, methods = []) => {
+      if (xsSlots.has(slot)) {
+        return xsSlots.get(slot);
+      }
+      const invoke = async (method, args) => {
+        await null;
+        const result = await callWorker({
+          type: 'call',
+          slot,
+          method,
+          args: encodeWireData(args),
+        });
+        await persistSnapshot(`call-${workerId}-${method}`);
+        return result;
+      };
+
+      const methodTable = Object.create(null);
+      for (const method of methods) {
+        methodTable[method] = (...args) => invoke(method, args);
+      }
+      const value = Far(`XsnapValue-${slot}`, methodTable);
+      xsSlots.set(slot, value);
+      return value;
+    };
+
+    await worker.evaluate(`
+      const encoder = new TextEncoder();
+      const decoder = new TextDecoder();
+      const formulas = new Map();
+      const xsSlots = new Map();
+      let nextXsSlot = 1;
+
+      const M = { interface: () => ({}) };
+      globalThis.M = M;
+      globalThis.makeExo = (_name, _iface, methods) => methods;
+      globalThis.E = target => new Proxy({}, {
+        get: (_obj, prop) => (...args) => target[prop](...args),
+      });
+      globalThis.E.get = target => target;
+
+      const issueHost = payload => {
+        const response = issueCommand(encoder.encode(JSON.stringify(payload)));
+        const parsed = JSON.parse(decoder.decode(response));
+        if (!parsed || parsed.ok !== true) {
+          throw new Error(parsed && parsed.message || 'Host command failed');
+        }
+        return parsed.value;
+      };
+
+      const decodeData = value => {
+        if (Array.isArray(value)) {
+          return value.map(decodeData);
+        }
+        if (value && typeof value === 'object') {
+          if ('hostSlot' in value) {
+            const hostSlot = value.hostSlot;
+            return new Proxy({}, {
+              get: (_obj, prop) => {
+                if (prop === 'then') {
+                  return undefined;
+                }
+                return (...args) =>
+                  decodeData(
+                    issueHost({
+                      type: 'host-call',
+                      slot: hostSlot,
+                      method: String(prop),
+                      args: encodeData(args),
+                    }),
+                  );
+              },
+            });
+          }
+          if ('xsSlot' in value) {
+            return xsSlots.get(value.xsSlot);
+          }
+          return Object.fromEntries(
+            Object.entries(value).map(([key, inner]) => [key, decodeData(inner)]),
+          );
+        }
+        return value;
+      };
+
+      const encodeData = value => {
+        if (value === null || value === undefined) {
+          return value;
+        }
+        const valueType = typeof value;
+        if (valueType === 'boolean' || valueType === 'number' || valueType === 'string') {
+          return value;
+        }
+        if (Array.isArray(value)) {
+          return value.map(encodeData);
+        }
+        if (valueType === 'object' || valueType === 'function') {
+          if (valueType === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+            return Object.fromEntries(
+              Object.entries(value).map(([key, inner]) => [key, encodeData(inner)]),
+            );
+          }
+          for (const [slot, stored] of xsSlots.entries()) {
+            if (stored === value) {
+              return { xsSlot: slot, methods: stored.__methodNames__ || [] };
+            }
+          }
+          const slot = nextXsSlot++;
+          const methodNames = Object.getOwnPropertyNames(value).filter(name =>
+            typeof value[name] === 'function',
+          );
+          value.__methodNames__ = methodNames;
+          xsSlots.set(slot, value);
+          return { xsSlot: slot, methods: methodNames };
+        }
+        throw new Error('Unsupported xs value type');
+      };
+
+      globalThis.handleCommand = message => {
+        const command = JSON.parse(decoder.decode(message));
+        try {
+          if (command.type === 'evaluate') {
+            const { id, source, names, values } = command;
+            if (formulas.has(id)) {
+              return encoder.encode(
+                JSON.stringify({ ok: true, value: encodeData(formulas.get(id)) }),
+              ).buffer;
+            }
+            const decodedValues = decodeData(values || []);
+            for (let i = 0; i < names.length; i += 1) {
+              globalThis[names[i]] = decodedValues[i];
+            }
+            const value = eval(source);
+            formulas.set(id, value);
+            return encoder.encode(
+              JSON.stringify({ ok: true, value: encodeData(value) }),
+            ).buffer;
+          }
+          if (command.type === 'call') {
+            const target = xsSlots.get(command.slot);
+            if (target === undefined) {
+              throw new Error('Unknown xs slot');
+            }
+            const decodedArgs = decodeData(command.args || []);
+            const value = target[command.method](...decodedArgs);
+            return encoder.encode(
+              JSON.stringify({ ok: true, value: encodeData(value) }),
+            ).buffer;
+          }
+          return encoder.encode(
+            JSON.stringify({ ok: false, message: 'Unknown command type' }),
+          ).buffer;
+        } catch (error) {
+          return encoder.encode(
+            JSON.stringify({
+              ok: false,
+              message: error instanceof Error ? error.message : String(error),
+            }),
+          ).buffer;
+        }
+      };
+    `);
+
+    const terminated = makePromiseKit();
+    const closeWorker = async () => {
+      await null;
+      try {
+        await persistSnapshot(`close-${workerId}`);
+      } finally {
+        await worker.close().catch(() => undefined);
+        terminated.resolve(undefined);
+      }
+    };
+    cancelled.catch(() => {
+      void closeWorker();
+    });
+
+    const workerDaemonFacet = Far(`EndoXsnapWorkerFacet-${workerId}`, {
+      terminate: async () => {
+        await closeWorker();
+      },
+      evaluate: async (source, names, values, id, _workerCancelled) => {
+        const result = await callWorker({
+          type: 'evaluate',
+          id,
+          source,
+          names,
+          values: encodeWireData(values),
+        });
+        await persistSnapshot(`eval-${workerId}`);
+        return result;
+      },
+      makeBundle: async () => {
+        throw new Error('xsnap worker does not support makeBundle yet');
+      },
+      makeUnconfined: async () => {
+        throw new Error('xsnap worker does not support makeUnconfined yet');
+      },
+    });
+
+    return {
+      workerTerminated: terminated.promise,
+      workerDaemonFacet,
+    };
+  };
+
   return harden({
     makeWorker,
+    makeXsnapWorker,
   });
 };
 

--- a/packages/daemon/src/daemon-node-powers.js
+++ b/packages/daemon/src/daemon-node-powers.js
@@ -842,6 +842,14 @@ export const makeDaemonicControlPowers = (
         get: (_obj, prop) => (...args) => target[prop](...args),
       });
       globalThis.E.get = target => target;
+      const baseEndowments = {
+        M: globalThis.M,
+        makeExo: globalThis.makeExo,
+        E: globalThis.E,
+        TextEncoder: globalThis.TextEncoder,
+        TextDecoder: globalThis.TextDecoder,
+        URL: globalThis.URL,
+      };
 
       const issueHost = payload => {
         const response = issueCommand(
@@ -933,10 +941,24 @@ export const makeDaemonicControlPowers = (
               ).buffer;
             }
             const decodedValues = decodeData(values || []);
-            for (let i = 0; i < names.length; i += 1) {
-              globalThis[names[i]] = decodedValues[i];
+            if (!Array.isArray(names) || names.length !== decodedValues.length) {
+              throw new Error('Invalid xsnap evaluate endowments');
             }
-            const value = eval(source);
+            const formulaEndowments = Object.fromEntries(
+              names.map((name, index) => {
+                if (typeof name !== 'string') {
+                  throw new Error('Invalid xsnap evaluate endowment name');
+                }
+                return [name, decodedValues[index]];
+              }),
+            );
+            const compartment = new Compartment();
+            Object.assign(compartment.globalThis, {
+              ...baseEndowments,
+              $id: id,
+              ...formulaEndowments,
+            });
+            const value = compartment.evaluate(source);
             formulas.set(id, value);
             return encoder.encode(
               JSON.stringify({ ok: true, value: encodeData(value) }),

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -556,7 +556,7 @@ const makeDaemonCore = async (
 
   /**
    * @param {FormulaIdentifier} targetId
-   * @param {FormulaIdentifier} workerId
+   * @param {FormulaIdentifier} _workerId
    * @param {FormulaIdentifier | undefined} hubId
    * @param {NamePath | undefined} path
    */
@@ -1907,24 +1907,6 @@ const makeDaemonCore = async (
     /** @type {WorkerFormula} */
     const formula = {
       type: 'worker',
-    };
-
-    return /** @type {FormulateResult<EndoWorker>} */ (
-      formulate(formulaNumber, formula)
-    );
-  };
-
-  /**
-   * Formulates an `xsnap-worker` formula and synchronously adds it to the
-   * formula graph.
-   *
-   * @param {FormulaNumber} formulaNumber - The xsnap worker formula number.
-   * @returns {ReturnType<DaemonCore['formulateXsnapWorker']>}
-   */
-  const formulateNumberedXsnapWorker = formulaNumber => {
-    /** @type {XsnapWorkerFormula} */
-    const formula = {
-      type: 'xsnap-worker',
     };
 
     return /** @type {FormulateResult<EndoWorker>} */ (

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2,10 +2,9 @@
 /* global setTimeout, clearTimeout */
 
 import harden from '@endo/harden';
-import { HandledPromise } from '@endo/eventual-send';
 import { makeExo } from '@endo/exo';
 import { E, Far } from '@endo/far';
-import { makeMarshal, Remotable } from '@endo/marshal';
+import { makeMarshal } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeError, q, X } from '@endo/errors';
 import { makeRefReader } from './ref-reader.js';
@@ -54,7 +53,7 @@ import {
 /** @import { Passable } from '@endo/pass-style' */
 /** @import { ERef, FarRef } from '@endo/eventual-send' */
 /** @import { PromiseKit } from '@endo/promise-kit' */
-/** @import { Builtins, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeBundleFormula, MakeCapletDeferredTaskParams, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha512, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, XsnapRefDeferredTaskParams, XsnapRefFormula, XsnapRefRuntime, XsnapWorkerFormula } from './types.js' */
+/** @import { Builtins, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeBundleFormula, MakeCapletDeferredTaskParams, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha512, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, XsnapWorkerFormula } from './types.js' */
 
 /**
  * @param {number} ms
@@ -559,149 +558,6 @@ const makeDaemonCore = async (
       // TODO fix type
       /** @type {any} */ (powersP),
       /** @type {any} */ (makeFarContext(context)),
-    );
-  };
-
-  /**
-   * @param {FormulaIdentifier} targetId
-   * @param {FormulaIdentifier} _workerId
-   * @param {FormulaIdentifier | undefined} hubId
-   * @param {NamePath | undefined} path
-   */
-  const makeXsnapRef = async (targetId, _workerId, hubId, path) => {
-    /** @type {string | undefined} */
-    let lastFailure;
-    /** @type {number | undefined} */
-    let lastRebindMs;
-    let currentTargetId = targetId;
-    let callCount = 0;
-
-    /**
-     * @param {unknown} error
-     */
-    const describeError = error => {
-      if (error instanceof Error) {
-        return error.message;
-      }
-      return String(error);
-    };
-
-    /**
-     * @param {boolean} record
-     */
-    const resolveTarget = async record => {
-      if (!hubId || !path) {
-        return provide(currentTargetId);
-      }
-      const hub = await provide(hubId, 'hub');
-      const rebound = await E(hub).identify(...path);
-      if (typeof rebound === 'string') {
-        assertValidId(rebound);
-        if (record && rebound !== currentTargetId) {
-          lastRebindMs = Date.now();
-        }
-        currentTargetId = rebound;
-        return provide(currentTargetId);
-      }
-      return provide(currentTargetId);
-    };
-
-    /** @param {() => Promise<unknown>} operation */
-    const attempt = async operation => {
-      await null;
-      callCount += 1;
-      lastFailure = undefined;
-      try {
-        const value = await operation();
-        lastFailure = undefined;
-        return value;
-      } catch (error) {
-        lastFailure = describeError(error);
-        throw error;
-      }
-    };
-
-    const handler = harden({
-      /**
-       * @param {unknown} _p
-       * @param {PropertyKey} propertyKey
-       */
-      get: (_p, propertyKey) =>
-        attempt(async () => {
-          const target = await resolveTarget(false);
-          if (propertyKey === 'diagnostics') {
-            return harden({
-              targetId: currentTargetId,
-              callCount,
-              lastRebindMs,
-              lastFailure,
-              ...(path !== undefined && { lookupPath: [...path] }),
-            });
-          }
-          return E.get(target)[propertyKey];
-        }),
-      /**
-       * @param {unknown} _p
-       * @param {PropertyKey | undefined} propertyKey
-       * @param {unknown[]} args
-       */
-      applyMethod: (_p, propertyKey, args) =>
-        attempt(async () => {
-          const target = await resolveTarget(true);
-          if (propertyKey === undefined) {
-            return /** @type {any} */ (E(target))(...args);
-          }
-          return /** @type {any} */ (E(target)[propertyKey])(...args);
-        }),
-      /**
-       * @param {unknown} _p
-       * @param {unknown[]} args
-       */
-      applyFunction: (_p, args) =>
-        attempt(async () => {
-          const target = await resolveTarget(true);
-          return /** @type {any} */ (E(target))(...args);
-        }),
-      /**
-       * @param {unknown} _p
-       * @param {PropertyKey} propertyKey
-       * @param {unknown[]} args
-       */
-      applyMethodSendOnly: (_p, propertyKey, args) => {
-        attempt(async () => {
-          const target = await resolveTarget(true);
-          E.sendOnly(target)[propertyKey](...args);
-        }).catch(_error => undefined);
-      },
-      /**
-       * @param {unknown} _p
-       * @param {unknown[]} args
-       */
-      applyFunctionSendOnly: (_p, args) => {
-        attempt(async () => {
-          const target = await resolveTarget(true);
-          /** @type {any} */ (E.sendOnly(target))(...args);
-        }).catch(_error => undefined);
-      },
-    });
-
-    /** @type {(presenceHandler: unknown) => object} */
-    let resolveWithPresence = _presenceHandler => {
-      throw new Error('xsnap-ref presence initializer not ready');
-    };
-    const settledPromise = new HandledPromise(
-      (_resolve, _reject, rwp) => {
-        resolveWithPresence = rwp;
-      },
-      handler,
-    );
-    const presence = resolveWithPresence(handler);
-    // Keep the promise chain settled and quiet in case internals reject.
-    settledPromise.catch(() => undefined);
-    return Remotable(
-      'Alleged: EndoXsnapRef',
-      undefined,
-      /** @type {Record<string | symbol, unknown>} */ (presence),
     );
   };
 
@@ -1372,8 +1228,6 @@ const makeDaemonCore = async (
       makeIdentifiedWorker(formulaNumber, context),
     'xsnap-worker': (_formula, context, _id, formulaNumber) =>
       makeIdentifiedWorker(formulaNumber, context, 'xsnap-worker'),
-    'xsnap-ref': ({ target, worker, hub, path }) =>
-      makeXsnapRef(target, worker, hub, path),
     'make-unconfined': (
       { worker: workerId, powers: powersId, specifier },
       context,
@@ -1969,56 +1823,6 @@ const makeDaemonCore = async (
     };
     return /** @type {FormulateResult<EndoWorker>} */ (
       formulate(formulaNumber, formula)
-    );
-  };
-
-  /** @type {DaemonCore['formulateXsnapRef']} */
-  const formulateXsnapRef = async (
-    targetId,
-    workerId,
-    deferredTasks,
-    hubId,
-    path,
-  ) => {
-    await null;
-    assertValidId(targetId);
-    assertValidId(workerId);
-    const workerFormula = await getFormulaForId(workerId);
-    if (workerFormula.type !== 'xsnap-worker') {
-      throw new TypeError(
-        `xsnap-ref requires an xsnap worker, got formula type ${q(
-          workerFormula.type,
-        )}`,
-      );
-    }
-    if (hubId !== undefined) {
-      assertValidId(hubId);
-    }
-    if (path !== undefined) {
-      assertNamePath(path);
-    }
-    const xsnapRefFormulaNumber = await formulaGraphJobs.enqueue(async () => {
-      const formulaNumber = /** @type {FormulaNumber} */ (await randomHex512());
-      await deferredTasks.execute({
-        xsnapRefId: formatId({
-          number: formulaNumber,
-          node: localNodeNumber,
-        }),
-      });
-      return formulaNumber;
-    });
-
-    /** @type {XsnapRefFormula} */
-    const formula = {
-      type: 'xsnap-ref',
-      target: targetId,
-      worker: workerId,
-      ...(hubId !== undefined && { hub: hubId }),
-      ...(path !== undefined && { path }),
-    };
-
-    return /** @type {FormulateResult<XsnapRefRuntime>} */ (
-      formulate(xsnapRefFormulaNumber, formula)
     );
   };
 
@@ -2793,7 +2597,6 @@ const makeDaemonCore = async (
     formulateEval,
     formulateUnconfined,
     formulateBundle,
-    formulateXsnapRef,
     formulateReadableBlob,
     formulateInvitation,
     makeMailbox,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -2,9 +2,10 @@
 /* global setTimeout, clearTimeout */
 
 import harden from '@endo/harden';
+import { HandledPromise } from '@endo/eventual-send';
 import { makeExo } from '@endo/exo';
 import { E, Far } from '@endo/far';
-import { makeMarshal } from '@endo/marshal';
+import { makeMarshal, Remotable } from '@endo/marshal';
 import { makePromiseKit } from '@endo/promise-kit';
 import { makeError, q, X } from '@endo/errors';
 import { makeRefReader } from './ref-reader.js';
@@ -53,7 +54,7 @@ import {
 /** @import { Passable } from '@endo/pass-style' */
 /** @import { ERef, FarRef } from '@endo/eventual-send' */
 /** @import { PromiseKit } from '@endo/promise-kit' */
-/** @import { Builtins, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeBundleFormula, MakeCapletDeferredTaskParams, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha512, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula } from './types.js' */
+/** @import { Builtins, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeBundleFormula, MakeCapletDeferredTaskParams, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha512, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, XsnapRefDeferredTaskParams, XsnapRefFormula } from './types.js' */
 
 /**
  * @param {number} ms
@@ -551,6 +552,103 @@ const makeDaemonCore = async (
       /** @type {any} */ (powersP),
       /** @type {any} */ (makeFarContext(context)),
     );
+  };
+
+  /** @param {'none' | 'once' | undefined} retry */
+  const normalizeXsnapRefRetry = retry => {
+    if (retry === undefined || retry === 'none' || retry === 'once') {
+      return retry ?? 'none';
+    }
+    throw new TypeError(`Invalid xsnap ref retry policy ${q(retry)}`);
+  };
+
+  /**
+   * @param {FormulaIdentifier} targetId
+   * @param {'none' | 'once' | undefined} retry
+   */
+  const makeXsnapRef = (targetId, retry) => {
+    const normalizedRetry = normalizeXsnapRefRetry(retry);
+
+    /** @param {() => Promise<unknown>} operation */
+    const attempt = async operation => {
+      await null;
+      try {
+        return await operation();
+      } catch (error) {
+        if (normalizedRetry !== 'once') {
+          throw error;
+        }
+      }
+      return operation();
+    };
+
+    const handler = harden({
+      /**
+       * @param {unknown} _p
+       * @param {PropertyKey} propertyKey
+       */
+      get: (_p, propertyKey) =>
+        attempt(async () => {
+          const target = await provide(targetId);
+          return E.get(target)[propertyKey];
+        }),
+      /**
+       * @param {unknown} _p
+       * @param {PropertyKey | undefined} propertyKey
+       * @param {unknown[]} args
+       */
+      applyMethod: (_p, propertyKey, args) =>
+        attempt(async () => {
+          const target = await provide(targetId);
+          if (propertyKey === undefined) {
+            return /** @type {any} */ (E(target))(...args);
+          }
+          return /** @type {any} */ (E(target)[propertyKey])(...args);
+        }),
+      /**
+       * @param {unknown} _p
+       * @param {unknown[]} args
+       */
+      applyFunction: (_p, args) =>
+        attempt(async () => {
+          const target = await provide(targetId);
+          return /** @type {any} */ (E(target))(...args);
+        }),
+      /**
+       * @param {unknown} _p
+       * @param {PropertyKey} propertyKey
+       * @param {unknown[]} args
+       */
+      applyMethodSendOnly: (_p, propertyKey, args) => {
+        attempt(async () => {
+          const target = await provide(targetId);
+          E.sendOnly(target)[propertyKey](...args);
+        }).catch(_error => undefined);
+      },
+      /**
+       * @param {unknown} _p
+       * @param {unknown[]} args
+       */
+      applyFunctionSendOnly: (_p, args) => {
+        attempt(async () => {
+          const target = await provide(targetId);
+          /** @type {any} */ (E.sendOnly(target))(...args);
+        }).catch(_error => undefined);
+      },
+    });
+
+    /** @type {(presenceHandler: unknown) => unknown} */
+    let resolveWithPresence;
+    const settledPromise = new HandledPromise(
+      (_resolve, _reject, rwp) => {
+        resolveWithPresence = rwp;
+      },
+      handler,
+    );
+    const presence = resolveWithPresence(handler);
+    // Keep the promise chain settled and quiet in case internals reject.
+    settledPromise.catch(() => undefined);
+    return Remotable('Alleged: EndoXsnapRef', undefined, presence);
   };
 
   /** @param {object} ref */
@@ -1218,6 +1316,7 @@ const makeDaemonCore = async (
     lookup: ({ hub, path }, context) => makeLookup(hub, path, context),
     worker: (_formula, context, _id, formulaNumber) =>
       makeIdentifiedWorker(formulaNumber, context),
+    'xsnap-ref': ({ target, retry }) => makeXsnapRef(target, retry),
     'make-unconfined': (
       { worker: workerId, powers: powersId, specifier },
       context,
@@ -1787,6 +1886,32 @@ const makeDaemonCore = async (
         return formulaNumber;
       }),
     );
+  };
+
+  /** @type {DaemonCore['formulateXsnapRef']} */
+  const formulateXsnapRef = async (targetId, deferredTasks, retry) => {
+    await null;
+    assertValidId(targetId);
+    const normalizedRetry = normalizeXsnapRefRetry(retry);
+    const xsnapRefFormulaNumber = await formulaGraphJobs.enqueue(async () => {
+      const formulaNumber = /** @type {FormulaNumber} */ (await randomHex512());
+      await deferredTasks.execute({
+        xsnapRefId: formatId({
+          number: formulaNumber,
+          node: localNodeNumber,
+        }),
+      });
+      return formulaNumber;
+    });
+
+    /** @type {XsnapRefFormula} */
+    const formula = {
+      type: 'xsnap-ref',
+      target: targetId,
+      ...(normalizedRetry !== 'none' && { retry: normalizedRetry }),
+    };
+
+    return formulate(xsnapRefFormulaNumber, formula);
   };
 
   /**
@@ -2559,6 +2684,7 @@ const makeDaemonCore = async (
     formulateEval,
     formulateUnconfined,
     formulateBundle,
+    formulateXsnapRef,
     formulateReadableBlob,
     formulateInvitation,
     makeMailbox,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -54,7 +54,7 @@ import {
 /** @import { Passable } from '@endo/pass-style' */
 /** @import { ERef, FarRef } from '@endo/eventual-send' */
 /** @import { PromiseKit } from '@endo/promise-kit' */
-/** @import { Builtins, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeBundleFormula, MakeCapletDeferredTaskParams, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha512, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, XsnapRefDeferredTaskParams, XsnapRefFormula, XsnapRefRetryPolicy } from './types.js' */
+/** @import { Builtins, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeBundleFormula, MakeCapletDeferredTaskParams, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha512, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, XsnapRefDeferredTaskParams, XsnapRefFormula, XsnapRefRuntime, XsnapWorkerFormula } from './types.js' */
 
 /**
  * @param {number} ms
@@ -554,34 +554,19 @@ const makeDaemonCore = async (
     );
   };
 
-  /** @param {XsnapRefRetryPolicy | undefined} retry */
-  const normalizeXsnapRefRetry = retry => {
-    if (
-      retry === undefined ||
-      retry === 'none' ||
-      retry === 'once' ||
-      retry === 'twice'
-    ) {
-      return retry ?? 'none';
-    }
-    throw new TypeError(`Invalid xsnap ref retry policy ${q(retry)}`);
-  };
-
   /**
    * @param {FormulaIdentifier} targetId
-   * @param {XsnapRefRetryPolicy | undefined} retry
+   * @param {FormulaIdentifier} workerId
    * @param {FormulaIdentifier | undefined} hubId
    * @param {NamePath | undefined} path
    */
-  const makeXsnapRef = (targetId, retry, hubId, path) => {
-    const normalizedRetry = normalizeXsnapRefRetry(retry);
+  const makeXsnapRef = async (targetId, _workerId, hubId, path) => {
     /** @type {string | undefined} */
     let lastFailure;
     /** @type {number | undefined} */
     let lastRebindMs;
     let currentTargetId = targetId;
     let callCount = 0;
-    let retryCount = 0;
 
     /**
      * @param {unknown} error
@@ -618,22 +603,13 @@ const makeDaemonCore = async (
       await null;
       callCount += 1;
       lastFailure = undefined;
-      const retryBudget =
-        normalizedRetry === 'none' ? 0 : normalizedRetry === 'once' ? 1 : 2;
-      let retriesRemaining = retryBudget;
-      for (;;) {
-        try {
-          const value = await operation();
-          lastFailure = undefined;
-          return value;
-        } catch (error) {
-          lastFailure = describeError(error);
-          if (retriesRemaining <= 0) {
-            throw error;
-          }
-          retryCount += 1;
-          retriesRemaining -= 1;
-        }
+      try {
+        const value = await operation();
+        lastFailure = undefined;
+        return value;
+      } catch (error) {
+        lastFailure = describeError(error);
+        throw error;
       }
     };
 
@@ -648,9 +624,7 @@ const makeDaemonCore = async (
           if (propertyKey === 'diagnostics') {
             return harden({
               targetId: currentTargetId,
-              retry: normalizedRetry,
               callCount,
-              retryCount,
               lastRebindMs,
               lastFailure,
               ...(path !== undefined && { lookupPath: [...path] }),
@@ -1388,8 +1362,10 @@ const makeDaemonCore = async (
     lookup: ({ hub, path }, context) => makeLookup(hub, path, context),
     worker: (_formula, context, _id, formulaNumber) =>
       makeIdentifiedWorker(formulaNumber, context),
-    'xsnap-ref': ({ target, retry, hub, path }) =>
-      makeXsnapRef(target, retry, hub, path),
+    'xsnap-worker': (_formula, context, _id, formulaNumber) =>
+      makeIdentifiedWorker(formulaNumber, context),
+    'xsnap-ref': ({ target, worker, hub, path }) =>
+      makeXsnapRef(target, worker, hub, path),
     'make-unconfined': (
       { worker: workerId, powers: powersId, specifier },
       context,
@@ -1939,6 +1915,24 @@ const makeDaemonCore = async (
   };
 
   /**
+   * Formulates an `xsnap-worker` formula and synchronously adds it to the
+   * formula graph.
+   *
+   * @param {FormulaNumber} formulaNumber - The xsnap worker formula number.
+   * @returns {ReturnType<DaemonCore['formulateXsnapWorker']>}
+   */
+  const formulateNumberedXsnapWorker = formulaNumber => {
+    /** @type {XsnapWorkerFormula} */
+    const formula = {
+      type: 'xsnap-worker',
+    };
+
+    return /** @type {FormulateResult<EndoWorker>} */ (
+      formulate(formulaNumber, formula)
+    );
+  };
+
+  /**
    * @type {DaemonCore['formulateWorker']}
    */
   const formulateWorker = async deferredTasks => {
@@ -1961,23 +1955,58 @@ const makeDaemonCore = async (
     );
   };
 
+  /**
+   * Formulates an `xsnap-worker` formula and synchronously adds it to the
+   * formula graph.
+   *
+   * @type {DaemonCore['formulateXsnapWorker']}
+   */
+  const formulateXsnapWorker = async deferredTasks => {
+    await null;
+    const formulaNumber = await formulaGraphJobs.enqueue(async () => {
+      const number = /** @type {FormulaNumber} */ (await randomHex512());
+      await deferredTasks.execute({
+        workerId: formatId({
+          number,
+          node: localNodeNumber,
+        }),
+      });
+      return number;
+    });
+    /** @type {XsnapWorkerFormula} */
+    const formula = {
+      type: 'xsnap-worker',
+    };
+    return /** @type {FormulateResult<EndoWorker>} */ (
+      formulate(formulaNumber, formula)
+    );
+  };
+
   /** @type {DaemonCore['formulateXsnapRef']} */
   const formulateXsnapRef = async (
     targetId,
+    workerId,
     deferredTasks,
-    retry,
     hubId,
     path,
   ) => {
     await null;
     assertValidId(targetId);
+    assertValidId(workerId);
+    const workerFormula = await getFormulaForId(workerId);
+    if (workerFormula.type !== 'xsnap-worker') {
+      throw new TypeError(
+        `xsnap-ref requires an xsnap worker, got formula type ${q(
+          workerFormula.type,
+        )}`,
+      );
+    }
     if (hubId !== undefined) {
       assertValidId(hubId);
     }
     if (path !== undefined) {
       assertNamePath(path);
     }
-    const normalizedRetry = normalizeXsnapRefRetry(retry);
     const xsnapRefFormulaNumber = await formulaGraphJobs.enqueue(async () => {
       const formulaNumber = /** @type {FormulaNumber} */ (await randomHex512());
       await deferredTasks.execute({
@@ -1993,12 +2022,14 @@ const makeDaemonCore = async (
     const formula = {
       type: 'xsnap-ref',
       target: targetId,
+      worker: workerId,
       ...(hubId !== undefined && { hub: hubId }),
       ...(path !== undefined && { path }),
-      ...(normalizedRetry !== 'none' && { retry: normalizedRetry }),
     };
 
-    return formulate(xsnapRefFormulaNumber, formula);
+    return /** @type {FormulateResult<XsnapRefRuntime>} */ (
+      formulate(xsnapRefFormulaNumber, formula)
+    );
   };
 
   /**
@@ -2765,6 +2796,7 @@ const makeDaemonCore = async (
     provideController,
     cancelValue,
     formulateWorker,
+    formulateXsnapWorker,
     formulateHost,
     formulateGuest,
     formulateMarshalValue,

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -399,19 +399,27 @@ const makeDaemonCore = async (
   /**
    * @param {string} workerId512
    * @param {Context} context
+   * @param {'worker' | 'xsnap-worker'} [workerType]
    */
-  const makeIdentifiedWorker = async (workerId512, context) => {
+  const makeIdentifiedWorker = async (
+    workerId512,
+    context,
+    workerType = 'worker',
+  ) => {
     const daemonWorkerFacet = makeDaemonFacetForWorker(workerId512);
 
     const { promise: forceCancelled, reject: forceCancel } =
       /** @type {PromiseKit<never>} */ (makePromiseKit());
 
-    const { workerTerminated, workerDaemonFacet } =
-      await controlPowers.makeWorker(
-        workerId512,
-        daemonWorkerFacet,
-        Promise.race([forceCancelled, gracePeriodElapsed]),
-      );
+    const makeWorkerPower =
+      workerType === 'xsnap-worker'
+        ? controlPowers.makeXsnapWorker
+        : controlPowers.makeWorker;
+    const { workerTerminated, workerDaemonFacet } = await makeWorkerPower(
+      workerId512,
+      daemonWorkerFacet,
+      Promise.race([forceCancelled, gracePeriodElapsed]),
+    );
 
     const gracefulCancel = async () => {
       E.sendOnly(workerDaemonFacet).terminate();
@@ -1363,7 +1371,7 @@ const makeDaemonCore = async (
     worker: (_formula, context, _id, formulaNumber) =>
       makeIdentifiedWorker(formulaNumber, context),
     'xsnap-worker': (_formula, context, _id, formulaNumber) =>
-      makeIdentifiedWorker(formulaNumber, context),
+      makeIdentifiedWorker(formulaNumber, context, 'xsnap-worker'),
     'xsnap-ref': ({ target, worker, hub, path }) =>
       makeXsnapRef(target, worker, hub, path),
     'make-unconfined': (

--- a/packages/daemon/src/daemon.js
+++ b/packages/daemon/src/daemon.js
@@ -54,7 +54,7 @@ import {
 /** @import { Passable } from '@endo/pass-style' */
 /** @import { ERef, FarRef } from '@endo/eventual-send' */
 /** @import { PromiseKit } from '@endo/promise-kit' */
-/** @import { Builtins, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeBundleFormula, MakeCapletDeferredTaskParams, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha512, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, XsnapRefDeferredTaskParams, XsnapRefFormula } from './types.js' */
+/** @import { Builtins, Context, Controller, DaemonCore, DaemonCoreExternal, DaemonicPowers, DeferredTasks, DirectoryFormula, EndoBootstrap, EndoDirectory, EndoFormula, EndoGateway, EndoGreeter, EndoGuest, EndoHost, EndoInspector, EndoNetwork, EndoPeer, EndoReadable, EndoWorker, EvalFormula, FarContext, Formula, FormulaIdentifier, FormulaNumber, FormulaMakerTable, FormulateResult, GuestFormula, HandleFormula, HostFormula, Invitation, InvitationDeferredTaskParams, InvitationFormula, KnownEndoInspectors, KnownPeersStore, LookupFormula, LoopbackNetworkFormula, MailboxStoreFormula, MailHubFormula, MakeBundleFormula, MakeCapletDeferredTaskParams, MakeUnconfinedFormula, MarshalDeferredTaskParams, MessageFormula, Name, NameHub, NamePath, NameOrPath, NodeNumber, PetName, PeerFormula, PeerInfo, PetInspectorFormula, PetStore, PetStoreFormula, PromiseFormula, Provide, ReadableBlobFormula, ResolverFormula, Sha512, Specials, MarshalFormula, WeakMultimap, WorkerDaemonFacet, WorkerFormula, XsnapRefDeferredTaskParams, XsnapRefFormula, XsnapRefRetryPolicy } from './types.js' */
 
 /**
  * @param {number} ms
@@ -554,9 +554,14 @@ const makeDaemonCore = async (
     );
   };
 
-  /** @param {'none' | 'once' | undefined} retry */
+  /** @param {XsnapRefRetryPolicy | undefined} retry */
   const normalizeXsnapRefRetry = retry => {
-    if (retry === undefined || retry === 'none' || retry === 'once') {
+    if (
+      retry === undefined ||
+      retry === 'none' ||
+      retry === 'once' ||
+      retry === 'twice'
+    ) {
       return retry ?? 'none';
     }
     throw new TypeError(`Invalid xsnap ref retry policy ${q(retry)}`);
@@ -564,22 +569,72 @@ const makeDaemonCore = async (
 
   /**
    * @param {FormulaIdentifier} targetId
-   * @param {'none' | 'once' | undefined} retry
+   * @param {XsnapRefRetryPolicy | undefined} retry
+   * @param {FormulaIdentifier | undefined} hubId
+   * @param {NamePath | undefined} path
    */
-  const makeXsnapRef = (targetId, retry) => {
+  const makeXsnapRef = (targetId, retry, hubId, path) => {
     const normalizedRetry = normalizeXsnapRefRetry(retry);
+    /** @type {string | undefined} */
+    let lastFailure;
+    /** @type {number | undefined} */
+    let lastRebindMs;
+    let currentTargetId = targetId;
+    let callCount = 0;
+    let retryCount = 0;
+
+    /**
+     * @param {unknown} error
+     */
+    const describeError = error => {
+      if (error instanceof Error) {
+        return error.message;
+      }
+      return String(error);
+    };
+
+    /**
+     * @param {boolean} record
+     */
+    const resolveTarget = async record => {
+      if (!hubId || !path) {
+        return provide(currentTargetId);
+      }
+      const hub = await provide(hubId, 'hub');
+      const rebound = await E(hub).identify(...path);
+      if (typeof rebound === 'string') {
+        assertValidId(rebound);
+        if (record && rebound !== currentTargetId) {
+          lastRebindMs = Date.now();
+        }
+        currentTargetId = rebound;
+        return provide(currentTargetId);
+      }
+      return provide(currentTargetId);
+    };
 
     /** @param {() => Promise<unknown>} operation */
     const attempt = async operation => {
       await null;
-      try {
-        return await operation();
-      } catch (error) {
-        if (normalizedRetry !== 'once') {
-          throw error;
+      callCount += 1;
+      lastFailure = undefined;
+      const retryBudget =
+        normalizedRetry === 'none' ? 0 : normalizedRetry === 'once' ? 1 : 2;
+      let retriesRemaining = retryBudget;
+      for (;;) {
+        try {
+          const value = await operation();
+          lastFailure = undefined;
+          return value;
+        } catch (error) {
+          lastFailure = describeError(error);
+          if (retriesRemaining <= 0) {
+            throw error;
+          }
+          retryCount += 1;
+          retriesRemaining -= 1;
         }
       }
-      return operation();
     };
 
     const handler = harden({
@@ -589,7 +644,18 @@ const makeDaemonCore = async (
        */
       get: (_p, propertyKey) =>
         attempt(async () => {
-          const target = await provide(targetId);
+          const target = await resolveTarget(false);
+          if (propertyKey === 'diagnostics') {
+            return harden({
+              targetId: currentTargetId,
+              retry: normalizedRetry,
+              callCount,
+              retryCount,
+              lastRebindMs,
+              lastFailure,
+              ...(path !== undefined && { lookupPath: [...path] }),
+            });
+          }
           return E.get(target)[propertyKey];
         }),
       /**
@@ -599,7 +665,7 @@ const makeDaemonCore = async (
        */
       applyMethod: (_p, propertyKey, args) =>
         attempt(async () => {
-          const target = await provide(targetId);
+          const target = await resolveTarget(true);
           if (propertyKey === undefined) {
             return /** @type {any} */ (E(target))(...args);
           }
@@ -611,7 +677,7 @@ const makeDaemonCore = async (
        */
       applyFunction: (_p, args) =>
         attempt(async () => {
-          const target = await provide(targetId);
+          const target = await resolveTarget(true);
           return /** @type {any} */ (E(target))(...args);
         }),
       /**
@@ -621,7 +687,7 @@ const makeDaemonCore = async (
        */
       applyMethodSendOnly: (_p, propertyKey, args) => {
         attempt(async () => {
-          const target = await provide(targetId);
+          const target = await resolveTarget(true);
           E.sendOnly(target)[propertyKey](...args);
         }).catch(_error => undefined);
       },
@@ -631,14 +697,16 @@ const makeDaemonCore = async (
        */
       applyFunctionSendOnly: (_p, args) => {
         attempt(async () => {
-          const target = await provide(targetId);
+          const target = await resolveTarget(true);
           /** @type {any} */ (E.sendOnly(target))(...args);
         }).catch(_error => undefined);
       },
     });
 
-    /** @type {(presenceHandler: unknown) => unknown} */
-    let resolveWithPresence;
+    /** @type {(presenceHandler: unknown) => object} */
+    let resolveWithPresence = _presenceHandler => {
+      throw new Error('xsnap-ref presence initializer not ready');
+    };
     const settledPromise = new HandledPromise(
       (_resolve, _reject, rwp) => {
         resolveWithPresence = rwp;
@@ -648,7 +716,11 @@ const makeDaemonCore = async (
     const presence = resolveWithPresence(handler);
     // Keep the promise chain settled and quiet in case internals reject.
     settledPromise.catch(() => undefined);
-    return Remotable('Alleged: EndoXsnapRef', undefined, presence);
+    return Remotable(
+      'Alleged: EndoXsnapRef',
+      undefined,
+      /** @type {Record<string | symbol, unknown>} */ (presence),
+    );
   };
 
   /** @param {object} ref */
@@ -1316,7 +1388,8 @@ const makeDaemonCore = async (
     lookup: ({ hub, path }, context) => makeLookup(hub, path, context),
     worker: (_formula, context, _id, formulaNumber) =>
       makeIdentifiedWorker(formulaNumber, context),
-    'xsnap-ref': ({ target, retry }) => makeXsnapRef(target, retry),
+    'xsnap-ref': ({ target, retry, hub, path }) =>
+      makeXsnapRef(target, retry, hub, path),
     'make-unconfined': (
       { worker: workerId, powers: powersId, specifier },
       context,
@@ -1889,9 +1962,21 @@ const makeDaemonCore = async (
   };
 
   /** @type {DaemonCore['formulateXsnapRef']} */
-  const formulateXsnapRef = async (targetId, deferredTasks, retry) => {
+  const formulateXsnapRef = async (
+    targetId,
+    deferredTasks,
+    retry,
+    hubId,
+    path,
+  ) => {
     await null;
     assertValidId(targetId);
+    if (hubId !== undefined) {
+      assertValidId(hubId);
+    }
+    if (path !== undefined) {
+      assertNamePath(path);
+    }
     const normalizedRetry = normalizeXsnapRefRetry(retry);
     const xsnapRefFormulaNumber = await formulaGraphJobs.enqueue(async () => {
       const formulaNumber = /** @type {FormulaNumber} */ (await randomHex512());
@@ -1908,6 +1993,8 @@ const makeDaemonCore = async (
     const formula = {
       type: 'xsnap-ref',
       target: targetId,
+      ...(hubId !== undefined && { hub: hubId }),
+      ...(path !== undefined && { path }),
       ...(normalizedRetry !== 'none' && { retry: normalizedRetry }),
     };
 

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -28,6 +28,7 @@ const formulaTypes = new Set([
   'readable-blob',
   'resolver',
   'worker',
+  'xsnap-worker',
   'xsnap-ref',
 ]);
 

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -28,6 +28,7 @@ const formulaTypes = new Set([
   'readable-blob',
   'resolver',
   'worker',
+  'xsnap-ref',
 ]);
 
 /** @param {string} allegedType */

--- a/packages/daemon/src/formula-type.js
+++ b/packages/daemon/src/formula-type.js
@@ -29,7 +29,6 @@ const formulaTypes = new Set([
   'resolver',
   'worker',
   'xsnap-worker',
-  'xsnap-ref',
 ]);
 
 /** @param {string} allegedType */

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 /** @import { ERef } from '@endo/eventual-send' */
-/** @import { AgentDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, MarshalDeferredTaskParams, WorkerDeferredTaskParams, XsnapRefDeferredTaskParams } from './types.js' */
+/** @import { AgentDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, MarshalDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
 
 import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
@@ -47,7 +47,6 @@ const assertPowersName = name => {
  * @param {DaemonCore['formulateEval']} args.formulateEval
  * @param {DaemonCore['formulateUnconfined']} args.formulateUnconfined
  * @param {DaemonCore['formulateBundle']} args.formulateBundle
- * @param {DaemonCore['formulateXsnapRef']} args.formulateXsnapRef
  * @param {DaemonCore['formulateReadableBlob']} args.formulateReadableBlob
  * @param {DaemonCore['formulateInvitation']} args.formulateInvitation
  * @param {DaemonCore['getAllNetworkAddresses']} args.getAllNetworkAddresses
@@ -67,7 +66,6 @@ export const makeHostMaker = ({
   formulateEval,
   formulateUnconfined,
   formulateBundle,
-  formulateXsnapRef,
   formulateReadableBlob,
   formulateInvitation,
   getAllNetworkAddresses,
@@ -514,45 +512,6 @@ export const makeHostMaker = ({
       return value;
     };
 
-    /** @type {EndoHost['makeXsnapRef']} */
-    const makeXsnapRef = async (workerName, targetNameOrPath, resultName) => {
-      if (workerName !== undefined) {
-        assertPetName(workerName);
-      }
-      const targetNamePath = namePathFrom(targetNameOrPath);
-      assertNamePath(targetNamePath);
-      if (resultName !== undefined) {
-        assertNamePath(namePathFrom(resultName));
-      }
-
-      const targetId = /** @type {FormulaIdentifier | undefined} */ (
-        await E(directory).identify(...targetNamePath)
-      );
-      if (targetId === undefined) {
-        throw new TypeError(
-          `Unknown target for xsnap ref: ${q(targetNamePath.join('/'))}`,
-        );
-      }
-
-      /** @type {DeferredTasks<XsnapRefDeferredTaskParams>} */
-      const tasks = makeDeferredTasks();
-      const workerId = await provideXsnapWorkerId(workerName);
-      if (resultName !== undefined) {
-        tasks.push(identifiers =>
-          E(directory).write(namePathFrom(resultName), identifiers.xsnapRefId),
-        );
-      }
-
-      const { value } = await formulateXsnapRef(
-        targetId,
-        workerId,
-        tasks,
-        hostId,
-        targetNamePath,
-      );
-      return value;
-    };
-
     /**
      * Attempts to introduce the given names to the specified agent. The agent in question
      * must be formulated before this function is called.
@@ -887,7 +846,6 @@ export const makeHostMaker = ({
       xsnapEvaluate,
       makeUnconfined,
       makeBundle,
-      makeXsnapRef,
       cancel,
       gateway,
       greeter,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -40,6 +40,7 @@ const assertPowersName = name => {
  * @param {DaemonCore['provideController']} args.provideController
  * @param {DaemonCore['cancelValue']} args.cancelValue
  * @param {DaemonCore['formulateWorker']} args.formulateWorker
+ * @param {DaemonCore['formulateXsnapWorker']} args.formulateXsnapWorker
  * @param {DaemonCore['formulateHost']} args.formulateHost
  * @param {DaemonCore['formulateGuest']} args.formulateGuest
  * @param {DaemonCore['formulateMarshalValue']} args.formulateMarshalValue
@@ -59,6 +60,7 @@ export const makeHostMaker = ({
   provideController,
   cancelValue,
   formulateWorker,
+  formulateXsnapWorker,
   formulateHost,
   formulateGuest,
   formulateMarshalValue,
@@ -228,6 +230,31 @@ export const makeHostMaker = ({
           return petStore.write(petName, identifiers.workerId);
         });
         return undefined;
+      }
+      return workerId;
+    };
+
+    /**
+     * @param {Name | undefined} workerName
+     * @returns {Promise<FormulaIdentifier>}
+     */
+    const provideXsnapWorkerId = async workerName => {
+      await null;
+      if (workerName === undefined) {
+        /** @type {DeferredTasks<WorkerDeferredTaskParams>} */
+        const tasks = makeDeferredTasks();
+        const { id } = await formulateXsnapWorker(tasks);
+        return id;
+      }
+      const workerId = /** @type {FormulaIdentifier | undefined} */ (
+        petStore.identifyLocal(workerName)
+      );
+      if (workerId === undefined) {
+        /** @type {DeferredTasks<WorkerDeferredTaskParams>} */
+        const tasks = makeDeferredTasks();
+        const { id } = await formulateXsnapWorker(tasks);
+        await petStore.write(/** @type {PetName} */ (workerName), id);
+        return id;
       }
       return workerId;
     };
@@ -410,7 +437,10 @@ export const makeHostMaker = ({
     };
 
     /** @type {EndoHost['makeXsnapRef']} */
-    const makeXsnapRef = async (targetNameOrPath, resultName, retry) => {
+    const makeXsnapRef = async (workerName, targetNameOrPath, resultName) => {
+      if (workerName !== undefined) {
+        assertPetName(workerName);
+      }
       const targetNamePath = namePathFrom(targetNameOrPath);
       assertNamePath(targetNamePath);
       if (resultName !== undefined) {
@@ -428,6 +458,7 @@ export const makeHostMaker = ({
 
       /** @type {DeferredTasks<XsnapRefDeferredTaskParams>} */
       const tasks = makeDeferredTasks();
+      const workerId = await provideXsnapWorkerId(workerName);
       if (resultName !== undefined) {
         tasks.push(identifiers =>
           E(directory).write(namePathFrom(resultName), identifiers.xsnapRefId),
@@ -436,8 +467,8 @@ export const makeHostMaker = ({
 
       const { value } = await formulateXsnapRef(
         targetId,
+        workerId,
         tasks,
-        retry,
         hostId,
         targetNamePath,
       );

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -260,6 +260,20 @@ export const makeHostMaker = ({
     };
 
     /**
+     * @param {string | string[]} workerNamePath
+     */
+    const provideXsnapWorker = async workerNamePath => {
+      const namePath = namePathFrom(workerNamePath);
+      assertNamePath(namePath);
+      if (namePath.length !== 1) {
+        throw new Error('Xsnap worker name path must have length 1');
+      }
+      const [workerName] = namePath;
+      const workerId = await provideXsnapWorkerId(workerName);
+      return provide(workerId, 'worker');
+    };
+
+    /**
      * @param {string | undefined} workerName
      * @param {string} source
      * @param {Array<string>} codeNames
@@ -325,6 +339,70 @@ export const makeHostMaker = ({
         endowmentFormulaIdsOrPaths,
         tasks,
         workerId,
+      );
+      return value;
+    };
+
+    /** @type {EndoHost['xsnapEvaluate']} */
+    const xsnapEvaluate = async (
+      workerName,
+      source,
+      codeNames,
+      petNamePaths,
+      resultName,
+    ) => {
+      if (workerName !== undefined) {
+        assertName(workerName);
+      }
+      if (!Array.isArray(codeNames)) {
+        throw new Error('Evaluator requires an array of code names');
+      }
+      for (const codeName of codeNames) {
+        if (typeof codeName !== 'string') {
+          throw new Error(`Invalid endowment name: ${q(codeName)}`);
+        }
+      }
+      if (resultName !== undefined) {
+        const resultNamePath = namePathFrom(resultName);
+        assertNamePath(resultNamePath);
+      }
+      if (petNamePaths.length !== codeNames.length) {
+        throw new Error('Evaluator requires one pet name for each code name');
+      }
+
+      /** @type {DeferredTasks<EvalDeferredTaskParams>} */
+      const tasks = makeDeferredTasks();
+      const specifiedWorkerId = await provideXsnapWorkerId(
+        /** @type {Name | undefined} */ (workerName),
+      );
+
+      /** @type {(FormulaIdentifier | NamePath)[]} */
+      const endowmentFormulaIdsOrPaths = petNamePaths.map(petNameOrPath => {
+        const petNamePath = namePathFrom(petNameOrPath);
+        if (petNamePath.length === 1) {
+          const id = petStore.identifyLocal(petNamePath[0]);
+          if (id === undefined) {
+            throw new Error(`Unknown pet name ${q(petNamePath[0])}`);
+          }
+          return /** @type {FormulaIdentifier} */ (id);
+        }
+        return petNamePath;
+      });
+
+      if (resultName !== undefined) {
+        const resultNamePath = namePathFrom(resultName);
+        tasks.push(identifiers =>
+          E(directory).write(resultNamePath, identifiers.evalId),
+        );
+      }
+
+      const { value } = await formulateEval(
+        hostId,
+        source,
+        codeNames,
+        endowmentFormulaIdsOrPaths,
+        tasks,
+        specifiedWorkerId,
       );
       return value;
     };
@@ -804,7 +882,9 @@ export const makeHostMaker = ({
       provideGuest,
       provideHost,
       provideWorker,
+      provideXsnapWorker,
       evaluate,
+      xsnapEvaluate,
       makeUnconfined,
       makeBundle,
       makeXsnapRef,

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -434,7 +434,13 @@ export const makeHostMaker = ({
         );
       }
 
-      const { value } = await formulateXsnapRef(targetId, tasks, retry);
+      const { value } = await formulateXsnapRef(
+        targetId,
+        tasks,
+        retry,
+        hostId,
+        targetNamePath,
+      );
       return value;
     };
 

--- a/packages/daemon/src/host.js
+++ b/packages/daemon/src/host.js
@@ -2,7 +2,7 @@
 /// <reference types="ses"/>
 
 /** @import { ERef } from '@endo/eventual-send' */
-/** @import { AgentDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, MarshalDeferredTaskParams, WorkerDeferredTaskParams } from './types.js' */
+/** @import { AgentDeferredTaskParams, Context, DaemonCore, DeferredTasks, EndoGuest, EndoHost, EvalDeferredTaskParams, FormulaIdentifier, FormulaNumber, InvitationDeferredTaskParams, MakeCapletDeferredTaskParams, MakeDirectoryNode, MakeHostOrGuestOptions, MakeMailbox, Name, NameOrPath, NamePath, NodeNumber, PeerInfo, PetName, ReadableBlobDeferredTaskParams, MarshalDeferredTaskParams, WorkerDeferredTaskParams, XsnapRefDeferredTaskParams } from './types.js' */
 
 import { E } from '@endo/far';
 import { makeExo } from '@endo/exo';
@@ -46,6 +46,7 @@ const assertPowersName = name => {
  * @param {DaemonCore['formulateEval']} args.formulateEval
  * @param {DaemonCore['formulateUnconfined']} args.formulateUnconfined
  * @param {DaemonCore['formulateBundle']} args.formulateBundle
+ * @param {DaemonCore['formulateXsnapRef']} args.formulateXsnapRef
  * @param {DaemonCore['formulateReadableBlob']} args.formulateReadableBlob
  * @param {DaemonCore['formulateInvitation']} args.formulateInvitation
  * @param {DaemonCore['getAllNetworkAddresses']} args.getAllNetworkAddresses
@@ -64,6 +65,7 @@ export const makeHostMaker = ({
   formulateEval,
   formulateUnconfined,
   formulateBundle,
+  formulateXsnapRef,
   formulateReadableBlob,
   formulateInvitation,
   getAllNetworkAddresses,
@@ -407,6 +409,35 @@ export const makeHostMaker = ({
       return value;
     };
 
+    /** @type {EndoHost['makeXsnapRef']} */
+    const makeXsnapRef = async (targetNameOrPath, resultName, retry) => {
+      const targetNamePath = namePathFrom(targetNameOrPath);
+      assertNamePath(targetNamePath);
+      if (resultName !== undefined) {
+        assertNamePath(namePathFrom(resultName));
+      }
+
+      const targetId = /** @type {FormulaIdentifier | undefined} */ (
+        await E(directory).identify(...targetNamePath)
+      );
+      if (targetId === undefined) {
+        throw new TypeError(
+          `Unknown target for xsnap ref: ${q(targetNamePath.join('/'))}`,
+        );
+      }
+
+      /** @type {DeferredTasks<XsnapRefDeferredTaskParams>} */
+      const tasks = makeDeferredTasks();
+      if (resultName !== undefined) {
+        tasks.push(identifiers =>
+          E(directory).write(namePathFrom(resultName), identifiers.xsnapRefId),
+        );
+      }
+
+      const { value } = await formulateXsnapRef(targetId, tasks, retry);
+      return value;
+    };
+
     /**
      * Attempts to introduce the given names to the specified agent. The agent in question
      * must be formulated before this function is called.
@@ -739,6 +770,7 @@ export const makeHostMaker = ({
       evaluate,
       makeUnconfined,
       makeBundle,
+      makeXsnapRef,
       cancel,
       gateway,
       greeter,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -112,28 +112,28 @@ type WorkerFormula = {
   type: 'worker';
 };
 
-export type XsnapRefRetryPolicy = 'none' | 'once' | 'twice';
-
 export type XsnapRefDiagnostics = {
   targetId: FormulaIdentifier;
-  retry: XsnapRefRetryPolicy;
   callCount: number;
-  retryCount: number;
   lastRebindMs?: number;
   lastFailure?: string;
   lookupPath?: string[];
 };
 
-export type XsnapRefRuntime = {
+export interface XsnapRefRuntime {
   diagnostics(): Promise<XsnapRefDiagnostics>;
+}
+
+type XsnapWorkerFormula = {
+  type: 'xsnap-worker';
 };
 
 type XsnapRefFormula = {
   type: 'xsnap-ref';
   target: FormulaIdentifier;
+  worker: FormulaIdentifier;
   hub?: FormulaIdentifier;
   path?: NamePath;
-  retry?: XsnapRefRetryPolicy;
 };
 
 export type WorkerDeferredTaskParams = {
@@ -331,6 +331,7 @@ export type Formula =
   | EndoFormula
   | LoopbackNetworkFormula
   | WorkerFormula
+  | XsnapWorkerFormula
   | XsnapRefFormula
   | HostFormula
   | GuestFormula
@@ -706,6 +707,7 @@ export interface EndoHost extends EndoAgent {
   ): Promise<EndoHost>;
   makeDirectory(petNamePath: string | string[]): Promise<EndoDirectory>;
   provideWorker(petNamePath: string | string[]): Promise<EndoWorker>;
+  provideXsnapWorker(petNamePath: string | string[]): Promise<EndoWorker>;
   evaluate(
     workerPetName: string | undefined,
     source: string,
@@ -726,10 +728,10 @@ export interface EndoHost extends EndoAgent {
     resultName?: string | string[],
   ): Promise<unknown>;
   makeXsnapRef(
+    workerName: string,
     targetNameOrPath: string | string[],
     resultName?: string | string[],
-    retry?: XsnapRefRetryPolicy,
-  ): Promise<unknown>;
+  ): Promise<XsnapRefRuntime>;
   cancel(petName: string, reason: Error): Promise<void>;
   greeter(): Promise<EndoGreeter>;
   gateway(): Promise<EndoGateway>;
@@ -952,6 +954,7 @@ export type FormulaValueTypes = {
   host: EndoHost;
   invitation: Invitation;
   worker: EndoWorker;
+  'xsnap-worker': EndoWorker;
   'xsnap-ref': XsnapRefRuntime;
 };
 
@@ -1092,13 +1095,17 @@ export interface DaemonCore {
     deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
   ) => FormulateResult<EndoWorker>;
 
+  formulateXsnapWorker: (
+    deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
+  ) => FormulateResult<EndoWorker>;
+
   formulateXsnapRef: (
     targetId: FormulaIdentifier,
+    workerId: FormulaIdentifier,
     deferredTasks: DeferredTasks<XsnapRefDeferredTaskParams>,
-    retry?: XsnapRefRetryPolicy,
     hubId?: FormulaIdentifier,
     path?: NamePath,
-  ) => FormulateResult<unknown>;
+  ) => FormulateResult<XsnapRefRuntime>;
 
   getAllNetworkAddresses: (
     networksDirectoryId: FormulaIdentifier,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -112,8 +112,18 @@ type WorkerFormula = {
   type: 'worker';
 };
 
+type XsnapRefFormula = {
+  type: 'xsnap-ref';
+  target: FormulaIdentifier;
+  retry?: 'none' | 'once';
+};
+
 export type WorkerDeferredTaskParams = {
   workerId: FormulaIdentifier;
+};
+
+export type XsnapRefDeferredTaskParams = {
+  xsnapRefId: FormulaIdentifier;
 };
 
 /**
@@ -303,6 +313,7 @@ export type Formula =
   | EndoFormula
   | LoopbackNetworkFormula
   | WorkerFormula
+  | XsnapRefFormula
   | HostFormula
   | GuestFormula
   | LeastAuthorityFormula
@@ -696,6 +707,11 @@ export interface EndoHost extends EndoAgent {
     powersName: string,
     resultName?: string | string[],
   ): Promise<unknown>;
+  makeXsnapRef(
+    targetNameOrPath: string | string[],
+    resultName?: string | string[],
+    retry?: 'none' | 'once',
+  ): Promise<unknown>;
   cancel(petName: string, reason: Error): Promise<void>;
   greeter(): Promise<EndoGreeter>;
   gateway(): Promise<EndoGateway>;
@@ -1056,6 +1072,12 @@ export interface DaemonCore {
   formulateWorker: (
     deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
   ) => FormulateResult<EndoWorker>;
+
+  formulateXsnapRef: (
+    targetId: FormulaIdentifier,
+    deferredTasks: DeferredTasks<XsnapRefDeferredTaskParams>,
+    retry?: 'none' | 'once',
+  ) => FormulateResult<unknown>;
 
   getAllNetworkAddresses: (
     networksDirectoryId: FormulaIdentifier,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -112,36 +112,12 @@ type WorkerFormula = {
   type: 'worker';
 };
 
-export type XsnapRefDiagnostics = {
-  targetId: FormulaIdentifier;
-  callCount: number;
-  lastRebindMs?: number;
-  lastFailure?: string;
-  lookupPath?: string[];
-};
-
-export interface XsnapRefRuntime {
-  diagnostics(): Promise<XsnapRefDiagnostics>;
-}
-
 type XsnapWorkerFormula = {
   type: 'xsnap-worker';
 };
 
-type XsnapRefFormula = {
-  type: 'xsnap-ref';
-  target: FormulaIdentifier;
-  worker: FormulaIdentifier;
-  hub?: FormulaIdentifier;
-  path?: NamePath;
-};
-
 export type WorkerDeferredTaskParams = {
   workerId: FormulaIdentifier;
-};
-
-export type XsnapRefDeferredTaskParams = {
-  xsnapRefId: FormulaIdentifier;
 };
 
 /**
@@ -332,7 +308,6 @@ export type Formula =
   | LoopbackNetworkFormula
   | WorkerFormula
   | XsnapWorkerFormula
-  | XsnapRefFormula
   | HostFormula
   | GuestFormula
   | LeastAuthorityFormula
@@ -734,11 +709,6 @@ export interface EndoHost extends EndoAgent {
     powersName: string,
     resultName?: string | string[],
   ): Promise<unknown>;
-  makeXsnapRef(
-    workerName: string,
-    targetNameOrPath: string | string[],
-    resultName?: string | string[],
-  ): Promise<XsnapRefRuntime>;
   cancel(petName: string, reason: Error): Promise<void>;
   greeter(): Promise<EndoGreeter>;
   gateway(): Promise<EndoGateway>;
@@ -970,7 +940,6 @@ export type FormulaValueTypes = {
   invitation: Invitation;
   worker: EndoWorker;
   'xsnap-worker': EndoWorker;
-  'xsnap-ref': XsnapRefRuntime;
 };
 
 export type ProvideTypes = FormulaValueTypes & {
@@ -1113,14 +1082,6 @@ export interface DaemonCore {
   formulateXsnapWorker: (
     deferredTasks: DeferredTasks<WorkerDeferredTaskParams>,
   ) => FormulateResult<EndoWorker>;
-
-  formulateXsnapRef: (
-    targetId: FormulaIdentifier,
-    workerId: FormulaIdentifier,
-    deferredTasks: DeferredTasks<XsnapRefDeferredTaskParams>,
-    hubId?: FormulaIdentifier,
-    path?: NamePath,
-  ) => FormulateResult<XsnapRefRuntime>;
 
   getAllNetworkAddresses: (
     networksDirectoryId: FormulaIdentifier,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -715,6 +715,13 @@ export interface EndoHost extends EndoAgent {
     petNames: Array<string>,
     resultName?: string | string[],
   ): Promise<unknown>;
+  xsnapEvaluate(
+    workerPetName: string | undefined,
+    source: string,
+    codeNames: Array<string>,
+    petNames: Array<string>,
+    resultName?: string | string[],
+  ): Promise<unknown>;
   makeUnconfined(
     workerName: string | undefined,
     specifier: string,

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -112,10 +112,28 @@ type WorkerFormula = {
   type: 'worker';
 };
 
+export type XsnapRefRetryPolicy = 'none' | 'once' | 'twice';
+
+export type XsnapRefDiagnostics = {
+  targetId: FormulaIdentifier;
+  retry: XsnapRefRetryPolicy;
+  callCount: number;
+  retryCount: number;
+  lastRebindMs?: number;
+  lastFailure?: string;
+  lookupPath?: string[];
+};
+
+export type XsnapRefRuntime = {
+  diagnostics(): Promise<XsnapRefDiagnostics>;
+};
+
 type XsnapRefFormula = {
   type: 'xsnap-ref';
   target: FormulaIdentifier;
-  retry?: 'none' | 'once';
+  hub?: FormulaIdentifier;
+  path?: NamePath;
+  retry?: XsnapRefRetryPolicy;
 };
 
 export type WorkerDeferredTaskParams = {
@@ -710,7 +728,7 @@ export interface EndoHost extends EndoAgent {
   makeXsnapRef(
     targetNameOrPath: string | string[],
     resultName?: string | string[],
-    retry?: 'none' | 'once',
+    retry?: XsnapRefRetryPolicy,
   ): Promise<unknown>;
   cancel(petName: string, reason: Error): Promise<void>;
   greeter(): Promise<EndoGreeter>;
@@ -934,6 +952,7 @@ export type FormulaValueTypes = {
   host: EndoHost;
   invitation: Invitation;
   worker: EndoWorker;
+  'xsnap-ref': XsnapRefRuntime;
 };
 
 export type ProvideTypes = FormulaValueTypes & {
@@ -1076,7 +1095,9 @@ export interface DaemonCore {
   formulateXsnapRef: (
     targetId: FormulaIdentifier,
     deferredTasks: DeferredTasks<XsnapRefDeferredTaskParams>,
-    retry?: 'none' | 'once',
+    retry?: XsnapRefRetryPolicy,
+    hubId?: FormulaIdentifier,
+    path?: NamePath,
   ) => FormulateResult<unknown>;
 
   getAllNetworkAddresses: (

--- a/packages/daemon/src/types.d.ts
+++ b/packages/daemon/src/types.d.ts
@@ -884,6 +884,14 @@ export type DaemonicControlPowers = {
     workerTerminated: Promise<void>;
     workerDaemonFacet: ERef<WorkerDaemonFacet>;
   }>;
+  makeXsnapWorker: (
+    id: string,
+    daemonWorkerFacet: DaemonWorkerFacet,
+    cancelled: Promise<never>,
+  ) => Promise<{
+    workerTerminated: Promise<void>;
+    workerDaemonFacet: ERef<WorkerDaemonFacet>;
+  }>;
 };
 
 export type DaemonicPowers = {

--- a/packages/daemon/test/formula-type.test.js
+++ b/packages/daemon/test/formula-type.test.js
@@ -10,6 +10,7 @@ test('isValidFormulaType', t => {
   const cases = [
     ['eval', true],
     ['make-unconfined', true],
+    ['xsnap-worker', true],
     ['xsnap-ref', true],
     ['', false],
     [null, false],

--- a/packages/daemon/test/formula-type.test.js
+++ b/packages/daemon/test/formula-type.test.js
@@ -11,7 +11,6 @@ test('isValidFormulaType', t => {
     ['eval', true],
     ['make-unconfined', true],
     ['xsnap-worker', true],
-    ['xsnap-ref', true],
     ['', false],
     [null, false],
     [undefined, false],

--- a/packages/daemon/test/formula-type.test.js
+++ b/packages/daemon/test/formula-type.test.js
@@ -10,6 +10,7 @@ test('isValidFormulaType', t => {
   const cases = [
     ['eval', true],
     ['make-unconfined', true],
+    ['xsnap-ref', true],
     ['', false],
     [null, false],
     [undefined, false],

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -1,0 +1,184 @@
+// @ts-check
+/* global process */
+
+// Establish a perimeter:
+import '@endo/init/debug.js';
+
+import baseTest from 'ava';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { E } from '@endo/far';
+import { makePromiseKit } from '@endo/promise-kit';
+
+import { netListenAllowed } from './_net-permission.js';
+import {
+  start,
+  stop,
+  restart,
+  purge,
+  makeEndoClient,
+} from '../index.js';
+import { parseId } from '../src/formula-identifier.js';
+
+const test = netListenAllowed ? baseTest : baseTest.skip;
+
+const makeConfig = root => ({
+  statePath: path.join(root, 'state'),
+  ephemeralStatePath: path.join(root, 'run'),
+  cachePath: path.join(root, 'cache'),
+  sockPath:
+    process.platform === 'win32'
+      ? `\\\\?\\pipe\\endo-${path.basename(root)}.sock`
+      : path.join(root, 'endo.sock'),
+  pets: new Map(),
+  values: new Map(),
+});
+
+/**
+ * @param {ReturnType<typeof makeConfig>} config
+ * @param {Promise<void>} cancelled
+ */
+const makeHost = async (config, cancelled) => {
+  const { getBootstrap } = await makeEndoClient(
+    'client',
+    config.sockPath,
+    cancelled,
+  );
+  const bootstrap = getBootstrap();
+  return E(bootstrap).host();
+};
+
+/**
+ * @param {ReturnType<typeof makeConfig>} config
+ * @param {string} id
+ */
+const readFormulaById = async (config, id) => {
+  const { number } = parseId(id);
+  const formulaPath = path.join(
+    config.statePath,
+    'formulas',
+    number.slice(0, 2),
+    `${number.slice(2)}.json`,
+  );
+  const formulaText = await fs.readFile(formulaPath, 'utf-8');
+  return JSON.parse(formulaText);
+};
+
+/** @param {import('ava').ExecutionContext<any>} t */
+const prepareConfig = async t => {
+  const rootPath = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'endo-xsnap-boundary-'),
+  );
+  const config = makeConfig(rootPath);
+  const { reject: cancel, promise: cancelled } = makePromiseKit();
+  await purge(config);
+  await start(config);
+  t.context.push({ rootPath, config, cancel, cancelled });
+  return { rootPath, config, cancel, cancelled };
+};
+
+baseTest.beforeEach(t => {
+  t.context = [];
+});
+
+baseTest.afterEach.always(async t => {
+  /** @type {Array<{rootPath: string, config: ReturnType<typeof makeConfig>, cancel: (reason: Error) => void, cancelled: Promise<never>}>} */
+  const contexts = /** @type {any} */ (t.context);
+  await Promise.allSettled(
+    contexts.flatMap(({ rootPath, config, cancel, cancelled }) => {
+      cancel(Error('teardown'));
+      return [cancelled, stop(config), fs.rm(rootPath, { recursive: true })];
+    }),
+  );
+});
+
+test('marshal formula persists smallcaps body and formula slot', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+  const host = await makeHost(config, cancelled);
+
+  await E(host).provideWorker(['w1']);
+  const counter = await E(host).evaluate(
+    'w1',
+    `
+      (() => {
+        let value = 0;
+        return makeExo(
+          'Counter',
+          M.interface('Counter', {}, { defaultGuards: 'passable' }),
+          { incr: () => value += 1 }
+        );
+      })()
+    `,
+    [],
+    [],
+    ['counter'],
+  );
+
+  await E(host).storeValue(counter, 'counter-copy');
+  const counterId = await E(host).identify('counter');
+  const counterCopyId = await E(host).identify('counter-copy');
+  t.truthy(counterId);
+  t.truthy(counterCopyId);
+
+  const formula = await readFormulaById(config, counterCopyId);
+  t.is(formula.type, 'marshal');
+  t.true(typeof formula.body === 'string' && formula.body.startsWith('#'));
+  t.deepEqual(formula.slots, [counterId]);
+});
+
+test('cross-worker reference keeps formula id across restart', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+
+  {
+    const host = await makeHost(config, cancelled);
+    await E(host).provideWorker(['w1']);
+    await E(host).provideWorker(['w2']);
+    await E(host).evaluate(
+      'w1',
+      `
+        (() => {
+          let value = 0;
+          return makeExo(
+            'Counter',
+            M.interface('Counter', {}, { defaultGuards: 'passable' }),
+            { incr: () => value += 1 }
+          );
+        })()
+      `,
+      [],
+      [],
+      ['counter'],
+    );
+    t.is(await E(host).evaluate('w2', 'E(counter).incr()', ['counter'], ['counter']), 1);
+    t.is(await E(host).evaluate('w2', 'E(counter).incr()', ['counter'], ['counter']), 2);
+  }
+
+  const hostBeforeRestart = await makeHost(config, cancelled);
+  const counterIdBefore = await E(hostBeforeRestart).identify('counter');
+
+  await restart(config);
+
+  const hostAfterRestart = await makeHost(config, cancelled);
+  const counterIdAfter = await E(hostAfterRestart).identify('counter');
+
+  t.is(counterIdAfter, counterIdBefore);
+  t.is(
+    await E(hostAfterRestart).evaluate(
+      'w2',
+      'E(counter).incr()',
+      ['counter'],
+      ['counter'],
+    ),
+    1,
+  );
+  t.is(
+    await E(hostAfterRestart).evaluate(
+      'w2',
+      'E(counter).incr()',
+      ['counter'],
+      ['counter'],
+    ),
+    2,
+  );
+});

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -592,78 +592,70 @@ test('bidirectional xsnap/non-xsnap calls survive full restart teardown', async 
   }
 });
 
-test('xsnapEvaluate creates xsnap-worker formulas with restart-scoped state', async t => {
+test('xsnapEvaluate uses xsnap-worker and recovers heap across restart', async t => {
   const { config, cancelled } = await prepareConfig(t);
 
   {
     const host = await makeHost(config, cancelled);
     await E(host).provideWorker(['w2']);
+    await E(host).provideXsnapWorker(['xsw']);
+    const xswId = await E(host).identify('xsw');
+    t.truthy(xswId);
+    const xswFormula = await readFormulaById(config, xswId);
+    t.is(xswFormula.type, 'xsnap-worker');
 
-    await E(host).xsnapEvaluate(
+    const first = await E(host).xsnapEvaluate(
       'xsw',
       `
         (() => {
-          let value = 0;
-          return makeExo(
-            'XsnapCounter',
-            M.interface('XsnapCounter', {}, { defaultGuards: 'passable' }),
-            { incr: () => value += 1 }
-          );
+          globalThis.__xsnapCounter = (globalThis.__xsnapCounter || 0) + 1;
+          return globalThis.__xsnapCounter;
         })()
       `,
       [],
       [],
-      ['xsnap-counter'],
+      ['xsnap-value-1'],
     );
+    const second = await E(host).xsnapEvaluate(
+      'xsw',
+      `
+        (() => {
+          globalThis.__xsnapCounter = (globalThis.__xsnapCounter || 0) + 1;
+          return globalThis.__xsnapCounter;
+        })()
+      `,
+      [],
+      [],
+      ['xsnap-value-2'],
+    );
+    t.is(first, 1);
+    t.is(second, 2);
 
-    const xsnapCounterId = await E(host).identify('xsnap-counter');
-    t.truthy(xsnapCounterId);
-    const xsnapCounterFormula = await readFormulaById(config, xsnapCounterId);
+    const xsnapValueId = await E(host).identify('xsnap-value-1');
+    t.truthy(xsnapValueId);
+    const xsnapCounterFormula = await readFormulaById(config, xsnapValueId);
     t.is(xsnapCounterFormula.type, 'eval');
     const workerFormula = await readFormulaById(config, xsnapCounterFormula.worker);
     t.is(workerFormula.type, 'xsnap-worker');
-
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-counter'],
-      ),
-      1,
-    );
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-counter'],
-      ),
-      2,
-    );
   }
 
   await restart(config);
 
   {
     const host = await makeHost(config, cancelled);
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-counter'],
-      ),
-      1,
+    await E(host).provideXsnapWorker(['xsw']);
+    const third = await E(host).xsnapEvaluate(
+      'xsw',
+      `
+        (() => {
+          globalThis.__xsnapCounter = (globalThis.__xsnapCounter || 0) + 1;
+          return globalThis.__xsnapCounter;
+        })()
+      `,
+      [],
+      [],
+      ['xsnap-value-3'],
     );
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-counter'],
-      ),
-      2,
-    );
+    t.is(third, 3);
   }
 });

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -206,7 +206,7 @@ test('host makeXsnapRef forwards with formula-like ergonomics across restart', a
       [],
       ['counter'],
     );
-    await E(host).makeXsnapRef('counter', 'counter-facade');
+    await E(host).makeXsnapRef('xsw', 'counter', 'counter-facade');
     t.is(
       await E(host).evaluate(
         'w2',
@@ -241,7 +241,7 @@ test('host makeXsnapRef forwards with formula-like ergonomics across restart', a
     const { node: facadeHubNode } = parseId(facadeFormula.hub);
     t.is(facadeHubNode, selfNode);
     t.deepEqual(facadeFormula.path, ['counter']);
-    t.is(facadeFormula.retry, undefined);
+    t.is(facadeFormula.worker, await E(host).identify('xsw'));
     t.is(
       await E(host).evaluate(
         'w2',
@@ -254,7 +254,38 @@ test('host makeXsnapRef forwards with formula-like ergonomics across restart', a
   }
 });
 
-test('xsnap facade retry once rebinds after transient target failure', async t => {
+test('xsnap ref requires xsnap worker formula', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+  const host = await makeHost(config, cancelled);
+  await E(host).provideWorker(['w1']);
+  await E(host).provideWorker(['w2']);
+  await E(host).evaluate(
+    'w1',
+    `
+      (() => {
+        let value = 0;
+        return makeExo(
+          'Counter',
+          M.interface('Counter', {}, { defaultGuards: 'passable' }),
+          { incr: () => value += 1 }
+        );
+      })()
+    `,
+    [],
+    [],
+    ['counter'],
+  );
+  await E(host).provideWorker(['plain-worker']);
+
+  await t.throwsAsync(
+    E(host).makeXsnapRef('plain-worker', 'counter', 'bad-facade'),
+    {
+      message: /xsnap worker/u,
+    },
+  );
+});
+
+test('xsnap facade forwards target failures without retry semantics', async t => {
   const { config, cancelled } = await prepareConfig(t);
   const host = await makeHost(config, cancelled);
   await E(host).provideWorker(['w1']);
@@ -283,7 +314,14 @@ test('xsnap facade retry once rebinds after transient target failure', async t =
     [],
     ['flaky'],
   );
-  await E(host).makeXsnapRef('flaky', 'flaky-facade', 'once');
+  await E(host).makeXsnapRef('xsw', 'flaky', 'flaky-facade');
+
+  await t.throwsAsync(
+    E(host).evaluate('w2', 'E(facade).incr()', ['facade'], ['flaky-facade']),
+    {
+      message: 'transient',
+    },
+  );
 
   const value = await E(host).evaluate(
     'w2',
@@ -297,10 +335,40 @@ test('xsnap facade retry once rebinds after transient target failure', async t =
   t.truthy(facadeId);
   const facadeFormula = await readFormulaById(config, facadeId);
   t.is(facadeFormula.type, 'xsnap-ref');
-  t.is(facadeFormula.retry, 'once');
+  t.is(facadeFormula.worker, await E(host).identify('xsw'));
 });
 
-test('xsnap facade diagnostics report retries and failures', async t => {
+test('xsnap facade rejects non-xsnap worker selection', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+  const host = await makeHost(config, cancelled);
+  await E(host).provideWorker(['w1']);
+  await E(host).provideWorker(['w2']);
+  await E(host).provideWorker(['plain-worker']);
+  await E(host).evaluate(
+    'w1',
+    `
+      (() => {
+        let value = 0;
+        return makeExo(
+          'Counter',
+          M.interface('Counter', {}, { defaultGuards: 'passable' }),
+          { incr: () => value += 1 }
+        );
+      })()
+    `,
+    [],
+    [],
+    ['counter'],
+  );
+  await t.throwsAsync(
+    E(host).makeXsnapRef('plain-worker', 'counter', 'counter-facade'),
+    {
+      message: /xsnap-ref requires an xsnap worker/u,
+    },
+  );
+});
+
+test('xsnap facade diagnostics report call counts and failures', async t => {
   const { config, cancelled } = await prepareConfig(t);
   const host = await makeHost(config, cancelled);
   await E(host).provideWorker(['w1']);
@@ -326,7 +394,7 @@ test('xsnap facade diagnostics report retries and failures', async t => {
     [],
     ['always-fail'],
   );
-  await E(host).makeXsnapRef('always-fail', 'always-fail-facade', 'twice');
+  await E(host).makeXsnapRef('xsw', 'always-fail', 'always-fail-facade');
 
   await t.throwsAsync(
     E(host).evaluate(
@@ -347,11 +415,8 @@ test('xsnap facade diagnostics report retries and failures', async t => {
     ['always-fail-facade'],
   );
   const typedDiagnostics = /** @type {any} */ (diagnostics);
-  t.is(typedDiagnostics.retry, 'twice');
   t.is(typeof typedDiagnostics.callCount, 'number');
-  t.is(typeof typedDiagnostics.retryCount, 'number');
   t.truthy(typedDiagnostics.callCount);
-  t.truthy(typedDiagnostics.retryCount);
   t.true(
     typedDiagnostics.lastFailure === undefined ||
       typeof typedDiagnostics.lastFailure === 'string',
@@ -380,7 +445,7 @@ test('xsnap facade rebinds to latest name target via hub/path', async t => {
     [],
     ['counter'],
   );
-  await E(host).makeXsnapRef('counter', 'counter-facade', 'twice');
+  await E(host).makeXsnapRef('xsw', 'counter', 'counter-facade');
   t.is(
     await E(host).evaluate(
       'w2',
@@ -425,5 +490,8 @@ test('xsnap facade rebinds to latest name target via hub/path', async t => {
   );
   const typedDiagnostics = /** @type {any} */ (diagnostics);
   t.true(typeof typedDiagnostics.lastRebindMs === 'number');
-  t.is(typedDiagnostics.retry, 'twice');
+  t.true(
+    typedDiagnostics.lookupPath === undefined ||
+      Array.isArray(typedDiagnostics.lookupPath),
+  );
 });

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -183,45 +183,62 @@ test('cross-worker reference keeps formula id across restart', async t => {
   );
 });
 
-test('host makeXsnapRef forwards with formula-like ergonomics across restart', async t => {
+test('non-xsnap callers can invoke xsnapEvaluate values across restart', async t => {
   const { config, cancelled } = await prepareConfig(t);
 
   {
     const host = await makeHost(config, cancelled);
-    await E(host).provideWorker(['w1']);
     await E(host).provideWorker(['w2']);
-    await E(host).evaluate(
-      'w1',
+    await E(host).provideXsnapWorker(['xsw']);
+
+    await E(host).xsnapEvaluate(
+      'xsw',
       `
         (() => {
           let value = 0;
           return makeExo(
-            'Counter',
-            M.interface('Counter', {}, { defaultGuards: 'passable' }),
+            'XsnapCounter',
+            M.interface('PlainCounter', {}, { defaultGuards: 'passable' }),
             { incr: () => value += 1 }
           );
         })()
       `,
       [],
       [],
-      ['counter'],
+      ['xsnap-counter'],
     );
-    await E(host).makeXsnapRef('xsw', 'counter', 'counter-facade');
+
+    await E(host).evaluate(
+      'w2',
+      `
+        (() => makeExo(
+          'PlainCaller',
+          M.interface('PlainCaller', {}, { defaultGuards: 'passable' }),
+          {
+            callIncr: target => E(target).incr(),
+          },
+        ))()
+      `,
+      [],
+      [],
+      ['plain-caller'],
+    );
+
     t.is(
       await E(host).evaluate(
         'w2',
-        'E(facade).incr()',
-        ['facade'],
-        ['counter-facade'],
+        'E(caller).callIncr(counter)',
+        ['caller', 'counter'],
+        ['plain-caller', 'xsnap-counter'],
       ),
       1,
     );
     t.is(
       await E(host).evaluate(
         'w2',
-        'E(facade).incr()',
-        ['facade'],
-        ['counter-facade'],
+        'E(caller).callIncr(counter)',
+        ['caller', 'counter'],
+        ['plain-caller', 'xsnap-counter'],
       ),
       2,
     );
@@ -231,280 +248,38 @@ test('host makeXsnapRef forwards with formula-like ergonomics across restart', a
 
   {
     const host = await makeHost(config, cancelled);
-    const facadeId = await E(host).identify('counter-facade');
-    t.truthy(facadeId);
-    const facadeFormula = await readFormulaById(config, facadeId);
-    t.is(facadeFormula.type, 'xsnap-ref');
-    const selfId = await E(host).identify('SELF');
-    t.truthy(selfId);
-    const { node: selfNode } = parseId(selfId);
-    const { node: facadeHubNode } = parseId(facadeFormula.hub);
-    t.is(facadeHubNode, selfNode);
-    t.deepEqual(facadeFormula.path, ['counter']);
-    t.is(facadeFormula.worker, await E(host).identify('xsw'));
+    await E(host).provideXsnapWorker(['xsw']);
+
     t.is(
       await E(host).evaluate(
         'w2',
-        'E(facade).incr()',
-        ['facade'],
-        ['counter-facade'],
+        'E(caller).callIncr(counter)',
+        ['caller', 'counter'],
+        ['plain-caller', 'xsnap-counter'],
       ),
-      1,
+      3,
+    );
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(caller).callIncr(counter)',
+        ['caller', 'counter'],
+        ['plain-caller', 'xsnap-counter'],
+      ),
+      4,
     );
   }
 });
 
-test('xsnap ref requires xsnap worker formula', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-  const host = await makeHost(config, cancelled);
-  await E(host).provideWorker(['w1']);
-  await E(host).provideWorker(['w2']);
-  await E(host).evaluate(
-    'w1',
-    `
-      (() => {
-        let value = 0;
-        return makeExo(
-          'Counter',
-          M.interface('Counter', {}, { defaultGuards: 'passable' }),
-          { incr: () => value += 1 }
-        );
-      })()
-    `,
-    [],
-    [],
-    ['counter'],
-  );
-  await E(host).provideWorker(['plain-worker']);
-
-  await t.throwsAsync(
-    E(host).makeXsnapRef('plain-worker', 'counter', 'bad-facade'),
-    {
-      message: /xsnap worker/u,
-    },
-  );
-});
-
-test('xsnap facade forwards target failures without retry semantics', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-  const host = await makeHost(config, cancelled);
-  await E(host).provideWorker(['w1']);
-  await E(host).provideWorker(['w2']);
-  await E(host).evaluate(
-    'w1',
-    `
-      (() => {
-        let failNextCall = true;
-        return makeExo(
-          'FlakyCounter',
-          M.interface('FlakyCounter', {}, { defaultGuards: 'passable' }),
-          {
-            incr: () => {
-              if (failNextCall) {
-                failNextCall = false;
-                throw new Error('transient');
-              }
-              return 42;
-            },
-          }
-        );
-      })()
-    `,
-    [],
-    [],
-    ['flaky'],
-  );
-  await E(host).makeXsnapRef('xsw', 'flaky', 'flaky-facade');
-
-  await t.throwsAsync(
-    E(host).evaluate('w2', 'E(facade).incr()', ['facade'], ['flaky-facade']),
-    {
-      message: 'transient',
-    },
-  );
-
-  const value = await E(host).evaluate(
-    'w2',
-    'E(facade).incr()',
-    ['facade'],
-    ['flaky-facade'],
-  );
-  t.is(value, 42);
-
-  const facadeId = await E(host).identify('flaky-facade');
-  t.truthy(facadeId);
-  const facadeFormula = await readFormulaById(config, facadeId);
-  t.is(facadeFormula.type, 'xsnap-ref');
-  t.is(facadeFormula.worker, await E(host).identify('xsw'));
-});
-
-test('xsnap facade rejects non-xsnap worker selection', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-  const host = await makeHost(config, cancelled);
-  await E(host).provideWorker(['w1']);
-  await E(host).provideWorker(['w2']);
-  await E(host).provideWorker(['plain-worker']);
-  await E(host).evaluate(
-    'w1',
-    `
-      (() => {
-        let value = 0;
-        return makeExo(
-          'Counter',
-          M.interface('Counter', {}, { defaultGuards: 'passable' }),
-          { incr: () => value += 1 }
-        );
-      })()
-    `,
-    [],
-    [],
-    ['counter'],
-  );
-  await t.throwsAsync(
-    E(host).makeXsnapRef('plain-worker', 'counter', 'counter-facade'),
-    {
-      message: /xsnap-ref requires an xsnap worker/u,
-    },
-  );
-});
-
-test('xsnap facade diagnostics report call counts and failures', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-  const host = await makeHost(config, cancelled);
-  await E(host).provideWorker(['w1']);
-  await E(host).provideWorker(['w2']);
-  await E(host).evaluate(
-    'w1',
-    `
-      (() => {
-        let calls = 0;
-        return makeExo(
-          'AlwaysFail',
-          M.interface('AlwaysFail', {}, { defaultGuards: 'passable' }),
-          {
-            incr: () => {
-              calls += 1;
-              throw new Error('always-fails-' + calls);
-            },
-          }
-        );
-      })()
-    `,
-    [],
-    [],
-    ['always-fail'],
-  );
-  await E(host).makeXsnapRef('xsw', 'always-fail', 'always-fail-facade');
-
-  await t.throwsAsync(
-    E(host).evaluate(
-      'w2',
-      'E(facade).incr()',
-      ['facade'],
-      ['always-fail-facade'],
-    ),
-    {
-      message: /always-fails-/u,
-    },
-  );
-
-  const diagnostics = await E(host).evaluate(
-    'w2',
-    'E.get(facade).diagnostics',
-    ['facade'],
-    ['always-fail-facade'],
-  );
-  const typedDiagnostics = /** @type {any} */ (diagnostics);
-  t.is(typeof typedDiagnostics.callCount, 'number');
-  t.truthy(typedDiagnostics.callCount);
-  t.true(
-    typedDiagnostics.lastFailure === undefined ||
-      typeof typedDiagnostics.lastFailure === 'string',
-  );
-  t.is(typedDiagnostics.targetId, await E(host).identify('always-fail'));
-});
-
-test('xsnap facade rebinds to latest name target via hub/path', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-  const host = await makeHost(config, cancelled);
-  await E(host).provideWorker(['w1']);
-  await E(host).provideWorker(['w2']);
-  await E(host).evaluate(
-    'w1',
-    `
-      (() => {
-        let value = 0;
-        return makeExo(
-          'CounterA',
-          M.interface('CounterA', {}, { defaultGuards: 'passable' }),
-          { incr: () => value += 1 }
-        );
-      })()
-    `,
-    [],
-    [],
-    ['counter'],
-  );
-  await E(host).makeXsnapRef('xsw', 'counter', 'counter-facade');
-  t.is(
-    await E(host).evaluate(
-      'w2',
-      'E(facade).incr()',
-      ['facade'],
-      ['counter-facade'],
-    ),
-    1,
-  );
-
-  await E(host).evaluate(
-    'w1',
-    `
-      (() => {
-        let value = 100;
-        return makeExo(
-          'CounterB',
-          M.interface('CounterB', {}, { defaultGuards: 'passable' }),
-          { incr: () => value += 1 }
-        );
-      })()
-    `,
-    [],
-    [],
-    ['counter-new'],
-  );
-  await E(host).move(['counter-new'], ['counter']);
-
-  const reboundValue = await E(host).evaluate(
-    'w2',
-    'E(facade).incr()',
-    ['facade'],
-    ['counter-facade'],
-  );
-  t.is(reboundValue, 101);
-
-  const diagnostics = await E(host).evaluate(
-    'w2',
-    'E.get(facade).diagnostics',
-    ['facade'],
-    ['counter-facade'],
-  );
-  const typedDiagnostics = /** @type {any} */ (diagnostics);
-  t.true(typeof typedDiagnostics.lastRebindMs === 'number');
-  t.true(
-    typedDiagnostics.lookupPath === undefined ||
-      Array.isArray(typedDiagnostics.lookupPath),
-  );
-});
-
-test('bidirectional xsnap/non-xsnap calls survive full restart teardown', async t => {
+test('xsnapEvaluate callers can invoke non-xsnap values across restart', async t => {
   const { config, cancelled } = await prepareConfig(t);
 
   {
     const host = await makeHost(config, cancelled);
     await E(host).provideWorker(['w1']);
     await E(host).provideWorker(['w2']);
+    await E(host).provideXsnapWorker(['xsw']);
 
-    // Non-xsnap formula in worker w1.
     await E(host).evaluate(
       'w1',
       `
@@ -522,70 +297,66 @@ test('bidirectional xsnap/non-xsnap calls survive full restart teardown', async 
       ['plain-counter'],
     );
 
-    // Non-xsnap caller formula in worker w2.
-    await E(host).evaluate(
-      'w2',
+    await E(host).xsnapEvaluate(
+      'xsw',
       `
-        (() => makeExo(
-          'PlainCaller',
-          M.interface('PlainCaller', {}, { defaultGuards: 'passable' }),
-          {
-            callIncr: target => E(target).incr(),
-          },
-        ))()
+        (() => {
+          globalThis.__xsnapCallerBridge = globalThis.__xsnapCallerBridge || makeExo(
+            'XsnapCallerBridge',
+            M.interface('XsnapCallerBridge', {}, { defaultGuards: 'passable' }),
+            {
+              callIncr: () => E(counter).incr(),
+            }
+          );
+          return globalThis.__xsnapCallerBridge;
+        })()
       `,
-      [],
-      [],
-      ['plain-caller'],
+      ['counter'],
+      ['plain-counter'],
+      ['xsnap-caller'],
     );
 
-    // Xsnap-scoped facade formula (materialized by an xsnap worker).
-    await E(host).makeXsnapRef('xsw', 'plain-counter', 'xsnap-counter');
-
-    // Direction 1: non-xsnap worker -> xsnap formula (facade value).
     t.is(
       await E(host).evaluate(
         'w2',
-        'E(caller).callIncr(counter)',
-        ['caller', 'counter'],
-        ['plain-caller', 'xsnap-counter'],
+        'E(caller).callIncr()',
+        ['caller'],
+        ['xsnap-caller'],
       ),
       1,
     );
-
-    // Direction 2: xsnap formula (facade value) -> non-xsnap formula target.
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-counter'],
-      ),
-      2,
+    const xsnapCallerId = await E(host).identify('xsnap-caller');
+    t.truthy(xsnapCallerId);
+    const xsnapCallerFormula = await readFormulaById(config, xsnapCallerId);
+    t.is(xsnapCallerFormula.type, 'eval');
+    const callerWorkerFormula = await readFormulaById(
+      config,
+      xsnapCallerFormula.worker,
     );
+    t.is(callerWorkerFormula.type, 'xsnap-worker');
   }
 
   await restart(config);
 
   {
     const host = await makeHost(config, cancelled);
+    await E(host).provideXsnapWorker(['xsw']);
 
-    // Re-verify both directions after full daemon restart/teardown.
     t.is(
       await E(host).evaluate(
         'w2',
-        'E(caller).callIncr(counter)',
-        ['caller', 'counter'],
-        ['plain-caller', 'xsnap-counter'],
+        'E(caller).callIncr()',
+        ['caller'],
+        ['xsnap-caller'],
       ),
       1,
     );
     t.is(
       await E(host).evaluate(
         'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-counter'],
+        'E(caller).callIncr()',
+        ['caller'],
+        ['xsnap-caller'],
       ),
       2,
     );

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -93,96 +93,6 @@ baseTest.afterEach.always(async t => {
   );
 });
 
-test('marshal formula persists smallcaps body and formula slot', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-  const host = await makeHost(config, cancelled);
-
-  await E(host).provideWorker(['w1']);
-  const counter = await E(host).evaluate(
-    'w1',
-    `
-      (() => {
-        let value = 0;
-        return makeExo(
-          'Counter',
-          M.interface('Counter', {}, { defaultGuards: 'passable' }),
-          { incr: () => value += 1 }
-        );
-      })()
-    `,
-    [],
-    [],
-    ['counter'],
-  );
-
-  await E(host).storeValue(counter, 'counter-copy');
-  const counterId = await E(host).identify('counter');
-  const counterCopyId = await E(host).identify('counter-copy');
-  t.truthy(counterId);
-  t.truthy(counterCopyId);
-
-  const formula = await readFormulaById(config, counterCopyId);
-  t.is(formula.type, 'marshal');
-  t.true(typeof formula.body === 'string' && formula.body.startsWith('#'));
-  t.deepEqual(formula.slots, [counterId]);
-});
-
-test('cross-worker reference keeps formula id across restart', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-
-  {
-    const host = await makeHost(config, cancelled);
-    await E(host).provideWorker(['w1']);
-    await E(host).provideWorker(['w2']);
-    await E(host).evaluate(
-      'w1',
-      `
-        (() => {
-          let value = 0;
-          return makeExo(
-            'Counter',
-            M.interface('Counter', {}, { defaultGuards: 'passable' }),
-            { incr: () => value += 1 }
-          );
-        })()
-      `,
-      [],
-      [],
-      ['counter'],
-    );
-    t.is(await E(host).evaluate('w2', 'E(counter).incr()', ['counter'], ['counter']), 1);
-    t.is(await E(host).evaluate('w2', 'E(counter).incr()', ['counter'], ['counter']), 2);
-  }
-
-  const hostBeforeRestart = await makeHost(config, cancelled);
-  const counterIdBefore = await E(hostBeforeRestart).identify('counter');
-
-  await restart(config);
-
-  const hostAfterRestart = await makeHost(config, cancelled);
-  const counterIdAfter = await E(hostAfterRestart).identify('counter');
-
-  t.is(counterIdAfter, counterIdBefore);
-  t.is(
-    await E(hostAfterRestart).evaluate(
-      'w2',
-      'E(counter).incr()',
-      ['counter'],
-      ['counter'],
-    ),
-    1,
-  );
-  t.is(
-    await E(hostAfterRestart).evaluate(
-      'w2',
-      'E(counter).incr()',
-      ['counter'],
-      ['counter'],
-    ),
-    2,
-  );
-});
-
 test('non-xsnap callers can invoke xsnapEvaluate values across restart', async t => {
   const { config, cancelled } = await prepareConfig(t);
 
@@ -248,7 +158,6 @@ test('non-xsnap callers can invoke xsnapEvaluate values across restart', async t
 
   {
     const host = await makeHost(config, cancelled);
-    await E(host).provideXsnapWorker(['xsw']);
 
     t.is(
       await E(host).evaluate(
@@ -300,16 +209,13 @@ test('xsnapEvaluate callers can invoke non-xsnap values across restart', async t
     await E(host).xsnapEvaluate(
       'xsw',
       `
-        (() => {
-          globalThis.__xsnapCallerBridge = globalThis.__xsnapCallerBridge || makeExo(
-            'XsnapCallerBridge',
-            M.interface('XsnapCallerBridge', {}, { defaultGuards: 'passable' }),
-            {
-              callIncr: () => E(counter).incr(),
-            }
-          );
-          return globalThis.__xsnapCallerBridge;
-        })()
+        (() => makeExo(
+          'XsnapCallerBridge',
+          M.interface('XsnapCallerBridge', {}, { defaultGuards: 'passable' }),
+          {
+            callIncr: () => E(counter).incr(),
+          }
+        ))()
       `,
       ['counter'],
       ['plain-counter'],
@@ -340,7 +246,6 @@ test('xsnapEvaluate callers can invoke non-xsnap values across restart', async t
 
   {
     const host = await makeHost(config, cancelled);
-    await E(host).provideXsnapWorker(['xsw']);
 
     t.is(
       await E(host).evaluate(
@@ -359,145 +264,6 @@ test('xsnapEvaluate callers can invoke non-xsnap values across restart', async t
         ['xsnap-caller'],
       ),
       2,
-    );
-  }
-});
-
-test('xsnapEvaluate uses xsnap-worker and recovers heap across restart', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-
-  {
-    const host = await makeHost(config, cancelled);
-    await E(host).provideWorker(['w2']);
-    await E(host).provideXsnapWorker(['xsw']);
-    const xswId = await E(host).identify('xsw');
-    t.truthy(xswId);
-    const xswFormula = await readFormulaById(config, xswId);
-    t.is(xswFormula.type, 'xsnap-worker');
-
-    const first = await E(host).xsnapEvaluate(
-      'xsw',
-      `
-        (() => {
-          globalThis.__xsnapCounter = (globalThis.__xsnapCounter || 0) + 1;
-          return globalThis.__xsnapCounter;
-        })()
-      `,
-      [],
-      [],
-      ['xsnap-value-1'],
-    );
-    const second = await E(host).xsnapEvaluate(
-      'xsw',
-      `
-        (() => {
-          globalThis.__xsnapCounter = (globalThis.__xsnapCounter || 0) + 1;
-          return globalThis.__xsnapCounter;
-        })()
-      `,
-      [],
-      [],
-      ['xsnap-value-2'],
-    );
-    t.is(first, 1);
-    t.is(second, 2);
-
-    const xsnapValueId = await E(host).identify('xsnap-value-1');
-    t.truthy(xsnapValueId);
-    const xsnapCounterFormula = await readFormulaById(config, xsnapValueId);
-    t.is(xsnapCounterFormula.type, 'eval');
-    const workerFormula = await readFormulaById(config, xsnapCounterFormula.worker);
-    t.is(workerFormula.type, 'xsnap-worker');
-  }
-
-  await restart(config);
-
-  {
-    const host = await makeHost(config, cancelled);
-    await E(host).provideXsnapWorker(['xsw']);
-    const third = await E(host).xsnapEvaluate(
-      'xsw',
-      `
-        (() => {
-          globalThis.__xsnapCounter = (globalThis.__xsnapCounter || 0) + 1;
-          return globalThis.__xsnapCounter;
-        })()
-      `,
-      [],
-      [],
-      ['xsnap-value-3'],
-    );
-    t.is(third, 3);
-  }
-});
-
-test('xsnapEvaluate retains ordinary closure heap state across restart', async t => {
-  const { config, cancelled } = await prepareConfig(t);
-
-  {
-    const host = await makeHost(config, cancelled);
-    await E(host).provideWorker(['w2']);
-    await E(host).provideXsnapWorker(['xsw']);
-
-    await E(host).xsnapEvaluate(
-      'xsw',
-      `
-        (() => {
-          let value = 0;
-          return makeExo(
-            'ClosureCounter',
-            M.interface('ClosureCounter', {}, { defaultGuards: 'passable' }),
-            { incr: () => (value += 1) }
-          );
-        })()
-      `,
-      [],
-      [],
-      ['xsnap-closure-counter'],
-    );
-
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-closure-counter'],
-      ),
-      1,
-    );
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-closure-counter'],
-      ),
-      2,
-    );
-  }
-
-  await restart(config);
-
-  {
-    const host = await makeHost(config, cancelled);
-    await E(host).provideXsnapWorker(['xsw']);
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-closure-counter'],
-      ),
-      3,
-    );
-    t.is(
-      await E(host).evaluate(
-        'w2',
-        'E(counter).incr()',
-        ['counter'],
-        ['xsnap-closure-counter'],
-      ),
-      4,
     );
   }
 });

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -659,3 +659,74 @@ test('xsnapEvaluate uses xsnap-worker and recovers heap across restart', async t
     t.is(third, 3);
   }
 });
+
+test('xsnapEvaluate retains ordinary closure heap state across restart', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+
+  {
+    const host = await makeHost(config, cancelled);
+    await E(host).provideWorker(['w2']);
+    await E(host).provideXsnapWorker(['xsw']);
+
+    await E(host).xsnapEvaluate(
+      'xsw',
+      `
+        (() => {
+          let value = 0;
+          return makeExo(
+            'ClosureCounter',
+            M.interface('ClosureCounter', {}, { defaultGuards: 'passable' }),
+            { incr: () => (value += 1) }
+          );
+        })()
+      `,
+      [],
+      [],
+      ['xsnap-closure-counter'],
+    );
+
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-closure-counter'],
+      ),
+      1,
+    );
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-closure-counter'],
+      ),
+      2,
+    );
+  }
+
+  await restart(config);
+
+  {
+    const host = await makeHost(config, cancelled);
+    await E(host).provideXsnapWorker(['xsw']);
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-closure-counter'],
+      ),
+      3,
+    );
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-closure-counter'],
+      ),
+      4,
+    );
+  }
+});

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -267,3 +267,63 @@ test('xsnapEvaluate callers can invoke non-xsnap values across restart', async t
     );
   }
 });
+
+test('xsnapEvaluate uses compartment endowments without global name leakage', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+
+  const host = await makeHost(config, cancelled);
+  await E(host).provideWorker(['w1']);
+  await E(host).provideXsnapWorker(['xsw']);
+
+  await E(host).evaluate(
+    'w1',
+    `
+      (() => makeExo(
+        'PlainCounter',
+        M.interface('PlainCounter', {}, { defaultGuards: 'passable' }),
+        {
+          incr: (() => {
+            let value = 0;
+            return () => value += 1;
+          })(),
+        },
+      ))()
+    `,
+    [],
+    [],
+    ['plain-counter'],
+  );
+
+  await E(host).xsnapEvaluate(
+    'xsw',
+    `
+      (() => makeExo(
+        'BridgeCounter',
+        M.interface('BridgeCounter', {}, { defaultGuards: 'passable' }),
+        { callIncr: () => E(counter).incr() },
+      ))()
+    `,
+    ['counter'],
+    ['plain-counter'],
+    ['bridge-counter'],
+  );
+
+  t.is(
+    await E(host).evaluate(
+      'w1',
+      'typeof counter',
+      [],
+      [],
+    ),
+    'undefined',
+  );
+  t.is(
+    await E(host).evaluate(
+      'w1',
+      'E(counter).callIncr()',
+      ['counter'],
+      ['bridge-counter'],
+    ),
+    1,
+  );
+});

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -495,3 +495,99 @@ test('xsnap facade rebinds to latest name target via hub/path', async t => {
       Array.isArray(typedDiagnostics.lookupPath),
   );
 });
+
+test('bidirectional xsnap/non-xsnap calls survive full restart teardown', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+
+  {
+    const host = await makeHost(config, cancelled);
+    await E(host).provideWorker(['w1']);
+    await E(host).provideWorker(['w2']);
+
+    // Non-xsnap formula in worker w1.
+    await E(host).evaluate(
+      'w1',
+      `
+        (() => {
+          let value = 0;
+          return makeExo(
+            'PlainCounter',
+            M.interface('PlainCounter', {}, { defaultGuards: 'passable' }),
+            { incr: () => value += 1 }
+          );
+        })()
+      `,
+      [],
+      [],
+      ['plain-counter'],
+    );
+
+    // Non-xsnap caller formula in worker w2.
+    await E(host).evaluate(
+      'w2',
+      `
+        (() => makeExo(
+          'PlainCaller',
+          M.interface('PlainCaller', {}, { defaultGuards: 'passable' }),
+          {
+            callIncr: target => E(target).incr(),
+          },
+        ))()
+      `,
+      [],
+      [],
+      ['plain-caller'],
+    );
+
+    // Xsnap-scoped facade formula (materialized by an xsnap worker).
+    await E(host).makeXsnapRef('xsw', 'plain-counter', 'xsnap-counter');
+
+    // Direction 1: non-xsnap worker -> xsnap formula (facade value).
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(caller).callIncr(counter)',
+        ['caller', 'counter'],
+        ['plain-caller', 'xsnap-counter'],
+      ),
+      1,
+    );
+
+    // Direction 2: xsnap formula (facade value) -> non-xsnap formula target.
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-counter'],
+      ),
+      2,
+    );
+  }
+
+  await restart(config);
+
+  {
+    const host = await makeHost(config, cancelled);
+
+    // Re-verify both directions after full daemon restart/teardown.
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(caller).callIncr(counter)',
+        ['caller', 'counter'],
+        ['plain-caller', 'xsnap-counter'],
+      ),
+      1,
+    );
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-counter'],
+      ),
+      2,
+    );
+  }
+});

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -268,6 +268,95 @@ test('xsnapEvaluate callers can invoke non-xsnap values across restart', async t
   }
 });
 
+/** @type {any} */ (test).failing(
+  'xsnapEvaluate stores promised counter reference across restart (exploration)',
+  async t => {
+    const { config, cancelled } = await prepareConfig(t);
+
+    {
+      const host = await makeHost(config, cancelled);
+      await E(host).provideWorker(['w1']);
+      await E(host).provideWorker(['w2']);
+      await E(host).provideXsnapWorker(['xsw']);
+
+      await E(host).evaluate(
+        'w1',
+        `
+          (() => makeExo(
+            'CounterFactory',
+            M.interface('CounterFactory', {}, { defaultGuards: 'passable' }),
+            {
+              makeCounter: async () => {
+                let value = 0;
+                return makeExo(
+                  'Counter',
+                  M.interface('Counter', {}, { defaultGuards: 'passable' }),
+                  { incr: () => value += 1 }
+                );
+              },
+            }
+          ))()
+        `,
+        [],
+        [],
+        ['counter-factory'],
+      );
+
+      await E(host).xsnapEvaluate(
+        'xsw',
+        `
+          (() => {
+            let storedCounterP;
+            return makeExo(
+              'StoredCounterHolder',
+              M.interface('StoredCounterHolder', {}, { defaultGuards: 'passable' }),
+              {
+                initAndIncr: async () => {
+                  storedCounterP = storedCounterP || E(factory).makeCounter();
+                  const counter = await storedCounterP;
+                  return E(counter).incr();
+                },
+                incrStored: async () => {
+                  const counter = await storedCounterP;
+                  return E(counter).incr();
+                },
+              }
+            );
+          })()
+        `,
+        ['factory'],
+        ['counter-factory'],
+        ['xsnap-stored-counter-holder'],
+      );
+
+      t.is(
+        await E(host).evaluate(
+          'w2',
+          'E(holder).initAndIncr()',
+          ['holder'],
+          ['xsnap-stored-counter-holder'],
+        ),
+        1,
+      );
+    }
+
+    await restart(config);
+
+    {
+      const host = await makeHost(config, cancelled);
+      t.is(
+        await E(host).evaluate(
+          'w2',
+          'E(holder).incrStored()',
+          ['holder'],
+          ['xsnap-stored-counter-holder'],
+        ),
+        2,
+      );
+    }
+  },
+);
+
 test('xsnapEvaluate uses compartment endowments without global name leakage', async t => {
   const { config, cancelled } = await prepareConfig(t);
 

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -182,3 +182,114 @@ test('cross-worker reference keeps formula id across restart', async t => {
     2,
   );
 });
+
+test('host makeXsnapRef forwards with formula-like ergonomics across restart', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+
+  {
+    const host = await makeHost(config, cancelled);
+    await E(host).provideWorker(['w1']);
+    await E(host).provideWorker(['w2']);
+    await E(host).evaluate(
+      'w1',
+      `
+        (() => {
+          let value = 0;
+          return makeExo(
+            'Counter',
+            M.interface('Counter', {}, { defaultGuards: 'passable' }),
+            { incr: () => value += 1 }
+          );
+        })()
+      `,
+      [],
+      [],
+      ['counter'],
+    );
+    await E(host).makeXsnapRef('counter', 'counter-facade');
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(facade).incr()',
+        ['facade'],
+        ['counter-facade'],
+      ),
+      1,
+    );
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(facade).incr()',
+        ['facade'],
+        ['counter-facade'],
+      ),
+      2,
+    );
+  }
+
+  await restart(config);
+
+  {
+    const host = await makeHost(config, cancelled);
+    const facadeId = await E(host).identify('counter-facade');
+    t.truthy(facadeId);
+    const facadeFormula = await readFormulaById(config, facadeId);
+    t.is(facadeFormula.type, 'xsnap-ref');
+    t.is(facadeFormula.retry, undefined);
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(facade).incr()',
+        ['facade'],
+        ['counter-facade'],
+      ),
+      1,
+    );
+  }
+});
+
+test('xsnap facade retry once rebinds after transient target failure', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+  const host = await makeHost(config, cancelled);
+  await E(host).provideWorker(['w1']);
+  await E(host).provideWorker(['w2']);
+  await E(host).evaluate(
+    'w1',
+    `
+      (() => {
+        let failNextCall = true;
+        return makeExo(
+          'FlakyCounter',
+          M.interface('FlakyCounter', {}, { defaultGuards: 'passable' }),
+          {
+            incr: () => {
+              if (failNextCall) {
+                failNextCall = false;
+                throw new Error('transient');
+              }
+              return 42;
+            },
+          }
+        );
+      })()
+    `,
+    [],
+    [],
+    ['flaky'],
+  );
+  await E(host).makeXsnapRef('flaky', 'flaky-facade', 'once');
+
+  const value = await E(host).evaluate(
+    'w2',
+    'E(facade).incr()',
+    ['facade'],
+    ['flaky-facade'],
+  );
+  t.is(value, 42);
+
+  const facadeId = await E(host).identify('flaky-facade');
+  t.truthy(facadeId);
+  const facadeFormula = await readFormulaById(config, facadeId);
+  t.is(facadeFormula.type, 'xsnap-ref');
+  t.is(facadeFormula.retry, 'once');
+});

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -591,3 +591,79 @@ test('bidirectional xsnap/non-xsnap calls survive full restart teardown', async 
     );
   }
 });
+
+test('xsnapEvaluate creates xsnap-worker formulas with restart-scoped state', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+
+  {
+    const host = await makeHost(config, cancelled);
+    await E(host).provideWorker(['w2']);
+
+    await E(host).xsnapEvaluate(
+      'xsw',
+      `
+        (() => {
+          let value = 0;
+          return makeExo(
+            'XsnapCounter',
+            M.interface('XsnapCounter', {}, { defaultGuards: 'passable' }),
+            { incr: () => value += 1 }
+          );
+        })()
+      `,
+      [],
+      [],
+      ['xsnap-counter'],
+    );
+
+    const xsnapCounterId = await E(host).identify('xsnap-counter');
+    t.truthy(xsnapCounterId);
+    const xsnapCounterFormula = await readFormulaById(config, xsnapCounterId);
+    t.is(xsnapCounterFormula.type, 'eval');
+    const workerFormula = await readFormulaById(config, xsnapCounterFormula.worker);
+    t.is(workerFormula.type, 'xsnap-worker');
+
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-counter'],
+      ),
+      1,
+    );
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-counter'],
+      ),
+      2,
+    );
+  }
+
+  await restart(config);
+
+  {
+    const host = await makeHost(config, cancelled);
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-counter'],
+      ),
+      1,
+    );
+    t.is(
+      await E(host).evaluate(
+        'w2',
+        'E(counter).incr()',
+        ['counter'],
+        ['xsnap-counter'],
+      ),
+      2,
+    );
+  }
+});

--- a/packages/daemon/test/xsnap-boundary-exploration.test.js
+++ b/packages/daemon/test/xsnap-boundary-exploration.test.js
@@ -235,6 +235,12 @@ test('host makeXsnapRef forwards with formula-like ergonomics across restart', a
     t.truthy(facadeId);
     const facadeFormula = await readFormulaById(config, facadeId);
     t.is(facadeFormula.type, 'xsnap-ref');
+    const selfId = await E(host).identify('SELF');
+    t.truthy(selfId);
+    const { node: selfNode } = parseId(selfId);
+    const { node: facadeHubNode } = parseId(facadeFormula.hub);
+    t.is(facadeHubNode, selfNode);
+    t.deepEqual(facadeFormula.path, ['counter']);
     t.is(facadeFormula.retry, undefined);
     t.is(
       await E(host).evaluate(
@@ -292,4 +298,132 @@ test('xsnap facade retry once rebinds after transient target failure', async t =
   const facadeFormula = await readFormulaById(config, facadeId);
   t.is(facadeFormula.type, 'xsnap-ref');
   t.is(facadeFormula.retry, 'once');
+});
+
+test('xsnap facade diagnostics report retries and failures', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+  const host = await makeHost(config, cancelled);
+  await E(host).provideWorker(['w1']);
+  await E(host).provideWorker(['w2']);
+  await E(host).evaluate(
+    'w1',
+    `
+      (() => {
+        let calls = 0;
+        return makeExo(
+          'AlwaysFail',
+          M.interface('AlwaysFail', {}, { defaultGuards: 'passable' }),
+          {
+            incr: () => {
+              calls += 1;
+              throw new Error('always-fails-' + calls);
+            },
+          }
+        );
+      })()
+    `,
+    [],
+    [],
+    ['always-fail'],
+  );
+  await E(host).makeXsnapRef('always-fail', 'always-fail-facade', 'twice');
+
+  await t.throwsAsync(
+    E(host).evaluate(
+      'w2',
+      'E(facade).incr()',
+      ['facade'],
+      ['always-fail-facade'],
+    ),
+    {
+      message: /always-fails-/u,
+    },
+  );
+
+  const diagnostics = await E(host).evaluate(
+    'w2',
+    'E.get(facade).diagnostics',
+    ['facade'],
+    ['always-fail-facade'],
+  );
+  const typedDiagnostics = /** @type {any} */ (diagnostics);
+  t.is(typedDiagnostics.retry, 'twice');
+  t.is(typeof typedDiagnostics.callCount, 'number');
+  t.is(typeof typedDiagnostics.retryCount, 'number');
+  t.truthy(typedDiagnostics.callCount);
+  t.truthy(typedDiagnostics.retryCount);
+  t.true(
+    typedDiagnostics.lastFailure === undefined ||
+      typeof typedDiagnostics.lastFailure === 'string',
+  );
+  t.is(typedDiagnostics.targetId, await E(host).identify('always-fail'));
+});
+
+test('xsnap facade rebinds to latest name target via hub/path', async t => {
+  const { config, cancelled } = await prepareConfig(t);
+  const host = await makeHost(config, cancelled);
+  await E(host).provideWorker(['w1']);
+  await E(host).provideWorker(['w2']);
+  await E(host).evaluate(
+    'w1',
+    `
+      (() => {
+        let value = 0;
+        return makeExo(
+          'CounterA',
+          M.interface('CounterA', {}, { defaultGuards: 'passable' }),
+          { incr: () => value += 1 }
+        );
+      })()
+    `,
+    [],
+    [],
+    ['counter'],
+  );
+  await E(host).makeXsnapRef('counter', 'counter-facade', 'twice');
+  t.is(
+    await E(host).evaluate(
+      'w2',
+      'E(facade).incr()',
+      ['facade'],
+      ['counter-facade'],
+    ),
+    1,
+  );
+
+  await E(host).evaluate(
+    'w1',
+    `
+      (() => {
+        let value = 100;
+        return makeExo(
+          'CounterB',
+          M.interface('CounterB', {}, { defaultGuards: 'passable' }),
+          { incr: () => value += 1 }
+        );
+      })()
+    `,
+    [],
+    [],
+    ['counter-new'],
+  );
+  await E(host).move(['counter-new'], ['counter']);
+
+  const reboundValue = await E(host).evaluate(
+    'w2',
+    'E(facade).incr()',
+    ['facade'],
+    ['counter-facade'],
+  );
+  t.is(reboundValue, 101);
+
+  const diagnostics = await E(host).evaluate(
+    'w2',
+    'E.get(facade).diagnostics',
+    ['facade'],
+    ['counter-facade'],
+  );
+  const typedDiagnostics = /** @type {any} */ (diagnostics);
+  t.true(typeof typedDiagnostics.lastRebindMs === 'number');
+  t.is(typedDiagnostics.retry, 'twice');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,87 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@agoric/base-zone@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@agoric/base-zone@npm:0.2.0"
+  dependencies:
+    "@agoric/store": "npm:0.10.0"
+    "@endo/common": "npm:^1.2.13"
+    "@endo/errors": "npm:^1.2.13"
+    "@endo/exo": "npm:^1.5.12"
+    "@endo/far": "npm:^1.1.14"
+    "@endo/pass-style": "npm:^1.6.3"
+    "@endo/patterns": "npm:^1.7.0"
+  checksum: 10c0/74b284f39a4dab72aa918bde5642003440db18f63a955e915e7115a66c5507310354bbd2fe26d428f8590e360f19fc40e276cac8be7ad81232e5c17ba0e1460d
+  languageName: node
+  linkType: hard
+
+"@agoric/internal@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@agoric/internal@npm:0.4.0"
+  dependencies:
+    "@agoric/base-zone": "npm:0.2.0"
+    "@endo/common": "npm:^1.2.13"
+    "@endo/compartment-mapper": "npm:^1.6.3"
+    "@endo/errors": "npm:^1.2.13"
+    "@endo/eventual-send": "npm:^1.3.4"
+    "@endo/far": "npm:^1.1.14"
+    "@endo/init": "npm:^1.1.12"
+    "@endo/marshal": "npm:^1.8.0"
+    "@endo/nat": "npm:^5.1.3"
+    "@endo/pass-style": "npm:^1.6.3"
+    "@endo/patterns": "npm:^1.7.0"
+    "@endo/promise-kit": "npm:^1.1.13"
+    "@endo/stream": "npm:^1.2.13"
+    anylogger: "npm:^0.21.0"
+    jessie.js: "npm:^0.3.4"
+  checksum: 10c0/6127460268d9d15f671b6fa194de78fbb10194eb58202f1a509e1867a149aba7d059222786c751a108967d481d48cf4b98f63376b2775d139646c9aec1febe9b
+  languageName: node
+  linkType: hard
+
+"@agoric/store@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@agoric/store@npm:0.10.0"
+  dependencies:
+    "@endo/errors": "npm:^1.2.13"
+    "@endo/exo": "npm:^1.5.12"
+    "@endo/marshal": "npm:^1.8.0"
+    "@endo/pass-style": "npm:^1.6.3"
+    "@endo/patterns": "npm:^1.7.0"
+  checksum: 10c0/6f48367b8e2394ea3f07e586018df9de714b54fc50b9412b2c1741f19f84b44bd16d67d987ebe0f462e6ffba2c1e3d80522f2a1b50a8779b3e8b08baa92ec859
+  languageName: node
+  linkType: hard
+
+"@agoric/xsnap-lockdown@npm:0.14.1":
+  version: 0.14.1
+  resolution: "@agoric/xsnap-lockdown@npm:0.14.1"
+  checksum: 10c0/644b0e3299322ac3faf5421199579066e6d476941804029c5b721f87a675f111d9a75c771d3276384319a4b847f40f5a7d6df280aa934ebc6805bfc0da4973ef
+  languageName: node
+  linkType: hard
+
+"@agoric/xsnap@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@agoric/xsnap@npm:0.15.0"
+  dependencies:
+    "@agoric/internal": "npm:0.4.0"
+    "@agoric/xsnap-lockdown": "npm:0.14.1"
+    "@endo/bundle-source": "npm:^4.1.2"
+    "@endo/errors": "npm:^1.2.13"
+    "@endo/eventual-send": "npm:^1.3.4"
+    "@endo/init": "npm:^1.1.12"
+    "@endo/netstring": "npm:^1.0.18"
+    "@endo/promise-kit": "npm:^1.1.13"
+    "@endo/stream": "npm:^1.2.13"
+    "@endo/stream-node": "npm:^1.1.13"
+    glob: "npm:^7.1.6"
+    tmp: "npm:^0.2.1"
+  bin:
+    ava-xs: ./src/ava-xs.js
+    xsrepl: ./src/xsrepl
+  checksum: 10c0/36284a1857da750d6df08f836423abc4290d7a617e31bc50da90d7d223fa8a83356f1efd2c429e99fb765303151d421e5ade8da0e937560e079f7b48d4e4c831
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
@@ -433,7 +514,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/bundle-source@workspace:^, @endo/bundle-source@workspace:packages/bundle-source":
+"@endo/bundle-source@npm:^4.1.2, @endo/bundle-source@workspace:^, @endo/bundle-source@workspace:packages/bundle-source":
   version: 0.0.0-use.local
   resolution: "@endo/bundle-source@workspace:packages/bundle-source"
   dependencies:
@@ -458,7 +539,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/cache-map@workspace:^, @endo/cache-map@workspace:packages/cache-map":
+"@endo/cache-map@npm:^1.1.0, @endo/cache-map@workspace:^, @endo/cache-map@workspace:packages/cache-map":
   version: 0.0.0-use.local
   resolution: "@endo/cache-map@workspace:packages/cache-map"
   dependencies:
@@ -518,7 +599,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/cjs-module-analyzer@workspace:^, @endo/cjs-module-analyzer@workspace:packages/cjs-module-analyzer":
+"@endo/cjs-module-analyzer@npm:^1.0.11, @endo/cjs-module-analyzer@workspace:^, @endo/cjs-module-analyzer@workspace:packages/cjs-module-analyzer":
   version: 0.0.0-use.local
   resolution: "@endo/cjs-module-analyzer@workspace:packages/cjs-module-analyzer"
   dependencies:
@@ -564,7 +645,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/common@workspace:^, @endo/common@workspace:packages/common":
+"@endo/common@npm:^1.2.13, @endo/common@workspace:^, @endo/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@endo/common@workspace:packages/common"
   dependencies:
@@ -582,6 +663,20 @@ __metadata:
     typescript: "catalog:dev"
   languageName: unknown
   linkType: soft
+
+"@endo/compartment-mapper@npm:^1.6.3":
+  version: 1.6.3
+  resolution: "@endo/compartment-mapper@npm:1.6.3"
+  dependencies:
+    "@endo/cjs-module-analyzer": "npm:^1.0.11"
+    "@endo/module-source": "npm:^1.3.3"
+    "@endo/path-compare": "npm:^1.1.0"
+    "@endo/trampoline": "npm:^1.0.5"
+    "@endo/zip": "npm:^1.0.11"
+    ses: "npm:^1.14.0"
+  checksum: 10c0/869b0f4eb62ab621d8bf0dd62f11e1e3498ab57cf4f5d1ae9a27492155af52746a86cce21ed972c07b4c6785238113400b9df1c82ed4662252fdad171ab56ff7
+  languageName: node
+  linkType: hard
 
 "@endo/compartment-mapper@workspace:^, @endo/compartment-mapper@workspace:packages/compartment-mapper":
   version: 0.0.0-use.local
@@ -615,6 +710,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/daemon@workspace:packages/daemon"
   dependencies:
+    "@agoric/xsnap": "npm:^0.15.0"
     "@endo/base64": "workspace:^"
     "@endo/bundle-source": "workspace:^"
     "@endo/captp": "workspace:^"
@@ -644,7 +740,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/env-options@workspace:^, @endo/env-options@workspace:packages/env-options":
+"@endo/env-options@npm:^1.1.11, @endo/env-options@workspace:^, @endo/env-options@workspace:packages/env-options":
   version: 0.0.0-use.local
   resolution: "@endo/env-options@workspace:packages/env-options"
   dependencies:
@@ -654,7 +750,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/errors@workspace:^, @endo/errors@workspace:packages/errors":
+"@endo/errors@npm:^1.2.13, @endo/errors@workspace:^, @endo/errors@workspace:packages/errors":
   version: 0.0.0-use.local
   resolution: "@endo/errors@workspace:packages/errors"
   dependencies:
@@ -707,7 +803,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/eventual-send@workspace:^, @endo/eventual-send@workspace:packages/eventual-send":
+"@endo/eventual-send@npm:^1.3.4, @endo/eventual-send@workspace:^, @endo/eventual-send@workspace:packages/eventual-send":
   version: 0.0.0-use.local
   resolution: "@endo/eventual-send@workspace:packages/eventual-send"
   dependencies:
@@ -723,7 +819,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/exo@workspace:^, @endo/exo@workspace:packages/exo":
+"@endo/exo@npm:^1.5.12, @endo/exo@workspace:^, @endo/exo@workspace:packages/exo":
   version: 0.0.0-use.local
   resolution: "@endo/exo@workspace:packages/exo"
   dependencies:
@@ -752,7 +848,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/far@workspace:^, @endo/far@workspace:packages/far":
+"@endo/far@npm:^1.0.0, @endo/far@npm:^1.1.14, @endo/far@workspace:^, @endo/far@workspace:packages/far":
   version: 0.0.0-use.local
   resolution: "@endo/far@workspace:packages/far"
   dependencies:
@@ -783,7 +879,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/immutable-arraybuffer@workspace:^, @endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer":
+"@endo/immutable-arraybuffer@npm:^1.1.2, @endo/immutable-arraybuffer@workspace:^, @endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer":
   version: 0.0.0-use.local
   resolution: "@endo/immutable-arraybuffer@workspace:packages/immutable-arraybuffer"
   dependencies:
@@ -817,7 +913,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/init@workspace:^, @endo/init@workspace:packages/init":
+"@endo/init@npm:^1.1.12, @endo/init@workspace:^, @endo/init@workspace:packages/init":
   version: 0.0.0-use.local
   resolution: "@endo/init@workspace:packages/init"
   dependencies:
@@ -858,7 +954,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/marshal@workspace:^, @endo/marshal@workspace:packages/marshal":
+"@endo/marshal@npm:^1.8.0, @endo/marshal@workspace:^, @endo/marshal@workspace:packages/marshal":
   version: 0.0.0-use.local
   resolution: "@endo/marshal@workspace:packages/marshal"
   dependencies:
@@ -901,7 +997,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/module-source@workspace:^, @endo/module-source@workspace:packages/module-source":
+"@endo/module-source@npm:^1.3.3, @endo/module-source@workspace:^, @endo/module-source@workspace:packages/module-source":
   version: 0.0.0-use.local
   resolution: "@endo/module-source@workspace:packages/module-source"
   dependencies:
@@ -920,7 +1016,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/nat@workspace:^, @endo/nat@workspace:packages/nat":
+"@endo/nat@npm:^5.1.3, @endo/nat@workspace:^, @endo/nat@workspace:packages/nat":
   version: 0.0.0-use.local
   resolution: "@endo/nat@workspace:packages/nat"
   dependencies:
@@ -935,7 +1031,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/netstring@workspace:^, @endo/netstring@workspace:packages/netstring":
+"@endo/netstring@npm:^1.0.18, @endo/netstring@workspace:^, @endo/netstring@workspace:packages/netstring":
   version: 0.0.0-use.local
   resolution: "@endo/netstring@workspace:packages/netstring"
   dependencies:
@@ -1002,7 +1098,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/pass-style@workspace:^, @endo/pass-style@workspace:packages/pass-style":
+"@endo/pass-style@npm:^1.6.3, @endo/pass-style@workspace:^, @endo/pass-style@workspace:packages/pass-style":
   version: 0.0.0-use.local
   resolution: "@endo/pass-style@workspace:packages/pass-style"
   dependencies:
@@ -1030,7 +1126,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/path-compare@workspace:^, @endo/path-compare@workspace:packages/path-compare":
+"@endo/path-compare@npm:^1.1.0, @endo/path-compare@workspace:^, @endo/path-compare@workspace:packages/path-compare":
   version: 0.0.0-use.local
   resolution: "@endo/path-compare@workspace:packages/path-compare"
   dependencies:
@@ -1042,7 +1138,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/patterns@workspace:^, @endo/patterns@workspace:packages/patterns":
+"@endo/patterns@npm:^1.7.0, @endo/patterns@workspace:^, @endo/patterns@workspace:packages/patterns":
   version: 0.0.0-use.local
   resolution: "@endo/patterns@workspace:packages/patterns"
   dependencies:
@@ -1070,7 +1166,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/promise-kit@workspace:^, @endo/promise-kit@workspace:packages/promise-kit":
+"@endo/promise-kit@npm:^1.1.13, @endo/promise-kit@workspace:^, @endo/promise-kit@workspace:packages/promise-kit":
   version: 0.0.0-use.local
   resolution: "@endo/promise-kit@workspace:packages/promise-kit"
   dependencies:
@@ -1114,7 +1210,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/stream-node@workspace:^, @endo/stream-node@workspace:packages/stream-node":
+"@endo/stream-node@npm:^1.1.13, @endo/stream-node@workspace:^, @endo/stream-node@workspace:packages/stream-node":
   version: 0.0.0-use.local
   resolution: "@endo/stream-node@workspace:packages/stream-node"
   dependencies:
@@ -1142,7 +1238,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/stream@workspace:^, @endo/stream@workspace:packages/stream":
+"@endo/stream@npm:^1.2.13, @endo/stream@workspace:^, @endo/stream@workspace:packages/stream":
   version: 0.0.0-use.local
   resolution: "@endo/stream@workspace:packages/stream"
   dependencies:
@@ -1171,7 +1267,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/trampoline@workspace:^, @endo/trampoline@workspace:packages/trampoline":
+"@endo/trampoline@npm:^1.0.5, @endo/trampoline@workspace:^, @endo/trampoline@workspace:packages/trampoline":
   version: 0.0.0-use.local
   resolution: "@endo/trampoline@workspace:packages/trampoline"
   dependencies:
@@ -1194,7 +1290,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/zip@workspace:^, @endo/zip@workspace:packages/zip":
+"@endo/zip@npm:^1.0.11, @endo/zip@workspace:^, @endo/zip@workspace:packages/zip":
   version: 0.0.0-use.local
   resolution: "@endo/zip@workspace:packages/zip"
   dependencies:
@@ -3052,6 +3148,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
+  languageName: node
+  linkType: hard
+
+"anylogger@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "anylogger@npm:0.21.0"
+  checksum: 10c0/1ca7fcf5bc2b78d1e1d9b8c8cc7ce50b5c6cc67a8da5a28c9c975b7b46fff255a04abab02de38a5139190c9d8b34b3d6c59af6724521b077f7d7dfbad9b47a9c
   languageName: node
   linkType: hard
 
@@ -7317,6 +7420,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jessie.js@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "jessie.js@npm:0.3.4"
+  dependencies:
+    "@endo/far": "npm:^1.0.0"
+  checksum: 10c0/853ab3f8a0e30df11742882f5e11479d1303033a5a203a247d8ffbf4c6f3f3d4bcbefa53084ae4632e6ab106e348f23dc988280486cbeaaf5d16487fa3d40e96
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:>=29.4.3 < 30, jest-diff@npm:^29.0.3, jest-diff@npm:^29.4.1":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
@@ -10346,6 +10458,17 @@ __metadata:
   version: 0.18.3
   resolution: "ses@npm:0.18.3"
   checksum: 10c0/c07df71cf297f31e862efbc2cc46ee724e85f73cc67002b9b4fa47089fc89d147a56e579b8012fb1534419c77afafbb98bc5808fae82096951479d0bd6dfb377
+  languageName: node
+  linkType: hard
+
+"ses@npm:^1.14.0":
+  version: 1.15.0
+  resolution: "ses@npm:1.15.0"
+  dependencies:
+    "@endo/cache-map": "npm:^1.1.0"
+    "@endo/env-options": "npm:^1.1.11"
+    "@endo/immutable-arraybuffer": "npm:^1.1.2"
+  checksum: 10c0/1fd8661905acbd61006a8528f3c7e1d8839e645eae2148eace99df2421c18947c2f470de7fde7b27764aca1b297c429dc92688770a5c146ecfa14c81cc76a9da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs: durability-boundary research task

## Description

This PR removes the `xsnap-ref` facade path, focuses boundary coverage on `xsnapEvaluate`, evaluates xsnap formulas in a `Compartment` with formula endowments, and adds an explicit **known-failing exploration** for a promised-reference durability edge.

## What changed

### 1) Removed `xsnap-ref` and `makeXsnapRef` end-to-end

- deleted `makeXsnapRef` host API and wiring
- deleted `formulateXsnapRef` and runtime maker support in daemon core
- removed `xsnap-ref` formula type and related TS types/runtime value mappings
- removed formula-type tests that validated `xsnap-ref`

### 2) Focused `xsnapEvaluate` cross-boundary restart coverage

In `packages/daemon/test/xsnap-boundary-exploration.test.js`:

- `non-xsnap callers can invoke xsnapEvaluate values across restart`
- `xsnapEvaluate callers can invoke non-xsnap values across restart`

Per review feedback, removed unrelated/redundant exploration tests and removed unnecessary explicit `provideXsnapWorker(...)` after restart in these scenarios.

### 3) Evaluate in Compartment with formula endowments

In `packages/daemon/src/daemon-node-powers.js` xs runtime command handler:

- `evaluate` builds `formulaEndowments` from `(names, values)`
- evaluates source with compartment-scoped globals:
  - `new Compartment()` then `Object.assign(compartment.globalThis, { ...baseEndowments, $id, ...formulaEndowments })`
  - `compartment.evaluate(source)`
- no longer writes formula endowment names onto ambient `globalThis`

Formula-value durability behavior remains map-based by formula id (`formulas` map).

### 4) Added regression test for endowment leakage

- `xsnapEvaluate uses compartment endowments without global name leakage`
- verifies one formula can use an endowment name (`counter`) while a separate formula in the same worker does not see that name unless explicitly endowed.

### 5) Added exploratory known-failing durability-regime test

- `xsnapEvaluate stores promised counter reference across restart (exploration)` (marked with `test.failing`)

Scenario:
- plain worker provides `factory.makeCounter()` (async) returning a counter remotable
- xsnap formula stores that promised counter reference in closure state
- call once, restart, then attempt to keep using the stored reference

Current observed behavior:
- failure happens **before restart target assertion** (first call result shape is unexpected), indicating this path is not yet supported cleanly.
- test is intentionally marked failing to track the gap while keeping CI green.

## Validation

Executed in `packages/daemon`:

- `yarn lint`
- `yarn ava test/xsnap-boundary-exploration.test.js`
- `yarn test`

All pass (with the single expected failing exploration test).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8724e399-bfc0-4906-9505-05403946b66f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8724e399-bfc0-4906-9505-05403946b66f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

