### PR TITLE
ci(ocapn-guile-interop): reorder substitute servers and widen sturdyref wait

### DIFF
--- a/.github/workflows/ocapn-guile-interop.yml
+++ b/.github/workflows/ocapn-guile-interop.yml
@@ -143,13 +143,23 @@ jobs:
           export GUIX_PATH=/var/guix/profiles/per-user/root/current-guix
 
           sudo cp "$GUIX_PATH/lib/systemd/system/gnu-store.mount" /etc/systemd/system/
-          # Configure the daemon with both substitute servers up front so
-          # `guix build` falls back to bordeaux.guix.gnu.org whenever
-          # ci.guix.gnu.org is degraded. Both keys are authorized below
-          # from the tarball's bundled `share/guix/*.pub` files.
-          # `--fallback` is a client-side flag (e.g. for `guix build`)
-          # and is rejected by the daemon, so it goes on the build
-          # invocations themselves rather than here.
+          # Configure the daemon with both substitute servers up front
+          # so degradation of one does not block the other. The order
+          # below puts `ci.guix.gnu.org` first because the daemon's
+          # per-item slow path is "first server unreachable" (each
+          # lookup eats a connection timeout before falling through),
+          # not "first server returns 5xx", and the recent failure
+          # window (2026-05-14) saw sustained "Network is unreachable"
+          # from `bordeaux.guix.gnu.org` while `ci.guix.gnu.org` served
+          # substitutes normally. The asymmetry is acceptable: when
+          # `ci.guix.gnu.org` is the one degraded (the failure mode
+          # iteration I in #82 originally addressed), the daemon still
+          # falls back to `bordeaux.guix.gnu.org`. Both keys are
+          # authorized below from the tarball's bundled
+          # `share/guix/*.pub` files. `--fallback` is a client-side
+          # flag (e.g. for `guix build`) and is rejected by the
+          # daemon, so it goes on the build invocations themselves
+          # rather than here.
           cat <<'EOF' | sudo tee /etc/systemd/system/guix-daemon.service > /dev/null
           # Service unit file for guix-daemon, modeled on the upstream
           # template in the Guix install tarball but with explicit
@@ -161,7 +171,7 @@ jobs:
           [Service]
           ExecStart=/var/guix/profiles/per-user/root/current-guix/bin/guix-daemon \
               --build-users-group=guixbuild --discover=yes \
-              --substitute-urls='https://bordeaux.guix.gnu.org https://ci.guix.gnu.org'
+              --substitute-urls='https://ci.guix.gnu.org https://bordeaux.guix.gnu.org'
           Environment='GUIX_LOCPATH=/var/guix/profiles/per-user/root/guix-profile/lib/locale' LC_ALL=en_US.utf8
 
           StandardOutput=syslog
@@ -196,12 +206,14 @@ jobs:
         run: guix describe || guix --version
 
       # The substitute fetches that follow inherit `--substitute-urls`
-      # from the daemon, so they consult bordeaux.guix.gnu.org when
-      # ci.guix.gnu.org is degraded. We pass `--fallback` per-invocation
-      # to permit local builds when neither server has the requested
-      # item. The retry wrapper guards against transient daemon errors
-      # during the bordeaux <-> ci handoff, and against the daemon
-      # socket not being ready for the first few seconds after Install.
+      # from the daemon, so they consult `bordeaux.guix.gnu.org` when
+      # `ci.guix.gnu.org` is degraded (and vice-versa, per the daemon
+      # unit's reordered list above). We pass `--fallback` per
+      # invocation to permit local builds when neither server has the
+      # requested item. The retry wrapper guards against transient
+      # daemon errors during the ci <-> bordeaux handoff, and against
+      # the daemon socket not being ready for the first few seconds
+      # after Install.
       - name: Resolve Guix module paths
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
@@ -284,8 +296,14 @@ jobs:
           # with auto-compile disabled; allow Guile to compile modules first.
           # `--fallback` permits local builds when neither substitute server
           # has the requested item (it is a client flag, not a daemon flag).
+          # The 600s upper bound covers the `guix shell` startup (substitute
+          # fetch + local build of any missing item) plus the Guile host's
+          # steady-state lifetime while the Endo client connects. The
+          # polling-for-sturdyref loop below caps the startup portion at
+          # 240s and leaves at least 360s for the Endo client to drive the
+          # interop, which the Endo step itself bounds at 120s.
           OCAPN_TEST_PORT="$OCAPN_TEST_PORT" GUILE_AUTO_COMPILE=1 \
