### PR TITLE
fix(bundle-source): include cacheSourceMaps in options type (#2834)

### DIFF
--- a/.changeset/bundle-source-cache-source-maps-types.md
+++ b/.changeset/bundle-source-cache-source-maps-types.md
@@ -1,0 +1,11 @@
+---
+'@endo/bundle-source': patch
+---
+
+Update `BundleOptions` and the `powers` parameter types to reflect what
+`bundleSource` already accepts at runtime: `cacheSourceMaps` is now
+documented on `BundleOptions`, `commonDependencies` and `importHook`
+(only for the `endoZipBase64` format) are surfaced, and the optional
+`powers` parameter accepts the wider `BundlePowers` shape (including
+`pathResolve`, `userInfo`, `env`, `platform`, and `computeSha512`).
+This is a JSDoc/typings-only change; no runtime behavior changes.

--- a/packages/bundle-source/src/types.ts
+++ b/packages/bundle-source/src/types.ts
@@ -214,6 +214,12 @@ export type BundleSourceResult<T extends ModuleFormat> =
           }
         : never;
 
+export interface BundlePowers extends SharedPowers {
+  read?: ReadFn | undefined;
+  canonical?: CanonicalFn | undefined;
+  externals?: string[] | undefined;
+}
+
 export type BundleSourceSimple = <T extends 'endoZipBase64'>(
   startFilename: string,
 ) => Promise<BundleSourceResult<T>>;
@@ -221,11 +227,7 @@ export type BundleSourceSimple = <T extends 'endoZipBase64'>(
 export type BundleSourceWithFormat = <T extends ModuleFormat = 'endoZipBase64'>(
   startFilename: string,
   format: T,
-  powers?: {
-    read?: ReadFn;
-    canonical?: CanonicalFn;
-    externals?: string[];
-  },
+  powers?: BundlePowers,
 ) => Promise<BundleSourceResult<T>>;
 
 export type BundleSourceWithOptions = <
@@ -233,25 +235,21 @@ export type BundleSourceWithOptions = <
 >(
   startFilename: string,
   bundleOptions: BundleOptions<T>,
-  powers?: {
-    read?: ReadFn;
-    canonical?: CanonicalFn;
-    externals?: string[];
-  },
+  powers?: BundlePowers,
 ) => Promise<BundleSourceResult<T>>;
 
 export type BundleSourceGeneral = <T extends ModuleFormat = 'endoZipBase64'>(
   startFilename: string,
   formatOrOptions?: T | BundleOptions<T>,
-  powers?: {
-    read?: ReadFn;
-    canonical?: CanonicalFn;
-    externals?: string[];
-  },
+  powers?: BundlePowers,
 ) => Promise<BundleSourceResult<T>>;
 
 export type BundleOptions<T extends ModuleFormat> = {
   format?: T | undefined;
+  /**
+   * when true, render source maps to a per-user per-host cache
+   * directory. Defaults to false. See README for details.
+   */
   cacheSourceMaps?: boolean | undefined;
   /**
    * - development mode, for test bundles that need
@@ -275,7 +273,21 @@ export type BundleOptions<T extends ModuleFormat> = {
    * exports and imports.
    */
   conditions?: string[] | undefined;
-};
+  /**
+   * common dependencies for the entry package.
+   */
+  commonDependencies?: Record<string, string> | undefined;
+} & (T extends 'endoZipBase64'
+  ? {
+      /**
+       * import hook for exit modules, only honored
+       * for the `endoZipBase64` format.
+       */
+      importHook?:
+        | import('@endo/compartment-mapper').ExitModuleImportHook
+        | undefined;
+    }
+  : {});
 
 export type ReadFn = (location: string) => Promise<Uint8Array>;
 

--- a/packages/bundle-source/test/explicit.test.js
+++ b/packages/bundle-source/test/explicit.test.js
@@ -5,7 +5,6 @@ import test from '@endo/ses-ava/prepare-endo.js';
 import bundleSource from '../src/index.js';
 
 test('explicit authority', async t => {
-  // @ts-expect-error BundleOptions needs updating
   const { moduleFormat } = await bundleSource(
     url.fileURLToPath(new URL(`../demo/dir1`, import.meta.url)),
     'getExport',

--- a/packages/bundle-source/test/external-fs.test.js
+++ b/packages/bundle-source/test/external-fs.test.js
@@ -37,13 +37,16 @@ const testFsImportHookEndoZipBase64 = (name, file) => {
 
     const testFile = url.fileURLToPath(new URL(file, import.meta.url));
 
-    // @ts-expect-error BundleOptions needs updating
     await bundleSource(testFile, {
       format: 'endoZipBase64',
       importHook: async specifier => {
         if (specifier === 'fs') {
           t.is(specifier, 'fs', 'imported fs module');
-          return true;
+          return {
+            imports: [],
+            exports: [],
+            execute() {},
+          };
         }
         return undefined;
       },

--- a/packages/import-bundle/test/import-bundle.test.js
+++ b/packages/import-bundle/test/import-bundle.test.js
@@ -126,7 +126,6 @@ test('test fs import with importHook', async t => {
     },
   };
 
-  // @ts-expect-error no overload matches
   const bundle = await bundleSource(testFilePath, options);
   const ns = await importBundle(bundle, options);
 


### PR DESCRIPTION
Document `cacheSourceMaps` in the `BundleOptions` JSDoc, surface `importHook` (only for the `endoZipBase64` format) and `commonDependencies`, and align the optional `powers` parameter with the `SharedPowers` shape that the runtime accepts (so callers may pass `pathResolve`, `userInfo`, etc.). Drop the `@ts-expect-error BundleOptions needs updating` markers that those gaps required.
