### PR TITLE
fix(ocapn): mark connection destroyed when underlying socket closes

### DIFF
--- a/packages/ocapn/src/client/handshake.js
+++ b/packages/ocapn/src/client/handshake.js
@@ -275,8 +275,17 @@ export const handleHandshakeMessageData = (
       try {
         message = readOcapnHandshakeMessage(syrupReader);
       } catch (err) {
+        // Best-effort diagnostic: try to render the bytes as generic syrup
+        // for the log. If they can't even be decoded as syrup (e.g. junk
+        // bytes), don't let the diagnostic itself mask the original error.
         const problematicBytes = data.slice(start);
-        const syrupMessage = decodeSyrup(problematicBytes);
+        let syrupMessage;
+        try {
+          syrupMessage = decodeSyrup(problematicBytes);
+        } catch (decodeErr) {
+          syrupMessage = '<undecodable syrup>';
+          logger.error(`Bytes are not valid syrup:`, decodeErr);
+        }
         logger.error(
           `Message decode error:`,
           err,

--- a/packages/ocapn/src/client/index.js
+++ b/packages/ocapn/src/client/index.js
@@ -352,6 +352,13 @@ export const makeClient = ({
    */
   const handleConnectionClose = (connection, reason) => {
     logger.info(`handleConnectionClose called`, { reason });
+    // The underlying socket has closed, so the connection is no longer
+    // usable regardless of how it got here (graceful op:abort, error,
+    // remote RST, etc). Marking it destroyed here is idempotent and
+    // ensures `connection.isDestroyed` is always true once the socket
+    // is gone, even when a netlayer fires close without an intervening
+    // userland call to connection.end().
+    connection.end();
     const session = sessionManager.getSessionForConnection(connection);
     if (session) {
       const locationId = locationToLocationId(session.peer.location);

--- a/packages/ocapn/src/client/ocapn.js
+++ b/packages/ocapn/src/client/ocapn.js
@@ -1217,16 +1217,27 @@ export const makeOcapn = (
       } catch (err) {
         // Tell the engine message deserialization has failed.
         ocapnTable.clearPendingRefCounts();
+        // Best-effort diagnostic: try to render the bytes as generic syrup
+        // for the log. If they can't even be decoded as syrup (e.g. junk
+        // bytes), don't let the diagnostic itself mask the original error
+        // or skip the connection.end() cleanup below.
         const problematicBytes = data.slice(start);
-        const syrupMessage = decodeSyrup(problematicBytes);
-        logger.error(`Message decode error:`);
-        logger.error(
-          JSON.stringify(
-            syrupMessage,
-            (key, value) => (typeof value === 'bigint' ? `${value}n` : value),
-            2,
-          ),
-        );
+        try {
+          const syrupMessage = decodeSyrup(problematicBytes);
+          logger.error(`Message decode error:`);
+          logger.error(
+            JSON.stringify(
+              syrupMessage,
+              (key, value) => (typeof value === 'bigint' ? `${value}n` : value),
+              2,
+            ),
+          );
+        } catch (decodeErr) {
+          logger.error(
+            `Message decode error (bytes are not valid syrup):`,
+            decodeErr,
+          );
+        }
         connection.end();
         throw err;
       }

--- a/packages/ocapn/src/netlayers/tcp-test-only.js
+++ b/packages/ocapn/src/netlayers/tcp-test-only.js
@@ -153,6 +153,12 @@ export const makeTcpNetLayer = async ({
       if (onClose) {
         onClose();
       }
+      // Mark the connection destroyed before notifying the client.
+      // Otherwise a socket that closes without the userland data handler
+      // first observing an op:abort (e.g. RST, dropped in-flight bytes,
+      // or close racing data delivery) would leave `connection.isDestroyed`
+      // false, which causes test waiters and reconnect logic to hang.
+      connection.end();
       handlers.handleConnectionClose(connection);
     });
   };
@@ -182,7 +188,14 @@ export const makeTcpNetLayer = async ({
     const connection = handlers.makeConnection(netlayer, true, socketOps);
 
     setupSocketHandlers(socket, connection, () => {
-      outgoingConnections.delete(location.designator);
+      // Only evict ourselves from the outgoing map. The map may contain a
+      // *different* connection for this designator (e.g. one created by a
+      // later `lookupOrConnect`) when this one was created via the debug
+      // `establishConnection` helper that bypasses registration. An
+      // unconditional delete would silently break later sessions.
+      if (outgoingConnections.get(location.designator) === connection) {
+        outgoingConnections.delete(location.designator);
+      }
     });
 
     return { connection, socket };


### PR DESCRIPTION
`Connection.isDestroyed` was only flipped inside `Connection.end()`, so any path where the socket terminates without the userland data handler first observing an `op:abort` (RST instead of FIN, dropped in-flight bytes, or close racing data delivery under load) left `isDestroyed` false forever. Two `client.test.js` cases that wait on `firstConnection.isDestroyed` after sending bad bytes intermittently timed out as a result.

Mark the connection destroyed at both layers when the socket closes: the test netlayer's `socket.on('close')` handler, and the client's `handleConnectionClose` (defense in depth for any future netlayer).

Also fix two related diagnostic bugs surfaced while debugging:

- The catch handlers in `handshake.js` and `ocapn.js` invoked `decodeSyrup(problematicBytes)` for log diagnostics, but on truly junk bytes the diagnostic itself throws — masking the original parse error in the log and, in `ocapn.js`, skipping the subsequent `connection.end()` cleanup. Wrap the diagnostic decode in its own try/catch.

- `_debug.establishConnection` (test-only) installed an `onClose` callback that unconditionally evicted `outgoingConnections` by designator, even though the debug-created connection was never in that map — silently breaking subsequent `lookupOrConnect` sessions to the same designator within a single test. Only evict ourselves.

Made-with: Cursor
