### PR TITLE
feat(compartment-mapper): expose findUnknownCanonicalNames

### DIFF
--- a/.changeset/cozy-bushes-allow.md
+++ b/.changeset/cozy-bushes-allow.md
@@ -1,0 +1,5 @@
+---
+'@endo/compartment-mapper': minor
+---
+
+Expose `findUnknownCanonicalNames()` from new export `@endo/compartment-mapper/policy.js`.

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -46,6 +46,7 @@
     "./script-lite.js": "./script-lite.js",
     "./node-powers.js": "./node-powers.js",
     "./node-modules.js": "./node-modules.js",
+    "./policy.js": "./policy.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/compartment-mapper/policy.js
+++ b/packages/compartment-mapper/policy.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/export -- just types
+export * from './src/types-external.js';
+
+export { findUnknownCanonicalNames } from './src/policy.js';

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -23,7 +23,11 @@ import {
   ENTRY_COMPARTMENT,
   generateCanonicalName,
 } from './policy-format.js';
-import { dependencyAllowedByPolicy, makePackagePolicy } from './policy.js';
+import {
+  dependencyAllowedByPolicy,
+  makePackagePolicy,
+  findUnknownCanonicalNames,
+} from './policy.js';
 import { unpackReadPowers } from './powers.js';
 import { search, searchDescriptor } from './search.js';
 import { GenericGraph, makeShortestPath } from './generic-graph.js';
@@ -1269,73 +1273,6 @@ const finalizeGraph = (
 };
 
 /**
- * Returns an array of "issue" objects if any resources referenced in `policy`
- * are unknown.
- *
- * @param {Set<CanonicalName>} canonicalNames Set of all known canonical names
- * @param {SomePolicy} policy Policy to validate
- * @returns {Array<{canonicalName: CanonicalName, message: string, path:
- * string[], suggestion?: CanonicalName}>} Array of issue objects, or `undefined` if no issues were
- * found
- */
-const validatePolicyResources = (canonicalNames, policy) => {
-  /**
-   * Finds a suggestion for `badName` if it is a suffix of any
-   * canonical name in `canonicalNames`.
-   *
-   * @param {string} badName Unknown canonical name
-   * @returns {CanonicalName | undefined}
-   */
-  const findSuggestion = badName => {
-    for (const canonicalName of canonicalNames) {
-      if (canonicalName.endsWith(`>${badName}`)) {
-        return canonicalName;
-      }
-    }
-    return undefined;
-  };
-
-  /** @type {Array<{canonicalName: CanonicalName, message: string, path: string[], suggestion?: CanonicalName}>} */
-  const issues = [];
-  for (const [resourceName, resourcePolicy] of entries(
-    policy.resources ?? {},
-  )) {
-    if (!canonicalNames.has(resourceName)) {
-      const issueMessage = `Resource ${q(resourceName)} was not found`;
-      const suggestion = findSuggestion(resourceName);
-      const issue = {
-        canonicalName: resourceName,
-        message: issueMessage,
-        path: ['resources', resourceName],
-      };
-      if (suggestion) {
-        issue.suggestion = suggestion;
-      }
-      issues.push(issue);
-    }
-    if (typeof resourcePolicy?.packages === 'object') {
-      for (const packageName of keys(resourcePolicy.packages)) {
-        if (!canonicalNames.has(packageName)) {
-          const issueMessage = `Resource ${q(packageName)} from resource ${q(resourceName)} was not found`;
-          const suggestion = findSuggestion(packageName);
-          const issue = {
-            canonicalName: packageName,
-            message: issueMessage,
-            path: ['resources', resourceName, 'packages', packageName],
-          };
-          if (suggestion) {
-            issue.suggestion = suggestion;
-          }
-          issues.push(issue);
-        }
-      }
-    }
-  }
-
-  return issues;
-};
-
-/**
  * @param {ReadFn | ReadPowers<FileUrlString> | MaybeReadPowers<FileUrlString>} readPowers
  * @param {FileUrlString} entryPackageLocation
  * @param {Set<string>} conditionsOption
@@ -1472,8 +1409,8 @@ export const compartmentMapForNodeModules_ = async (
   // of known canonical names and fire the `unknownCanonicalName` hook for each
   // unknown resource, if found
   if (policy) {
-    const canonicalNames = new Set(canonicalNameMap.keys());
-    const issues = validatePolicyResources(canonicalNames, policy) ?? [];
+    const knownCanonicalNames = new Set(canonicalNameMap.keys());
+    const issues = findUnknownCanonicalNames(knownCanonicalNames, policy);
     // Call default handler first if policy exists
     for (const { message, canonicalName, path, suggestion } of issues) {
       const hookInput = {

--- a/packages/compartment-mapper/src/policy.js
+++ b/packages/compartment-mapper/src/policy.js
@@ -638,3 +638,105 @@ export const attenuateModuleHook = async (
     moduleDescriptor: attenuatable,
   });
 };
+
+/**
+ * Returns an array of "issue" objects for each unknown canonical name referenced
+ * in `policy`.
+ *
+ * @param {Set<CanonicalName>} canonicalNames Set of all known canonical names
+ * @param {SomePolicy} policy Policy to validate
+ * @returns {Array<{canonicalName: CanonicalName, message: string, path:
+ * string[], suggestion?: CanonicalName}>} Array of "issue" objects
+ */
+export const findUnknownCanonicalNames = (canonicalNames, policy) => {
+  /**
+   * Finds a suggestion for `badName` if it is a suffix of any canonical name in
+   * `canonicalNames`.
+   *
+   * @param {string} badName Unknown canonical name
+   * @returns {CanonicalName | undefined} Canonical name with a suffix of
+   * `>${badName}`, or `undefined` if none found
+   */
+  const findSuggestion = badName => {
+    for (const canonicalName of canonicalNames) {
+      if (canonicalName.endsWith(`>${badName}`)) {
+        return canonicalName;
+      }
+    }
+    return undefined;
+  };
+
+  /**
+   * @type {Array<{canonicalName: CanonicalName, message: string, path:
+   * string[], suggestion?: CanonicalName}>}
+   */
+  const issues = [];
+
+  // check any packages referenced by entry compartment
+  if (typeof policy.entry?.packages === 'object' && policy.entry.packages) {
+    for (const entryPackageName of keys(policy.entry?.packages ?? {})) {
+      if (!canonicalNames.has(entryPackageName)) {
+        const issueMessage = `Resource ${q(entryPackageName)} from entry policy was not found`;
+        const suggestion = findSuggestion(entryPackageName);
+        const issue = {
+          canonicalName: entryPackageName,
+          message: issueMessage,
+          path: ['entry', 'packages', entryPackageName],
+        };
+        if (suggestion) {
+          issue.suggestion = suggestion;
+        }
+        issues.push(issue);
+      }
+    }
+  }
+
+  // drill into resources, checking the resource name (key) first
+  for (const [resourceName, resourcePolicy] of entries(
+    policy.resources ?? {},
+  )) {
+    if (
+      resourceName !== ENTRY_COMPARTMENT &&
+      !canonicalNames.has(resourceName)
+    ) {
+      const issueMessage = `Resource ${q(resourceName)} was not found`;
+      const suggestion = findSuggestion(resourceName);
+      const issue = {
+        canonicalName: resourceName,
+        message: issueMessage,
+        path: ['resources', resourceName],
+      };
+      if (suggestion) {
+        issue.suggestion = suggestion;
+      }
+      issues.push(issue);
+    }
+
+    // check any packages referenced from within a resource
+    if (
+      resourcePolicy?.packages &&
+      typeof resourcePolicy.packages === 'object'
+    ) {
+      for (const packageName of keys(resourcePolicy.packages)) {
+        if (
+          resourceName !== ENTRY_COMPARTMENT &&
+          !canonicalNames.has(packageName)
+        ) {
+          const issueMessage = `Resource ${q(packageName)} from resource ${q(resourceName)} was not found`;
+          const suggestion = findSuggestion(packageName);
+          const issue = {
+            canonicalName: packageName,
+            message: issueMessage,
+            path: ['resources', resourceName, 'packages', packageName],
+          };
+          if (suggestion) {
+            issue.suggestion = suggestion;
+          }
+          issues.push(issue);
+        }
+      }
+    }
+  }
+
+  return issues;
+};

