### PR TITLE
feat(base64): Fall through to native Uint8Array

### DIFF
--- a/.changeset/base64-harden.md
+++ b/.changeset/base64-harden.md
@@ -1,0 +1,13 @@
+---
+'@endo/base64': minor
+'@endo/bundle-source': patch
+---
+
+`@endo/base64`'s named exports (`encodeBase64`, `decodeBase64`, `atob`, `btoa`)
+are now frozen.
+Consumers that previously assigned to or extended these exports will see a
+`TypeError` under SES; read-only consumers are unaffected.
+
+The shim entry point `@endo/base64/shim.js` (which `@endo/init/pre.js` uses to
+install `globalThis.atob` / `globalThis.btoa` before `lockdown()`) is unchanged
+and continues to be safe to load pre-lockdown.

--- a/.changeset/base64-native-fallthrough.md
+++ b/.changeset/base64-native-fallthrough.md
@@ -1,0 +1,11 @@
+---
+'@endo/base64': patch
+---
+
+`encodeBase64` and `decodeBase64` now dispatch to the native
+`Uint8Array.prototype.toBase64` and `Uint8Array.fromBase64` intrinsics (TC39
+proposal-arraybuffer-base64, Stage 4) on platforms that ship them, falling back
+to the existing pure-JavaScript implementation otherwise.
+Existing call sites pick up the speedup with no API change, and `decodeBase64`'s
+error messages (including any caller-supplied `name` and the failing offset) are
+unchanged.

--- a/packages/base64/atob.js
+++ b/packages/base64/atob.js
@@ -8,3 +8,4 @@ export const atob = encodedData => {
   const buf = decodeBase64(encodedData);
   return String.fromCharCode(...buf);
 };
+Object.freeze(atob);

--- a/packages/base64/btoa.js
+++ b/packages/base64/btoa.js
@@ -15,3 +15,4 @@ export const btoa = stringToEncode => {
   const buf = new Uint8Array(bytes);
   return encodeBase64(buf);
 };
+Object.freeze(btoa);

--- a/packages/base64/index.js
+++ b/packages/base64/index.js
@@ -1,3 +1,13 @@
+// Re-exports the package's named bindings.  Each source module
+// (`./src/encode.js`, `./src/decode.js`, `./atob.js`, `./btoa.js`)
+// applies `Object.freeze` to its export at module-evaluation time, so
+// the bindings are hardened on both the public path through this
+// module and on the pre-lockdown shim path that `@endo/init/pre.js`
+// uses (`@endo/base64/shim.js` -> `./atob.js` / `./btoa.js`).  Using
+// `Object.freeze` rather than `@endo/harden` keeps the shim path free
+// of any module that would install a fallback `harden` before SES
+// `lockdown()` freezes the well-known properties of `globalThis`.
+
 export { encodeBase64 } from './src/encode.js';
 export { decodeBase64 } from './src/decode.js';
 export { btoa } from './btoa.js';

--- a/packages/base64/src/decode.js
+++ b/packages/base64/src/decode.js
@@ -4,17 +4,30 @@
 
 import { monodu64, padding } from './common.js';
 
