### PR TITLE
fix(compartment-mapper,bundle-source): Improve error diagnostic for nameless packages

### DIFF
--- a/packages/bundle-source/demo/endo/package.json
+++ b/packages/bundle-source/demo/endo/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "dependencies": {
     "@endo/marshal": "*"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/bundle-source/demo/endo/package.json
+++ b/packages/bundle-source/demo/endo/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "endo-marshal-demo",
+  "private": true,
   "type": "module",
   "dependencies": {
     "@endo/marshal": "*"

--- a/packages/bundle-source/demo/node_modules/conditional-exports/package.json
+++ b/packages/bundle-source/demo/node_modules/conditional-exports/package.json
@@ -5,5 +5,8 @@
   "exports": {
     "a": "./a.js",
     "b": "./b.js"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/bundle-source/demo/node_modules/conditional-reexports/package.json
+++ b/packages/bundle-source/demo/node_modules/conditional-reexports/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "dependencies": {
     "conditional-exports": "*"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
   }
 }

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -199,12 +199,13 @@ export const basename = location => {
 };
 
 /**
- * Asserts that the given value is a `PackageDescriptor`.
+ * Asserts that the given value is a plain-object `PackageDescriptor`.
  *
- * TODO: This only validates that the value is a plain object. As mentioned in
- * {@link PackageDescriptor}, `name` is currently a required field, but in the
- * real world this is not so. We _do_ make assumptions about the shape of a
- * `PackageDescriptor`, but it may not be worth eagerly validating further.
+ * Note: this does _not_ enforce the presence of a `name`. Callers that adopt
+ * a descriptor as the root of a compartment must additionally call
+ * {@link assertPackageDescriptorHasName} so that the diagnostic blames the
+ * correct `package.json`.
+ *
  * @param {unknown} allegedPackageDescriptor
  * @returns {asserts allegedPackageDescriptor is PackageDescriptor}
  */
@@ -214,6 +215,33 @@ const assertPackageDescriptor = allegedPackageDescriptor => {
       Object(allegedPackageDescriptor) === allegedPackageDescriptor,
     `Package descriptor must be a plain object, got ${q(allegedPackageDescriptor)}`,
   );
+};
+
+/**
+ * Asserts that the given `PackageDescriptor` has a non-empty `name`.
+ *
+ * `name` is required by {@link PackageDescriptor} and the compartment mapper
+ * relies on it to label and link compartments. Without it, downstream
+ * failures are obscure (for example, the bundler reports an undefined name
+ * far from the offending `package.json`). This surfaces a precise
+ * diagnostic that points at the offending file so the misconfiguration
+ * is easy to fix.
+ *
+ * @param {PackageDescriptor} packageDescriptor
+ * @param {string} packageDescriptorLocation - URL of the `package.json`
+ * file that produced this descriptor, used to attribute errors.
+ * @returns {void}
+ */
+const assertPackageDescriptorHasName = (
+  packageDescriptor,
+  packageDescriptorLocation,
+) => {
+  const { name } = packageDescriptor;
+  if (name === undefined || name === '') {
+    throw Error(
+      `package.json at ${q(packageDescriptorLocation)} must have a "name" field; consider naming it after the parent directory`,
+    );
+  }
 };
 
 /**
@@ -229,6 +257,11 @@ const readDescriptor = async (maybeRead, packageLocation) => {
   }
   const descriptorText = decoder.decode(descriptorBytes);
   const descriptor = parseLocatedJson(descriptorText, descriptorLocation);
+  // Only validate plain-object shape here. The `name` requirement is enforced
+  // separately at sites that adopt a descriptor as the root of a compartment,
+  // because `readDescriptorUpwards` legitimately reads ancestor `package.json`
+  // files (e.g., declaring `type: "module"` for sub-folder module resolution)
+  // that are not themselves package roots.
   assertPackageDescriptor(descriptor);
   return descriptor;
 };
@@ -282,6 +315,13 @@ const findPackage = async (readDescriptor, canonical, directory, name) => {
     // eslint-disable-next-line no-await-in-loop
     const packageDescriptor = await readDescriptor(packageLocation);
     if (packageDescriptor !== undefined) {
+      // Surface a precise diagnostic when a node_modules dependency lacks a
+      // "name". This is a strict requirement of the compartment mapper that
+      // would otherwise produce an obscure failure deep in the bundler.
+      assertPackageDescriptorHasName(
+        packageDescriptor,
+        resolveLocation('package.json', packageLocation),
+      );
       return { packageLocation, packageDescriptor };
     }
 
@@ -753,6 +793,10 @@ const graphPackages = async (
   }
 
   assertPackageDescriptor(allegedPackageDescriptor);
+  assertPackageDescriptorHasName(
+    allegedPackageDescriptor,
+    resolveLocation('package.json', packageLocation),
+  );
   const packageDescriptor = allegedPackageDescriptor;
 
   conditions = new Set(conditions || []);
@@ -1518,6 +1562,7 @@ export const mapNodeModules = async (
   )(packageDescriptorText, packageDescriptorLocation);
 
   assertPackageDescriptor(packageDescriptor);
+  assertPackageDescriptorHasName(packageDescriptor, packageDescriptorLocation);
   assertFileUrlString(packageLocation);
 
   return compartmentMapForNodeModules_(

--- a/packages/compartment-mapper/test/fixtures-no-name/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-no-name/node_modules/app/index.js
@@ -1,0 +1,1 @@
+export { default } from 'no-name-pkg';

--- a/packages/compartment-mapper/test/fixtures-no-name/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-no-name/node_modules/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "module",
+  "dependencies": {
+    "no-name-pkg": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-no-name/node_modules/no-name-pkg/index.js
+++ b/packages/compartment-mapper/test/fixtures-no-name/node_modules/no-name-pkg/index.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/compartment-mapper/test/fixtures-no-name/node_modules/no-name-pkg/package.json
+++ b/packages/compartment-mapper/test/fixtures-no-name/node_modules/no-name-pkg/package.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "main": "./index.js",
+  "type": "module",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/no-name.test.js
+++ b/packages/compartment-mapper/test/no-name.test.js
@@ -1,0 +1,64 @@
+// @ts-check
+import 'ses';
+import fs from 'fs';
+import url from 'url';
+import test from 'ava';
+
+import { makeBundle } from '../bundle.js';
+import { mapNodeModules } from '../node-modules.js';
+import { makeReadPowers } from '../node-powers.js';
+
+const readPowers = makeReadPowers({ fs, url });
+
+const escapeRegex = /** @param {string} s */ s =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const dependencyEntry = new URL(
+  'fixtures-no-name/node_modules/app/index.js',
+  import.meta.url,
+).toString();
+
+const noNameEntry = new URL(
+  'fixtures-no-name/node_modules/no-name-pkg/index.js',
+  import.meta.url,
+).toString();
+
+const dependencyDescriptorLocation = new URL(
+  'fixtures-no-name/node_modules/no-name-pkg/package.json',
+  import.meta.url,
+).toString();
+
+const entryDescriptorLocation = new URL(
+  'fixtures-no-name/node_modules/no-name-pkg/package.json',
+  import.meta.url,
+).toString();
+
+test('mapNodeModules: dependency package.json without "name" yields a precise diagnostic', async t => {
+  await t.throwsAsync(mapNodeModules(readPowers, dependencyEntry), {
+    message: new RegExp(
+      `package\\.json at "${escapeRegex(
+        dependencyDescriptorLocation,
+      )}" must have a "name" field`,
+    ),
+  });
+});
+
+test('mapNodeModules: entry package.json without "name" yields a precise diagnostic', async t => {
+  await t.throwsAsync(mapNodeModules(readPowers, noNameEntry), {
+    message: new RegExp(
+      `package\\.json at "${escapeRegex(
+        entryDescriptorLocation,
+      )}" must have a "name" field`,
+    ),
+  });
+});
+
+test('makeBundle: dependency package.json without "name" yields a precise diagnostic', async t => {
+  await t.throwsAsync(makeBundle(readPowers.read, dependencyEntry), {
+    message: new RegExp(
+      `package\\.json at "${escapeRegex(
+        dependencyDescriptorLocation,
+      )}" must have a "name" field`,
+    ),
+  });
+});


### PR DESCRIPTION
Closes: #1845

## Description

When a `package.json` lacks a `name` field, the compartment mapper previously produced cryptic downstream failures: a bundler error of the form `Cannot import name X (has ...)`, or a compartment with `name: undefined` whose location was not reported anywhere. This change surfaces a precise diagnostic at the point the offending descriptor is adopted as the root of a compartment, blaming the file by URL and suggesting a fix.

The new error reads:

```
package.json at "file:///.../no-name-pkg/package.json" must have a "name" field; consider naming it after the parent directory
```

A new helper `assertPackageDescriptorHasName(packageDescriptor, packageDescriptorLocation)` lives in `packages/compartment-mapper/src/node-modules.js` and is invoked at the three sites that adopt a descriptor as the root of a compartment: `mapNodeModules` for the entry package's `package.json`, `graphPackages` as a defensive double-check on the entry package, and `findPackage` for every dependency discovered under `node_modules/`.

`assertPackageDescriptor` is unchanged structurally and still validates plain-object shape without requiring `name`, so `readDescriptorUpwards` can continue to walk ancestor `package.json` files that legitimately exist only to declare `type: "module"` for sub-folder module resolution. The existing `nested-pkg` test continues to pass.

A new fixture under `packages/compartment-mapper/test/fixtures-no-name/` and three regression tests in `packages/compartment-mapper/test/no-name.test.js` cover the entry-package, dependency, and bundler paths. Reverting the new check causes all three to fail with the original cryptic outputs, confirming they are load-bearing.

A second commit names the previously-anonymous `packages/bundle-source/demo/endo/package.json` fixture (`name: "endo-demo"`, `private: true`) so that the new diagnostic does not fire on `bundle-source`'s own `marshal-failure.test.js`.

### Security Considerations

No impact.

### Scaling Considerations

No impact.

### Documentation Considerations

No impact. The error message itself is the user-facing documentation of the new requirement.

### Testing Considerations

The new fixture and `no-name.test.js` cover the three call sites that adopt a descriptor. The unrelated `bundle-source` demo fixture was renamed in a separate commit to keep the two concerns reviewable independently.

### Compatibility Considerations

A `package.json` that participates in the compartment graph and lacks a `name` now produces an error rather than a silent miscompile. Any consumer that relied on the previous undefined-name behavior will see a clear diagnostic and can add the missing field. Ancestor `package.json` files that exist only to declare `type: "module"` are unaffected.

### Upgrade Considerations

No impact.
