### PR TITLE
fix(evasive-transforms,ses): fix lint warnings

### DIFF
--- a/.changeset/tender-mangos-lead.md
+++ b/.changeset/tender-mangos-lead.md
@@ -1,0 +1,6 @@
+---
+'@endo/evasive-transform': patch
+'ses': patch
+---
+
+Exposed a mistakenly hidden type declaration

--- a/packages/evasive-transform/src/index.js
+++ b/packages/evasive-transform/src/index.js
@@ -23,7 +23,7 @@ import { generate } from './generate.js';
  * @property {import('./parse-ast.js').SourceType | undefined} [sourceType] - Module source type
  * @property {boolean | undefined} [onlyComments] - if true, will limit transformation to
 comment contents, preserving code positions within each line
-* @property {(path: import('@babel/traverse').NodePath) => void} [customVisitor] - A visitor function to be called on each node, in addition to the standard transforms. Receives the same path argument as a normal Babel visitor.
+ * @property {(path: import('@babel/traverse').NodePath) => void} [customVisitor] - A visitor function to be called on each node, in addition to the standard transforms. Receives the same path argument as a normal Babel visitor.
  * @property {boolean | undefined} [useLocationUnmap] - deprecated, vestigial
  * @public
  */

--- a/packages/ses/src/compartment.js
+++ b/packages/ses/src/compartment.js
@@ -335,9 +335,9 @@ export const makeCompartmentConstructor = (
   { parentCompartment = undefined, enforceNew = false } = {},
 ) => {
   /**
-   * @param {...CompartmentOptionsArgs|LegacyCompartmentOptionsArgs} args
+   * @param {CompartmentOptionsArgs|LegacyCompartmentOptionsArgs} args
+   * @this {Compartment}
    */
-  /** @this {Compartment} */
   function Compartment(...args) {
     if (enforceNew && new.target === undefined) {
       throw TypeError(


### PR DESCRIPTION

Closes: #XXXX
Refs: #XXXX

## Description

I was getting two lint warnings from running `yarn lint` locally:

```
/Users/markmiller/src/ongithub/endojs/endo/packages/evasive-transform/src/index.js
  25:1  warning  Expected JSDoc block to be aligned  jsdoc/check-alignment

/Users/markmiller/src/ongithub/endojs/endo/packages/ses/src/compartment.js
  340:3  warning  Missing JSDoc @param "args" declaration  jsdoc/require-param
```

The first was trivial. The second was caused by an accidental split of a doc-comment into two. Repairing that, the missing args declaration had an incorrect "...". Fixing both of those, local `yarn lint` is now clean.

### Security Considerations

none
### Scaling Considerations

none
### Documentation Considerations

none
### Testing Considerations

none
### Compatibility Considerations

none. That is, unless something outside the endo repo relied on the mistakenly hidden type decl being absent. Unlikely.

### Upgrade Considerations

none.