+// Capture `Reflect.apply` once at module load, before any consumer
+// can tamper with `Function.prototype.call`.
+// Using `Reflect.apply` for the native dispatch ensures a tampered
+// `Function.prototype.call` cannot redirect the dispatched native
+// intrinsic invocation.
+const { apply } = Reflect;
+
 /**
- * Decodes a Base64 string into bytes, as specified in
- * https://tools.ietf.org/html/rfc4648#section-4
+ * Pure-JavaScript base64 decoder, exported for benchmarking and for
+ * environments where the native TC39 `Uint8Array.fromBase64` intrinsic
+ * (proposal-arraybuffer-base64) is unavailable or has been removed.
+ * See `decodeBase64` below for the dispatched default.
  *
- * XSnap is a JavaScript engine based on Moddable/XS.
- * The algorithm below is orders of magnitude too slow on this VM, but it
- * arranges a native binding on the global object.
- * We use that if it is available instead.
+ * XSnap, a JavaScript engine based on Moddable/XS, runs this polyfill
+ * orders of magnitude slower than V8.
+ * Older XS builds expose a native `globalThis.Base64` binding that the
+ * dispatched `decodeBase64` uses ahead of the polyfill on legacy
+ * Agoric chain XS; going forward, XS is expected to favor the standard
+ * `Uint8Array.fromBase64`.
  *
  * This function is exported from this *file* for use in benchmarking,
  * but is not part of the *module*'s public API.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc4648#section-4
  *
  * @param {string} string Base64-encoded string
  * @param {string} [name] The name of the string as it will appear in error
@@ -64,21 +77,89 @@ export const jsDecodeBase64 = (string, name = '<unknown>') => {
 
   return data.subarray(0, j);
 };
+Object.freeze(jsDecodeBase64);
 
-// The XS Base64.decode function is faster, but might return ArrayBuffer (not
-// Uint8Array).  Adapt it to our needs.
+// Capture the native TC39 `Uint8Array.fromBase64` intrinsic at module
+// load, before any caller can reach `decodeBase64` and before SES
+// lockdown freezes `Uint8Array`.
+// Post-lockdown mutation cannot redirect the dispatched binding.
+/** @type {typeof Uint8Array.fromBase64 | undefined} */
+const nativeFromBase64 = /** @type {any} */ (Uint8Array).fromBase64;
+
+// Pin native options to the strictest semantics that match
+// `jsDecodeBase64`:
+//   - `lastChunkHandling: 'strict'` rejects unpadded / short final
+//     chunks (the proposal default `'loose'` would silently accept
+//     them).
+//   - `alphabet: 'base64'` rejects URL-safe characters (`-_`) and
+//     pins forward compatibility against any future spec drift.
+const nativeFromBase64Options = Object.freeze({
+  lastChunkHandling: 'strict',
+  alphabet: 'base64',
+});
+
+/** @type {typeof jsDecodeBase64} */
+const nativeDecodeBase64 = (string, name) => {
+  try {
+    return apply(
+      /** @type {typeof Uint8Array.fromBase64} */ (nativeFromBase64),
+      Uint8Array,
+      [string, nativeFromBase64Options],
+    );
+  } catch (err) {
+    // Prefer the polyfill's precise diagnostic on any native throw:
+    // native error messages are implementation-defined and do not
+    // embed `name` or report the failing offset.
+    // jsDecodeBase64 is expected to reject anything native rejected;
+    // if it does not, fall back to propagating the caught native error.
+    jsDecodeBase64(string, name);
+    throw err;
+  }
+};
+
+// Legacy XSnap path.
+// Older Moddable/XS builds ship a native `globalThis.Base64.decode`
+// that predates the TC39 intrinsic; we dispatch to it on Agoric chain
+// XS.
+// Going forward, XS will favor the standard `Uint8Array.fromBase64`
+// and this branch will retire.
+//
+// The legacy XS `Base64.decode` may return ArrayBuffer (not
+// Uint8Array); adapt it.
 const adaptDecoder =
-  nativeDecodeBase64 =>
+  nativeDecoder =>
   (...args) => {
-    const decoded = nativeDecodeBase64(...args);
+    const decoded = nativeDecoder(...args);
     if (decoded instanceof Uint8Array) {
       return decoded;
     }
     return new Uint8Array(decoded);
   };
 
-/** @type {typeof jsDecodeBase64} */
-export const decodeBase64 =
+/** @type {typeof jsDecodeBase64 | undefined} */
+const xsDecodeBase64 =
   globalThis.Base64 !== undefined
     ? adaptDecoder(globalThis.Base64.decode)
-    : jsDecodeBase64;
+    : undefined;
+
+/**
+ * Decodes a Base64 string into bytes, as specified in
+ * https://tools.ietf.org/html/rfc4648#section-4.
+ *
+ * Dispatches to the native `Uint8Array.fromBase64` intrinsic when
+ * available (stage-4 TC39 proposal-arraybuffer-base64).
+ * Otherwise falls through to the legacy `globalThis.Base64.decode` XS
+ * binding, and finally to the pure-JavaScript `jsDecodeBase64`.
+ *
+ * On any native throw, the polyfill is re-run to surface a
+ * diagnostic that embeds `name` and the failing offset; native
+ * error messages are implementation-defined and do neither.
+ *
+ * @type {typeof jsDecodeBase64}
+ */
+export const decodeBase64 = (() => {
+  if (nativeFromBase64 !== undefined) return nativeDecodeBase64;
+  if (xsDecodeBase64 !== undefined) return xsDecodeBase64;
+  return jsDecodeBase64;
+})();
+Object.freeze(decodeBase64);

