### PR TITLE
fix(skel): remove too-broad includes from default tsconfig

### DIFF
--- a/packages/skel/tsconfig.json
+++ b/packages/skel/tsconfig.json
@@ -2,8 +2,19 @@
   "extends": "../../tsconfig.eslint-base.json",
   "include": [
     "*.js",
-    "*.ts",
-    "src",
+    "src/**/*.js",
     "test"
+    
+    // if any .ts sources exist, add them here
+    // then use a negation pattern to exclude them from the include list
+    // e.g.
+    // ```
+    // "src/types/*.ts",
+    // "!src/types/*.d.ts"
+    // ```
+
+    // add any hand-rolled .d.ts files to this list manually
+
   ]
+  // do not use `exclude` here; it will be overridden by tsconfig.build.json
 }


### PR DESCRIPTION
This moves the defaults generated by `@endo/skel` in-line with support for composite configurations.

`*.ts` or `**/*.ts` is too broad, since it will catch generated `.d.ts` files.

Adds instructions on how to edit `tsconfig.json`.