### PR TITLE
fix(lockdown): tame TextDecoder fast-path symbols

### DIFF
--- a/.changeset/lockdown-text-decoder-fast-path.md
+++ b/.changeset/lockdown-text-decoder-fast-path.md
@@ -1,0 +1,17 @@
+---
+'@endo/lockdown': patch
+---
+
+Fix `TypeError: Cannot assign to read only property 'Symbol(kUTF8FastPath)'`
+(and the analogous `kWindows1252FastPath` variant) when calling `decode()` on a
+hardened `TextDecoder` instance under recent Node.js releases.
+
+Node stores per-instance "fast path" flags as own data properties keyed by
+internal symbols and mutates them on every `decode()` call. Once the instance
+was hardened the flags became non-writable and the next `decode()` threw. The
+post-lockdown setup now wraps `globalThis.TextDecoder` so that the affected
+flags are exposed via accessor properties on `TextDecoder.prototype`, backed by
+a `WeakMap`. The accessor only honors writes that lower the flag, matching
+Node's own one-way `&&=` semantics, and so does not introduce a covert channel
+beyond the one already observable on an unhardened instance. See
+https://github.com/endojs/endo/issues/2813.

--- a/packages/init/test/text-decoder.test.js
+++ b/packages/init/test/text-decoder.test.js
@@ -1,0 +1,65 @@
+// @ts-nocheck
+
+// Use a package self-reference to go through the "exports" resolution and
+// install the hardened environment exactly the way an `@endo/init` consumer
+// would see it.
+import '@endo/init';
+import test from 'ava';
+
+// Regression tests for https://github.com/endojs/endo/issues/2813.
+// Recent Node.js releases store private "fast path" flags on each TextDecoder
+// instance as own data properties keyed by symbols (e.g. `kUTF8FastPath`,
+// `kWindows1252FastPath`). The `decode()` method mutates these flags via
+// `&&=`, so once a TextDecoder instance is hardened the subsequent decode
+// call would throw. The patch in `@endo/lockdown/post.js` migrates these flags
+// to accessor properties on the prototype that are backed by a WeakMap.
+
+const bytes = (...values) => Uint8Array.of(...values);
+const HELLO = bytes(72, 101, 108, 108, 111);
+
+for (const encoding of [
+  'utf-8',
+  'ascii',
+  'latin1',
+  'iso-8859-1',
+  'windows-1252',
+]) {
+  test(`hardened TextDecoder('${encoding}') decodes`, t => {
+    const decoder = harden(new TextDecoder(encoding, { fatal: true }));
+    t.is(decoder.decode(HELLO), 'Hello');
+    // Decoding twice exercises the fast-path branch a second time.
+    t.is(decoder.decode(HELLO), 'Hello');
+  });
+}
+
+test('hardened TextDecoder decodes with stream option', t => {
+  // The `stream: true` path is the case that toggles the fast-path flag from
+  // `true` to `false`, which is precisely the assignment that used to throw on
+  // a hardened instance.
+  const decoder = harden(new TextDecoder('utf-8'));
+  const part1 = decoder.decode(bytes(0xe2, 0x82), { stream: true });
+  const part2 = decoder.decode(bytes(0xac));
+  t.is(part1 + part2, '€');
+});
+
+test('hardened TextDecoder for an encoding without a fast path still works', t => {
+  const decoder = harden(new TextDecoder('utf-16le'));
+  t.is(decoder.decode(bytes(72, 0, 105, 0)), 'Hi');
+});
+
+test('non-hardened TextDecoder still decodes normally', t => {
+  const decoder = new TextDecoder('utf-8');
+  t.is(decoder.decode(HELLO), 'Hello');
+});
+
+test('TextDecoder subclass instances can be hardened and decoded', t => {
+  class MyDecoder extends TextDecoder {}
+  const decoder = harden(new MyDecoder('ascii'));
+  t.true(decoder instanceof MyDecoder);
+  t.true(decoder instanceof TextDecoder);
+  t.is(decoder.decode(HELLO), 'Hello');
+});
+
+test('calling TextDecoder without `new` still throws', t => {
+  t.throws(() => TextDecoder('utf-8'), { instanceOf: TypeError });
+});