--- a/packages/base64/src/encode.js
+++ b/packages/base64/src/encode.js
@@ -4,11 +4,25 @@
 
 import { alphabet64, padding } from './common.js';
 
+// Capture `Reflect.apply` once at module load; we prefer it to
+// `Function.prototype.call` even where `.call` is assumed to be
+// primordial, so a tampered `Function.prototype.call` cannot redirect
+// the dispatched native intrinsic invocation.
+const { apply } = Reflect;
+
 /**
- * XSnap is a JavaScript engine based on Moddable/XS.
- * The algorithm below is orders of magnitude too slow on this VM, but it
- * arranges a native binding on the global object.
- * We use that if it is available instead.
+ * Pure-JavaScript base64 encoder, exported for benchmarking and for
+ * environments where the native TC39 `Uint8Array.prototype.toBase64`
+ * intrinsic (proposal-arraybuffer-base64) is unavailable or has been
+ * removed.
+ * See `encodeBase64` below for the dispatched default.
+ *
+ * XSnap, a JavaScript engine based on Moddable/XS, runs this polyfill
+ * orders of magnitude slower than V8.
+ * Older XS builds expose a native `globalThis.Base64` binding that the
+ * dispatched `encodeBase64` uses ahead of the polyfill on legacy
+ * Agoric chain XS; going forward, XS is expected to favor the standard
+ * `Uint8Array.prototype.toBase64`.
  *
  * This function is exported from this *file* for use in benchmarking,
  * but is not part of the *module*'s public API.
@@ -61,12 +75,52 @@ export const jsEncodeBase64 = data => {
   }
   return string;
 };
+Object.freeze(jsEncodeBase64);
+
+// Capture the native TC39 `Uint8Array.prototype.toBase64` intrinsic at
+// module load, before any caller can reach `encodeBase64` and before
+// SES lockdown freezes the prototype.
+// Post-lockdown mutation cannot redirect the dispatched binding.
+/** @type {typeof Uint8Array.prototype.toBase64 | undefined} */
+const nativeToBase64 = /** @type {any} */ (Uint8Array.prototype).toBase64;
+
+/** @type {typeof jsEncodeBase64} */
+const nativeEncodeBase64 = data =>
+  apply(
+    /** @type {typeof Uint8Array.prototype.toBase64} */ (nativeToBase64),
+    data,
+    [],
+  );
+
+// Legacy XSnap path.
+// Older Moddable/XS builds ship a native `globalThis.Base64.encode`
+// that predates the TC39 intrinsic; we dispatch to it on Agoric chain
+// XS.
+// Going forward, XS will favor the standard
+// `Uint8Array.prototype.toBase64` and this branch will retire.
+/** @type {typeof jsEncodeBase64 | undefined} */
+const xsEncodeBase64 = (() => {
+  if (globalThis.Base64 === undefined) return undefined;
+  const { encode } = globalThis.Base64;
+  // eslint-disable-next-line no-shadow
+  const xsEncodeBase64 = data => apply(encode, undefined, [data]);
+  return xsEncodeBase64;
+})();
 
 /**
  * Encodes bytes into a Base64 string, as specified in
- * https://tools.ietf.org/html/rfc4648#section-4
+ * https://tools.ietf.org/html/rfc4648#section-4.
+ *
+ * Dispatches to the native `Uint8Array.prototype.toBase64` intrinsic
+ * when available (stage-4 TC39 proposal-arraybuffer-base64).
+ * Otherwise falls through to the legacy `globalThis.Base64.encode` XS
+ * binding, and finally to the pure-JavaScript `jsEncodeBase64`.
  *
  * @type {typeof jsEncodeBase64}
  */
-export const encodeBase64 =
-  globalThis.Base64 !== undefined ? globalThis.Base64.encode : jsEncodeBase64;
+export const encodeBase64 = (() => {
+  if (nativeToBase64 !== undefined) return nativeEncodeBase64;
+  if (xsEncodeBase64 !== undefined) return xsEncodeBase64;
+  return jsEncodeBase64;
+})();
+Object.freeze(encodeBase64);

