### PR TITLE
feat(marshal,pass-style): admit immutable ArrayBuffer through codecs

### DIFF
--- a/.changeset/byte-array-hex-codecs.md
+++ b/.changeset/byte-array-hex-codecs.md
@@ -1,0 +1,26 @@
+---
+'@endo/hex': minor
+'@endo/pass-style': minor
+'@endo/marshal': minor
+---
+
+Immutable `ArrayBuffer` (passStyle `'byteArray'`) is now serializable through
+the capdata, smallcaps, and encode-passable codecs.
+
+- New `@endo/hex` package providing `encodeHex`/`decodeHex` (with
+  `toHex`/`fromHex` aliases for the TC39 spelling).  Short-circuits to native
+  `Uint8Array.prototype.toHex` and `Uint8Array.fromHex` when available.
+- `@endo/pass-style` gains `byteArrayToHex`, `hexToByteArray`,
+  `byteArrayToUint8Array`, and `uint8ArrayToByteArray` helpers.
+- `@endo/marshal`:
+  - **capdata**: byteArray encodes as `{"@qclass":"byteArray","data":"<hex>"}`.
+  - **smallcaps**: byteArray encodes as `"*<hex>"`.  The `*` prefix is now
+    reserved.
+  - **encode-passable**: byteArray encodes as
+    `a<encodeBigInt(byteLength)>:<hex>`.  The Elias-delta length prefix gives
+    shortlex ordering (matching `compareRank`) with no arbitrary size cap, and
+    every character in the body is safe inside both `legacyOrdered` and
+    `compactOrdered` array framings.
+  - **marshal-justin**: renders byteArray as `hexToByteArray("<hex>")`.
+
+Syrup already supported this value; no change required there.

