### PR TITLE
feat(syrup-frame): add @endo/syrup-frame package and opt-in syrup framing for OCapN TCP-for-testing

### DIFF
--- a/.changeset/ocapn-tcp-syrup-framing.md
+++ b/.changeset/ocapn-tcp-syrup-framing.md
@@ -1,0 +1,5 @@
+---
+'@endo/ocapn': minor
+---
+
+- Add a `framing` option to `makeTcpNetLayer` (`@endo/ocapn/netlayer/tcp-testing`). The default is `'syrup'`, which wraps each message in the `<length>:<payload>` framing implemented by `@endo/syrup-frame`. This is the framing the OCapN TCP-for-testing netlayer is moving toward (cf. the 2025-12-09 OCapN plenary, https://github.com/ocapn/ocapn/blob/main/meeting-minutes/2025-12-09.md), and is robust to TCP chunk boundaries that split a single OCapN message. Pass `framing: 'none'` to interoperate with the existing `ocapn/ocapn-test-suite` Python `testing_only_tcp` netlayer, which writes a syrup-encoded record with `sendall` and reads one back with `syrup.syrup_read` (no length prefix on the wire). The `'none'` option exists only for that suite's sake and goes away once the suite either adopts syrup framing or is retired.

--- a/.changeset/syrup-initial.md
+++ b/.changeset/syrup-initial.md
@@ -1,0 +1,18 @@
+---
+'@endo/syrup-frame': patch
+---
+
+- New package `@endo/syrup-frame`: a sibling of `@endo/netstring` that
+  drops the trailing `,` separator, so each framed payload on the wire
+  is literally a Syrup byte-string record (`<length>:<payload>`).
+- Provides `makeSyrupReader` and `makeSyrupWriter` with the
+  same shape as the netstring equivalents, including the `chunked`
+  zero-copy writer mode.
+- Intended for testing interoperability with the OCapN
+  TCP-for-testing protocol, which has moved to adopt this framing.
+  The framing is among the protocols under consideration in the
+  OCapN pre-standards group at time of writing; the 2025-12-09 OCapN
+  plenary recorded the consensus that the TCP-for-testing netlayer
+  should carry messages as length-prefixed Syrup byte strings
+  (https://github.com/ocapn/ocapn/blob/main/meeting-minutes/2025-12-09.md
+  and the parallel discussion on ocapn/ocapn#104).

--- a/packages/ocapn/package.json
+++ b/packages/ocapn/package.json
@@ -47,6 +47,8 @@
     "@endo/nat": "workspace:^",
     "@endo/pass-style": "workspace:^",
     "@endo/promise-kit": "workspace:^",
+    "@endo/stream": "workspace:^",
+    "@endo/syrup-frame": "workspace:^",
     "@noble/curves": "^1.9.0",
     "@noble/hashes": "^1.8.0",
     "ws": "^8.20.0"

--- a/packages/ocapn/src/netlayers/tcp-test-only.js
+++ b/packages/ocapn/src/netlayers/tcp-test-only.js
@@ -3,15 +3,42 @@
 
 import net from 'net';
 import harden from '@endo/harden';
+import { makePipe } from '@endo/stream';
+import { makeSyrupReader } from '@endo/syrup-frame/reader.js';
 
 import { locationToLocationId } from '../client/util.js';
 
 /**
- * @import { Connection, NetLayer, NetlayerHandlers, SocketOperations } from '../client/types.js'
+ * @import { Connection, Logger, NetLayer, NetlayerHandlers, SocketOperations } from '../client/types.js'
  * @import { OcapnLocation } from '../codecs/components.js'
+ * @import { Reader, Writer } from '@endo/stream'
+ */
+
+/**
+ * Wire framing for the test-only TCP netlayer.
+ *
+ * - `'syrup'` (default): each message is wrapped in the
+ *   `<length>:<payload>` framing implemented by `@endo/syrup-frame`.
+ *   Robust against TCP chunk boundaries that split a single OCapN
+ *   message; the spec is moving toward this framing for the
+ *   TCP-for-testing netlayer.
+ * - `'none'`: each write is sent as raw bytes, and each
+ *   `socket.on('data')` chunk is dispatched as a complete OCapN
+ *   message. Retained only for compatibility with the existing
+ *   `ocapn/ocapn-test-suite` Python `testing_only_tcp` netlayer,
+ *   which writes a syrup-encoded record with `sendall` and reads
+ *   one back with `syrup.syrup_read` (no length prefix on the wire).
+ *   That suite is known to be inadequate against the possibility of
+ *   a TCP chunk getting split across packets; the `'none'` option
+ *   goes away once the Python suite either adopts syrup framing or
+ *   is retired.
+ *
+ * @typedef {'none' | 'syrup'} TcpTestOnlyFraming
  */
 
 const { isNaN } = Number;
+
+const textEncoder = new TextEncoder();
 
 /**
  * @param {Buffer} buffer
@@ -47,6 +74,92 @@ const makeSocketOperations = (socket, writeLatencyMs) => {
 };
 
 /**
+ * Wraps `socketOps` so that `write(bytes)` emits a syrup-framed
+ * record (`<length>:<payload>`) instead of raw bytes. Builds the
+ * length-prefixed buffer synchronously and forwards a single
+ * `socketOps.write` call, matching the synchronous shape of the
+ * `SocketOperations` interface. (The earlier indirection through
+ * `@endo/syrup-frame`'s async `Writer` over a microtask-resolving
+ * sink was a sync/async impedance mismatch: the returned promise was
+ * always discarded and any write error from the sink would have been
+ * silently swallowed. Socket-level errors surface through the
+ * `socket.on('error')` handler set up in `setupSocketHandlers`.)
+ *
+ * @param {SocketOperations} socketOps
+ * @returns {SocketOperations}
+ */
+const makeSyrupWritingSocketOperations = socketOps => {
+  return {
+    write(bytes) {
+      const prefix = textEncoder.encode(`${bytes.length}:`);
+      const frame = new Uint8Array(prefix.length + bytes.length);
+      frame.set(prefix, 0);
+      frame.set(bytes, prefix.length);
+      socketOps.write(frame);
+    },
+    end() {
+      socketOps.end();
+    },
+  };
+};
+
+/**
+ * Wires a stream pipe between socket `data` events and the
+ * `@endo/syrup-frame` reader. Each whole frame is forwarded to
+ * `onFrame`. Errors and pipe closure are reported to `logger`.
+ *
+ * @param {Logger} logger
+ * @param {(frame: Uint8Array) => void} onFrame
+ * @returns {{ pushChunk: (chunk: Uint8Array) => void, end: () => void }}
+ */
+const makeSyrupDeframer = (logger, onFrame) => {
+  /** @type {[Writer<Uint8Array>, Reader<Uint8Array>]} */
+  const pipe = makePipe();
+  const [chunkWriter, chunkReader] = pipe;
+  const syrupReader = makeSyrupReader(chunkReader, {
+    name: 'tcp-testing-only',
+  });
+  let closed = false;
+  // Drain the reader in the background; surface decode errors via
+  // the logger and stop forwarding once closed.
+  const drain = async () => {
+    await null;
+    try {
+      for await (const frame of syrupReader) {
+        if (closed) {
+          break;
+        }
+        // The syrup reader may yield a `subarray()` of an internal
+        // buffer; downstream OCapN syrup decoding requires a
+        // zero-`byteOffset` view, so `slice()` to allocate a fresh
+        // owned copy before dispatching.
+        onFrame(frame.slice());
+      }
+    } catch (err) {
+      if (!closed) {
+        logger.error('Syrup deframer error:', err);
+      }
+    }
+  };
+  drain();
+  return {
+    pushChunk(chunk) {
+      if (closed) {
+        return;
+      }
+      chunkWriter.next(chunk).catch(() => {});
+    },
+    end() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      chunkWriter.return(undefined).catch(() => {});
+    },
+  };
+};
+
+/**
  * @typedef {object} ConnectionSocketPair
  * @property {Connection} connection
  * @property {net.Socket} socket
@@ -68,6 +181,7 @@ const makeSocketOperations = (socket, writeLatencyMs) => {
  * @param {string} [options.specifiedHostname]
  * @param {string} [options.specifiedDesignator]
  * @param {number} [options.writeLatencyMs] - Optional artificial latency for writes (ms), useful for testing pipelining
+ * @param {TcpTestOnlyFraming} [options.framing] - Wire framing for outbound writes and inbound reads. Defaults to `'syrup'`, the framing the OCapN TCP-for-testing netlayer is moving toward. Pass `'none'` to interoperate with the existing Python `ocapn-test-suite` `testing_only_tcp` netlayer (raw syrup record per write, no length prefix).
  * @returns {Promise<TcpTestOnlyNetLayer>}
  */
 export const makeTcpNetLayer = async ({
@@ -78,7 +192,11 @@ export const makeTcpNetLayer = async ({
   // Unclear if a fallback value is reasonable.
   specifiedDesignator = '0000',
   writeLatencyMs = 0,
+  framing = 'syrup',
 }) => {
+  if (framing !== 'none' && framing !== 'syrup') {
+    throw Error(`Unsupported framing: ${framing}`);
+  }
   // Create and start TCP server
   const server = net.createServer();
 
@@ -131,8 +249,29 @@ export const makeTcpNetLayer = async ({
   const setupSocketHandlers = (socket, connection, onClose) => {
     activeSockets.add(socket);
 
+    // When framing is `'syrup'`, run inbound bytes through the
+    // syrup deframer so each call to `handleMessageData` carries
+    // exactly one OCapN message regardless of how TCP chunked the
+    // wire. With `'none'` framing, dispatch raw chunks unchanged.
+    const deframer =
+      framing === 'syrup'
+        ? makeSyrupDeframer(logger, frame => {
+            if (!connection.isDestroyed) {
+              handlers.handleMessageData(connection, frame);
+            } else {
+              logger.info(
+                'TcpTestOnlyNetLayer received message after connection was destroyed',
+              );
+            }
+          })
+        : undefined;
+
     socket.on('data', data => {
       const bytes = bufferToBytes(data);
+      if (deframer) {
+        deframer.pushChunk(bytes);
+        return;
+      }
       if (!connection.isDestroyed) {
         handlers.handleMessageData(connection, bytes);
       } else {
@@ -150,6 +289,9 @@ export const makeTcpNetLayer = async ({
     socket.on('close', () => {
       logger.info('Connection closed');
       activeSockets.delete(socket);
+      if (deframer) {
+        deframer.end();
+      }
       if (onClose) {
         onClose();
       }
@@ -161,6 +303,26 @@ export const makeTcpNetLayer = async ({
       connection.end();
       handlers.handleConnectionClose(connection);
     });
+  };
+
+  /**
+   * Returns the socket operations the client connection should use.
+   * For `'syrup'` framing, wraps the raw socket operations in a
+   * syrup writer so every call to `connection.write` becomes one
+   * length-prefixed frame on the wire.
+   * @param {net.Socket} socket
+   * @returns {SocketOperations}
+   */
+  const makeFramedSocketOperations = socket => {
+    const rawOps = makeSocketOperations(socket, writeLatencyMs);
+    if (framing === 'syrup') {
+      return makeSyrupWritingSocketOperations(rawOps);
+    }
+    // `'none'` framing is retained only for the existing Python
+    // `ocapn-test-suite` `testing_only_tcp` netlayer, which is
+    // inadequate against TCP chunks split across packets. See the
+    // `TcpTestOnlyFraming` typedef.
+    return rawOps;
   };
 
   /**
@@ -183,7 +345,7 @@ export const makeTcpNetLayer = async ({
     }
     const socket = net.createConnection({ host, port: remotePort });
 
-    const socketOps = makeSocketOperations(socket, writeLatencyMs);
+    const socketOps = makeFramedSocketOperations(socket);
     // eslint-disable-next-line no-use-before-define
     const connection = handlers.makeConnection(netlayer, true, socketOps);
 
@@ -264,7 +426,7 @@ export const makeTcpNetLayer = async ({
       `${socket.remoteAddress}:${socket.remotePort}`,
     );
 
-    const socketOps = makeSocketOperations(socket, writeLatencyMs);
+    const socketOps = makeFramedSocketOperations(socket);
     const connection = handlers.makeConnection(netlayer, false, socketOps);
 
     setupSocketHandlers(socket, connection);

--- a/packages/ocapn/test/netlayer-tcp-syrup.test.js
+++ b/packages/ocapn/test/netlayer-tcp-syrup.test.js
@@ -1,0 +1,233 @@
+// @ts-check
+
+import net from 'net';
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+import { test } from './_util.js';
+import { makeClient } from '../src/client/index.js';
+import { makeTcpNetLayer } from '../src/netlayers/tcp-test-only.js';
+import { encodeSwissnum } from '../src/client/util.js';
+
+const COMMA = ','.charCodeAt(0);
+const COLON = ':'.charCodeAt(0);
+const ZERO = '0'.charCodeAt(0);
+const NINE = '9'.charCodeAt(0);
+
+/**
+ * Establishes a TCP server that accepts a single inbound connection,
+ * accumulates every byte the client writes until the client closes
+ * (or the server destroys) the socket, then resolves `sessionBytes`
+ * with the concatenated capture. Used to peek at the wire format of
+ * an outgoing handshake from the test-only TCP netlayer.
+ *
+ * Capturing the whole session (rather than just the first
+ * `socket.on('data')` chunk) removes a non-deterministic dependency
+ * on the first TCP packet happening to carry a complete OCapN
+ * message; the syrup writer is free to flush its prefix and payload
+ * in separate `socket.write` calls.
+ *
+ * @returns {Promise<{
+ *   port: number,
+ *   address: string,
+ *   sessionBytes: Promise<Uint8Array>,
+ *   close: () => void,
+ * }>}
+ */
+const makeSnifferServer = async () => {
+  /** @type {(bytes: Uint8Array) => void} */
+  let resolveBytes;
+  /** @type {(err: Error) => void} */
+  let rejectBytes;
+  const sessionBytes = new Promise((resolve, reject) => {
+    resolveBytes = resolve;
+    rejectBytes = reject;
+  });
+  const server = net.createServer(socket => {
+    /** @type {Uint8Array[]} */
+    const chunks = [];
+    socket.on('data', data => {
+      chunks.push(
+        new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+      );
+    });
+    socket.on('error', err => rejectBytes(err));
+    socket.on('close', () => {
+      let total = 0;
+      for (const chunk of chunks) {
+        total += chunk.length;
+      }
+      const concatenated = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of chunks) {
+        concatenated.set(chunk, offset);
+        offset += chunk.length;
+      }
+      resolveBytes(concatenated);
+    });
+    // Close the write half once the client's first burst arrives, so
+    // the client sees EOF and stops talking; the `close` event above
+    // then fires with everything the client managed to send.
+    socket.once('data', () => {
+      socket.end();
+    });
+  });
+  await /** @type {Promise<void>} */ (
+    new Promise((resolve, reject) => {
+      server.listen(0, '127.0.0.1', err =>
+        err ? reject(err) : resolve(undefined),
+      );
+    })
+  );
+  const addressInfo = server.address();
+  if (typeof addressInfo !== 'object' || addressInfo === null) {
+    throw Error('Unexpected server address');
+  }
+  return {
+    port: addressInfo.port,
+    address: addressInfo.address,
+    sessionBytes,
+    close: () => server.close(),
+  };
+};
+
+test('syrup framing wraps outgoing bytes with <length>:<payload> and contains no comma', async t => {
+  const sniffer = await makeSnifferServer();
+  t.teardown(() => sniffer.close());
+
+  const client = makeClient({ debugLabel: 'syrup-sniff', debugMode: true });
+  t.teardown(() => client.shutdown());
+
+  const netlayer = await client.registerNetlayer((handlers, logger) =>
+    makeTcpNetLayer({
+      handlers,
+      logger,
+      specifiedDesignator: 'sniff-A',
+      framing: 'syrup',
+    }),
+  );
+
+  // Trigger an outbound handshake to the sniffer. The sniffer
+  // half-closes its write side as soon as the first chunk arrives,
+  // so the pending session rejects; swallow it so it does not
+  // surface as an unhandled rejection.
+  client
+    .provideSession({
+      type: 'ocapn-peer',
+      transport: netlayer.location.transport,
+      designator: 'sniff-B',
+      hints: { host: sniffer.address, port: String(sniffer.port) },
+    })
+    .catch(() => {});
+
+  const bytes = await sniffer.sessionBytes;
+
+  // The first bytes on the wire must be ASCII digits forming the
+  // syrup length prefix.
+  t.true(bytes.length > 2, 'sniffer captured at least 3 bytes');
+  t.true(
+    bytes[0] >= ZERO && bytes[0] <= NINE,
+    `first byte is an ASCII digit (got ${bytes[0]})`,
+  );
+
+  // The first ':' separates the length prefix from the payload; all
+  // bytes before it must be ASCII digits. Crucially, no comma
+  // appears in or before that prefix: a netstring frame for a
+  // payload of N bytes would be `<digits>:<payload>,` with the comma
+  // sitting at index `1 + ceil(log10(N+1)) + N`, but a syrup frame
+  // omits that trailing separator. Decode the prefix and confirm
+  // there is no comma at the netstring-terminator position.
+  const colonIndex = bytes.indexOf(COLON);
+  t.true(colonIndex > 0, 'a ":" separator follows the length prefix');
+  for (let i = 0; i < colonIndex; i += 1) {
+    t.true(
+      bytes[i] >= ZERO && bytes[i] <= NINE,
+      `prefix byte at index ${i} is an ASCII digit`,
+    );
+  }
+  const declaredPayloadLength = Number(
+    String.fromCharCode(...bytes.subarray(0, colonIndex)),
+  );
+  const netstringTerminatorIndex = colonIndex + 1 + declaredPayloadLength;
+  // The captured chunk must contain at least the framed handshake.
+  t.true(
+    bytes.length >= netstringTerminatorIndex,
+    `captured ${bytes.length} bytes covers the framed payload (${netstringTerminatorIndex})`,
+  );
+  // If there are any bytes past the payload, none of them is a
+  // netstring `,` separator at the position a netstring writer
+  // would have placed it.
+  if (bytes.length > netstringTerminatorIndex) {
+    t.not(
+      bytes[netstringTerminatorIndex],
+      COMMA,
+      'no trailing "," at the position a netstring writer would emit one',
+    );
+  } else {
+    t.pass(
+      'captured chunk ends exactly at the framed payload, with no trailing separator',
+    );
+  }
+});
+
+test('syrup framing round-trip through the test-only TCP netlayer', async t => {
+  const swissnumTable = new Map();
+  swissnumTable.set(
+    'Echo',
+    Far('echo', {
+      echo: value => value,
+    }),
+  );
+
+  const clientA = makeClient({
+    debugLabel: 'syrup-A',
+    debugMode: true,
+  });
+  const clientB = makeClient({
+    debugLabel: 'syrup-B',
+    debugMode: true,
+    swissnumTable,
+  });
+  t.teardown(() => {
+    clientA.shutdown();
+    clientB.shutdown();
+  });
+
+  await clientA.registerNetlayer((handlers, logger) =>
+    makeTcpNetLayer({
+      handlers,
+      logger,
+      specifiedDesignator: 'syrup-A',
+      framing: 'syrup',
+    }),
+  );
+  const netlayerB = await clientB.registerNetlayer((handlers, logger) =>
+    makeTcpNetLayer({
+      handlers,
+      logger,
+      specifiedDesignator: 'syrup-B',
+      framing: 'syrup',
+    }),
+  );
+
+  const session = await clientA.provideSession(netlayerB.location);
+  const bootstrap = session.getBootstrap();
+  const echoRef = await E(bootstrap).fetch(encodeSwissnum('Echo'));
+  const result = await E(echoRef).echo('hello syrup');
+  t.is(result, 'hello syrup');
+});
+
+test('rejects unknown framing option', async t => {
+  await t.throwsAsync(
+    () =>
+      makeTcpNetLayer({
+        framing: /** @type {'syrup'} */ (/** @type {unknown} */ ('bogus')),
+        handlers: /** @type {any} */ ({}),
+        logger: /** @type {any} */ ({
+          log: () => {},
+          error: () => {},
+          info: () => {},
+        }),
+      }),
+    { message: /Unsupported framing/ },
+  );
+});

--- a/packages/ocapn/test/python-test-suite/index.js
+++ b/packages/ocapn/test/python-test-suite/index.js
@@ -166,6 +166,11 @@ const start = async () => {
       handlers,
       logger,
       specifiedPort: 22046,
+      // The Python `ocapn-test-suite` `testing_only_tcp` netlayer
+      // writes a raw syrup record per `sendall` with no length prefix.
+      // Opt out of the JS netlayer's default `'syrup'` framing to
+      // interoperate with that suite.
+      framing: 'none',
     }),
   );
 };

--- a/packages/syrup-frame/LICENSE
+++ b/packages/syrup-frame/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Endo Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/syrup-frame/README.md
+++ b/packages/syrup-frame/README.md
@@ -1,0 +1,83 @@
+# @endo/syrup-frame
+
+`@endo/syrup-frame` implements an async-iterator protocol for framing
+binary messages as a length-prefix followed by a payload, with **no
+trailing separator**.
+
+It is a sibling of [`@endo/netstring`][netstring] whose only difference
+is the absence of the trailing `,` separator.
+The grammar is:
+
+```
+frame   = length ":" payload
+length  = 1*DIGIT
+payload = length * OCTET
+```
+
+A framed message on the wire is therefore literally a Syrup byte-string
+record: identical to Syrup's `<length>:<bytes>` grammar.
+This is the whole motivation for the package.
+OCapN transports that carry Syrup-encoded messages can share a single
+length-prefixed primitive with the payload format itself, eliminating
+a redundant delimiter byte per message and giving "a frame" and "a
+Syrup byte string" the same on-the-wire encoding.
+
+## Why not `@endo/netstring`?
+
+[DJB's netstring][djb] specification is explicit that a netstring
+carries a trailing `,`.
+A netstring without the separator is **not** a netstring; conflating
+the two by adding an option to `@endo/netstring` would blur the
+identity of that package.
+`@endo/syrup-frame` is a deliberate departure, named for its purpose.
+
+## Scope
+
+This package exists to test interoperability with the OCapN
+TCP-for-testing protocol, which has moved to adopt this framing.
+That framing is among the protocols under consideration in the OCapN
+pre-standards group at time of writing.
+The existing `@endo/netstring` package remains the canonical netstring
+implementation and continues to serve the Endo daemon's
+`tcp+netstring+json+captp0` transport and any other caller that wants
+strict netstring compliance.
+
+## API
+
+```js
+import {
+  makeSyrupReader,
+  makeSyrupWriter,
+} from '@endo/syrup-frame';
+```
+
+### `makeSyrupReader(input, opts?) -> Reader<Uint8Array, undefined>`
+
+Wraps an iterable/async-iterable of byte chunks into an async iterator
+of whole frames.
+Handles arbitrary chunk boundaries (length prefix split across chunks,
+payload split across chunks).
+
+Options:
+
+- `name`: identifier embedded in error messages.
+- `maxMessageLength`: upper bound on any single payload, default
+  `999_999_999` (same as `@endo/netstring`).
+
+### `makeSyrupWriter(output, opts?) -> Writer<Uint8Array | Uint8Array[]>`
+
+Wraps an output byte writer into a frame writer.
+
+Options:
+
+- `chunked`: when true, emit the prefix and each payload chunk as
+  separate writes.  Required for zero-copy writers.  Identical to
+  `@endo/netstring`'s `chunked` option minus the separator write.
+
+## Design
+
+See [`designs/ocapn-tcp-syrup-framing.md`](../../designs/ocapn-tcp-syrup-framing.md)
+in the repository root.
+
+[netstring]: ../netstring/
+[djb]: https://cr.yp.to/proto/netstrings.txt

--- a/packages/syrup-frame/SECURITY.md
+++ b/packages/syrup-frame/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+The SES package and associated Endo packages are still undergoing development and security review, and all
+users are encouraged to use the latest version available. Security fixes will
+be made for the most recent branch only.
+
+## Coordinated Vulnerability Disclosure of Security Bugs
+
+SES stands for fearless cooperation, and strong security requires strong collaboration with security researchers. If you believe that you have found a security sensitive bug that should not be disclosed until a fix has been made available, we encourage you to report it. To report a bug in HardenedJS, you have several options that include:
+
+* Reporting the issue to the [Agoric HackerOne vulnerability rewards program](https://hackerone.com/agoric).
+
+* Sending an email to security at (@) agoric.com., encrypted or unencrypted. To encrypt, please use  @Warner’s personal GPG key  [A476E2E6 11880C98 5B3C3A39 0386E81B 11CAA07A](http://www.lothar.com/warner-gpg.html)  .
+
+* Sending a message on Keybase to `@agoric_security`, or sharing code and other log files via Keybase’s encrypted file system. ((_keybase_private/agoric_security,$YOURNAME).
+
+* It is important to be able to provide steps that reproduce the issue and demonstrate its impact with a Proof of Concept example in an initial bug report. Before reporting a bug, a reporter may want to have another trusted individual reproduce the issue.
+
+* A bug reporter can expect acknowledgment of a potential vulnerability reported through  [security@agoric.com](mailto:security@agoric.com)  within one business day of submitting a report. If an acknowledgement of an issue is not received within this time frame, especially during a weekend or holiday period, please reach out again. Any issues reported to the HackerOne program will be acknowledged within the time frames posted on the program page.
+	* The bug triage team and Agoric code maintainers are primarily located in the San Francisco Bay Area with business hours in  [Pacific Time](https://www.timeanddate.com/worldclock/usa/san-francisco) .
+
+* For the safety and security of those who depend on the code, bug reporters should avoid publicly sharing the details of a security bug on Twitter, Discord, Telegram, or in public Github issues during the coordination process.
+
+* Once a vulnerability report has been received and triaged:
+	* Agoric code maintainers will confirm whether it is valid, and will provide updates to the reporter on validity of the report.
+	* It may take up to 72 hours for an issue to be validated, especially if reported during holidays or on weekends.
+
+* When the Agoric team has verified an issue, remediation steps and patch release timeline information will be shared with the reporter.
+	* Complexity, severity, impact, and likelihood of exploitation are all vital factors that determine the amount of time required to remediate an issue and distribute a software patch.
+	* If an issue is Critical or High Severity, Agoric code maintainers will release a security advisory to notify impacted parties to prepare for an emergency patch.
+	* While the current industry standard for vulnerability coordination resolution is 90 days, Agoric code maintainers will strive to release a patch as quickly as possible.
+
+When a bug patch is included in a software release, the Agoric code maintainers will:
+	* Confirm the version and date of the software release with the reporter.
+	* Provide information about the security issue that the software release resolves.
+	* Credit the bug reporter for discovery by adding thanks in release notes, securing a CVE designation, or adding the researcher’s name to a Hall of Fame.

--- a/packages/syrup-frame/index.js
+++ b/packages/syrup-frame/index.js
@@ -1,0 +1,2 @@
+export { makeSyrupReader } from './reader.js';
+export { makeSyrupWriter } from './writer.js';

--- a/packages/syrup-frame/package.json
+++ b/packages/syrup-frame/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@endo/syrup-frame",
+  "version": "0.1.0",
+  "description": "Implements a JavaScript async iterator protocol for consuming and producing Syrup byte-string-framed streams: a sibling of @endo/netstring with no trailing comma.",
+  "keywords": [
+    "syrup",
+    "ocapn",
+    "framing",
+    "netstring"
+  ],
+  "author": "Endo contributors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/endojs/endo/blob/master/packages/syrup-frame/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/endojs/endo.git",
+    "directory": "packages/syrup-frame"
+  },
+  "bugs": {
+    "url": "https://github.com/endojs/endo/issues"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "module": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./reader.js": "./reader.js",
+    "./writer.js": "./writer.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "prepack": "git clean -fX -e node_modules/ && tsc --build tsconfig.build.json",
+    "postpack": "git clean -fX -e node_modules/",
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint-fix": "eslint --fix .",
+    "lint:eslint": "eslint .",
+    "lint:types": "tsc",
+    "test": "ses-ava",
+    "test:c8": "c8 ${C8_OPTIONS:-} ses-ava"
+  },
+  "dependencies": {
+    "@endo/harden": "workspace:^",
+    "@endo/init": "workspace:^",
+    "@endo/promise-kit": "workspace:^",
+    "@endo/stream": "workspace:^"
+  },
+  "devDependencies": {
+    "@endo/eventual-send": "workspace:^",
+    "@endo/ses-ava": "workspace:^",
+    "ava": "catalog:dev",
+    "c8": "catalog:dev",
+    "eslint": "catalog:dev",
+    "typescript": "catalog:dev"
+  },
+  "files": [
+    "./*.d.ts",
+    "./*.js",
+    "./*.map",
+    "LICENSE*",
+    "SECURITY*",
+    "dist",
+    "lib",
+    "src",
+    "tools"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "plugin:@endo/internal"
+    ]
+  },
+  "sesAvaConfigs": {
+    "lockdown": "../../ava-endo-lockdown.config.mjs",
+    "base": "../../ava-base.config.mjs",
+    "noop-harden": "../../ava-noop-harden.config.mjs"
+  },
+  "typeCoverage": {
+    "atLeast": 100
+  }
+}

--- a/packages/syrup-frame/reader.js
+++ b/packages/syrup-frame/reader.js
@@ -1,0 +1,147 @@
+// @ts-check
+
+import harden from '@endo/harden';
+
+// Syrup grammar: <length> ":" <payload> (no trailing separator).
+// Derived from @endo/netstring; the only behavioral difference is that
+// there is no COMMA check after the payload.  See
+// designs/ocapn-tcp-syrup-framing.md.
+
+const COLON = ':'.charCodeAt(0);
+const ZERO = '0'.charCodeAt(0);
+const NINE = '9'.charCodeAt(0);
+
+/**
+ * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} input
+ * @param {object} opts
+ * @param {string} [opts.name]
+ * @param {number} [opts.maxMessageLength]
+ */
+async function* makeSyrupIterator(
+  input,
+  { name = '<unknown>', maxMessageLength = 999_999_999 } = {},
+) {
+  // eslint-disable-next-line no-bitwise
+  const maxPrefixLength = `${maxMessageLength | 0}:`.length;
+
+  // byte offset of data consumed so far in the input stream
+  let offset = 0;
+
+  // The iterator can be in 2 states: waiting for the length, or waiting
+  // for the data.
+  // - When waiting for the length, the lengthBuffer is an array of digit
+  //   charCodes for the length prefix.
+  // - When waiting for the data, the dataBuffer is either:
+  //   - null, to indicate no data has been received yet, or
+  //   - a newly allocated buffer large enough for the whole payload.
+  //   In either case, remainingDataLength contains how many bytes are
+  //   still needed.  If the whole payload is received in one chunk, no
+  //   copy is made.
+  /** @type {number[] | null} */
+  let lengthBuffer = [];
+  /** @type {Uint8Array | null} */
+  let dataBuffer = null;
+  let remainingDataLength = -1;
+
+  for await (const chunk of input) {
+    let buffer = chunk;
+
+    while (buffer.length) {
+      // Waiting for full length prefix
+      if (lengthBuffer) {
+        let i = 0;
+        while (i < buffer.length) {
+          const c = buffer[i];
+          i += 1;
+          if (c >= ZERO && c <= NINE) {
+            lengthBuffer.push(c);
+            if (lengthBuffer.length === maxPrefixLength) {
+              throw Error(
+                `Too long syrup length prefix ${JSON.stringify(
+                  String.fromCharCode(...lengthBuffer),
+                )}... at offset ${offset} of ${name}`,
+              );
+            }
+          } else if (c === COLON && lengthBuffer.length) {
+            lengthBuffer.push(c);
+            break;
+          } else {
+            throw Error(
+              `Invalid syrup length prefix ${JSON.stringify(
+                String.fromCharCode(...lengthBuffer, c),
+              )} at offset ${offset} of ${name}`,
+            );
+          }
+        }
+
+        buffer = buffer.subarray(i);
+
+        if (lengthBuffer[lengthBuffer.length - 1] === COLON) {
+          lengthBuffer.pop();
+          // The prefix is composed only of ASCII digits (the inner
+          // loop pushes on `c >= ZERO && c <= NINE` and rejects
+          // everything else), so `+prefix` is always a finite,
+          // non-negative integer.  No NaN guard needed.
+          const prefix = String.fromCharCode(...lengthBuffer);
+          remainingDataLength = +prefix;
+          if (remainingDataLength > maxMessageLength) {
+            throw Error(
+              `Syrup message too big (length ${remainingDataLength}) at offset ${offset} of ${name}`,
+            );
+          }
+          offset += lengthBuffer.length + 1;
+          lengthBuffer = null;
+        }
+      }
+
+      // Waiting for data.  The payload is exactly `remainingDataLength`
+      // bytes with no trailing separator.  This is the one behavioral
+      // departure from @endo/netstring.
+      if (!lengthBuffer) {
+        if (buffer.length >= remainingDataLength) {
+          const remainingData = buffer.subarray(0, remainingDataLength);
+          const data = dataBuffer
+            ? (dataBuffer.set(
+                remainingData,
+                dataBuffer.length - remainingDataLength,
+              ),
+              dataBuffer)
+            : remainingData;
+          dataBuffer = null;
+          offset += data.length;
+          buffer = buffer.subarray(remainingDataLength);
+          remainingDataLength = -1;
+          lengthBuffer = [];
+          yield data;
+        } else if (buffer.length) {
+          // The outer `>=` guard is false here, so buffer.length is
+          // strictly less than remainingDataLength.  Allocate or
+          // grow into a payload buffer and copy the partial chunk.
+          dataBuffer = dataBuffer || new Uint8Array(remainingDataLength);
+          dataBuffer.set(buffer, dataBuffer.length - remainingDataLength);
+          remainingDataLength -= buffer.length;
+          buffer = buffer.subarray(buffer.length);
+        }
+      }
+    }
+  }
+
+  if (!lengthBuffer) {
+    throw Error(`Unexpected dangling message at offset ${offset} of ${name}`);
+  }
+
+  return undefined;
+}
+harden(makeSyrupIterator);
+
+/**
+ * @param {Iterable<Uint8Array> | AsyncIterable<Uint8Array>} input
+ * @param {object} [opts]
+ * @param {string} [opts.name]
+ * @param {number} [opts.maxMessageLength]
+ * @returns {import('@endo/stream').Reader<Uint8Array, undefined>} input
+ */
+export const makeSyrupReader = (input, opts) => {
+  return harden(makeSyrupIterator(input, opts));
+};
+harden(makeSyrupReader);

--- a/packages/syrup-frame/test/syrup-frame.test.js
+++ b/packages/syrup-frame/test/syrup-frame.test.js
@@ -1,0 +1,466 @@
+// @ts-nocheck
+/* global setTimeout */
+
+import '@endo/init/debug.js';
+
+import test from 'ava';
+import { makePipe } from '@endo/stream';
+import { makeSyrupReader } from '../reader.js';
+import { makeSyrupWriter } from '../writer.js';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+async function read(source) {
+  const array = [];
+  for await (const chunk of source) {
+    // Capture current state, allocating a copy.
+    array.push(chunk.slice());
+  }
+  return array;
+}
+
+const readChunkedMessage = async (t, chunkStrings, expectedDataStrings) => {
+  const r = makeSyrupReader(
+    chunkStrings.map(chunkString => encoder.encode(chunkString)),
+    {
+      name: '<unknown>',
+    },
+  );
+  const array = await read(r);
+  t.deepEqual(
+    expectedDataStrings,
+    array.map(chunk => decoder.decode(chunk)),
+  );
+};
+
+test('read short messages', readChunkedMessage, ['0:1:A'], ['', 'A']);
+test(
+  'read short messages with data divided over chunk boundaries',
+  readChunkedMessage,
+  ['0:', '1:A'],
+  ['', 'A'],
+);
+
+test(
+  'read a message in single chunk',
+  readChunkedMessage,
+  ['5:hello'],
+  ['hello'],
+);
+test(
+  'read a message with data in separate chunk',
+  readChunkedMessage,
+  ['5:', 'hello'],
+  ['hello'],
+);
+test(
+  'read a message with data divided over a chunk boundary',
+  readChunkedMessage,
+  ['5:hel', 'lo'],
+  ['hello'],
+);
+
+test(
+  'read messages divided over chunk boundaries',
+  readChunkedMessage,
+  ['5:hello', '5:world8:good ', 'bye'],
+  ['hello', 'world', 'good bye'],
+);
+
+test(
+  'read prefix colon divided over chunk boundary',
+  readChunkedMessage,
+  ['0', ':', '1', ':A'],
+  ['', 'A'],
+);
+
+test(
+  'read length prefix divided over chunk boundaries',
+  readChunkedMessage,
+  ['1', '1:hello world'],
+  ['hello world'],
+);
+
+const readErroneousChunkedMessage = async (t, chunkStrings, opts) => {
+  const r = makeSyrupReader(
+    chunkStrings.map(chunkString => encoder.encode(chunkString)),
+    opts,
+  );
+  return t.throwsAsync(() => read(r));
+};
+
+test('fails reading invalid prefix', readErroneousChunkedMessage, ['1.0:A']);
+test('fails reading incomplete data', readErroneousChunkedMessage, ['5:hell']);
+test('fails reading no colon', readErroneousChunkedMessage, ['1A']);
+test('fails reading empty prefix before colon', readErroneousChunkedMessage, [
+  ':',
+]);
+
+test(
+  'fails reading too long prefix',
+  readErroneousChunkedMessage,
+  ['11:hello world'],
+  { maxMessageLength: 9 },
+);
+test(
+  'fails reading if message length over max',
+  readErroneousChunkedMessage,
+  ['11:hello world'],
+  { maxMessageLength: 10 },
+);
+
+// Trailing characters after a valid frame are treated as the beginning
+// of the next frame's length prefix.  A ',' is not a digit, so the
+// reader rejects it.  This test exists specifically to confirm that the
+// reader does not consume a trailing comma (the one behavioral departure
+// from @endo/netstring).
+test(
+  'trailing comma after frame is rejected (not silently consumed)',
+  readErroneousChunkedMessage,
+  ['5:hello,'],
+);
+
+function delay(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+// TODO refactor: when `@endo/stream` gains a `mapReader` (or similar)
+// helper that can capture a snapshot of each yielded chunk, replace
+// `makeArrayWriter` with `makePipe()` + the mapped reader so the
+// writer-to-reader bridge is the same shape these tests would
+// actually use in production. Per kriskowal review on PR #109; the
+// same opportunity exists in the sibling `cbor-frame` test suite,
+// where the TODO landed under PR #288.
+const makeArrayWriter = opts => {
+  const array = [];
+  const writer = makeSyrupWriter(
+    {
+      async next(value) {
+        // Provide some back pressure to give the producer an
+        // opportunity to make the mistake of overwriting the given
+        // slice.
+        await delay(10);
+        // slice to capture before yielding.
+        array.push(value.slice());
+        return { done: false };
+      },
+      async return() {
+        return { done: true };
+      },
+      async throw() {
+        return { done: true };
+      },
+    },
+    opts,
+  );
+  return { array, writer };
+};
+
+const shortMessages = async (t, opts) => {
+  const { array, writer } = makeArrayWriter(opts);
+  await writer.next(encoder.encode(''));
+  await writer.next(encoder.encode('A'));
+  await writer.next(encoder.encode('hello'));
+  await writer.return();
+
+  t.deepEqual(
+    [encoder.encode(''), encoder.encode('A'), encoder.encode('hello')],
+    await read(makeSyrupReader(array)),
+  );
+};
+test('round-trip short messages', shortMessages);
+test('round-trip short messages (chunked)', shortMessages, { chunked: true });
+
+const concurrentWrites = async (t, opts) => {
+  const { array, writer } = makeArrayWriter(opts);
+  await Promise.all([
+    writer.next(encoder.encode('')),
+    writer.next(encoder.encode('A')),
+    writer.next(encoder.encode('hello')),
+    writer.return(),
+  ]);
+
+  t.deepEqual(
+    [encoder.encode(''), encoder.encode('A'), encoder.encode('hello')],
+    await read(makeSyrupReader(array)),
+  );
+};
+test('concurrent writes', concurrentWrites);
+test('concurrent writes (chunked)', concurrentWrites, { chunked: true });
+
+const chunkedWrite = async (t, opts) => {
+  const { array, writer } = makeArrayWriter(opts);
+  const strChunks = ['hello', ' ', 'world'];
+  await writer.next(strChunks.map(strChunk => encoder.encode(strChunk)));
+  await writer.return();
+
+  t.deepEqual(
+    [encoder.encode(strChunks.join(''))],
+    await read(makeSyrupReader(array)),
+  );
+};
+test('chunked write', chunkedWrite);
+test('chunked write (chunked)', chunkedWrite, { chunked: true });
+
+test('writer closes anywhere within chunk', async t => {
+  await null;
+  // The chunked write produces prefix + N payload chunks (no trailing
+  // comma); iterate past each boundary and confirm that closing the
+  // reader at any point yields `done: true` to the writer.
+  for (let count = 0; count < 3; count += 1) {
+    const pipe = makePipe();
+    const writer = makeSyrupWriter(pipe[1], { chunked: true });
+    for (let i = 0; i < count; i += 1) {
+      pipe[0].next();
+    }
+    // close the writer:
+    pipe[0].return();
+    // eslint-disable-next-line no-await-in-loop
+    const { done } = await writer.next(
+      ['Hello, ', 'World!\n'].map(str => encoder.encode(str)),
+    );
+    t.assert(done);
+  }
+});
+
+const varyingMessages = async (t, opts) => {
+  const array = ['', 'A', 'hello'];
+
+  for (let i = 1_020; i < 1_030; i += 1) {
+    array.push(new Array(i).fill(':').join(''));
+  }
+  for (let i = 2_040; i < 2_050; i += 1) {
+    array.push(new Array(i).fill(':').join(''));
+  }
+
+  t.plan(array.length);
+
+  const [input, output] = makePipe();
+
+  const producer = (async () => {
+    await null;
+    /** @type {import('@endo/stream').Writer<Uint8Array, undefined>} */
+    const w = makeSyrupWriter(output, opts);
+    for (let i = 0; i < array.length; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await w.next(encoder.encode(array[i]));
+      // eslint-disable-next-line no-await-in-loop
+      await delay(10);
+    }
+    await w.return();
+  })();
+
+  const consumer = (async () => {
+    /** @type {import('@endo/stream').Reader<Uint8Array, undefined>} */
+    const r = makeSyrupReader(input);
+    let i = 0;
+    for await (const message of r) {
+      await delay(10);
+      t.is(array[i], decoder.decode(message));
+      i += 1;
+    }
+    t.log('end');
+  })();
+
+  await Promise.all([producer, consumer]);
+};
+test('round-trip varying messages', varyingMessages);
+test('round-trip varying messages (chunked)', varyingMessages, {
+  chunked: true,
+});
+
+// Exercise the exact motivating case: small concurrent writes whose
+// frames straddle arbitrary chunk boundaries must reassemble correctly.
+test('round-trip across adversarial chunk boundaries', async t => {
+  const messages = ['', 'A', 'hello', 'op:start-session', '1234567890'];
+  const [input, output] = makePipe();
+
+  const producer = (async () => {
+    await null;
+    const w = makeSyrupWriter(output);
+    for (const m of messages) {
+      // eslint-disable-next-line no-await-in-loop
+      await w.next(encoder.encode(m));
+    }
+    await w.return();
+  })();
+
+  // Fragment into tiny 1-byte slices on the read side by wrapping the
+  // input in a generator that yields byte-at-a-time.
+  async function* byteByByteGen() {
+    for await (const chunk of input) {
+      const n = Number(chunk.length);
+      for (let i = 0; i < n; i += 1) {
+        yield chunk.subarray(i, i + 1);
+      }
+    }
+  }
+  const byteByByte = byteByByteGen();
+
+  const r = makeSyrupReader(byteByByte);
+  const got = await read(r);
+  await producer;
+  t.deepEqual(
+    messages.map(m => encoder.encode(m)),
+    got,
+  );
+});
+
+// Exercise writer.throw(): the syrup writer must forward the error to
+// the underlying output stream's throw().  pump() in @endo/stream calls
+// writer.throw(err) when the reader side fails, so the writer must
+// honor the iterator-protocol throw method.
+test('writer.throw forwards the error to the underlying output', async t => {
+  /** @type {Error[]} */
+  const thrown = [];
+  const writer = makeSyrupWriter({
+    async next() {
+      return { done: false };
+    },
+    async return() {
+      return { done: true };
+    },
+    async throw(error) {
+      thrown.push(error);
+      return { done: true };
+    },
+  });
+  const boom = Error('boom');
+  const result = await writer.throw(boom);
+  t.is(result.done, true);
+  t.deepEqual(thrown, [boom]);
+});
+
+// Exercise Symbol.asyncIterator: the syrup writer is itself an async
+// iterator, and `for await ... of writer` is the protocol-level way to
+// drive a writer.  This confirms the writer returns itself from
+// Symbol.asyncIterator (the iterable contract).
+test('writer is its own async iterator', t => {
+  const writer = makeSyrupWriter({
+    async next() {
+      return { done: false };
+    },
+    async return() {
+      return { done: true };
+    },
+    async throw() {
+      return { done: true };
+    },
+  });
+  t.is(writer[Symbol.asyncIterator](), writer);
+});
+
+// maxMessageLength is the upper bound; a payload of exactly that length
+// must round-trip without error.  Catches an off-by-one in either the
+// prefix-length cap or the message-length cap.
+test('reads message at exactly maxMessageLength', async t => {
+  await null;
+  const payload = encoder.encode('a'.repeat(10));
+  const r = makeSyrupReader([encoder.encode('10:'), payload], {
+    maxMessageLength: 10,
+  });
+  const got = await read(r);
+  t.deepEqual(got, [payload]);
+});
+
+// A prefix with leading zeros is well-formed (digits only).  This
+// confirms the reader does not reject it as invalid.
+test('reads message with leading-zero prefix', async t => {
+  await null;
+  const r = makeSyrupReader([encoder.encode('05:hello')]);
+  const got = await read(r);
+  t.deepEqual(got, [encoder.encode('hello')]);
+});
+
+// A clean EOF after consuming zero bytes must not throw.  The
+// contract's "Unexpected dangling message" error is for a partial
+// frame at end-of-stream; an empty stream is a valid no-frame stream.
+test('empty input yields no frames without error', async t => {
+  await null;
+  const r = makeSyrupReader([]);
+  t.deepEqual(await read(r), []);
+});
+
+// A zero-length chunk in the input must not advance state and must not
+// throw.  Real socket sources can yield empty chunks when the kernel
+// buffers are momentarily empty.
+test('zero-length chunks are skipped without error', async t => {
+  await null;
+  const r = makeSyrupReader([
+    encoder.encode(''),
+    encoder.encode('5:'),
+    encoder.encode(''),
+    encoder.encode('hello'),
+    encoder.encode(''),
+  ]);
+  t.deepEqual(await read(r), [encoder.encode('hello')]);
+});
+
+// Two adjacent valid frames in a single chunk must be read as two
+// frames, not one.  The contract requires the reader to rearm its
+// length-buffer state after each yielded frame.
+test('two adjacent frames in one chunk read as two', async t => {
+  await null;
+  const r = makeSyrupReader([encoder.encode('5:hello5:world')]);
+  t.deepEqual(await read(r), [
+    encoder.encode('hello'),
+    encoder.encode('world'),
+  ]);
+});
+
+// maxMessageLength: 0 must reject any non-empty message.  An empty
+// frame ('0:') is below the limit and must round-trip; '1:A' must
+// reject.
+test('maxMessageLength: 0 accepts empty frame and rejects non-empty', async t => {
+  await null;
+  const accepting = makeSyrupReader([encoder.encode('0:')], {
+    maxMessageLength: 0,
+  });
+  t.deepEqual(await read(accepting), [encoder.encode('')]);
+
+  const rejecting = makeSyrupReader([encoder.encode('1:A')], {
+    maxMessageLength: 0,
+  });
+  await t.throwsAsync(() => read(rejecting), {
+    message: /too big/,
+  });
+});
+
+// writer.return() must propagate to the underlying output exactly
+// once.  The writer is documented as a transparent forwarder; a
+// double-close upstream would surface as a double-close downstream
+// and confuse half-closed sockets.
+test('writer.return propagates exactly once to the underlying output', async t => {
+  await null;
+  let returnCalls = 0;
+  const writer = makeSyrupWriter({
+    async next() {
+      return { done: false };
+    },
+    async return() {
+      returnCalls += 1;
+      return { done: true };
+    },
+    async throw() {
+      return { done: true };
+    },
+  });
+  const result = await writer.return();
+  t.is(result.done, true);
+  t.is(returnCalls, 1);
+});
+
+// A partial prefix at EOF (digits only, no colon) is silently
+// discarded by the reader: the "Unexpected dangling message" check
+// only fires when the prefix completed and the payload was partial
+// (`lengthBuffer === null` at the post-loop check).  This matches the
+// inherited behavior of @endo/netstring and is not claimed otherwise
+// by the syrup contract; documented here as the explicit invariant.
+test('partial prefix at EOF is silently discarded (matches netstring)', async t => {
+  await null;
+  const r = makeSyrupReader([encoder.encode('123')]);
+  t.deepEqual(await read(r), []);
+});

--- a/packages/syrup-frame/tsconfig.build.json
+++ b/packages/syrup-frame/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../tsconfig-build-options.json"
+  ],
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "exclude": [
+    "test/"
+  ]
+}

--- a/packages/syrup-frame/tsconfig.composite.json
+++ b/packages/syrup-frame/tsconfig.composite.json
@@ -6,37 +6,16 @@
   },
   "references": [
     {
-      "path": "../bytes/tsconfig.composite.json"
-    },
-    {
-      "path": "../eventual-send/tsconfig.composite.json"
-    },
-    {
       "path": "../harden/tsconfig.composite.json"
     },
     {
-      "path": "../hex/tsconfig.composite.json"
-    },
-    {
       "path": "../init/tsconfig.composite.json"
-    },
-    {
-      "path": "../marshal/tsconfig.composite.json"
-    },
-    {
-      "path": "../nat/tsconfig.composite.json"
-    },
-    {
-      "path": "../pass-style/tsconfig.composite.json"
     },
     {
       "path": "../promise-kit/tsconfig.composite.json"
     },
     {
       "path": "../stream/tsconfig.composite.json"
-    },
-    {
-      "path": "../syrup-frame/tsconfig.composite.json"
     }
   ]
 }

--- a/packages/syrup-frame/tsconfig.json
+++ b/packages/syrup-frame/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.eslint-base.json",
+  "include": [
+    "*.js",
+    "*.ts",
+    "src",
+    "test"
+  ]
+}

--- a/packages/syrup-frame/writer.js
+++ b/packages/syrup-frame/writer.js
@@ -1,0 +1,103 @@
+// @ts-check
+
+import harden from '@endo/harden';
+import { makePromiseKit } from '@endo/promise-kit';
+
+// Syrup grammar: <length> ":" <payload> (no trailing separator).
+// Derived from @endo/netstring; the only behavioral difference is that
+// the writer emits no trailing comma after the payload.  See
+// designs/ocapn-tcp-syrup-framing.md.
+
+/** @param {number} length */
+const getLengthPrefixCharCodes = length =>
+  // eslint-disable-next-line no-bitwise
+  [...`${length | 0}:`].map(char => char.charCodeAt(0));
+
+/**
+ * Create a writer stream which wraps messages into the syrup
+ * encoding and writes them to an output writer stream.
+ *
+ * This transform can be zero-copy, if the output stream supports
+ * consecutive writes without waiting.  In that case the by-default-off
+ * `chunked` mode can be enabled.
+ *
+ * Accepts the message as an array of buffers in case the producer would
+ * like to avoid pre-concatenating them.
+ *
+ * @param {import('@endo/stream').Writer<Uint8Array, undefined>} output
+ * @param {object} opts
+ * @param {boolean} [opts.chunked]
+ * @returns {import('@endo/stream').Writer<Uint8Array | Uint8Array[], undefined>}
+ */
+export const makeSyrupWriter = (output, { chunked = false } = {}) => {
+  return harden({
+    async next(messageChunks) {
+      if (!Array.isArray(messageChunks)) {
+        messageChunks = [messageChunks];
+      }
+
+      const messageLength = messageChunks.reduce(
+        (acc, { length }) => acc + length,
+        0,
+      );
+
+      const prefix = getLengthPrefixCharCodes(messageLength);
+
+      if (chunked) {
+        const ack = makePromiseKit();
+
+        const partsWritten = [
+          output.next(new Uint8Array(prefix)),
+          ...messageChunks.map(chunk => output.next(chunk)),
+        ];
+
+        // Resolve early if the output writer closes early.  Each
+        // per-chunk promise also gets a swallowing catch so that a
+        // rejection from one chunk (e.g. socket FIN'd mid-stream)
+        // does not surface as an unhandled rejection.  The aggregate
+        // is already observed by the Promise.all chain below, which
+        // routes failures into ack.reject.
+        for (const promise of partsWritten) {
+          promise.then(
+            partWritten => {
+              if (partWritten.done) {
+                ack.resolve(partWritten);
+              }
+            },
+            () => {},
+          );
+        }
+
+        Promise.all(partsWritten).then(results => {
+          // Redundant resolution is safe and clean.
+          ack.resolve({
+            done: results.some(({ done }) => done),
+            value: undefined,
+          });
+        }, ack.reject);
+
+        return ack.promise;
+      } else {
+        const buffer = new Uint8Array(prefix.length + messageLength);
+        buffer.set(prefix, 0);
+        let i = prefix.length;
+        for (const chunk of messageChunks) {
+          buffer.set(chunk, i);
+          i += chunk.length;
+        }
+
+        return output.next(buffer);
+      }
+    },
+    async return() {
+      return output.return(undefined);
+    },
+    async throw(error) {
+      return output.throw(error);
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  });
+};
+harden(makeSyrupWriter);

--- a/tsconfig.composite.json
+++ b/tsconfig.composite.json
@@ -129,6 +129,9 @@
       "path": "packages/stream-node/tsconfig.composite.json"
     },
     {
+      "path": "packages/syrup-frame/tsconfig.composite.json"
+    },
+    {
       "path": "packages/test262-runner/tsconfig.composite.json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,6 +1094,8 @@ __metadata:
     "@endo/pass-style": "workspace:^"
     "@endo/promise-kit": "workspace:^"
     "@endo/ses-ava": "workspace:^"
+    "@endo/stream": "workspace:^"
+    "@endo/syrup-frame": "workspace:^"
     "@noble/curves": "npm:^1.9.0"
     "@noble/hashes": "npm:^1.8.0"
     "@types/ws": "npm:^8"
@@ -1272,6 +1274,23 @@ __metadata:
     c8: "catalog:dev"
     eslint: "catalog:dev"
     ses: "workspace:^"
+    typescript: "catalog:dev"
+  languageName: unknown
+  linkType: soft
+
+"@endo/syrup-frame@workspace:^, @endo/syrup-frame@workspace:packages/syrup-frame":
+  version: 0.0.0-use.local
+  resolution: "@endo/syrup-frame@workspace:packages/syrup-frame"
+  dependencies:
+    "@endo/eventual-send": "workspace:^"
+    "@endo/harden": "workspace:^"
+    "@endo/init": "workspace:^"
+    "@endo/promise-kit": "workspace:^"
+    "@endo/ses-ava": "workspace:^"
+    "@endo/stream": "workspace:^"
+    ava: "catalog:dev"
+    c8: "catalog:dev"
+    eslint: "catalog:dev"
     typescript: "catalog:dev"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Adds a new workspace package `@endo/syrup-frame`: a sibling of `@endo/netstring` whose framing omits the trailing `,` separator, so each framed payload on the wire is literally a Syrup byte-string record (`<length>:<payload>`). The exported surface is symmetric with `@endo/netstring`: `makeSyrupsReader` and `makeSyrupsWriter`, including the `chunked` zero-copy writer mode.

The OCapN TCP-for-testing netlayer gains an opt-in `framing` option. The default `'none'` preserves the current wire format used by the `ocapn/ocapn-test-suite` Python `testing_only_tcp` netlayer (a single syrup-encoded record per write, no length prefix). Passing `framing: 'syrups'` wraps each message in the new framing so the transport becomes robust to TCP chunk boundaries that split a single OCapN message, and two peers that both opt in share a single length-prefixed primitive with the syrup payload format itself.

### Security Considerations

The package parses untrusted byte streams. The reader rejects malformed prefixes, oversize length declarations (configurable via `maxMessageLength`, default 999_999_999), missing colon, empty prefix, and trailing characters after a complete frame. No new authority is introduced beyond the `Uint8Array` reader/writer pair the package exports. All exported factories, the inner generator, and the returned writer object are `harden()`-ed. The opt-in TCP netlayer framing does not alter the authority boundary of the netlayer; it changes only how bytes are grouped on the wire.

### Scaling Considerations

`maxMessageLength` bounds reader memory at the message granularity. The chunked writer mode avoids a prefix-plus-payload buffer copy. The netlayer framing wrapper adds one length-prefix per message and no other steady-state cost.

### Documentation Considerations

The new package's `README.md` describes the grammar, the asymmetry against `@endo/netstring`, the OCapN TCP-for-testing scope, the API, and the options. Initial-release notes ship in the package changeset. The TCP-netlayer framing option ships with its own changeset describing the opt-in. No deployed-data migration is required.

### Testing Considerations

The new package carries reader, writer, chunked-write, concurrent-write, byte-by-byte fragmentation, trailing-comma rejection, and `writer.throw` forwarding tests, run under both `lockdown` and `noop-harden` configurations. An additional netlayer test exercises a syrups-framed TCP handshake end to end against the JS netlayer.

### Compatibility Considerations

New package; no backwards-compatibility concerns. `@endo/netstring` is unmodified; existing callers are unaffected. The Endo daemon's `tcp+netstring+json+captp0` transport remains netstring-compliant. The TCP-for-testing netlayer's default framing is unchanged; the new behavior is opt-in.

### Upgrade Considerations

No upgrade action required. Initial release of a new package and an additive, opt-in option on an existing test-only netlayer.