--- a/packages/base64/test/forced-polyfill.test.js
+++ b/packages/base64/test/forced-polyfill.test.js
@@ -1,0 +1,96 @@
+// @ts-check
+
+// Exercises the pure-JavaScript polyfill directly, regardless of whether
+// the current runtime provides the native TC39 `Uint8Array.fromBase64` /
+// `Uint8Array.prototype.toBase64` intrinsics.
+// This ensures the polyfill path in src/encode.js and src/decode.js
+// stays exercised by CI even on Node versions that ship the native
+// intrinsic.
+
+import test from 'ava';
+import { jsEncodeBase64, encodeBase64 } from '../src/encode.js';
+import { jsDecodeBase64, decodeBase64 } from '../src/decode.js';
+
+/** @param {string} asciiString */
+const asciiStringToUint8Array = asciiString => {
+  const data = new Uint8Array(asciiString.length);
+  for (let i = 0; i < asciiString.length; i += 1) {
+    data[i] = asciiString.charCodeAt(i);
+  }
+  return data;
+};
+
+/** @param {Uint8Array} data */
+const uint8ArrayToAsciiString = data => String.fromCharCode(...data);
+
+test('jsEncodeBase64 round-trips through jsDecodeBase64', t => {
+  const inputs = [
+    '',
+    'f',
+    'fo',
+    'foo',
+    'foob',
+    'fooba',
+    'foobar',
+    'Hello, world!',
+    '\x00\x01\x02\xff\xfe\xfd',
+  ];
+  for (const input of inputs) {
+    const bytes = asciiStringToUint8Array(input);
+    const encoded = jsEncodeBase64(bytes);
+    const decoded = jsDecodeBase64(encoded);
+    t.is(
+      uint8ArrayToAsciiString(decoded),
+      input,
+      `${JSON.stringify(input)} round-trips via js* path`,
+    );
+  }
+});
+
+test('native-available: dispatched functions match polyfill on clean inputs', t => {
+  const inputs = [
+    '',
+    'f',
+    'fo',
+    'foo',
+    'foob',
+    'fooba',
+    'foobar',
+    '\x00\x01\x02\xff\xfe\xfd',
+  ];
+  for (const input of inputs) {
+    const bytes = asciiStringToUint8Array(input);
+    t.is(
+      encodeBase64(bytes),
+      jsEncodeBase64(bytes),
+      `encode(${JSON.stringify(input)}) matches polyfill`,
+    );
+    const encoded = jsEncodeBase64(bytes);
+    t.is(
+      uint8ArrayToAsciiString(decodeBase64(encoded)),
+      uint8ArrayToAsciiString(jsDecodeBase64(encoded)),
+      `decode(${JSON.stringify(encoded)}) matches polyfill`,
+    );
+  }
+});
+
+test('jsDecodeBase64 rejects malformed inputs with polyfill-specific messages', t => {
+  t.throws(() => jsDecodeBase64('%'), {
+    message: /Invalid base64 character %/,
+  });
+  t.throws(() => jsDecodeBase64('Z'), {
+    message: /Missing padding at offset 1/,
+  });
+  t.throws(() => jsDecodeBase64('Zg==%'), {
+    message: /trailing garbage %/,
+  });
+});
+
+test('jsDecodeBase64 preserves the optional name parameter in error messages', t => {
+  t.throws(() => jsDecodeBase64('%', 'my-input'), {
+    message: /in string my-input/,
+  });
+  t.throws(() => jsDecodeBase64('Z', 'other'), {
+    message: /of string other/,
+  });
+});

--- a/packages/bundle-source/test/_lockdown-concise.js
+++ b/packages/bundle-source/test/_lockdown-concise.js
@@ -1,0 +1,4 @@
+import { lockdown } from '@endo/lockdown';
+
+lockdown({ errorTaming: 'unsafe', stackFiltering: 'concise' });
+Error.stackTraceLimit = Infinity;

--- a/packages/bundle-source/test/_lockdown-verbose.js
+++ b/packages/bundle-source/test/_lockdown-verbose.js
@@ -1,0 +1,4 @@
+import { lockdown } from '@endo/lockdown';
+
+lockdown({ errorTaming: 'unsafe', stackFiltering: 'verbose' });
+Error.stackTraceLimit = Infinity;

--- a/packages/bundle-source/test/_sanity.js
+++ b/packages/bundle-source/test/_sanity.js
@@ -1,10 +1,8 @@
 // @ts-check
-import { lockdown } from '@endo/lockdown';
-
 import url from 'url';
+import test from 'ava';
 import { decodeBase64 } from '@endo/base64';
 import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
