### PR TITLE
ci: add zizmor workflow audit and harden workflows to pass at pedantic persona

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -28,3 +30,5 @@ updates:
       interval: weekly
     commit-message:
       prefix: chore
+    cooldown:
+      default-days: 7

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 # Cancel in-progress runs for the same branch when a new run is started
 concurrency:

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 18
       - name: Provide yarn # yarn is missing in the Selenium image

--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Put unstable chrome where playwright would look for it
         run: mv /opt/google/chrome /opt/google/chrome-unstable
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,8 +423,10 @@ jobs:
       - name: Choose XS download or build
         if: steps.restore-xs.outputs.cache-hit != 'true'
         id: check-release
+        env:
+          MODDABLE_VERSION: ${{ matrix.moddable-version }}
         run: |
-          if curl -f -s -o /dev/null -I -L https://api.github.com/repos/Moddable-OpenSource/moddable/releases/tags/${{ matrix.moddable-version }}
+          if curl -f -s -o /dev/null -I -L "https://api.github.com/repos/Moddable-OpenSource/moddable/releases/tags/${MODDABLE_VERSION}"
           then
             echo release=download
           else
@@ -433,8 +435,10 @@ jobs:
 
       - name: Download XS
         if: steps.check-release.outputs.release == 'download'
+        env:
+          MODDABLE_VERSION: ${{ matrix.moddable-version }}
         run: |
-          wget "https://github.com/Moddable-OpenSource/moddable/releases/download/${{ matrix.moddable-version }}/xst-lin64.zip"
+          wget "https://github.com/Moddable-OpenSource/moddable/releases/download/${MODDABLE_VERSION}/xst-lin64.zip"
           unzip xst-lin64.zip -d bin
           mkdir -p bin
           chmod 755 bin/xst

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: yarn
@@ -88,7 +88,7 @@ jobs:
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -156,7 +156,7 @@ jobs:
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -195,7 +195,7 @@ jobs:
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -233,7 +233,7 @@ jobs:
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -270,7 +270,7 @@ jobs:
       - run: corepack enable
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: yarn
@@ -301,7 +301,7 @@ jobs:
       - run: corepack enable
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: yarn
@@ -311,7 +311,7 @@ jobs:
 
       - name: Detect workflow changes
         id: paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
             workflows:
@@ -343,7 +343,7 @@ jobs:
       - run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -393,7 +393,7 @@ jobs:
         working-directory: endo
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -487,7 +487,7 @@ jobs:
         working-directory: endo
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20.x
           cache: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ on:
     branches: [master]
   pull_request:
 
-# Minimal permissions for workflows and jobs (cache uses actions API).
+# Minimal permissions for workflows and jobs. `actions/cache` and
+# `setup-node`'s `cache: yarn` use the runner's built-in cache service,
+# which is authenticated independently of the `actions:` permission;
+# `contents: read` is sufficient for every job below.
 permissions:
   contents: read
-  actions: write
 
 # Cancel in-progress runs for the same branch when a new run is started
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -79,6 +81,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -145,6 +149,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -182,6 +188,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -218,6 +226,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -253,6 +263,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -282,6 +294,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -322,6 +336,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -370,6 +386,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: endo
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
@@ -429,6 +446,7 @@ jobs:
           repository: moddable-OpenSource/moddable
           ref: ${{ matrix.moddable-version }}
           path: moddable
+          persist-credentials: false
 
       - name: Build XS
         if: steps.check-release.outputs.release == 'build'
@@ -454,6 +472,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: endo
+          persist-credentials: false
 
       - name: Checkout OCapN Test Suite
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -462,6 +481,7 @@ jobs:
           repository: ocapn/ocapn-test-suite
           ref: 74db78f08a40efba1e2b975d809374ff0e7acf60
           path: ocapn-test-suite
+          persist-credentials: false
 
       - run: corepack enable
         working-directory: endo

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -28,7 +28,7 @@ jobs:
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 18.x
       - name: Install graphviz

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: 'true'
+          persist-credentials: false
 
       # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable

--- a/.github/workflows/ocapn-guile-interop.yml
+++ b/.github/workflows/ocapn-guile-interop.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: endo
+          persist-credentials: false
 
       - name: Clone Spritely Goblins + goblin-chat from Codeberg
         run: |

--- a/.github/workflows/ocapn-guile-interop.yml
+++ b/.github/workflows/ocapn-guile-interop.yml
@@ -64,7 +64,7 @@ jobs:
         working-directory: endo
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20.x
           cache: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,22 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-permissions:
-  contents: write
-  pull-requests: write
+# Default to no permissions at the workflow level so any new job added
+# in the future has to opt in explicitly. The `release` job below
+# enumerates the writes it actually needs.
+permissions: {}
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # `changesets/action` pushes tags and creates/updates the release PR,
+    # so the job needs `contents: write` and `pull-requests: write`. Keep
+    # the grants on the job (not the workflow) so they cannot leak into
+    # any future sibling job.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         # zizmor: ignore[artipacked]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # `changesets/action` pushes tags and creates/updates the release PR,
-    # so the job needs `contents: write` and `pull-requests: write`. Keep
-    # the grants on the job (not the workflow) so they cannot leak into
-    # any future sibling job.
+    # Keep the grants on the job (not the workflow) so they cannot leak
+    # into any future sibling job.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # `changesets/action` pushes release tags
+      pull-requests: write # `changesets/action` creates/updates the release PR
     steps:
       - name: Checkout Repo
         # zizmor: ignore[artipacked]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         # without this, setup-node errors on mismatched yarn versions
       - run: corepack enable
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
+        # zizmor: ignore[artipacked]
+        # `changesets/action` (below) and the `git config` step rely on the
+        # persisted `RELEASE_TOKEN` to push tags and the release PR back to
+        # this repository, so credential persistence is intentional here.
+        # This workflow runs only on `push: master`, never on PR-triggered
+        # untrusted code, and uploads no artifacts that could leak `.git/`.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - run: corepack enable
 
       - name: Setup Node.js 20
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: yarn
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         # This action will create/update Changesets' Release PR *or* create a
         # GitHub Release and tags if its Release PR was just merged
-        uses: changesets/action@c48e67d110a68bc90ccf1098e9646092baacaa87 # v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           publish: yarn changeset tag
           createGithubReleases: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,12 @@ on:
     branches:
       - master
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Serialize release runs on the same ref but never cancel an
+# in-progress release: a cancelled `changesets/action` may leave tags
+# pushed without their matching GitHub release, or vice versa.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 # Default to no permissions at the workflow level so any new job added
 # in the future has to opt in explicitly. The `release` job below

--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
   actions: read
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -36,10 +35,12 @@ jobs:
           path: ./api-docs # the "out" path in typedoc.json
   deploy:
     runs-on: ubuntu-latest
-    # Job-level permissions override the workflow-level block (they do not
-    # merge), so `id-token: write` is enumerated here even while it is also
-    # still declared at the workflow level. A subsequent commit removes the
-    # workflow-level `id-token: write` so this becomes the sole grant.
+    # Only the deploy step (`actions/deploy-pages`) mints an OIDC token and
+    # writes to Pages. Keeping these grants on the deploy job — not the
+    # workflow — ensures the `build` job's dependency graph (TypeDoc, yarn
+    # install) cannot reach an `id-token: write` context, which is the
+    # primary surface for OIDC-extraction supply-chain attacks of the
+    # TanStack / tj-actions class.
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  actions: read
+  contents: read # checkout source for `yarn docs`
+  actions: read # `actions/configure-pages` reads workflow-run metadata
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -37,15 +37,14 @@ jobs:
           path: ./api-docs # the "out" path in typedoc.json
   deploy:
     runs-on: ubuntu-latest
-    # Only the deploy step (`actions/deploy-pages`) mints an OIDC token and
-    # writes to Pages. Keeping these grants on the deploy job — not the
-    # workflow — ensures the `build` job's dependency graph (TypeDoc, yarn
-    # install) cannot reach an `id-token: write` context, which is the
-    # primary surface for OIDC-extraction supply-chain attacks of the
+    # Keeping these grants on the deploy job — not the workflow —
+    # ensures the `build` job's dependency graph (TypeDoc, yarn install)
+    # cannot reach an `id-token: write` context, which is the primary
+    # surface for OIDC-extraction supply-chain attacks of the
     # TanStack / tj-actions class.
     permissions:
