### PR TITLE
chore(ts): fix tsconfigs

### DIFF
--- a/packages/bytes/tsconfig.build.json
+++ b/packages/bytes/tsconfig.build.json
@@ -3,9 +3,6 @@
     "./tsconfig.json",
     "../../tsconfig-build-options.json"
   ],
-  "compilerOptions": {
-    "allowJs": true
-  },
   "exclude": [
     "test/"
   ]

--- a/packages/bytes/tsconfig.json
+++ b/packages/bytes/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.eslint-base.json",
   "include": [
     "*.js",
-    "*.ts",
-    "src",
+    "src/**/*.js",
     "test"
   ]
 }

--- a/packages/pass-style/tsconfig.json
+++ b/packages/pass-style/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "../../tsconfig.eslint-base.json",
   "include": [
     "*.js",
-    "*.ts",
     "src/**/*.js",
-    "src/**/*.ts",
+    "src/types.d.ts",
     "test",
     "tools/**/*.js",
   ]

--- a/packages/syrup-frame/tsconfig.json
+++ b/packages/syrup-frame/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.eslint-base.json",
   "include": [
     "*.js",
-    "*.ts",
     "src",
-    "test"
+    "test/*.js"
   ]
 }


### PR DESCRIPTION
This fixes the `tsconfig.json` files for `@endo/bytes`, `@endo/pass-style` & `@endo/syrup-frame`, which were incompatible with the composite build. It also removes a redundant option from `packages/bytes/tsconfig.build.json`.

take two... (Ref: #3270)