### PR TITLE
chore(eslint): disable jsdoc/require-param for .ts files (#2749)

### DIFF
--- a/packages/eslint-plugin/lib/configs/style.js
+++ b/packages/eslint-plugin/lib/configs/style.js
@@ -63,6 +63,7 @@ module.exports = {
       rules: {
         'import/no-unresolved': 'off',
         'no-unused-vars': 'off',
+        'jsdoc/require-param': 'off',
         'jsdoc/require-param-type': 'off',
       },
     },


### PR DESCRIPTION
TypeScript already requires every parameter to have a name and a type,
so JSDoc @param is redundant noise on .ts files; the lint rule should
not fire there.

Mirrors Agoric/agoric-sdk#11165.

Closes: #2749