-      pages: write
-      id-token: write
+      pages: write # `actions/deploy-pages` publishes the built site
+      id-token: write # `actions/deploy-pages` mints an OIDC token to authenticate
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
   actions: read
-  pages: write
   id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
@@ -37,6 +36,13 @@ jobs:
           path: ./api-docs # the "out" path in typedoc.json
   deploy:
     runs-on: ubuntu-latest
+    # Job-level permissions override the workflow-level block (they do not
+    # merge), so `id-token: write` is enumerated here even while it is also
+    # still declared at the workflow level. A subsequent commit removes the
+    # workflow-level `id-token: write` so this becomes the sole grant.
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/typedoc-gh-pages.yml
+++ b/.github/workflows/typedoc-gh-pages.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
       # Without this, setup-node errors on mismatched yarn versions
       - run: corepack enable

--- a/.github/workflows/update-action-pins-major.yml
+++ b/.github/workflows/update-action-pins-major.yml
@@ -16,11 +16,9 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
-    # `peter-evans/create-pull-request` pushes the chore branch and opens
-    # the PR; both grants are required for that single action.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # `peter-evans/create-pull-request` pushes the chore branch
+      pull-requests: write # `peter-evans/create-pull-request` opens the PR
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/update-action-pins-major.yml
+++ b/.github/workflows/update-action-pins-major.yml
@@ -5,9 +5,9 @@ on:
     - cron: '0 3 1 * *' # Monthly on the 1st
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+# Default to no permissions at the workflow level; the `update` job
+# below enumerates the writes it actually needs.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,6 +16,11 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    # `peter-evans/create-pull-request` pushes the chore branch and opens
+    # the PR; both grants are required for that single action.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/update-action-pins-major.yml
+++ b/.github/workflows/update-action-pins-major.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # `peter-evans/create-pull-request` accepts its own `token` input
+          # (default `${{ github.token }}`) for the branch push and PR
+          # creation; it does not rely on credentials persisted into
+          # `.git/config` by checkout.
+          persist-credentials: false
       - name: Enable Corepack
         run: corepack enable
       - name: Use Node.js

--- a/.github/workflows/update-action-pins-major.yml
+++ b/.github/workflows/update-action-pins-major.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: yarn
@@ -37,7 +37,7 @@ jobs:
       - name: Update action pins (major)
         run: node scripts/update-action-pins.mjs --major --report /tmp/action-pin-report.md
       - name: Create pull request
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: 'chore: update action pins (major)'
           title: 'chore: update action pins (major)'

--- a/.github/workflows/update-action-pins.yml
+++ b/.github/workflows/update-action-pins.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
           cache: yarn
@@ -37,7 +37,7 @@ jobs:
       - name: Update action pins
         run: node scripts/update-action-pins.mjs --report /tmp/action-pin-report.md
       - name: Create pull request
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: 'chore: update action pins'
           title: 'chore: update action pins'

