### PR TITLE
fix(eslint-plugin): harden-exports handles destructuring patterns (#2390)

### DIFF
--- a/.changeset/harden-exports-destructuring.md
+++ b/.changeset/harden-exports-destructuring.md
@@ -1,0 +1,10 @@
+---
+'@endo/eslint-plugin': patch
+---
+
+`harden-exports` now collects export names from all binding pattern shapes
+that may appear on the left-hand side of `export const ... = ...`:
+aliased object destructuring (`{ propName: aliasName }`), object and array
+rest, nested patterns, sparse holes, and default-value assignment patterns.
+A new `unknownBindingPattern` report surfaces any pattern type the helper
+does not recognize, in place of silent passthrough.

--- a/packages/eslint-plugin/lib/rules/harden-exports.js
+++ b/packages/eslint-plugin/lib/rules/harden-exports.js
@@ -11,6 +11,85 @@
  */
 
 /**
+ * Recursively collect the names introduced by a destructuring or identifier
+ * binding pattern.
+ *
+ * Handles all binding pattern shapes that may appear on the left-hand side of
+ * any `export <kind> ... = ...` declaration where `<kind>` is `const`, `let`,
+ * or `var` (the rule visits every `ExportNamedDeclaration` carrying a
+ * `VariableDeclaration`, not just `const`):
+ *
+ * - Identifier: `export const a = ...`.
+ * - ObjectPattern properties: `export const { a } = ...` and
+ *   `export const { propName: aliasName } = ...`. We recurse into prop.value
+ *   (the binding target) rather than prop.key (the source property name);
+ *   in shorthand they are the same node, but with an alias they differ.
+ * - ObjectPattern rest: `export const { ...rest } = ...`.
+ * - ArrayPattern elements: `export const [ a, b ] = ...`. Skips null elements
+ *   that represent sparse holes (`[ , a ]`).
+ * - AssignmentPattern: defaults like `export const [ a = 1 ] = ...` or
+ *   `export const { a: b = 1 } = ...`. The bound name lives in node.left.
+ * - RestElement: `export const [ a, ...rest ] = ...` and object rest above.
+ *
+ * Returns true if every encountered sub-pattern was a recognized shape, false
+ * if any unknown pattern type was traversed (so the caller may decide whether
+ * to surface a report rather than silently produce a possibly incomplete name
+ * list).
+ * @param {ESTree.Pattern | null} pattern
+ * @param {string[]} names
+ * @returns {boolean}
+ */
+const pushDeclaredNames = (pattern, names) => {
+  if (pattern === null) {
+    // Sparse array hole, e.g., `const [ , a ] = ...`.
+    return true;
+  }
+  switch (pattern.type) {
+    case 'Identifier': {
+      names.push(pattern.name);
+      return true;
+    }
+    case 'ObjectPattern': {
+      let ok = true;
+      for (const prop of pattern.properties) {
+        if (prop.type === 'RestElement') {
+          ok = pushDeclaredNames(prop.argument, names) && ok;
+        } else if (prop.type === 'Property') {
+          // For `{ propName: aliasName }`, prop.value is the binding target
+          // (`aliasName`); for shorthand `{ name }`, prop.value === prop.key.
+          // ESTree narrows ObjectPattern's properties to Property|RestElement,
+          // so prop.value is always a Pattern here.
+          ok = pushDeclaredNames(prop.value, names) && ok;
+        } else {
+          ok = false;
+        }
+      }
+      return ok;
+    }
+    case 'ArrayPattern': {
+      let ok = true;
+      for (const element of pattern.elements) {
+        ok = pushDeclaredNames(element, names) && ok;
+      }
+      return ok;
+    }
+    case 'AssignmentPattern': {
+      // The default value lives in node.right; the binding is in node.left.
+      return pushDeclaredNames(pattern.left, names);
+    }
+    case 'RestElement': {
+      return pushDeclaredNames(pattern.argument, names);
+    }
+    default: {
+      // Unknown pattern shape; the caller is responsible for surfacing this.
+      // Returning false keeps the helper resilient to future ECMAScript
+      // binding patterns while making the gap visible.
+      return false;
+    }
+  }
+};
+
+/**
  * ESLint rule module for ensuring each named export is followed by a call to `harden` function.
  * @type {Rule.RuleModule}
  */
@@ -25,6 +104,14 @@ module.exports = {
     },
     fixable: 'code',
     schema: [],
+    messages: {
+      missingHardenCall:
+        "Named export(s) '{{names}}' should be followed by a call to 'harden'.",
+      functionExportNotConst:
+        "Export '{{name}}' should be a const declaration with an arrow function.",
+      unknownBindingPattern:
+        'Unrecognized binding pattern in named export; rule cannot verify harden coverage.',
+    },
   },
   /**
    * Create function for the rule.
@@ -46,63 +133,80 @@ module.exports = {
         for (const exportNode of exportNodes) {
           /** @type {string[]} */
           const exportNames = [];
