### PR TITLE
ocapn: guile spritely interop test + goblin-chat tui client

### DIFF
--- a/.changeset/ocapn-websocket-netlayer.md
+++ b/.changeset/ocapn-websocket-netlayer.md
@@ -1,0 +1,9 @@
+---
+'@endo/ocapn': minor
+---
+
+- Add a WebSocket netlayer exported as `@endo/ocapn/netlayer/ws` (`makeWebSocketNetLayer`). Used for interop with Guile-Goblins peers and for any other transport that prefers a framed WebSocket over the raw TCP test netlayer.
+- Add `@endo/ocapn/netlayer/tcp-testing` to the package's `exports` map so consumers can import the existing test netlayer without reaching into `src/`.
+- The main entry (`@endo/ocapn`) now re-exports `makeClient` and the swissnum helpers `swissnumFromBytes` / `swissnumToBytes` so consumers don't need a deep `src/client/...` import for the common case.
+- `makeClient` accepts a new `logger` option; when omitted the existing console-based logger is used, so this is backwards-compatible.
+- The CapTP version-mismatch log on `start-session` now includes both the received and expected version strings.

--- a/.github/workflows/ocapn-guile-interop.yml
+++ b/.github/workflows/ocapn-guile-interop.yml
@@ -1,0 +1,191 @@
+name: OCapN Guile interop
+
+# Mirrors the `test-ocapn-python` job in ci.yml but drives Endo `@endo/ocapn`
+# as a client joining a Goblins (Guile)-hosted chatroom over the websocket netlayer.
+#
+# This currently targets Spritely git repos directly (both goblins + goblin-chat),
+# pinned by commit. The flow asserts full Guile-hosted/Endo-joined interoperability:
+# sturdyref publication, websocket session establishment, and bilateral message exchange.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/ocapn/**'
+      - 'packages/goblin-chat/**'
+      - '.github/workflows/ocapn-guile-interop.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-ocapn-guile-interop:
+    name: test-ocapn-guile-interop
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout Endo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: endo
+
+      - name: Clone Spritely Goblins + goblin-chat from Codeberg
+        run: |
+          # Both repos are hosted on Codeberg. We pin to explicit commits so CI
+          # stays deterministic while still tracking git repositories directly.
+          GOBLINS_COMMIT=d42d3a4ff560ecd2a1ac8ef0e44e52ad9e20bdb6
+          GOBLIN_CHAT_COMMIT=fd0b3fcec186e54f978fb24b23bb46a65ae2e0a7
+          git clone https://codeberg.org/spritely/goblins goblins
+          git -C goblins checkout --detach "$GOBLINS_COMMIT"
+          git clone https://codeberg.org/spritely/goblin-chat goblin-chat
+          git -C goblin-chat checkout --detach "$GOBLIN_CHAT_COMMIT"
+          echo "GOBLINS_COMMIT=$GOBLINS_COMMIT" >> "$GITHUB_ENV"
+          echo "GOBLIN_CHAT_COMMIT=$GOBLIN_CHAT_COMMIT" >> "$GITHUB_ENV"
+
+      - run: corepack enable
+        working-directory: endo
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: 20.x
+          cache: yarn
+          cache-dependency-path: endo/yarn.lock
+
+      - name: Install Node dependencies
+        working-directory: endo
+        run: yarn install --immutable
+
+      - name: Build Endo
+        working-directory: endo
+        run: yarn build
+
+      - name: Install GNU Guix
+        uses: PromyLOPh/guix-install-action@40615e98e5c16a451aec10fe01c214ed07cbaa77 # v1
+        with:
+          # Skip `guix pull`: the default action behavior updates channels to
+          # bleeding edge and costs most of the runtime in this workflow.
+          pullAfterInstall: false
+
+      - name: Report Guix version
+        run: guix describe || guix --version
+
+      - name: Resolve Guix module paths
+        run: |
+          # We shell into Guix for execution, but also pass explicit -L paths so
+          # module resolution is deterministic in pure environments.
+          echo "FIBERS_OUT=$(guix build guile-fibers | tail -n 1)" >> "$GITHUB_ENV"
+          echo "WEBSOCKET_OUT=$(guix build guile-websocket | tail -n 1)" >> "$GITHUB_ENV"
+          echo "GNUTLS_OUT=$(guix build guile-gnutls | tail -n 1)" >> "$GITHUB_ENV"
+          echo "GCRYPT_OUT=$(guix build guile-gcrypt | tail -n 1)" >> "$GITHUB_ENV"
+
+      - name: Start Guile goblin-chat host
+        working-directory: endo
+        env:
+          INTEROP_CLIENT: ${{ github.workspace }}/endo/packages/goblin-chat/test/guile-interop/interop-client.scm
+          GOBLINS_REPO: ${{ github.workspace }}/goblins
+          GOBLIN_CHAT_REPO: ${{ github.workspace }}/goblin-chat
+        run: |
+          # Generate module expected by latest goblins source checkout.
+          DOT_PATH="$(command -v dot || echo dot)"
+          sed "s|@DOT@|$DOT_PATH|g" \
+            "$GOBLINS_REPO/goblins/config.scm.in" \
+            > "$GOBLINS_REPO/goblins/config.scm"
+
+          # Runtime compatibility shim while goblin-chat imports the legacy
+          # module path `(goblins ghash)`. Goblins moved the module to
+          # `(goblins utils ghash)` in v0.16.0 (commit 5587721, 2025-04-30)
+          # but goblin-chat has not yet been updated. Drop this once the
+          # upstream fix lands: https://codeberg.org/spritely/goblin-chat/pulls/17
+          sed -i 's/(goblins ghash)/(goblins utils ghash)/' \
+            "$GOBLIN_CHAT_REPO/goblin-chat/backend.scm"
+
+          # Use a non-default port to reduce cross-job collisions.
+          OCAPN_TEST_PORT=26804
+
+          # Goblins from raw git source has exhibited interpreter-only failures
+          # with auto-compile disabled; allow Guile to compile modules first.
+          OCAPN_TEST_PORT="$OCAPN_TEST_PORT" GUILE_AUTO_COMPILE=1 \
+            timeout 300s guix shell --pure --no-grafts \
+            --preserve='^OCAPN_TEST_PORT$|^GUILE_AUTO_COMPILE$' \
+            guile guile-fibers guile-websocket guile-gnutls guile-gcrypt -- \
+            guile \
+              -L "$FIBERS_OUT/share/guile/site/3.0" \
+              -L "$WEBSOCKET_OUT/share/guile/site/3.0" \
+              -L "$GNUTLS_OUT/share/guile/site/3.0" \
+              -L "$GCRYPT_OUT/share/guile/site/3.0" \
+              -L "$GOBLINS_REPO" \
+              -L "$GOBLIN_CHAT_REPO" \
+              "$INTEROP_CLIENT" \
+              "hello from Guile CI" "hello from Endo OCapN" \
+              > /tmp/guile-interop.log 2>&1 &
+          echo $! > /tmp/guile-interop.pid
+          # Wait for the Guile host to advertise its sturdyref.
+          for i in $(seq 1 120); do
+            if grep -q 'sturdyref:' /tmp/guile-interop.log; then break; fi
+            if ! kill -0 "$(cat /tmp/guile-interop.pid)" 2>/dev/null; then break; fi
+            sleep 1
+          done
+          cat /tmp/guile-interop.log
+          STURDYREF=$(sed -n 's/.*sturdyref: \(ocapn:[^ ]*\).*/\1/p' /tmp/guile-interop.log | head -n1)
+          if [ -z "$STURDYREF" ]; then
+            echo "Failed to read sturdyref from Guile host log"
+            exit 1
+          fi
+          echo "STURDYREF=$STURDYREF" >> $GITHUB_ENV
+
+      - name: Run Endo interop client
+        working-directory: endo
+        env:
+          # Newer Goblins reports CapTP version `1.0`.
+          OCAPN_CAPTP_VERSION: '1.0'
+          OCAPN_INTEROP_GUILE_MESSAGE: hello from Guile CI
+          OCAPN_INTEROP_ENDO_MESSAGE: hello from Endo OCapN
+          # Endo only needs an outbound websocket client in this flow, so bind
+          # its local netlayer listener to an ephemeral port.
+          OCAPN_TEST_PORT: '0'
+        run: |
+          set +e
+          timeout 120s node ./packages/goblin-chat/test/guile-interop/index.js "$STURDYREF" \
+            > /tmp/endo-interop.log 2>&1
+          ENDO_EXIT=$?
+          set -e
+          echo "ENDO_EXIT=$ENDO_EXIT" >> "$GITHUB_ENV"
+          cat /tmp/endo-interop.log
+
+      - name: Assert interop success
+        run: |
+          test "${ENDO_EXIT:-1}" -eq 0
+          # Verify Guile host started and published a sturdyref.
+          grep -q 'sturdyref: ocapn:' /tmp/guile-interop.log
+          grep -q 'interop-client: subscription ready' /tmp/guile-interop.log
+          grep -q 'interop-client: sent message, ack' /tmp/guile-interop.log
+          # The Endo participant logs status via the shared
+          # `runChatParticipant` driver in @endo/goblin-chat, which prefixes
+          # each line with the participant name (`endo-interop-ocapn`). Use
+          # fixed-string matching so the brackets stay literal.
+          grep -Fq '*** [endo-interop-ocapn] subscription ready' /tmp/endo-interop.log
+          grep -Fq '*** [endo-interop-ocapn] sent message, ack =' /tmp/endo-interop.log
+          grep -Fq '*** [endo-interop-ocapn] interop observer received message: hello from Guile CI' /tmp/endo-interop.log
+          grep -Fq '*** [endo-interop-ocapn] interop observer received message: hello from Endo OCapN' /tmp/endo-interop.log
+          grep -Fq '*** Endo interop completed' /tmp/endo-interop.log
+
+      - name: Show interop logs on failure
+        if: failure()
+        run: |
+          echo "=== Guile goblin-chat host log ==="
+          cat /tmp/guile-interop.log || echo "(no log)"
+          echo "=== Endo interop client log ==="
+          cat /tmp/endo-interop.log || echo "(no log)"
+
+      - name: Stop Guile host (always)
+        if: always()
+        run: |
+          if [ -f /tmp/guile-interop.pid ]; then
+            kill $(cat /tmp/guile-interop.pid) || true
+          fi