-import test from 'ava';
 import bundleSource from '../src/index.js';
 
 function evaluate(src, endowments) {
@@ -13,9 +11,6 @@ function evaluate(src, endowments) {
 }
 
 export function makeSanityTests(stackFiltering) {
-  lockdown({ errorTaming: 'unsafe', stackFiltering });
-  Error.stackTraceLimit = Infinity;
-
   const prefix = stackFiltering === 'concise' ? '' : '/bundled-source/.../';
 
   /**

--- a/packages/bundle-source/test/sanity-unfiltered.test.js
+++ b/packages/bundle-source/test/sanity-unfiltered.test.js
@@ -1,4 +1,5 @@
 // Like test-sanity.js but with { stackFiltering: 'verbose' }
+import './_lockdown-verbose.js';
 import { makeSanityTests } from './_sanity.js';
 
 makeSanityTests('verbose');

--- a/packages/bundle-source/test/sanity.test.js
+++ b/packages/bundle-source/test/sanity.test.js
@@ -1,4 +1,5 @@
 // Like test-sanity-unfiltered.js but with { stackFiltering: 'concise' }
+import './_lockdown-concise.js';
 import { makeSanityTests } from './_sanity.js';
 
 // 'concise' is currently the default. But the purpose of this


### PR DESCRIPTION

## Description

Makes `@endo/base64`'s `encodeBase64` and `decodeBase64` dispatch to the native
TC39 `Uint8Array` base64 intrinsics (proposal-arraybuffer-base64, Stage 4) when
available, falling through to the legacy `globalThis.Base64` XS binding and
finally to the existing pure-JavaScript polyfill.
Also hardens the package's named exports while preserving the pre-lockdown
shim path that `@endo/init/pre.js` relies on.

This branch also adds `CLAUDE.md` with guiding principles distilled from
review feedback during the AI-assisted sessions on this work.

### Security Considerations

- Native intrinsics are captured at module load via `Reflect.apply`, with
  `Reflect.apply` itself destructured at module load, so a tampered
  `Function.prototype.call` cannot redirect the dispatched invocation.
- The native options bag is `Object.freeze`'d (not `harden`'d), since
  `src/decode.js` is on the pre-lockdown shim path.
  Importing `@endo/harden` here would install its fallback `harden` before SES
  `lockdown()` and break it.
- Hardening lives in `index.js`, not in the shim path
  (`shim.js` -> `atob.js` / `btoa.js`).
  `@endo/init/pre.js` continues to install `globalThis.atob` /
  `globalThis.btoa` before `lockdown()` without poisoning it.
- `decodeBase64` re-runs the polyfill on any native error to surface the
  polyfill's diagnostic.
  Native error message text is implementation-defined and does not embed the
  caller-supplied `name` or the failing offset.

### Scaling Considerations

The native intrinsic is materially faster than the pure-JS polyfill on V8 and
orders of magnitude faster on XSnap.
Existing call sites pick up the speedup without any change.

### Documentation Considerations

Two changesets ship with this PR:

- `@endo/base64: minor` — exports are now frozen.
  Read-only consumers are unaffected; consumers that previously assigned to or
  extended `encodeBase64`, `decodeBase64`, `atob`, or `btoa` will see a
  `TypeError` under SES.
- `@endo/base64: patch` — native dispatch with no API change.
  `decodeBase64` error messages (including any caller-supplied `name` and the
  failing offset) are unchanged.

### Testing Considerations

- `forced-polyfill.test.js` exercises the polyfill directly (via the
  package-internal `./src/encode.js` / `./src/decode.js` paths) and
  cross-checks dispatched output against polyfill output, so CI continues to
  cover the polyfill on runtimes that ship the native intrinsic.
- Existing `@endo/base64` tests pass unchanged.
- `@endo/bundle-source` sanity tests pass under both
  `stackFiltering: 'concise'` and `stackFiltering: 'verbose'`.

### Compatibility Considerations

- Public API unchanged.
- Polyfill error-message text contract preserved on the native path through
  the polyfill-rerun-on-throw fallback.
- `@endo/base64` adds a runtime dependency on `@endo/harden`.
  The shim path (`@endo/base64/shim.js`) remains free of `@endo/harden` so it
  is still safe to load pre-lockdown.

### Upgrade Considerations

No production upgrade work is required for typical consumers.
Consumers that mutate `@endo/base64`'s exports (an unusual pattern) must stop
or clone first; the failure mode is a clear `TypeError` under SES, not a
silent change.