+          // Stays true only if every binding pattern encountered for this
+          // export was a shape `pushDeclaredNames` recognized.
+          let allRecognized = true;
           if (exportNode.declaration) {
-            // @ts-expect-error xxx typedef
-            if (exportNode.declaration.declarations) {
-              // @ts-expect-error xxx typedef
+            if (exportNode.declaration.type === 'VariableDeclaration') {
               for (const declaration of exportNode.declaration.declarations) {
-                if (declaration.id.type === 'ObjectPattern') {
-                  for (const prop of declaration.id.properties) {
-                    exportNames.push(prop.key.name);
-                  }
-                } else {
-                  exportNames.push(declaration.id.name);
+                const recognized = pushDeclaredNames(
+                  declaration.id,
+                  exportNames,
+                );
+                if (!recognized) {
+                  allRecognized = false;
+                  context.report({
+                    node: declaration,
+                    messageId: 'unknownBindingPattern',
+                  });
                 }
               }
             } else if (exportNode.declaration.type === 'FunctionDeclaration') {
               context.report({
                 node: exportNode,
-                // The 'function' keyword hoisting makes the valuable mutable before it can be hardened.
-                message: `Export '${exportNode.declaration.id.name}' should be a const declaration with an arrow function.`,
+                // The 'function' keyword hoisting makes the value mutable
+                // before it can be hardened.
+                messageId: 'functionExportNotConst',
+                data: { name: exportNode.declaration.id.name },
               });
             }
           } else if (exportNode.specifiers) {
             for (const spec of exportNode.specifiers) {
-              exportNames.push(spec.exported.name);
-            }
-          }
-
-          const missingHardenCalls = [];
-          for (const exportName of exportNames) {
-            const hasHardenCall = sourceCode.ast.body.some(statement => {
-              return (
-                statement.type === 'ExpressionStatement' &&
-                statement.expression.type === 'CallExpression' &&
-                // @ts-expect-error xxx typedef
-                statement.expression.callee.name === 'harden' &&
-                statement.expression.arguments.length === 1 &&
-                // @ts-expect-error xxx typedef
-                statement.expression.arguments[0].name === exportName
+              exportNames.push(
+                /** @type {ESTree.Identifier} */ (spec.exported).name,
               );
-            });
-
-            if (!hasHardenCall) {
-              missingHardenCalls.push(exportName);
             }
           }
 
-          if (missingHardenCalls.length > 0) {
-            const noun = missingHardenCalls.length === 1 ? 'export' : 'exports';
-            context.report({
-              node: exportNode,
-              message: `Named ${noun} '${missingHardenCalls.join(', ')}' should be followed by a call to 'harden'.`,
-              fix(fixer) {
-                const hardenCalls = missingHardenCalls
-                  .map(name => `harden(${name});`)
-                  .join('\n');
-                return fixer.insertTextAfter(exportNode, `\n${hardenCalls}`);
-              },
-            });
+          // Skip the missing-harden enforcement for this export entirely
+          // when any binding pattern was unrecognized. The
+          // `unknownBindingPattern` report above already names the
+          // declaration as unverifiable; emitting a missing-harden report
+          // and autofix on top of a possibly incomplete name list would
+          // contradict that admission and risk inserting wrong fixes.
+          if (allRecognized) {
+            const missingHardenCalls = [];
+            for (const exportName of exportNames) {
+              const hasHardenCall = sourceCode.ast.body.some(statement => {
+                return (
+                  statement.type === 'ExpressionStatement' &&
+                  statement.expression.type === 'CallExpression' &&
+                  // @ts-expect-error xxx typedef
+                  statement.expression.callee.name === 'harden' &&
+                  statement.expression.arguments.length === 1 &&
+                  // @ts-expect-error xxx typedef
+                  statement.expression.arguments[0].name === exportName
+                );
+              });
+
+              if (!hasHardenCall) {
+                missingHardenCalls.push(exportName);
+              }
+            }
+
+            if (missingHardenCalls.length > 0) {
+              context.report({
+                node: exportNode,
+                messageId: 'missingHardenCall',
+                data: { names: missingHardenCalls.join(', ') },
+                fix(fixer) {
+                  const hardenCalls = missingHardenCalls
+                    .map(name => `harden(${name});`)
+                    .join('\n');
+                  return fixer.insertTextAfter(exportNode, `\n${hardenCalls}`);
+                },
+              });
+            }
           }
         }
       },

--- a/packages/eslint-plugin/test/harden-exports.test.js
+++ b/packages/eslint-plugin/test/harden-exports.test.js
@@ -30,6 +30,79 @@ harden(getEnvironmentOptionsList);
 harden(environmentOptionsListHas);
         `,
   },
+  // Aliased destructuring: { propName: exportName } binds exportName.
+  {
+    code: `
+export const { propName: exportName } = obj;
+harden(exportName);
+        `,
+  },
+  // Object rest binding.
+  {
+    code: `
+export const { name, ...rest } = obj;
+harden(name);
+harden(rest);
+        `,
+  },
+  // Nested object destructuring.
+  {
+    code: `
+export const { name, parent: { subName } } = obj;
+harden(name);
+harden(subName);
+        `,
+  },
+  // Array destructuring.
+  {
+    code: `
+export const [ first, second ] = array;
+harden(first);
+harden(second);
+        `,
+  },
+  // Array rest binding.
+  {
+    code: `
+export const [ head, ...tail ] = array;
+harden(head);
+harden(tail);
+        `,
+  },
+  // Sparse array hole; the hole introduces no binding.
+  {
+    code: `
+export const [ , second ] = array;
+harden(second);
+        `,
+  },
+  // Default-value assignment patterns in array and object destructuring.
+  {
+    code: `
+export const [ first = 1 ] = array;
+harden(first);
+        `,
+  },
+  {
+    code: `
+export const { name = 'default' } = obj;
+harden(name);
+        `,
+  },
+  {
+    code: `
+export const { propName: aliasName = 1 } = obj;
+harden(aliasName);
+        `,
+  },
+  // Deeply nested destructuring with array, object, alias and default.
+  {
+    code: `
+export const [ { propName: aliasName = 1 }, [ inner ] ] = data;
+harden(aliasName);
+harden(inner);
+        `,
+  },
 ];
 
 const invalid = [
@@ -42,7 +115,8 @@ harden(a);
               `,
     errors: [
       {
-        message: "Named export 'b' should be followed by a call to 'harden'.",
+        message:
+          "Named export(s) 'b' should be followed by a call to 'harden'.",
       },
     ],
     output: `
@@ -59,7 +133,8 @@ export const a = 1;
               `,
     errors: [
       {
-        message: "Named export 'a' should be followed by a call to 'harden'.",
+        message:
+          "Named export(s) 'a' should be followed by a call to 'harden'.",
       },
     ],
     output: `
@@ -123,10 +198,12 @@ export function
         `,
     errors: [
       {
-        message: "Named export 'a' should be followed by a call to 'harden'.",
+        message:
+          "Named export(s) 'a' should be followed by a call to 'harden'.",
       },
       {
-        message: "Named export 'b' should be followed by a call to 'harden'.",
+        message:
+          "Named export(s) 'b' should be followed by a call to 'harden'.",
       },
       {
         message:
@@ -166,7 +243,7 @@ environmentOptionsListHas,
     errors: [
       {
         message:
-          "Named exports 'getEnvironmentOption, getEnvironmentOptionsList, environmentOptionsListHas' should be followed by a call to 'harden'.",
+          "Named export(s) 'getEnvironmentOption, getEnvironmentOptionsList, environmentOptionsListHas' should be followed by a call to 'harden'.",
       },
     ],
     output: `
@@ -180,10 +257,196 @@ harden(getEnvironmentOptionsList);
 harden(environmentOptionsListHas);
     `,
   },
+  // Aliased destructuring: only the alias is the binding name; the rule
+  // must not chase the source property name.
+  {
+    code: `
+export const { propName: exportName } = obj;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'exportName' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const { propName: exportName } = obj;
+harden(exportName);
+    `,
+  },
+  // Object rest.
+  {
+    code: `
+export const { name, ...rest } = obj;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'name, rest' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const { name, ...rest } = obj;
+harden(name);
+harden(rest);
+    `,
+  },
+  // Nested object pattern.
+  {
+    code: `
+export const { name, parent: { subName } } = obj;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'name, subName' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const { name, parent: { subName } } = obj;
+harden(name);
+harden(subName);
+    `,
+  },
+  // Array pattern.
+  {
+    code: `
+export const [ first, second ] = array;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'first, second' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const [ first, second ] = array;
+harden(first);
+harden(second);
+    `,
+  },
+  // Array rest.
+  {
+    code: `
+export const [ head, ...tail ] = array;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'head, tail' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const [ head, ...tail ] = array;
+harden(head);
+harden(tail);
+    `,
+  },
+  // Sparse array hole introduces no binding for the hole.
+  {
+    code: `
+export const [ , second ] = array;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'second' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const [ , second ] = array;
+harden(second);
+    `,
+  },
+  // Default-value (AssignmentPattern) bindings.
+  {
+    code: `
+export const [ first = 1 ] = array;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'first' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const [ first = 1 ] = array;
+harden(first);
+    `,
+  },
+  {
+    code: `
+export const { name = 'default' } = obj;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'name' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const { name = 'default' } = obj;
+harden(name);
+    `,
+  },
+  {
+    code: `
+export const { propName: aliasName = 1 } = obj;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'aliasName' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const { propName: aliasName = 1 } = obj;
+harden(aliasName);
+    `,
+  },
+  // Deeply nested destructuring combining array, object, alias and default.
+  {
+    code: `
+export const [ { propName: aliasName = 1 }, [ inner ] ] = data;
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'aliasName, inner' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const [ { propName: aliasName = 1 }, [ inner ] ] = data;
+harden(aliasName);
+harden(inner);
+    `,
+  },
+  // Object rest with a hardened sibling but a different identifier hardened
+  // alongside: the rule must still flag the rest binding by its own name and
+  // not be fooled by an unrelated harden() call.
+  {
+    code: `
+export const { name, ...rest } = obj;
+harden(name);
+harden(notRest);
+    `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'rest' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const { name, ...rest } = obj;
+harden(rest);
+harden(name);
+harden(notRest);
+    `,
+  },
 ];
 
 const jsTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2018, sourceType: 'module' },
 });
 jsTester.run('harden JS exports', rule, {
   valid: jsValid,
@@ -192,7 +455,7 @@ jsTester.run('harden JS exports', rule, {
 
 const tsTester = new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
-  parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2018, sourceType: 'module' },
 });
 tsTester.run('harden TS exports', rule, {
   valid: [
@@ -206,6 +469,34 @@ export interface Bar {
 }
           `,
     },
+    // TypeScript-annotated destructuring still binds the names; harden covers.
+    {
+      code: `
+export const { name, ...rest }: { name: string; [k: string]: unknown } = obj;
+harden(name);
+harden(rest);
+          `,
+    },
   ],
-  invalid,
+  invalid: [
+    ...invalid,
+    // TypeScript-annotated destructuring missing harden calls; the rule must
+    // see through the type annotation and report the value bindings.
+    {
+      code: `
+export const { name, ...rest }: { name: string; [k: string]: unknown } = obj;
+    `,
+      errors: [
+        {
+          message:
+            "Named export(s) 'name, rest' should be followed by a call to 'harden'.",
+        },
+      ],
+      output: `
+export const { name, ...rest }: { name: string; [k: string]: unknown } = obj;
+harden(name);
+harden(rest);
+    `,
+    },
+  ],
 });