--- a/.github/workflows/update-action-pins.yml
+++ b/.github/workflows/update-action-pins.yml
@@ -16,11 +16,9 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
-    # `peter-evans/create-pull-request` pushes the chore branch and opens
-    # the PR; both grants are required for that single action.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # `peter-evans/create-pull-request` pushes the chore branch
+      pull-requests: write # `peter-evans/create-pull-request` opens the PR
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/update-action-pins.yml
+++ b/.github/workflows/update-action-pins.yml
@@ -5,9 +5,9 @@ on:
     - cron: '0 3 * * 1' # Weekly on Monday
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+# Default to no permissions at the workflow level; the `update` job
+# below enumerates the writes it actually needs.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,6 +16,11 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    # `peter-evans/create-pull-request` pushes the chore branch and opens
+    # the PR; both grants are required for that single action.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/update-action-pins.yml
+++ b/.github/workflows/update-action-pins.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # `peter-evans/create-pull-request` accepts its own `token` input
+          # (default `${{ github.token }}`) for the branch push and PR
+          # creation; it does not rely on credentials persisted into
+          # `.git/config` by checkout.
+          persist-credentials: false
       - name: Enable Corepack
         run: corepack enable
       - name: Use Node.js

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,46 @@
+name: Workflow security audit
+
+# Static analysis of GitHub Actions workflows using zizmor
+# (https://docs.zizmor.sh/). Surfaces the workflow-level patterns that
+# enable supply-chain attacks like the TanStack May 2026 npm compromise:
+# `pull_request_target` "Pwn Request", template injection, excessive
+# permissions, OIDC token exposure, cache poisoning, and unpinned uses.
+#
+# Initial gate is set to fail only on `high` severity so the noise floor
+# from existing medium findings does not block PRs. Once those are
+# addressed in follow-ups, tighten `min-severity` to `medium`.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # Block only on high-severity findings until existing medium
+          # warnings (mostly `artipacked` on checkout steps) are cleaned up.
+          min-severity: high
+          # `advanced-security: true` would upload SARIF to GitHub Code
+          # Scanning, which requires Advanced Security to be enabled on the
+          # repository and `security-events: write` on this job. Until that
+          # is set up, emit inline PR annotations instead.
+          advanced-security: 'false'
+          annotations: 'true'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,14 +6,14 @@ name: Workflow security audit
 # `pull_request_target` "Pwn Request", template injection, excessive
 # permissions, OIDC token exposure, cache poisoning, and unpinned uses.
 #
-# Gate is set to `min-severity: low`. At the `regular` persona, no
-# additional audits fire at `low` or `informational` beyond the ones
-# already covered at `medium`, so this is functionally equivalent today
-# — but it tightens the floor for any future audits that land in those
-# tiers without requiring a follow-up PR. To surface more findings now,
-# switch `persona:` to `pedantic` (catches scope-to-job-level
-# permission improvements) or `auditor` (adds defense-in-depth
-# recommendations like `secrets-outside-env`).
+# Gate is `persona: pedantic` + `min-severity: low`. Pedantic surfaces
+# "code smell" findings beyond what `regular` catches — most notably
+# `excessive-permissions` at the workflow level when grants could live
+# on a single job, `template-injection` from `${{ }}` expansion in
+# `run:` blocks, and `undocumented-permissions`. To tighten further,
+# switch `persona:` to `auditor`, which adds defense-in-depth
+# recommendations like `secrets-outside-env` (wrap publish secrets in
+# a deployment environment with required reviewers).
 
 on:
   push:
@@ -40,6 +40,7 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
+          persona: pedantic
           min-severity: low
           # `advanced-security: true` would upload SARIF to GitHub Code
           # Scanning, which requires Advanced Security to be enabled on the

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,9 +6,12 @@ name: Workflow security audit
 # `pull_request_target` "Pwn Request", template injection, excessive
 # permissions, OIDC token exposure, cache poisoning, and unpinned uses.
 #
-# Initial gate is set to fail only on `high` severity so the noise floor
-# from existing medium findings does not block PRs. Once those are
-# addressed in follow-ups, tighten `min-severity` to `medium`.
+# Gate is set to `min-severity: medium`, which blocks on the audits most
+# directly relevant to the TanStack-class attack chain (dangerous
+# triggers, excessive permissions, template injection, OIDC exposure,
+# artipacked credential persistence). To tighten further, drop to `low`
+# or `informational` after auditing the additional findings those levels
+# surface.
 
 on:
   push:
@@ -35,9 +38,7 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
-          # Block only on high-severity findings until existing medium
-          # warnings (mostly `artipacked` on checkout steps) are cleaned up.
-          min-severity: high
+          min-severity: medium
           # `advanced-security: true` would upload SARIF to GitHub Code
           # Scanning, which requires Advanced Security to be enabled on the
           # repository and `security-events: write` on this job. Until that

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,12 +6,14 @@ name: Workflow security audit
 # `pull_request_target` "Pwn Request", template injection, excessive
 # permissions, OIDC token exposure, cache poisoning, and unpinned uses.
 #