--- a/packages/compartment-mapper/test/policy.test.js
+++ b/packages/compartment-mapper/test/policy.test.js
@@ -8,7 +8,7 @@ import {
   ATTENUATORS_COMPARTMENT,
   ENTRY_COMPARTMENT,
 } from '../src/policy-format.js';
-import { makePackagePolicy } from '../src/policy.js';
+import { makePackagePolicy, findUnknownCanonicalNames } from '../src/policy.js';
 
 function combineAssertions(...assertionFunctions) {
   return async (...args) => {
@@ -729,4 +729,163 @@ test('makePackagePolicy() - empty resources object returns empty package policy'
   const result = makePackagePolicy('alice', { policy: testPolicy });
 
   t.deepEqual(result, {});
+});
+
+test('findUnknownCanonicalNames() - returns empty array when all names are known', t => {
+  const known = new Set(['alice', 'alice>carol']);
+  const testPolicy = {
+    entry: {},
+    resources: {
+      alice: {
+        packages: { 'alice>carol': true },
+      },
+    },
+  };
+
+  const result = findUnknownCanonicalNames(known, testPolicy);
+
+  t.deepEqual(result, []);
+});
+
+test('findUnknownCanonicalNames() - detects unknown top-level resource names', t => {
+  const known = new Set(['alice']);
+  const testPolicy = {
+    entry: {},
+    resources: {
+      alice: {},
+      ghost: {},
+    },
+  };
+
+  const result = findUnknownCanonicalNames(known, testPolicy);
+
+  t.deepEqual(result, [
+    {
+      canonicalName: 'ghost',
+      message: 'Resource "ghost" was not found',
+      path: ['resources', 'ghost'],
+    },
+  ]);
+});
+
+test('findUnknownCanonicalNames() - detects unknown names nested in packages', t => {
+  const known = new Set(['alice', 'bob']);
+  const testPolicy = {
+    entry: {},
+    resources: {
+      alice: {
+        packages: {
+          bob: true,
+          'alice>nobody': true,
+        },
+      },
+    },
+  };
+
+  const result = findUnknownCanonicalNames(known, testPolicy);
+
+  t.deepEqual(result, [
+    {
+      canonicalName: 'alice>nobody',
+      message: 'Resource "alice>nobody" from resource "alice" was not found',
+      path: ['resources', 'alice', 'packages', 'alice>nobody'],
+    },
+  ]);
+});
+
+test('findUnknownCanonicalNames() - includes a suggestion when an unknown name is a suffix of a known one', t => {
+  const known = new Set(['alice>carol']);
+  const testPolicy = {
+    entry: {},
+    resources: {
+      carol: {},
+    },
+  };
+
+  const result = findUnknownCanonicalNames(known, testPolicy);
+
+  t.deepEqual(result, [
+    {
+      canonicalName: 'carol',
+      message: 'Resource "carol" was not found',
+      path: ['resources', 'carol'],
+      suggestion: 'alice>carol',
+    },
+  ]);
+});
+
+test('findUnknownCanonicalNames() - returns a separate issue for each occurrence, without deduplicating', t => {
+  const known = new Set(['alice']);
+  const testPolicy = {
+    entry: {},
+    resources: {
+      alice: {
+        packages: { ghost: true },
+      },
+      ghost: {
+        packages: { ghost: true },
+      },
+    },
+  };
+
+  const result = findUnknownCanonicalNames(known, testPolicy);
+
+  t.deepEqual(result, [
+    {
+      canonicalName: 'ghost',
+      message: 'Resource "ghost" from resource "alice" was not found',
+      path: ['resources', 'alice', 'packages', 'ghost'],
+    },
+    {
+      canonicalName: 'ghost',
+      message: 'Resource "ghost" was not found',
+      path: ['resources', 'ghost'],
+    },
+    {
+      canonicalName: 'ghost',
+      message: 'Resource "ghost" from resource "ghost" was not found',
+      path: ['resources', 'ghost', 'packages', 'ghost'],
+    },
+  ]);
+});
+
+test('findUnknownCanonicalNames() - returns empty array for policy with no resources', t => {
+  const known = new Set(['alice']);
+  const testPolicy = { entry: {} };
+
+  const result = findUnknownCanonicalNames(known, testPolicy);
+
+  t.deepEqual(result, []);
+});
+
+test('findUnknownCanonicalNames() - detects unknown names referenced from entry policy packages', t => {
+  const known = new Set(['alice']);
+  const testPolicy = {
+    entry: {
+      packages: { alice: true, ghost: true },
+    },
+    resources: {},
+  };
+
+  const result = findUnknownCanonicalNames(known, testPolicy);
+
+  t.deepEqual(result, [
+    {
+      canonicalName: 'ghost',
+      message: 'Resource "ghost" from entry policy was not found',
+      path: ['entry', 'packages', 'ghost'],
+    },
+  ]);
+});
+
+test('findUnknownCanonicalNames() - returns empty array when entry has no packages', t => {
+  const known = new Set(['alice']);
+  const testPolicy = {
+    entry: {},
+    resources: {},
+  };
+
+  const result = findUnknownCanonicalNames(known, testPolicy);
+
+  t.deepEqual(result, []);
 });


### PR DESCRIPTION
Expose `findUnknownCanonicalNames()` from new export `@endo/compartment-mapper/policy.js`.

Should be used _after_ `captureFromMap` when called without policy, since unknown canonical names are not emitted by the `UnknownCanonicalNameHook` unless a policy is present. Practically, `@lavamoat/node` can provide it with canonical names from its own generated policy or policy overrides.

* * * 

**UPDATE** Jul 16 2026

Alternatively, we could thread an option through so that `mapNodeModules()` can receive an arbitrary list of canonical names which could potentially be reported by `UnknownCanonicalNameHook`.  

> [!NOTE]
> In the case where `@lavamoat/node` already has a policy (execution), we do not need `findUnknownCanonicalNames()` because `UnknownCanonicalNameHook` reports them as expected.  At the time of calling `mapNodeModules()` during our policy generation, we may have policy overrides (and implicitly a list of canonical names).

Another idea would be to just keep `findUnknownCanonicalNames()` out of this package entirely (since it doesn't absolutely need to live here!) and move the function into `@lavamoat/node`, since it's _yet another random function_ exported from `@endo/compartment-mapper`.