--- a/packages/goblin-chat/LICENSE
+++ b/packages/goblin-chat/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/goblin-chat/README.md
+++ b/packages/goblin-chat/README.md
@@ -1,0 +1,257 @@
+# @endo/goblin-chat
+
+OCapN chat protocol implementation and an [Ink](https://github.com/vadimdemedes/ink)-based
+TUI client. Interoperable with Spritely's [`(goblin-chat backend)`](https://codeberg.org/spritely/goblin-chat/) — see the bit-for-bit notes in
+[`src/backend.js`](./src/backend.js).
+
+The package ships:
+
+- **Chat protocol** — `^chatroom`, `^user`, `^user-controller`,
+  `^user-inbox`, `^user-messaging-channel`, `^authenticated-channel`.
+  A direct port of the Guile reference implementation, suitable for
+  hosting a chatroom from JS or for talking to a Goblins-hosted one.
+- **TUI client** — a full-screen Ink app with a main menu (join new /
+  host new / join previous / set name), persistent settings, an
+  optional diagnostic log panel, and per-session log file. The
+  "Host a new chat" entry stands up an in-process chatroom on a
+  loopback websocket and copies the freshly minted sturdyref URI to
+  the system clipboard so it can be pasted to a peer.
+
+## Quickstart — connect to a chatroom
+
+```bash
+node ./packages/goblin-chat
+```
+
+(or `node ./packages/goblin-chat/index.js`, or
+`yarn workspace @endo/goblin-chat start`, or just `goblin-chat` if the
+package is installed and on `PATH` via its `bin` entry).
+
+The TUI takes over the terminal (alt screen) and opens on the main
+menu. Keys:
+
+| Key            | Effect                                                        |
+| -------------- | ------------------------------------------------------------- |
+| `↑` `↓`        | Move the menu / list cursor                                   |
+| `Enter`        | Activate the highlighted item / submit the current input      |
+| `1`–`5`        | Quick-pick the corresponding menu item                        |
+| `Esc`          | Cancel name / URI / room-name input and return to the menu    |
+| `d`            | (Recent-list) delete the highlighted entry                    |
+| `Ctrl+L`       | Toggle the diagnostic log panel (hidden by default)           |
+| `Ctrl+C`       | From chat: leave the room. From menu: quit.                   |
+
+Pasting a sturdyref URI works in the URI input phase — most terminals
+emit the whole pasted blob as a single keystroke event, including the
+trailing newline, which the TUI treats as `Enter`.
+
+## Hosting your own chat
+
+Pick **Host a new chat** from the main menu, type a chatroom name, and
+the TUI will:
+
+1. Stand up a fresh `^chatroom` Far in a separate OCapN client.
+2. Bind a websocket netlayer to a random port on `127.0.0.1`.
+3. Build a sturdyref URI of the form
+   `ocapn://<designator>.websocket/s/<base64url>?url=ws://127.0.0.1:<port>`
+4. Copy that URI to the system clipboard (via `pbcopy` on macOS,
+   `clip` on Windows, or `wl-copy`/`xclip`/`xsel` on Linux/BSD — the
+   first one that runs wins; absence is non-fatal).
+5. Auto-join you to your own chatroom over the loopback websocket so
+   you're sitting in the room ready to receive participants.
+
+The URI is also rendered into the chat events stream as an `info`
+event, so you can read it without leaving the TUI even if the
+clipboard write failed.
+
+A few caveats:
+
+- The URI is single-use: closing the TUI tears down the websocket
+  server, and the next session generates a fresh ephemeral port and
+  swissnum. Hosted joins are deliberately *not* added to the
+  persistent recent-rooms list for that reason.
+- The default `127.0.0.1:<random-port>` bind is reachable only from
+  this machine. To share off-host, see "Hosting publicly" below.
+- The host stays alive even after you `Ctrl+C` out of the chat back
+  to the menu — only quitting the TUI shuts it down.
+
+### Hosting publicly
+
+When deploying as a server (or on a LAN box you want peers to dial
+into), point the websocket netlayer at a real interface and tell it
+the URL to advertise:
+
+| Variable                  | Default            | Effect                                                                                                                                                              |
+| ------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GOBLIN_CHAT_HOST_BIND`   | `127.0.0.1`        | Network interface the websocket server listens on. Set to `0.0.0.0` (or a specific NIC IP) to accept off-host connections.                                          |
+| `GOBLIN_CHAT_HOST_PORT`   | `0` (ephemeral)    | TCP port the websocket server listens on. Pin to a stable number when running behind a firewall / port-forward so the URI doesn't change between restarts.          |
+| `GOBLIN_CHAT_HOST_URL`    | `ws://<bind>:<port>` | URL announced to peers in the sturdyref's `hints.url`. Override when the externally reachable URL differs from the bind address — e.g. behind a TLS-terminating reverse proxy (`wss://chat.example.com`), or when the public hostname/port differs from the bind. |
+
+Typical deployment shapes:
+
+- **Bare public IP**, no proxy:
+
+  ```bash
+  GOBLIN_CHAT_HOST_BIND=0.0.0.0 \
+  GOBLIN_CHAT_HOST_PORT=9000 \
+  GOBLIN_CHAT_HOST_URL=ws://chat.example.com:9000 \
+    goblin-chat
+  ```
+
+- **Behind an nginx/Caddy reverse proxy with TLS termination**:
+
+  ```bash
+  GOBLIN_CHAT_HOST_BIND=127.0.0.1 \
+  GOBLIN_CHAT_HOST_PORT=9000 \
+  GOBLIN_CHAT_HOST_URL=wss://chat.example.com \
+    goblin-chat
+  ```
+
+  The proxy forwards `wss://chat.example.com` → `ws://127.0.0.1:9000`.
+
+The host's designator (the long base32 string before `.websocket` in
+the URI) is generated fresh each time the netlayer starts and is part
+of the OCapN peer-auth handshake; nothing you set in env can pin it.
+The swissnum (the `/s/<…>` segment) is likewise re-generated on every
+"Host a new chat", so each chatroom hosted within a session gets its
+own unguessable URI even if the netlayer's bind/URL is fixed.
+
+## Persistent state
+
+Settings persist between sessions in a small JSON file:
+
+- `$XDG_CONFIG_HOME/goblin-chat/state.json` — when `XDG_CONFIG_HOME`
+  is set (Linux/macOS users with explicit XDG configuration).
+- `$APPDATA/goblin-chat/state.json` — Windows.
+- `$HOME/.config/goblin-chat/state.json` — POSIX fallback.
+
+The file stores:
+
+```json
+{
+  "name": "your-display-name",
+  "recentRooms": [
+    {
+      "uri": "ocapn://….websocket/s/<base64url>?url=ws://….",
+      "displayName": "general",
+      "lastJoinedAt": "2026-04-20T12:34:56.789Z"
+    }
+  ]
+}
+```
+
+The list is bounded at 32 entries and writes are atomic
+(`<file>.tmp` → `rename`). Override the path with
+`GOBLIN_CHAT_STATE_FILE=/some/other/path.json` for tests or to keep
+multiple personas separate.
+
+## Diagnostic logs
+
+The log panel is **hidden by default** so the chat view stays
+uncluttered. Toggle it on with `Ctrl+L`. It collects:
+
+- the OCapN client's `log`/`info`/`error` lines (handshake, session
+  setup, connection close);
+- the active netlayer's lines (websocket connect/disconnect, framing);
+- TUI diagnostic lines (URI parse details, name-lookup failures,
+  in-flight join errors).
+
+These never go to the chat events stream — `parsed sturdyref URI: …`
+and `failed to resolve user name: Connection closed during handshake.`
+specifically belong here, not in the conversation log.
+
+A per-session log file is also written to the current working
+directory: `goblin-chat-YYYYMMDD-HHMMSS.log`. Override with
+`GOBLIN_CHAT_LOG_FILE=/some/path.log`; pass an empty string to disable
+file logging entirely.
+
+## Environment knobs
+
+| Variable                  | Default              | Effect                                                                       |
+| ------------------------- | -------------------- | ---------------------------------------------------------------------------- |
+| `GOBLIN_CHAT_NAME`        | `goblin-chatter`     | Initial display name (overridden by stored).                                 |
+| `OCAPN_CAPTP_VERSION`     | `1.0`                | Handshake CapTP version.                                                     |
+| `GOBLIN_CHAT_STATE_FILE`  | platform default     | Path to the persisted state JSON.                                            |
+| `GOBLIN_CHAT_LOG_FILE`    | auto-named in CWD    | Path to per-session log; `''` disables.                                      |
+| `GOBLIN_CHAT_HOST_BIND`   | `127.0.0.1`          | Hosted-chat websocket bind interface; set to `0.0.0.0` to listen publicly.   |
+| `GOBLIN_CHAT_HOST_PORT`   | `0` (ephemeral)      | Hosted-chat websocket bind port; pin for stable, firewall-friendly URIs.     |
+| `GOBLIN_CHAT_HOST_URL`    | `ws://<bind>:<port>` | URL announced in `hints.url`; override behind a TLS-terminating proxy/NAT.   |
+
+See ["Hosting publicly"](#hosting-publicly) below for full details on
+the host-side variables.
+
+## Programmatic surface
+
+```js
+import { makeChatroom, makeUserControllerPair, parseLocator } from '@endo/goblin-chat';
+```
+
+The same protocol pieces back the [Guile interop
+harness](./test/guile-interop/) which connects an Endo client to a
+Guile-hosted chatroom, alongside the all-JS
+[`test/interop-self.test.js`](./test/interop-self.test.js).
+
+Lower-level subpaths are also available for consumers that need them
+directly:
+
+- `@endo/goblin-chat/backend` — the protocol port (`makeChatroom`,
+  `makeUserControllerPair`).
+- `@endo/goblin-chat/uri-parse` — the OCapN URI parser.
+- `@endo/goblin-chat/chat-state` — the pure reducer + typedefs.
+- `@endo/goblin-chat/use-goblin-chat` — the React hook (requires
+  `react`).
+- `@endo/goblin-chat/state-store` — the JSON persistence helper.
+
+## Module map
+
+```
+index.js                     runnable TUI entry (loads @endo/init, then renders)
+api.js                       package main: pure re-exports (no side effects)
+bin/
+  goblin-chat.js             tiny shebang shim that imports ../index.js
+src/
+  backend.js                 ^chatroom / ^user / ^user-controller / ...
+  uri-parse.js               ocapn:// URI parser
+  chat-state.js              reducer, typedefs, pure helpers
+  use-goblin-chat.js         React hook: OCapN session orchestration
+  state-store.js             on-disk persistence (name + recent rooms)
+  host-room.js               stand up a chatroom + websocket + sturdyref URI
+  clipboard.js               best-effort pbcopy/clip/wl-copy/xclip/xsel writer
+```
+
+`index.js` deliberately includes `import '@endo/init';` — that
+transitively performs SES lockdown, which `@endo/eventual-send` and
+`@endo/marshal` need at module evaluation time. The library entry
+`api.js` does *not* lock down on import, so embedders that already
+manage their own SES initialisation can `import { ... } from
+'@endo/goblin-chat'` without surprise side effects.
+
+## Bit-for-bit interop
+
+The chat backend mirrors quirks (and outright bugs) in the upstream
+Guile implementation deliberately, so that a Goblins peer talking to
+us, or vice versa, sees identical semantics. The notable ones, all
+called out with `Bit-for-bit with Guile` / `Bug-for-bug with upstream`
+comments in `src/backend.js`:
+
+- `^user-messaging-channel.leave` `bcom`s the actor into a behaviour
+  that returns `'CONNECTION-CLOSED'` for any further selector
+  invocation.
+- `^user-messaging-channel.list-users` resolves to unspecified —
+  upstream uses `ghash-for-each` with a TODO comment about adding a
+  `'keys` method.
+- The `^unsubscribe` thunk handed back from `subscribe` reaches for
+  an `'unsubscribe` selector that the controller-only methods table
+  doesn't define, so calling it errors.
+- `^finalize-subscription` backfill iterates over the subscribers
+  *after* inserting the new user, so the joiner sees a
+  `user-joined(self)` echo as the last item of the backfill.
+
+The TUI's observer absorbs the self-echoes transparently.
+
+## See also
+
+- [`packages/ocapn`](../ocapn) — the underlying CapTP / OCapN client +
+  netlayer.
+- [`./test/guile-interop/`](./test/guile-interop) — bilateral interop
+  test against a Guile-hosted chatroom; uses this package's
+  `makeUserControllerPair` and `@endo/ocapn`'s websocket netlayer.

--- a/packages/goblin-chat/SECURITY.md
+++ b/packages/goblin-chat/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+The SES package and associated Endo packages are still undergoing development and security review, and all
+users are encouraged to use the latest version available. Security fixes will
+be made for the most recent branch only.
+
+## Coordinated Vulnerability Disclosure of Security Bugs
+
+SES stands for fearless cooperation, and strong security requires strong collaboration with security researchers. If you believe that you have found a security sensitive bug that should not be disclosed until a fix has been made available, we encourage you to report it. To report a bug in HardenedJS, you have several options that include:
+
+* Reporting the issue to the [Agoric HackerOne vulnerability rewards program](https://hackerone.com/agoric).
+
+* Sending an email to security at (@) agoric.com., encrypted or unencrypted. To encrypt, please use  @Warner’s personal GPG key  [A476E2E6 11880C98 5B3C3A39 0386E81B 11CAA07A](http://www.lothar.com/warner-gpg.html)  .
+
+* Sending a message on Keybase to `@agoric_security`, or sharing code and other log files via Keybase’s encrypted file system. ((_keybase_private/agoric_security,$YOURNAME).
+
+* It is important to be able to provide steps that reproduce the issue and demonstrate its impact with a Proof of Concept example in an initial bug report. Before reporting a bug, a reporter may want to have another trusted individual reproduce the issue.
+
+* A bug reporter can expect acknowledgment of a potential vulnerability reported through  [security@agoric.com](mailto:security@agoric.com)  within one business day of submitting a report. If an acknowledgement of an issue is not received within this time frame, especially during a weekend or holiday period, please reach out again. Any issues reported to the HackerOne program will be acknowledged within the time frames posted on the program page.
+	* The bug triage team and Agoric code maintainers are primarily located in the San Francisco Bay Area with business hours in  [Pacific Time](https://www.timeanddate.com/worldclock/usa/san-francisco) .
+
+* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public Github issues during the coordination process.
+
+* Once a vulnerability report has been received and triaged:
+	* Agoric code maintainers will confirm whether it is valid, and will provide updates to the reporter on validity of the report.
+	* It may take up to 72 hours for an issue to be validated, especially if reported during holidays or on weekends.
+
+* When the Agoric team has verified an issue, remediation steps and patch release timeline information will be shared with the reporter.
+	* Complexity, severity, impact, and likelihood of exploitation are all vital factors that determine the amount of time required to remediate an issue and distribute a software patch.
+	* If an issue is Critical or High Severity, Agoric code maintainers will release a security advisory to notify impacted parties to prepare for an emergency patch.
+	* While the current industry standard for vulnerability coordination resolution is 90 days, Agoric code maintainers will strive to release a patch as quickly as possible.
+
+When a bug patch is included in a software release, the Agoric code maintainers will:
+	* Confirm the version and date of the software release with the reporter.
+	* Provide information about the security issue that the software release resolves.
+	* Credit the bug reporter for discovery by adding thanks in release notes, securing a CVE designation, or adding the researcher’s name to a Hall of Fame.

--- a/packages/goblin-chat/api.js
+++ b/packages/goblin-chat/api.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+/**
+ * `@endo/goblin-chat` — JavaScript port of Spritely's `(goblin-chat
+ * backend)` plus an Ink-based TUI client. The backend is interoperable
+ * with Goblins peers (per the bit-for-bit notes in `src/backend.js`);
+ * the TUI under `bin/goblin-chat.js` connects to a chatroom from a
+ * pasted sturdyref URI.
+ *
+ * This module re-exports the protocol surface so other consumers
+ * (e.g. interop tests, alternative front-ends) can build on top of
+ * the same chat backend without reaching into the package's `src/`
+ * paths directly.
+ */
+
+export { makeChatroom, makeUserControllerPair } from './src/backend.js';
+export { parseLocator } from './src/uri-parse.js';

--- a/packages/goblin-chat/bin/goblin-chat.js
+++ b/packages/goblin-chat/bin/goblin-chat.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// @ts-check
+
+/**
+ * Thin shebang shim. The TUI itself lives in the package's `index.js`
+ * so `node packages/goblin-chat/index.js` works directly; this script
+ * exists only so that the npm `bin` entry can launch it via `PATH`.
+ */
+
+import '../index.js';

--- a/packages/goblin-chat/index.js
+++ b/packages/goblin-chat/index.js
@@ -1,0 +1,1072 @@
+#!/usr/bin/env node
+// @ts-check
+/* eslint-disable import/no-unresolved */
+/* global process */
+
+/**
+ * `@endo/goblin-chat` — Ink-based TUI client for the OCapN chat
+ * protocol. Connects to a chatroom hosted by an Endo OCapN peer or a
+ * Spritely Goblins peer, given a sturdyref URI.
+ *
+ * This file is the **runnable entrypoint**: `node packages/goblin-chat`
+ * (or `node packages/goblin-chat/index.js`, or the `goblin-chat` shim
+ * under `bin/`) launches the TUI. It is *not* the library entrypoint
+ * — programmatic consumers import from `@endo/goblin-chat` (resolves
+ * to `./api.js`, no side effects) or from one of the explicit
+ * subpath exports (e.g. `@endo/goblin-chat/backend`).
+ *
+ * Why split? `@endo/init` performs SES lockdown as a side effect of
+ * being imported, so a module that includes it can't double as a
+ * library export — every library consumer would get lockdown
+ * unconditionally. Keeping lockdown here, in the runnable script,
+ * preserves the choice for embedders.
+ *
+ * Layout (top to bottom):
+ *   - header              room name + phase status
+ *   - main body           varies by phase: menu / inputs / chat scroll
+ *   - log panel           hidden by default; toggle with Ctrl+L
+ *   - input / hints       phase-appropriate input box and key hints
+ *
+ * Persisted state lives at `$XDG_CONFIG_HOME/goblin-chat/state.json`
+ * (or platform default — see `src/state-store.js`). It carries the
+ * user's display name and a most-recent-first list of rooms they've
+ * joined, so subsequent launches surface a "Join previous chat"
+ * picker instead of forcing them to dig the URI out of scrollback.
+ *
+ * No JSX — this file runs directly under Node without a transform.
+ */
+
+import '@endo/init';
+
+import { createWriteStream } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text, render, useApp, useInput, useStdout } from 'ink';
+
+import { lookupName } from './src/chat-state.js';
+import { useGoblinChat, shutdownHandle } from './src/use-goblin-chat.js';
+import { openStateStore } from './src/state-store.js';
+import { AnimatedLogo } from './src/animated-logo.js';
+import { hostRoom, hostRegistry } from './src/host-room.js';
+import { copyToClipboard } from './src/clipboard.js';
+
+/**
+ * @typedef {import('./src/chat-state.js').ChatMessage} ChatMessage
+ * @typedef {import('./src/chat-state.js').SystemEvent} SystemEvent
+ * @typedef {import('./src/chat-state.js').LogEntry}    LogEntry
+ * @typedef {import('./src/chat-state.js').Phase}       Phase
+ * @typedef {import('./src/state-store.js').StateStore} StateStore
+ * @typedef {import('./src/state-store.js').RecentRoom} RecentRoom
+ * @typedef {import('./src/use-goblin-chat.js').LogSink} LogSink
+ */
+
+const h = React.createElement;
+
+const DEFAULT_NAME = process.env.GOBLIN_CHAT_NAME || 'goblin-chatter';
+const DEFAULT_CAPTP_VERSION = process.env.OCAPN_CAPTP_VERSION || '1.0'; // 'goblins-0.16';
+
+// ---------------------------------------------------------------------------
+// Hosting configuration (read from env once, applied to every "Host a
+// new chat" invocation in this session)
+// ---------------------------------------------------------------------------
+//
+// `GOBLIN_CHAT_HOST_BIND` — interface the websocket server listens on.
+//   Default `127.0.0.1` (loopback only) so casual local hosting can't
+//   accidentally expose a chatroom off-host. Set to `0.0.0.0` (or a
+//   specific NIC address) when deploying as a server.
+//
+// `GOBLIN_CHAT_HOST_PORT` — port the websocket server listens on.
+//   Default `0` (ephemeral) so an ad-hoc host doesn't collide with a
+//   neighbour. Set to a stable number when running behind a firewall
+//   or port-forwarding rule so the URI can be re-used across restarts.
+//
+// `GOBLIN_CHAT_HOST_URL` — the URL announced to peers in `hints.url`.
+//   Default `ws://<bind-host>:<bind-port>`. Override when the
+//   externally reachable URL differs from the bind address — e.g.
+//   running behind a reverse proxy that terminates TLS
+//   (`wss://chat.example.com`), or NAT'd to a public IP under a
+//   different port.
+const DEFAULT_HOST_BIND = process.env.GOBLIN_CHAT_HOST_BIND || '127.0.0.1';
+const DEFAULT_HOST_PORT_RAW = process.env.GOBLIN_CHAT_HOST_PORT;
+const DEFAULT_HOST_PORT = (() => {
+  if (!DEFAULT_HOST_PORT_RAW) return 0;
+  const parsed = Number.parseInt(DEFAULT_HOST_PORT_RAW, 10);
+  if (
+    !Number.isInteger(parsed) ||
+    parsed < 0 ||
+    parsed > 65535 ||
+    String(parsed) !== DEFAULT_HOST_PORT_RAW.trim()
+  ) {
+    // Fail loud-but-gentle: print a warning, fall back to ephemeral.
+    // We don't want to refuse to launch over a typo in a deployment
+    // env file.
+    process.stderr.write(
+      `goblin-chat: ignoring invalid GOBLIN_CHAT_HOST_PORT=${JSON.stringify(DEFAULT_HOST_PORT_RAW)}; using ephemeral port\n`,
+    );
+    return 0;
+  }
+  return parsed;
+})();
+const DEFAULT_HOST_PUBLIC_URL = process.env.GOBLIN_CHAT_HOST_URL || undefined;
+
+// Height of the log panel when visible. Hidden by default; toggled
+// with Ctrl+L. Picked to be tall enough to read the most recent few
+// netlayer/client lines without crowding out the main view.
+const LOG_PANEL_ROWS = 8;
+
+// ---------------------------------------------------------------------------
+// Per-session log file
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a filename-safe local timestamp: `YYYYMMDD-HHMMSS`. We avoid
+ * `:` (illegal on Windows / awkward in shells) and the timezone suffix
+ * so the filename stays short and predictable.
+ * @param {Date} d
+ */
+const formatTimestampForFilename = d => {
+  const pad = (/** @type {number} */ n) => String(n).padStart(2, '0');
+  return (
+    `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}` +
+    `-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`
+  );
+};
+
+/**
+ * Open a per-session log file in CWD and return a `LogSink` plus a
+ * `close` function. The sink is non-blocking (write stream) and never
+ * throws — failed writes are swallowed so a full disk or revoked
+ * permission can't take the TUI down. `GOBLIN_CHAT_LOG_FILE`, when set,
+ * overrides the auto-generated path; pass an empty string to disable
+ * file logging entirely.
+ * @param {Date} startedAt
+ * @returns {{ sink: LogSink, close: () => void, filePath: string | undefined }}
+ */
+const openLogFile = startedAt => {
+  const override = process.env.GOBLIN_CHAT_LOG_FILE;
+  if (override === '') {
+    return {
+      sink: () => undefined,
+      close: () => undefined,
+      filePath: undefined,
+    };
+  }
+  const filePath = resolvePath(
+    override ?? `goblin-chat-${formatTimestampForFilename(startedAt)}.log`,
+  );
+  const stream = createWriteStream(filePath, { flags: 'a' });
+  // Swallow stream-level errors (EPIPE on a yanked file, ENOSPC on a
+  // full disk, etc.) so a broken log can never take the TUI down.
+  stream.on('error', () => undefined);
+  // Header so a file appended across multiple runs stays readable.
+  stream.write(
+    `# goblin-chat tui session — started ${startedAt.toISOString()}\n`,
+  );
+  /** @type {LogSink} */
+  const sink = (level, source, text) => {
+    // After Ctrl+C, the websocket's `close` event fires a tick later
+    // and emits one last `info` log via `handleConnectionClose`. By
+    // that point we may have already closed the file (or be about to),
+    // so the write would explode with "write after end". Bail out
+    // silently if the stream is no longer writable — the panel still
+    // shows the line, we just can't archive it.
+    if (!stream.writable || stream.writableEnded) return;
+    const line = `${new Date().toISOString()} ${level.padEnd(5)} [${source}] ${text}\n`;
+    try {
+      stream.write(line);
+    } catch (_) {
+      // belt-and-suspenders: even with the writableEnded guard above
+      // we can race the close event; never let a logging line throw.
+    }
+  };
+  const close = () => {
+    if (stream.writableEnded) return;
+    try {
+      stream.end();
+    } catch (_) {
+      // best-effort
+    }
+  };
+  return { sink, close, filePath };
+};
+
+// ---------------------------------------------------------------------------
+// View-level helpers
+// ---------------------------------------------------------------------------
+
+/** @param {{ message: ChatMessage, userNames: Map<object, string> }} props */
+const MessageLine = ({ message, userNames }) => {
+  const name =
+    message.sender.kind === 'self'
+      ? message.sender.name
+      : lookupName(userNames, message.sender.user);
+  return h(
+    Text,
+    {
+      color: message.sender.kind === 'self' ? 'green' : undefined,
+      wrap: 'wrap',
+    },
+    `<${name}> ${message.text}`,
+  );
+};
+
+/** @param {{ event: SystemEvent, userNames: Map<object, string> }} props */
+const EventLine = ({ event, userNames }) => {
+  switch (event.kind) {
+    case 'joined':
+      return h(
+        Text,
+        { color: 'magenta', dimColor: true, wrap: 'wrap' },
+        `* ${lookupName(userNames, event.user)} joined`,
+      );
+    case 'left':
+      return h(
+        Text,
+        { color: 'magenta', dimColor: true, wrap: 'wrap' },
+        `* ${lookupName(userNames, event.user)} left`,
+      );
+    case 'present': {
+      const names = event.users.map(u => lookupName(userNames, u));
+      return h(
+        Text,
+        { color: 'magenta', dimColor: true, wrap: 'wrap' },
+        `present: ${names.join(', ')}`,
+      );
+    }
+    case 'info':
+      return h(Text, { color: 'gray', wrap: 'wrap' }, `· ${event.text}`);
+    case 'error':
+    default:
+      return h(Text, { color: 'red', wrap: 'wrap' }, `! ${event.text}`);
+  }
+};
+
+const LOG_LEVEL_COLORS = /** @type {const} */ ({
+  log: 'white',
+  info: 'gray',
+  error: 'red',
+});
+
+/** @param {{ entry: LogEntry }} props */
+const LogLine = ({ entry }) => {
+  // Collapse to a single line — the panel is height-constrained so a
+  // wrapped multi-line stack would push older entries off-screen quickly.
+  const oneLine = entry.text.replace(/\s+/gu, ' ').trim();
+  return h(
+    Text,
+    { color: LOG_LEVEL_COLORS[entry.level], wrap: 'truncate-end' },
+    `[${entry.source}] ${oneLine}`,
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main menu
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {(
+ *   | 'set-name'
+ *   | 'join-new'
+ *   | 'host-new'
+ *   | 'join-previous'
+ *   | 'quit'
+ * )} MenuItemId
+ */
+
+/** @type {{ id: MenuItemId, label: string }[]} */
+const BASE_MENU_ITEMS = [
+  { id: 'join-new', label: 'Join a new chat' },
+  { id: 'host-new', label: 'Host a new chat' },
+  { id: 'join-previous', label: 'Join a previous chat' },
+  { id: 'set-name', label: 'Set your name' },
+  { id: 'quit', label: 'Quit' },
+];
+
+/**
+ * @param {{
+ *   currentName: string,
+ *   recentRoomCount: number,
+ *   selected: number,
+ * }} props
+ */
+const MainMenu = ({ currentName, recentRoomCount, selected }) =>
+  h(
+    Box,
+    { flexDirection: 'column', paddingY: 1, paddingX: 2 },
+    h(Text, { dimColor: true }, `current name: ${currentName}`),
+    h(Text, null, ' '),
+    ...BASE_MENU_ITEMS.map((item, i) => {
+      const disabled = item.id === 'join-previous' && recentRoomCount === 0;
+      const cursor = i === selected ? '› ' : '  ';
+      const text = disabled ? `${item.label} (none yet)` : item.label;
+      // dimColor for disabled, inverse for selection; never both — a
+      // disabled+selected row should still be visibly the cursor row,
+      // just not invitingly so.
+      return h(
+        Text,
+        {
+          key: item.id,
+          inverse: i === selected,
+          dimColor: disabled,
+        },
+        `${cursor}${text}`,
+      );
+    }),
+  );
+
+// ---------------------------------------------------------------------------
+// Recent-rooms picker
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {{ recentRooms: RecentRoom[], selected: number }} props
+ */
+const RecentRoomsList = ({ recentRooms, selected }) => {
+  if (recentRooms.length === 0) {
+    return h(
+      Box,
+      { paddingY: 1, paddingX: 2 },
+      h(Text, { dimColor: true }, 'No previous chats yet.'),
+    );
+  }
+  return h(
+    Box,
+    { flexDirection: 'column', paddingY: 1, paddingX: 2 },
+    ...recentRooms.map((room, i) => {
+      const cursor = i === selected ? '› ' : '  ';
+      const label = room.displayName
+        ? `${room.displayName} — ${room.uri}`
+        : room.uri;
+      return h(
+        Text,
+        {
+          key: `${room.uri}-${i}`,
+          inverse: i === selected,
+          wrap: 'truncate-end',
+        },
+        `${cursor}${label}`,
+      );
+    }),
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Top-level App
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {{
+ *   logSink?: LogSink,
+ *   logFilePath?: string,
+ *   store: StateStore,
+ *   initialName: string,
+ * }} props
+ */
+const App = ({ logSink, logFilePath, store, initialName }) => {
+  const { exit } = useApp();
+  const { stdout } = useStdout();
+
+  // Snapshot of the persisted store. We re-read it after every
+  // mutation rather than wiring a subscription — mutations are rare
+  // and originate from the UI itself, so a synchronous re-read is
+  // both simpler and avoids stale-closure bugs.
+  const [storedSnap, setStoredSnap] = useState(() => store.read());
+  const refreshStore = () => setStoredSnap(store.read());
+
+  const [name, setName] = useState(initialName);
+  const [input, setInput] = useState('');
+  const [menuSelected, setMenuSelected] = useState(0);
+  const [recentSelected, setRecentSelected] = useState(0);
+  const [showLog, setShowLog] = useState(false);
+
+  // The hook owns OCapN-side state. We hand it an `onJoined` callback
+  // so successful joins push into our persisted recent-rooms list
+  // without the hook having to know what a state-store is.
+  const onJoinedRef = useRef(
+    /** @type {((args: { uri: string, roomName?: string }) => void) | undefined} */ (
+      undefined
+    ),
+  );
+  const { state, joinRoom, sendMessage, leaveRoom, setPhase, addInfo } =
+    useGoblinChat({
+      captpVersion: DEFAULT_CAPTP_VERSION,
+      logSink,
+      onJoined: ({ uri, roomName }) => {
+        // Indirection through a ref so we always see the latest store
+        // reference without re-creating the hook on every render.
+        if (onJoinedRef.current) onJoinedRef.current({ uri, roomName });
+      },
+    });
+
+  useEffect(() => {
+    onJoinedRef.current = ({ uri, roomName }) => {
+      store.recordJoin(uri, roomName);
+      refreshStore();
+    };
+  }, [store]);
+
+  /**
+   * Run the action selected from the main menu.
+   * @param {MenuItemId} id
+   */
+  const activateMenuItem = id => {
+    setInput('');
+    switch (id) {
+      case 'set-name':
+        setInput(name);
+        setPhase('name-input');
+        break;
+      case 'join-new':
+        setPhase('uri-input');
+        break;
+      case 'host-new':
+        setPhase('host-name-input');
+        break;
+      case 'join-previous':
+        if (storedSnap.recentRooms.length === 0) return;
+        setRecentSelected(0);
+        setPhase('recent-list');
+        break;
+      case 'quit':
+        leaveRoom();
+        exit();
+        break;
+      default:
+        break;
+    }
+  };
+
+  /**
+   * Stand up a freshly hosted chatroom on a loopback websocket and
+   * auto-join it as a participant. The URI is copied to the clipboard
+   * (best-effort) and rendered into the chat events stream so the user
+   * can paste it manually if every clipboard provider is missing.
+   * @param {string} roomName
+   */
+  const startHosting = async roomName => {
+    await null;
+    setPhase('connecting');
+    /** @type {{ uri: string, shutdown: () => void } | undefined} */
+    let hosted;
+    try {
+      hosted = await hostRoom({
+        roomName,
+        captpVersion: DEFAULT_CAPTP_VERSION,
+        logSink,
+        bindHostname: DEFAULT_HOST_BIND,
+        bindPort: DEFAULT_HOST_PORT,
+        publicUrl: DEFAULT_HOST_PUBLIC_URL,
+      });
+    } catch (err) {
+      // Hosting itself failed (port bind error, etc.). Bail back to the
+      // menu with a hint in the status line; the log panel carries the
+      // actual exception via the host-client/host-netlayer sources.
+      logSink?.('error', 'tui', `hostRoom failed: ${String(err)}`);
+      setPhase('menu');
+      return;
+    }
+    const { uri } = hosted;
+    // Best-effort clipboard write. Failure is recorded in the log
+    // panel and surfaced inline (so the user knows to copy manually);
+    // it never blocks the join.
+    const clipResult = await copyToClipboard(uri);
+    if (!clipResult.ok) {
+      logSink?.(
+        'error',
+        'tui',
+        `clipboard copy failed: ${String(clipResult.error)}`,
+      );
+    }
+    // `transient: true` keeps the auto-join out of the persistent
+    // recent-rooms list — the URI is single-use (fresh ephemeral port
+    // every session), so saving it would clutter history with stale
+    // entries.
+    await joinRoom({ uri, name, transient: true });
+    // Push a friendly inline notice so the URI is visible in the chat
+    // body without the user having to toggle the diagnostic log panel.
+    const clipNote = clipResult.ok
+      ? 'copied to clipboard'
+      : 'clipboard unavailable — copy manually';
+    addInfo(`Hosting #${roomName} at ${uri} (${clipNote})`);
+  };
+
+  /**
+   * Submit whatever the user just typed for the current input phase.
+   * @param {string} value
+   */
+  const submit = value => {
+    const trimmed = value.trim();
+    setInput('');
+    switch (state.phase) {
+      case 'name-input': {
+        if (trimmed.length > 0) {
+          setName(trimmed);
+          store.setName(trimmed);
+          refreshStore();
+        }
+        setPhase('menu');
+        break;
+      }
+      case 'uri-input': {
+        if (trimmed.length === 0) {
+          setPhase('menu');
+          return;
+        }
+        joinRoom({ uri: trimmed, name });
+        break;
+      }
+      case 'host-name-input': {
+        if (trimmed.length === 0) {
+          setPhase('menu');
+          return;
+        }
+        startHosting(trimmed);
+        break;
+      }
+      case 'chat': {
+        if (trimmed.length === 0) return;
+        sendMessage(trimmed);
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  useInput((rawInput, key) => {
+    // Top-level keys, available in every phase.
+    if (key.ctrl && rawInput === 'c') {
+      // From the menu, Ctrl+C exits. From elsewhere it backs out to
+      // the menu (leaving any active room politely on the way).
+      if (state.phase === 'menu') {
+        leaveRoom();
+        exit();
+        return;
+      }
+      if (state.phase === 'chat') {
+        leaveRoom();
+        return;
+      }
+      setPhase('menu');
+      setInput('');
+      return;
+    }
+    if (key.ctrl && rawInput === 'l') {
+      // Toggle the log panel. Ctrl+L is intentional: in raw mode the
+      // shell's clear-screen meaning doesn't apply, the byte never
+      // collides with regular chat input, and "L" reads as "log".
+      setShowLog(prev => !prev);
+      return;
+    }
+
+    // Per-phase handlers below.
+    switch (state.phase) {
+      case 'menu': {
+        if (key.upArrow) {
+          setMenuSelected(
+            prev =>
+              (prev - 1 + BASE_MENU_ITEMS.length) % BASE_MENU_ITEMS.length,
+          );
+          return;
+        }
+        if (key.downArrow) {
+          setMenuSelected(prev => (prev + 1) % BASE_MENU_ITEMS.length);
+          return;
+        }
+        if (key.return || /** @type {any} */ (key).enter) {
+          activateMenuItem(BASE_MENU_ITEMS[menuSelected].id);
+          return;
+        }
+        // Number-key shortcuts (1-N) for quick access.
+        const idx = Number.parseInt(rawInput, 10);
+        if (!Number.isNaN(idx) && idx >= 1 && idx <= BASE_MENU_ITEMS.length) {
+          activateMenuItem(BASE_MENU_ITEMS[idx - 1].id);
+        }
+        return;
+      }
+
+      case 'recent-list': {
+        const list = storedSnap.recentRooms;
+        if (list.length === 0) {
+          setPhase('menu');
+          return;
+        }
+        if (key.escape) {
+          setPhase('menu');
+          return;
+        }
+        if (key.upArrow) {
+          setRecentSelected(prev => (prev - 1 + list.length) % list.length);
+          return;
+        }
+        if (key.downArrow) {
+          setRecentSelected(prev => (prev + 1) % list.length);
+          return;
+        }
+        if (key.return || /** @type {any} */ (key).enter) {
+          const room = list[recentSelected];
+          if (room) joinRoom({ uri: room.uri, name });
+          return;
+        }
+        if (rawInput === 'd') {
+          // Prune the highlighted room from the persisted list.
+          const room = list[recentSelected];
+          if (room) {
+            store.forgetRoom(room.uri);
+            const next = store.read();
+            setStoredSnap(next);
+            // Clamp the cursor to the new bounds so a delete-from-end
+            // doesn't leave us pointing past the array.
+            if (recentSelected >= next.recentRooms.length) {
+              setRecentSelected(Math.max(0, next.recentRooms.length - 1));
+            }
+          }
+        }
+        return;
+      }
+
+      case 'connecting':
+        // Connecting is non-interactive; only Ctrl+C/Ctrl+L (handled
+        // above) work. A future enhancement might add an Esc-to-cancel
+        // path, but `client.shutdown()` mid-handshake is messy.
+        return;
+
+      case 'name-input':
+      case 'uri-input':
+      case 'host-name-input':
+      case 'chat':
+        // Fall through to the shared text-editor block below.
+        break;
+
+      default:
+        return;
+    }
+
+    // Shared text-editor handling for the input phases above.
+    if (key.escape) {
+      // Esc backs out of name/uri/host inputs; in chat it's a no-op
+      // (use Ctrl+C to leave the room — Esc is too easy to hit by
+      // accident mid-message).
+      if (
+        state.phase === 'name-input' ||
+        state.phase === 'uri-input' ||
+        state.phase === 'host-name-input'
+      ) {
+        setInput('');
+        setPhase('menu');
+      }
+      return;
+    }
+    // Enter: commit. Ink reports it as `key.return` (CR) or `key.enter`
+    // (LF, from PTYs that only forward \n). It can also deliver a
+    // pasted blob ending in \r/\n as a single event with the newline
+    // embedded in `rawInput`, in which case neither key flag is set.
+    const enterPressed = key.return || /** @type {any} */ (key).enter;
+    if (enterPressed || /[\r\n]/u.test(rawInput)) {
+      const buffered = enterPressed
+        ? rawInput
+        : rawInput.replace(/[\r\n].*$/u, '');
+      const cleaned = buffered.replace(/[\r\n]/gu, '');
+      submit(input + cleaned);
+      return;
+    }
+    if (key.backspace || key.delete) {
+      setInput(prev => prev.slice(0, -1));
+      return;
+    }
+    if (key.ctrl || key.meta) {
+      return;
+    }
+    if (
+      rawInput &&
+      !key.upArrow &&
+      !key.downArrow &&
+      !key.leftArrow &&
+      !key.rightArrow
+    ) {
+      setInput(prev => prev + rawInput);
+    }
+  });
+
+  const rows = (stdout && stdout.rows) || 24;
+  const cols = (stdout && stdout.columns) || 80;
+
+  /**
+   * @typedef {(
+   *   | { kind: 'message', entry: ChatMessage }
+   *   | { kind: 'event',   entry: SystemEvent }
+   * )} TimelineItem
+   */
+
+  /** @type {TimelineItem[]} */
+  const timeline = useMemo(() => {
+    /** @type {TimelineItem[]} */
+    const items = [
+      ...state.messages.map(
+        m => /** @type {TimelineItem} */ ({ kind: 'message', entry: m }),
+      ),
+      ...state.events.map(
+        e => /** @type {TimelineItem} */ ({ kind: 'event', entry: e }),
+      ),
+    ];
+    items.sort((a, b) => a.entry.seq - b.entry.seq);
+    return items;
+  }, [state.messages, state.events]);
+
+  // --- header ----------------------------------------------------------
+  const headerLine = (() => {
+    if (state.phase === 'chat' && state.roomName) {
+      return `goblin-chat #${state.roomName} — ${state.status}`;
+    }
+    if (state.phase === 'menu') {
+      return `goblin-chat — ${state.status}`;
+    }
+    return `goblin-chat — ${state.status}`;
+  })();
+
+  // --- footer ----------------------------------------------------------
+  const phaseHints = {
+    menu: '↑/↓ select • Enter activate • 1–5 quick • Ctrl+C quit',
+    'name-input': 'type your name • Enter save • Esc cancel',
+    'uri-input': 'paste an ocapn://… URI • Enter join • Esc cancel',
+    'host-name-input': 'name your chatroom • Enter host • Esc cancel',
+    'recent-list': '↑/↓ select • Enter join • d delete • Esc back',
+    connecting: 'connecting…  • Ctrl+C cancel',
+    chat: 'Enter send • Ctrl+C leave room',
+  };
+  const baseHint = phaseHints[state.phase] ?? '';
+  const logHint = `Ctrl+L ${showLog ? 'hide' : 'show'} log`;
+  const footerLeft = `${baseHint}  •  ${logHint}`;
+
+  // --- input box -------------------------------------------------------
+  const inputBox = (() => {
+    /** @type {string} */
+    let prompt = '';
+    /** @type {string} */
+    const value = input;
+    if (state.phase === 'name-input') {
+      prompt = 'name> ';
+    } else if (state.phase === 'uri-input') {
+      prompt = 'sturdyref> ';
+    } else if (state.phase === 'host-name-input') {
+      prompt = 'room name> ';
+    } else if (state.phase === 'chat') {
+      prompt = `${name}> `;
+    } else {
+      // No editable input in menu / recent-list / connecting phases.
+      return undefined;
+    }
+    return h(
+      Box,
+      { borderStyle: 'single', borderColor: 'gray', paddingX: 1 },
+      h(
+        Text,
+        null,
+        h(Text, { color: 'yellow' }, prompt),
+        h(Text, null, value),
+        h(Text, { inverse: true }, ' '),
+      ),
+    );
+  })();
+
+  // --- main body -------------------------------------------------------
+  // Carve out vertical room. Header(3) + footer(1) + input(3 if shown) +
+  // log(LOG_PANEL_ROWS if shown) ≈ overhead. We compute the remaining
+  // rows for the body so it scrolls instead of overflowing.
+  const inputHeight = inputBox ? 3 : 0;
+  const logHeight = showLog ? LOG_PANEL_ROWS : 0;
+  const bodyRows = Math.max(1, rows - 4 - inputHeight - logHeight);
+
+  /** @returns {React.ReactElement} */
+  const renderBody = () => {
+    switch (state.phase) {
+      case 'menu':
+        // Centre the logo + menu group both vertically and horizontally
+        // within the body. `justifyContent: 'center'` puts the group on
+        // the body's vertical midline; `alignItems: 'center'` centres
+        // each child horizontally, so the menu lines up directly under
+        // the logo regardless of the menu's intrinsic width.
+        return h(
+          Box,
+          {
+            flexDirection: 'column',
+            flexGrow: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+          },
+          h(AnimatedLogo, { cols }),
+          h(MainMenu, {
+            currentName: name,
+            recentRoomCount: storedSnap.recentRooms.length,
+            selected: menuSelected,
+          }),
+        );
+      case 'recent-list':
+        return h(RecentRoomsList, {
+          recentRooms: storedSnap.recentRooms,
+          selected: recentSelected,
+        });
+      case 'name-input':
+        return h(
+          Box,
+          { paddingY: 1, paddingX: 2, flexDirection: 'column' },
+          h(Text, null, 'Set your display name.'),
+          h(Text, { dimColor: true }, 'It will be saved for next time.'),
+        );
+      case 'uri-input':
+        return h(
+          Box,
+          { paddingY: 1, paddingX: 2, flexDirection: 'column' },
+          h(Text, null, 'Paste an OCapN sturdyref URI.'),
+          h(
+            Text,
+            { dimColor: true },
+            'e.g. ocapn://….websocket/s/<base64url>?url=ws://….',
+          ),
+        );
+      case 'host-name-input':
+        return h(
+          Box,
+          { paddingY: 1, paddingX: 2, flexDirection: 'column' },
+          h(Text, null, 'Name your chatroom.'),
+          h(
+            Text,
+            { dimColor: true },
+            "We'll spin up a local websocket host and copy the sturdyref URI to your clipboard.",
+          ),
+          h(
+            Text,
+            { dimColor: true },
+            'The room is reachable from this machine; share the URI off-host only with port-forwarding in place.',
+          ),
+        );
+      case 'connecting':
+        return h(
+          Box,
+          { paddingY: 1, paddingX: 2, flexDirection: 'column' },
+          h(Text, null, state.status),
+        );
+      case 'chat':
+      default:
+        return h(
+          Box,
+          {
+            flexDirection: 'column',
+            flexGrow: 1,
+            paddingX: 1,
+            overflowY: 'hidden',
+          },
+          ...timeline.slice(-Math.max(1, bodyRows - 1)).map(item =>
+            item.kind === 'message'
+              ? h(MessageLine, {
+                  key: `m${item.entry.id}`,
+                  message: item.entry,
+                  userNames: state.userNames,
+                })
+              : h(EventLine, {
+                  key: `e${item.entry.id}`,
+                  event: item.entry,
+                  userNames: state.userNames,
+                }),
+          ),
+        );
+    }
+  };
+
+  /** @type {(React.ReactElement | undefined)[]} */
+  const children = [
+    h(
+      Box,
+      {
+        key: 'header',
+        borderStyle: 'single',
+        borderColor: 'cyan',
+        paddingX: 1,
+      },
+      h(Text, { bold: true, color: 'cyan' }, headerLine),
+    ),
+    h(
+      Box,
+      {
+        key: 'body',
+        flexDirection: 'column',
+        flexGrow: 1,
+        height: bodyRows,
+        overflowY: 'hidden',
+      },
+      renderBody(),
+    ),
+    showLog
+      ? h(
+          Box,
+          {
+            key: 'log',
+            borderStyle: 'single',
+            borderColor: 'gray',
+            flexDirection: 'column',
+            height: LOG_PANEL_ROWS,
+            paddingX: 1,
+          },
+          // Header line for the panel: combines the toggle hint with
+          // the on-disk log path. Putting the path here (instead of
+          // the global footer) means the bottom bar stays uncluttered
+          // when the panel is hidden — nobody needs to know the log
+          // path until they're actually looking at the log.
+          h(
+            Box,
+            { justifyContent: 'space-between' },
+            h(Text, { dimColor: true }, 'log (Ctrl+L to hide)'),
+            logFilePath
+              ? h(
+                  Text,
+                  { dimColor: true, wrap: 'truncate-middle' },
+                  logFilePath,
+                )
+              : null,
+          ),
+          ...state.logs
+            .slice(-(LOG_PANEL_ROWS - 3))
+            .map(entry => h(LogLine, { key: `l${entry.id}`, entry })),
+        )
+      : undefined,
+    inputBox ? h(React.Fragment, { key: 'input' }, inputBox) : undefined,
+    h(
+      Box,
+      { key: 'footer', paddingX: 1 },
+      h(Text, { dimColor: true, wrap: 'truncate-end' }, footerLeft),
+    ),
+  ].filter(Boolean);
+
+  return h(
+    Box,
+    { flexDirection: 'column', width: cols, height: rows },
+    ...children,
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Entrypoint
+// ---------------------------------------------------------------------------
+
+const ALT_SCREEN_ON = '\u001B[?1049h';
+const ALT_SCREEN_OFF = '\u001B[?1049l';
+
+const main = () => {
+  // Open the per-session log file *before* any other side effects so
+  // the very first netlayer/client log line is captured. The filename
+  // is pinned to the wallclock at process start, so each TUI
+  // invocation gets its own file even if multiple instances run in
+  // the same dir.
+  const startedAt = new Date();
+  const {
+    sink: logSink,
+    close: closeLogFile,
+    filePath: logFilePath,
+  } = openLogFile(startedAt);
+
+  // Persistent state (name + recent rooms). IO errors funnel through
+  // the log file (when it's open) — the TUI itself never sees them.
+  const store = openStateStore({
+    onError: (err, op) => {
+      try {
+        logSink('error', 'state-store', `${op}: ${err}`);
+      } catch (_) {
+        // best-effort
+      }
+    },
+  });
+  const initialName = store.read().name ?? DEFAULT_NAME;
+
+  const useAltScreen = Boolean(process.stdout.isTTY);
+  let altScreenLeft = false;
+  const leaveAltScreen = () => {
+    if (useAltScreen && !altScreenLeft) {
+      altScreenLeft = true;
+      process.stdout.write(ALT_SCREEN_OFF);
+    }
+  };
+  // Enter the alt screen *before* the first React commit so the
+  // initial frame is never painted onto the user's scrollback. The
+  // matching restore must run on every exit path (clean exit,
+  // unhandled error, SIGINT, SIGTERM) — losing it strands the user on
+  // a blank alt buffer.
+  if (useAltScreen) {
+    process.stdout.write(ALT_SCREEN_ON);
+  }
+  process.once('exit', leaveAltScreen);
+  process.once('exit', closeLogFile);
+  // Hosted chatrooms live in their own OCapN clients with their own
+  // websocket servers; without an explicit shutdown those servers
+  // would keep the event loop pinned open after a clean menu-Ctrl+C.
+  process.once('exit', () => {
+    try {
+      hostRegistry.shutdownAll();
+    } catch (_) {
+      // best-effort
+    }
+  });
+  // Catch the cases ink's `useInput` Ctrl+C branch doesn't see:
+  //   SIGINT  — `kill -INT $pid`, or Ctrl+C from a parent if we ever
+  //             lose raw mode (e.g. during a crash unwind).
+  //   SIGTERM — `kill $pid`, init-system shutdown.
+  //   SIGHUP  — controlling terminal went away (closed tab, ssh
+  //             dropped).
+  //
+  // Everything in here MUST be synchronous. Ink registers its own
+  // listener via `signal-exit`, which re-raises the signal with
+  // default disposition once all listeners return — so any
+  // `setTimeout`/microtask we schedule will never fire.
+  // `client.shutdown()` (via `shutdownHandle.run`) closes the
+  // websocket synchronously (the TCP FIN/close frame goes straight
+  // onto the wire), which is the message the chatroom most needs to
+  // see; the eventual-send `leave`/`unsubscribe` calls only really
+  // get to flush on the in-app Ctrl+C path, where we exit through
+  // ink's normal unmount instead of a signal.
+  for (const signal of /** @type {const} */ (['SIGINT', 'SIGTERM', 'SIGHUP'])) {
+    process.once(signal, () => {
+      try {
+        shutdownHandle.run();
+      } catch (_) {
+        // best-effort; never block exit on cleanup
+      }
+      try {
+        hostRegistry.shutdownAll();
+      } catch (_) {
+        // best-effort; never block exit on cleanup
+      }
+      leaveAltScreen();
+      closeLogFile();
+      process.exit(0);
+    });
+  }
+
+  const { waitUntilExit } = render(
+    h(App, { logSink, logFilePath, store, initialName }),
+    {
+      exitOnCtrlC: false,
+      // SES lockdown removes console.Console, which ink's patchConsole
+      // needs.
+      patchConsole: false,
+    },
+  );
+  // Note: we deliberately don't `closeLogFile()` here. Ink's
+  // `waitUntilExit()` resolves as soon as the React tree unmounts,
+  // but the websocket's `close` event (which writes one last
+  // `handleConnectionClose` log line) fires a tick later. Closing the
+  // stream now would race that write and surface as "write after
+  // end". The `process.once('exit', closeLogFile)` registered above
+  // runs once the event loop drains, by which point the late log
+  // lines have flushed.
+  waitUntilExit()
+    .catch(err => {
+      leaveAltScreen();
+      console.error(err);
+      process.exit(1);
+    })
+    .then(() => {
+      leaveAltScreen();
+    });
+};
+
+main();

--- a/packages/goblin-chat/package.json
+++ b/packages/goblin-chat/package.json
@@ -1,0 +1,108 @@
+{
+  "name": "@endo/goblin-chat",
+  "version": "0.1.0",
+  "private": true,
+  "description": "OCapN chat protocol implementation and Ink-based TUI client, interoperable with Spritely Goblins' goblin-chat.",
+  "keywords": [
+    "ocapn",
+    "captp",
+    "chat",
+    "endo",
+    "goblins"
+  ],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/tree/master/packages/goblin-chat#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/goblin-chat"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "main": "./api.js",
+  "module": "./api.js",
+  "exports": {
+    ".": "./api.js",
+    "./backend": "./src/backend.js",
+    "./interop-driver": "./src/interop-driver.js",
+    "./uri-parse": "./src/uri-parse.js",
+    "./chat-state": "./src/chat-state.js",
+    "./use-goblin-chat": "./src/use-goblin-chat.js",
+    "./state-store": "./src/state-store.js",
+    "./src/interop-driver.js": "./src/interop-driver.js",
+    "./package.json": "./package.json"
+  },
+  "bin": "./bin/goblin-chat.js",
+  "scripts": {
+    "build": "exit 0",
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
+    "lint:eslint": "eslint '**/*.js'",
+    "lint:types": "tsc",
+    "prepack": "git clean -fX -e node_modules/ && tsc --build tsconfig.build.json",
+    "postpack": "git clean -fX -e node_modules/",
+    "start": "node ./index.js",
+    "test": "ava",
+    "test:c8": "c8 ${C8_OPTIONS:-} ses-ava",
+    "test:xs": "exit 0"
+  },
+  "dependencies": {
+    "@endo/base64": "workspace:^",
+    "@endo/eventual-send": "workspace:^",
+    "@endo/exo": "workspace:^",
+    "@endo/init": "workspace:^",
+    "@endo/marshal": "workspace:^",
+    "@endo/ocapn": "workspace:^",
+    "@endo/patterns": "workspace:^",
+    "ink": "^7.0.1",
+    "react": "^19.2.0"
+  },
+  "devDependencies": {
+    "@endo/lockdown": "workspace:^",
+    "@endo/ses-ava": "workspace:^",
+    "@types/react": "^19.2.0",
+    "ava": "catalog:dev",
+    "c8": "catalog:dev",
+    "eslint": "catalog:dev",
+    "ses": "workspace:^",
+    "tsd": "catalog:dev",
+    "typescript": "catalog:dev"
+  },
+  "files": [
+    "./*.d.ts",
+    "./*.js",
+    "./*.map",
+    "LICENSE*",
+    "SECURITY*",
+    "bin",
+    "src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "plugin:@endo/internal"
+    ],
+    "rules": {
+      "import/no-unresolved": [
+        "error",
+        {
+          "ignore": [
+            "ava",
+            "^@endo/ocapn(?:/.*)?$"
+          ]
+        }
+      ]
+    }
+  },
+  "ava": {
+    "files": [
+      "test/**/*.test.*"
+    ],
+    "timeout": "2m"
+  }
+}

--- a/packages/goblin-chat/src/animated-logo.js
+++ b/packages/goblin-chat/src/animated-logo.js
@@ -1,0 +1,343 @@
+// @ts-check
+/* eslint-disable no-bitwise, no-continue, import/no-unresolved */
+/* global performance, setInterval, clearInterval */
+
+/**
+ * Animated ASCII logo for the goblin-chat TUI.
+ *
+ * Renders the "OCAPN CHAT" figlet as a 2D glyph map and shades each
+ * non-space cell every frame using a small lighting model:
+ *
+ *   - **Diagonal sweep**: a Gaussian band of bright light travels
+ *     across the logo along a vector that itself slowly rotates, so
+ *     successive sweeps approach from slightly different angles.
+ *   - **Counter sweep**: a fainter, warmer band crosses the opposite
+ *     way at a different speed. The two never quite line up, so the
+ *     interference pattern never visibly repeats.
+ *   - **Volumetric density**: each cell's "matter density" is the
+ *     fraction of non-space neighbours in a 5×3 stencil, computed
+ *     once at module load. Dense regions glow more, mimicking
+ *     subsurface scattering — letter bodies fluoresce, decorative
+ *     thin strokes stay cooler.
+ *   - **Plasma shimmer**: three layered sin/cos terms with
+ *     incommensurate frequencies add a low-amplitude wandering
+ *     perturbation. Keeps the surface alive even when the sweeps
+ *     are far away.
+ *   - **Specular desaturation**: peaks of the sweep bleach toward
+ *     white instead of just brightening the hue, so the highlight
+ *     reads as a hot reflection rather than a colour shift.
+ *   - **Breath**: a long-period (~9s) global brightness oscillation
+ *     gives the whole sign a slow lung-like rise and fall.
+ *   - **Sparkle**: a deterministic per-cell hash gates a brief
+ *     overshoot when both the sweep and the sin-locked sparkle clock
+ *     line up. Most cells never sparkle; a handful pop occasionally.
+ *
+ * Output is 24-bit colour (`\u001B[38;2;R;G;Bm`). Each row is built
+ * as one string with the per-cell escapes embedded, then handed to a
+ * single `<Text>` node. Spaces emit no escape so the row stays sparse.
+ *
+ * Falls back to a plain "goblin-chat" line when the terminal is too
+ * narrow to fit the glyph (avoids ugly mid-line wraps).
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Text } from 'ink';
+
+const h = React.createElement;
+
+// The ASCII art. `String.raw` preserves backslashes verbatim so the
+// source matches the rendered glyphs character-for-character. Backticks
+// (which would terminate the template) are interpolated as `${BT}`.
+const BT = '`';
+const LOGO_LINES = [
+  String.raw`   )\.-.      .-./(     /(,-.   .')      .'(   )\  )\          )\.-.       .'(     /${BT}-.   .-,.-.,-. `,
+  String.raw` ,' ,-,_)   ,'     )  ,' _   ) ( /       \  ) (  \, /        ,' ,-,_)  ,') \  )  ,' _  \  ) ,, ,. ( `,
+  String.raw`(  .   __  (  .-, (  (  '-' (   ))       ) (   ) \ (        (  .   _  (  '-' (  (  '-' (  \( |(  )/ `,
+  String.raw` ) '._\ _)  ) '._\ )  )  _   )  )'._.-.  \  ) ( ( \ \        ) '..' )  ) .-.  )  )   _  )    ) \    `,
+  String.raw`(  ,   (   (  ,   (  (  '-' /  (       )  ) \  ${BT}.)/  )      (  ,   (  (  ,  ) \ (  ,' ) \    \ (    `,
+  String.raw` )/'._.'    )/ ._.'   )/._.'    )/,__.'    )/     '.(        )/'._.'   )/    )/  )/    )/     )/    `,
+];
+
+const LOGO_WIDTH = Math.max(...LOGO_LINES.map(l => l.length));
+const LOGO_HEIGHT = LOGO_LINES.length;
+
+// Precomputed density field. For each cell, the fraction of non-space
+// cells in a 5×3 stencil centred on (x, y). Used to make dense glyph
+// regions glow more — the "matter" in the ASCII has volume, the
+// surrounding void doesn't.
+const DENSITY = LOGO_LINES.map((line, y) => {
+  /** @type {number[]} */
+  const row = [];
+  for (let x = 0; x < line.length; x += 1) {
+    let count = 0;
+    let total = 0;
+    for (let dy = -1; dy <= 1; dy += 1) {
+      const yy = y + dy;
+      if (yy < 0 || yy >= LOGO_LINES.length) continue;
+      const lineYY = LOGO_LINES[yy];
+      for (let dx = -2; dx <= 2; dx += 1) {
+        const xx = x + dx;
+        if (xx < 0 || xx >= lineYY.length) continue;
+        total += 1;
+        if (lineYY[xx] !== ' ') count += 1;
+      }
+    }
+    row.push(total === 0 ? 0 : count / total);
+  }
+  return row;
+});
+
+// Cheap deterministic per-cell hash in (0, 1). Uses a Weyl-like
+// integer scramble so neighbouring cells get uncorrelated values
+// without needing a real PRNG.
+/**
+ * @param {number} x
+ * @param {number} y
+ * @returns {number}
+ */
+const cellHash = (x, y) => {
+  let n = (x * 374761393 + y * 668265263) | 0;
+  n = (n ^ (n >>> 13)) * 1274126177;
+  n = (n ^ (n >>> 16)) >>> 0;
+  return n / 0x100000000;
+};
+
+/**
+ * HSL→RGB. hue, sat, light in [0, 1]; returns each channel in [0, 255].
+ * Single-pass formulation (Wikipedia "Alternative HSL→RGB").
+ *
+ * @param {number} hue
+ * @param {number} sat
+ * @param {number} light
+ * @returns {[number, number, number]}
+ */
+const hslToRgb = (hue, sat, light) => {
+  const a = sat * Math.min(light, 1 - light);
+  /** @param {number} n */
+  const f = n => {
+    const k = (n + hue * 12) % 12;
+    return light - a * Math.max(-1, Math.min(k - 3, Math.min(9 - k, 1)));
+  };
+  return [
+    Math.round(f(0) * 255),
+    Math.round(f(8) * 255),
+    Math.round(f(4) * 255),
+  ];
+};
+
+/**
+ * Wrap a signed offset into the half-open interval (-period/2, period/2].
+ * Used to pick the "nearest" sweep so a band coming in from the left
+ * is treated symmetrically with one leaving on the right.
+ *
+ * @param {number} x
+ * @param {number} period
+ */
+const wrapCentred = (x, period) => {
+  const m = ((x % period) + period * 1.5) % period;
+  return m - period / 2;
+};
+
+/**
+ * Compute the 24-bit ANSI foreground escape for a single cell at
+ * time `t` seconds. Returns the escape sequence including the
+ * leading `\u001B[`.
+ *
+ * @param {number} x
+ * @param {number} y
+ * @param {number} t
+ * @returns {string}
+ */
+const cellColor = (x, y, t) => {
+  // --- primary sweep -------------------------------------------------
+  // The light direction itself rotates very slowly (~30s period), so
+  // the band tilts from "almost horizontal" up to "steeply diagonal"
+  // and back. The y axis is stretched ×4 because terminal cells are
+  // roughly twice as tall as wide; without that compensation the band
+  // looks nearly horizontal regardless of the chosen angle.
+  const rot = t * 0.21;
+  const cosA = Math.cos(rot);
+  const sinA = 0.25 + 0.18 * Math.sin(rot * 0.7);
+  const proj1 = x * cosA + y * 4 * sinA;
+  const period1 = LOGO_WIDTH + 28;
+  const sweepPos1 = (t * 13) % period1;
+  const d1 = wrapCentred(proj1 - sweepPos1, period1);
+  const sigma1 = 7.5;
+  const sweep1 = Math.exp(-(d1 * d1) / (2 * sigma1 * sigma1));
+
+  // --- counter sweep -------------------------------------------------
+  // Going the other way, slower, narrower, dimmer; warm-tinted via
+  // the hue mix below. Two non-commensurate sweep speeds (13 vs 7)
+  // mean the interference pattern never visibly repeats over a
+  // session.
+  const proj2 = -x * 0.85 + y * 4 * 0.5;
+  const period2 = LOGO_WIDTH + 47;
+  const sweepPos2 = (t * 7) % period2;
+  const d2 = wrapCentred(proj2 - sweepPos2, period2);
+  const sigma2 = 5.5;
+  const sweep2 = Math.exp(-(d2 * d2) / (2 * sigma2 * sigma2)) * 0.55;
+
+  // --- plasma shimmer ------------------------------------------------
+  // Three layers, frequencies chosen to be mutually irrational-ish.
+  const shimmer =
+    0.05 * Math.sin(x * 0.27 + t * 1.7) * Math.cos(y * 0.9 + t * 1.1) +
+    0.04 * Math.sin((x + y * 3) * 0.11 + t * 0.9) +
+    0.03 * Math.cos((x * 0.6 - y * 1.7) * 0.15 + t * 0.6);
+
+  // --- breath --------------------------------------------------------
+  // Long-period global brightness wave — a bit like a slow inhale.
+  const breath = 0.06 * Math.sin(t * 0.7);
+
+  // --- ambient + density --------------------------------------------
+  // Static fill light fades upper-left → lower-right. Density
+  // multiplier ranges 0.55..1.25 so empty cells (which we won't draw
+  // anyway) sit cool, while dense centres of letters bloom.
+  const density = DENSITY[y][x];
+  const fill =
+    0.3 + 0.1 * (1 - x / LOGO_WIDTH) + 0.06 * (1 - y / (LOGO_HEIGHT - 1));
+  const ambient = fill * (0.55 + 0.7 * density);
+
+  // --- sparkle -------------------------------------------------------
+  // Most cells: zero. A few cells: a brief overshoot when the cell's
+  // private clock (driven off its hash) lines up with the global
+  // sparkle phase. The hash also picks each cell's frequency, so the
+  // sparkles fire asynchronously across the sign.
+  const hash = cellHash(x, y);
+  const sparkleFreq = 0.6 + hash * 1.4;
+  const sparklePhase = hash * Math.PI * 2;
+  const sparkleRaw = Math.sin(t * sparkleFreq + sparklePhase);
+  // Threshold high so only the top few percent of the cycle fires.
+  const sparkle = sparkleRaw > 0.985 ? (sparkleRaw - 0.985) * 60 : 0;
+
+  // --- combine to lightness -----------------------------------------
+  let l =
+    ambient + shimmer + breath + sweep1 * 0.55 + sweep2 * 0.3 + sparkle * 0.4;
+  if (l < 0.04) l = 0.04;
+  if (l > 0.96) l = 0.96;
+
+  // --- hue -----------------------------------------------------------
+  // Anchored at cyan (0.55), drifts ±0.10 across width, slow time
+  // wobble, plus a warm push from the counter sweep so the second
+  // band reads as a different "colour" of light. Always wrapped into
+  // [0, 1).
+  let hue =
+    0.55 +
+    0.1 * (x / LOGO_WIDTH - 0.5) +
+    0.05 * Math.sin(t * 0.25) -
+    0.18 * sweep2;
+  hue -= Math.floor(hue);
+
+  // --- saturation ----------------------------------------------------
+  // Spec highlight bleaches toward white; sparkle does too.
+  const sat = Math.max(
+    0.1,
+    0.78 - 0.55 * sweep1 - 0.3 * sweep2 - 0.4 * sparkle,
+  );
+
+  const [r, g, b] = hslToRgb(hue, sat, l);
+  // Quantise to 16 levels per channel. Dropping the low nibble means
+  // adjacent cells with very similar lighting share an escape, so the
+  // run-length collapse in `renderLogoRow` actually helps. Visually
+  // indistinguishable from full 8-bit at this scale.
+  const qr = r & 0xf0;
+  const qg = g & 0xf0;
+  const qb = b & 0xf0;
+  return `\u001B[38;2;${qr};${qg};${qb}m`;
+};
+
+const ANSI_RESET = '\u001B[0m';
+
+/**
+ * Render one logo row as a single string with embedded 24-bit colour
+ * escapes. Spaces emit no escape (and reset `lastColor` so the next
+ * non-space cell always re-establishes its colour explicitly — a
+ * conservative choice that keeps the row valid even if the terminal
+ * resets state on whitespace).
+ *
+ * @param {string} line
+ * @param {number} rowIdx
+ * @param {number} t
+ * @returns {string}
+ */
+const renderLogoRow = (line, rowIdx, t) => {
+  let out = '';
+  let lastColor = '';
+  for (let x = 0; x < line.length; x += 1) {
+    const ch = line[x];
+    if (ch === ' ') {
+      out += ' ';
+      lastColor = '';
+      continue;
+    }
+    const color = cellColor(x, rowIdx, t);
+    if (color !== lastColor) {
+      out += color;
+      lastColor = color;
+    }
+    out += ch;
+  }
+  return out + ANSI_RESET;
+};
+
+/**
+ * @typedef {{
+ *   cols: number,
+ *   fps?: number,
+ * }} AnimatedLogoProps
+ */
+
+/**
+ * Animated logo component. Re-renders at ~14fps by default; the
+ * timer is owned by the component itself so the rest of the app
+ * doesn't pay the re-render cost.
+ *
+ * The first frame is computed synchronously on mount so a slow
+ * terminal still shows a fully-coloured logo before the first tick.
+ *
+ * @param {AnimatedLogoProps} props
+ */
+export const AnimatedLogo = ({ cols, fps = 14 }) => {
+  const startedAt = useRef(/** @type {number | undefined} */ (undefined));
+  if (startedAt.current === undefined) {
+    startedAt.current =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+  }
+  const [, setFrame] = useState(0);
+
+  useEffect(() => {
+    const intervalMs = Math.max(20, Math.round(1000 / fps));
+    const id = setInterval(() => {
+      // Mask to 16 bits so the counter never grows unboundedly. We
+      // only need it to change; the actual value is unused.
+      setFrame(f => (f + 1) & 0xffff);
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [fps]);
+
+  // Too narrow: collapse to a single cyan line. Picking the threshold
+  // at LOGO_WIDTH + 4 (logo + Box paddingX of 2 on each side) ensures
+  // we never half-draw a row.
+  if (cols < LOGO_WIDTH + 4) {
+    return h(
+      Box,
+      { paddingX: 2, paddingY: 1 },
+      h(Text, { color: 'cyan', bold: true }, 'goblin-chat'),
+    );
+  }
+
+  const now =
+    typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const t = (now - /** @type {number} */ (startedAt.current)) / 1000;
+
+  return h(
+    Box,
+    { flexDirection: 'column', paddingX: 2, paddingTop: 1 },
+    ...LOGO_LINES.map((line, i) =>
+      h(
+        Text,
+        { key: `logo-${i}`, wrap: 'truncate-end' },
+        renderLogoRow(line, i, t),
+      ),
+    ),
+  );
+};

--- a/packages/goblin-chat/src/backend.js
+++ b/packages/goblin-chat/src/backend.js
@@ -1,0 +1,317 @@
+// @ts-check
+
+/**
+ * JavaScript port of the Guile Goblins `(goblin-chat backend)` module.
+ *
+ * This is a test utility so an Endo OCapN peer can host a chatroom that a
+ * Goblins peer (e.g. `spritely/goblin-chat`) can join, or join a chatroom
+ * hosted by a Goblins peer. Method names are kebab-case to match the
+ * selectors Goblins sends over CapTP; the Endo OCapN dispatcher coerces
+ * incoming selector symbols to string method names.
+ *
+ * The aim of this port is to be observably **bit-for-bit equivalent** to
+ * upstream `(goblin-chat backend)` over the wire. Where upstream has
+ * documented quirks or outright bugs (e.g. `list-users` is a no-op, the
+ * `unsubscribe` thunk dangles, the join backfill echoes the joiner back
+ * to themselves), we mirror them rather than "fix" them — interop tests
+ * are easier when both peers agree on how things misbehave. Each such
+ * site is called out with a "Bit-for-bit with Guile" comment.
+ *
+ * Source compared against:
+ *   https://codeberg.org/spritely/goblin-chat/raw/branch/main/goblin-chat/backend.scm
+ *
+ * Original copyright, carried over since this is a direct port:
+ *   Copyright 2023 Jessica Tallon
+ *   Copyright 2020-2022 Christine Lemmer-Webber
+ *   Licensed under the Apache License, Version 2.0
+ */
+
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+/**
+ * Sealer / unsealer / sealed? triplet. The sealed handles are plain Far
+ * remotables; the WeakMap stores only the unsealed value, so a handle that
+ * escapes to another peer carries no value and cannot be forged.
+ */
+const spawnSealerTriplet = () => {
+  /** @type {WeakMap<object, any>} */
+  const contents = new WeakMap();
+  const sealer = Far('sealer', value => {
+    const handle = Far('sealed', {});
+    contents.set(handle, value);
+    return handle;
+  });
+  const unsealer = Far('unsealer', handle => {
+    if (!contents.has(handle)) {
+      throw Error('unsealer: value was not sealed by the matching sealer');
+    }
+    return contents.get(handle);
+  });
+  const isSealed = Far('sealed?', handle => contents.has(handle));
+  return { sealer, unsealer, isSealed };
+};
+
+/**
+ * ^chatroom
+ *
+ * @param {string} selfProposedName
+ */
+export const makeChatroom = selfProposedName => {
+  /** @type {Map<any, any>} user -> user-messaging-channel inbox */
+  const subscribers = new Map();
+
+  const sendToSubscribers = (selector, ...args) => {
+    for (const inbox of subscribers.values()) {
+      E.sendOnly(inbox)[selector](...args);
+    }
+  };
+
+  /**
+   * ^user-messaging-channel
+   *
+   * One of these is handed back to each user after their subscription is
+   * finalized. It's the capability they use to speak in the room.
+   *
+   * Mirrors the Guile `^user-messaging-channel`: on `leave` the actor
+   * `bcom`s into a `dead-beh` that returns the symbol `'CONNECTION-CLOSED`
+   * for any subsequent invocation. We approximate that here by flipping
+   * an `alive` flag and short-circuiting each known selector to the
+   * string `'CONNECTION-CLOSED'`. (We can't intercept *unknown*
+   * selectors short of using a Proxy, which Far doesn't compose with;
+   * for the protocol's documented surface this is equivalent.)
+   *
+   * @param {any} associatedUser
+   * @param {any} _userInbox
+   */
+  const makeUserMessagingChannel = (associatedUser, _userInbox) => {
+    let alive = true;
+    const dead = () => 'CONNECTION-CLOSED';
+    return Far('user-messaging-channel', {
+      leave: () => {
+        if (!alive) return dead();
+        subscribers.delete(associatedUser);
+        sendToSubscribers('user-left', associatedUser);
+        alive = false;
+        // Guile's `(bcom dead-beh)` evaluates to unspecified; the leave
+        // call itself returns nothing meaningful (only subsequent calls
+        // see the dead behavior).
+        return undefined;
+      },
+      'send-message': sealedMsg => {
+        if (!alive) return dead();
+        sendToSubscribers('new-message', associatedUser, sealedMsg);
+        return 'OK';
+      },
+      'list-users': () => {
+        if (!alive) return dead();
+        // Bug-for-bug with upstream: Guile uses `ghash-for-each` here
+        // (iteration-for-side-effect) with a TODO note "add 'keys to
+        // ^ghash". The lambda body produces the user, but `for-each`
+        // discards it, so the call resolves to unspecified. We mirror
+        // that — walk the keys, return nothing.
+        Array.from(subscribers.keys());
+        return undefined;
+      },
+    });
+  };
+
+  /**
+   * ^finalize-subscription
+   *
+   * Sealed by the user before being returned from `subscribe`. The
+   * user-controller unseals it and calls it once with the user's inbox; it
+   * then wires the subscription up and returns the messaging channel.
+   *
+   * @param {any} associatedUser
+   */
+  const makeFinalizeSubscription = associatedUser => {
+    let finalized = false;
+    return Far('finalize-subscription', userInbox => {
+      if (finalized) {
+        throw Error('Already finalized');
+      }
+      finalized = true;
+      // notify other subscribers first
+      sendToSubscribers('user-joined', associatedUser);
+      // subscribe the new user
+      subscribers.set(associatedUser, userInbox);
+      // Backfill: tell the new user about everyone already present.
+      //
+      // Bit-for-bit with Guile: the iteration runs over `subscribers`
+      // *after* the new user has been inserted, with no self-skip. So
+      // the joiner receives a `user-joined` echo of themselves as the
+      // last item in the backfill. The TUI handles the self-echo on
+      // its end.
+      for (const presentUser of subscribers.keys()) {
+        E.sendOnly(userInbox)['user-joined'](presentUser);
+      }
+      return makeUserMessagingChannel(associatedUser, userInbox);
+    });
+  };
+
+  return Far('chatroom', {
+    'self-proposed-name': () => selfProposedName,
+    subscribe: async user => {
+      const subscriptionSealer = await E(user)['get-subscription-sealer']();
+      const finalizeSub = makeFinalizeSubscription(user);
+      // Ask the user's sealer to seal our finalizer; return the sealed
+      // handle to the caller so only the owning controller can activate it.
+      return E(subscriptionSealer)(finalizeSub);
+    },
+  });
+};
+
+/**
+ * spawn-user-controller-pair
+ *
+ * @param {string} selfProposedName
+ */
+export const makeUserControllerPair = selfProposedName => {
+  const chatMsg = spawnSealerTriplet();
+  const subscription = spawnSealerTriplet();
+
+  /** @type {Map<any, any>} room -> authenticated channel */
+  const roomsToChannels = new Map();
+  /** @type {Set<any>} */
+  const clientSubscribers = new Set();
+
+  const user = Far('user', {
+    'self-proposed-name': () => selfProposedName,
+    'get-chat-sealed?': () => chatMsg.isSealed,
+    'get-chat-unsealer': () => chatMsg.unsealer,
+    'get-subscription-sealer': () => subscription.sealer,
+  });
+
+  const sendToClients = (selector, ...args) => {
+    for (const client of clientSubscribers) {
+      E.sendOnly(client)[selector](...args);
+    }
+  };
+
+  /**
+   * ^user-inbox
+   *
+   * The Guile version wards the controller-only methods (`revoke`,
+   * `subscribe`) behind an incanter so only the local controller can
+   * reach them. We keep the same controller-only surface (and only
+   * those two methods, matching upstream) as a closed-over plain
+   * object, and expose only the public surface to the wire. Same
+   * access gate, no warden dance.
+   *
+   * @param {any} context
+   */
+  const makeUserInbox = context => {
+    const roomUsers = new Set();
+    /** @type {Set<any>} subscribers receiving 'user-joined'/'user-left'/'new-message'. */
+    const inboxSubscribers = new Set();
+    let revoked = false;
+
+    const publish = (selector, ...args) => {
+      for (const sub of inboxSubscribers) {
+        E.sendOnly(sub)[selector](...args);
+      }
+    };
+
+    // Public surface: what the chatroom calls on us. Kebab-case to match
+    // Goblins selectors.
+    const publicInbox = Far('user-inbox', {
+      'new-message': async (fromUser, sealedMsg) => {
+        if (revoked) throw Error('Revoked!');
+        const chatUnsealer = await E(fromUser)['get-chat-unsealer']();
+        const message = await E(chatUnsealer)(sealedMsg);
+        publish('new-message', context, fromUser, message);
+      },
+      'user-joined': joiningUser => {
+        if (revoked) throw Error('Revoked!');
+        roomUsers.add(joiningUser);
+        publish('user-joined', joiningUser);
+      },
+      'user-left': leavingUser => {
+        if (revoked) throw Error('Revoked!');
+        roomUsers.delete(leavingUser);
+        publish('user-left', leavingUser);
+      },
+      context: () => context,
+    });
+
+    // Bit-for-bit with Guile `controller-methods`: only `revoke` and
+    // `subscribe` exist on the controller surface. Upstream's
+    // `^unsubscribe` thunk reaches in for an `'unsubscribe` selector
+    // that has no implementation, so it errors at call time — we
+    // mirror that by leaving `unsubscribe` off the controller. The
+    // `^authenticated-channel.subscribe` path below still hands back
+    // the unsubscribe thunk so the on-the-wire shape matches; calling
+    // it just rejects, exactly as in Guile.
+    const controller = Object.freeze({
+      revoke: () => {
+        revoked = true;
+      },
+      subscribe: subscriber => {
+        inboxSubscribers.add(subscriber);
+        for (const u of roomUsers) {
+          E.sendOnly(subscriber)['user-joined'](u);
+        }
+        return true;
+      },
+    });
+
+    return { publicInbox, controller };
+  };
+
+  /**
+   * ^authenticated-channel
+   *
+   * Wraps the room-channel returned by the chatroom so clients can hand off
+   * a plain message; we seal it on the way out and forward subscribe
+   * through the inbox controller.
+   *
+   * @param {any} roomChannel
+   * @param {any} inboxController
+   */
+  const makeAuthenticatedChannel = (roomChannel, inboxController) =>
+    Far('authenticated-channel', {
+      'send-message': async contents => {
+        const sealedMsg = await E(chatMsg.sealer)(contents);
+        return E(roomChannel)['send-message'](sealedMsg);
+      },
+      subscribe: subscriber => {
+        inboxController.subscribe(subscriber);
+        return [
+          'OK',
+          // Bit-for-bit with Guile: the thunk reaches for an
+          // `'unsubscribe` method on the inbox controller that the
+          // controller-methods table doesn't define. Calling it
+          // therefore rejects with "no such method", same as upstream.
+          Far('unsubscribe', () =>
+            /** @type {any} */ (inboxController).unsubscribe(subscriber),
+          ),
+        ];
+      },
+      leave: () => E(roomChannel).leave(),
+      'list-users': () => E(roomChannel)['list-users'](),
+    });
+
+  const userController = Far('user-controller', {
+    whoami: () => user,
+    'connect-client': client => {
+      clientSubscribers.add(client);
+      return ['OK', new Map(roomsToChannels)];
+    },
+    'join-room': async room => {
+      if (roomsToChannels.has(room)) {
+        throw Error('Already subscribed to the room');
+      }
+      const { publicInbox, controller } = makeUserInbox(room);
+      const sealedFinalizer = await E(room).subscribe(user);
+      const finalizer = await E(subscription.unsealer)(sealedFinalizer);
+      const roomChannel = await E(finalizer)(publicInbox);
+      const authenticated = makeAuthenticatedChannel(roomChannel, controller);
+      roomsToChannels.set(room, authenticated);
+      sendToClients('we-joined-room', room, authenticated);
+      return authenticated;
+    },
+  });
+
+  return { user, userController };
+};

--- a/packages/goblin-chat/src/base64url.js
+++ b/packages/goblin-chat/src/base64url.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+/**
+ * Base64url (RFC 4648 §5) wrappers around `@endo/base64`. The OCapN
+ * sturdyref URI grammar carries the swiss-num path segment in base64url
+ * without padding, so we keep the conversion in one place rather than
+ * sprinkling Node `Buffer` calls (and therefore a Node coupling) through
+ * the host/parse code paths.
+ */
+
+import { decodeBase64, encodeBase64 } from '@endo/base64';
+
+/**
+ * Encode bytes as base64url without trailing padding.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+export const encodeBase64Url = bytes =>
+  encodeBase64(bytes)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/u, '');
+
+/**
+ * Decode a base64url string (with or without padding) into bytes. The
+ * input alphabet is validated by `decodeBase64` after the URL-alphabet
+ * substitutions.
+ *
+ * @param {string} value
+ * @param {string} [name]
+ * @returns {Uint8Array}
+ */
+export const decodeBase64Url = (value, name) => {
+  const standard = value.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = standard + '='.repeat((4 - (standard.length % 4)) % 4);
+  return decodeBase64(padded, name);
+};

--- a/packages/goblin-chat/src/chat-state.js
+++ b/packages/goblin-chat/src/chat-state.js
@@ -1,0 +1,287 @@
+// @ts-check
+
+/**
+ * Pure state module for the goblin-chat TUI.
+ *
+ * Owns the typedefs, the reducer, the initial state, and pure helpers
+ * (`formatError`, `lookupName`). Has no dependency on React, ink, or
+ * `@endo/eventual-send`, so it can be reasoned about and unit-tested in
+ * isolation from the view layer.
+ *
+ * The reducer state is split into three append-only logs:
+ *   - `messages`   chat lines (incl. our own).
+ *   - `events`     room transitions + status meta (joins, leaves, info, errors).
+ *   - `logs`       OCapN-side log lines piped from `client`/`netlayer`.
+ *
+ * Each `messages`/`events` entry carries a monotonically-increasing
+ * `seq` so the view can merge the two streams chronologically without
+ * losing event identity. `logs` get their own id sequence — they're
+ * rendered in a separate panel.
+ *
+ * `userNames` is a Map keyed by user capability; entries are populated
+ * lazily by background `self-proposed-name` lookups so the view never
+ * blocks waiting on a name to render.
+ */
+
+const MAX_MESSAGES = 1000;
+const MAX_EVENTS = 500;
+const MAX_LOGS = 500;
+
+/**
+ * @typedef {{ kind: 'self', name: string } | { kind: 'remote', user: object }} MessageSender
+ *
+ * @typedef {{
+ *   id: number,
+ *   seq: number,
+ *   timestamp: number,
+ *   sender: MessageSender,
+ *   text: string,
+ * }} ChatMessage
+ *
+ * @typedef {(
+ *   | { id: number, seq: number, timestamp: number, kind: 'joined', user: object }
+ *   | { id: number, seq: number, timestamp: number, kind: 'left', user: object }
+ *   | { id: number, seq: number, timestamp: number, kind: 'present', users: object[] }
+ *   | { id: number, seq: number, timestamp: number, kind: 'info', text: string }
+ *   | { id: number, seq: number, timestamp: number, kind: 'error', text: string }
+ * )} SystemEvent
+ *
+ * @typedef {'log' | 'info' | 'error'} LogLevel
+ *
+ * @typedef {{
+ *   id: number,
+ *   timestamp: number,
+ *   level: LogLevel,
+ *   source: string,
+ *   text: string,
+ * }} LogEntry
+ *
+ * High-level UI phases. Roughly:
+ *   - `menu`              main menu (set name / join new / host / join previous)
+ *   - `name-input`        single-line text editor for the user's name
+ *   - `uri-input`         single-line text editor for an ocapn:// URI
+ *   - `host-name-input`   single-line text editor for a chatroom name to host
+ *   - `recent-list`       list-picker over `recentRooms`
+ *   - `connecting`        joinRoom (or hostRoom) in flight, no input accepted
+ *   - `chat`              in a room, normal chat input
+ *
+ * @typedef {(
+ *   | 'menu'
+ *   | 'name-input'
+ *   | 'uri-input'
+ *   | 'host-name-input'
+ *   | 'recent-list'
+ *   | 'connecting'
+ *   | 'chat'
+ * )} Phase
+ *
+ * @typedef {{
+ *   messages: ChatMessage[],
+ *   events: SystemEvent[],
+ *   logs: LogEntry[],
+ *   userNames: Map<object, string>,
+ *   nextId: number,
+ *   nextSeq: number,
+ *   nextLogId: number,
+ *   status: string,
+ *   roomName: string | undefined,
+ *   phase: Phase,
+ * }} State
+ *
+ * @typedef {(
+ *   | { type: 'message-received', user: object, text: string }
+ *   | { type: 'message-sent', name: string, text: string }
+ *   | { type: 'user-joined', user: object }
+ *   | { type: 'user-left', user: object }
+ *   | { type: 'users-present', users: object[] }
+ *   | { type: 'info', text: string }
+ *   | { type: 'error', text: string }
+ *   | { type: 'log', level: LogLevel, source: string, text: string }
+ *   | { type: 'name-resolved', user: object, name: string }
+ *   | { type: 'set-status', status: string }
+ *   | { type: 'set-phase', phase: Phase }
+ *   | { type: 'set-room', roomName: string }
+ *   | { type: 'reset-room' }
+ * )} Action
+ */
+
+/** @type {State} */
+export const initialState = {
+  messages: [],
+  events: [],
+  logs: [],
+  userNames: new Map(),
+  nextId: 1,
+  nextSeq: 1,
+  nextLogId: 1,
+  status: 'main menu',
+  roomName: undefined,
+  phase: 'menu',
+};
+
+/**
+ * @template T
+ * @param {T[]} list
+ * @param {number} max
+ * @returns {T[]}
+ */
+const trimTail = (list, max) =>
+  list.length > max ? list.slice(list.length - max) : list;
+
+/**
+ * @param {State} state
+ * @param {Action} action
+ * @returns {State}
+ */
+export const reducer = (state, action) => {
+  switch (action.type) {
+    case 'message-received': {
+      /** @type {ChatMessage} */
+      const message = {
+        id: state.nextId,
+        seq: state.nextSeq,
+        timestamp: Date.now(),
+        sender: { kind: 'remote', user: action.user },
+        text: action.text,
+      };
+      return {
+        ...state,
+        messages: trimTail([...state.messages, message], MAX_MESSAGES),
+        nextId: state.nextId + 1,
+        nextSeq: state.nextSeq + 1,
+      };
+    }
+    case 'message-sent': {
+      /** @type {ChatMessage} */
+      const message = {
+        id: state.nextId,
+        seq: state.nextSeq,
+        timestamp: Date.now(),
+        sender: { kind: 'self', name: action.name },
+        text: action.text,
+      };
+      return {
+        ...state,
+        messages: trimTail([...state.messages, message], MAX_MESSAGES),
+        nextId: state.nextId + 1,
+        nextSeq: state.nextSeq + 1,
+      };
+    }
+    case 'user-joined':
+    case 'user-left': {
+      /** @type {SystemEvent} */
+      const event = {
+        id: state.nextId,
+        seq: state.nextSeq,
+        timestamp: Date.now(),
+        kind: action.type === 'user-joined' ? 'joined' : 'left',
+        user: action.user,
+      };
+      return {
+        ...state,
+        events: trimTail([...state.events, event], MAX_EVENTS),
+        nextId: state.nextId + 1,
+        nextSeq: state.nextSeq + 1,
+      };
+    }
+    case 'users-present': {
+      /** @type {SystemEvent} */
+      const event = {
+        id: state.nextId,
+        seq: state.nextSeq,
+        timestamp: Date.now(),
+        kind: 'present',
+        users: action.users,
+      };
+      return {
+        ...state,
+        events: trimTail([...state.events, event], MAX_EVENTS),
+        nextId: state.nextId + 1,
+        nextSeq: state.nextSeq + 1,
+      };
+    }
+    case 'info':
+    case 'error': {
+      /** @type {SystemEvent} */
+      const event = {
+        id: state.nextId,
+        seq: state.nextSeq,
+        timestamp: Date.now(),
+        kind: action.type,
+        text: action.text,
+      };
+      return {
+        ...state,
+        events: trimTail([...state.events, event], MAX_EVENTS),
+        nextId: state.nextId + 1,
+        nextSeq: state.nextSeq + 1,
+      };
+    }
+    case 'log': {
+      /** @type {LogEntry} */
+      const entry = {
+        id: state.nextLogId,
+        timestamp: Date.now(),
+        level: action.level,
+        source: action.source,
+        text: action.text,
+      };
+      return {
+        ...state,
+        logs: trimTail([...state.logs, entry], MAX_LOGS),
+        nextLogId: state.nextLogId + 1,
+      };
+    }
+    case 'name-resolved': {
+      // Skip if we already have a (presumably good) name for this user; the
+      // first answer wins so a slow second lookup can't clobber it.
+      if (state.userNames.has(action.user)) {
+        return state;
+      }
+      const userNames = new Map(state.userNames);
+      userNames.set(action.user, action.name);
+      return { ...state, userNames };
+    }
+    case 'set-status':
+      return { ...state, status: action.status };
+    case 'set-phase':
+      return { ...state, phase: action.phase };
+    case 'set-room':
+      return { ...state, roomName: action.roomName };
+    case 'reset-room':
+      return {
+        ...state,
+        messages: [],
+        events: [],
+        userNames: new Map(),
+        roomName: undefined,
+      };
+    default:
+      return state;
+  }
+};
+
+/**
+ * @param {unknown} err
+ * @returns {string}
+ */
+export const formatError = err => {
+  if (err instanceof Error) {
+    return err.stack ? `${err.message}\n${err.stack}` : err.message;
+  }
+  try {
+    return String(err);
+  } catch (_) {
+    return '<unprintable error>';
+  }
+};
+
+/**
+ * Resolve a user capability into a printable name using the in-state
+ * cache, falling back to a placeholder so the line never reads
+ * `<undefined>` while the lookup is still pending.
+ * @param {Map<object, string>} userNames
+ * @param {object} user
+ * @returns {string}
+ */
+export const lookupName = (userNames, user) => userNames.get(user) ?? '…';

--- a/packages/goblin-chat/src/clipboard.js
+++ b/packages/goblin-chat/src/clipboard.js
@@ -1,0 +1,124 @@
+// @ts-check
+/* global process */
+
+/**
+ * Best-effort clipboard write for the goblin-chat TUI.
+ *
+ * The TUI has one consumer for this — the "Host a new chat" flow, which
+ * stuffs the freshly minted sturdyref URI onto the clipboard so the
+ * user can paste it to whoever they want to invite. A failure here is
+ * never fatal; the URI is also rendered into the chat events stream so
+ * the user can copy it manually if every clipboard provider is missing.
+ *
+ * Provider selection:
+ *
+ *   - macOS:   `pbcopy`
+ *   - Windows: `clip`
+ *   - Linux/BSD: try `wl-copy` (Wayland), then `xclip`, then `xsel`,
+ *     in that order. The first one that exits 0 wins.
+ *
+ * We deliberately avoid pulling in a dependency for this — every
+ * clipboard library on npm shells out to the same set of binaries, and
+ * adding a transitive dep would bloat the package for one quality-of-life
+ * feature.
+ */
+
+import { spawn } from 'node:child_process';
+
+/**
+ * Try a single command. Resolves to `{ ok: true }` if the child exited
+ * with code 0, `{ ok: false, error }` otherwise (including the
+ * spawn-failed-with-ENOENT case).
+ *
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {string} text
+ * @returns {Promise<{ ok: true } | { ok: false, error: unknown }>}
+ */
+const tryCommand = (cmd, args, text) =>
+  new Promise(resolve => {
+    /** @type {import('node:child_process').ChildProcess} */
+    let child;
+    try {
+      child = spawn(cmd, args, { stdio: ['pipe', 'ignore', 'ignore'] });
+    } catch (err) {
+      resolve({ ok: false, error: err });
+      return;
+    }
+    let settled = false;
+    const settle = (
+      /** @type {{ ok: true } | { ok: false, error: unknown }} */ result,
+    ) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    child.on('error', err => settle({ ok: false, error: err }));
+    child.on('close', code => {
+      if (code === 0) {
+        settle({ ok: true });
+      } else {
+        settle({
+          ok: false,
+          error: Error(`${cmd} exited with code ${code ?? 'null'}`),
+        });
+      }
+    });
+    const stdin = child.stdin;
+    if (!stdin) {
+      settle({ ok: false, error: Error(`${cmd} has no stdin`) });
+      return;
+    }
+    stdin.on('error', err => settle({ ok: false, error: err }));
+    try {
+      stdin.end(text, 'utf8');
+    } catch (err) {
+      settle({ ok: false, error: err });
+    }
+  });
+
+/**
+ * @returns {Array<[string, string[]]>}
+ */
+const platformCandidates = () => {
+  if (process.platform === 'darwin') {
+    return [['pbcopy', []]];
+  }
+  if (process.platform === 'win32') {
+    return [['clip', []]];
+  }
+  // Linux / BSD: try Wayland first (the native clipboard on a Wayland
+  // session), then X11. `xsel` last because some distros default to it
+  // but most ship `xclip` instead.
+  return [
+    ['wl-copy', []],
+    ['xclip', ['-selection', 'clipboard']],
+    ['xsel', ['--clipboard', '--input']],
+  ];
+};
+
+/**
+ * Copy `text` to the system clipboard. The promise always resolves —
+ * callers should branch on the returned `ok` flag. The first candidate
+ * that succeeds wins; if none does, the last error is returned so the
+ * caller can surface it (e.g. into a log panel).
+ *
+ * @param {string} text
+ * @returns {Promise<{ ok: true } | { ok: false, error: unknown }>}
+ */
+export const copyToClipboard = async text => {
+  // First-await-not-nested: required by `@jessie.js/safe-await-separator`
+  // so the body of this async function reads as straight-line code from
+  // the first suspension point onward.
+  await null;
+  const candidates = platformCandidates();
+  /** @type {unknown} */
+  let lastError = Error('no clipboard provider available');
+  for (const [cmd, args] of candidates) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await tryCommand(cmd, args, text);
+    if (result.ok) return result;
+    lastError = result.error;
+  }
+  return { ok: false, error: lastError };
+};

--- a/packages/goblin-chat/src/host-room.js
+++ b/packages/goblin-chat/src/host-room.js
@@ -1,0 +1,306 @@
+// @ts-check
+/* eslint-disable import/no-unresolved */
+
+/**
+ * Hosting helper for the goblin-chat TUI.
+ *
+ * Stands up a `^chatroom` Far behind a websocket netlayer, registers
+ * it under a freshly generated swissnum, and produces the corresponding
+ * sturdyref URI. The host is owned by its own OCapN client — separate
+ * from the participant client in `useGoblinChat` — so the user can join
+ * their own hosted room over the loopback websocket and exercise the
+ * exact code path a remote joiner would use.
+ *
+ * Two important things to know about the URI we hand back:
+ *
+ *   1. The websocket netlayer's `hints.url` defaults to
+ *      `ws://127.0.0.1:<random-port>`, which is reachable only from the
+ *      same machine. Sharing a hosted URI off-host requires the user to
+ *      do their own port-forwarding / public-IP wiring — that's out of
+ *      scope here.
+ *
+ *   2. Because the host advertises a fresh ephemeral port (and a fresh
+ *      random swissnum) every session, the URI is single-use: it stops
+ *      working the moment the TUI exits. Callers that record joined
+ *      rooms in persistent history should treat self-hosted URIs as
+ *      transient (see the `transient` flag on `useGoblinChat.joinRoom`).
+ *
+ * The module also keeps a process-wide `hostRegistry` so the entrypoint
+ * can shut every host cleanly on process exit / SIGINT / SIGTERM. The
+ * websocket server holds the event loop open, so missing this teardown
+ * means a clean Ctrl+C from the menu wouldn't actually exit.
+ */
+
+import { randomBytes } from 'node:crypto';
+
+import { makeClient } from '@endo/ocapn';
+import { makeWebSocketNetLayer } from '@endo/ocapn/netlayer/ws';
+
+import { makeChatroom } from './backend.js';
+import { encodeBase64Url } from './base64url.js';
+
+/**
+ * @typedef {import('./use-goblin-chat.js').LogSink} LogSink
+ * @typedef {import('@endo/ocapn').OcapnLocation} OcapnLocation
+ */
+
+// 16 bytes of entropy → 22 base64url chars; enough that a directed
+// guess across an ephemeral port is astronomically unlikely, short
+// enough that the URI fits on one terminal line.
+const SWISSNUM_BYTE_LENGTH = 16;
+
+/**
+ * Generate a fresh swissnum string. We use random bytes encoded as
+ * URL-safe base64 (no padding), which guarantees an ASCII string —
+ * the OCapN client's `decodeSwissnum` is strict ASCII, so a raw random
+ * byte sequence (which would routinely contain non-ASCII bytes) can't
+ * be used as a swissnum string directly.
+ *
+ * @returns {string}
+ */
+const makeFreshSwissString = () =>
+  encodeBase64Url(Uint8Array.from(randomBytes(SWISSNUM_BYTE_LENGTH)));
+
+/**
+ * Build the `/s/<…>` segment of an OCapN sturdyref URI from a swissnum
+ * string. Per the OCapN draft spec the path segment is
+ * `base64url(swiss-bytes)` where `swiss-bytes` is the on-the-wire
+ * bytestring representation of the swissnum. Endo represents that
+ * bytestring as the ASCII bytes of the registered swissnum string —
+ * see the `decodeSwissnum`/`encodeSwissnum` pair in
+ * `@endo/ocapn/src/client/util.js` — so we re-encode those ASCII bytes
+ * here.
+ *
+ * @param {string} swissStr
+ * @returns {string}
+ */
+const swissStringToUriSegment = swissStr => {
+  const bytes = new Uint8Array(swissStr.length);
+  for (let i = 0; i < swissStr.length; i += 1) {
+    bytes[i] = swissStr.charCodeAt(i);
+  }
+  return encodeBase64Url(bytes);
+};
+
+/**
+ * Render a hints map onto an OCapN URI's query string. Keys are sorted
+ * for byte-stable output — we don't care about hint ordering on the
+ * wire, but a stable URI is friendlier to log/snapshot diffs and to
+ * humans comparing two URIs by eye.
+ *
+ * @param {OcapnLocation['hints']} hints
+ * @returns {string}
+ */
+const formatHintsQuery = hints => {
+  if (!hints || typeof hints !== 'object') return '';
+  const keys = Object.keys(hints).sort();
+  if (keys.length === 0) return '';
+  const params = new URLSearchParams();
+  for (const key of keys) {
+    params.append(key, String(hints[key]));
+  }
+  return `?${params.toString()}`;
+};
+
+/**
+ * Format the user-facing sturdyref URI for a hosted chatroom from its
+ * peer location and swissnum.
+ *
+ * @param {OcapnLocation} location
+ * @param {string} swissStr
+ * @returns {string}
+ */
+const formatLocator = (location, swissStr) => {
+  const { designator, transport, hints } = location;
+  const segment = swissStringToUriSegment(swissStr);
+  return `ocapn://${designator}.${transport}/s/${segment}${formatHintsQuery(hints)}`;
+};
+
+/**
+ * Wrap a `LogSink` into the `Logger` shape that `makeClient` /
+ * `makeWebSocketNetLayer` expect. Each level forwards through to the
+ * sink (when one is provided), tagged with `source` so the entrypoint
+ * file log can distinguish host-side lines from participant-side lines.
+ * A missing sink degrades gracefully to no-op.
+ *
+ * @param {string} source
+ * @param {LogSink} [logSink]
+ */
+const makeForwardingLogger = (source, logSink) => {
+  /** @param {'log' | 'info' | 'error'} level */
+  const make =
+    level =>
+    /** @param {unknown[]} args */
+    (...args) => {
+      if (!logSink) return;
+      // Mirror `useGoblinChat`'s `formatLogArg` shape: strings pass
+      // through, errors render their message, everything else gets
+      // JSON-stringified with a String() fallback.
+      const text = args
+        .map(value => {
+          if (typeof value === 'string') return value;
+          if (value instanceof Error) return value.message;
+          try {
+            return JSON.stringify(value);
+          } catch (_) {
+            try {
+              return String(value);
+            } catch (__) {
+              return '<unprintable>';
+            }
+          }
+        })
+        .join(' ');
+      try {
+        logSink(level, source, text);
+      } catch (_) {
+        // never let a broken sink take down the host
+      }
+    };
+  return harden({
+    log: make('log'),
+    info: make('info'),
+    error: make('error'),
+  });
+};
+
+/**
+ * @typedef {object} HostHandle
+ * @property {() => void} shutdown
+ *   Synchronous teardown of the host's OCapN client (which in turn
+ *   closes its websocket server and any active sockets). Safe to call
+ *   multiple times.
+ */
+
+/** @type {Set<HostHandle>} */
+const activeHosts = new Set();
+
+/**
+ * Process-wide registry of live hosts. The entrypoint installs a
+ * signal handler that calls `shutdownAll()` on the way out so a Ctrl+C
+ * from the menu actually exits — the websocket server otherwise keeps
+ * the event loop pinned open.
+ */
+export const hostRegistry = harden({
+  /** @param {HostHandle} handle */
+  register(handle) {
+    activeHosts.add(handle);
+  },
+  /** @param {HostHandle} handle */
+  unregister(handle) {
+    activeHosts.delete(handle);
+  },
+  shutdownAll() {
+    for (const handle of activeHosts) {
+      try {
+        handle.shutdown();
+      } catch (_) {
+        // best-effort
+      }
+    }
+    activeHosts.clear();
+  },
+});
+
+/**
+ * @typedef {object} HostRoomOptions
+ * @property {string} roomName
+ *   The chatroom's `self-proposed-name`. Returned to remote subscribers
+ *   verbatim from the `'self-proposed-name'` selector.
+ * @property {string} [captpVersion]
+ *   Forwarded to `makeClient`. Defaults to the client's own default
+ *   when omitted.
+ * @property {LogSink} [logSink]
+ *   Optional log sink for the host's `client` and `netlayer` logs (the
+ *   TUI hands in its per-session file sink).
+ * @property {string} [bindHostname='127.0.0.1']
+ *   Network interface the websocket server should listen on. Defaults
+ *   to loopback so a casual `Host a new chat` doesn't expose anything
+ *   off-host. Set to `0.0.0.0` (or a specific public IP) when
+ *   deploying as a server.
+ * @property {number} [bindPort=0]
+ *   TCP port the websocket server should listen on. `0` picks an
+ *   ephemeral port (the default for ad-hoc local hosting); set to a
+ *   stable number when running behind a firewall / forwarding rule
+ *   so the advertised URI doesn't change between sessions.
+ * @property {string} [publicUrl]
+ *   The `ws://…` or `wss://…` URL that should appear in the
+ *   sturdyref's `hints.url` (and therefore in the URI handed out to
+ *   peers). When omitted, defaults to `ws://<bind-host>:<bind-port>`,
+ *   which is what other peers will dial. Override this when the
+ *   externally reachable URL differs from the bind address — e.g.
+ *   running behind a reverse proxy that terminates TLS
+ *   (`wss://chat.example.com`) or NAT'd to a public IP under a
+ *   different port.
+ *
+ * @typedef {object} HostedRoom
+ * @property {string} uri
+ *   The full `ocapn://…/s/<base64url>?url=ws://…` sturdyref URI. Pass
+ *   to a participant's `joinRoom` (or copy to the clipboard for a
+ *   peer to paste).
+ * @property {() => void} shutdown
+ *   Polite teardown — closes the websocket server, terminates active
+ *   sockets, removes the host from the process-wide registry. Safe to
+ *   call multiple times.
+ */
+
+/**
+ * Stand up a hosted chatroom. The returned handle owns the lifetime of
+ * the underlying OCapN client + websocket server; the caller is
+ * responsible for invoking `shutdown()` (or relying on
+ * `hostRegistry.shutdownAll()` at process exit).
+ *
+ * @param {HostRoomOptions} options
+ * @returns {Promise<HostedRoom>}
+ */
+export const hostRoom = async ({
+  roomName,
+  captpVersion,
+  logSink,
+  bindHostname = '127.0.0.1',
+  bindPort = 0,
+  publicUrl,
+}) => {
+  const swissStr = makeFreshSwissString();
+  const chatroom = makeChatroom(roomName);
+
+  const client = makeClient({
+    verbose: true,
+    ...(captpVersion ? { captpVersion } : {}),
+    logger: makeForwardingLogger('host-client', logSink),
+  });
+  client.registerSturdyRef(swissStr, chatroom);
+
+  const netlayer = await client.registerNetlayer(handlers =>
+    makeWebSocketNetLayer({
+      handlers,
+      logger: makeForwardingLogger('host-netlayer', logSink),
+      specifiedHostname: bindHostname,
+      specifiedPort: bindPort,
+      ...(publicUrl ? { specifiedUrl: publicUrl } : {}),
+    }),
+  );
+
+  const uri = formatLocator(netlayer.location, swissStr);
+
+  let shutDown = false;
+  /** @type {HostHandle} */
+  const handle = {
+    shutdown: () => {
+      if (shutDown) return;
+      shutDown = true;
+      try {
+        client.shutdown();
+      } catch (_) {
+        // best-effort
+      }
+      hostRegistry.unregister(handle);
+    },
+  };
+  hostRegistry.register(handle);
+
+  return harden({
+    uri,
+    shutdown: handle.shutdown,
+  });
+};

--- a/packages/goblin-chat/src/interop-driver.js
+++ b/packages/goblin-chat/src/interop-driver.js
@@ -1,0 +1,170 @@
+// @ts-check
+/* global setTimeout, clearTimeout */
+
+/**
+ * Shared driver for one side of a goblin-chat interop exchange.
+ *
+ * The chatroom protocol is symmetric: every participant joins the same
+ * room, subscribes an observer, sends one local message, and waits to
+ * see both the remote participant's message and the echo of its own.
+ * The same routine therefore drives:
+ *
+ *   - the Endo OCapN client side of the Endo↔Guile CI test (against
+ *     a Guile-hosted chatroom; see `../test/guile-interop/`),
+ *   - both sides of the all-JS self-interop test in
+ *     `../test/interop-self.test.js` (where one
+ *     participant holds the local `^chatroom` Far and the other talks
+ *     to it through the OCapN websocket netlayer).
+ *
+ * Sending is gated on observing a `user-joined` event for a *different*
+ * participant. This matches the trigger the Guile interop client uses
+ * (`(not (eq? joining-user user))`) and avoids a race where one side
+ * sends before the other has finished subscribing — the chatroom would
+ * broadcast the message only to subscribers present at send time, so
+ * an early send would silently drop on the floor.
+ */
+
+import { E } from '@endo/eventual-send';
+import { makeExo } from '@endo/exo';
+import { M } from '@endo/patterns';
+
+import { makeUserControllerPair } from './backend.js';
+
+const InteropObserverI = M.interface('InteropObserver', {
+  'new-message': M.call(M.any(), M.any(), M.any()).returns(),
+  'user-joined': M.call(M.any()).returns(),
+  'user-left': M.call(M.any()).returns(),
+});
+
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/**
+ * @typedef {(line: string) => void} InteropLog
+ */
+
+/**
+ * @typedef {object} ChatParticipantOptions
+ * @property {any} chatroom
+ *   The chatroom to join. May be a local `^chatroom` Far (from
+ *   `makeChatroom`) or a remote presence enlivened from an OCapN
+ *   sturdyref.
+ * @property {string} name
+ *   `self-proposed-name` for this participant's user-controller pair.
+ * @property {string} localMessage
+ *   What this participant sends once it observes another joiner.
+ * @property {string} expectedRemoteMessage
+ *   What this participant expects the other side to send. Resolution
+ *   is gated on observing this string in `new-message`.
+ * @property {number} [timeoutMs]
+ *   Hard deadline for the whole exchange. Defaults to 30s.
+ * @property {InteropLog} [log]
+ *   Optional progress sink for human-readable status lines.
+ */
+
+/**
+ * Drive one side of a goblin-chat interop exchange.
+ *
+ * Resolves once **all** of the following have happened:
+ *   1. our `send-message` has been ack'd by the chatroom,
+ *   2. an inbound `new-message` carrying `expectedRemoteMessage` was
+ *      observed on our subscription, and
+ *   3. an inbound `new-message` carrying `localMessage` was observed
+ *      (the chatroom echoes our own send back to all subscribers,
+ *      including ourselves — observing it confirms full round-trip).
+ *
+ * Rejects if the deadline elapses, if `subscribe` returns a non-`OK`
+ * status, or if `send-message` rejects.
+ *
+ * @param {ChatParticipantOptions} options
+ * @returns {Promise<void>}
+ */
+export const runChatParticipant = async ({
+  chatroom,
+  name,
+  localMessage,
+  expectedRemoteMessage,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  log = () => undefined,
+}) => {
+  const { user, userController } = makeUserControllerPair(name);
+  const channel = await E(userController)['join-room'](chatroom);
+
+  /** @type {Set<string>} */
+  const seenMessages = new Set();
+  let sentLocalMessageAck = false;
+  let sendInFlight = false;
+
+  /** @type {(value?: unknown) => void} */
+  let resolveDone;
+  /** @type {(reason?: any) => void} */
+  let rejectDone;
+  const done = new Promise((resolve, reject) => {
+    resolveDone = resolve;
+    rejectDone = reject;
+  });
+  const timeout = setTimeout(() => {
+    rejectDone(
+      Error(
+        `[${name}] timed out waiting for interop messages (${timeoutMs}ms); ` +
+          `seen=${[...seenMessages].join('|')} sentAck=${sentLocalMessageAck}`,
+      ),
+    );
+  }, timeoutMs);
+
+  const finishIfReady = () => {
+    if (
+      sentLocalMessageAck &&
+      seenMessages.has(expectedRemoteMessage) &&
+      seenMessages.has(localMessage)
+    ) {
+      log(`[${name}] interop observer received both expected messages`);
+      resolveDone(undefined);
+    }
+  };
+
+  const sendOnce = () => {
+    if (sendInFlight || sentLocalMessageAck) return;
+    sendInFlight = true;
+    E(channel)
+      ['send-message'](localMessage)
+      .then(ack => {
+        sentLocalMessageAck = true;
+        log(`[${name}] sent message, ack = ${JSON.stringify(ack)}`);
+        finishIfReady();
+      })
+      .catch(err => {
+        rejectDone(err);
+      });
+  };
+
+  const observer = makeExo('interop-observer', InteropObserverI, {
+    'new-message': (_context, _fromUser, message) => {
+      if (typeof message !== 'string') return;
+      log(`[${name}] interop observer received message: ${message}`);
+      seenMessages.add(message);
+      finishIfReady();
+    },
+    'user-joined': joiningUser => {
+      // Skip the chatroom backfill self-echo (see `Bit-for-bit with
+      // Guile` notes in src/backend.js): the joiner's own user appears
+      // last in the backfill. We send only when we observe a different
+      // participant, mirroring the Guile interop client's trigger.
+      if (joiningUser === user) return;
+      sendOnce();
+    },
+    'user-left': _user => undefined,
+  });
+
+  const [status] = await E(channel).subscribe(observer);
+  if (status !== 'OK') {
+    clearTimeout(timeout);
+    throw Error(`[${name}] unexpected subscribe status: ${status}`);
+  }
+  log(`[${name}] subscription ready`);
+
+  try {
+    await done;
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/packages/goblin-chat/src/state-store.js
+++ b/packages/goblin-chat/src/state-store.js
@@ -1,0 +1,249 @@
+// @ts-check
+/* global process */
+
+/**
+ * Persistent on-disk state for the goblin-chat TUI.
+ *
+ * Stores two things between sessions:
+ *   - `name`         the user's `self-proposed-name`.
+ *   - `recentRooms`  a most-recent-first list of past chatroom URIs,
+ *                    with optional `displayName` (the room's
+ *                    `self-proposed-name`) and `lastJoinedAt` for the
+ *                    "join previous chat" picker.
+ *
+ * File location follows the XDG Base Directory spec where possible:
+ *   $XDG_CONFIG_HOME/goblin-chat/state.json   (if set)
+ *   $HOME/.config/goblin-chat/state.json      (POSIX fallback)
+ *   $APPDATA/goblin-chat/state.json           (Windows)
+ *
+ * Reads are synchronous and resilient: a missing file or a corrupted
+ * file both yield the default (empty) state with no warning at the
+ * call site — the TUI's own log panel surfaces issues via the
+ * optional `onError` callback.
+ *
+ * Writes are also synchronous (the persisted state is tiny — kilobytes
+ * at most — and we only write on user actions like rename or join).
+ * Atomic-write via `<file>.tmp` + `rename` so a crash mid-write can't
+ * leave a half-written file on disk.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve as resolvePath } from 'node:path';
+
+const MAX_RECENT_ROOMS = 32;
+
+/**
+ * @typedef {object} RecentRoom
+ * @property {string} uri
+ *   The full `ocapn://…/s/<base64url>?…` sturdyref URI as the user
+ *   originally pasted it. We keep the raw string rather than a parsed
+ *   form so future re-joins go through the same parser path and any
+ *   parser-improvement applies retroactively.
+ * @property {string} [displayName]
+ *   The chatroom's `self-proposed-name` as observed on the most recent
+ *   successful join. Optional — older entries (or rooms whose name
+ *   lookup failed) won't have it. Only used as a label in the picker.
+ * @property {string} lastJoinedAt
+ *   ISO-8601 wallclock of the most recent successful join. Used to
+ *   sort the picker most-recent-first; also handy for users to spot a
+ *   stale entry.
+ *
+ * @typedef {object} PersistedState
+ * @property {string} [name]
+ *   `self-proposed-name` to use on the next join. Persists across
+ *   sessions so the user doesn't have to retype it.
+ * @property {RecentRoom[]} recentRooms
+ *   Most-recent-first; bounded at `MAX_RECENT_ROOMS` entries.
+ */
+
+/** @returns {PersistedState} */
+const emptyState = () => ({ recentRooms: [] });
+
+/**
+ * Resolve the on-disk path to the persisted state file. Honors
+ * `GOBLIN_CHAT_STATE_FILE` for tests / advanced users; otherwise picks
+ * the platform-appropriate location.
+ *
+ * @returns {string}
+ */
+export const defaultStateFilePath = () => {
+  const override = process.env.GOBLIN_CHAT_STATE_FILE;
+  if (override && override.length > 0) {
+    return resolvePath(override);
+  }
+  // XDG: explicit XDG_CONFIG_HOME wins on any platform that sets it,
+  // since some Linux/macOS users keep all dotfiles under a non-default
+  // root via XDG.
+  const xdg = process.env.XDG_CONFIG_HOME;
+  if (xdg && xdg.length > 0) {
+    return join(xdg, 'goblin-chat', 'state.json');
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData && appData.length > 0) {
+      return join(appData, 'goblin-chat', 'state.json');
+    }
+  }
+  return join(homedir(), '.config', 'goblin-chat', 'state.json');
+};
+
+/**
+ * Validate-and-coerce a raw JSON parse into the persisted-state shape.
+ * Anything we don't recognise is dropped silently — the file format is
+ * an internal cache, not an API.
+ *
+ * @param {unknown} raw
+ * @returns {PersistedState}
+ */
+const coerce = raw => {
+  if (!raw || typeof raw !== 'object') return emptyState();
+  const r = /** @type {Record<string, unknown>} */ (raw);
+  /** @type {PersistedState} */
+  const out = emptyState();
+  if (typeof r.name === 'string' && r.name.length > 0) {
+    out.name = r.name;
+  }
+  if (Array.isArray(r.recentRooms)) {
+    for (const item of r.recentRooms) {
+      if (item && typeof item === 'object') {
+        const rec = /** @type {Record<string, unknown>} */ (item);
+        if (typeof rec.uri === 'string' && rec.uri.length > 0) {
+          /** @type {RecentRoom} */
+          const room = {
+            uri: rec.uri,
+            lastJoinedAt:
+              typeof rec.lastJoinedAt === 'string'
+                ? rec.lastJoinedAt
+                : new Date(0).toISOString(),
+          };
+          if (
+            typeof rec.displayName === 'string' &&
+            rec.displayName.length > 0
+          ) {
+            room.displayName = rec.displayName;
+          }
+          out.recentRooms.push(room);
+        }
+      }
+    }
+  }
+  return out;
+};
+
+/**
+ * @typedef {object} StateStore
+ * @property {string} filePath
+ * @property {() => PersistedState} read
+ *   Snapshot of the in-memory state (also reflects the on-disk file at
+ *   construction time). Returns a *copy* so callers can't mutate
+ *   internal state by accident.
+ * @property {(name: string) => void} setName
+ * @property {(uri: string, displayName?: string) => void} recordJoin
+ *   Push the room to the front of `recentRooms` (deduped by `uri`),
+ *   stamp `lastJoinedAt` to now, and persist. If the room is already
+ *   present, its existing `displayName` is preserved unless the new
+ *   call provides one.
+ * @property {(uri: string) => void} forgetRoom
+ *   Remove a room from `recentRooms` (e.g. so the user can prune a
+ *   stale entry). No-op if the URI isn't present.
+ */
+
+/**
+ * Open (or create) the state store. Reads the file once at
+ * construction; subsequent mutators write through synchronously. The
+ * store keeps an in-memory copy so the hot path (rendering the recent
+ * list) doesn't re-read the file on every frame.
+ *
+ * @param {object} [options]
+ * @param {string} [options.filePath]   Override the default location.
+ * @param {(err: unknown, op: 'read' | 'write') => void} [options.onError]
+ *   Optional sink for IO errors. Defaults to a no-op so a busted home
+ *   directory can't crash the TUI on first launch.
+ * @returns {StateStore}
+ */
+export const openStateStore = ({ filePath, onError } = {}) => {
+  const path = filePath || defaultStateFilePath();
+  const reportError = onError || (() => undefined);
+
+  /** @type {PersistedState} */
+  let state = emptyState();
+  try {
+    if (existsSync(path)) {
+      const text = readFileSync(path, 'utf8');
+      state = coerce(JSON.parse(text));
+    }
+  } catch (err) {
+    reportError(err, 'read');
+    state = emptyState();
+  }
+
+  const persist = () => {
+    try {
+      mkdirSync(dirname(path), { recursive: true });
+      const tmp = `${path}.tmp`;
+      writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+      // `renameSync` is atomic on POSIX (and best-effort on Windows);
+      // either the new file is fully present or the old one survives.
+      renameSync(tmp, path);
+    } catch (err) {
+      reportError(err, 'write');
+    }
+  };
+
+  /** @returns {PersistedState} */
+  const read = () => ({
+    name: state.name,
+    recentRooms: state.recentRooms.map(r => ({ ...r })),
+  });
+
+  /** @param {string} name */
+  const setName = name => {
+    const trimmed = name.trim();
+    if (trimmed.length === 0) return;
+    if (state.name === trimmed) return;
+    state = { ...state, name: trimmed };
+    persist();
+  };
+
+  /**
+   * @param {string} uri
+   * @param {string} [displayName]
+   */
+  const recordJoin = (uri, displayName) => {
+    const now = new Date().toISOString();
+    const existing = state.recentRooms.find(r => r.uri === uri);
+    /** @type {RecentRoom} */
+    const updated = {
+      uri,
+      lastJoinedAt: now,
+      displayName: displayName ?? existing?.displayName,
+    };
+    const others = state.recentRooms.filter(r => r.uri !== uri);
+    const recentRooms = [updated, ...others].slice(0, MAX_RECENT_ROOMS);
+    state = { ...state, recentRooms };
+    persist();
+  };
+
+  /** @param {string} uri */
+  const forgetRoom = uri => {
+    const next = state.recentRooms.filter(r => r.uri !== uri);
+    if (next.length === state.recentRooms.length) return;
+    state = { ...state, recentRooms: next };
+    persist();
+  };
+
+  return harden({
+    filePath: path,
+    read,
+    setName,
+    recordJoin,
+    forgetRoom,
+  });
+};

--- a/packages/goblin-chat/src/uri-parse.js
+++ b/packages/goblin-chat/src/uri-parse.js
@@ -1,0 +1,132 @@
+// @ts-check
+
+/**
+ * @import { OcapnLocation, SwissNum } from '@endo/ocapn'
+ */
+
+import { swissnumFromBytes } from '@endo/ocapn';
+
+import { decodeBase64Url } from './base64url.js';
+
+/**
+ * Decode a base64url-encoded string (RFC 4648 §5) without padding into
+ * raw bytes wrapped as a `SwissNum`. The Spritely Goblins reference
+ * implementation of `string->ocapn-id` (`goblins/ocapn/ids.scm`) treats
+ * the `/s/<value>` URI segment exactly this way:
+ *
+ *   (base64-decode (substring path …)
+ *                  #:alphabet base64-url-alphabet
+ *                  #:padding? #f)
+ *
+ * The OCapN draft spec's Syrup serialization for `<ocapn-sturdyref>`
+ * carries `swiss-num` as a bytevector (and Endo's `OcapnSturdyRefCodec`
+ * already uses `read/writeBytestring`), so this is the only sound
+ * interpretation for an interoperable sturdyref URI.
+ *
+ * Validation is strict: the alphabet check rejects characters that the
+ * underlying decoder would silently skip, which would otherwise let
+ * typos slip through and produce a wrong-but-plausible swissnum that
+ * fails far from the parser.
+ *
+ * @param {string} value  Path segment as it appears after `/s/` (already
+ *   percent-decoded by the caller).
+ * @returns {SwissNum}
+ */
+const decodeBase64UrlSwissnum = value => {
+  if (!/^[A-Za-z0-9_-]+$/u.test(value)) {
+    throw Error(
+      `Sturdyref swiss-num must be base64url (RFC 4648 §5) without padding: ${value}`,
+    );
+  }
+  return swissnumFromBytes(decodeBase64Url(value, 'swiss-num'));
+};
+
+/**
+ * @typedef {object} ParsedOcapnLocator
+ * @property {OcapnLocation} location
+ *   The peer locator (designator + transport + hints).
+ * @property {SwissNum | undefined} swissNum
+ *   Present for sturdyref URIs (`/s/<swiss>`); `undefined` for plain peer URIs.
+ * @property {'peer' | 'sturdyref'} kind
+ */
+
+/**
+ * Parse an OCapN locator URI of the form
+ *   `ocapn://<designator>.<transport>[/s/<swiss>][?hint=value&...]`
+ *
+ * The swissnum, when present, is base64url(no-padding) of the raw
+ * swissnum bytes per the OCapN spec (`draft-specifications/Locators.md`)
+ * and the Spritely Goblins reference implementation
+ * (`goblins/ocapn/ids.scm`). No other encodings are accepted.
+ *
+ * The host portion of an `ocapn://` URI encodes a `<designator>.<transport>`
+ * pair, with the transport occupying the last dot-separated label. We
+ * lean on the standard `URL` parser for the heavy lifting (scheme,
+ * percent-decoding, query parameters) and only special-case that split.
+ *
+ * @param {string} uri
+ * @returns {ParsedOcapnLocator}
+ */
+export const parseLocator = uri => {
+  const trimmed = uri.trim();
+  if (!URL.canParse(trimmed)) {
+    throw Error(`Not a valid ocapn:// URI: ${uri}`);
+  }
+  const url = new URL(trimmed);
+  if (url.protocol !== 'ocapn:') {
+    throw Error(`Not a valid ocapn:// URI: ${uri}`);
+  }
+  // `URL` does not parse a host for arbitrary schemes; OCapN URIs use
+  // `ocapn://`, but Node's URL parser exposes the authority via `host`
+  // for hierarchical schemes. Empty host means a malformed URI.
+  const hostPart = url.host;
+  if (!hostPart) {
+    throw Error(`OCapN URI is missing a host: ${uri}`);
+  }
+  if (url.username || url.password || url.port) {
+    throw Error(`OCapN URI must not carry userinfo or port: ${uri}`);
+  }
+
+  const lastDot = hostPart.lastIndexOf('.');
+  if (lastDot <= 0 || lastDot === hostPart.length - 1) {
+    throw Error(
+      `OCapN URI host must be of the form <designator>.<transport>: ${hostPart}`,
+    );
+  }
+  const designator = hostPart.slice(0, lastDot);
+  const transport = hostPart.slice(lastDot + 1);
+
+  /** @type {Record<string, string>} */
+  const hints = {};
+  for (const [key, value] of url.searchParams) {
+    hints[key] = value;
+  }
+
+  /** @type {'peer' | 'sturdyref'} */
+  let kind = 'peer';
+  /** @type {SwissNum | undefined} */
+  let swissNum;
+  const path = url.pathname.replace(/\/+$/u, '');
+  if (path.length > 0) {
+    const sMatch = path.match(/^\/s\/(.+)$/u);
+    if (!sMatch) {
+      throw Error(`Unsupported OCapN URI path: ${url.pathname}`);
+    }
+    kind = 'sturdyref';
+    swissNum = decodeBase64UrlSwissnum(decodeURIComponent(sMatch[1]));
+  }
+
+  /** @type {OcapnLocation} */
+  const location = {
+    type: 'ocapn-peer',
+    designator,
+    transport,
+    hints: Object.keys(hints).length === 0 ? false : hints,
+  };
+
+  return {
+    location,
+    swissNum,
+    kind,
+  };
+};

--- a/packages/goblin-chat/src/use-goblin-chat.js
+++ b/packages/goblin-chat/src/use-goblin-chat.js
@@ -1,0 +1,614 @@
+// @ts-check
+/* eslint-disable import/no-unresolved */
+
+/**
+ * `useGoblinChat` — React hook that owns the OCapN-side state machine and
+ * side effects for the goblin-chat TUI.
+ *
+ * The hook deliberately encapsulates the `makeClient` call so the same
+ * reducer-backed `Logger` can be wired in once and pumped into both the
+ * client and any registered netlayer. Callers get back a `state` slice
+ * (matching the `chat-state.js` shape) and a small set of action
+ * functions; everything else — sessions, capabilities, name lookups —
+ * is internal.
+ *
+ * Two log streams flow out of the hook:
+ *   - the **chat events** stream (`messages`, `events`) — strictly
+ *     human-meaningful per-room activity (joins, leaves, message
+ *     traffic). Diagnostic info and non-critical errors do *not* land
+ *     here, so a connect-time hiccup or a missing display-name doesn't
+ *     pollute the chat view.
+ *   - the **log panel** stream (`logs`) — every diagnostic line, every
+ *     non-critical error, plus the verbatim output of the OCapN client
+ *     and netlayer. This panel is hidden by default in the TUI; users
+ *     toggle it on for forensics.
+ *
+ * Shutdown is handled cooperatively. The hook installs a polite-leave
+ * function into the exported `shutdownHandle` on mount and clears it on
+ * unmount, so signal handlers in the entrypoint can invoke the same
+ * teardown as the in-app Ctrl+C path. See the comment on
+ * `shutdownHandle` for the raw-mode/`signal-exit` race-condition story.
+ */
+
+/**
+ * @import { SwissNum } from '@endo/ocapn'
+ */
+
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+import { makeClient, swissnumToBytes } from '@endo/ocapn';
+import { makeWebSocketNetLayer } from '@endo/ocapn/netlayer/ws';
+import { makeUserControllerPair } from './backend.js';
+import { parseLocator } from './uri-parse.js';
+import { encodeBase64Url } from './base64url.js';
+import { initialState, reducer, formatError } from './chat-state.js';
+
+const ASCII_DECODER = new TextDecoder('ascii');
+
+/**
+ * Render a swissnum for log display.
+ *
+ * Two cases:
+ *
+ *   1. Endo-originated swissnums that happen to be printable ASCII
+ *      (e.g. the built-in `'Echo'` test object's name). Show the
+ *      literal string — much more useful than its base64 form.
+ *
+ *   2. The general case: opaque random bytes, e.g. the 32-byte values
+ *      that appear in `ocapn://…/s/<base64url>` URIs. Render in the
+ *      same canonical base64url form they appeared on the wire.
+ *
+ * NOTE: this used to delegate to `decodeSwissnum` and rely on its
+ * `TextDecoder('ascii', { fatal: true })` to throw on non-ASCII. That
+ * doesn't work — per the WHATWG encoding spec the `'ascii'` label is
+ * aliased to `'windows-1252'`, every byte 0–255 is "valid" in
+ * windows-1252, so `fatal` never fires and 32 random bytes come back
+ * as Latin-1 garbage like `ôr¤\`RB…`. We do the printable-ASCII check
+ * ourselves now.
+ *
+ * @param {SwissNum} swissNum
+ * @returns {string}
+ */
+const formatSwissnumForLog = swissNum => {
+  const bytes = swissnumToBytes(swissNum);
+  let allPrintable = bytes.length > 0;
+  for (let i = 0; i < bytes.length; i += 1) {
+    const c = bytes[i];
+    // 0x20 (space) through 0x7e (~) inclusive — the printable ASCII
+    // range. Tab/newline are excluded on purpose; a swissnum that
+    // contains them is interesting enough to want the base64url form.
+    if (c < 0x20 || c > 0x7e) {
+      allPrintable = false;
+      break;
+    }
+  }
+  if (allPrintable) {
+    return ASCII_DECODER.decode(bytes);
+  }
+  return encodeBase64Url(bytes);
+};
+
+/**
+ * @typedef {import('./chat-state.js').State} State
+ * @typedef {import('./chat-state.js').Action} Action
+ * @typedef {import('./chat-state.js').LogLevel} LogLevel
+ * @typedef {import('./chat-state.js').Phase} Phase
+ */
+
+/**
+ * Mutable handle the hook fills in on mount with a function that
+ * politely tears down whatever OCapN session is currently live
+ * (`unsubscribe` → `leave` → `client.shutdown()`). Both the in-app
+ * Ctrl+C keystroke and the out-of-app signal handlers in the
+ * entrypoint invoke it on the way out so we don't disappear from the
+ * chatroom without saying goodbye, and so the websocket gets closed
+ * cleanly instead of half-open.
+ *
+ * Why not just use signals? While the TUI is running ink puts the TTY
+ * into raw mode, which disables the kernel's ISIG translation — so a
+ * literal `^C` keystroke arrives as the byte 0x03 via `useInput`, NOT
+ * as SIGINT. Conversely, SIGTERM/SIGHUP and `kill -INT $pid` never
+ * touch `useInput`. Both code paths converge through this handle.
+ *
+ * @type {{ run: () => void }}
+ */
+export const shutdownHandle = { run: () => undefined };
+
+/**
+ * Render an arbitrary `console.*`-style argument for inline display in
+ * the log panel. Strings pass through; errors get their `.message`;
+ * everything else is JSON-stringified, falling back to `String(value)`
+ * when that fails (e.g. circular references, BigInts).
+ * @param {unknown} value
+ * @returns {string}
+ */
+const formatLogArg = value => {
+  if (typeof value === 'string') return value;
+  if (value instanceof Error) return formatError(value);
+  try {
+    return JSON.stringify(value);
+  } catch (_) {
+    try {
+      return String(value);
+    } catch (__) {
+      return '<unprintable>';
+    }
+  }
+};
+
+/**
+ * @callback LogSink
+ * @param {LogLevel} level
+ * @param {string} source
+ * @param {string} text
+ * @returns {void}
+ */
+
+/**
+ * Build a `Logger` (matching the ocapn `Logger` typedef) that pipes
+ * every call into the reducer as a `log` action. Each level is tagged
+ * with the supplied `source` so the panel can distinguish e.g.
+ * `client` from `netlayer` lines. If a `logSink` is provided, every
+ * formatted line is also forwarded there (used by the entrypoint to
+ * mirror logs into a session file).
+ * @param {(action: Action) => void} dispatch
+ * @param {string} source
+ * @param {LogSink} [logSink]
+ */
+const makeReducerLogger = (dispatch, source, logSink) => {
+  /** @param {LogLevel} level */
+  const make =
+    level =>
+    /** @param {unknown[]} args */
+    (...args) => {
+      const text = args.map(formatLogArg).join(' ');
+      dispatch({ type: 'log', level, source, text });
+      if (logSink) {
+        try {
+          logSink(level, source, text);
+        } catch (_) {
+          // Never let a broken sink (e.g. closed file) take down the app.
+        }
+      }
+    };
+  return harden({
+    log: make('log'),
+    info: make('info'),
+    error: make('error'),
+  });
+};
+
+/**
+ * @typedef {object} JoinedRoom
+ * @property {string} uri          The full `ocapn://…` URI just joined.
+ * @property {string} [roomName]   The chatroom's `self-proposed-name`,
+ *   when the lookup succeeded.
+ */
+
+/**
+ * @typedef {object} GoblinChatConfig
+ * @property {string} [captpVersion]    Forwarded to `makeClient`.
+ * @property {boolean} [verbose=true]   Forwarded to `makeClient`. The
+ *   default is `true` because the dedicated log panel is the whole
+ *   point of having a logger; `info` lines flowing through is what
+ *   makes that panel useful.
+ * @property {LogSink} [logSink]        Optional side-channel called for
+ *   every log line in addition to the reducer dispatch. The TUI
+ *   entrypoint uses this to mirror logs to a per-session file.
+ * @property {(joined: JoinedRoom) => void} [onJoined]
+ *   Called once per successful `join-room`, after the chatroom name
+ *   has been fetched (or skipped). The TUI uses this to push the room
+ *   into its persistent recent-rooms list. Errors thrown by the
+ *   callback are caught and logged — they never block the join.
+ */
+
+/**
+ * @typedef {object} JoinRoomOptions
+ * @property {string} uri
+ * @property {string} name
+ * @property {boolean} [transient=false]
+ *   When true, suppress the `onJoined` callback so the join doesn't
+ *   land in any persistent recent-rooms list. Used by the "host a new
+ *   chat" flow, where the URI is single-use (fresh ephemeral port and
+ *   swissnum every session) and saving it would clutter history with
+ *   stale entries.
+ */
+
+/**
+ * @typedef {object} GoblinChatActions
+ * @property {(args: JoinRoomOptions) => Promise<void>} joinRoom
+ *   Parse a sturdyref URI, stand up a websocket netlayer, enliven the
+ *   chatroom, join, and subscribe. Errors are caught: the failure is
+ *   recorded in the log panel and the phase falls back to `menu` with
+ *   a `connect failed` status — the returned promise itself never
+ *   rejects.
+ * @property {(text: string) => Promise<void>} sendMessage
+ *   Send a message into the joined room. Errors are caught and
+ *   surfaced in the log panel.
+ * @property {() => void} leaveRoom
+ *   Politely tear down the active session (unsubscribe → leave →
+ *   `client.shutdown()`), reset the room slice of state, and return
+ *   to the `menu` phase. Safe to call when no session is active.
+ * @property {(phase: Phase) => void} setPhase
+ *   Drive the high-level phase transition. The TUI uses this to move
+ *   between `menu`, `name-input`, `uri-input`, `host-name-input`, and
+ *   `recent-list`.
+ * @property {(text: string) => void} addInfo
+ *   Push an `info` system event onto the chat events stream. Used by
+ *   the host-a-new-chat flow to render the freshly minted sturdyref
+ *   URI inline with the chat (so the user sees what landed on their
+ *   clipboard, even with the diagnostic log panel hidden).
+ * @property {() => void} shutdown
+ *   Synchronous polite teardown for process exit: unsubscribe
+ *   (eventual), leave (eventual), `client.shutdown()` (sync). Safe to
+ *   call multiple times. The same function is wired into
+ *   `shutdownHandle.run` for signal-handler use.
+ */
+
+/**
+ * @typedef {{
+ *   client: ReturnType<typeof makeClient> | undefined,
+ *   channel: any,
+ *   unsubscribe: any,
+ *   selfUser: any,
+ *   activeName: string | undefined,
+ *   pendingNames: WeakSet<object>,
+ * }} SessionRef
+ */
+
+/**
+ * @param {GoblinChatConfig} [config]
+ * @returns {{ state: State } & GoblinChatActions}
+ */
+export const useGoblinChat = ({
+  captpVersion,
+  verbose = true,
+  logSink,
+  onJoined,
+} = {}) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const sessionRef = useRef(
+    /** @type {SessionRef} */ ({
+      client: undefined,
+      channel: undefined,
+      unsubscribe: undefined,
+      selfUser: undefined,
+      activeName: undefined,
+      pendingNames: new WeakSet(),
+    }),
+  );
+
+  // Diagnostic logging — these always go to the (toggleable) log panel
+  // and never to the chat events stream. The chat events stream is
+  // reserved for human-meaningful per-room activity (joins, leaves,
+  // message traffic) so connect-time noise and best-effort name
+  // lookups don't push the actual conversation off-screen.
+  const logDiag = useCallback(
+    /** @param {string} text */
+    text => dispatch({ type: 'log', level: 'info', source: 'tui', text }),
+    [],
+  );
+
+  const logDiagError = useCallback(
+    /**
+     * @param {unknown} err
+     * @param {string} [context]
+     */
+    (err, context) => {
+      const text = context
+        ? `${context}: ${formatError(err)}`
+        : formatError(err);
+      dispatch({ type: 'log', level: 'error', source: 'tui', text });
+    },
+    [],
+  );
+
+  /**
+   * Fire-and-forget background lookup of `self-proposed-name`. Dedupes
+   * by remembering which capabilities we've already asked about
+   * (whether or not the response has come back yet). We never re-ask,
+   * even on failure; a failed lookup is recorded as a placeholder name
+   * so the cache lookup succeeds on subsequent calls.
+   * @param {object} user
+   */
+  const kickResolveName = useCallback(
+    user => {
+      const { pendingNames } = sessionRef.current;
+      if (pendingNames.has(user)) return;
+      pendingNames.add(user);
+      E(user)
+        ['self-proposed-name']()
+        .then(resolved => {
+          const display =
+            typeof resolved === 'string' ? resolved : '<anonymous>';
+          dispatch({ type: 'name-resolved', user, name: display });
+        })
+        .catch(err => {
+          dispatch({
+            type: 'name-resolved',
+            user,
+            name: '<unknown user>',
+          });
+          logDiagError(err, 'failed to resolve user name');
+        });
+    },
+    [logDiagError],
+  );
+
+  const setPhase = useCallback(
+    /** @param {Phase} phase */
+    phase => dispatch({ type: 'set-phase', phase }),
+    [],
+  );
+
+  const teardownSession = useCallback(() => {
+    const { client, channel, unsubscribe } = sessionRef.current;
+    // Best-effort polite leave so the remote chatroom hears us go.
+    // Each call is independently try/caught because any one failing
+    // (e.g. the channel is already closed) shouldn't skip the others.
+    if (unsubscribe) {
+      try {
+        E(unsubscribe)().catch(() => undefined);
+      } catch (_) {
+        // ignore
+      }
+    }
+    if (channel) {
+      try {
+        E(channel)
+          .leave()
+          .catch(() => undefined);
+      } catch (_) {
+        // ignore
+      }
+    }
+    if (client) {
+      try {
+        client.shutdown();
+      } catch (err) {
+        logDiagError(err, 'shutdown');
+      }
+    }
+    sessionRef.current.client = undefined;
+    sessionRef.current.channel = undefined;
+    sessionRef.current.unsubscribe = undefined;
+    sessionRef.current.selfUser = undefined;
+    sessionRef.current.activeName = undefined;
+    sessionRef.current.pendingNames = new WeakSet();
+  }, [logDiagError]);
+
+  const leaveRoom = useCallback(() => {
+    teardownSession();
+    dispatch({ type: 'reset-room' });
+    dispatch({ type: 'set-phase', phase: 'menu' });
+    dispatch({ type: 'set-status', status: 'main menu' });
+  }, [teardownSession]);
+
+  const joinRoom = useCallback(
+    /** @param {{ uri: string, name: string, transient?: boolean }} args */
+    async ({ uri, name, transient = false }) => {
+      await null;
+      try {
+        // Tear down any prior session before standing up a new one.
+        // Without this, repeatedly joining different rooms would leak
+        // websockets and clients per visit.
+        teardownSession();
+
+        dispatch({ type: 'reset-room' });
+        dispatch({ type: 'set-phase', phase: 'connecting' });
+        dispatch({ type: 'set-status', status: 'parsing URI…' });
+        const { location, swissNum, kind } = parseLocator(uri);
+        if (!swissNum) {
+          throw Error(
+            'URI does not include a swiss number (expected ocapn://…/s/<base64url-swiss>)',
+          );
+        }
+        logDiag(
+          `parsed ${kind} URI: transport=${location.transport} designator=${location.designator} swissNum=${formatSwissnumForLog(swissNum)}`,
+        );
+
+        dispatch({
+          type: 'set-status',
+          status: 'starting websocket netlayer…',
+        });
+        const client = makeClient({
+          verbose,
+          ...(captpVersion ? { captpVersion } : {}),
+          logger: makeReducerLogger(dispatch, 'client', logSink),
+        });
+        sessionRef.current.client = client;
+        await client.registerNetlayer(handlers =>
+          makeWebSocketNetLayer({
+            handlers,
+            logger: makeReducerLogger(dispatch, 'netlayer', logSink),
+            specifiedHostname: '127.0.0.1',
+            specifiedPort: 0,
+          }),
+        );
+
+        dispatch({ type: 'set-status', status: 'enlivening sturdyref…' });
+
+        const sref = client.makeSturdyRef(location, swissNum);
+        const chatroom = await client.enlivenSturdyRef(sref);
+
+        dispatch({ type: 'set-status', status: 'fetching room name…' });
+        /** @type {string | undefined} */
+        let resolvedRoomName;
+        try {
+          const roomName = await E(chatroom)['self-proposed-name']();
+          if (typeof roomName === 'string') {
+            resolvedRoomName = roomName;
+            dispatch({ type: 'set-room', roomName });
+          }
+        } catch (err) {
+          logDiagError(err, 'self-proposed-name');
+        }
+
+        dispatch({ type: 'set-status', status: 'joining room…' });
+        const { user: selfUser, userController } = makeUserControllerPair(name);
+        sessionRef.current.selfUser = selfUser;
+        sessionRef.current.activeName = name;
+        const channel = await E(userController)['join-room'](chatroom);
+        sessionRef.current.channel = channel;
+
+        // The chatroom (per `backend.js`) broadcasts `new-message` to
+        // *every* subscriber including the sender, and some chatroom
+        // implementations (e.g. Spritely Goblins) likewise echo
+        // `user-joined`/`user-left` back at the actor that triggered
+        // them. We render those events optimistically (in `sendMessage`
+        // for messages; the menu→chat phase transition implicitly
+        // covers our own join), so the echo would show up as a
+        // duplicate if we didn't filter it out here.
+        //
+        // Identity check: when our own `user` Far is sent out and comes
+        // back, Endo's CapTP canonicalises the inbound reference back
+        // to the original local Far, so `===` is a sound test for
+        // "this is me". We compare against `sessionRef.current.selfUser`
+        // (rather than closing over `selfUser`) so that a future
+        // `joinRoom` call with a fresh user-controller pair uses the
+        // new identity.
+        const isSelf = candidate => candidate === sessionRef.current.selfUser;
+
+        const observer = Far('tui-observer', {
+          'new-message': (_context, fromUser, message) => {
+            if (isSelf(fromUser)) return;
+            const text =
+              typeof message === 'string'
+                ? message
+                : `<non-string message: ${formatError(message)}>`;
+            dispatch({ type: 'message-received', user: fromUser, text });
+            kickResolveName(fromUser);
+          },
+          'user-joined': user => {
+            if (isSelf(user)) return;
+            dispatch({ type: 'user-joined', user });
+            kickResolveName(user);
+          },
+          'user-left': user => {
+            if (isSelf(user)) return;
+            dispatch({ type: 'user-left', user });
+            kickResolveName(user);
+          },
+        });
+
+        const subResult = await E(channel).subscribe(observer);
+        const [status, unsubscribe] = Array.isArray(subResult)
+          ? subResult
+          : [subResult, undefined];
+        if (status !== 'OK') {
+          throw Error(`Unexpected subscribe status: ${formatError(status)}`);
+        }
+        sessionRef.current.unsubscribe = unsubscribe;
+
+        try {
+          const users = await E(channel)['list-users']();
+          if (Array.isArray(users)) {
+            // The chatroom roster includes us; filter ourselves out so
+            // the panel reads as "everyone else who's already here".
+            const others = users.filter(u => !isSelf(u));
+            if (others.length > 0) {
+              dispatch({ type: 'users-present', users: others });
+              for (const u of others) kickResolveName(u);
+            }
+          }
+        } catch (err) {
+          logDiagError(err, 'list-users');
+        }
+
+        dispatch({ type: 'set-phase', phase: 'chat' });
+        dispatch({
+          type: 'set-status',
+          status: `connected as ${name}`,
+        });
+
+        if (onJoined && !transient) {
+          try {
+            onJoined({ uri, roomName: resolvedRoomName });
+          } catch (err) {
+            logDiagError(err, 'onJoined');
+          }
+        }
+      } catch (err) {
+        // Connect-failure flow: details land in the log panel (so
+        // toggling Ctrl+L shows the actual exception), and the status
+        // line carries the user-facing message so the menu indicates
+        // *something* went wrong even with the log hidden. We
+        // deliberately don't push an `error` event into the chat
+        // stream — that stream is reserved for real per-room activity.
+        logDiagError(err, 'joinRoom');
+        dispatch({
+          type: 'set-status',
+          status: 'connect failed — try again',
+        });
+        dispatch({ type: 'set-phase', phase: 'menu' });
+      }
+    },
+    [
+      captpVersion,
+      verbose,
+      logSink,
+      logDiag,
+      logDiagError,
+      kickResolveName,
+      teardownSession,
+      onJoined,
+    ],
+  );
+
+  const sendMessage = useCallback(
+    /** @param {string} text */
+    async text => {
+      await null;
+      const { channel, activeName } = sessionRef.current;
+      if (!channel) {
+        logDiagError(Error('no channel'));
+        return;
+      }
+      try {
+        await E(channel)['send-message'](text);
+        dispatch({
+          type: 'message-sent',
+          name: activeName ?? '<self>',
+          text,
+        });
+      } catch (err) {
+        logDiagError(err, 'send-message');
+      }
+    },
+    [logDiagError],
+  );
+
+  const addInfo = useCallback(
+    /** @param {string} text */
+    text => dispatch({ type: 'info', text }),
+    [],
+  );
+
+  const shutdown = useCallback(() => {
+    teardownSession();
+  }, [teardownSession]);
+
+  // Install the polite-shutdown into the module-level handle so signal
+  // handlers in the entrypoint can invoke the same teardown as the
+  // in-app Ctrl+C path. Cleared on unmount so a stale closure can't
+  // fire after React has torn the tree down.
+  useEffect(() => {
+    shutdownHandle.run = shutdown;
+    return () => {
+      shutdownHandle.run = () => undefined;
+    };
+  }, [shutdown]);
+
+  return {
+    state,
+    joinRoom,
+    sendMessage,
+    leaveRoom,
+    setPhase,
+    addInfo,
+    shutdown,
+  };
+};

--- a/packages/goblin-chat/test/guile-interop/README.md
+++ b/packages/goblin-chat/test/guile-interop/README.md
@@ -1,0 +1,76 @@
+# Goblin Chat interop utility
+
+Interop harness for Endo ↔ Guile Goblins chatroom tests.
+
+The user-facing chatroom client (Ink TUI) and the JS port of the
+Goblins `(goblin-chat backend)` module live in this same package
+(`@endo/goblin-chat`). This directory contains only the **interop
+harness** that drives the Endo client against a Guile-hosted
+sturdyref under CI. Its all-JS counterpart lives in
+[`../interop-self.test.js`](../interop-self.test.js).
+
+- `interop-client.scm` — Guile-hosted side. Uses Spritely's existing
+  `(goblin-chat backend)` implementation to host a room, registers it on
+  the websocket netlayer, and prints a sturdyref for Endo to join.
+- `index.js` — Endo client side. Accepts the Guile sturdyref URI, joins
+  that room (using `makeUserControllerPair` from `@endo/goblin-chat`),
+  and verifies bilateral message flow.
+
+## Direction under test (current)
+
+Current CI direction is:
+
+1. **Guile hosts** the chatroom (existing Goblins backend).
+2. Guile prints `sturdyref: ocapn://...`.
+3. **Endo joins** that Guile-hosted sturdyref.
+4. Both sides exchange one message and assert bilateral receive.
+
+## Run Endo client against a Guile-hosted sturdyref
+
+```bash
+node ./packages/goblin-chat/test/guile-interop/index.js "ocapn://.../s/..."
+```
+
+Environment knobs:
+
+- `OCAPN_CAPTP_VERSION` (default: `1.0`)
+- `OCAPN_INTEROP_GUILE_MESSAGE` (default: `hello from Guile CI`)
+- `OCAPN_INTEROP_ENDO_MESSAGE` (default: `hello from Endo OCapN`)
+- `OCAPN_TEST_PORT` (optional local Endo websocket bind; default ephemeral)
+
+## Interactive client (TUI)
+
+For the human-driven TUI client (main menu, persistent settings,
+log panel, recent rooms), use the dedicated package:
+
+```bash
+node ./packages/goblin-chat/bin/goblin-chat.js
+```
+
+See the package [`README.md`](../../README.md) for keys and
+configuration.
+
+## App-layer surface (matches Guile implementation)
+
+These are reproduced bit-for-bit by the JS port that lives in
+[`../../src/backend.js`](../../src/backend.js):
+
+- `^chatroom`: `self-proposed-name`, `subscribe`.
+- `^user`: `self-proposed-name`, `get-chat-sealed?`, `get-chat-unsealer`,
+  `get-subscription-sealer`.
+- `^user-controller`: `whoami`, `connect-client`, `join-room`.
+- `^user-inbox` (public surface called by the chatroom): `new-message`,
+  `user-joined`, `user-left`, `context`.
+- `^user-messaging-channel`: `leave`, `send-message`, `list-users`.
+- `^authenticated-channel` (local wrapper returned by `join-room`):
+  `send-message`, `subscribe`, `leave`, `list-users`.
+
+## Caveats
+
+- The Guile backend gates `^user-inbox` controller-only methods behind a
+  warden/incanter pair. The JS port keeps those methods off the wire
+  entirely (held as closed-over functions on the controller side) instead
+  of reifying the warden, which is equivalent for the interop surface.
+- `ghash` and `seteq` are approximated with `Map` and `Set`.
+- `<-np` fire-and-forget sends use `E.sendOnly` so promise GC matches
+  Goblins' expectations.

--- a/packages/goblin-chat/test/guile-interop/index.js
+++ b/packages/goblin-chat/test/guile-interop/index.js
@@ -1,0 +1,145 @@
+// @ts-check
+/* global process */
+
+/**
+ * Endo interop client for a Guile-hosted Goblin Chat room.
+ *
+ * The exchange itself (join → subscribe → bilateral send/receive →
+ * verify) lives in `../../src/interop-driver.js` so it can be shared
+ * with the all-JS self-interop test in `../interop-self.test.js`.
+ * This script's job is just to stand up an Endo-side websocket
+ * netlayer, parse the Guile-printed sturdyref URI, enliven it, and
+ * hand the resulting `^chatroom` presence to that shared driver.
+ */
+
+import '@endo/init';
+
+/**
+ * @import { OcapnLocation, SwissNum } from '@endo/ocapn'
+ */
+
+import { makeClient, swissnumFromBytes } from '@endo/ocapn';
+import { makeWebSocketNetLayer } from '@endo/ocapn/netlayer/ws';
+import { decodeBase64Url } from '../../src/base64url.js';
+import { runChatParticipant } from '../../src/interop-driver.js';
+
+const swissnumEncoder = new TextEncoder();
+
+const DEFAULT_PORT = 0;
+const DEFAULT_CAPTP_VERSION = '1.0';
+const DEFAULT_GUILE_MESSAGE = 'hello from Guile CI';
+const DEFAULT_ENDO_MESSAGE = 'hello from Endo OCapN';
+
+/**
+ * @param {string} value
+ * @returns {SwissNum}
+ */
+const swissnumFromBase64Url = value =>
+  swissnumFromBytes(decodeBase64Url(value));
+
+/**
+ * Local equivalent of `encodeSwissnum`, kept inline so this script
+ * doesn't pull a swissnum-encoding helper into `@endo/ocapn`'s public
+ * exports map (mirrors `test/interop-self.test.js`).
+ *
+ * @param {string} value
+ * @returns {SwissNum}
+ */
+const swissnumFromAsciiString = value => {
+  for (let i = 0; i < value.length; i += 1) {
+    if (value.charCodeAt(i) > 127) {
+      throw Error(`Non-ASCII byte in swissnum at position ${i}: ${value[i]}`);
+    }
+  }
+  return swissnumFromBytes(swissnumEncoder.encode(value));
+};
+
+/**
+ * @param {string} uri
+ * @returns {{ location: OcapnLocation; swissNum: SwissNum }}
+ */
+const parseSturdyrefUri = uri => {
+  const match = /^ocapn:\/\/([^/?#]+)(\/[^?#]*)?(?:\?([^#]*))?$/.exec(uri);
+  if (!match) {
+    throw Error(`Invalid OCapN URI: ${uri}`);
+  }
+  const [, host, path = '/', query = ''] = match;
+  const hostParts = host.split('.');
+  if (hostParts.length < 2) {
+    throw Error(`Invalid OCapN host: ${host}`);
+  }
+  const transport = hostParts.pop();
+  const designator = hostParts.join('.');
+  if (!transport) {
+    throw Error(`Missing transport in OCapN host: ${host}`);
+  }
+
+  /** @type {Record<string, string>} */
+  const hints = {};
+  for (const [key, value] of new URLSearchParams(query).entries()) {
+    hints[key] = value;
+  }
+
+  /** @type {SwissNum} */
+  let swissNum;
+  if (path && path !== '/') {
+    if (!path.startsWith('/s/')) {
+      throw Error(`Unsupported OCapN URI path: ${path}`);
+    }
+    swissNum = swissnumFromBase64Url(path.slice(3));
+  } else if (typeof hints.swiss === 'string' && hints.swiss.length > 0) {
+    swissNum = swissnumFromAsciiString(hints.swiss);
+  } else {
+    throw Error(`No sturdyref swiss number found in URI: ${uri}`);
+  }
+
+  return {
+    location: {
+      type: 'ocapn-peer',
+      designator,
+      transport,
+      hints,
+    },
+    swissNum,
+  };
+};
+
+const main = async () => {
+  const sturdyrefUri = process.argv[2];
+  if (!sturdyrefUri) {
+    throw Error('Usage: node index.js <guile-chatroom-sturdyref-uri>');
+  }
+
+  const port = Number(process.env.OCAPN_TEST_PORT) || DEFAULT_PORT;
+  const expectedGuileMessage =
+    process.env.OCAPN_INTEROP_GUILE_MESSAGE || DEFAULT_GUILE_MESSAGE;
+  const endoMessage =
+    process.env.OCAPN_INTEROP_ENDO_MESSAGE || DEFAULT_ENDO_MESSAGE;
+
+  const { location, swissNum } = parseSturdyrefUri(sturdyrefUri);
+  const captpVersion = process.env.OCAPN_CAPTP_VERSION || DEFAULT_CAPTP_VERSION;
+  const client = makeClient({ verbose: true, captpVersion });
+  await null;
+  try {
+    await client.registerNetlayer((handlers, logger) =>
+      makeWebSocketNetLayer({ handlers, logger, specifiedPort: port }),
+    );
+    const sturdyRef = client.makeSturdyRef(location, swissNum);
+    const chatroom = await client.enlivenSturdyRef(sturdyRef);
+    await runChatParticipant({
+      chatroom,
+      name: 'endo-interop-ocapn',
+      localMessage: endoMessage,
+      expectedRemoteMessage: expectedGuileMessage,
+      log: line => console.log(`*** ${line}`),
+    });
+    console.log('*** Endo interop completed');
+  } finally {
+    client.shutdown();
+  }
+};
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/goblin-chat/test/guile-interop/interop-client.scm
+++ b/packages/goblin-chat/test/guile-interop/interop-client.scm
@@ -1,0 +1,192 @@
+;;; Minimal websocket interop host for Endo OCapN.
+;;;
+;;; This intentionally keeps Guile-side logic small and uses Spritely's
+;;; existing `(goblin-chat backend)` to host the chatroom.
+
+(use-modules (goblins core)
+             (goblins vat)
+             (goblin-chat backend)
+             (goblins actor-lib methods)
+             (goblins utils crypto)
+             (goblins ocapn captp)
+             (goblins ocapn ids)
+             (goblins ocapn netlayer websocket)
+             (fibers conditions))
+
+;; Global condition used as a one-shot "done" signal for this script.
+;; We wait on it at the end and exit as soon as either success or fatal
+;; failure has been observed.
+(define done? (make-condition))
+
+;; Command-line handling: we optionally accept two messages so CI/local runs
+;; can override defaults without editing the file.
+(define args (cdr (command-line)))
+
+(define (arg-or-default idx default)
+  (if (> (length args) idx)
+      (list-ref args idx)
+      default))
+
+;; Message values used by both sides of the interop check:
+;; - `local-message` is what Guile sends once Endo joins.
+;; - `expected-remote-message` is what Guile expects Endo to send back.
+(define local-message
+  (arg-or-default 0 "hello from Guile CI"))
+(define expected-remote-message
+  (arg-or-default 1 "hello from Endo OCapN"))
+
+;; Websocket bind port is controllable via env for CI orchestration, with a
+;; deterministic fallback for ad-hoc local runs.
+(define websocket-port
+  (let ((env-port (getenv "OCAPN_TEST_PORT")))
+    (if env-port
+        (string->number env-port)
+        22047)))
+
+;; Interop progress flags. We only declare success once all required events
+;; have happened: Guile sent, send ack arrived, and both messages were seen.
+(define sent-local-message? #f)
+(define sent-ack? #f)
+(define saw-local-message? #f)
+(define saw-remote-message? #f)
+(define finished? #f)
+
+;; Success gate for the script. When both sides' messages and Guile's send
+;; acknowledgement are observed, emit a stable log marker and unblock `(wait done?)`.
+(define (finish-if-ready!)
+  (when (and (not finished?)
+             sent-ack?
+             saw-local-message?
+             saw-remote-message?)
+    (set! finished? #t)
+    (display "interop-client: observed local+remote messages and ack")
+    (newline)
+    (force-output)
+    (signal-condition! done?)))
+
+;; Fatal helper used by all async error paths so failures are consistently
+;; logged and cause an immediate non-zero exit.
+(define (fatal! label err)
+  (display "interop-client: ")
+  (display label)
+  (display ": ")
+  (write err)
+  (newline)
+  (force-output)
+  (signal-condition! done?)
+  (primitive-exit 1))
+
+;; Observer actor subscribed to the chat channel.
+;; - `new-message`: records message observations for the bilateral assertion.
+;; - `user-joined`: sends Guile's local message exactly once when a remote
+;;   participant joins.
+;; - `user-left`: currently ignored for test success criteria.
+(define (^interop-observer _bcom user channel)
+  (methods
+   ((new-message _context _from-user observed-message)
+    ;; Normalize to string so logs/assertions remain robust if a backend
+    ;; sends a non-string payload in the future.
+    (define message-string
+      (if (string? observed-message)
+          observed-message
+          (format #f "~a" observed-message)))
+    (when (string=? message-string local-message)
+      (set! saw-local-message? #t))
+    (when (string=? message-string expected-remote-message)
+      (set! saw-remote-message? #t))
+    (finish-if-ready!)
+    #t)
+   ((user-joined joining-user)
+    (when (and (not sent-local-message?)
+               (not (eq? joining-user user)))
+      (set! sent-local-message? #t)
+      (on (<- channel 'send-message local-message)
+          (lambda (ack)
+            (display "interop-client: sent message, ack = ")
+            (write ack)
+            (newline)
+            (force-output)
+            (set! sent-ack? #t)
+            (finish-if-ready!))
+          #:catch
+          (lambda (err)
+            (fatal! "send-message failed" err))
+          #:promise? #t))
+    #t)
+   ((user-left _user) #t)))
+
+;; Two vats:
+;; - machine-vat hosts transport/captp machinery.
+;; - user-vat hosts chatroom/user actors.
+;; Keeping these separated mirrors Goblins examples and avoids mixing
+;; transport lifecycle with app actor lifecycle.
+(define machine-vat (spawn-vat))
+(define user-vat (spawn-vat))
+(define (machine-run thunk) (with-vat machine-vat (thunk)))
+(define (user-run thunk) (with-vat user-vat (thunk)))
+
+;; Boot transport and app objects:
+;; - websocket netlayer bound to `websocket-port`
+;; - mycapn node on that netlayer
+;; - chatroom actor plus a local user/controller pair
+;;
+;; We provide a pre-generated designator key to avoid the websocket netlayer's
+;; async key-generation handoff path, which has proven flaky in this harness.
+(define netlayer-designator-key
+  (generate-key-pair))
+(define netlayer
+  (machine-run
+   (lambda ()
+     (spawn ^websocket-netlayer
+            #:encrypted? #f
+            #:port websocket-port
+            #:designator-key netlayer-designator-key))))
+(define mycapn
+  (machine-run (lambda () (spawn-mycapn netlayer))))
+(define chatroom
+  (user-run (lambda () (spawn ^chatroom "#interop-room"))))
+(define-values (user user-controller)
+  (user-run (lambda () (spawn-user-controller-pair "guile-interop-host"))))
+
+;; Start the local user flow (join + subscribe) after we have successfully
+;; registered and published the sturdyref. This avoids contradictory states
+;; where join-side logs appear even though registration failed.
+(define (start-user-flow!)
+  (user-run
+   (lambda ()
+     (on (<- user-controller 'join-room chatroom)
+         (lambda (channel)
+           (on (<- channel 'subscribe (spawn ^interop-observer user channel))
+               (lambda (_subscription-result)
+                 (display "interop-client: subscription ready")
+                 (newline)
+                 (force-output))
+               #:catch
+               (lambda (err)
+                 (fatal! "subscribe failed" err))
+               #:promise? #t))
+         #:catch
+         (lambda (err)
+           (fatal! "join-room failed" err))
+         #:promise? #t))))
+
+;; Register the chatroom on websocket, print sturdyref for Endo, then start
+;; the local user flow.
+(machine-run
+ (lambda ()
+   (on (<- mycapn 'register chatroom 'websocket)
+       (lambda (chat-sref)
+         (display "sturdyref: ")
+         (display (ocapn-id->string chat-sref))
+         (newline)
+         (force-output)
+         (start-user-flow!))
+       #:catch
+       (lambda (err)
+         (fatal! "register failed" err))
+       #:promise? #t)))
+
+;; Block the process until success/failure path signals `done?`.
+;; Success exits 0; fatal paths exit non-zero from `fatal!`.
+(wait done?)
+(primitive-exit 0)

--- a/packages/goblin-chat/test/guile-interop/interop-manifest.scm
+++ b/packages/goblin-chat/test/guile-interop/interop-manifest.scm
@@ -1,0 +1,11 @@
+;;; Slim Guix manifest for the Endo↔Goblins chat interop client.
+;;;
+;;; Spritely's own goblin-chat/manifest.scm pulls GTK/G-Golf/mesa for the
+;;; GUI; none of that is reachable from our headless interop client, so we
+;;; stick to guile + guile-goblins + guile-fibers to keep `guix shell`
+;;; resolution fast in CI.
+
+(specifications->manifest
+ '("guile"
+   "guile-goblins"
+   "guile-fibers"))

--- a/packages/goblin-chat/test/host-room.test.js
+++ b/packages/goblin-chat/test/host-room.test.js
@@ -1,0 +1,125 @@
+// @ts-check
+/* eslint-disable import/no-unresolved */
+
+/**
+ * `hostRoom` end-to-end test.
+ *
+ * Stands up a hosted chatroom via `hostRoom`, parses the URI it hands
+ * back, and resolves the chatroom from a fresh OCapN client over the
+ * loopback websocket — i.e. exercises the exact path the TUI's
+ * "Host a new chat" menu item drives. Covers:
+ *
+ *   - URI shape: parses cleanly via `parseLocator`, carries a swissnum
+ *     swissnum, and the websocket netlayer is reachable at the
+ *     advertised `hints.url`.
+ *   - Cap surface: a remote peer can fetch `self-proposed-name` and
+ *     get back the room name we passed in.
+ *   - Lifecycle: `shutdownAll()` reliably closes the underlying
+ *     websocket server (so the event loop doesn't stay pinned open).
+ */
+
+import '@endo/init';
+
+import test from '@endo/ses-ava/test.js';
+
+import { E } from '@endo/eventual-send';
+import { makeClient } from '@endo/ocapn';
+import { makeWebSocketNetLayer } from '@endo/ocapn/netlayer/ws';
+
+import { hostRoom, hostRegistry } from '../src/host-room.js';
+import { parseLocator } from '../src/uri-parse.js';
+
+// Match what the in-process interop test uses; the websocket loopback
+// path through `makeClient`/`makeWebSocketNetLayer` is most-tested at
+// this version.
+const CAPTP_VERSION = 'goblins-0.16';
+
+// Both tests in this file touch the module-level `hostRegistry`, so
+// run them serially: a stray `shutdownAll()` from one would otherwise
+// race-shut the other's host mid-handshake.
+test.serial(
+  'hostRoom builds a sturdyref URI a remote OCapN client can resolve',
+  async t => {
+    const hosted = await hostRoom({
+      roomName: '#test-host',
+      captpVersion: CAPTP_VERSION,
+    });
+    t.true(hosted.uri.startsWith('ocapn://'));
+    t.regex(hosted.uri, /\/s\/[A-Za-z0-9_-]+/u);
+
+    const parsed = parseLocator(hosted.uri);
+    t.is(parsed.kind, 'sturdyref');
+    t.is(parsed.location.transport, 'websocket');
+    t.truthy(parsed.swissNum);
+    t.truthy(parsed.location.hints);
+    if (parsed.location.hints && typeof parsed.location.hints === 'object') {
+      t.regex(String(parsed.location.hints.url), /^ws:\/\/127\.0\.0\.1:\d+$/u);
+    }
+
+    const remote = makeClient({ captpVersion: CAPTP_VERSION });
+    await remote.registerNetlayer(handlers =>
+      makeWebSocketNetLayer({
+        handlers,
+        // tests run quietly; the netlayer logger only fires on
+        // exceptional paths anyway.
+        logger: { log: () => {}, info: () => {}, error: () => {} },
+      }),
+    );
+
+    try {
+      if (!parsed.swissNum) {
+        throw Error('parsed sturdyref URI missing swissNum');
+      }
+      const sref = remote.makeSturdyRef(parsed.location, parsed.swissNum);
+      const chatroom = await remote.enlivenSturdyRef(sref);
+      const name = await E(chatroom)['self-proposed-name']();
+      t.is(name, '#test-host');
+    } finally {
+      remote.shutdown();
+      hosted.shutdown();
+    }
+  },
+);
+
+test.serial(
+  'hostRoom honours publicUrl override (advertises a different URL than it binds)',
+  async t => {
+    // We don't actually run a reverse proxy here — just verify the
+    // sturdyref URI's `hints.url` reflects the override rather than
+    // the bind address. A peer trying to dial it would fail (the URL
+    // points nowhere reachable), but the netlayer-level wiring is
+    // what we care about for this test.
+    const hosted = await hostRoom({
+      roomName: '#proxied',
+      captpVersion: CAPTP_VERSION,
+      bindHostname: '127.0.0.1',
+      bindPort: 0,
+      publicUrl: 'wss://chat.example.invalid:443/proxy',
+    });
+    try {
+      const parsed = parseLocator(hosted.uri);
+      t.truthy(parsed.location.hints);
+      if (parsed.location.hints && typeof parsed.location.hints === 'object') {
+        t.is(
+          parsed.location.hints.url,
+          'wss://chat.example.invalid:443/proxy',
+          'hints.url should reflect publicUrl override, not the loopback bind',
+        );
+      }
+    } finally {
+      hosted.shutdown();
+    }
+  },
+);
+
+test.serial('hostRegistry.shutdownAll closes outstanding hosts', async t => {
+  const a = await hostRoom({ roomName: '#a', captpVersion: CAPTP_VERSION });
+  const b = await hostRoom({ roomName: '#b', captpVersion: CAPTP_VERSION });
+  t.not(a.uri, b.uri);
+  // Each call should be idempotent: registry-driven shutdown shouldn't
+  // throw if the per-handle shutdown was already invoked, and vice
+  // versa.
+  hostRegistry.shutdownAll();
+  t.notThrows(() => a.shutdown());
+  t.notThrows(() => b.shutdown());
+});

--- a/packages/goblin-chat/test/interop-self.test.js
+++ b/packages/goblin-chat/test/interop-self.test.js
@@ -1,0 +1,112 @@
+// @ts-check
+
+/**
+ * All-JS bilateral interop test.
+ *
+ * Mirrors the structure of `./guile-interop/` (where
+ * an Endo OCapN client connects to a Guile-hosted chatroom over the
+ * websocket netlayer) — but here both sides run in this process. One
+ * side hosts the JS port of `^chatroom` and registers it under a
+ * known swissnum on a websocket netlayer; the other side enlivens it
+ * via `makeSturdyRef` + `enlivenSturdyRef` and joins as a remote
+ * participant.
+ *
+ * Both sides are driven by the same `runChatParticipant` helper that
+ * the Guile-interop CI script uses, so this test exercises that
+ * helper end-to-end against the real OCapN websocket transport (not
+ * just an in-process Far reference).
+ */
+
+import '@endo/init';
+
+import test from '@endo/ses-ava/test.js';
+
+import { makeClient, swissnumFromBytes } from '@endo/ocapn';
+import { makeWebSocketNetLayer } from '@endo/ocapn/netlayer/ws';
+
+import { makeChatroom } from '../src/backend.js';
+import { runChatParticipant } from '../src/interop-driver.js';
+
+// Local equivalent of `encodeSwissnum`, kept inline so this test
+// doesn't drag the helper into `@endo/ocapn`'s public exports map.
+// Validates printable ASCII so a stray non-ASCII char in the room
+// constant fails loudly here rather than producing a wire-level mystery.
+const swissnumEncoder = new TextEncoder();
+/** @param {string} value */
+const swissnumFromAsciiString = value => {
+  for (let i = 0; i < value.length; i += 1) {
+    if (value.charCodeAt(i) > 127) {
+      throw Error(`Non-ASCII byte in swissnum at position ${i}: ${value[i]}`);
+    }
+  }
+  return swissnumFromBytes(swissnumEncoder.encode(value));
+};
+
+const ROOM_SWISS = 'interop-room';
+const ROOM_NAME = '#interop-room';
+const HOST_MESSAGE = 'hello from JS host';
+const CLIENT_MESSAGE = 'hello from Endo OCapN';
+// Match what the Guile-interop CI test uses, so the wire-level
+// handshake is exercised against the same CapTP version.
+const CAPTP_VERSION = 'goblins-0.16';
+
+test('endo OCapN client interops with the JS goblin-chat backend', async t => {
+  const chatroom = makeChatroom(ROOM_NAME);
+
+  // Host: owns the chatroom Far and exposes it under a known
+  // swissnum so the remote side can enliven it via sturdyref.
+  const hostClient = makeClient({
+    debugLabel: 'js-host',
+    captpVersion: CAPTP_VERSION,
+  });
+  hostClient.registerSturdyRef(ROOM_SWISS, chatroom);
+  const hostNetlayer = await hostClient.registerNetlayer((handlers, logger) =>
+    makeWebSocketNetLayer({ handlers, logger }),
+  );
+
+  // Remote participant: a fully separate OCapN client, talks to the
+  // host through its websocket netlayer just like the Endo CI client
+  // talks to the Guile host.
+  const remoteClient = makeClient({
+    debugLabel: 'endo-remote',
+    captpVersion: CAPTP_VERSION,
+  });
+  await remoteClient.registerNetlayer((handlers, logger) =>
+    makeWebSocketNetLayer({ handlers, logger }),
+  );
+
+  try {
+    const sturdyRef = remoteClient.makeSturdyRef(
+      hostNetlayer.location,
+      swissnumFromAsciiString(ROOM_SWISS),
+    );
+    const remoteChatroom = await remoteClient.enlivenSturdyRef(sturdyRef);
+
+    // Both sides run the same driver. Each subscribes, waits to see a
+    // non-self `user-joined`, sends its local message, and resolves
+    // once both sides' messages have round-tripped through the
+    // chatroom. Drive them concurrently so the timeout in the driver
+    // catches a deadlock in either direction.
+    await Promise.all([
+      runChatParticipant({
+        chatroom,
+        name: 'js-host',
+        localMessage: HOST_MESSAGE,
+        expectedRemoteMessage: CLIENT_MESSAGE,
+        log: line => t.log(line),
+      }),
+      runChatParticipant({
+        chatroom: remoteChatroom,
+        name: 'endo-remote',
+        localMessage: CLIENT_MESSAGE,
+        expectedRemoteMessage: HOST_MESSAGE,
+        log: line => t.log(line),
+      }),
+    ]);
+
+    t.pass('both participants observed bilateral message exchange');
+  } finally {
+    remoteClient.shutdown();
+    hostClient.shutdown();
+  }
+});

--- a/packages/goblin-chat/tsconfig.build.json
+++ b/packages/goblin-chat/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../tsconfig-build-options.json"
+  ],
+  "exclude": [
+    "test/"
+  ]
+}

--- a/packages/goblin-chat/tsconfig.json
+++ b/packages/goblin-chat/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.eslint-base.json",
+  "include": [
+    "*.js",
+    "*.ts",
+    "bin",
+    "src",
+    "test"
+  ]
+}

--- a/packages/ocapn/index.js
+++ b/packages/ocapn/index.js
@@ -1,0 +1,25 @@
+// @ts-check
+
+/**
+ * Public entry point for `@endo/ocapn`.
+ *
+ * The exports map deliberately keeps the public runtime surface tiny:
+ * this main entry (which re-exports swissnum helpers below) plus
+ * explicit netlayer subpaths such as `@endo/ocapn/netlayer/ws` for the
+ * websocket transport. Any new value or type that consumers need should
+ * be added here in preference to opening another subpath, since each
+ * subpath is a long-term API commitment.
+ *
+ * Note for typedef forwards below: a JS `export *` does NOT re-export
+ * `@typedef` declarations — typedefs aren't part of the runtime
+ * namespace, and JSDoc-checkJs only finds them by direct module
+ * identity. Forwarding them with explicit `@typedef {import(...)}`
+ * lines is what makes `@import { Foo } from '@endo/ocapn'` resolve in
+ * downstream JSDoc.
+ *
+ * @typedef {import('./src/client/types.js').SwissNum} SwissNum
+ * @typedef {import('./src/codecs/components.js').OcapnLocation} OcapnLocation
+ */
+
+export { makeClient } from './src/client/index.js';
+export { swissnumFromBytes, swissnumToBytes } from './src/client/util.js';

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -19,6 +19,7 @@
   "module": "./index.js",
   "exports": {
     ".": "./index.js",
+    "./netlayer/tcp-testing": "./src/netlayers/tcp-test-only.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -20,6 +20,7 @@
   "exports": {
     ".": "./index.js",
     "./netlayer/tcp-testing": "./src/netlayers/tcp-test-only.js",
+    "./netlayer/ws": "./src/netlayers/websocket.js",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -46,11 +47,13 @@
     "@endo/pass-style": "workspace:^",
     "@endo/promise-kit": "workspace:^",
     "@noble/curves": "^1.9.0",
-    "@noble/hashes": "^1.8.0"
+    "@noble/hashes": "^1.8.0",
+    "ws": "^8.20.0"
   },
   "devDependencies": {
     "@endo/lockdown": "workspace:^",
     "@endo/ses-ava": "workspace:^",
+    "@types/ws": "^8",
     "ava": "catalog:dev",
     "c8": "catalog:dev",
     "eslint": "catalog:dev",

--- a/packages/ocapn/src/client/handshake.js
+++ b/packages/ocapn/src/client/handshake.js
@@ -148,8 +148,10 @@ const handleSessionHandshakeMessage = (
       } = message;
       // Handle invalid version
       if (messageCaptpVersion !== captpVersion) {
-        // send op abort
-        logger.info(`Abort during start-session message with invalid version`);
+        logger.info('Abort during start-session message with invalid version', {
+          received: messageCaptpVersion,
+          expected: captpVersion,
+        });
         sendAbortAndClose(connection, 'invalid-version');
         sessionManager.deleteConnection(connection);
         return;

--- a/packages/ocapn/src/client/handshake.js
+++ b/packages/ocapn/src/client/handshake.js
@@ -277,8 +277,17 @@ export const handleHandshakeMessageData = (
       try {
         message = readOcapnHandshakeMessage(syrupReader);
       } catch (err) {
+        // Best-effort diagnostic: try to render the bytes as generic syrup
+        // for the log. If they can't even be decoded as syrup (e.g. junk
+        // bytes), don't let the diagnostic itself mask the original error.
         const problematicBytes = data.slice(start);
-        const syrupMessage = decodeSyrup(problematicBytes);
+        let syrupMessage;
+        try {
+          syrupMessage = decodeSyrup(problematicBytes);
+        } catch (decodeErr) {
+          syrupMessage = '<undecodable syrup>';
+          logger.error(`Bytes are not valid syrup:`, decodeErr);
+        }
         logger.error(
           `Message decode error:`,
           err,

--- a/packages/ocapn/src/client/index.js
+++ b/packages/ocapn/src/client/index.js
@@ -176,6 +176,7 @@ const makeSessionManager = () => {
  * @param {string} [options.captpVersion] - For testing: override the CapTP version sent in handshakes
  * @param {boolean} [options.enableImportCollection] - If true, imports are tracked with WeakRefs and GC'd when unreachable. Default: true.
  * @param {boolean} [options.debugMode] - **EXPERIMENTAL**: If true, exposes `_debug` object on Ocapn instances with internal APIs for testing. Default: false.
+ * @param {Logger} [options.logger] - If provided, overrides the default console-based logger. The same logger is also handed to netlayer factories registered via `registerNetlayer`. When omitted, defaults to a console-based logger labelled with `debugLabel`; `info` is suppressed unless `verbose` is true.
  * @returns {Client}
  */
 export const makeClient = ({
@@ -186,18 +187,21 @@ export const makeClient = ({
   captpVersion = '1.0',
   enableImportCollection = true,
   debugMode = false,
+  logger: providedLogger,
 } = {}) => {
   /** @type {Map<string, NetLayer>} */
   const netlayers = new Map();
 
   /** @type {Logger} */
-  const logger = harden({
-    log: (...args) => console.log(`${debugLabel} [${Date.now()}]:`, ...args),
-    error: (...args) =>
-      console.error(`${debugLabel} [${Date.now()}}:`, ...args),
-    info: (...args) =>
-      verbose && console.info(`${debugLabel} [${Date.now()}]:`, ...args),
-  });
+  const logger =
+    providedLogger ||
+    harden({
+      log: (...args) => console.log(`${debugLabel} [${Date.now()}]:`, ...args),
+      error: (...args) =>
+        console.error(`${debugLabel} [${Date.now()}]:`, ...args),
+      info: (...args) =>
+        verbose && console.info(`${debugLabel} [${Date.now()}]:`, ...args),
+    });
 
   const sessionManager = makeSessionManager();
 

--- a/packages/ocapn/src/client/index.js
+++ b/packages/ocapn/src/client/index.js
@@ -356,6 +356,13 @@ export const makeClient = ({
    */
   const handleConnectionClose = (connection, reason) => {
     logger.info(`handleConnectionClose called`, { reason });
+    // The underlying socket has closed, so the connection is no longer
+    // usable regardless of how it got here (graceful op:abort, error,
+    // remote RST, etc). Marking it destroyed here is idempotent and
+    // ensures `connection.isDestroyed` is always true once the socket
+    // is gone, even when a netlayer fires close without an intervening
+    // userland call to connection.end().
+    connection.end();
     const session = sessionManager.getSessionForConnection(connection);
     if (session) {
       const locationId = locationToLocationId(session.peer.location);

--- a/packages/ocapn/src/client/ocapn.js
+++ b/packages/ocapn/src/client/ocapn.js
@@ -1217,16 +1217,27 @@ export const makeOcapn = (
       } catch (err) {
         // Tell the engine message deserialization has failed.
         ocapnTable.clearPendingRefCounts();
+        // Best-effort diagnostic: try to render the bytes as generic syrup
+        // for the log. If they can't even be decoded as syrup (e.g. junk
+        // bytes), don't let the diagnostic itself mask the original error
+        // or skip the connection.end() cleanup below.
         const problematicBytes = data.slice(start);
-        const syrupMessage = decodeSyrup(problematicBytes);
-        logger.error(`Message decode error:`);
-        logger.error(
-          JSON.stringify(
-            syrupMessage,
-            (key, value) => (typeof value === 'bigint' ? `${value}n` : value),
-            2,
-          ),
-        );
+        try {
+          const syrupMessage = decodeSyrup(problematicBytes);
+          logger.error(`Message decode error:`);
+          logger.error(
+            JSON.stringify(
+              syrupMessage,
+              (key, value) => (typeof value === 'bigint' ? `${value}n` : value),
+              2,
+            ),
+          );
+        } catch (decodeErr) {
+          logger.error(
+            `Message decode error (bytes are not valid syrup):`,
+            decodeErr,
+          );
+        }
         connection.end();
         throw err;
       }

--- a/packages/ocapn/src/client/util.js
+++ b/packages/ocapn/src/client/util.js
@@ -78,3 +78,33 @@ export const encodeSwissnum = value => {
   // @ts-expect-error - Branded type: SwissNum is ArrayBufferLike at runtime
   return uint8ArrayToImmutableArrayBuffer(swissnumEncoder.encode(value));
 };
+
+/**
+ * Wrap raw swissnum bytes as a hardened immutable `SwissNum`. Use this
+ * when the bytes already came from a wire-format source (e.g. the
+ * base64url-decoded `/s/<…>` segment of a sturdyref URI) and only the
+ * branded type wrapping is missing.
+ *
+ * For the common case of constructing a swissnum from a printable
+ * ASCII string (e.g. a hard-coded test name), use `encodeSwissnum`,
+ * which validates the alphabet for you.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {SwissNum}
+ */
+export const swissnumFromBytes = bytes => {
+  // @ts-expect-error - Branded type: SwissNum is ArrayBufferLike at runtime
+  return uint8ArrayToImmutableArrayBuffer(bytes);
+};
+
+/**
+ * View the raw bytes of a swissnum. Returns a freshly allocated
+ * (mutable) `Uint8Array` over a copy, so the caller may safely write
+ * into it without disturbing the underlying immutable `SwissNum`.
+ *
+ * @param {SwissNum} swissNum
+ * @returns {Uint8Array}
+ */
+export const swissnumToBytes = swissNum => {
+  return immutableArrayBufferToUint8Array(swissNum);
+};

--- a/packages/ocapn/src/netlayers/tcp-test-only.js
+++ b/packages/ocapn/src/netlayers/tcp-test-only.js
@@ -153,6 +153,12 @@ export const makeTcpNetLayer = async ({
       if (onClose) {
         onClose();
       }
+      // Mark the connection destroyed before notifying the client.
+      // Otherwise a socket that closes without the userland data handler
+      // first observing an op:abort (e.g. RST, dropped in-flight bytes,
+      // or close racing data delivery) would leave `connection.isDestroyed`
+      // false, which causes test waiters and reconnect logic to hang.
+      connection.end();
       handlers.handleConnectionClose(connection);
     });
   };
@@ -182,7 +188,14 @@ export const makeTcpNetLayer = async ({
     const connection = handlers.makeConnection(netlayer, true, socketOps);
 
     setupSocketHandlers(socket, connection, () => {
-      outgoingConnections.delete(location.designator);
+      // Only evict ourselves from the outgoing map. The map may contain a
+      // *different* connection for this designator (e.g. one created by a
+      // later `lookupOrConnect`) when this one was created via the debug
+      // `establishConnection` helper that bypasses registration. An
+      // unconditional delete would silently break later sessions.
+      if (outgoingConnections.get(location.designator) === connection) {
+        outgoingConnections.delete(location.designator);
+      }
     });
 
     return { connection, socket };

--- a/packages/ocapn/src/netlayers/websocket.js
+++ b/packages/ocapn/src/netlayers/websocket.js
@@ -1,0 +1,504 @@
+// @ts-check
+
+import { randomBytes } from 'node:crypto';
+import { WebSocket, WebSocketServer } from 'ws';
+import harden from '@endo/harden';
+
+import { makeOcapnKeyPair, makeOcapnPublicKey } from '../cryptography.js';
+import {
+  immutableArrayBufferToUint8Array,
+  uint8ArrayToImmutableArrayBuffer,
+} from '../buffer-utils.js';
+import { locationToLocationId } from '../client/util.js';
+import { makeSyrupReader } from '../syrup/decode.js';
+import { makeSyrupWriter } from '../syrup/encode.js';
+import { OcapnSignatureCodec } from '../codecs/components.js';
+import { makeOcapnRecordCodecFromDefinition } from '../codecs/util.js';
+
+/**
+ * @import { RawData } from 'ws'
+ * @import { Connection, NetLayer, NetlayerHandlers, SocketOperations } from '../client/types.js'
+ * @import { OcapnLocation, OcapnSignature } from '../codecs/components.js'
+ */
+
+/**
+ * Authentication protocol (matches Spritely Goblins websocket netlayer):
+ *
+ *   1. Outgoing client opens the websocket and sends a syrup-encoded
+ *      `<init:peer-auth payload>` record where `payload` is 32 random bytes.
+ *      The record wrapper is required to prevent a signing-oracle attack
+ *      (the server only ever signs typed `init:peer-auth` payloads).
+ *   2. Incoming server decodes the message, asserts it is a valid
+ *      `init:peer-auth` record, then signs the received bytes with its
+ *      designator key and replies with a syrup-encoded
+ *      `<desc:sig-envelope object signature>` record carrying both the
+ *      original `init:peer-auth` and the signature.
+ *   3. Outgoing client decodes the envelope, extracts the signature, and
+ *      verifies it against the bytes it originally sent using the public
+ *      key encoded in the remote designator.
+ *
+ * See goblins/ocapn/netlayer/websocket.scm in spritely/goblins.
+ */
+
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+const DESIGNATOR_CHALLENGE_PAYLOAD_BYTES = 32;
+const DESIGNATOR_PUBLIC_KEY_BYTES = 32;
+
+/** @type {Map<string, number>} */
+const BASE32_DECODE_TABLE = new Map(
+  [...BASE32_ALPHABET].map((char, index) => [char, index]),
+);
+
+/**
+ * @typedef {object} InitPeerAuth
+ * @property {'init:peer-auth'} type
+ * @property {ArrayBufferLike} payload
+ */
+
+/**
+ * @typedef {object} InitPeerAuthSigEnvelope
+ * @property {'desc:sig-envelope'} type
+ * @property {InitPeerAuth} object
+ * @property {OcapnSignature} signature
+ */
+
+const InitPeerAuthCodec = makeOcapnRecordCodecFromDefinition(
+  'InitPeerAuth',
+  'init:peer-auth',
+  {
+    payload: 'bytestring',
+  },
+);
+
+const InitPeerAuthSigEnvelopeCodec = makeOcapnRecordCodecFromDefinition(
+  'InitPeerAuthSigEnvelope',
+  'desc:sig-envelope',
+  {
+    object: InitPeerAuthCodec,
+    signature: OcapnSignatureCodec,
+  },
+);
+
+/**
+ * @param {RawData} rawData
+ * @returns {Uint8Array}
+ */
+const rawDataToBytes = rawData => {
+  if (Array.isArray(rawData)) {
+    const totalLength = rawData.reduce(
+      (sum, piece) => sum + piece.byteLength,
+      0,
+    );
+    const joined = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const piece of rawData) {
+      joined.set(piece, offset);
+      offset += piece.byteLength;
+    }
+    return joined;
+  }
+  if (rawData instanceof ArrayBuffer) {
+    return new Uint8Array(rawData);
+  }
+  if (ArrayBuffer.isView(rawData)) {
+    const view = new Uint8Array(
+      rawData.buffer,
+      rawData.byteOffset,
+      rawData.byteLength,
+    );
+    // Syrup reader requires byteOffset === 0.
+    return new Uint8Array(view);
+  }
+  throw Error('Unsupported websocket message type');
+};
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+const base32Encode = bytes => {
+  let value = 0;
+  let bits = 0;
+  let output = '';
+  for (const byte of bytes) {
+    value = value * 256 + byte;
+    bits += 8;
+    while (bits >= 5) {
+      const divisor = 2 ** (bits - 5);
+      const index = Math.floor(value / divisor);
+      output += BASE32_ALPHABET[index];
+      value -= index * divisor;
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    output += BASE32_ALPHABET[value * 2 ** (5 - bits)];
+  }
+  return output;
+};
+
+/**
+ * @param {string} value
+ * @returns {Uint8Array}
+ */
+const base32Decode = value => {
+  const cleaned = value.toLowerCase().replaceAll('=', '').replaceAll('-', '');
+  let bits = 0;
+  let accumulator = 0;
+  /** @type {number[]} */
+  const output = [];
+  for (const char of cleaned) {
+    const index = BASE32_DECODE_TABLE.get(char);
+    if (index === undefined) {
+      throw Error(`Invalid base32 character: ${char}`);
+    }
+    accumulator = accumulator * 32 + index;
+    bits += 5;
+    while (bits >= 8) {
+      const divisor = 2 ** (bits - 8);
+      const byte = Math.floor(accumulator / divisor);
+      output.push(byte);
+      accumulator -= byte * divisor;
+      bits -= 8;
+    }
+  }
+  return new Uint8Array(output);
+};
+
+/**
+ * @param {Uint8Array} payload
+ * @returns {Uint8Array}
+ */
+const encodeInitPeerAuth = payload => {
+  const syrupWriter = makeSyrupWriter();
+  InitPeerAuthCodec.write(
+    {
+      type: 'init:peer-auth',
+      payload: uint8ArrayToImmutableArrayBuffer(payload),
+    },
+    syrupWriter,
+  );
+  return syrupWriter.getBytes();
+};
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {InitPeerAuth}
+ */
+const decodeInitPeerAuth = bytes => {
+  const syrupReader = makeSyrupReader(bytes);
+  return InitPeerAuthCodec.read(syrupReader);
+};
+
+/**
+ * @param {InitPeerAuth} initPeerAuth
+ * @param {OcapnSignature} signature
+ * @returns {Uint8Array}
+ */
+const encodeInitPeerAuthSigEnvelope = (initPeerAuth, signature) => {
+  const syrupWriter = makeSyrupWriter();
+  InitPeerAuthSigEnvelopeCodec.write(
+    {
+      type: 'desc:sig-envelope',
+      object: initPeerAuth,
+      signature,
+    },
+    syrupWriter,
+  );
+  return syrupWriter.getBytes();
+};
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {InitPeerAuthSigEnvelope}
+ */
+const decodeInitPeerAuthSigEnvelope = bytes => {
+  const syrupReader = makeSyrupReader(bytes);
+  return InitPeerAuthSigEnvelopeCodec.read(syrupReader);
+};
+
+/**
+ * @typedef {object} OutgoingSocketState
+ * @property {boolean} authenticated
+ * @property {Uint8Array[]} pendingWrites
+ */
+
+/**
+ * @param {WebSocket} ws
+ * @param {OutgoingSocketState} state
+ * @returns {SocketOperations}
+ */
+const makeOutgoingSocketOperations = (ws, state) => {
+  return {
+    write(bytes) {
+      if (state.authenticated && ws.readyState === WebSocket.OPEN) {
+        ws.send(bytes, { binary: true });
+      } else {
+        state.pendingWrites.push(bytes);
+      }
+    },
+    end() {
+      ws.close();
+    },
+  };
+};
+
+/**
+ * @param {WebSocket} ws
+ * @returns {SocketOperations}
+ */
+const makeIncomingSocketOperations = ws => {
+  return {
+    write(bytes) {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(bytes, { binary: true });
+      }
+    },
+    end() {
+      ws.close();
+    },
+  };
+};
+
+/**
+ * @typedef {object} WebSocketNetLayerDebug
+ * @property {Uint8Array} designatorPublicKey
+ *
+ * @typedef {NetLayer & { _debug: WebSocketNetLayerDebug }} WebSocketNetLayer
+ */
+
+/**
+ * @param {object} options
+ * @param {NetlayerHandlers} options.handlers
+ * @param {import('../client/types.js').Logger} options.logger
+ * @param {number} [options.specifiedPort]
+ * @param {string} [options.specifiedHostname]
+ * @param {string} [options.specifiedUrl]
+ * @returns {Promise<WebSocketNetLayer>}
+ */
+export const makeWebSocketNetLayer = async ({
+  handlers,
+  logger,
+  specifiedPort = 0,
+  specifiedHostname = '127.0.0.1',
+  specifiedUrl,
+}) => {
+  const designatorKeyPair = makeOcapnKeyPair();
+  const designatorPublicKey = immutableArrayBufferToUint8Array(
+    designatorKeyPair.publicKey.bytes,
+  );
+  const designator = base32Encode(designatorPublicKey);
+
+  const server = new WebSocketServer({
+    host: specifiedHostname,
+    port: specifiedPort,
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+
+  const addressInfo = server.address();
+  if (!addressInfo || typeof addressInfo === 'string') {
+    throw Error('Unexpected websocket server address info');
+  }
+  const host = addressInfo.address;
+  const port = addressInfo.port;
+  const publicUrl = specifiedUrl ?? `ws://${host}:${port}`;
+
+  /** @type {OcapnLocation} */
+  const localLocation = {
+    type: 'ocapn-peer',
+    transport: 'websocket',
+    designator,
+    hints: {
+      url: publicUrl,
+    },
+  };
+
+  /** @type {Map<string, Connection>} */
+  const outgoingConnections = new Map();
+  /** @type {Set<WebSocket>} */
+  const activeSockets = new Set();
+  /** @type {WebSocketNetLayer} */
+  let netlayer;
+
+  /**
+   * @param {OcapnLocation} remoteLocation
+   * @returns {Connection}
+   */
+  const connect = remoteLocation => {
+    if (remoteLocation.transport !== localLocation.transport) {
+      throw Error(`Unsupported transport: ${remoteLocation.transport}`);
+    }
+    if (
+      typeof remoteLocation.hints !== 'object' ||
+      remoteLocation.hints === null
+    ) {
+      throw Error('Websocket location requires hints.url');
+    }
+    const wsUrl = remoteLocation.hints.url;
+    if (typeof wsUrl !== 'string' || wsUrl.length === 0) {
+      throw Error('Websocket location requires a non-empty hints.url');
+    }
+
+    const locationId = locationToLocationId(remoteLocation);
+    const existing = outgoingConnections.get(locationId);
+    if (existing && !existing.isDestroyed) {
+      return existing;
+    }
+    if (existing) {
+      outgoingConnections.delete(locationId);
+    }
+
+    const remotePublicKeyBytes = base32Decode(remoteLocation.designator);
+    if (remotePublicKeyBytes.byteLength !== DESIGNATOR_PUBLIC_KEY_BYTES) {
+      throw Error(
+        `Expected websocket designator to decode to ${DESIGNATOR_PUBLIC_KEY_BYTES} bytes, got ${remotePublicKeyBytes.byteLength}`,
+      );
+    }
+    const remotePublicKey = makeOcapnPublicKey(
+      uint8ArrayToImmutableArrayBuffer(remotePublicKeyBytes),
+    );
+
+    logger.info('Connecting to websocket', { wsUrl });
+    const ws = new WebSocket(wsUrl);
+    activeSockets.add(ws);
+
+    /** @type {OutgoingSocketState} */
+    const socketState = {
+      authenticated: false,
+      pendingWrites: [],
+    };
+
+    /** @type {Uint8Array} */
+    let challengeMessage = new Uint8Array(0);
+    const socketOps = makeOutgoingSocketOperations(ws, socketState);
+    const connection = handlers.makeConnection(netlayer, true, socketOps);
+
+    ws.on('open', () => {
+      const payload = Uint8Array.from(
+        randomBytes(DESIGNATOR_CHALLENGE_PAYLOAD_BYTES),
+      );
+      challengeMessage = encodeInitPeerAuth(payload);
+      ws.send(challengeMessage, { binary: true });
+    });
+
+    ws.on('message', rawData => {
+      const messageBytes = rawDataToBytes(rawData);
+      if (!socketState.authenticated) {
+        try {
+          const envelope = decodeInitPeerAuthSigEnvelope(messageBytes);
+          remotePublicKey.assertSignatureValid(
+            uint8ArrayToImmutableArrayBuffer(challengeMessage),
+            envelope.signature,
+          );
+          socketState.authenticated = true;
+          for (const pendingWrite of socketState.pendingWrites) {
+            if (ws.readyState === WebSocket.OPEN) {
+              ws.send(pendingWrite, { binary: true });
+            }
+          }
+          socketState.pendingWrites = [];
+        } catch (error) {
+          logger.error('Websocket outgoing auth failure', error);
+          connection.end();
+        }
+        return;
+      }
+      if (!connection.isDestroyed) {
+        handlers.handleMessageData(connection, messageBytes);
+      }
+    });
+
+    ws.on('error', error => {
+      logger.error('Websocket outgoing connection error', error);
+      connection.end();
+    });
+
+    ws.on('close', () => {
+      activeSockets.delete(ws);
+      outgoingConnections.delete(locationId);
+      handlers.handleConnectionClose(connection);
+    });
+
+    outgoingConnections.set(locationId, connection);
+    return connection;
+  };
+
+  const shutdown = () => {
+    for (const socket of activeSockets) {
+      socket.terminate();
+    }
+    activeSockets.clear();
+    outgoingConnections.clear();
+    server.close();
+  };
+
+  netlayer = harden({
+    location: localLocation,
+    locationId: locationToLocationId(localLocation),
+    connect,
+    shutdown,
+    // eslint-disable-next-line no-underscore-dangle
+    _debug: {
+      designatorPublicKey,
+    },
+  });
+
+  server.on('connection', ws => {
+    activeSockets.add(ws);
+    /** @type {Connection | undefined} */
+    let connection;
+
+    ws.on('message', rawData => {
+      const messageBytes = rawDataToBytes(rawData);
+
+      if (!connection) {
+        try {
+          const initPeerAuth = decodeInitPeerAuth(messageBytes);
+          // Sign the received bytes verbatim. The wrapping `init:peer-auth`
+          // record prevents this from being used as a generic signing oracle.
+          const signature = designatorKeyPair.sign(
+            uint8ArrayToImmutableArrayBuffer(messageBytes),
+          );
+          const responseBytes = encodeInitPeerAuthSigEnvelope(
+            initPeerAuth,
+            signature,
+          );
+          ws.send(responseBytes, { binary: true });
+
+          const socketOps = makeIncomingSocketOperations(ws);
+          connection = handlers.makeConnection(netlayer, false, socketOps);
+        } catch (error) {
+          logger.error('Websocket incoming auth failure', error);
+          ws.close();
+        }
+        return;
+      }
+
+      if (!connection.isDestroyed) {
+        handlers.handleMessageData(connection, messageBytes);
+      }
+    });
+
+    ws.on('error', error => {
+      logger.error('Websocket incoming connection error', error);
+      if (connection) {
+        connection.end();
+      } else {
+        ws.close();
+      }
+    });
+
+    ws.on('close', () => {
+      activeSockets.delete(ws);
+      if (connection) {
+        handlers.handleConnectionClose(connection);
+      }
+    });
+  });
+
+  return netlayer;
+};

--- a/packages/ocapn/test/netlayer-websocket.test.js
+++ b/packages/ocapn/test/netlayer-websocket.test.js
@@ -1,0 +1,95 @@
+// @ts-check
+
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+import { test } from './_util.js';
+import { makeClient } from '../src/client/index.js';
+import { makeWebSocketNetLayer } from '../src/netlayers/websocket.js';
+import { encodeSwissnum } from '../src/client/util.js';
+
+test('websocket netlayer establishes session and delivers messages', async t => {
+  const objectTable = new Map();
+  objectTable.set(
+    'Echo',
+    Far('echo', {
+      echo: value => value,
+    }),
+  );
+
+  const clientA = makeClient({ debugLabel: 'ws-A', debugMode: true });
+  const clientB = makeClient({
+    debugLabel: 'ws-B',
+    swissnumTable: objectTable,
+    debugMode: true,
+  });
+
+  const netlayerA = await clientA.registerNetlayer((handlers, logger) =>
+    makeWebSocketNetLayer({ handlers, logger }),
+  );
+  const netlayerB = await clientB.registerNetlayer((handlers, logger) =>
+    makeWebSocketNetLayer({ handlers, logger }),
+  );
+
+  try {
+    // eslint-disable-next-line no-underscore-dangle
+    const debugA = clientA._debug;
+    // eslint-disable-next-line no-underscore-dangle
+    const debugB = clientB._debug;
+    t.truthy(debugA);
+    t.truthy(debugB);
+    if (!debugA || !debugB) {
+      throw Error('Expected debug mode clients');
+    }
+    const sessionA = await debugA.provideInternalSession(netlayerB.location);
+    await debugB.provideInternalSession(netlayerA.location);
+
+    const bootstrap = sessionA.ocapn.getRemoteBootstrap();
+    const echoRef = await E(bootstrap).fetch(encodeSwissnum('Echo'));
+    const echoed = await E(echoRef).echo('hello websocket');
+    t.is(echoed, 'hello websocket');
+  } finally {
+    clientA.shutdown();
+    clientB.shutdown();
+  }
+});
+
+test('websocket netlayer rejects peer with mismatched designator', async t => {
+  const clientA = makeClient({ debugLabel: 'ws-auth-A', debugMode: true });
+  const clientB = makeClient({ debugLabel: 'ws-auth-B', debugMode: true });
+
+  await clientA.registerNetlayer((handlers, logger) =>
+    makeWebSocketNetLayer({ handlers, logger }),
+  );
+  const netlayerB = await clientB.registerNetlayer((handlers, logger) =>
+    makeWebSocketNetLayer({ handlers, logger }),
+  );
+
+  const badLocation = {
+    ...netlayerB.location,
+    designator: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  };
+
+  try {
+    // eslint-disable-next-line no-underscore-dangle
+    const debugA = clientA._debug;
+    t.truthy(debugA);
+    if (!debugA) {
+      throw Error('Expected debug mode client');
+    }
+    const sessionPromise = clientA.provideSession(badLocation);
+    const err = await t.throwsAsync(() => sessionPromise, {
+      instanceOf: Error,
+    });
+    t.regex(
+      err.message,
+      /Connection closed during handshake|Session ended/,
+      'session establishment should fail on invalid designator proof',
+    );
+
+    const active = debugA.sessionManager.getActiveSession(netlayerB.locationId);
+    t.is(active, undefined);
+  } finally {
+    clientA.shutdown();
+    clientB.shutdown();
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,12 +1005,14 @@ __metadata:
     "@endo/ses-ava": "workspace:^"
     "@noble/curves": "npm:^1.9.0"
     "@noble/hashes": "npm:^1.8.0"
+    "@types/ws": "npm:^8"
     ava: "catalog:dev"
     c8: "catalog:dev"
     eslint: "catalog:dev"
     ses: "workspace:^"
     tsd: "catalog:dev"
     typescript: "catalog:dev"
+    ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
 
@@ -2682,6 +2684,15 @@ __metadata:
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -12169,7 +12180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:>=8.14.2, ws@npm:^8.13.0":
+"ws@npm:>=8.14.2, ws@npm:^8.13.0, ws@npm:^8.20.0":
   version: 8.20.0
   resolution: "ws@npm:8.20.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@alcalzone/ansi-tokenize@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@alcalzone/ansi-tokenize@npm:0.3.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    is-fullwidth-code-point: "npm:^5.0.0"
+  checksum: 10c0/a6dc3328be7631b42ca76af518c9ecdc2c4edb1b961165db6d570805f5505fdfaf0d11c53c38eb5a5a215844e7a0ece4d1e49e0db5abf049983956be5b95cf4f
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
@@ -775,6 +785,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@endo/goblin-chat@workspace:packages/goblin-chat":
+  version: 0.0.0-use.local
+  resolution: "@endo/goblin-chat@workspace:packages/goblin-chat"
+  dependencies:
+    "@endo/base64": "workspace:^"
+    "@endo/eventual-send": "workspace:^"
+    "@endo/exo": "workspace:^"
+    "@endo/init": "workspace:^"
+    "@endo/lockdown": "workspace:^"
+    "@endo/marshal": "workspace:^"
+    "@endo/ocapn": "workspace:^"
+    "@endo/patterns": "workspace:^"
+    "@endo/ses-ava": "workspace:^"
+    "@types/react": "npm:^19.2.0"
+    ava: "catalog:dev"
+    c8: "catalog:dev"
+    eslint: "catalog:dev"
+    ink: "npm:^7.0.1"
+    react: "npm:^19.2.0"
+    ses: "workspace:^"
+    tsd: "catalog:dev"
+    typescript: "catalog:dev"
+  bin:
+    goblin-chat: ./bin/goblin-chat.js
+  languageName: unknown
+  linkType: soft
+
 "@endo/harden@workspace:^, @endo/harden@workspace:packages/harden":
   version: 0.0.0-use.local
   resolution: "@endo/harden@workspace:packages/harden"
@@ -989,7 +1026,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@endo/ocapn@workspace:packages/ocapn":
+"@endo/ocapn@workspace:^, @endo/ocapn@workspace:packages/ocapn":
   version: 0.0.0-use.local
   resolution: "@endo/ocapn@workspace:packages/ocapn"
   dependencies:
@@ -2664,6 +2701,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react@npm:^19.2.0":
+  version: 19.2.14
+  resolution: "@types/react@npm:19.2.14"
+  dependencies:
+    csstype: "npm:^3.2.2"
+  checksum: 10c0/7d25bf41b57719452d86d2ac0570b659210402707313a36ee612666bf11275a1c69824f8c3ee1fdca077ccfe15452f6da8f1224529b917050eb2d861e52b59b7
+  languageName: node
+  linkType: hard
+
 "@types/resolve@npm:1.20.2":
   version: 1.20.2
   resolution: "@types/resolve@npm:1.20.2"
@@ -3030,6 +3076,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "ansi-escapes@npm:7.3.0"
+  dependencies:
+    environment: "npm:^1.0.0"
+  checksum: 10c0/068961d99f0ef28b661a4a9f84a5d645df93ccf3b9b93816cc7d46bbe1913321d4cdf156bb842a4e1e4583b7375c631fa963efb43001c4eb7ff9ab8f78fc0679
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^2.0.0":
   version: 2.1.1
   resolution: "ansi-regex@npm:2.1.1"
@@ -3055,6 +3110,13 @@ __metadata:
   version: 6.0.1
   resolution: "ansi-regex@npm:6.0.1"
   checksum: 10c0/cbe16dbd2c6b2735d1df7976a7070dd277326434f0212f43abf6d87674095d247968209babdaad31bb00882fa68807256ba9be340eec2f1004de14ca75f52a08
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "ansi-regex@npm:6.2.2"
+  checksum: 10c0/05d4acb1d2f59ab2cf4b794339c7b168890d44dda4bf0ce01152a8da0213aca207802f930442ce8cd22d7a92f44907664aac6508904e75e038fa944d2601b30f
   languageName: node
   linkType: hard
 
@@ -3087,6 +3149,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^6.2.3":
+  version: 6.2.3
+  resolution: "ansi-styles@npm:6.2.3"
+  checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
   languageName: node
   linkType: hard
 
@@ -3305,6 +3374,13 @@ __metadata:
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
   checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
+  languageName: node
+  linkType: hard
+
+"auto-bind@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "auto-bind@npm:5.0.1"
+  checksum: 10c0/a703375350ea7b6e92405d8e6bcc6dbfb84b0d7c7172b33e5788a7593929a18227999ff9aa9c32436741d06d021e6672457b1cec73287efe3fab95cff6627eaf
   languageName: node
   linkType: hard
 
@@ -3797,6 +3873,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "chalk@npm:5.6.2"
+  checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
+  languageName: node
+  linkType: hard
+
 "chardet@npm:^0.7.0":
   version: 0.7.0
   resolution: "chardet@npm:0.7.0"
@@ -3886,12 +3969,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-boxes@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "cli-boxes@npm:4.0.1"
+  checksum: 10c0/a61d28caf46b35ffbc1797736ccdbd6af37357b08dc773ae874c9645eec063ec4fb55225304109979d3419d560acf572d78c743b2cf78b7c50e8a18b30a2bb59
+  languageName: node
+  linkType: hard
+
 "cli-cursor@npm:3.1.0, cli-cursor@npm:^3.1.0":
   version: 3.1.0
   resolution: "cli-cursor@npm:3.1.0"
   dependencies:
     restore-cursor: "npm:^3.1.0"
   checksum: 10c0/92a2f98ff9037d09be3dfe1f0d749664797fb674bf388375a2207a1203b69d41847abf16434203e0089212479e47a358b13a0222ab9fccfe8e2644a7ccebd111
+  languageName: node
+  linkType: hard
+
+"cli-cursor@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "cli-cursor@npm:4.0.0"
+  dependencies:
+    restore-cursor: "npm:^4.0.0"
+  checksum: 10c0/e776e8c3c6727300d0539b0d25160b2bb56aed1a63942753ba1826b012f337a6f4b7ace3548402e4f2f13b5e16bfd751be672c44b203205e7eca8be94afec42c
   languageName: node
   linkType: hard
 
@@ -3934,6 +4033,16 @@ __metadata:
     slice-ansi: "npm:^5.0.0"
     string-width: "npm:^7.0.0"
   checksum: 10c0/d7f0b73e3d9b88cb496e6c086df7410b541b56a43d18ade6a573c9c18bd001b1c3fba1ad578f741a4218fdc794d042385f8ac02c25e1c295a2d8b9f3cb86eb4c
+  languageName: node
+  linkType: hard
+
+"cli-truncate@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "cli-truncate@npm:6.0.0"
+  dependencies:
+    slice-ansi: "npm:^9.0.0"
+    string-width: "npm:^8.2.0"
+  checksum: 10c0/e0abb91a00dd20c64b93345e0235e780a5f2cf182c529235bae83f1ab1488b90b047838c1e72b9b472cb5cd6f294f017dac6afed511fa3996d710d3675dec6f7
   languageName: node
   linkType: hard
 
@@ -4423,6 +4532,13 @@ __metadata:
   bin:
     cssesc: bin/cssesc
   checksum: 10c0/6bcfd898662671be15ae7827120472c5667afb3d7429f1f917737f3bf84c4176003228131b643ae74543f17a394446247df090c597bb9a728cce298606ed0aa7
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.2.2":
+  version: 3.2.3
+  resolution: "csstype@npm:3.2.3"
+  checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
   languageName: node
   linkType: hard
 
@@ -4932,6 +5048,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"environment@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "environment@npm:1.1.0"
+  checksum: 10c0/fb26434b0b581ab397039e51ff3c92b34924a98b2039dcb47e41b7bca577b9dbf134a8eadb364415c74464b682e2d3afe1a4c0eb9873dc44ea814c5d3103331d
+  languageName: node
+  linkType: hard
+
 "err-code@npm:^2.0.2":
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
@@ -5078,6 +5201,18 @@ __metadata:
     is-date-object: "npm:^1.0.5"
     is-symbol: "npm:^1.0.4"
   checksum: 10c0/c7e87467abb0b438639baa8139f701a06537d2b9bc758f23e8622c3b42fd0fdb5bde0f535686119e446dd9d5e4c0f238af4e14960f4771877cf818d023f6730b
+  languageName: node
+  linkType: hard
+
+"es-toolkit@npm:^1.45.1":
+  version: 1.46.1
+  resolution: "es-toolkit@npm:1.46.1"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+  checksum: 10c0/6a4c3dd0ddc2138fa13d983d93ebaf8061759c52c2cf7c3101315139fc1fca826d253daa67fe85ad880c03cc4c092bd53a83a7cbf58b4721c251479122ba5303
   languageName: node
   linkType: hard
 
@@ -5990,6 +6125,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-east-asian-width@npm:^1.3.1, get-east-asian-width@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "get-east-asian-width@npm:1.5.0"
+  checksum: 10c0/bff8bbc8d81790b9477f7aa55b1806b9f082a8dc1359fff7bd8b96939622c86b729685afc2bfeb22def1fc6ef1e5228e4d87dd4e6da60bc43a5edfb03c4ee167
+  languageName: node
+  linkType: hard
+
 "get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
@@ -6685,6 +6827,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ink@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "ink@npm:7.0.1"
+  dependencies:
+    "@alcalzone/ansi-tokenize": "npm:^0.3.0"
+    ansi-escapes: "npm:^7.3.0"
+    ansi-styles: "npm:^6.2.3"
+    auto-bind: "npm:^5.0.1"
+    chalk: "npm:^5.6.2"
+    cli-boxes: "npm:^4.0.1"
+    cli-cursor: "npm:^4.0.0"
+    cli-truncate: "npm:^6.0.0"
+    code-excerpt: "npm:^4.0.0"
+    es-toolkit: "npm:^1.45.1"
+    indent-string: "npm:^5.0.0"
+    is-in-ci: "npm:^2.0.0"
+    patch-console: "npm:^2.0.0"
+    react-reconciler: "npm:^0.33.0"
+    scheduler: "npm:^0.27.0"
+    signal-exit: "npm:^3.0.7"
+    slice-ansi: "npm:^9.0.0"
+    stack-utils: "npm:^2.0.6"
+    string-width: "npm:^8.2.0"
+    terminal-size: "npm:^4.0.1"
+    type-fest: "npm:^5.5.0"
+    widest-line: "npm:^6.0.0"
+    wrap-ansi: "npm:^10.0.0"
+    ws: "npm:^8.20.0"
+    yoga-layout: "npm:~3.2.1"
+  peerDependencies:
+    "@types/react": ">=19.2.0"
+    react: ">=19.2.0"
+    react-devtools-core: ">=6.1.2"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react-devtools-core:
+      optional: true
+  checksum: 10c0/c5b695a5a81360db2be26d0623641454974f797be6f52ac310d24e61d340eae1ff4e86df3a2d405725df2a5ab26d37b883f06b166fa6c86af316b7ed0920fb2d
+  languageName: node
+  linkType: hard
+
 "inquirer@npm:^7.3.3":
   version: 7.3.3
   resolution: "inquirer@npm:7.3.3"
@@ -6931,6 +7115,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-fullwidth-code-point@npm:^5.0.0, is-fullwidth-code-point@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "is-fullwidth-code-point@npm:5.1.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.3.1"
+  checksum: 10c0/c1172c2e417fb73470c56c431851681591f6a17233603a9e6f94b7ba870b2e8a5266506490573b607fb1081318589372034aa436aec07b465c2029c0bc7f07a4
+  languageName: node
+  linkType: hard
+
 "is-generator-function@npm:^1.0.10":
   version: 1.0.10
   resolution: "is-generator-function@npm:1.0.10"
@@ -6946,6 +7139,15 @@ __metadata:
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
+  languageName: node
+  linkType: hard
+
+"is-in-ci@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-in-ci@npm:2.0.0"
+  bin:
+    is-in-ci: cli.js
+  checksum: 10c0/1e1d1056939a681e8206035de5ad84e0404556eaa7622bb55f0f1868b9788bff3df427bc0b1ed5a172623154a90fcb1e759a230817cd73d09435543ae3c71feb
   languageName: node
   linkType: hard
 
@@ -9400,6 +9602,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"patch-console@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "patch-console@npm:2.0.0"
+  checksum: 10c0/486602591a0af7af8d4c76d8eea42cad32b6de7200488819c6383c75e43733ca7bdc80e30f2e68ce05f06a1607cce1683a1706c6672ca27dada1921b366e8f1c
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-exists@npm:3.0.0"
@@ -9784,6 +9993,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-reconciler@npm:^0.33.0":
+  version: 0.33.0
+  resolution: "react-reconciler@npm:0.33.0"
+  dependencies:
+    scheduler: "npm:^0.27.0"
+  peerDependencies:
+    react: ^19.2.0
+  checksum: 10c0/3f7b27ea8d0ff4c8bf0e402a285e1af9b7d0e6f4c1a70a28f4384938bc1130bc82a90a31df0b79ef5e380e2e55e2598bd90b4dbf802b1203d735ba0355817d3a
+  languageName: node
+  linkType: hard
+
+"react@npm:^19.2.0":
+  version: 19.2.5
+  resolution: "react@npm:19.2.5"
+  checksum: 10c0/4b5f231dbef92886f602533c9ce3bde04d99f0e71dfb5d794c43e02726efaad0421c08688f75fc98a6d6e1dc017372e1af7abbfecdc86a79968f461675931a7a
+  languageName: node
+  linkType: hard
+
 "read-cmd-shim@npm:4.0.0, read-cmd-shim@npm:^4.0.0":
   version: 4.0.0
   resolution: "read-cmd-shim@npm:4.0.0"
@@ -10047,6 +10274,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"restore-cursor@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "restore-cursor@npm:4.0.0"
+  dependencies:
+    onetime: "npm:^5.1.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/6f7da8c5e422ac26aa38354870b1afac09963572cf2879443540449068cb43476e9cbccf6f8de3e0171e0d6f7f533c2bc1a0a008003c9a525bbc098e89041318
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -10304,6 +10541,13 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "scheduler@npm:0.27.0"
+  checksum: 10c0/4f03048cb05a3c8fddc45813052251eca00688f413a3cee236d984a161da28db28ba71bd11e7a3dd02f7af84ab28d39fb311431d3b3772fed557945beb00c452
   languageName: node
   linkType: hard
 
@@ -10589,6 +10833,16 @@ __metadata:
     ansi-styles: "npm:^6.0.0"
     is-fullwidth-code-point: "npm:^4.0.0"
   checksum: 10c0/2d4d40b2a9d5cf4e8caae3f698fe24ae31a4d778701724f578e984dcb485ec8c49f0c04dab59c401821e80fcdfe89cace9c66693b0244e40ec485d72e543914f
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "slice-ansi@npm:9.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    is-fullwidth-code-point: "npm:^5.1.0"
+  checksum: 10c0/fd97f0e3a48386dbf1cbc2f10134f1e345c161188adb6928856079b4c0117c221a5405a7bff341e1a6e428721c5236353ab26b7d777a4f2f35a8ed2a91d82e7a
   languageName: node
   linkType: hard
 
@@ -10898,6 +11152,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^8.1.0, string-width@npm:^8.2.0":
+  version: 8.2.1
+  resolution: "string-width@npm:8.2.1"
+  dependencies:
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/d467b4eaf4c40a01bb438a2620e77badd2456ffd5131c9973abe4f3acf7c802d5b21f3b6a00a5e33a7fc28ca8f9c103226e01bac61e9f259659c6f46d78e353a
+  languageName: node
+  linkType: hard
+
 "string.prototype.trim@npm:^1.2.10":
   version: 1.2.10
   resolution: "string.prototype.trim@npm:1.2.10"
@@ -10978,6 +11242,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.2":
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
+  dependencies:
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10c0/544d13b7582f8254811ea97db202f519e189e59d35740c46095897e254e4f1aa9fe1524a83ad6bc5ad67d4dd6c0281d2e0219ed62b880a6238a16a17d375f221
   languageName: node
   linkType: hard
 
@@ -11098,6 +11371,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10c0/91d25c9ffb86a91f20522cefb2cbec9b64caa1febe27ad0df52f08993ff60888022d771e868e6416cf2e72dab68449d2139e8709ba009b74c6c7ecd4000048d1
+  languageName: node
+  linkType: hard
+
 "tar-stream@npm:~2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
@@ -11180,6 +11460,13 @@ __metadata:
   version: 2.2.1
   resolution: "term-size@npm:2.2.1"
   checksum: 10c0/89f6bba1d05d425156c0910982f9344d9e4aebf12d64bfa1f460d93c24baa7bc4c4a21d355fbd7153c316433df0538f64d0ae6e336cc4a69fdda4f85d62bc79d
+  languageName: node
+  linkType: hard
+
+"terminal-size@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "terminal-size@npm:4.0.1"
+  checksum: 10c0/89afd9d816dd9dbfe4499da9aeea70491bbde4ff4592226a9c8ac71074a7580afead6a78e95ecc35f6d42e09087b55ffcb1019302cd55e0cc957b6ce5c4847e8
   languageName: node
   linkType: hard
 
@@ -11544,6 +11831,15 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^5.5.0":
+  version: 5.6.0
+  resolution: "type-fest@npm:5.6.0"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10c0/5468a8ffda7f3904e6f7bbd8069eb8b6dd4bd9156e206df7a01d09a73e28cd1afedf74ead9d0fc12841c8c90074194859feca240511c50800962fde1bd9ddcbc
   languageName: node
   linkType: hard
 
@@ -12029,6 +12325,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"widest-line@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "widest-line@npm:6.0.0"
+  dependencies:
+    string-width: "npm:^8.1.0"
+  checksum: 10c0/735f1fdcd97fe765a07bb8b5e73c020bed8e53ab34e83ce0ef01693ba3c914d9e7977fe5f5facf0d0b670297a82dd5e376d3efa0896860dfcdaf7cd6924c0fb7
+  languageName: node
+  linkType: hard
+
 "window-size@npm:^0.1.4":
   version: 0.1.4
   resolution: "window-size@npm:0.1.4"
@@ -12060,6 +12365,17 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "wrap-ansi@npm:10.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    string-width: "npm:^8.2.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/6b163457630fe6d1c72aeed283a7410b2cc7487312df8b0ce96df3fbd64a2a7c948856ea97c25148c848627587c5c7945be474d8e723ab6011bb0756a53a9e89
   languageName: node
   linkType: hard
 
@@ -12442,6 +12758,13 @@ __metadata:
   version: 2.1.1
   resolution: "yoctocolors@npm:2.1.1"
   checksum: 10c0/85903f7fa96f1c70badee94789fade709f9d83dab2ec92753d612d84fcea6d34c772337a9f8914c6bed2f5fc03a428ac5d893e76fab636da5f1236ab725486d0
+  languageName: node
+  linkType: hard
+
+"yoga-layout@npm:~3.2.1":
+  version: 3.2.1
+  resolution: "yoga-layout@npm:3.2.1"
+  checksum: 10c0/9001e51be993c85e03757e5a04a2b61b8b30c9e5a7865d0156ca87a6431a3b717d51eb4990bfe588189fcfeac688dd9c3de707bbd50d1c344a84e63974cc54a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
pending https://github.com/endojs/endo/pull/3207 (this to be rebased on top)

## Summary

This adds a CI test against Spritely's Guile implementation.

It also adds a new package `goblin-chat` including a TUI for working with https://codeberg.org/spritely/goblin-chat/ built on OCapN.

⚠️ This adds a new workflow that builds and tests against Guile Goblins (typical runtime is 3m20s). This workflow could be change to be gated behind PR changes to the `ocapn` package.

## Test plan

- [x] CI: `ocapn-guile-interop` workflow exercises bilateral chatroom interop against guile-goblins via `guix shell`
- [x] CI: `@endo/ocapn` and `@endo/goblin-chat` package tests pass (incl. websocket netlayer tests and the all-JS interop self-test)
- [x] Manual: `goblin-chat` TUI hosts a room, prints a sturdyref URI, and a second client can join it

## Notes for reviewers

- Final tree is identical to #3194; this PR is a history cleanup, not a content change. Consider closing #3194 in favor of this one.
- Intermediate commits 1 and 2 are not yarn-install-clean on their own (the lockfile lives in commit 3 with the bulk of the new deps); only the final tree is verified.