### PR DESCRIPTION
Closes: #2390

## Description

The `harden-exports` ESLint rule now handles every binding-pattern shape that can appear on the left-hand side of an `export const … = …` declaration. The previous implementation mishandled several shapes: `export const { propName: exportName } = obj` pulled `propName` (the source property) instead of `exportName` (the binding); `export const { name, ...rest } = obj` ignored the rest binding; `export const { name, parent: { subName } } = obj` ignored nested patterns; and `export const [ a, b ] = arr` was skipped entirely because the rule only branched on `ObjectPattern`.

A recursive `pushDeclaredNames(pattern, names)` helper now walks every binding-pattern shape: `Identifier`; `ObjectPattern` shorthand and alias properties (recursing into `prop.value`, not `prop.key`); object rest (`{ a, ...rest }`); `ArrayPattern` elements including sparse holes; array rest (`[ head, ...tail ]`); `AssignmentPattern` defaults (`[ a = 1 ]`, `{ a: b = 1 }`); and arbitrary nesting of all of the above. The default branch of the helper returns a recognized flag and surfaces an `unknownBindingPattern` report so future ECMAScript binding patterns do not silently slip past the rule. Report messages moved into `meta.messages` with `messageId`/`data` to match sibling-rule conventions.

### Security Considerations

No new authority. The rule's surface is lint-time analysis of source files in the repos that adopt the rule; it neither grants nor restricts runtime capability.