-# Gate is set to `min-severity: medium`, which blocks on the audits most
-# directly relevant to the TanStack-class attack chain (dangerous
-# triggers, excessive permissions, template injection, OIDC exposure,
-# artipacked credential persistence). To tighten further, drop to `low`
-# or `informational` after auditing the additional findings those levels
-# surface.
+# Gate is set to `min-severity: low`. At the `regular` persona, no
+# additional audits fire at `low` or `informational` beyond the ones
+# already covered at `medium`, so this is functionally equivalent today
+# — but it tightens the floor for any future audits that land in those
+# tiers without requiring a follow-up PR. To surface more findings now,
+# switch `persona:` to `pedantic` (catches scope-to-job-level
+# permission improvements) or `auditor` (adds defense-in-depth
+# recommendations like `secrets-outside-env`).
 
 on:
   push:
@@ -38,7 +40,7 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
-          min-severity: medium
+          min-severity: low
           # `advanced-security: true` would upload SARIF to GitHub Code
           # Scanning, which requires Advanced Security to be enabled on the
           # repository and `security-events: write` on this job. Until that


### PR DESCRIPTION
## Summary

Introduces [`zizmor`](https://docs.zizmor.sh/) as a CI check that statically audits every workflow under `.github/workflows/**` on each PR and on pushes to `master`, then ratchets the existing workflows up to pass cleanly under the `pedantic` persona at `min-severity: low`. The intent is to convert the workflow-hardening conventions this repo already follows (no `pull_request_target`, no PR-context OIDC, SHA-pinned actions) from aspirational into enforceable, so configuration cannot quietly drift into the patterns that enabled the TanStack May 2026 npm supply-chain compromise ([postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)).

The attack chain the audit gate is calibrated against:

1. **`pull_request_target` "Pwn Request"** — untrusted PR code runs with base-repo write tokens.
2. **Cache poisoning across the fork ↔ base trust boundary** — PR-side cache writes consumed by privileged jobs.
3. **In-memory OIDC token extraction (`/proc/<runner>/mem`)** — untrusted code in a job with `id-token: write` exfiltrates the token and publishes to npm directly.

zizmor's `dangerous-triggers`, `excessive-permissions`, `template-injection`, `cache-poisoning`, `unpinned-uses`, `artipacked`, `dependabot-cooldown`, and `stale-action-refs` audits cover the lever points in that chain.

## Configuration choices for the new check

- **Trigger**: `pull_request` (any) and `push` to `master`. The audit is sub-second, so it always runs rather than gating on `paths:`. Always-on makes it eligible to become a required status check via branch protection.
- **Severity / persona**: `persona: pedantic` + `min-severity: low`. Persona surfaces "code smell" findings beyond `regular` (most importantly the workflow-level-vs-job-level scoping of `id-token: write`); the low severity floor future-proofs against any future audits that land at that tier without requiring a follow-up.
- **Output**: inline PR annotations (`annotations: true`). `advanced-security` (SARIF upload to Code Scanning) is left disabled until GitHub Advanced Security is enabled on the repo and `security-events: write` can be granted to this job.
- **Pinning**: `zizmorcore/zizmor-action` is SHA-pinned with a `# v0.5.3` comment, consistent with the repo convention and the `scripts/update-action-pins.mjs --check-pins` enforcement.

## What got hardened on the way to "clean at pedantic"

All landed in this branch; each is its own commit. Grouped by audit class:

### High-severity `excessive-permissions` (the TanStack-class lever)

- `ci.yml`: dropped unnecessary workflow-level `actions: write` (`actions/cache` doesn't need it). `64e75ef2`
- `typedoc-gh-pages.yml`: moved `pages: write` from workflow level to the `deploy` job. `01e1dd14`
- `typedoc-gh-pages.yml`: moved `id-token: write` from workflow level to the `deploy` job. `5284a490`

### Medium `artipacked` (checkout credential persistence)

- 18 read-only `actions/checkout` steps gained `persist-credentials: false`. `bab98d8e`
- The one deliberately-persistent checkout (`release.yml`, which feeds `RELEASE_TOKEN` to `changesets/action`) got an inline `# zizmor: ignore[artipacked]` with a rationale comment. `555fa19d`

### Medium `dependabot-cooldown` and `stale-action-refs` (online audits)

- `dependabot.yml`: 7-day `cooldown.default-days` on both `npm` and `github-actions` ecosystems, matching `update-action-pins.mjs`'s default `--min-age-days=5`. `a77b7e55`
- Four upstream-bumped action tags refreshed to current SHAs (all >= 5 days old): `actions/setup-node@v6`, `dorny/paths-filter@v3`, `changesets/action@v1`, `peter-evans/create-pull-request@v8`. `93f57b34`

### Pedantic-tier scoping and hygiene

- `browser-test.yml`: dropped unnecessary `actions: write`. `e1c01bd8`
- `release.yml`: moved `contents: write` + `pull-requests: write` from workflow level to the `release` job; workflow now defaults to `permissions: {}`. `f7f92fc6`
- `update-action-pins{,-major}.yml`: same — writes scoped to the `update` job, workflow defaults to `permissions: {}`. `1ad1f00f`
- `ci.yml`: routed `${{ matrix.moddable-version }}` through an `env:` var instead of interpolating into `run:` strings (defense-in-depth against `template-injection`). `d90681b9`
- `release.yml`: made `concurrency.cancel-in-progress: false` explicit (mid-release cancellation could leave tags pushed without their matching GitHub release). `15466daa`
- Inline rationale comments on every job-level permission grant so a reviewer can tell at a glance which step consumes each grant. `5b5f441d`

### Gate ratchets

- `min-severity: high` (initial). `73bc9d3e`
- `min-severity: medium`. `0837f45e`
- `min-severity: low`. `0a5cedaf`
- `persona: pedantic`. `cb563931`

## Verification

Local `zizmor --persona pedantic --min-severity low .github/workflows .github/dependabot.yml` reports **zero findings** (9 ignored by the `# zizmor: ignore[...]` directive in `release.yml`, 26 suppressed by zizmor's default rules).

## Suggested follow-ups (not in this PR)

These were on the original list; they're orthogonal enough to belong in their own PRs:

1. **`CODEOWNERS` for `.github/workflows/`** — routes every future workflow edit through a security-aware reviewer regardless of what zizmor says.
2. **Extend `scripts/update-action-pins.mjs --check-pins`** with the anti-pattern assertions (`no pull_request_target`, `no workflow-level id-token: write`, `no ${{ github.event.* }}` in `run:` blocks). Defense-in-depth: if zizmor is ever disabled or its upstream compromised, the home-grown check still fires.
3. **Investigate why `update-action-pins` cron missed the four stale pins** that this PR refreshed manually. They were >= 5 days old at the most recent Monday run, so the age gate isn't the cause — the cron may be silently failing or unable to push the chore branch.
4. **`persona: auditor`** — adds `secrets-outside-env`, which would require wrapping the `release` job in a GitHub deployment Environment with required reviewers. Real behavioral change rather than a configuration tweak; worth its own discussion.
5. **Admin-side, not in-repo**: make the new `zizmor` job a required status check, set default `GITHUB_TOKEN` workflow permissions to read-only, and require approval for all outside-collaborator workflow runs.

## Test plan

- [x] Local `zizmor --persona pedantic --min-severity low` reports zero findings against the final tree.
- [x] All third-party actions remain SHA-pinned; `scripts/update-action-pins.mjs --check-pins` accepts the new pins on `zizmorcore/zizmor-action` and the four refreshed actions.
- [ ] CI on this PR runs the new `zizmor` job and exits zero.
- [ ] Every existing CI job still runs and exits zero (i.e., the permission-scoping moves didn't strand any job below the permissions it actually needs).
- [ ] After merge, the next `update-action-pins` cron run produces no diff (i.e., we already landed everything its weekly bump would have proposed).

https://claude.ai/code/session_013UFBZh9WsjfZtDHiLWFNv9