### PR TITLE
feat(xorshift): Factor out prng used for testing

### DIFF
--- a/.changeset/byte-array-hex-codecs.md
+++ b/.changeset/byte-array-hex-codecs.md
@@ -1,0 +1,23 @@
+---
+'@endo/pass-style': minor
+'@endo/marshal': minor
+---
+
+Immutable `ArrayBuffer` (passStyle `'byteArray'`) is now serializable through
+the capdata, smallcaps, and encode-passable codecs.
+
+- `@endo/pass-style` gains `byteArrayToHex`, `hexToByteArray`,
+  `byteArrayToUint8Array`, and `uint8ArrayToByteArray` helpers, all routed
+  through `@endo/hex`.
+- `@endo/marshal`:
+  - **capdata**: byteArray encodes as `{"@qclass":"byteArray","data":"<hex>"}`.
+  - **smallcaps**: byteArray encodes as `"*<hex>"`.  The `*` prefix is now
+    reserved.
+  - **encode-passable**: byteArray encodes as
+    `a<encodeBigInt(byteLength)>:<hex>`.  The Elias-delta length prefix gives
+    shortlex ordering (matching `compareRank`) with no arbitrary size cap, and
+    every character in the body is safe inside both `legacyOrdered` and
+    `compactOrdered` array framings.
+  - **marshal-justin**: renders byteArray as `hexToByteArray("<hex>")`.
+
+Syrup already supported this value; no change required there.

