### PR TITLE
fix(ses): Further harden internal use of regular expressions

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -246,12 +246,19 @@ export const regexpReplace = /** @type {any} */ (
   uncurryThis(regexpPrototype[replaceSymbol])
 );
 export const matchAllRegExp = uncurryThis(regexpPrototype[matchAllSymbol]);
-const { _regexpConstructor, ...regexpDescriptors } =
-  getOwnPropertyDescriptors(regexpPrototype);
+const regexpDescriptors = getOwnPropertyDescriptors(regexpPrototype);
 arrayForEach(ownKeys(regexpDescriptors), key => {
   const desc = regexpDescriptors[/** @type {any} */ (key)];
   desc.configurable = false;
   if (desc.writable) desc.writable = false;
+});
+// Don't follow Symbol.species
+// https://tc39.es/ecma262/multipage/abstract-operations.html#sec-speciesconstructor
+defineProperty(regexpDescriptors, 'constructor', {
+  value: undefined,
+  enumerable: false,
+  configurable: false,
+  writable: false,
 });
 /**
  * Protect a RegExp instance against RegExp.prototype poisoning ("exec",

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -64,7 +64,6 @@ export const {
   create,
   defineProperties,
   entries,
-  freeze,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
   getOwnPropertyNames,
@@ -82,12 +81,24 @@ export const {
   fromEntries,
 } = Object;
 
+/**
+ * For use with any value except a regular expression (@see {@link sealRegexp}
+ * and {@link freezeRegexp}).
+ *
+ * @type { &
+ *   ((obj: RegExp) => void) &
+ *   typeof Object.freeze
+ * }
+ */
+export const freeze = /** @type {any} */ (Object.freeze);
+
 export const {
   species: speciesSymbol,
   toStringTag: toStringTagSymbol,
   iterator: iteratorSymbol,
   matchAll: matchAllSymbol,
   replace: replaceSymbol,
+  search: searchSymbol,
   unscopables: unscopablesSymbol,
   keyFor: symbolKeyFor,
   for: symbolFor,
@@ -236,6 +247,7 @@ export const iterateSet = uncurryThis(setPrototype[iteratorSymbol]);
  * vulnerable to RegExp.prototype poisoning.
  */
 export const regexpExec = uncurryThis(regexpPrototype.exec);
+
 /**
  * @type { &
  *   ((thisArg: RegExp, string: string, replaceValue: string) => string) &
@@ -245,7 +257,21 @@ export const regexpExec = uncurryThis(regexpPrototype.exec);
 export const regexpReplace = /** @type {any} */ (
   uncurryThis(regexpPrototype[replaceSymbol])
 );
+
+/**
+ * `regexpSearch` can be used with a frozen non-global non-sticky RegExp.
+ *
+ * @type {(thisArg: RegExp, string: string) => number}
+ */
+export const regexpSearch = uncurryThis(regexpPrototype[searchSymbol]);
+
+/**
+ * `matchAll` internally creates a new RegExp vulnerable to prototype poisoning,
+ * but this function is still needed to reach %RegExpStringIteratorPrototype%.
+ * @private
+ */
 export const matchAllRegExp = uncurryThis(regexpPrototype[matchAllSymbol]);
+
 const regexpDescriptors = getOwnPropertyDescriptors(regexpPrototype);
 arrayForEach(ownKeys(regexpDescriptors), key => {
   const desc = regexpDescriptors[/** @type {any} */ (key)];
@@ -260,13 +286,28 @@ defineProperty(regexpDescriptors, 'constructor', {
   configurable: false,
   writable: false,
 });
+
 /**
  * Protect a RegExp instance against RegExp.prototype poisoning ("exec",
- * "flags", Symbol.replace, etc.).
+ * "flags", Symbol.replace, etc.) while still maintaining mutability of its
+ * "lastIndex" property (which is necessary with flags "g" and/or "y" for some
+ * operations, most notably {@link regexpReplace}).
+ *
  * @type {<T extends RegExp>(regexp: T) => T}
  */
 export const sealRegexp = regexp =>
   seal(defineProperties(regexp, regexpDescriptors));
+
+/**
+ * Protect a RegExp instance against RegExp.prototype poisoning ("exec",
+ * "flags", Symbol.replace, etc.) and freeze its "lastIndex" property, rendering
+ * it fully inert but (absent flags "g" and/or "y") still usable by
+ * {@link regexpExec} and {@link regexpSearch}.
+ *
+ * @type {<T extends RegExp>(regexp: T) => T}
+ */
+export const freezeRegexp = regexp =>
+  freeze(/** @type {any} */ (defineProperties(regexp, regexpDescriptors)));
 //
 export const stringEndsWith = uncurryThis(stringPrototype.endsWith);
 export const stringIncludes = uncurryThis(stringPrototype.includes);

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -22,12 +22,12 @@ import {
   assign,
   freeze,
   defineProperty,
+  freezeRegexp,
   globalThis,
   is,
   isError,
-  regexpExec,
-  regexpReplace,
-  sealRegexp,
+  regexpSearch,
+  stringEndsWith,
   stringIndexOf,
   stringSlice,
   stringStartsWith,
@@ -74,13 +74,13 @@ const quote = (value, spaces = undefined) => {
 };
 freeze(quote);
 
-const canBeBare = freeze(/^[\w:-]( ?[\w:-])*$/);
+const canBeBare = freezeRegexp(/^[\w:-]( ?[\w:-])*$/);
 
 /**
  * @type {AssertionUtilities['bare']}
  */
 const bare = (text, spaces = undefined) => {
-  if (typeof text !== 'string' || !regexpExec(canBeBare, text)) {
+  if (typeof text !== 'string' || regexpSearch(canBeBare, text) === -1) {
     return quote(text, spaces);
   }
   const result = freeze({
@@ -201,9 +201,6 @@ const unredactedDetails = (template, ...args) => {
 freeze(unredactedDetails);
 export { unredactedDetails };
 
-const leadingSpacePattern = sealRegexp(/^ /);
-const trailingSpacePattern = sealRegexp(/ $/);
-
 /**
  * Get arguments suitable for a console logger function (e.g., `console.error`)
  * from `details` template literal contents, unquoting quoted substitution
@@ -221,20 +218,18 @@ const getLogArgs = ({ template, args }) => {
     }
     // Remove substitution-adjacent spaces from template fixed-string parts
     // (since console logging inserts its own argument-separating spaces).
-    const prevLiteralPart = regexpReplace(
-      trailingSpacePattern,
-      arrayPop(logArgs) || '',
-      '',
-    );
-    if (prevLiteralPart !== '') {
-      arrayPush(logArgs, prevLiteralPart);
+    const prevLiteralPart = arrayPop(logArgs) || '';
+    const trimmedPrev = stringEndsWith(prevLiteralPart, ' ')
+      ? stringSlice(prevLiteralPart, 0, -1)
+      : prevLiteralPart;
+    if (trimmedPrev !== '') {
+      arrayPush(logArgs, trimmedPrev);
     }
-    const nextLiteralPart = regexpReplace(
-      leadingSpacePattern,
-      template[i + 1],
-      '',
-    );
-    arrayPush(logArgs, arg, nextLiteralPart);
+    const nextLiteralPart = template[i + 1];
+    const trimmedNext = stringStartsWith(nextLiteralPart, ' ')
+      ? stringSlice(nextLiteralPart, 1)
+      : nextLiteralPart;
+    arrayPush(logArgs, arg, trimmedNext);
   }
   if (logArgs[logArgs.length - 1] === '') {
     arrayPop(logArgs);

--- a/packages/ses/src/error/tame-v8-error-constructor.js
+++ b/packages/ses/src/error/tame-v8-error-constructor.js
@@ -8,9 +8,11 @@ import {
   arraySlice,
   create,
   defineProperties,
+  freezeRegexp,
   fromEntries,
   reflectSet,
   regexpExec,
+  regexpSearch,
   weakmapGet,
   weakmapSet,
   weaksetAdd,
@@ -63,27 +65,33 @@ const safeV8SST = sst => arrayMap(sst, safeV8CallSiteFacet);
 // If it has `/node_modules/` anywhere in it, on Node it is likely
 // to be a dependent package of the current package, and so to
 // be an infrastructure frame to be dropped from concise stack traces.
-const FILENAME_NODE_DEPENDENTS_CENSOR = /\/node_modules\//;
+const FILENAME_NODE_DEPENDENTS_CENSOR = freezeRegexp(/\/node_modules\//);
 
 // If it begins with `internal/` or `node:internal` then it is likely
 // part of the node infrustructre itself, to be dropped from concise
 // stack traces.
-const FILENAME_NODE_INTERNALS_CENSOR = /^(?:node:)?internal\//;
+const FILENAME_NODE_INTERNALS_CENSOR = freezeRegexp(/^(?:node:)?internal\//);
 
 // Frames within SES `assert.js` should be dropped from concise stack traces, as
 // these are just steps towards creating the error object in question.
-const FILENAME_ASSERT_CENSOR = /\/packages\/ses\/src\/error\/assert\.js$/;
+const FILENAME_ASSERT_CENSOR = freezeRegexp(
+  /\/packages\/ses\/src\/error\/assert\.js$/,
+);
 
 // Frames within the `eventual-send` shim should be dropped so that concise
 // deep stacks omit the internals of the eventual-sending mechanism causing
 // asynchronous messages to be sent.
 // Note that the eventual-send package will move from agoric-sdk to
 // Endo, so this rule will be of general interest.
-const FILENAME_EVENTUAL_SEND_CENSOR = /\/packages\/eventual-send\/src\//;
+const FILENAME_EVENTUAL_SEND_CENSOR = freezeRegexp(
+  /\/packages\/eventual-send\/src\//,
+);
 
 // Frames within the `ses-ava` package should be dropped from concise stack
 // traces, as they just support exposing error details to AVA.
-const FILENAME_SES_AVA_CENSOR = /\/packages\/ses-ava\/src\/ses-ava-test\.js$/;
+const FILENAME_SES_AVA_CENSOR = freezeRegexp(
+  /\/packages\/ses-ava\/src\/ses-ava-test\.js$/,
+);
 
 // Any stack frame whose `fileName` matches any of these censor patterns
 // will be omitted from concise stacks.
@@ -106,7 +114,7 @@ export const filterFileName = fileName => {
     return false;
   }
   for (const filter of FILENAME_CENSORS) {
-    if (regexpExec(filter, fileName)) {
+    if (regexpSearch(filter, fileName) !== -1) {
       return false;
     }
   }
@@ -123,7 +131,9 @@ export const filterFileName = fileName => {
 //
 // See thread starting at
 // https://github.com/Agoric/agoric-sdk/issues/2326#issuecomment-773020389
-const CALLSITE_ELLIPSIS_PATTERN1 = /^((?:.*[( ])?)[:/\w_-]*\/\.\.\.\/(.+)$/;
+const CALLSITE_ELLIPSIS_PATTERN1 = freezeRegexp(
+  /^((?:.*[( ])?)[:/\w_-]*\/\.\.\.\/(.+)$/,
+);
 
 // The ad-hoc rule of the current pattern is that any likely-file-path or
 // likely url-path prefix consisting of `.../` should get dropped.
@@ -135,7 +145,7 @@ const CALLSITE_ELLIPSIS_PATTERN1 = /^((?:.*[( ])?)[:/\w_-]*\/\.\.\.\/(.+)$/;
 //
 // See thread starting at
 // https://github.com/Agoric/agoric-sdk/issues/2326#issuecomment-773020389
-const CALLSITE_ELLIPSIS_PATTERN2 = /^((?:.*[( ])?)\.\.\.\/(.+)$/;
+const CALLSITE_ELLIPSIS_PATTERN2 = freezeRegexp(/^((?:.*[( ])?)\.\.\.\/(.+)$/);
 
 // The ad-hoc rule of the current pattern is that any likely-file-path or
 // likely url-path prefix, ending in a `/` and prior to `package/` should get
@@ -147,7 +157,9 @@ const CALLSITE_ELLIPSIS_PATTERN2 = /^((?:.*[( ])?)\.\.\.\/(.+)$/;
 // `'Object.bar (packages/errors/test/deep-send.test.js:13:21)'`.
 // Note that `/packages/` is a convention for monorepos encouraged by
 // lerna.
-const CALLSITE_PACKAGES_PATTERN = /^((?:.*[( ])?)[:/\w_-]*\/(packages\/.+)$/;
+const CALLSITE_PACKAGES_PATTERN = freezeRegexp(
+  /^((?:.*[( ])?)[:/\w_-]*\/(packages\/.+)$/,
+);
 
 // The ad-hoc rule of the current pattern is that any likely-file-path or
 // likely url-path prefix of the form `file://` but not `file:///` gets
@@ -163,7 +175,9 @@ const CALLSITE_PACKAGES_PATTERN = /^((?:.*[( ])?)[:/\w_-]*\/(packages\/.+)$/;
 // clickable without removing the `file:///`, whereas `file://` usually precedes
 // a relative path which, for whatever vscode reason, is not clickable until the
 // `file://` is removed.
-const CALLSITE_FILE_2SLASH_PATTERN = /^((?:.*[( ])?)file:\/\/([^/].*)$/;
+const CALLSITE_FILE_2SLASH_PATTERN = freezeRegexp(
+  /^((?:.*[( ])?)file:\/\/([^/].*)$/,
+);
 
 // The use of these callSite patterns below assumes that any match will bind
 // capture groups containing the parts of the original string we want

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -60,7 +60,7 @@ export const getAnonymousIntrinsics = () => {
 
   // 21.2.7.1 The %RegExpStringIteratorPrototype% Object
   const RegExpStringIterator =
-    regexpPrototype[matchAllSymbol] && matchAllRegExp(/./);
+    regexpPrototype[matchAllSymbol] && matchAllRegExp(/./, '');
   const RegExpStringIteratorPrototype =
     RegExpStringIterator && getPrototypeOf(RegExpStringIterator);
 

--- a/packages/ses/src/get-source-url.js
+++ b/packages/ses/src/get-source-url.js
@@ -1,4 +1,9 @@
-import { FERAL_REG_EXP, regexpExec, stringSlice } from './commons.js';
+import {
+  FERAL_REG_EXP,
+  freezeRegexp,
+  regexpExec,
+  stringSlice,
+} from './commons.js';
 
 // Captures a key and value of the form #key=value or @key=value
 const sourceMetaEntryRegExp =
@@ -9,8 +14,10 @@ const sourceMetaEntryRegExp =
 // On account of the mechanics of regular expressions, scanning from the end
 // does not allow us to capture every pair, so getSourceURL must capture and
 // trim until there are no matching comments.
-const sourceMetaEntriesRegExp = new FERAL_REG_EXP(
-  `(?:\\s*//${sourceMetaEntryRegExp}|/\\*${sourceMetaEntryRegExp}\\s*\\*/)\\s*$`,
+const sourceMetaEntriesRegExp = freezeRegexp(
+  new FERAL_REG_EXP(
+    `(?:\\s*//${sourceMetaEntryRegExp}|/\\*${sourceMetaEntryRegExp}\\s*\\*/)\\s*$`,
+  ),
 );
 
 /**
@@ -31,7 +38,7 @@ export const getSourceURL = src => {
     if (match === null) {
       break;
     }
-    src = stringSlice(src, 0, src.length - match[0].length);
+    src = stringSlice(src, 0, -match[0].length);
 
     // We skip $0 since it contains the entire match.
     // The match contains four capture groups,

--- a/packages/ses/src/scope-constants.js
+++ b/packages/ses/src/scope-constants.js
@@ -1,10 +1,11 @@
 import {
   arrayFilter,
   arrayIncludes,
+  freezeRegexp,
   getOwnPropertyDescriptor,
   getOwnPropertyNames,
   hasOwn,
-  regexpExec,
+  regexpSearch,
   Set,
   setHas,
 } from './commons.js';
@@ -91,7 +92,7 @@ const reservedNames = new Set([
  * Note: \w is equivalent [a-zA-Z_0-9]
  * See 11.6.1 Identifier Names
  */
-const identifierPattern = /^[a-zA-Z_$][\w$]*$/;
+const identifierPattern = freezeRegexp(/^[a-zA-Z_$][\w$]*$/);
 
 /**
  * isValidIdentifierName()
@@ -100,7 +101,7 @@ const identifierPattern = /^[a-zA-Z_$][\w$]*$/;
  * @param {string} name
  */
 export const isValidIdentifierName = name =>
-  !setHas(reservedNames, name) && !!regexpExec(identifierPattern, name);
+  !setHas(reservedNames, name) && regexpSearch(identifierPattern, name) !== -1;
 
 /*
  * isImmutableDataProperty

--- a/packages/ses/src/tame-locale-methods.js
+++ b/packages/ses/src/tame-locale-methods.js
@@ -3,6 +3,7 @@ import {
   String,
   TypeError,
   defineProperty,
+  freezeRegexp,
   getOwnPropertyNames,
   isPrimitive,
   regexpExec,
@@ -11,7 +12,7 @@ import { assert } from './error/assert.js';
 
 const { Fail, quote: q } = assert;
 
-const localePattern = /^(\w*[a-z])Locale([A-Z]\w*)$/;
+const localePattern = freezeRegexp(/^(\w*[a-z])Locale([A-Z]\w*)$/);
 
 // Use concise methods to obtain named functions without constructor
 // behavior or `.prototype` property.

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -3,9 +3,10 @@
 import {
   FERAL_REG_EXP,
   SyntaxError,
+  freezeRegexp,
   regexpReplace,
+  regexpSearch,
   sealRegexp,
-  stringSearch,
   stringSlice,
   stringSplit,
   freeze,
@@ -21,7 +22,7 @@ import { getSourceURL } from './get-source-url.js';
  * @returns {number}
  */
 function getLineNumber(src, pattern) {
-  const index = stringSearch(src, pattern);
+  const index = regexpSearch(pattern, src);
   if (index < 0) {
     return -1;
   }
@@ -177,9 +178,8 @@ export const evadeImportExpressionTest = src => {
 
 // /////////////////////////////////////////////////////////////////////////////
 
-const someDirectEvalPattern = new FERAL_REG_EXP(
-  '(^|[^.])\\beval(\\s*\\()',
-  'g',
+const someDirectEvalPattern = freezeRegexp(
+  new FERAL_REG_EXP('(^|[^.])\\beval(\\s*\\()'),
 );
 
 /**


### PR DESCRIPTION
## Description

As discovered by @ChALkeR, `_regexpConstructor` was accidentally set to undefined rather than the intended `RegExp.prototype.constructor`.

### Security Considerations

A hardened environment preserves primordial prototype properties, but package "ses" still strives for very defensive code, which this aligns with.

### Scaling Considerations

n/a

### Documentation Considerations

Nothing beyond the included JSDoc.

### Testing Considerations

Just the current tests.

### Compatibility Considerations

None.

### Upgrade Considerations

None.