--- a/packages/lockdown/post.js
+++ b/packages/lockdown/post.js
@@ -1,10 +1,18 @@
 /* global globalThis */
 
+import { patchTextDecoderFastPath } from './text-decoder-fast-path-patch.js';
+
 // The post lockdown thunk.
 export default () => {
   // Even on non-v8, we tame the start compartment's Error constructor so
   // this assignment is not rejected, even if it does nothing.
   Error.stackTraceLimit = Infinity;
+
+  // Mitigate https://github.com/endojs/endo/issues/2813. Must precede the
+  // `harden(globalThis.TextDecoder)` below so that the wrapped constructor and
+  // the accessors it installs on `TextDecoder.prototype` are part of the
+  // hardened object graph.
+  patchTextDecoderFastPath();
 
   harden(globalThis.TextEncoder); // Absent in eshost
   harden(globalThis.TextDecoder); // Absent in eshost

--- a/packages/lockdown/text-decoder-fast-path-patch.js
+++ b/packages/lockdown/text-decoder-fast-path-patch.js
@@ -1,0 +1,159 @@
+// @ts-nocheck
+/* global globalThis */
+
+// Node.js stores private "fast path" flags on each `TextDecoder` instance as
+// own data properties keyed by symbols such as `Symbol(kUTF8FastPath)` and
+// `Symbol(kWindows1252FastPath)`. The `decode()` method mutates these flags via
+// a logical-and-assignment of the form
+//
+//   this[kUTF8FastPath] &&= !options?.stream;
+//
+// Once a `TextDecoder` instance is hardened the own data properties become
+// non-writable, so any subsequent `decode()` call that would re-assign one of
+// the flags throws a TypeError. The bug surfaces for any encoding whose initial
+// fast-path flag is `true` (e.g. `'utf-8'`, `'ascii'`, `'latin1'`,
+// `'iso-8859-1'`, `'windows-1252'`).
+//
+// See https://github.com/endojs/endo/issues/2813 and
+// https://github.com/nodejs/node/pull/55275.
+//
+// Mitigation: replace the per-instance own data properties with accessors
+// defined on `TextDecoder.prototype`, backed by a `WeakMap`. The `decode()`
+// implementation can then read and write these flags freely even when the
+// instance is frozen. Because Node only ever toggles the flags from `true` to
+// `false` (a logical AND can never re-enable a falsy flag), the setter only
+// honors writes that lower the flag. This preserves Node's observable
+// semantics and limits the patched accessor to a single one-way bit per
+// instance — the same observability already available on an unhardened
+// instance — so it does not introduce a new covert channel between holders of
+// the same `TextDecoder`.
+export const patchTextDecoderFastPath = () => {
+  const NativeTextDecoder = globalThis.TextDecoder;
+  if (typeof NativeTextDecoder !== 'function') {
+    return;
+  }
+
+  let probe;
+  try {
+    probe = new NativeTextDecoder();
+  } catch (_err) {
+    return;
+  }
+
+  const ownSymbols = Object.getOwnPropertySymbols(probe);
+  const fastPathSymbols = ownSymbols.filter(sym => {
+    const { description } = sym;
+    return (
+      typeof description === 'string' &&
+      description.startsWith('k') &&
+      description.endsWith('FastPath')
+    );
+  });
+
+  if (fastPathSymbols.length === 0) {
+    return;
+  }
+
+  const proto = NativeTextDecoder.prototype;
+
+  // Bail out if `TextDecoder.prototype` is already frozen (e.g. an outer
+  // lockdown has already run). In that case we cannot install accessors and
+  // the original bug remains, but at least we do not throw.
+  if (Object.isFrozen(proto)) {
+    return;
+  }
+
+  // One state object per `TextDecoder` instance, keyed in a `WeakMap` so that
+  // hardening the instance does not pin the state.
+  const states = new WeakMap();
+
+  const ensureState = instance => {
+    let state = states.get(instance);
+    if (state === undefined) {
+      state = Object.create(null);
+      states.set(instance, state);
+    }
+    return state;
+  };
+
+  for (const sym of fastPathSymbols) {
+    const existing = Object.getOwnPropertyDescriptor(proto, sym);
+    if (existing && !existing.configurable) {
+      // Cannot install our accessor; skip this symbol.
+      continue;
+    }
+    Object.defineProperty(proto, sym, {
+      get() {
+        const state = states.get(this);
+        return state === undefined ? undefined : state[sym];
+      },
+      set(value) {
+        // Node toggles the flag from `true` to `false` via `&&=`; it never
+        // raises a falsy flag back to `true`. Honor only the lowering write
+        // so the accessor is not usable as a multi-bit covert channel.
+        if (value === false) {
+          ensureState(this)[sym] = false;
+        }
+      },
+      enumerable: false,
+      configurable: true,
+    });
+  }
+
+  // Wrap the constructor so freshly-constructed instances expose the flags via
+  // the prototype accessors rather than as own data properties.
+  function TextDecoder(...args) {
+    if (new.target === undefined) {
+      // Match the native class's "cannot be invoked without 'new'" behavior.
+      // Delegating to `Reflect.construct(NativeTextDecoder, [])` would raise
+      // the appropriate `TypeError`.
+      Reflect.apply(NativeTextDecoder, undefined, args);
+      // The line above is expected to throw; bail just in case it does not.
+      throw TypeError(`Constructor TextDecoder requires 'new'`);
+    }
+    const decoder = Reflect.construct(NativeTextDecoder, args, new.target);
+    const state = ensureState(decoder);
+    for (const sym of fastPathSymbols) {
+      const desc = Object.getOwnPropertyDescriptor(decoder, sym);
+      if (desc && 'value' in desc && desc.configurable) {
+        state[sym] = desc.value;
+        delete decoder[sym];
+      }
+    }
+    return decoder;
+  }
+
+  Object.defineProperty(TextDecoder, 'prototype', {
+    value: proto,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  Object.defineProperty(TextDecoder, 'name', {
+    value: NativeTextDecoder.name,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  Object.defineProperty(TextDecoder, 'length', {
+    value: NativeTextDecoder.length,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  Object.setPrototypeOf(TextDecoder, Object.getPrototypeOf(NativeTextDecoder));
+
+  // Replace the prototype's `constructor` back-link so that
+  // `instance.constructor === globalThis.TextDecoder`.
+  const ctorDesc = Object.getOwnPropertyDescriptor(proto, 'constructor');
+  if (ctorDesc && ctorDesc.configurable) {
+    Object.defineProperty(proto, 'constructor', {
+      value: TextDecoder,
+      writable: ctorDesc.writable !== false,
+      enumerable: ctorDesc.enumerable === true,
+      configurable: true,
+    });
+  }
+
+  globalThis.TextDecoder = TextDecoder;
+};


### PR DESCRIPTION
Recent Node.js releases (20.18.3+, 22.15.1+, 24.x) store private
"fast path" flags on each TextDecoder instance as own data properties
keyed by `Symbol(kUTF8FastPath)` and `Symbol(kWindows1252FastPath)`.
The decode() method mutates these flags via `&&=`, so once a
TextDecoder instance was hardened the next decode() call threw
`TypeError: Cannot assign to read only property` for any encoding
whose initial flag is `true` (utf-8, ascii, latin1, iso-8859-1,
windows-1252).

Following Mathieu's suggestion in the bug report, replace the
per-instance own data properties with prototype accessors backed by
a WeakMap. The setter only honors writes that lower the flag, which
matches Node's one-way `&&=` semantics and avoids introducing a new
covert channel beyond what is already observable on an unhardened
instance.

Closes: https://github.com/endojs/endo/issues/2813