--- a/packages/marshal/docs/smallcaps-cheatsheet.md
+++ b/packages/marshal/docs/smallcaps-cheatsheet.md
@@ -10,7 +10,7 @@ An example-based summary of the Smallcaps encoding of the OCapN [Abstract Syntax
 | bigint           | Integer       | `7n`<br>`-7n`         | `"+7"`<br>`"-7"`     |
 | number           | Float64       | `Infinity`<br>`-Infinity`<br>`NaN`<br>`-0`<br>`7.1` | `"#Infinity"`<br>`"#-Infinity"`<br>`"#NaN"`<br>`"#-0"` // unimplemented<br>`7.1` |
 | string           | String        | `'#foo'`<br>`'foo'`   | `"!#foo"` // special strings<br>`"foo"` // other strings |
-| byteArray        | ByteArray     | `buf.toImmutable()`   | // undecided & unimplemented |
+| byteArray        | ByteArray     | `buf.toImmutable()`   | `"*deadbeef"` // after `*`, hex encoding |
 | passable symbols | Symbol        | `passableSymbolForName('foo')` | `"%foo"` // in transition |
 | copyArray        | List          | `[a,b]`               | `[<a>,<b>]`          |
 | copyRecord       | Struct        | `{foo:a,'#foo':b}`    | `{"!#foo":<b>,"foo":<a>}` // keys sorted  |
@@ -28,7 +28,6 @@ An example-based summary of the Smallcaps encoding of the OCapN [Abstract Syntax
 * Structs [can only have string-named properties](https://github.com/endojs/endo/blob/master/packages/pass-style/doc/copyRecord-guarantees.md).
 * Errors can also carry an optional `errorId` string property.
 * We expect to expand the optional error properties over time.
-* The ByteArray encoding is not yet designed or implemented.
 
 ## Readability Invariants
 

--- a/packages/marshal/src/encodePassable.js
+++ b/packages/marshal/src/encodePassable.js
@@ -10,6 +10,8 @@ import {
   isErrorLike,
   nameForPassableSymbol,
   passableSymbolForName,
+  byteArrayToHex,
+  hexToByteArray,
 } from '@endo/pass-style';
 
 /**
@@ -473,14 +475,47 @@ const decodeLegacyArray = (encoded, decodePassable, skip = 0) => {
 };
 
 /**
+ * Encodes a ByteArray as `a<length><:><hex>`, where `<length>` is the
+ * `encodeBigInt` of `byteLength` (a non-negative bigint, which already
+ * encodes in shortlex-numerical order), followed by the explicit
+ * separator `:` and the lowercase hex of the bytes.
+ *
+ * Shortlex is inherited in two stages:
+ *  1. `encodeBigInt` on the length preserves numerical order, so shorter
+ *     byteArrays sort before longer ones.
+ *  2. At equal length, the length encodings are identical and ordering
+ *     falls through to the byte-lex-preserving hex body.
+ *
+ * Every character used here — `a`, `p`/`n`/`~`/`#`, decimal digits, `:`,
+ * and hex digits `[0-9a-f]` — is outside the escape-reserved sets of
+ * both the `legacyOrdered` and `compactOrdered` array framings, so no
+ * escaping is needed.
+ *
  * @param {ByteArray} byteArray
  * @param {(byteArray: ByteArray) => string} _encodePassable
  * @returns {string}
  */
 const encodeByteArray = (byteArray, _encodePassable) => {
-  // TODO implement
-  Fail`encodePassable(byteArray) not yet implemented: ${byteArray}`;
-  return ''; // Just for the type
+  const lenEnc = encodeBigInt(BigInt(byteArray.byteLength));
+  return `a${lenEnc}:${byteArrayToHex(byteArray)}`;
+};
+
+const rByteArrayPayload = /^(p[~]*[0-9]+:[0-9]+):([0-9a-f]*)$/;
+
+/**
+ * Inverse of {@link encodeByteArray}.
+ *
+ * @param {string} encoded The body after the leading `'a'` prefix char.
+ * @returns {import('@endo/pass-style').ByteArray}
+ */
+const decodeByteArray = encoded => {
+  const match = encoded.match(rByteArrayPayload);
+  match || Fail`Encoded byteArray expected: ${encoded}`;
+  const [, lenEnc, hex] = /** @type {RegExpMatchArray} */ (match);
+  const byteLength = Number(decodeBigInt(lenEnc));
+  hex.length === byteLength * 2 ||
+    Fail`byteArray length mismatch: header ${q(byteLength)} vs body ${q(hex.length / 2)}`;
+  return hexToByteArray(hex, 'encodePassable byteArray');
 };
 
 const encodeRecord = (record, encodeArray, encodePassable) => {
@@ -748,6 +783,9 @@ const makeInnerDecode = (decodeStringSuffix, decodeArray, options) => {
       }
       case ':': {
         return decodeTagged(encoded, decodeArray, innerDecode, skip);
+      }
+      case 'a': {
+        return decodeByteArray(getSuffix(encoded, skip + 1));
       }
       default: {
         throw Fail`invalid database key: ${getSuffix(encoded, skip)}`;

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -14,6 +14,8 @@ import {
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
+  byteArrayToHex,
+  hexToByteArray,
 } from '@endo/pass-style';
 import { X, Fail, q } from '@endo/errors';
 
@@ -194,8 +196,10 @@ export const makeEncodeToCapData = (encodeOptions = {}) => {
         return passable.map(encodeToCapDataRecur);
       }
       case 'byteArray': {
-        // TODO implement
-        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+        return {
+          [QCLASS]: 'byteArray',
+          data: byteArrayToHex(passable),
+        };
       }
       case 'tagged': {
         return {
@@ -366,6 +370,12 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
         case 'tagged': {
           const { tag, payload } = jsonEncoded;
           return makeTagged(tag, decodeFromCapData(payload));
+        }
+        case 'byteArray': {
+          const { data } = jsonEncoded;
+          typeof data === 'string' ||
+            Fail`invalid byteArray data typeof ${q(typeof data)}`;
+          return hexToByteArray(data, 'capData byteArray');
         }
         case 'slot': {
           // See note above about how the current encoding cannot reliably

--- a/packages/marshal/src/encodeToCapData.js
+++ b/packages/marshal/src/encodeToCapData.js
@@ -451,3 +451,4 @@ export const makeDecodeFromCapData = (decodeOptions = {}) => {
   };
   return harden(decodeFromCapData);
 };
+harden(makeDecodeFromCapData);

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -17,6 +17,8 @@ import {
   assertPassableSymbol,
   nameForPassableSymbol,
   passableSymbolForName,
+  byteArrayToHex,
+  hexToByteArray,
 } from '@endo/pass-style';
 
 /** @import {Passable, RemotableObject} from '@endo/pass-style' */
@@ -50,6 +52,7 @@ const DASH = '-'.charCodeAt(0);
  * Of these, smallcaps currently uses the following:
  *
  *  * `!` - escaped string
+ *  * `*` - byteArray (hardened Immutable ArrayBuffer), hex-encoded
  *  * `+` - non-negative bigint
  *  * `-` - negative bigint
  *  * `#` - manifest constant
@@ -57,7 +60,7 @@ const DASH = '-'.charCodeAt(0);
  *  * `$` - remotable
  *  * `&` - promise
  *
- * All other special characters (`"'()*,`) are reserved for future use.
+ * All other special characters (`"'(),`) are reserved for future use.
  *
  * The manifest constants that smallcaps currently uses for values:
  *  * `#undefined`
@@ -230,8 +233,7 @@ export const makeEncodeToSmallcaps = (encodeOptions = {}) => {
         return passable.map(encodeToSmallcapsRecur);
       }
       case 'byteArray': {
-        // TODO implement
-        throw Fail`marsal of byteArray not yet implemented: ${passable}`;
+        return `*${byteArrayToHex(passable)}`;
       }
       case 'tagged': {
         return {
@@ -406,6 +408,9 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
               Fail`internal: decodePromiseFromSmallcaps option must return a promise: ${result}`;
             }
             return result;
+          }
+          case '*': {
+            return hexToByteArray(encoding.slice(1), 'smallcaps byteArray');
           }
           default: {
             throw Fail`Special char ${q(

--- a/packages/marshal/src/encodeToSmallcaps.js
+++ b/packages/marshal/src/encodeToSmallcaps.js
@@ -477,3 +477,4 @@ export const makeDecodeFromSmallcaps = (decodeOptions = {}) => {
   };
   return harden(decodeFromSmallcaps);
 };
+harden(makeDecodeFromSmallcaps);

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -177,6 +177,11 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
           assert.typeof(sym, 'symbol');
           return;
         }
+        case 'byteArray': {
+          const { data } = rawTree;
+          assert.typeof(data, 'string');
+          return;
+        }
         case 'tagged': {
           const { tag, payload } = rawTree;
           assert.typeof(tag, 'string');
@@ -338,6 +343,11 @@ const decodeToJustin = (encoding, shouldIndent = false, slots = []) => {
             return out.next(`Symbol.${suffix}`);
           }
           return out.next(`passableSymbolForName(${quote(registeredName)})`);
+        }
+        case 'byteArray': {
+          const { data } = rawTree;
+          assert.typeof(data, 'string');
+          return out.next(`hexToByteArray(${quote(data)})`);
         }
         case 'tagged': {
           const { tag, payload } = rawTree;

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -47,7 +47,8 @@ export {};
  *           } |
  *           EncodingClass<'tagged'> & { tag: string,
  *                                       payload: Encoding
- *           }
+ *           } |
+ *           EncodingClass<'byteArray'> & { data: string }
  * } EncodingUnion
  *
  * Note that the '@@asyncIterator' encoding is deprecated. Use 'symbol' instead.

--- a/packages/marshal/test/byteArray.test.js
+++ b/packages/marshal/test/byteArray.test.js
@@ -1,0 +1,179 @@
+// @ts-nocheck
+import test from '@endo/ses-ava/test.js';
+
+import harden from '@endo/harden';
+import {
+  byteArrayToUint8Array,
+  passStyleOf,
+  uint8ArrayToByteArray,
+} from '@endo/pass-style';
+import { makeMarshal } from '../src/marshal.js';
+import {
+  makeEncodePassable,
+  makeDecodePassable,
+} from '../src/encodePassable.js';
+import { compareRank } from '../src/rankOrder.js';
+
+const mkByteArray = bytes => uint8ArrayToByteArray(new Uint8Array(bytes));
+
+const fixtures = harden([
+  { name: 'empty', bytes: [] },
+  { name: 'single-zero', bytes: [0x00] },
+  { name: 'single-ff', bytes: [0xff] },
+  { name: 'two-zeroes', bytes: [0x00, 0x00] },
+  { name: 'deadbeef', bytes: [0xde, 0xad, 0xbe, 0xef] },
+  { name: 'long', bytes: Array.from({ length: 256 }, (_, i) => i) },
+]);
+
+test('smallcaps round-trips byteArray', t => {
+  const { serialize, unserialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'smallcaps',
+    errorTagging: 'off',
+  });
+  for (const { name, bytes } of fixtures) {
+    const ba = mkByteArray(bytes);
+    const { body } = serialize(ba);
+    const decoded = unserialize({ body, slots: [] });
+    t.is(passStyleOf(decoded), 'byteArray', name);
+    t.deepEqual(
+      [...byteArrayToUint8Array(decoded)],
+      bytes,
+      `smallcaps ${name}`,
+    );
+  }
+});
+
+test('smallcaps byteArray uses "*" prefix with hex body', t => {
+  const { serialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'smallcaps',
+    errorTagging: 'off',
+  });
+  const { body } = serialize(mkByteArray([0xde, 0xad, 0xbe, 0xef]));
+  // smallcaps body has a leading `#` sentinel before the JSON text.
+  t.true(body.includes('"*deadbeef"'), `got ${body}`);
+});
+
+test('capdata round-trips byteArray', t => {
+  const { serialize, unserialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'capdata',
+    errorTagging: 'off',
+  });
+  for (const { name, bytes } of fixtures) {
+    const ba = mkByteArray(bytes);
+    const { body } = serialize(ba);
+    const decoded = unserialize({ body, slots: [] });
+    t.is(passStyleOf(decoded), 'byteArray', name);
+    t.deepEqual([...byteArrayToUint8Array(decoded)], bytes, `capdata ${name}`);
+  }
+});
+
+test('capdata byteArray uses @qclass "byteArray" with hex data', t => {
+  const { serialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'capdata',
+    errorTagging: 'off',
+  });
+  const { body } = serialize(mkByteArray([0xde, 0xad, 0xbe, 0xef]));
+  t.true(
+    body.includes('"@qclass":"byteArray"') && body.includes('"deadbeef"'),
+    `got ${body}`,
+  );
+});
+
+test('byteArray nested in copyArray, copyRecord, tagged', t => {
+  const { serialize, unserialize } = makeMarshal(undefined, undefined, {
+    serializeBodyFormat: 'smallcaps',
+    errorTagging: 'off',
+  });
+  const ba = mkByteArray([1, 2, 3]);
+  const structure = harden({
+    arr: [ba, ba],
+    rec: { k: ba },
+  });
+  const { body } = serialize(structure);
+  const decoded = unserialize({ body, slots: [] });
+  t.is(passStyleOf(decoded.arr[0]), 'byteArray');
+  t.is(passStyleOf(decoded.rec.k), 'byteArray');
+  t.deepEqual([...byteArrayToUint8Array(decoded.arr[1])], [1, 2, 3]);
+});
+
+test('encodePassable round-trips byteArray (legacyOrdered)', t => {
+  const encode = makeEncodePassable({ format: 'legacyOrdered' });
+  const decode = makeDecodePassable({ format: 'legacyOrdered' });
+  for (const { name, bytes } of fixtures) {
+    const ba = mkByteArray(bytes);
+    const enc = encode(ba);
+    t.is(enc.charAt(0), 'a', `legacy ${name} starts with 'a'`);
+    const back = decode(enc);
+    t.deepEqual([...byteArrayToUint8Array(back)], bytes, `legacy ${name}`);
+  }
+});
+
+test('encodePassable round-trips byteArray (compactOrdered)', t => {
+  const encode = makeEncodePassable({ format: 'compactOrdered' });
+  const decode = makeDecodePassable({ format: 'compactOrdered' });
+  for (const { name, bytes } of fixtures) {
+    const ba = mkByteArray(bytes);
+    const enc = encode(ba);
+    const back = decode(enc);
+    t.deepEqual([...byteArrayToUint8Array(back)], bytes, `compact ${name}`);
+  }
+});
+
+test('encodePassable byteArray preserves shortlex order', t => {
+  const encode = makeEncodePassable({ format: 'legacyOrdered' });
+  // Listed in the expected shortlex order.
+  const orderedBytes = [
+    [],
+    [0x00],
+    [0x01],
+    [0xff],
+    [0x00, 0x00],
+    [0x00, 0x01],
+    [0x01, 0x00],
+    [0xff, 0xfe],
+    [0xff, 0xff],
+    [0x00, 0x00, 0x00],
+  ];
+  const encodings = orderedBytes.map(bs => encode(mkByteArray(bs)));
+  const sorted = [...encodings].sort();
+  t.deepEqual(sorted, encodings, `sorted=${sorted.join(',')}`);
+});
+
+test('encodePassable byteArray agrees with compareRank', t => {
+  const encode = makeEncodePassable({ format: 'legacyOrdered' });
+  const values = harden([
+    mkByteArray([]),
+    mkByteArray([0x00]),
+    mkByteArray([0xff]),
+    mkByteArray([0x00, 0x00]),
+    mkByteArray([0x00, 0x01]),
+    mkByteArray([0xff, 0xff]),
+    mkByteArray([0x00, 0x00, 0x00]),
+  ]);
+  for (let i = 0; i < values.length; i += 1) {
+    for (let j = 0; j < values.length; j += 1) {
+      const rank = compareRank(values[i], values[j]);
+      const encA = encode(values[i]);
+      const encB = encode(values[j]);
+      // eslint-disable-next-line no-nested-ternary
+      const lex = encA < encB ? -1 : encA > encB ? 1 : 0;
+      t.is(
+        Math.sign(rank),
+        lex,
+        `pair i=${i} j=${j}: rank ${rank} vs lex ${lex}`,
+      );
+    }
+  }
+});
+
+test('encodePassable byteArray cover sits between promise and boolean', t => {
+  const encode = makeEncodePassable({
+    format: 'legacyOrdered',
+    encodePromise: (_p, _r) => '?0',
+  });
+  const promiseEnc = '?0';
+  const boolTrue = encode(true);
+  const byteEnc = encode(mkByteArray([0xff]));
+  t.true(promiseEnc < byteEnc, `${promiseEnc} < ${byteEnc}`);
+  t.true(byteEnc < boolTrue, `${byteEnc} < ${boolTrue}`);
+});

--- a/packages/marshal/test/encodePassable.test.js
+++ b/packages/marshal/test/encodePassable.test.js
@@ -16,7 +16,7 @@ import {
 import { compareRank, makeFullOrderComparatorKit } from '../src/rankOrder.js';
 import { unsortedSample } from '../tools/marshal-test-data.js';
 
-const { arbPassable } = makeArbitraries(fc, ['byteArray']);
+const { arbPassable } = makeArbitraries(fc);
 
 const statelessEncodePassableLegacy = makeEncodePassable();
 

--- a/packages/marshal/test/marshal-justin.test.js
+++ b/packages/marshal/test/marshal-justin.test.js
@@ -5,6 +5,7 @@ import { makeError, X } from '@endo/errors';
 import {
   Far,
   Remotable,
+  hexToByteArray,
   makeTagged,
   passableSymbolForName,
 } from '@endo/pass-style';
@@ -42,6 +43,7 @@ const fakeJustinCompartment = () => {
   return new Compartment({
     slot,
     slotToVal,
+    hexToByteArray,
     makeTagged,
     passableSymbolForName,
   });

--- a/packages/marshal/tools/marshal-test-data.js
+++ b/packages/marshal/tools/marshal-test-data.js
@@ -1,5 +1,9 @@
 import harden from '@endo/harden';
-import { makeTagged, passableSymbolForName } from '@endo/pass-style';
+import {
+  hexToByteArray,
+  makeTagged,
+  passableSymbolForName,
+} from '@endo/pass-style';
 import {
   exampleAlice,
   exampleBob,
@@ -128,6 +132,15 @@ export const roundTripPairs = harden([
   // Normal json reviver cannot make properties with undefined values
   [[undefined], [{ '@qclass': 'undefined' }]],
   [{ foo: undefined }, { foo: { '@qclass': 'undefined' } }],
+
+  // byteArray
+  [
+    hexToByteArray('0f'),
+    {
+      '@qclass': 'byteArray',
+      data: '0f',
+    },
+  ],
 
   // tagged
   [
@@ -258,6 +271,9 @@ export const jsonJustinPairs = harden([
   ['{"@qclass":"symbol","name":"foo"}', 'passableSymbolForName("foo")'],
   ['{"@qclass":"symbol","name":"@@@@foo"}', 'passableSymbolForName("@@@@foo")'],
 
+  // byteArray
+  ['{"@qclass":"byteArray","data":"0aff"}', 'hexToByteArray("0aff")'],
+
   // Arrays and objects
   ['[{"@qclass":"undefined"}]', '[undefined]'],
   ['{"foo":{"@qclass":"undefined"}}', '{foo:undefined}'],
@@ -334,6 +350,7 @@ export const unsortedSample = harden([
   undefined,
   -Infinity,
   [5],
+  hexToByteArray('0f'),
   exampleAlice,
   [],
   passableSymbolForName('foo'),
@@ -347,6 +364,7 @@ export const unsortedSample = harden([
   [exampleAlice, 'a'],
   [exampleBob, 'z'],
   -0,
+  hexToByteArray('aa'),
   {},
   [5, undefined],
   -3,
@@ -356,6 +374,7 @@ export const unsortedSample = harden([
   ]),
   true,
   'bar',
+  hexToByteArray('0a'),
   [5, null],
   new Promise(() => {}), // forever unresolved
   makeTagged('nonsense', [
@@ -428,6 +447,10 @@ export const sortedSample = harden([
   [exampleAlice, 'a'],
   [exampleCarol, 'm'],
   [exampleBob, 'z'],
+
+  hexToByteArray('0a'),
+  hexToByteArray('0f'),
+  hexToByteArray('aa'),
 
   false,
   true,

--- a/packages/pass-style/index.js
+++ b/packages/pass-style/index.js
@@ -27,6 +27,13 @@ export {
 } from './src/string.js';
 
 export {
+  byteArrayToUint8Array,
+  uint8ArrayToByteArray,
+  byteArrayToHex,
+  hexToByteArray,
+} from './src/byteArray.js';
+
+export {
   passStyleOf,
   isPassable,
   assertPassable,

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -40,6 +40,7 @@
     "@endo/errors": "workspace:^",
     "@endo/eventual-send": "workspace:^",
     "@endo/harden": "workspace:^",
+    "@endo/hex": "workspace:^",
     "@endo/promise-kit": "workspace:^"
   },
   "devDependencies": {

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -1,7 +1,9 @@
 import harden from '@endo/harden';
 import { X, Fail } from '@endo/errors';
+import { encodeHex, decodeHex } from '@endo/hex';
 
 /**
+ * @import {ByteArray} from './types.js';
  * @import {PassStyleHelper} from './internal-types.js';
  */
 
@@ -66,3 +68,60 @@ export const ByteArrayHelper = harden({
       );
   },
 });
+harden(ByteArrayHelper);
+
+/**
+ * Returns a Uint8Array reflecting the current contents of `byteArray`.
+ *
+ * On platforms with native immutable ArrayBuffer support, the byteArray
+ * inherits directly from `ArrayBuffer.prototype` and the returned
+ * `Uint8Array` is a zero-copy view. On platforms using the
+ * `@endo/immutable-arraybuffer` shim, the shim-emulated buffer does not
+ * admit a `Uint8Array` view, so this slices out a fresh mutable copy.
+ *
+ * @param {ArrayBuffer} byteArray A `passStyleOf === 'byteArray'` value
+ * (hardened Immutable ArrayBuffer), or a plain mutable ArrayBuffer
+ * (in which case the returned Uint8Array is a read-write view).
+ * @returns {Uint8Array}
+ */
+export const byteArrayToUint8Array = byteArray => {
+  if (getPrototypeOf(byteArray) === ArrayBuffer.prototype) {
+    return new Uint8Array(byteArray);
+  }
+  const genuineArrayBuffer = byteArray.slice();
+  return new Uint8Array(genuineArrayBuffer);
+};
+harden(byteArrayToUint8Array);
+
+/**
+ * Converts a `Uint8Array` to a `ByteArray`, i.e., a hardened Immutable
+ * ArrayBuffer whose `passStyleOf` is `'byteArray'`.
+ *
+ * @param {Uint8Array} uint8Array
+ * @returns {ArrayBuffer}
+ */
+export const uint8ArrayToByteArray = uint8Array =>
+  // @ts-expect-error shim-augmented ArrayBuffer type
+  harden(uint8Array.buffer.sliceToImmutable(0, uint8Array.length));
+harden(uint8ArrayToByteArray);
+
+/**
+ * Hex-encodes the contents of a ByteArray.
+ *
+ * @param {ByteArray} byteArray
+ * @returns {string}
+ */
+export const byteArrayToHex = byteArray =>
+  encodeHex(byteArrayToUint8Array(byteArray));
+harden(byteArrayToHex);
+
+/**
+ * Decodes a hex string into a ByteArray (hardened Immutable ArrayBuffer).
+ *
+ * @param {string} hex
+ * @param {string} [name]
+ * @returns {ByteArray}
+ */
+export const hexToByteArray = (hex, name) =>
+  uint8ArrayToByteArray(decodeHex(hex, name));
+harden(hexToByteArray);

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -97,16 +97,34 @@ harden(byteArrayToUint8Array);
  * Converts a `Uint8Array` to a `ByteArray`, i.e., a hardened Immutable
  * ArrayBuffer whose `passStyleOf` is `'byteArray'`.
  *
+ * Honors the `Uint8Array`'s `byteOffset` and `length` so that a view
+ * over a slice of a larger buffer round-trips correctly:
+ * `uint8ArrayToByteArray(new Uint8Array(buf, byteOffset, length))`
+ * always represents exactly the bytes in `[byteOffset, byteOffset +
+ * length)`.
+ *
+ * If the underlying platform implements `sliceToImmutable` natively
+ * with the obvious zero-copy optimization on an already-immutable
+ * source buffer, this conversion is zero-copy.  Otherwise, it pays
+ * the copy cost implicit in `sliceToImmutable`.
+ *
  * @param {Uint8Array} uint8Array
  * @returns {ArrayBuffer}
  */
-export const uint8ArrayToByteArray = uint8Array =>
+export const uint8ArrayToByteArray = uint8Array => {
+  const { byteOffset, length } = uint8Array;
   // @ts-expect-error shim-augmented ArrayBuffer type
-  harden(uint8Array.buffer.sliceToImmutable(0, uint8Array.length));
+  const byteArray = uint8Array.buffer.sliceToImmutable(
+    byteOffset,
+    byteOffset + length,
+  );
+  return harden(byteArray);
+};
 harden(uint8ArrayToByteArray);
 
 /**
- * Hex-encodes the contents of a ByteArray.
+ * Like `encodeHex` but starting from a presumably frozen (immutable)
+ * ByteArray.
  *
  * @param {ByteArray} byteArray
  * @returns {string}
@@ -116,7 +134,9 @@ export const byteArrayToHex = byteArray =>
 harden(byteArrayToHex);
 
 /**
- * Decodes a hex string into a ByteArray (hardened Immutable ArrayBuffer).
+ * Like `decodeHex` but producing a hardened Immutable ArrayBuffer
+ * (`passStyleOf === 'byteArray'`) instead of a fresh mutable
+ * `Uint8Array`.
  *
  * @param {string} hex
  * @param {string} [name]

--- a/packages/pass-style/test/byte-array.test.js
+++ b/packages/pass-style/test/byte-array.test.js
@@ -1,0 +1,49 @@
+import test from '@endo/ses-ava/test.js';
+
+import harden from '@endo/harden';
+import { passStyleOf } from '../src/passStyleOf.js';
+import {
+  byteArrayToUint8Array,
+  uint8ArrayToByteArray,
+  byteArrayToHex,
+  hexToByteArray,
+} from '../src/byteArray.js';
+
+test('passStyleOf recognizes immutable ArrayBuffer as byteArray', t => {
+  const buf = new ArrayBuffer(4);
+  const view = new Uint8Array(buf);
+  view[0] = 0xde;
+  view[1] = 0xad;
+  view[2] = 0xbe;
+  view[3] = 0xef;
+  const immutable = harden(buf.sliceToImmutable());
+  t.is(/** @type {string} */ (passStyleOf(immutable)), 'byteArray');
+});
+
+test('passStyleOf byteArray with empty buffer', t => {
+  const buf = new ArrayBuffer(0);
+  const immutable = harden(buf.sliceToImmutable());
+  t.is(/** @type {string} */ (passStyleOf(immutable)), 'byteArray');
+});
+
+test('byteArrayToHex / hexToByteArray round-trip', t => {
+  const source = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+  const byteArray = uint8ArrayToByteArray(source);
+  t.is(/** @type {string} */ (passStyleOf(byteArray)), 'byteArray');
+  const hex = byteArrayToHex(byteArray);
+  t.is(hex, 'deadbeef');
+  const decoded = hexToByteArray(hex);
+  t.is(/** @type {string} */ (passStyleOf(decoded)), 'byteArray');
+  t.deepEqual([...byteArrayToUint8Array(decoded)], [...source]);
+});
+
+test('empty byteArray round-trip', t => {
+  const byteArray = uint8ArrayToByteArray(new Uint8Array(0));
+  t.is(byteArrayToHex(byteArray), '');
+  const decoded = hexToByteArray('');
+  t.is(byteArrayToUint8Array(decoded).length, 0);
+});
+
+test('hexToByteArray rejects odd-length input', t => {
+  t.throws(() => hexToByteArray('a'), { message: /hex/i });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,6 +1074,7 @@ __metadata:
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"
     "@endo/harden": "workspace:^"
+    "@endo/hex": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"


### PR DESCRIPTION

## Description

Admits the immutable `ArrayBuffer` (passStyle `'byteArray'`) through the
capdata, smallcaps, and encode-passable codecs in `@endo/marshal`, and
adds the supporting hex/byteArray helpers in `@endo/pass-style`.

- `@endo/pass-style` gains `byteArrayToHex`, `hexToByteArray`,
  `byteArrayToUint8Array`, and `uint8ArrayToByteArray`, all routed
  through `@endo/hex`.
- `@endo/marshal`:
  - **capdata**: `byteArray` encodes as
    `{"@qclass":"byteArray","data":"<hex>"}`.
  - **smallcaps**: `byteArray` encodes as `"*<hex>"`; the `*` prefix is
    now reserved for byteArray.
  - **encode-passable**: `byteArray` encodes as
    `a<encodeBigInt(byteLength)>:<hex>`. The Elias-delta length prefix
    gives shortlex ordering matching `compareRank` with no arbitrary
    size cap, and every body character is safe inside both
    `legacyOrdered` and `compactOrdered` array framings.
  - **marshal-justin**: renders `byteArray` as `hexToByteArray("<hex>")`.

Syrup already supported this value through its bytestring primitive; CBOR
remains out of scope until `packages/ocapn/src/cbor` lands.

Most critical files to review:
- `packages/marshal/src/encodePassable.js` (ordering + framing safety)
- `packages/marshal/src/encodeToSmallcaps.js` (new reserved prefix)
- `packages/marshal/src/encodeToCapData.js` (new `@qclass`)
- `packages/pass-style/src/byteArray.js` (helper surface and validation)

### Security Considerations

The new encodings introduce new vocabulary that decoders must validate:
the smallcaps `*` prefix, the capdata `@qclass: "byteArray"`, and the
encode-passable `a` prefix. Decoders reject malformed hex and
length-mismatched payloads, and the resulting `ArrayBuffer` is hardened
(immutable) before exposure, preserving the pass-style invariant that
peers cannot mutate shared bytes. No new authority is introduced; this
admits existing immutable-`ArrayBuffer` values through codecs that
previously rejected them.

### Scaling Considerations

Hex encoding doubles payload size relative to raw bytes for capdata and
smallcaps. The encode-passable form uses an Elias-delta-encoded
`byteLength` prefix, so there is no arbitrary size cap and the cost is
logarithmic in `byteLength`. Callers that need compact wire formats for
large byte payloads should continue to prefer Syrup (or, eventually,
CBOR).

### Documentation Considerations

- `packages/marshal/docs/smallcaps-cheatsheet.md` is updated to list the
  newly reserved `*` prefix.
- The changeset (`.changeset/byte-array-hex-codecs.md`) describes the
  user-visible additions across `@endo/hex`, `@endo/pass-style`, and
  `@endo/marshal`.
- Downstream docs should note that `byteArray` values are now
  round-trippable through all three codecs and that the `*` smallcaps
  prefix is reserved.

### Testing Considerations

- `packages/marshal/test/byteArray.test.js` covers round-tripping
  through capdata, smallcaps, encode-passable, and marshal-justin, plus
  decoder rejection of malformed payloads.
- `packages/pass-style/test/byte-array.test.js` covers the new
  hex/Uint8Array helpers.
- `packages/marshal/test/encodePassable.test.js` is updated to reflect
  the new `a`-prefix encoding and shortlex ordering.

No CI or testnet impact beyond the new unit tests.

### Compatibility Considerations

This is purely additive at the producer side: codecs only emit the new
forms when given an immutable `ArrayBuffer`, which older versions of
`@endo/pass-style` cannot produce. However, **older decoders will reject
messages containing byteArray-encoded values** they do not recognize
(unknown `@qclass`, unknown smallcaps prefix, unknown encode-passable
prefix). This is fail-closed behavior, but it means upgrades must
sequence consumers ahead of producers.

The smallcaps `*` prefix was previously unassigned but unreserved; any
ad-hoc consumer that happened to accept `*`-prefixed strings will now
see them interpreted as byteArray.

### Upgrade Considerations

- Deploy decoders that understand the new encodings before deploying any
  producer that emits immutable `ArrayBuffer` values into a capdata,
  smallcaps, or encode-passable channel.
- No data migration is required; persisted data written before this
  change cannot contain byteArray values, so existing stores remain
  decodable.
- Not a breaking change in the SemVer sense (minor bumps for
  `@endo/hex`, `@endo/pass-style`, and `@endo/marshal`).
