### PR TITLE
fix(module-source): share robust babel parse resolution

### DIFF
--- a/packages/module-source/src/parse-babel.js
+++ b/packages/module-source/src/parse-babel.js
@@ -1,0 +1,28 @@
+import * as babelParser from '@babel/parser';
+
+// @babel/parser import shape differs across ESM/CJS interop paths. We resolve
+// parse defensively because CI (Node 20 on macOS) has surfaced a runtime where
+// `default` exists but `default.parse` is not the callable parser.
+const resolveBabelParse = () => {
+  if (typeof babelParser.parse === 'function') {
+    return babelParser.parse;
+  }
+  if (babelParser.default) {
+    if (typeof babelParser.default.parse === 'function') {
+      return babelParser.default.parse;
+    }
+    if (typeof babelParser.default === 'function') {
+      return babelParser.default;
+    }
+  }
+  if (typeof babelParser === 'function') {
+    return babelParser;
+  }
+  return undefined;
+};
+
+export const babelParse = resolveBabelParse();
+
+if (typeof babelParse !== 'function') {
+  throw Error('Unable to resolve @babel/parser parse function');
+}

--- a/packages/module-source/src/transform-source.js
+++ b/packages/module-source/src/transform-source.js
@@ -1,12 +1,8 @@
 // @ts-nocheck XXX Babel types
-import * as babelParser from '@babel/parser';
 import babelGenerate from '@babel/generator';
 import babelTraverse from '@babel/traverse';
 import * as babelTypes from '@babel/types';
-
-const parseBabel = babelParser.default
-  ? babelParser.default.parse
-  : babelParser.parse || babelParser;
+import { babelParse } from './parse-babel.js';
 
 const visitorFromPlugin = plugin => plugin({ types: babelTypes }).visitor;
 
@@ -26,7 +22,7 @@ export const makeTransformSource = (makeModulePlugins, babel = null) => {
     const { sourceUrl, sourceMapUrl, sourceType, sourceMap, sourceMapHook } =
       sourceOptions;
 
-    const ast = parseBabel(source, {
+    const ast = babelParse(source, {
       sourceType,
       tokens: true,
       createParenthesizedExpressions: true,

--- a/packages/module-source/test/fixtures/small.js
+++ b/packages/module-source/test/fixtures/small.js
@@ -1,15 +1,11 @@
 /* eslint-disable */
 console.error("This is a code sample for trying out babel transforms, it's not meant to be run");
-import * as babelParser from '@babel/parser';
 import babelGenerate from '@babel/generator';
 import babelTraverse from '@babel/traverse';
 import * as babelTypes from '@babel/types';
 
 import makeModulePlugins from './babelPlugin.js';
-
-const parseBabel = babelParser.default
-  ? babelParser.default.parse
-  : babelParser.parse || babelParser;
+import { babelParse } from '../../src/parse-babel.js';
 
 const visitorFromPlugin = plugin => plugin({ types: babelTypes }).visitor;
 
@@ -27,7 +23,7 @@ export const makeTransformSource = (babel = null) => {
     // console.log(`transforming`, sourceOptions, code);
     const { analyzePlugin, transformPlugin } = makeModulePlugins(sourceOptions);
 
-    const ast = parseBabel(code, { sourceType: sourceOptions.sourceType });
+    const ast = babelParse(code, { sourceType: sourceOptions.sourceType });
 
     traverseBabel(ast, visitorFromPlugin(analyzePlugin));
     traverseBabel(ast, visitorFromPlugin(transformPlugin));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR factors the `@babel/parser` parse-function resolution into a private internal module and reuses it in both runtime and fixture code.

Critical files:
- `packages/module-source/src/parse-babel.js` (new internal helper)
- `packages/module-source/src/transform-source.js`
- `packages/module-source/test/fixtures/small.js`

Key behavior:
- Adds an explanatory comment documenting why defensive resolution exists: CI surfaced an ESM/CJS interop shape where `default` is present but not callable as expected.
- Exports `babelParse` only from the internal helper module (not from package public exports).
- Deduplicates parse resolution logic by importing the same helper in runtime transform code and fixture transform code.

### Security Considerations

No new authority or external dependency is introduced. This is an internal refactor plus explanatory comment.

### Scaling Considerations

No material runtime scaling impact; this centralizes existing logic.

### Documentation Considerations

No user-facing API or docs changes required. The helper remains internal-only.

### Testing Considerations

Validated in package:
- `yarn lint` in `packages/module-source`
- `yarn test` in `packages/module-source`

### Compatibility Considerations

No public API changes. Behavior should be more robust across Node/module interop environments.

### Upgrade Considerations

No upgrade/migration action needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bac377b3-8717-4178-8c22-75ec373b66c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bac377b3-8717-4178-8c22-75ec373b66c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