### Scaling Considerations

The recursive helper visits each binding node once. Asymptotic cost is unchanged from the prior ad-hoc traversal; nested patterns that the prior code skipped now incur their own constant per-node cost.

### Documentation Considerations

No documentation surface changes. A `patch` changeset accompanies the change.

### Testing Considerations

Every binding shape listed above is exercised by paired `valid` (with the proper `harden(...)` call) and `invalid` fixtures in `packages/eslint-plugin/test/harden-exports.test.js`, including a TypeScript-annotated `{ name, ...rest }: { name: string; [k: string]: unknown } = obj` case under both testers. Coverage was verified per the contributor checklist by temporarily removing the `RestElement` branch inside `ObjectPattern`; the rest-binding fixtures failed as expected before the handling was restored.

### Compatibility Considerations

The rule will now flag previously-uncaught `export const` destructuring shapes that lack a matching `harden(...)` call. Downstream consumers may see new lint errors at the existing rule severity; the fix is to add the missing `harden(...)` call for the binding name(s) the rule now recognizes. The alias-misnaming case is a bug fix: code that satisfied the prior rule by hardening the source property name was hardening the wrong identifier and will now report; the fix is to harden the binding name instead.

### Upgrade Considerations

No data or wire-format change. Consumers upgrading the eslint plugin run `yarn lint` and address any newly-surfaced reports per the Compatibility note above.
