### PR TITLE
chore(ci): drop Node.js 20 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
         platform: [ubuntu-latest, macos-15]
         # windows-latest exhibited flakey tests that are not yet worth the
         # trouble to investigate, and blocked us from upgrading yarn from 1 to
@@ -129,15 +129,20 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          # Historical record of Node patch-version compatibility for the
+          # SES-viable promise-hook surface (entries removed as their Node
+          # major lines reached EOL or left CI):
           # '16.1' last version before some significant promise hooks changes
           # '16.5' last version before unconditional promise fast-path
           # '16.6' first version after unconditional promise fast-path
           - '18'
-          # '20.6' not viable due to https://github.com/nodejs/node/issues/49497
           # '20.3' to '20.6' not viable due to https://github.com/nodejs/node/pull/49211
-          # '20.7' first SES-viable version
-          # '20.9' first LTS of 20
-          - '20'
+          # '20.6' not viable due to https://github.com/nodejs/node/issues/49497
+          # '20.7' first SES-viable version of Node 20
+          # '20.9' first LTS of Node 20
+          # '22' is the post-promise-fast-path lane on a current LTS
+          # (the SES-viable promise-hook lane the Node-20 entry was guarding).
+          - '22'
         platform:
           - ubuntu-latest
 
@@ -177,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -213,7 +218,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -315,7 +320,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         platform: [ubuntu-latest]
 
     steps:
@@ -359,7 +364,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         # may include release tags and hashes:
         moddable-version: [5.0.0]
         platform: [ubuntu-latest]


### PR DESCRIPTION
## Description

This PR drops Node.js 20.x from the CI matrices. It is stacked on `endojs/endo#3084` (the Node 18 drop); together they drop both Node 18 and Node 20 from the CI matrices, leaving Node 22.x (active LTS) and the per-job pins advanced from 20.x to 22.x where they applied.

Node 20 enters maintenance and is winding down through its LTS lifecycle. Standalone Node-20 jobs (`test-xs`, `test-ocapn-python`, `cover`, `test262`, `viable-release`) are advanced to Node 22.x rather than removed. The `test-async-hooks` matrix's `'20'` entry is also advanced to `'22'`, framed as the SES-viable promise-hook lane that the Node-20 entry was guarding. The Node-20 patch-version compatibility commentary (the `'20.3'`/`'20.6'`/`'20.7'`/`'20.9'` history) is preserved above the surviving `'22'` entry as a historical record so future readers can see the lineage; the Node-20 `test-xs (macos-15)` lane was filed as flaky on the bot side and the move off Node 20 closes that lane out.

### Security Considerations

No security-boundary changes. CI matrix scope only.

### Scaling Considerations

The CI matrix shrinks (one fewer Node major across multiple jobs). No new resource consumption.

### Documentation Considerations

No downstream documentation impact. The `engines.node` declarations in package manifests are out of scope for this PR; consumers continue to receive the same engines guidance until a separate change advances those declarations.

### Testing Considerations

CI exercises the change directly. The `test-async-hooks` lane on `'22'` is the SES-viable promise-hook surface that the Node-20 entry previously guarded.

### Compatibility Considerations

This PR does not modify `engines.node`. Consumers running Node 18, 20, or 22 are not affected by the CI matrix narrowing in itself; the practical compatibility envelope continues to be governed by `engines.node` until a separate change advances it.

### Upgrade Considerations

No live production system upgrade implications.
