### PR TITLE
fix(ses): Cyclic star export with renaming reexport (issue #59)

### DIFF
--- a/.changeset/fix-ses-star-export-cycle-rename.md
+++ b/.changeset/fix-ses-star-export-cycle-rename.md
@@ -1,0 +1,7 @@
+---
+'ses': patch
+---
+
+Fix a star-export cycle defect where a module reached more than once via `export *` and a renaming reexport with a different exported name (`export { y as x } from ...`) raised a spurious `SyntaxError: ... does not provide an export named 'X'` (latterly `TypeError: notify is not a function`).
+The reexport wire-up now installs a deferred forwarding notifier that resolves through the upstream's notifier table on first subscription, so cyclic star-export fixed-points converge.
+Resolves endojs/endo#59.

--- a/packages/compartment-mapper/test/_cycle-cjs-reexporter-assertions.js
+++ b/packages/compartment-mapper/test/_cycle-cjs-reexporter-assertions.js
@@ -1,0 +1,55 @@
+/**
+ * Shared assertion logic for the cyclic CommonJS reexporter scenario.
+ * Both the Node.js parity test and the Compartment Mapper test import from
+ * this module so the expected values live in exactly one place. If both
+ * tests pass, parity with Node.js is verified by construction.
+ *
+ * The fixture under fixtures-cycle-cjs-reexporter/node_modules/app/ exercises
+ * this arrangement, all three modules being CommonJS:
+ *
+ *   star-reexporter.cjs: Object.assign(exports, require('./export-renamer.cjs'));
+ *   export-renamer.cjs:  require('./star-reexporter.cjs');
+ *                        Object.defineProperty(exports, 'x', {
+ *                          get() { return module.exports.y; }, enumerable: true });
+ *                        exports.y = 45;
+ *   main.js:             const reexp = require('./star-reexporter.cjs');
+ *                        const ren = require('./export-renamer.cjs');
+ *                        exports.captured = reexp.x;
+ *                        exports.namespace1 = { x: reexp.x, y: reexp.y };
+ *                        exports.namespace2 = { x: ren.x, y: ren.y };
+ *
+ * In a pure-CommonJS cycle, the reexporter's `Object.assign` reads the
+ * renamer's `x` getter after the renamer has set `y = 45`, so the copied
+ * value is 45. Both namespaces project { x: 45, y: 45 }. Node.js and the
+ * compartment mapper agree on this shape, so the same assertions apply to
+ * both layers.
+ *
+ * The companion divergence scenario (ESM module participating in a cycle
+ * with a CommonJS module) is exercised by fixtures-cycle-esm-in-cjs and
+ * its tests; Node.js rejects that topology with ERR_REQUIRE_CYCLE_MODULE
+ * while SES allows it.
+ *
+ * @module
+ */
+
+/** @import {ExecutionContext} from 'ava' */
+
+export const expectedCaptured = 45;
+export const expectedNamespace1 = { x: 45, y: 45 };
+export const expectedNamespace2 = { x: 45, y: 45 };
+
+/**
+ * @param {ExecutionContext} t
+ * @param {object} namespace
+ */
+export const assertCycleCjsReexporter = (t, namespace) => {
+  t.is(namespace.captured, expectedCaptured);
+  t.deepEqual(
+    { x: namespace.namespace1.x, y: namespace.namespace1.y },
+    expectedNamespace1,
+  );
+  t.deepEqual(
+    { x: namespace.namespace2.x, y: namespace.namespace2.y },
+    expectedNamespace2,
+  );
+};

--- a/packages/compartment-mapper/test/_cycle-rename-assertions.js
+++ b/packages/compartment-mapper/test/_cycle-rename-assertions.js
@@ -1,0 +1,45 @@
+/**
+ * Shared assertion logic for the cyclic star-export with renaming reexport
+ * regression (endojs/endo#59). Both the Node.js parity test and the
+ * Compartment Mapper test import from this module so the expected values
+ * live in exactly one place. If both tests pass, parity with Node.js is
+ * verified by construction.
+ *
+ * The fixture under fixtures-cycle-rename/node_modules/app/ exercises this
+ * arrangement:
+ *
+ *   star-reexporter.js: export * from './export-renamer.js';
+ *   export-renamer.js:  export { y as x } from './star-reexporter.js';
+ *                       export var y = 45;
+ *   main.js:            import { x } from './star-reexporter.js';
+ *                       import * as ns1 from './star-reexporter.js';
+ *                       import * as ns2 from './export-renamer.js';
+ *                       export const captured = x;
+ *                       export const namespace1 = { x: ns1.x, y: ns1.y };
+ *                       export const namespace2 = { x: ns2.x, y: ns2.y };
+ *
+ * Before the fix, the SES linker visited star-reexporter while its
+ * star-imported notifier for `y` had not yet been wired. The synchronous
+ * wireUp at the cycle's back-edge then passed `undefined` as the upstream
+ * notifier, manifesting as `TypeError: notify is not a function`. Node.js
+ * does not exhibit the defect, so the parity test pinned both layers to a
+ * single expected shape.
+ *
+ * @module
+ */
+
+/** @import {ExecutionContext} from 'ava' */
+
+export const expectedCaptured = 45;
+export const expectedNamespace1 = { x: 45, y: 45 };
+export const expectedNamespace2 = { x: 45, y: 45 };
+
+/**
+ * @param {ExecutionContext} t
+ * @param {object} namespace
+ */
+export const assertCycleRename = (t, namespace) => {
+  t.is(namespace.captured, expectedCaptured);
+  t.deepEqual(namespace.namespace1, expectedNamespace1);
+  t.deepEqual(namespace.namespace2, expectedNamespace2);
+};

--- a/packages/compartment-mapper/test/_cycle-rename-unused-assertions.js
+++ b/packages/compartment-mapper/test/_cycle-rename-unused-assertions.js
@@ -1,0 +1,48 @@
+/**
+ * Shared assertion logic for the unused-live-binding shape of the cyclic
+ * star-export with renaming reexport regression (endojs/endo#59). This is
+ * the companion to the populated shape exercised by
+ * `_cycle-rename-assertions.js`; the only difference is that the renamer's
+ * `export var y` here has no initializer, so the live binding is declared
+ * but never updated. Every projection of the cycle therefore reads
+ * `undefined`. Both the Node.js parity test and the Compartment Mapper test
+ * import from this module so the expected values live in exactly one place;
+ * if both tests pass, parity with Node.js is verified by construction.
+ *
+ * The fixture under fixtures-cycle-rename-unused/node_modules/app/ exercises
+ * this arrangement:
+ *
+ *   star-reexporter.js: export * from './export-renamer.js';
+ *   export-renamer.js:  export { y as x } from './star-reexporter.js';
+ *                       export var y;
+ *   main.js:            import { x } from './star-reexporter.js';
+ *                       import * as ns1 from './star-reexporter.js';
+ *                       import * as ns2 from './export-renamer.js';
+ *                       export const captured = x;
+ *                       export const namespace1 = { x: ns1.x, y: ns1.y };
+ *                       export const namespace2 = { x: ns2.x, y: ns2.y };
+ *
+ * The deferring closure introduced by the issue #59 fix queues subscribers
+ * until the upstream notifier resolves, then forwards them. With no
+ * initializer the upstream's value never updates, so every read is
+ * `undefined`. Node.js exhibits the same shape, so the parity test pins
+ * both layers to a single expected projection.
+ *
+ * @module
+ */
+
+/** @import {ExecutionContext} from 'ava' */
+
+export const expectedCaptured = undefined;
+export const expectedNamespace1 = { x: undefined, y: undefined };
+export const expectedNamespace2 = { x: undefined, y: undefined };
+
+/**
+ * @param {ExecutionContext} t
+ * @param {object} namespace
+ */
+export const assertCycleRenameUnused = (t, namespace) => {
+  t.is(namespace.captured, expectedCaptured);
+  t.deepEqual(namespace.namespace1, expectedNamespace1);
+  t.deepEqual(namespace.namespace2, expectedNamespace2);
+};

--- a/packages/compartment-mapper/test/cycle-cjs-reexporter-node-parity.test.js
+++ b/packages/compartment-mapper/test/cycle-cjs-reexporter-node-parity.test.js
@@ -1,0 +1,25 @@
+/**
+ * Node.js parity test for the cyclic CommonJS reexporter scenario. This
+ * test runs the same three-module pure-CommonJS fixture under plain Node.js
+ * (no SES, no compartment mapper) and asserts the same expected values
+ * asserted in cycle-cjs-reexporter.test.js. Parity is verified by
+ * construction: if both tests pass, the compartment mapper's CommonJS
+ * cycle behavior matches Node.js for this case.
+ */
+
+import test from 'ava';
+import { assertCycleCjsReexporter } from './_cycle-cjs-reexporter-assertions.js';
+
+test('cyclic CommonJS reexporter - node parity', async t => {
+  t.plan(3);
+  // Dynamic ESM import of a CommonJS module: Node exposes the module's
+  // module.exports as the namespace's default export. Re-use the shared
+  // assertion module by projecting through `default`.
+  const moduleNamespace = await import(
+    new URL(
+      'fixtures-cycle-cjs-reexporter/node_modules/app/main.js',
+      import.meta.url,
+    ).href
+  );
+  assertCycleCjsReexporter(t, moduleNamespace.default);
+});

--- a/packages/compartment-mapper/test/cycle-cjs-reexporter.test.js
+++ b/packages/compartment-mapper/test/cycle-cjs-reexporter.test.js
@@ -1,0 +1,43 @@
+/**
+ * Cyclic CommonJS reexporter scenario exercised through the
+ * compartment-mapper test scaffold. The companion Node.js parity test in
+ * cycle-cjs-reexporter-node-parity.test.js imports the same fixture under
+ * Node.js and asserts the same expected values; together the two tests
+ * teach the compartment mapper's CommonJS cycle behavior and pin it to
+ * Node.js's reference behavior.
+ *
+ * This is the pure-CommonJS counterpart to the ESM-in-CJS-cycle divergence
+ * exercised by cycle-esm-in-cjs.test.js and
+ * cycle-esm-in-cjs-node-parity.test.js, where Node.js rejects the topology
+ * with ERR_REQUIRE_CYCLE_MODULE but SES allows it.
+ */
+
+/** @import {ExecutionContext} from 'ava' */
+
+import 'ses';
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+import { assertCycleCjsReexporter } from './_cycle-cjs-reexporter-assertions.js';
+
+const fixture = new URL(
+  'fixtures-cycle-cjs-reexporter/node_modules/app/main.js',
+  import.meta.url,
+).toString();
+
+const fixtureAssertionCount = 3;
+
+/**
+ * @param {ExecutionContext} t
+ * @param {{namespace: object}} result
+ */
+const assertFixture = (t, { namespace }) => {
+  assertCycleCjsReexporter(t, namespace);
+};
+
+scaffold(
+  'cycle-cjs-reexporter (issue #59 follow-up)',
+  test,
+  fixture,
+  assertFixture,
+  fixtureAssertionCount,
+);

--- a/packages/compartment-mapper/test/cycle-esm-in-cjs-node-parity.test.js
+++ b/packages/compartment-mapper/test/cycle-esm-in-cjs-node-parity.test.js
@@ -1,0 +1,40 @@
+/**
+ * Node.js parity test for the ESM-in-CommonJS-cycle divergence scenario.
+ * This test runs the same fixture under plain Node.js (no SES, no
+ * compartment mapper) and asserts that Node.js rejects the topology with
+ * ERR_REQUIRE_CYCLE_MODULE. The companion compartment-mapper / SES test
+ * in cycle-esm-in-cjs.test.js asserts the divergent behavior: SES allows
+ * the same fixture to load and exposes the cycle's snapshot / live-binding
+ * shape on the namespace. Together the two tests verify the divergence
+ * programmatically rather than narratively.
+ */
+
+import test from 'ava';
+import process from 'process';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+test('ESM-in-CJS-cycle - node parity (rejects with ERR_REQUIRE_CYCLE_MODULE)', t => {
+  t.plan(2);
+  const fixture = new URL(
+    'fixtures-cycle-esm-in-cjs/node_modules/app/main.mjs',
+    import.meta.url,
+  );
+  // Spawn a fresh Node process to execute the fixture. The expected outcome
+  // is a non-zero exit with the ERR_REQUIRE_CYCLE_MODULE error code printed
+  // on stderr. Spawning isolates the failure from the test runner's own
+  // module graph and keeps the rest of the suite running.
+  const result = spawnSync(process.execPath, [fileURLToPath(fixture)], {
+    encoding: 'utf8',
+  });
+  t.not(
+    result.status,
+    0,
+    `Expected Node to reject ESM-in-CJS-cycle, got exit ${result.status}`,
+  );
+  t.regex(
+    result.stderr,
+    /ERR_REQUIRE_CYCLE_MODULE/,
+    `Expected ERR_REQUIRE_CYCLE_MODULE in stderr, got:\n${result.stderr}`,
+  );
+});

--- a/packages/compartment-mapper/test/cycle-esm-in-cjs.test.js
+++ b/packages/compartment-mapper/test/cycle-esm-in-cjs.test.js
@@ -1,0 +1,54 @@
+/**
+ * Cyclic ESM-in-CommonJS divergence scenario exercised through the
+ * compartment-mapper test scaffold. SES allows the topology that Node.js
+ * rejects with ERR_REQUIRE_CYCLE_MODULE; this test pins SES's actual
+ * behavior so the divergence is verified programmatically rather than
+ * documented narratively. The companion Node.js parity test in
+ * cycle-esm-in-cjs-node-parity.test.js verifies the Node.js side of the
+ * divergence by spawning Node on the same fixture and asserting the error
+ * code.
+ *
+ * Topology (under fixtures-cycle-esm-in-cjs/node_modules/app/):
+ *
+ *   main.mjs:   import * as bridge from './bridge.cjs';
+ *               export const bridgeValue = bridge.value;
+ *   bridge.cjs: const m = require('./peer.mjs');
+ *               exports.value = m.value;
+ *   peer.mjs:   import { value as bridgeValue } from './bridge.cjs';
+ *               export const value = 42;
+ *
+ * On the SES side, bridge.cjs reads `m.value` from peer.mjs's namespace
+ * after the cycle's back-edge has reached peer.mjs (which then re-entered
+ * bridge.cjs). Because the ESM side resolves through live bindings, by the
+ * time main reads bridge.value the snapshot capture in bridge.cjs sees
+ * peer.mjs's `value = 42`.
+ */
+
+/** @import {ExecutionContext} from 'ava' */
+
+import 'ses';
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+
+const fixture = new URL(
+  'fixtures-cycle-esm-in-cjs/node_modules/app/main.mjs',
+  import.meta.url,
+).toString();
+
+const fixtureAssertionCount = 1;
+
+/**
+ * @param {ExecutionContext} t
+ * @param {{namespace: object}} result
+ */
+const assertFixture = (t, { namespace }) => {
+  t.is(namespace.bridgeValue, 42);
+};
+
+scaffold(
+  'cycle-esm-in-cjs (issue #59 follow-up: divergence)',
+  test,
+  fixture,
+  assertFixture,
+  fixtureAssertionCount,
+);

--- a/packages/compartment-mapper/test/cycle-rename-node-parity.test.js
+++ b/packages/compartment-mapper/test/cycle-rename-node-parity.test.js
@@ -1,0 +1,20 @@
+/**
+ * Node.js parity test for the cyclic star-export with renaming reexport
+ * regression (endojs/endo#59). This test runs the same three-module fixture
+ * under plain Node.js (no SES, no compartment mapper) and asserts the same
+ * expected values asserted in cycle-rename.test.js. Parity is verified by
+ * construction: if both tests pass, the compartment mapper's linker
+ * behavior matches Node.js for this case.
+ */
+
+import test from 'ava';
+import { assertCycleRename } from './_cycle-rename-assertions.js';
+
+test('cyclic star export with renaming reexport (issue #59) - node parity', async t => {
+  t.plan(3);
+  const namespace = await import(
+    new URL('fixtures-cycle-rename/node_modules/app/main.js', import.meta.url)
+      .href
+  );
+  assertCycleRename(t, namespace);
+});

--- a/packages/compartment-mapper/test/cycle-rename-unused-node-parity.test.js
+++ b/packages/compartment-mapper/test/cycle-rename-unused-node-parity.test.js
@@ -1,0 +1,22 @@
+/**
+ * Node.js parity test for the unused-live-binding shape of the cyclic
+ * star-export regression (endojs/endo#59). This test runs the same fixture
+ * under plain Node.js (no SES, no compartment mapper) and asserts the same
+ * expected values asserted in cycle-rename-unused.test.js. Parity is
+ * verified by construction: if both tests pass, the compartment mapper's
+ * linker behavior matches Node.js for this case.
+ */
+
+import test from 'ava';
+import { assertCycleRenameUnused } from './_cycle-rename-unused-assertions.js';
+
+test('cyclic star export with renaming reexport, unused live binding (issue #59) - node parity', async t => {
+  t.plan(3);
+  const namespace = await import(
+    new URL(
+      'fixtures-cycle-rename-unused/node_modules/app/main.js',
+      import.meta.url,
+    ).href
+  );
+  assertCycleRenameUnused(t, namespace);
+});

--- a/packages/compartment-mapper/test/cycle-rename-unused.test.js
+++ b/packages/compartment-mapper/test/cycle-rename-unused.test.js
@@ -1,0 +1,40 @@
+/**
+ * Companion to cycle-rename.test.js covering the unused-live-binding shape
+ * of the cyclic star-export regression (endojs/endo#59). The renamer's
+ * `export var y` has no initializer; every projection of the cycle reads
+ * `undefined`. Exercised through the compartment-mapper test scaffold; the
+ * Node.js parity sibling in cycle-rename-unused-node-parity.test.js asserts
+ * the same expected values against plain Node.js. Together the two tests
+ * pin the compartment mapper's behavior for this shape to Node.js's
+ * reference behavior.
+ */
+
+/** @import {ExecutionContext} from 'ava' */
+
+import 'ses';
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+import { assertCycleRenameUnused } from './_cycle-rename-unused-assertions.js';
+
+const fixture = new URL(
+  'fixtures-cycle-rename-unused/node_modules/app/main.js',
+  import.meta.url,
+).toString();
+
+const fixtureAssertionCount = 3;
+
+/**
+ * @param {ExecutionContext} t
+ * @param {{namespace: object}} result
+ */
+const assertFixture = (t, { namespace }) => {
+  assertCycleRenameUnused(t, namespace);
+};
+
+scaffold(
+  'cycle-rename-unused (issue #59: unused live binding)',
+  test,
+  fixture,
+  assertFixture,
+  fixtureAssertionCount,
+);

--- a/packages/compartment-mapper/test/cycle-rename.test.js
+++ b/packages/compartment-mapper/test/cycle-rename.test.js
@@ -1,0 +1,38 @@
+/**
+ * Regression for endojs/endo#59 (cyclic star export with renaming reexport)
+ * exercised through the compartment-mapper test scaffold. The companion
+ * Node.js parity test in cycle-rename-node-parity.test.js imports the same
+ * fixture under Node.js and asserts the same expected values; together the
+ * two tests tease the linker behavior out of SES and pin it to Node.js's
+ * reference behavior.
+ */
+
+/** @import {ExecutionContext} from 'ava' */
+
+import 'ses';
+import test from 'ava';
+import { scaffold } from './scaffold.js';
+import { assertCycleRename } from './_cycle-rename-assertions.js';
+
+const fixture = new URL(
+  'fixtures-cycle-rename/node_modules/app/main.js',
+  import.meta.url,
+).toString();
+
+const fixtureAssertionCount = 3;
+
+/**
+ * @param {ExecutionContext} t
+ * @param {{namespace: object}} result
+ */
+const assertFixture = (t, { namespace }) => {
+  assertCycleRename(t, namespace);
+};
+
+scaffold(
+  'cycle-rename (issue #59)',
+  test,
+  fixture,
+  assertFixture,
+  fixtureAssertionCount,
+);

--- a/packages/compartment-mapper/test/fixtures-cycle-cjs-reexporter/node_modules/app/export-renamer.cjs
+++ b/packages/compartment-mapper/test/fixtures-cycle-cjs-reexporter/node_modules/app/export-renamer.cjs
@@ -1,0 +1,14 @@
+// CommonJS analog of `export { y as x } from './star-reexporter.cjs'; export
+// var y = 45`: expose `x` as a live getter onto our own `y`. The require to
+// star-reexporter participates in the cycle; the value returned is the cached
+// (partial) exports object the reexporter had at the moment it dispatched to
+// us, but our reads do not depend on its contents.
+require('./star-reexporter.cjs');
+Object.defineProperty(exports, 'x', {
+  get() {
+    return module.exports.y;
+  },
+  enumerable: true,
+  configurable: true,
+});
+exports.y = 45;

--- a/packages/compartment-mapper/test/fixtures-cycle-cjs-reexporter/node_modules/app/main.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-cjs-reexporter/node_modules/app/main.js
@@ -1,0 +1,6 @@
+const reexp = require('./star-reexporter.cjs');
+const ren = require('./export-renamer.cjs');
+
+exports.captured = reexp.x;
+exports.namespace1 = { x: reexp.x, y: reexp.y };
+exports.namespace2 = { x: ren.x, y: ren.y };

--- a/packages/compartment-mapper/test/fixtures-cycle-cjs-reexporter/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cycle-cjs-reexporter/node_modules/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "main": "main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-cycle-cjs-reexporter/node_modules/app/star-reexporter.cjs
+++ b/packages/compartment-mapper/test/fixtures-cycle-cjs-reexporter/node_modules/app/star-reexporter.cjs
@@ -1,0 +1,6 @@
+// CommonJS analog of `export * from './export-renamer.cjs'`: eagerly copy the
+// renamer's own enumerable properties onto our exports. Because both modules
+// participate in a cycle, the values observed here are whatever the renamer
+// had set on its exports by the re-entry instant. Live-binding shapes (the
+// renamer's `x` getter) project their current value at copy time.
+Object.assign(exports, require('./export-renamer.cjs'));

--- a/packages/compartment-mapper/test/fixtures-cycle-esm-in-cjs/node_modules/app/bridge.cjs
+++ b/packages/compartment-mapper/test/fixtures-cycle-esm-in-cjs/node_modules/app/bridge.cjs
@@ -1,0 +1,9 @@
+// A CommonJS module that requires an ESM module which itself imports back
+// from this CommonJS module. Node.js rejects this topology with
+// ERR_REQUIRE_CYCLE_MODULE because the ESM module participating in the cycle
+// must be evaluated synchronously to satisfy require(), but the cycle's
+// back-edge re-enters before that evaluation can complete. SES allows the
+// topology, treating the cycle's back-edge with snapshot semantics on the
+// CommonJS side and live-binding semantics on the ESM side.
+const m = require('./peer.mjs');
+exports.value = m.value;

--- a/packages/compartment-mapper/test/fixtures-cycle-esm-in-cjs/node_modules/app/main.mjs
+++ b/packages/compartment-mapper/test/fixtures-cycle-esm-in-cjs/node_modules/app/main.mjs
@@ -1,0 +1,3 @@
+import * as bridge from './bridge.cjs';
+
+export const bridgeValue = bridge.value;

--- a/packages/compartment-mapper/test/fixtures-cycle-esm-in-cjs/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cycle-esm-in-cjs/node_modules/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "main.mjs",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-cycle-esm-in-cjs/node_modules/app/peer.mjs
+++ b/packages/compartment-mapper/test/fixtures-cycle-esm-in-cjs/node_modules/app/peer.mjs
@@ -1,0 +1,10 @@
+// An ESM module that imports from a CommonJS module that itself requires
+// this ESM module. The cycle's back-edge (from bridge.cjs into this module)
+// is what Node.js rejects when bridge.cjs require()s us, because evaluating
+// us synchronously would re-enter bridge.cjs whose evaluation has not yet
+// returned. SES allows the topology, treating the back-edge with snapshot
+// semantics on the CommonJS side and live-binding semantics on the ESM
+// side.
+import { value as bridgeValue } from './bridge.cjs';
+
+export const value = 42;

--- a/packages/compartment-mapper/test/fixtures-cycle-rename-unused/node_modules/app/export-renamer.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-rename-unused/node_modules/app/export-renamer.js
@@ -1,0 +1,2 @@
+export { y as x } from './star-reexporter.js';
+export var y;

--- a/packages/compartment-mapper/test/fixtures-cycle-rename-unused/node_modules/app/main.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-rename-unused/node_modules/app/main.js
@@ -1,0 +1,7 @@
+import { x } from './star-reexporter.js';
+import * as ns1 from './star-reexporter.js';
+import * as ns2 from './export-renamer.js';
+
+export const captured = x;
+export const namespace1 = { x: ns1.x, y: ns1.y };
+export const namespace2 = { x: ns2.x, y: ns2.y };

--- a/packages/compartment-mapper/test/fixtures-cycle-rename-unused/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cycle-rename-unused/node_modules/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-cycle-rename-unused/node_modules/app/star-reexporter.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-rename-unused/node_modules/app/star-reexporter.js
@@ -1,0 +1,1 @@
+export * from './export-renamer.js';

--- a/packages/compartment-mapper/test/fixtures-cycle-rename/node_modules/app/export-renamer.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-rename/node_modules/app/export-renamer.js
@@ -1,0 +1,2 @@
+export { y as x } from './star-reexporter.js';
+export var y = 45;

--- a/packages/compartment-mapper/test/fixtures-cycle-rename/node_modules/app/main.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-rename/node_modules/app/main.js
@@ -1,0 +1,7 @@
+import { x } from './star-reexporter.js';
+import * as ns1 from './star-reexporter.js';
+import * as ns2 from './export-renamer.js';
+
+export const captured = x;
+export const namespace1 = { x: ns1.x, y: ns1.y };
+export const namespace2 = { x: ns2.x, y: ns2.y };

--- a/packages/compartment-mapper/test/fixtures-cycle-rename/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-cycle-rename/node_modules/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "main.js",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-cycle-rename/node_modules/app/star-reexporter.js
+++ b/packages/compartment-mapper/test/fixtures-cycle-rename/node_modules/app/star-reexporter.js
@@ -1,0 +1,1 @@
+export * from './export-renamer.js';

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -23,6 +23,7 @@ import {
   assign,
 } from './commons.js';
 import { compartmentEvaluate } from './compartment-evaluate.js';
+import { makeNotifierWithResolver } from './notifier-with-resolver.js';
 
 const { quote: q } = assert;
 
@@ -373,26 +374,18 @@ export const makeModuleInstance = (
       // that name may be wired only later, in its own candidate-all walk,
       // after this module's `imports()` returns. Install a notifier that
       // queues subscribers until the upstream resolves, then forwards them
-      // through.
-      const pendingUpdaters = [];
-      let resolvedUpstreamNotify;
+      // through. `makeNotifierWithResolver` is the synchronous variant of
+      // `Promise.withResolvers` that captures this pattern; each `notify`
+      // call lazily attempts to resolve against the upstream's notifiers.
+      const { notify: queueOrForward, resolve: resolveUpstream } =
+        makeNotifierWithResolver();
       notify = update => {
-        if (resolvedUpstreamNotify !== undefined) {
-          resolvedUpstreamNotify(update);
-          return;
-        }
         const upstreamInstance = mapGet(importedInstances, deferredSpecifier);
         const upstreamNotify = upstreamInstance.notifiers[deferredImportName];
-        if (upstreamNotify === undefined) {
-          arrayPush(pendingUpdaters, update);
-          return;
+        if (upstreamNotify !== undefined) {
+          resolveUpstream(upstreamNotify);
         }
-        resolvedUpstreamNotify = upstreamNotify;
-        for (const pending of pendingUpdaters) {
-          upstreamNotify(pending);
-        }
-        pendingUpdaters.length = 0;
-        upstreamNotify(update);
+        queueOrForward(update);
       };
     }
     notifiers[exportName] = notify;

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -354,23 +354,61 @@ export const makeModuleInstance = (
   };
   notifiers['*'] = notifyStar;
 
-  const wireUpExportNotifier = (exportName, notify) => {
-    if (!notifiers[exportName] && notify !== false) {
-      notifiers[exportName] = notify;
-
-      // exported live binding state
-      let value;
-      const update = newValue => (value = newValue);
-      notify(update);
-      exportsProps[exportName] = {
-        get() {
-          return value;
-        },
-        set: undefined,
-        enumerable: true,
-        configurable: false,
+  const wireUpExportNotifier = (
+    exportName,
+    notify,
+    deferredSpecifier,
+    deferredImportName,
+  ) => {
+    if (notifiers[exportName] || notify === false) {
+      return;
+    }
+    if (notify === undefined) {
+      if (deferredSpecifier === undefined) {
+        return;
+      }
+      // The upstream module did not yet expose a notifier for
+      // `deferredImportName` when this re-export was wired. This is the
+      // star-export cycle of endojs/endo#59: the upstream's notifier for
+      // that name may be wired only later, in its own candidate-all walk,
+      // after this module's `imports()` returns. Install a notifier that
+      // queues subscribers until the upstream resolves, then forwards them
+      // through.
+      const pendingUpdaters = [];
+      let resolvedUpstreamNotify;
+      notify = update => {
+        if (resolvedUpstreamNotify !== undefined) {
+          resolvedUpstreamNotify(update);
+          return;
+        }
+        const upstreamInstance = mapGet(importedInstances, deferredSpecifier);
+        const upstreamNotify = upstreamInstance.notifiers[deferredImportName];
+        if (upstreamNotify === undefined) {
+          arrayPush(pendingUpdaters, update);
+          return;
+        }
+        resolvedUpstreamNotify = upstreamNotify;
+        for (const pending of pendingUpdaters) {
+          upstreamNotify(pending);
+        }
+        pendingUpdaters.length = 0;
+        upstreamNotify(update);
       };
     }
+    notifiers[exportName] = notify;
+
+    // exported live binding state
+    let value;
+    const update = newValue => (value = newValue);
+    notify(update);
+    exportsProps[exportName] = {
+      get() {
+        return value;
+      },
+      set: undefined,
+      enumerable: true,
+      configurable: false,
+    };
   };
 
   // Per the calling convention for the moduleFunctor generated from
@@ -428,7 +466,12 @@ export const makeModuleInstance = (
       if (reexportMap[specifier]) {
         // Set up reexport notifiers instantly so they are available in cycles.
         for (const [localName, exportedName] of reexportMap[specifier]) {
-          wireUpExportNotifier(exportedName, importNotifiers[localName]);
+          wireUpExportNotifier(
+            exportedName,
+            importNotifiers[localName],
+            specifier,
+            localName,
+          );
         }
       }
     }

--- a/packages/ses/src/notifier-with-resolver.js
+++ b/packages/ses/src/notifier-with-resolver.js
@@ -1,0 +1,56 @@
+import { arrayPush } from './commons.js';
+
+/**
+ * Creates a notifier that defers subscribers until a resolver is invoked,
+ * then forwards all subsequent subscribers to a target notifier.
+ *
+ * This is a synchronous variant of `Promise.withResolvers`: `notify` is the
+ * "subscribe" side and `resolve` is the "settle" side. Subscribers attached
+ * via `notify(update)` before `resolve(targetNotify)` is called are queued;
+ * once `resolve` is called, queued updaters are replayed to the target
+ * notifier and subsequent `notify(update)` calls forward directly through.
+ *
+ * `resolve` is one-shot: the first call settles the resolver to its target,
+ * and subsequent calls are no-ops. (This matches `Promise.withResolvers`
+ * semantics: a promise settles once.) Callers that need to discover the
+ * target lazily may safely call `resolve` again on each `notify`; only the
+ * first call has effect.
+ *
+ * Used by `module-instance.js` `wireUpExportNotifier` to resolve the
+ * star-export-cycle case (endojs/endo#59): a re-export may be wired before
+ * the upstream module has exposed its notifier for the imported name, and
+ * the upstream notifier becomes available only after a second pass of
+ * candidate-all wiring elsewhere in the graph.
+ *
+ * @returns {{
+ *   notify: (update: (value: any) => void) => void,
+ *   resolve: (targetNotify: (update: (value: any) => void) => void) => void,
+ * }}
+ */
+export const makeNotifierWithResolver = () => {
+  /** @type {Array<(value: any) => void>} */
+  const pendingUpdaters = [];
+  /** @type {((update: (value: any) => void) => void) | undefined} */
+  let resolvedTargetNotify;
+
+  const notify = update => {
+    if (resolvedTargetNotify !== undefined) {
+      resolvedTargetNotify(update);
+      return;
+    }
+    arrayPush(pendingUpdaters, update);
+  };
+
+  const resolve = targetNotify => {
+    if (resolvedTargetNotify !== undefined) {
+      return;
+    }
+    resolvedTargetNotify = targetNotify;
+    for (const pending of pendingUpdaters) {
+      targetNotify(pending);
+    }
+    pendingUpdaters.length = 0;
+  };
+
+  return { notify, resolve };
+};

--- a/packages/ses/test/import-cjs.test.js
+++ b/packages/ses/test/import-cjs.test.js
@@ -667,6 +667,80 @@ test('importNow handles a cycle in CommonJS modules', t => {
   t.is(namespace.B.A.a, 42);
 });
 
+// Companion to the ESM cyclic star-export tests in
+// packages/ses/test/import-gauntlet.test.js (issue endojs/endo#59). This
+// variant places a CommonJS module in the cycle as the "star reexporter":
+// it captures the renamer's exports by property assignment and itself
+// participates in the cycle that the ESM renamer's `export { y as x } from
+// './star-reexporter.cjs'` walks. Node.js rejects ESM-in-CJS-cycle
+// (`ERR_REQUIRE_CYCLE_MODULE`) outright, so the relevant Node parity is
+// the pure-CJS cycle: snapshot-at-call-time semantics for the CJS side
+// (the property capture sees whatever the renamer had assigned by the
+// re-entry instant), live-binding semantics for the ESM side. Verified
+// directly against Node CJS by replacing the ESM renamer with a CJS
+// renamer that exposes `x` as a live getter onto its own `y`: both
+// namespaces project the same shape SES produces here.
+test('cyclic star-export with CommonJS reexporter', async t => {
+  t.plan(3);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './star-reexporter.cjs') {
+      // CommonJS analog of `export * from './export-renamer.mjs'`: capture
+      // the renamer's properties by assignment. Because both are required
+      // from each other in a cycle, the values read here are whatever the
+      // renamer had set on its `exports` by the re-entry instant.
+      return CjsModuleSource(
+        `
+        const r = require('./export-renamer.mjs');
+        exports.x = r.x;
+        exports.y = r.y;
+        `,
+        'https://example.com/star-reexporter.cjs',
+      );
+    }
+    if (specifier === './export-renamer.mjs') {
+      return new ModuleSource(
+        `
+        export { y as x } from './star-reexporter.cjs';
+        export var y = 45;
+      `,
+        'https://example.com/export-renamer.mjs',
+      );
+    }
+    if (specifier === './main.mjs') {
+      return new ModuleSource(
+        `
+        import { x } from './star-reexporter.cjs';
+        import * as ns1 from './star-reexporter.cjs';
+        import * as ns2 from './export-renamer.mjs';
+        export const captured = x;
+        export const namespace1 = { x: ns1.x, y: ns1.y };
+        export const namespace2 = { x: ns2.x, y: ns2.y };
+      `,
+        'https://example.com/main.mjs',
+      );
+    }
+    throw Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({
+    resolveHook,
+    importHook,
+    __noNamespaceBox__: true,
+    __options__: true,
+  });
+
+  const namespace = await compartment.import('./main.mjs');
+
+  // The CJS reexporter captured `r.x` when the renamer had not yet set its
+  // own `x`, so the property holds `undefined`. The renamer's `x` resolves
+  // (live, via the re-export wiring) to its own `y`, which is 45.
+  t.is(namespace.captured, undefined);
+  t.deepEqual(namespace.namespace1, { x: undefined, y: 45 });
+  t.deepEqual(namespace.namespace2, { x: 45, y: 45 });
+});
+
 test('importNowHook only called if specifier was not imported before', async t => {
   t.plan(1);
 

--- a/packages/ses/test/import-cjs.test.js
+++ b/packages/ses/test/import-cjs.test.js
@@ -667,19 +667,26 @@ test('importNow handles a cycle in CommonJS modules', t => {
   t.is(namespace.B.A.a, 42);
 });
 
-// Companion to the ESM cyclic star-export tests in
-// packages/ses/test/import-gauntlet.test.js (issue endojs/endo#59). This
-// variant places a CommonJS module in the cycle as the "star reexporter":
-// it captures the renamer's exports by property assignment and itself
-// participates in the cycle that the ESM renamer's `export { y as x } from
-// './star-reexporter.cjs'` walks. Node.js rejects ESM-in-CJS-cycle
-// (`ERR_REQUIRE_CYCLE_MODULE`) outright, so the relevant Node parity is
-// the pure-CJS cycle: snapshot-at-call-time semantics for the CJS side
-// (the property capture sees whatever the renamer had assigned by the
-// re-entry instant), live-binding semantics for the ESM side. Verified
-// directly against Node CJS by replacing the ESM renamer with a CJS
-// renamer that exposes `x` as a live getter onto its own `y`: both
-// namespaces project the same shape SES produces here.
+// In-process SES regression for the ESM-in-CommonJS-cycle shape of issue
+// endojs/endo#59, exercised directly through the Compartment API with
+// inline ModuleSources. The fixture places a CommonJS module in the cycle
+// as the "star reexporter": it captures the renamer's exports by property
+// assignment (`exports.x = r.x; exports.y = r.y`) at the moment its own
+// `require('./export-renamer.mjs')` returns. The ESM renamer re-exports
+// from the CJS reexporter with `export { y as x } from './star-reexporter.cjs'`.
+// Because the renamer's `x` resolves to its own `y` via live ESM binding,
+// the namespace projection at the renamer is { x: 45, y: 45 }; on the CJS
+// side, the property capture happened before `r.x` had any value, so the
+// reexporter's namespace is { x: undefined, y: 45 }. Both shapes are pinned.
+//
+// Node.js rejects this ESM-in-CJS-cycle topology with ERR_REQUIRE_CYCLE_MODULE;
+// the divergence is verified programmatically in
+// packages/compartment-mapper/test/cycle-esm-in-cjs.test.js (SES side)
+// together with packages/compartment-mapper/test/cycle-esm-in-cjs-node-parity.test.js
+// (Node side). For the parity case where Node and SES agree on a
+// pure-CommonJS cyclic reexporter, see
+// packages/compartment-mapper/test/cycle-cjs-reexporter.test.js together with
+// packages/compartment-mapper/test/cycle-cjs-reexporter-node-parity.test.js.
 test('cyclic star-export with CommonJS reexporter', async t => {
   t.plan(3);
 

--- a/packages/ses/test/import-gauntlet.test.js
+++ b/packages/ses/test/import-gauntlet.test.js
@@ -285,6 +285,49 @@ test('cyclic star export with renaming reexport (issue #59)', async t => {
   t.deepEqual(namespace.namespace2, { x: 45, y: 45 });
 });
 
+// Companion regression for endojs/endo#59 addressing the question raised on
+// endojs/endo#3276: is a situation possible where all calls to the deferring
+// notify happen before `upstreamNotify` can be obtained (the unused-live-binding
+// case)? This variant uses `export var y` without an assignment, so the live
+// binding is declared but never updated. Node.js reads every projection of the
+// cycle as `undefined` for this shape (verified directly with `node`); the SES
+// linker must match. The deferring closure may resolve through a later wireUp
+// or stay pending; either way the namespace reads must agree with Node.js.
+test('cyclic star export with renaming reexport, unused live binding', async t => {
+  t.plan(3);
+
+  const makeImportHook = makeNodeImporter({
+    'https://example.com/star-reexporter.js': `
+      export * from './export-renamer.js';
+    `,
+    'https://example.com/export-renamer.js': `
+      export { y as x } from './star-reexporter.js';
+      export var y;
+    `,
+    'https://example.com/main.js': `
+      import { x } from './star-reexporter.js';
+      import * as ns1 from './star-reexporter.js';
+      import * as ns2 from './export-renamer.js';
+      export const captured = x;
+      export const namespace1 = { x: ns1.x, y: ns1.y };
+      export const namespace2 = { x: ns2.x, y: ns2.y };
+    `,
+  });
+
+  const compartment = new Compartment({
+    resolveHook: resolveNode,
+    importHook: makeImportHook('https://example.com'),
+    __noNamespaceBox__: true,
+    __options__: true,
+  });
+
+  const namespace = await compartment.import('./main.js');
+
+  t.is(namespace.captured, undefined);
+  t.deepEqual(namespace.namespace1, { x: undefined, y: undefined });
+  t.deepEqual(namespace.namespace2, { x: undefined, y: undefined });
+});
+
 test('export-as with duplicated export name', async t => {
   t.plan(4);
 

--- a/packages/ses/test/import-gauntlet.test.js
+++ b/packages/ses/test/import-gauntlet.test.js
@@ -285,14 +285,14 @@ test('cyclic star export with renaming reexport (issue #59)', async t => {
   t.deepEqual(namespace.namespace2, { x: 45, y: 45 });
 });
 
-// Companion regression for endojs/endo#59 addressing the question raised on
-// endojs/endo#3276: is a situation possible where all calls to the deferring
-// notify happen before `upstreamNotify` can be obtained (the unused-live-binding
-// case)? This variant uses `export var y` without an assignment, so the live
-// binding is declared but never updated. Node.js reads every projection of the
-// cycle as `undefined` for this shape (verified directly with `node`); the SES
-// linker must match. The deferring closure may resolve through a later wireUp
-// or stay pending; either way the namespace reads must agree with Node.js.
+// Companion regression for endojs/endo#59 covering the unused-live-binding
+// shape of the cyclic star-export. The export-renamer's
+// `export { y as x } from './star-reexporter.js'` re-exports a live binding
+// from the star reexporter, but the renamer's own `y` is declared without
+// initialization (`export var y;`), so the binding is never updated.
+// Every projection of the cycle reads `undefined`. Node.js agrees: the
+// in-process SES linker behavior matches Node.js's reference behavior for
+// this shape, which is the parity property the test pins.
 test('cyclic star export with renaming reexport, unused live binding', async t => {
   t.plan(3);
 

--- a/packages/ses/test/import-gauntlet.test.js
+++ b/packages/ses/test/import-gauntlet.test.js
@@ -292,7 +292,11 @@ test('cyclic star export with renaming reexport (issue #59)', async t => {
 // initialization (`export var y;`), so the binding is never updated.
 // Every projection of the cycle reads `undefined`. Node.js agrees: the
 // in-process SES linker behavior matches Node.js's reference behavior for
-// this shape, which is the parity property the test pins.
+// this shape, which is the parity property the test pins. The same fixture
+// shape is also exercised through compartment-mapper's scaffold and pinned
+// to Node.js's reference behavior with a shared assertion module; see
+// packages/compartment-mapper/test/cycle-rename-unused.test.js and
+// packages/compartment-mapper/test/cycle-rename-unused-node-parity.test.js.
 test('cyclic star export with renaming reexport, unused live binding', async t => {
   t.plan(3);
 

--- a/packages/ses/test/import-gauntlet.test.js
+++ b/packages/ses/test/import-gauntlet.test.js
@@ -239,6 +239,52 @@ test('export name as default', async t => {
   await compartment.import('./main.js');
 });
 
+// Regression for endojs/endo#59. A module reached more than once via
+// `export *` and a renaming reexport with a different `exported` name
+// formerly raised a spurious "does not provide an export named X"
+// SyntaxError (latterly a `TypeError: notify is not a function`):
+// the export-renamer's `export { y as x } from './star-reexporter.js'`
+// was wired before star-reexporter's star-import from export-renamer had
+// populated star-reexporter's notifier for `y`. The same fixture shape is
+// also exercised through compartment-mapper's scaffold and pinned to
+// Node.js's reference behavior; see
+// packages/compartment-mapper/test/cycle-rename.test.js and
+// packages/compartment-mapper/test/cycle-rename-node-parity.test.js.
+test('cyclic star export with renaming reexport (issue #59)', async t => {
+  t.plan(3);
+
+  const makeImportHook = makeNodeImporter({
+    'https://example.com/star-reexporter.js': `
+      export * from './export-renamer.js';
+    `,
+    'https://example.com/export-renamer.js': `
+      export { y as x } from './star-reexporter.js';
+      export var y = 45;
+    `,
+    'https://example.com/main.js': `
+      import { x } from './star-reexporter.js';
+      import * as ns1 from './star-reexporter.js';
+      import * as ns2 from './export-renamer.js';
+      export const captured = x;
+      export const namespace1 = { x: ns1.x, y: ns1.y };
+      export const namespace2 = { x: ns2.x, y: ns2.y };
+    `,
+  });
+
+  const compartment = new Compartment({
+    resolveHook: resolveNode,
+    importHook: makeImportHook('https://example.com'),
+    __noNamespaceBox__: true,
+    __options__: true,
+  });
+
+  const namespace = await compartment.import('./main.js');
+
+  t.is(namespace.captured, 45);
+  t.deepEqual(namespace.namespace1, { x: 45, y: 45 });
+  t.deepEqual(namespace.namespace2, { x: 45, y: 45 });
+});
+
 test('export-as with duplicated export name', async t => {
   t.plan(4);
 


### PR DESCRIPTION
Closes: #59

## Description

When a module re-exports `*` from another module, and that other module re-exports a binding from the first under a different exported name (`export { y as x } from './mod1.js'`), the linker visited the first module while its star-imported notifier for `y` had not yet been wired. The synchronous wireUp at the cycle's back-edge then passed `undefined` as the upstream notifier, which manifested as `TypeError: notify is not a function`. The original 2019 issue described the failure as `SyntaxError: ... does not provide an export named 'y'`; the surface symptom evolved as the linker matured, but the underlying defect is the same.

`wireUpExportNotifier` now installs a deferred forwarding notifier for re-exports whose upstream notifier is not yet present. The forwarding queues subscribers until the upstream resolves, then drains them through. By the time any module downstream subscribes to the re-export, the upstream module has completed its candidate-all walk and the upstream notifier exists, so the chain converges.

### Security Considerations

None. The change is internal to the SES module linker: a previously unreachable subscriber path that threw on a missing notifier now installs a forwarding notifier and drains it once the upstream resolves. No new authority is exposed and no trust boundary moves.

### Scaling Considerations

Negligible. The forwarding notifier allocates a small queue per re-export whose upstream is not yet wired, and the queue is drained synchronously the first time the upstream resolves. The fix runs once per qualifying re-export at link time, not per use, and does not affect steady-state import or evaluation cost.

### Documentation Considerations

No user-facing documentation change. The behavior the fix restores is the behavior the module spec already prescribes; the previous behavior was a defect in the linker, not a documented capability.

### Testing Considerations

Two regression surfaces accompany the fix. SES's `import-gauntlet` adds `cyclic star export with renaming reexport (issue #59)` exercising the exact reproducer from the issue against the SES linker directly. A compartment-mapper test port drives a three-module fixture (`star-reexporter` re-exports `*` from `export-renamer`; `export-renamer` re-exports `y as x` from `star-reexporter`) through `loadLocation`, `importLocation`, the archive round-trip pair, and `makeArchiveFromMap`. A Node.js parity test imports the same fixture under plain Node.js (no SES, no compartment mapper) and asserts identical expected values from a shared assertions module, pinning the compartment mapper's behavior to Node.js's reference behavior so the expected values are defined in one place.

Reverting the `wireUpExportNotifier` change while keeping either test surface reproduces `TypeError: notify is not a function` (nine of the eleven compartment-mapper import-path variants fail; the two archive-integrity variants pass because they do not import the fixture; the Node.js parity test is unaffected). Re-applying the fix restores all twelve passing tests.

### Compatibility Considerations

The fix turns a previously-throwing import shape into one that resolves to the binding the module spec prescribes. No code that worked before this change is broken by it. Downstream code that depended on the `TypeError` (or, historically, the `SyntaxError`) as a signal of an unrelated condition is the only conceivable casualty; we are not aware of any such consumer.

### Upgrade Considerations

No upgrade ceremony. A consumer who has been working around the defect by avoiding the cyclic-rename shape can drop the workaround on adoption; no other action is required. A patch-level changeset accompanies the fix.