-            timeout 300s guix shell --pure --no-grafts --fallback \
+            timeout 600s guix shell --pure --no-grafts --fallback \
             --preserve='^OCAPN_TEST_PORT$|^GUILE_AUTO_COMPILE$' \
             guile guile-fibers guile-websocket guile-gnutls guile-gcrypt -- \
             guile \
@@ -299,8 +317,20 @@ jobs:
               "hello from Guile CI" "hello from Endo OCapN" \
               > /tmp/guile-interop.log 2>&1 &
           echo $! > /tmp/guile-interop.pid
-          # Wait for the Guile host to advertise its sturdyref.
-          for i in $(seq 1 120); do
+          # Wait for the Guile host to advertise its sturdyref. The
+          # previous 120-second ceiling was tight in the nominal case
+          # but tripped before `guix shell` could finish its
+          # substitute fetch on degraded-substitute-network days
+          # (2026-05-14: `bordeaux.guix.gnu.org` connection-timeouts
+          # added per-item overhead to every fetch, pushing the
+          # sturdyref publication past 120 seconds despite the daemon
+          # eventually completing). 240 seconds covers the slow path
+          # without inflating the nominal-case runtime; the `kill -0`
+          # guard breaks the loop early when the background process
+          # dies for any reason, so a hung 240-second wait is
+          # impossible in practice. The outer `timeout 600s` on the
+          # `guix shell` invocation above is the absolute upper bound.
+          for i in $(seq 1 240); do
             if grep -q 'sturdyref:' /tmp/guile-interop.log; then break; fi
             if ! kill -0 "$(cat /tmp/guile-interop.pid)" 2>/dev/null; then break; fi
             sleep 1


### PR DESCRIPTION
## Description

Reorders the `guix-daemon` substitute servers so `ci.guix.gnu.org` is consulted first and `bordeaux.guix.gnu.org` second, and widens the `ocapn-guile-interop` workflow's per-step time budgets to cover slow-substitute days.

Follow-up to 246c6a6c, which added `bordeaux.guix.gnu.org` as a fallback. That change handled the "ci.guix.gnu.org returns 5xx" failure mode (the daemon retries against Bordeaux and proceeds). The 2026-05-14 outage exhibited the symmetric case the original ordering did not cover: Bordeaux was unreachable from GitHub-hosted runners while `ci.guix.gnu.org` was healthy, and because Bordeaux was listed first, every per-item substitute lookup paid a connection-timeout before falling through. The accumulated per-item overhead pushed the Guile host's sturdyref publication past the workflow's 120-second polling ceiling even though the `guix shell` invocation itself was alive and making progress.

The fix is two coordinated adjustments. The daemon's `--substitute-urls` now lists `ci.guix.gnu.org` first because the daemon's slow path is "first server unreachable" rather than "first server returns 5xx"; the prior failure mode is still covered (a degraded `ci.guix.gnu.org` falls through to Bordeaux as before). The sturdyref polling window grows from 120 to 240 seconds and the outer `timeout` on `guix shell` grows from 300 to 600 seconds, so a slow-substitute day no longer trips the wait before the host has had a chance to publish.

### Security Considerations

No change to the trust boundary. Both substitute servers remain pinned by the keys authorized from the tarball's bundled `share/guix/*.pub` files; only their order in the daemon's URL list changes. The widened timeouts do not change what code runs, only how long the workflow is willing to wait for it.

### Scaling Considerations

The 600-second outer `timeout` is an upper bound, not a steady-state cost. In the nominal case (both substitute servers healthy) the workflow exits well before the old 300-second bound. The widened bound only consumes runner minutes on the slow path, which is the case this change exists to keep green.

### Documentation Considerations

No user-facing or API-facing surface changes. The reasoning for the ordering and the timeout values lives in comments adjacent to the lines they explain, so a future reader does not need to reconstruct the failure mode from the commit history.

### Testing Considerations

The change is CI-workflow-only and is exercised by the workflow itself on every PR. Behavior under degraded substitute conditions can only be observed in production (i.e., during an actual outage), which is why this PR is opened as draft: leaving it draft for a window lets the next slow-substitute day validate the behavior on the bot-side workflow before flagging for review.

### Compatibility Considerations

No effect on consumers of any published package. The change is internal to the CI workflow.

### Upgrade Considerations

None.
