### PR TITLE
Use Amaro for TypeScript type stripping

### DIFF
--- a/.changeset/amaro.md
+++ b/.changeset/amaro.md
@@ -1,0 +1,5 @@
+---
+'@endo/bundle-source': patch
+---
+
+Replace `ts-blank-space` with Amaro for TypeScript type erasure, matching the parser Node.js uses for type stripping.

--- a/packages/bundle-source/README.md
+++ b/packages/bundle-source/README.md
@@ -63,13 +63,14 @@ The syntax to begin or end comments remains.
 TypeScript modules with the `.ts`, `.mts`, and `.cts` extensions in
 packages that are not under a `node_modules` directory are automatically
 converted to JavaScript through type erasure using
-[`ts-blank-space`](https://bloomberg.github.io/ts-blank-space/).
+[`amaro`](https://github.com/nodejs/amaro), the TypeScript parser Node.js uses
+for type stripping.
 
 This will not function for packages that are published as their original
 TypeScript sources, as is consistent with `node
 --experimental-strip-types`.
 This will also not function properly for TypeScript modules that have
-[runtime impacting syntax](https://github.com/bloomberg/ts-blank-space/blob/main/docs/unsupported_syntax.md),
+[runtime impacting syntax](https://nodejs.org/api/typescript.html#typescript-features),
 such as `enum`.
 
 This also does not support importing a `.ts` file using the corresponding

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -30,7 +30,7 @@
     "@endo/init": "workspace:^",
     "@endo/promise-kit": "workspace:^",
     "@endo/where": "workspace:^",
-    "ts-blank-space": "^0.6.1"
+    "amaro": "^1.1.9"
   },
   "devDependencies": {
     "@endo/lockdown": "workspace:^",

--- a/packages/bundle-source/src/endo.js
+++ b/packages/bundle-source/src/endo.js
@@ -6,7 +6,7 @@ import { evadeCensor } from '@endo/evasive-transform';
 import { whereEndoCache } from '@endo/where';
 import { defaultParserForLanguage as transformingParserForLanguage } from '@endo/compartment-mapper/archive-parsers.js';
 import { defaultParserForLanguage as transparentParserForLanguage } from '@endo/compartment-mapper/import-parsers.js';
-import tsBlankSpace from 'ts-blank-space';
+import { transformSync } from 'amaro';
 
 /** @import {Language, ParserImplementation} from '@endo/compartment-mapper/node-powers.js' */
 /** @import {BundlingKit, BundlingKitIO, BundlingKitOptions, ModuleTransformsLike, ParserForLanguageLike, SourceMapDescriptor} from './types.js' */
@@ -199,7 +199,9 @@ export const makeBundlingKit = (
       options = undefined,
     ) {
       const sourceText = textDecoder.decode(sourceBytes);
-      const objectText = tsBlankSpace(sourceText);
+      const { code: objectText } = transformSync(sourceText, {
+        mode: 'strip-only',
+      });
       const objectBytes = textEncoder.encode(objectText);
       return parserForLanguage.mjs.parse(
         objectBytes,
@@ -223,7 +225,9 @@ export const makeBundlingKit = (
       options = undefined,
     ) {
       const sourceText = textDecoder.decode(sourceBytes);
-      const objectText = tsBlankSpace(sourceText);
+      const { code: objectText } = transformSync(sourceText, {
+        mode: 'strip-only',
+      });
       const objectBytes = textEncoder.encode(objectText);
       return parserForLanguage.cjs.parse(
         objectBytes,

--- a/tsconfig.eslint-base.json
+++ b/tsconfig.eslint-base.json
@@ -4,6 +4,7 @@
     "target": "esnext",
     "module": "NodeNext",
     "checkJs": true,
+    "erasableSyntaxOnly": true,
     "incremental": true,
     "noEmit": true,
     "verbatimModuleSyntax": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,11 +485,11 @@ __metadata:
     "@endo/ses-ava": "workspace:^"
     "@endo/where": "workspace:^"
     "@endo/zip": "workspace:^"
+    amaro: "npm:^1.1.9"
     ava: "catalog:dev"
     c8: "catalog:dev"
     eslint: "catalog:dev"
     ses: "workspace:^"
-    ts-blank-space: "npm:^0.6.1"
     typescript: "catalog:dev"
   bin:
     bundle-source: ./src/tool.js
@@ -3266,6 +3266,13 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+  languageName: node
+  linkType: hard
+
+"amaro@npm:^1.1.9":
+  version: 1.1.9
+  resolution: "amaro@npm:1.1.9"
+  checksum: 10c0/54a222810cfbc53c04286b20a64c65b8e8110199be94bce3380d090881c4521eb7545d2c0749afecffbaa9fe0b89f1050bfbc8b5bba755ba2e6f1bc81ebfa1f6
   languageName: node
   linkType: hard
 
@@ -11758,15 +11765,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-blank-space@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "ts-blank-space@npm:0.6.1"
-  dependencies:
-    typescript: "npm:5.1.6 - 5.8.x"
-  checksum: 10c0/cf674e96d204c3f6d99e29966580b7c3526680ff012dfa3e45aef10a1052011b5ced55bae81d57f46b153053ed9413082a2d15db7812c2c0eb138d178b0f376c
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^4.1.2":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
@@ -12053,16 +12051,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.1.6 - 5.8.x":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
-  languageName: node
-  linkType: hard
-
 "typescript@npm:>=3 < 6, typescript@npm:~5.9.2":
   version: 5.9.2
   resolution: "typescript@npm:5.9.2"
@@ -12080,16 +12068,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/4b860b0bf87cc0fee0f66d8ef2640b5a8a8a8c74d1129adb82e389e5f97124383823c47946bef8a73ede371461143a3aa8544399d2133c7b2e4f07e81860af7f
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A5.1.6 - 5.8.x#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR replaces `ts-blank-space` with `amaro` for TypeScript type erasure in `@endo/bundle-source`, updates the README, refreshes the lockfile, and adds a patch changeset.

The motivation is to align Endo with the same TypeScript stripping implementation Node itself uses. Amaro is stabilizing as Node’s TypeScript parser wrapper, and depending on `amaro` directly instead of reaching for `node:` utilities lets older Node versions get the latest, most reliable transform behavior without being coupled to the Node version that happens to run the bundler.

This PR also enables TypeScript’s `erasableSyntaxOnly` option in the shared base tsconfig so the repository checks reject TypeScript syntax that would require runtime transformation rather than type erasure.

Critical files to review:

- `packages/bundle-source/src/endo.js`
- `packages/bundle-source/package.json`
- `tsconfig.eslint-base.json`

### Security Considerations

This changes the implementation used to strip TypeScript syntax before bundling. It does not add new runtime authority or change boundaries between mutually-suspicious components. The new dependency is the package used by Node’s own TypeScript stripping path, reducing divergence from platform behavior.

### Scaling Considerations

No significant scaling impact is expected. Type stripping still happens once per TypeScript module during bundling.

### Documentation Considerations

`packages/bundle-source/README.md` now documents Amaro as the type erasure implementation and links to Node’s TypeScript syntax limitations. Existing bundles and deployments do not need migration.

### Testing Considerations

Validated with:

- `yarn workspace @endo/bundle-source lint`
- `yarn workspace @endo/bundle-source ava test/endo-script-format.test.js`
- `yarn workspace @endo/bundle-source test`
- `yarn tsc --noEmit --pretty false`
- `git diff --check`

The full `@endo/bundle-source` test suite passed with its existing known failures only.

### Compatibility Considerations

This should preserve the existing supported type-erasure behavior while aligning it with Node’s implementation. Enabling `erasableSyntaxOnly` may reject future checked TypeScript code that uses non-erasable syntax such as enums or parameter properties, which matches the intended bundling constraint.

### Upgrade Considerations

No production data migration is required. Consumers receive the Amaro dependency through `@endo/bundle-source`.
