### PR TITLE
chore(cli): remove unreachable branch in run command (#3081)

### DIFF
--- a/packages/cli/src/commands/run.js
+++ b/packages/cli/src/commands/run.js
@@ -79,13 +79,6 @@ export const run = async ({
         /** @type {any} */
         let bundle;
         if (bundleName !== undefined) {
-          if (importPath !== undefined) {
-            console.error(
-              'Must specify either --bundle or --UNCONFINED, not both',
-            );
-            process.exitCode = 1;
-            return;
-          }
           if (filePath !== undefined) {
             args.unshift(filePath);
           }


### PR DESCRIPTION
Closes #3081 

The inner `if (importPath !== undefined)` block sat inside the `else` branch of an outer `if (importPath !== undefined)`, so it could never be reached. The dead block re-emitted the same "Must specify either --bundle or --UNCONFINED, not both" error already produced by the live arm of the outer conditional, so deleting it is a pure dead-code removal with no observable behavior change.