--- a/packages/marshal/docs/smallcaps-cheatsheet.md
+++ b/packages/marshal/docs/smallcaps-cheatsheet.md
@@ -10,7 +10,7 @@ An example-based summary of the Smallcaps encoding of the OCapN [Abstract Syntax
 | bigint           | Integer       | `7n`<br>`-7n`         | `"+7"`<br>`"-7"`     |
 | number           | Float64       | `Infinity`<br>`-Infinity`<br>`NaN`<br>`-0`<br>`7.1` | `"#Infinity"`<br>`"#-Infinity"`<br>`"#NaN"`<br>`"#-0"` // unimplemented<br>`7.1` |
 | string           | String        | `'#foo'`<br>`'foo'`   | `"!#foo"` // special strings<br>`"foo"` // other strings |
-| byteArray        | ByteArray     | `buf.toImmutable()`   | // undecided & unimplemented |
+| byteArray        | ByteArray     | `buf.toImmutable()`   | `"*deadbeef"` // after `*`, hex encoding |
 | passable symbols | Symbol        | `passableSymbolForName('foo')` | `"%foo"` // in transition |
 | copyArray        | List          | `[a,b]`               | `[<a>,<b>]`          |
 | copyRecord       | Struct        | `{foo:a,'#foo':b}`    | `{"!#foo":<b>,"foo":<a>}` // keys sorted  |
@@ -28,7 +28,6 @@ An example-based summary of the Smallcaps encoding of the OCapN [Abstract Syntax
 * Structs [can only have string-named properties](https://github.com/endojs/endo/blob/master/packages/pass-style/doc/copyRecord-guarantees.md).
 * Errors can also carry an optional `errorId` string property.
 * We expect to expand the optional error properties over time.
-* The ByteArray encoding is not yet designed or implemented.
 
 ## Readability Invariants
 

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -10,6 +10,8 @@ import {
   isErrorLike,
   nameForPassableSymbol,
   passableSymbolForName,
+  byteArrayToHex,
+  hexToByteArray,
 } from '@endo/pass-style';
 
 /**
@@ -473,14 +475,47 @@ const decodeLegacyArray = (encoded, decodePassable, skip = 0) => {
 };
 
 /**
+ * Encodes a ByteArray as `a<length><:><hex>`, where `<length>` is the
+ * `encodeBigInt` of `byteLength` (a non-negative bigint, which already
+ * encodes in shortlex-numerical order), followed by the explicit
+ * separator `:` and the lowercase hex of the bytes.
+ *
+ * Shortlex is inherited in two stages:
+ *  1. `encodeBigInt` on the length preserves numerical order, so shorter
+ *     byteArrays sort before longer ones.
+ *  2. At equal length, the length encodings are identical and ordering
+ *     falls through to the byte-lex-preserving hex body.
+ *
+ * Every character used here — `a`, `p`/`n`/`~`/`#`, decimal digits, `:`,
+ * and hex digits `[0-9a-f]` — is outside the escape-reserved sets of
+ * both the `legacyOrdered` and `compactOrdered` array framings, so no
+ * escaping is needed.
+ *
  * @param {ByteArray} byteArray
  * @param {(byteArray: ByteArray) => string} _encodePassable
  * @returns {string}
  */
 const encodeByteArray = (byteArray, _encodePassable) => {
-  // TODO implement
-  Fail`encodePassable(byteArray) not yet implemented: ${byteArray}`;
-  return ''; // Just for the type
+  const lenEnc = encodeBigInt(BigInt(byteArray.byteLength));
+  return `a${lenEnc}:${byteArrayToHex(byteArray)}`;
+};
+
+const rByteArrayPayload = /^(p[~]*[0-9]+:[0-9]+):([0-9a-f]*)$/;
+
+/**
+ * Inverse of {@link encodeByteArray}.
+ *
+ * @param {string} encoded The body after the leading `'a'` prefix char.
+ * @returns {import('@endo/pass-style').ByteArray}
+ */
+const decodeByteArray = encoded => {
+  const match = encoded.match(rByteArrayPayload);
+  match || Fail`Encoded byteArray expected: ${encoded}`;
+  const [, lenEnc, hex] = /** @type {RegExpMatchArray} */ (match);
+  const byteLength = Number(decodeBigInt(lenEnc));
+  hex.length === byteLength * 2 ||
+    Fail`byteArray length mismatch: header ${q(byteLength)} vs body ${q(hex.length / 2)}`;
+  return hexToByteArray(hex, 'encodePassable byteArray');
 };
 
 const encodeRecord = (record, encodeArray, encodePassable) => {
@@ -748,6 +783,9 @@ const makeInnerDecode = (decodeStringSuffix, decodeArray, options) => {
       }
       case ':': {
         return decodeTagged(encoded, decodeArray, innerDecode, skip);
+      }
+      case 'a': {
+        return decodeByteArray(getSuffix(encoded, skip + 1));
       }
       default: {
         throw Fail`invalid database key: ${getSuffix(encoded, skip)}`;

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -14,6 +14,8 @@ import {
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
+  byteArrayToHex,
+  hexToByteArray,
 } from '@endo/pass-style';
 import { X, Fail, q } from '@endo/errors';
 
@@ -194,8 +196,10 @@ export const makeEncodeToCapData = (encodeOptions = {}) => {
         return passable.map(encodeToCapDataRecur);
       }
       case 'byteArray': {
-        // TODO implement
-        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+        return {
+          [QCLASS]: 'byteArray',
+          data: byteArrayToHex(passable),
+        };
       }
       case 'tagged': {
         return {
@@ -366,6 +370,12 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
         case 'tagged': {
           const { tag, payload } = jsonEncoded;
           return makeTagged(tag, decodeFromCapData(payload));
+        }
+        case 'byteArray': {
+          const { data } = jsonEncoded;
+          typeof data === 'string' ||
+            Fail`invalid byteArray data typeof ${q(typeof data)}`;
+          return hexToByteArray(data, 'capData byteArray');
         }
         case 'slot': {
           // See note above about how the current encoding cannot reliably

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -17,6 +17,8 @@ import {
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
+  byteArrayToHex,
+  hexToByteArray,
 } from '@endo/pass-style';
 
 /** @import {Passable, RemotableObject} from '@endo/pass-style' */
@@ -50,6 +52,7 @@ const DASH = '-'.charCodeAt(0);
  * Of these, smallcaps currently uses the following:
  *
  *  * `!` - escaped string
+ *  * `*` - byteArray (hardened Immutable ArrayBuffer), hex-encoded
  *  * `+` - non-negative bigint
  *  * `-` - negative bigint
  *  * `#` - manifest constant
@@ -57,7 +60,7 @@ const DASH = '-'.charCodeAt(0);
  *  * `$` - remotable
  *  * `&` - promise
  *
- * All other special characters (`"'()*,`) are reserved for future use.
+ * All other special characters (`"'(),`) are reserved for future use.
  *
  * The manifest constants that smallcaps currently uses for values:
  *  * `#undefined`
@@ -230,8 +233,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
         return passable.map(encodeToSmallcapsRecur);
       }
       case 'byteArray': {
-        // TODO implement
-        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+        return `*${byteArrayToHex(passable)}`;
       }
       case 'tagged': {
         return {
@@ -406,6 +408,9 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
               Fail`internal: decodePromiseFromSmallcaps option must return a promise: ${result}`;
             }
             return result;
+          }
+          case '*': {
+            return hexToByteArray(encoding.slice(1), 'smallcaps byteArray');
           }
           default: {
             throw Fail`Special char ${q(

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -177,6 +177,11 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
           assert.typeof(sym, 'symbol');
           return;
         }
+        case 'byteArray': {
+          const { data } = rawTree;
+          assert.typeof(data, 'string');
+          return;
+        }
         case 'tagged': {
           const { tag, payload } = rawTree;
           assert.typeof(tag, 'string');
@@ -338,6 +343,11 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
             return out.next(`Symbol.${suffix}`);
           }
           return out.next(`passableSymbolForName(${quote(registeredName)})`);
+        }
+        case 'byteArray': {
+          const { data } = rawTree;
+          assert.typeof(data, 'string');
+          return out.next(`hexToByteArray(${quote(data)})`);
         }
         case 'tagged': {
           const { tag, payload } = rawTree;

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -47,7 +47,8 @@ export {};
  *           } |
  *           EncodingClass<'tagged'> & { tag: string,
  *                                       payload: Encoding
- *           }
+ *           } |
+ *           EncodingClass<'byteArray'> & { data: string }
  * } EncodingUnion
  *
  * Note that the '@@asyncIterator' encoding is deprecated. Use 'symbol' instead.

--- a/packages/marshal/test/byteArray.test.js
+++ b/packages/marshal/test/byteArray.test.js
@@ -1,0 +1,179 @@
+// @ts-nocheck
+import test from '@endo/ses-ava/test.js';
+
+import harden from '@endo/harden';
+import {
+  byteArrayToUint8Array,
+  passStyleOf,
+  uint8ArrayToByteArray,
+} from '@endo/pass-style';
+import { makeMarshal } from '../src/marshal.js';
+import {
+  makeEncodePassable,
+  makeDecodePassable,
+} from '../src/encodePassable.js';
+import { compareRank } from '../src/rankOrder.js';
+
+const mkByteArray = bytes => uint8ArrayToByteArray(new Uint8Array(bytes));
+
+const fixtures = harden([
+  { name: 'empty', bytes: [] },
+  { name: 'single-zero', bytes: [0x00] },
+  { name: 'single-ff', bytes: [0xff] },
+  { name: 'two-zeroes', bytes: [0x00, 0x00] },
+  { name: 'deadbeef', bytes: [0xde, 0xad, 0xbe, 0xef] },
+  { name: 'long', bytes: Array.from({ length: 256 }, (_, i) => i) },
+]);
+
+test('smallcaps round-trips byteArray', t => {
+  const { serialize, unserialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'smallcaps',
+    errorTagging: 'off',
+  });
+  for (const { name, bytes } of fixtures) {
+    const ba = mkByteArray(bytes);
+    const { body } = serialize(ba);
+    const decoded = unserialize({ body, slots: [] });
+    t.is(passStyleOf(decoded), 'byteArray', name);
+    t.deepEqual(
+      [...byteArrayToUint8Array(decoded)],
+      bytes,
+      `smallcaps ${name}`,
+    );
+  }
+});
+
+test('smallcaps byteArray uses "*" prefix with hex body', t => {
+  const { serialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'smallcaps',
+    errorTagging: 'off',
+  });
+  const { body } = serialize(mkByteArray([0xde, 0xad, 0xbe, 0xef]));
+  // smallcaps body has a leading `#` sentinel before the JSON text.
+  t.true(body.includes('"*deadbeef"'), `got ${body}`);
+});
+
+test('capdata round-trips byteArray', t => {
+  const { serialize, unserialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'capdata',
+    errorTagging: 'off',
+  });
+  for (const { name, bytes } of fixtures) {
+    const ba = mkByteArray(bytes);
+    const { body } = serialize(ba);
+    const decoded = unserialize({ body, slots: [] });
+    t.is(passStyleOf(decoded), 'byteArray', name);
+    t.deepEqual([...byteArrayToUint8Array(decoded)], bytes, `capdata ${name}`);
+  }
+});
+
+test('capdata byteArray uses @qclass "byteArray" with hex data', t => {
+  const { serialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'capdata',
+    errorTagging: 'off',
+  });
+  const { body } = serialize(mkByteArray([0xde, 0xad, 0xbe, 0xef]));
+  t.true(
+    body.includes('"@qclass":"byteArray"') && body.includes('"deadbeef"'),
+    `got ${body}`,
+  );
+});
+
+test('byteArray nested in copyArray, copyRecord, tagged', t => {
+  const { serialize, unserialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'smallcaps',
+    errorTagging: 'off',
+  });
+  const ba = mkByteArray([1, 2, 3]);
+  const structure = harden({
+    arr: [ba, ba],
+    rec: { k: ba },
+  });
+  const { body } = serialize(structure);
+  const decoded = unserialize({ body, slots: [] });
+  t.is(passStyleOf(decoded.arr[0]), 'byteArray');
+  t.is(passStyleOf(decoded.rec.k), 'byteArray');
+  t.deepEqual([...byteArrayToUint8Array(decoded.arr[1])], [1, 2, 3]);
+});
+
+test('encodePassable round-trips byteArray (legacyOrdered)', t => {
+  const encode = makeEncodePassable({ format: 'legacyOrdered' });
+  const decode = makeDecodePassable({ format: 'legacyOrdered' });
+  for (const { name, bytes } of fixtures) {
+    const ba = mkByteArray(bytes);
+    const enc = encode(ba);
+    t.is(enc.charAt(0), 'a', `legacy ${name} starts with 'a'`);
+    const back = decode(enc);
+    t.deepEqual([...byteArrayToUint8Array(back)], bytes, `legacy ${name}`);
+  }
+});
+
+test('encodePassable round-trips byteArray (compactOrdered)', t => {
+  const encode = makeEncodePassable({ format: 'compactOrdered' });
+  const decode = makeDecodePassable({ format: 'compactOrdered' });
+  for (const { name, bytes } of fixtures) {
+    const ba = mkByteArray(bytes);
+    const enc = encode(ba);
+    const back = decode(enc);
+    t.deepEqual([...byteArrayToUint8Array(back)], bytes, `compact ${name}`);
+  }
+});
+
+test('encodePassable byteArray preserves shortlex order', t => {
+  const encode = makeEncodePassable({ format: 'legacyOrdered' });
+  // Listed in the expected shortlex order.
+  const orderedBytes = [
+    [],
+    [0x00],
+    [0x01],
+    [0xff],
+    [0x00, 0x00],
+    [0x00, 0x01],
+    [0x01, 0x00],
+    [0xff, 0xfe],
+    [0xff, 0xff],
+    [0x00, 0x00, 0x00],
+  ];
+  const encodings = orderedBytes.map(bs => encode(mkByteArray(bs)));
+  const sorted = [...encodings].sort();
+  t.deepEqual(sorted, encodings, `sorted=${sorted.join(',')}`);
+});
+
+test('encodePassable byteArray agrees with compareRank', t => {
+  const encode = makeEncodePassable({ format: 'legacyOrdered' });
+  const values = harden([
+    mkByteArray([]),
+    mkByteArray([0x00]),
+    mkByteArray([0xff]),
+    mkByteArray([0x00, 0x00]),
+    mkByteArray([0x00, 0x01]),
+    mkByteArray([0xff, 0xff]),
+    mkByteArray([0x00, 0x00, 0x00]),
+  ]);
+  for (let i = 0; i < values.length; i += 1) {
+    for (let j = 0; j < values.length; j += 1) {
+      const rank = compareRank(values[i], values[j]);
+      const encA = encode(values[i]);
+      const encB = encode(values[j]);
+      // eslint-disable-next-line no-nested-ternary
+      const lex = encA < encB ? -1 : encA > encB ? 1 : 0;
+      t.is(
+        Math.sign(rank),
+        lex,
+        `pair i=${i} j=${j}: rank ${rank} vs lex ${lex}`,
+      );
+    }
+  }
+});
+
+test('encodePassable byteArray cover sits between promise and boolean', t => {
+  const encode = makeEncodePassable({
+    format: 'legacyOrdered',
+    encodePromise: (_p, _r) => '?0',
+  });
+  const promiseEnc = '?0';
+  const boolTrue = encode(true);
+  const byteEnc = encode(mkByteArray([0xff]));
+  t.true(promiseEnc < byteEnc, `${promiseEnc} < ${byteEnc}`);
+  t.true(byteEnc < boolTrue, `${byteEnc} < ${boolTrue}`);
+});

--- a/packages/marshal/test/encodePassable.test.js
+++ b/packages/marshal/test/encodePassable.test.js
@@ -16,7 +16,7 @@ import {
 import { compareRank, makeFullOrderComparatorKit } from '../src/rankOrder.js';
 import { unsortedSample } from '../tools/marshal-test-data.js';
 
-const { arbPassable } = makeArbitraries(fc, ['byteArray']);
+const { arbPassable } = makeArbitraries(fc);
 
 const statelessEncodePassableLegacy = makeEncodePassable();
 

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -27,6 +27,13 @@ export {
 } from './src/string.js';
 
 export {
+  byteArrayToUint8Array,
+  uint8ArrayToByteArray,
+  byteArrayToHex,
+  hexToByteArray,
+} from './src/byteArray.js';
+
+export {
   passStyleOf,
   isPassable,
   assertPassable,

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -40,6 +40,7 @@
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
     "@endo/harden": "workspace:^",
+    "@endo/hex": "workspace:^",
     "@endo/promise-kit": "workspace:^"
   },
   "devDependencies": {

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -1,7 +1,9 @@
 import harden from '@endo/harden';
 import { X, Fail } from '@endo/errors';
+import { encodeHex, decodeHex } from '@endo/hex';
 
 /**
+ * @import {ByteArray} from './types.js';
  * @import {PassStyleHelper} from './internal-types.js';
  */
 
@@ -66,3 +68,60 @@ export const ByteArrayHelper = harden({
       );
   },
 });
+harden(ByteArrayHelper);
+
+/**
+ * Returns a Uint8Array reflecting the current contents of `byteArray`.
+ *
+ * On platforms with native immutable ArrayBuffer support, the byteArray
+ * inherits directly from `ArrayBuffer.prototype` and the returned
+ * `Uint8Array` is a zero-copy view. On platforms using the
+ * `@endo/immutable-arraybuffer` shim, the shim-emulated buffer does not
+ * admit a `Uint8Array` view, so this slices out a fresh mutable copy.
+ *
+ * @param {ArrayBuffer} byteArray A `passStyleOf === 'byteArray'` value
+ * (hardened Immutable ArrayBuffer), or a plain mutable ArrayBuffer
+ * (in which case the returned Uint8Array is a read-write view).
+ * @returns {Uint8Array}
+ */
+export const byteArrayToUint8Array = byteArray => {
+  if (getPrototypeOf(byteArray) === ArrayBuffer.prototype) {
+    return new Uint8Array(byteArray);
+  }
+  const genuineArrayBuffer = byteArray.slice();
+  return new Uint8Array(genuineArrayBuffer);
+};
+harden(byteArrayToUint8Array);
+
+/**
+ * Converts a `Uint8Array` to a `ByteArray`, i.e., a hardened Immutable
+ * ArrayBuffer whose `passStyleOf` is `'byteArray'`.
+ *
+ * @param {Uint8Array} uint8Array
+ * @returns {ArrayBuffer}
+ */
+export const uint8ArrayToByteArray = uint8Array =>
+  // @ts-expect-error shim-augmented ArrayBuffer type
+  harden(uint8Array.buffer.sliceToImmutable(0, uint8Array.length));
+harden(uint8ArrayToByteArray);
+
+/**
+ * Hex-encodes the contents of a ByteArray.
+ *
+ * @param {ByteArray} byteArray
+ * @returns {string}
+ */
+export const byteArrayToHex = byteArray =>
+  encodeHex(byteArrayToUint8Array(byteArray));
+harden(byteArrayToHex);
+
+/**
+ * Decodes a hex string into a ByteArray (hardened Immutable ArrayBuffer).
+ *
+ * @param {string} hex
+ * @param {string} [name]
+ * @returns {ByteArray}
+ */
+export const hexToByteArray = (hex, name) =>
+  uint8ArrayToByteArray(decodeHex(hex, name));
+harden(hexToByteArray);

--- a/packages/pass-style/test/byte-array.test.js
+++ b/packages/pass-style/test/byte-array.test.js
@@ -1,0 +1,49 @@
+import test from '@endo/ses-ava/test.js';
+
+import harden from '@endo/harden';
+import { passStyleOf } from '../src/passStyleOf.js';
+import {
+  byteArrayToUint8Array,
+  uint8ArrayToByteArray,
+  byteArrayToHex,
+  hexToByteArray,
+} from '../src/byteArray.js';
+
+test('passStyleOf recognizes immutable ArrayBuffer as byteArray', t => {
+  const buf = new ArrayBuffer(4);
+  const view = new Uint8Array(buf);
+  view[0] = 0xde;
+  view[1] = 0xad;
+  view[2] = 0xbe;
+  view[3] = 0xef;
+  const immutable = harden(buf.sliceToImmutable());
+  t.is(/** @type {string} */ (passStyleOf(immutable)), 'byteArray');
+});
+
+test('passStyleOf byteArray with empty buffer', t => {
+  const buf = new ArrayBuffer(0);
+  const immutable = harden(buf.sliceToImmutable());
+  t.is(/** @type {string} */ (passStyleOf(immutable)), 'byteArray');
+});
+
+test('byteArrayToHex / hexToByteArray round-trip', t => {
+  const source = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+  const byteArray = uint8ArrayToByteArray(source);
+  t.is(/** @type {string} */ (passStyleOf(byteArray)), 'byteArray');
+  const hex = byteArrayToHex(byteArray);
+  t.is(hex, 'deadbeef');
+  const decoded = hexToByteArray(hex);
+  t.is(/** @type {string} */ (passStyleOf(decoded)), 'byteArray');
+  t.deepEqual([...byteArrayToUint8Array(decoded)], [...source]);
+});
+
+test('empty byteArray round-trip', t => {
+  const byteArray = uint8ArrayToByteArray(new Uint8Array(0));
+  t.is(byteArrayToHex(byteArray), '');
+  const decoded = hexToByteArray('');
+  t.is(byteArrayToUint8Array(decoded).length, 0);
+});
+
+test('hexToByteArray rejects odd-length input', t => {
+  t.throws(() => hexToByteArray('a'), { message: /hex/i });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,6 +1035,7 @@ __metadata:
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
     "@endo/harden": "workspace:^"
+    "@endo/hex": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"


### PR DESCRIPTION
## Description

Adds a new `@endo/xorshift` package that hosts the xorshift128+ PRNG previously duplicated under `packages/ocapn/test/_xorshift.js` and `packages/hex/test/_xorshift.js`, then rewires both consumers to import from it and deletes the duplicates.

`makeXorShift(seed)` returns `{ random, int }`. `random` is a plain function, and `int(lo, hi)` is a sibling method on the returned object.

### Security Considerations

None for production. `@endo/xorshift` is documented as **not** cryptographically secure and is only consumed by test/bench files (`devDependencies`). The package itself runs `harden` on both the factory and the returned generator to prevent prototype tampering when imported after lockdown.

### Scaling Considerations

Test-only code; no production hot-path impact. The rejection-sampling loop in `int(lo, hi)` runs an expected `≤ 2` draws per call for any `range ≤ 2^53`, so worst-case fuzz/bench overhead is unchanged from the helpers it replaces.

### Documentation Considerations

- New `packages/xorshift/README.md` documents the seed format, returned shape, and the not-cryptographically-secure caveat.
- A changeset bumps `@endo/xorshift` (minor — first publish), `@endo/hex` (patch), and `@endo/ocapn` (patch).
- No downstream user migration: the deleted `_xorshift.js` files were internal test helpers, never exported.

### Testing Considerations

The new package ships its own ses-ava multi-config suite (lockdown / unsafe / shims-only) so portability across SES configurations is covered. The pre-existing hex benches and ocapn fuzz tests continue to pass against the new package, which exercises it under each consumer's actual usage pattern.

### Compatibility Considerations

No public-API breakage. The two deleted `_xorshift.js` helpers were never exported from their respective packages. The new `makeXorShift` shape (`{ random, int }`, `Uint8Array` seed) is internally consistent across both consumers; the seed format differs from the legacy 4-number array form used by the old helpers, but both call sites are migrated in the same PR.

### Upgrade Considerations

None — no production deployments are affected. Live systems do not import `@endo/xorshift`.