### PR TITLE
chore(ses): suppress TS2323 on top-level process.exitCode write

### DIFF
--- a/packages/ses/test/_console-error-trap/exit-code-lockdown.js
+++ b/packages/ses/test/_console-error-trap/exit-code-lockdown.js
@@ -1,3 +1,4 @@
 /* global process */
+// @ts-ignore Yes, we can assign to exitCode, typedoc.
 process.exitCode = 127;
 lockdown({ errorTrapping: 'exit' });


### PR DESCRIPTION
## Summary

Adds a `// @ts-ignore` annotation to the top-level `process.exitCode = 127` write in `packages/ses/test/_console-error-trap/exit-code-lockdown.js`, matching the existing convention in `packages/daemon/src/{worker,daemon}-node.js`.

This is a defensive fix that prevents `TS2323: Cannot redeclare exported variable 'exitCode'` from firing once `@types/ws` enters the program (e.g. via the OCapN WebSocket netlayer in PR #TODO).

## Root cause (for reviewers)

TypeScript's binder applies a CommonJS-style "expando" detection (`getAssignmentDeclarationKindWorker` returning `AssignmentDeclarationKind.Property`) to every top-level `Identifier.Property = expr` in `.js` files when `allowJs/checkJs` is enabled, regardless of the file's ESM classification. Each such write becomes a synthetic declaration in `file.jsGlobalAugmentations`, which `mergeSymbolTable(globals, file.jsGlobalAugmentations)` later folds into the global `process` symbol declared by `@types/node`.

When the program contains more than one top-level `process.exitCode = N;` write (and `@types/node`'s ambient `process` module is in scope), `checkExternalModuleExports` sees multiple non-interface declarations of the `exitCode` member of the `"process"` module and emits TS2323. We currently have three such top-level writes:

- `packages/daemon/src/worker-node.js` (already `@ts-ignore`d)
- `packages/daemon/src/daemon-node.js` (already `@ts-ignore`d)
- `packages/ses/test/_console-error-trap/exit-code-lockdown.js` (this PR)

Verified by removing any two of the three top-level writes locally — TS2323 disappears in each case.

## Test plan

- [x] `yarn lint` in `packages/ses` introduces no new TypeScript errors (the pre-existing `TS2304: Cannot find name 'ModuleSource'` errors in `module-source.test.js` are unrelated).
- [x] `// @ts-ignore` (rather than `// @ts-expect-error`) is used because `typedoc` runs the file through multiple compiler passes; in passes that don't include `@types/ws`, TS2323 doesn't fire and `@ts-expect-error` would itself trigger TS2578.

Made with [Cursor](https://cursor.com)