### PR TITLE
feat(eslint-plugin): harden-exports skips M.* pattern makers (#2632)

### DIFF
--- a/.changeset/harden-exports-pattern-makers.md
+++ b/.changeset/harden-exports-pattern-makers.md
@@ -1,0 +1,15 @@
+---
+'@endo/eslint-plugin': minor
+---
+
+The `@endo/harden-exports` rule now skips named exports whose initializer is
+a Pattern maker call of the form `M.something(...)`.
+Pattern makers return values that are already hardened, so a follow-up
+`harden(name)` after their export is redundant noise.
+
+A new companion rule, `@endo/no-harden-pattern-maker`, surfaces existing
+sites where code over-hardens a Pattern maker result.
+The rule fires on both `harden(M.string())` and the indirect form
+`const x = M.string(); harden(x);`, and is included in the recommended
+configuration as a warning so existing code doesn't break loudly while
+the redundant calls are cleaned up.

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -74,6 +74,7 @@ module.exports = {
   rules: {
     '@endo/assert-fail-as-throw': 'error',
     '@endo/no-assign-to-exported-let-var-or-function': 'error',
+    '@endo/no-harden-pattern-maker': 'warn',
     '@endo/no-multi-name-local-export': 'error',
     'guard-for-in': 'error',
     'no-self-compare': 'error',

--- a/packages/eslint-plugin/lib/rules/harden-exports.js
+++ b/packages/eslint-plugin/lib/rules/harden-exports.js
@@ -122,6 +122,25 @@ module.exports = {
     /** @type {Array<ESTree.ExportNamedDeclaration & Rule.NodeParentExtension>} */
     const exportNodes = [];
 
+    /**
+     * Returns true when the initializer is a call expression of the form
+     * `M.something(...)`. Such calls return values that are already hardened
+     * by Pattern makers, so a follow-up `harden(name)` would be redundant.
+     * @param {ESTree.Node | null | undefined} init
+     * @returns {boolean}
+     */
+    const isPatternMakerCall = init => {
+      if (!init || init.type !== 'CallExpression') {
+        return false;
+      }
+      const { callee } = init;
+      if (callee.type !== 'MemberExpression') {
+        return false;
+      }
+      const { object } = callee;
+      return object.type === 'Identifier' && object.name === 'M';
+    };
+
     return {
       /** @param {ESTree.ExportNamedDeclaration & Rule.NodeParentExtension} node */
       ExportNamedDeclaration(node) {
@@ -139,16 +158,21 @@ module.exports = {
           if (exportNode.declaration) {
             if (exportNode.declaration.type === 'VariableDeclaration') {
               for (const declaration of exportNode.declaration.declarations) {
-                const recognized = pushDeclaredNames(
-                  declaration.id,
-                  exportNames,
-                );
-                if (!recognized) {
-                  allRecognized = false;
-                  context.report({
-                    node: declaration,
-                    messageId: 'unknownBindingPattern',
-                  });
+                // Skip Pattern maker initializers like `M.string()` or
+                // `M.arrayOf(...)`; their results are already hardened, so
+                // a follow-up `harden(name)` is redundant.
+                if (!isPatternMakerCall(declaration.init)) {
+                  const recognized = pushDeclaredNames(
+                    declaration.id,
+                    exportNames,
+                  );
+                  if (!recognized) {
+                    allRecognized = false;
+                    context.report({
+                      node: declaration,
+                      messageId: 'unknownBindingPattern',
+                    });
+                  }
                 }
               }
             } else if (exportNode.declaration.type === 'FunctionDeclaration') {

--- a/packages/eslint-plugin/lib/rules/no-harden-pattern-maker.js
+++ b/packages/eslint-plugin/lib/rules/no-harden-pattern-maker.js
@@ -1,0 +1,173 @@
+/* eslint-disable func-names */
+/**
+ * @module Disallow `harden(x)` when `x` is the result of a Pattern maker
+ * (`M.something(...)`) because Pattern makers already return hardened values.
+ */
+
+'use strict';
+
+/**
+ * @import {Rule} from 'eslint';
+ * @import * as ESTree from 'estree';
+ */
+
+/**
+ * Returns true when the node is a `CallExpression` of the form
+ * `M.something(...)`. This is the conservative shape used by the existing
+ * `harden-exports` rule to detect Pattern makers; we keep the heuristic
+ * identical so the two rules stay in sync.
+ * @param {ESTree.Node | null | undefined} node
+ * @returns {boolean}
+ */
+const isPatternMakerCall = node => {
+  if (!node || node.type !== 'CallExpression') {
+    return false;
+  }
+  const { callee } = node;
+  if (callee.type !== 'MemberExpression') {
+    return false;
+  }
+  const { object } = callee;
+  return object.type === 'Identifier' && object.name === 'M';
+};
+
+/**
+ * ESLint rule module that flags `harden(x)` when `x` is, or was bound to,
+ * the result of a Pattern maker (`M.*(...)`).
+ *
+ * The rule has two shapes:
+ *   1. `harden(M.string())` — direct call.
+ *   2. `const x = M.string(); harden(x);` — identifier whose binding's
+ *      initializer is a pattern maker call.
+ *
+ * Only the bare identifier `M` is recognized as a Pattern maker namespace,
+ * matching the conservative heuristic used by `harden-exports`.
+ *
+ * @type {Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow harden() on values returned by Pattern makers (M.*) which are already hardened.',
+      category: 'Best Practices',
+      recommended: false,
+      url: 'https://github.com/endojs/endo/blob/master/packages/eslint-plugin/lib/rules/no-harden-pattern-maker.js',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      unnecessaryHardenOfPatternMaker:
+        'harden() is unnecessary for values returned by Pattern makers (M.*) which are already hardened.',
+    },
+  },
+  /**
+   * @param {Rule.RuleContext} context
+   * @returns {Rule.RuleListener}
+   */
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    /**
+     * Returns true when `name` resolves in the surrounding scope to a
+     * `const`/`let`/`var` binding whose single initializer is a
+     * Pattern maker call.
+     * @param {ESTree.Identifier} idNode - the identifier passed to harden().
+     * @param {Rule.Node} contextNode - the enclosing node used for scope lookup.
+     * @returns {boolean}
+     */
+    const identifierBoundToPatternMaker = (idNode, contextNode) => {
+      const scope =
+        (sourceCode.getScope && sourceCode.getScope(contextNode)) ||
+        // Fallback for older ESLint
+        // eslint-disable-next-line no-restricted-syntax
+        context.getScope();
+      // Walk outward through scopes looking for the binding.
+      /** @type {import('eslint').Scope.Scope | null} */
+      let current = scope;
+      while (current) {
+        const variable = current.variables.find(v => v.name === idNode.name);
+        if (variable) {
+          // Look at every definition; if any of them is a Pattern maker
+          // initializer, count the binding as already hardened.
+          for (const def of variable.defs) {
+            if (
+              def.type === 'Variable' &&
+              def.node &&
+              def.node.type === 'VariableDeclarator' &&
+              isPatternMakerCall(def.node.init)
+            ) {
+              return true;
+            }
+          }
+          return false;
+        }
+        current = current.upper;
+      }
+      return false;
+    };
+
+    return {
+      /** @param {ESTree.CallExpression & Rule.NodeParentExtension} node */
+      CallExpression(node) {
+        if (
+          node.callee.type !== 'Identifier' ||
+          node.callee.name !== 'harden'
+        ) {
+          return;
+        }
+        if (node.arguments.length !== 1) {
+          return;
+        }
+        const arg = node.arguments[0];
+
+        let matched = false;
+        if (isPatternMakerCall(arg)) {
+          matched = true;
+        } else if (
+          arg.type === 'Identifier' &&
+          identifierBoundToPatternMaker(arg, /** @type {Rule.Node} */ (node))
+        ) {
+          matched = true;
+        }
+
+        if (!matched) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'unnecessaryHardenOfPatternMaker',
+          fix(fixer) {
+            // If the harden() call is its own ExpressionStatement,
+            // delete the whole statement plus the indentation that
+            // precedes it on the same line, so we don't leave a line
+            // of trailing whitespace behind.
+            const { parent } = node;
+            if (
+              parent &&
+              parent.type === 'ExpressionStatement' &&
+              parent.expression === node
+            ) {
+              const text = sourceCode.getText();
+              const range = /** @type {[number, number]} */ (parent.range);
+              let removeStart = range[0];
+              const end = range[1];
+              while (
+                removeStart > 0 &&
+                (text.charAt(removeStart - 1) === ' ' ||
+                  text.charAt(removeStart - 1) === '\t')
+              ) {
+                removeStart -= 1;
+              }
+              return fixer.removeRange([removeStart, end]);
+            }
+            // Otherwise, replace `harden(x)` with `x`.
+            return fixer.replaceText(node, sourceCode.getText(arg));
+          },
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/test/harden-exports.test.js
+++ b/packages/eslint-plugin/test/harden-exports.test.js
@@ -103,6 +103,31 @@ harden(aliasName);
 harden(inner);
         `,
   },
+  {
+    // Pattern makers (M.something(...)) return already-hardened values,
+    // so a follow-up harden() is unnecessary noise.
+    code: `
+export const StringShape = M.string();
+              `,
+  },
+  {
+    code: `
+export const StringsShape = M.arrayOf(M.string());
+              `,
+  },
+  {
+    code: `
+export const a = M.string();
+export const b = M.arrayOf(M.string());
+              `,
+  },
+  {
+    // harden(name) on an M.* export is still allowed (sanity case).
+    code: `
+export const StringShape = M.string();
+harden(StringShape);
+              `,
+  },
 ];
 
 const invalid = [
@@ -442,6 +467,55 @@ harden(rest);
 harden(name);
 harden(notRest);
     `,
+  },
+  {
+    // Object literal initializers still need an explicit harden().
+    code: `
+export const x = { foo: 1 };
+              `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'x' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const x = { foo: 1 };
+harden(x);
+              `,
+  },
+  {
+    // Arrow function initializers still need an explicit harden().
+    code: `
+export const x = () => 1;
+              `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'x' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const x = () => 1;
+harden(x);
+              `,
+  },
+  {
+    // A non-M.* call expression (e.g. plain function call) is not
+    // recognized as already hardened and still warns.
+    code: `
+export const x = makeThing();
+              `,
+    errors: [
+      {
+        message:
+          "Named export(s) 'x' should be followed by a call to 'harden'.",
+      },
+    ],
+    output: `
+export const x = makeThing();
+harden(x);
+              `,
   },
 ];
 

--- a/packages/eslint-plugin/test/no-harden-pattern-maker.test.js
+++ b/packages/eslint-plugin/test/no-harden-pattern-maker.test.js
@@ -1,0 +1,78 @@
+const { RuleTester } = require('eslint');
+const rule = require('../lib/rules/no-harden-pattern-maker');
+
+const valid = [
+  // Plain object literals still need harden().
+  { code: `harden({ foo: 1 });` },
+  // Other call expressions are not Pattern makers.
+  { code: `const a = makeFoo(); harden(a);` },
+  // `M` referenced as a value (not as `M.foo()`) is fine.
+  { code: `harden(globalThis.M);` },
+  // Only the bare identifier `M` is recognized as the Pattern namespace.
+  { code: `harden(thirdPartyM.string());` },
+  // harden of an unrelated identifier whose initializer is not a call.
+  { code: `const a = 1; harden(a);` },
+  // harden(M) — `M` itself, not a member call — is left alone.
+  { code: `harden(M);` },
+  // Nested function with its own binding shadowing an outer one.
+  {
+    code: `
+      const a = makeOther();
+      function f() {
+        harden(a);
+      }
+    `,
+  },
+];
+
+const invalid = [
+  {
+    code: `harden(M.string());`,
+    errors: [{ messageId: 'unnecessaryHardenOfPatternMaker' }],
+    output: ``,
+  },
+  {
+    code: `const a = M.string(); harden(a);`,
+    errors: [{ messageId: 'unnecessaryHardenOfPatternMaker' }],
+    output: `const a = M.string();`,
+  },
+  {
+    code: `harden(M.arrayOf(M.string()));`,
+    errors: [
+      // Outer harden(M.arrayOf(...)) fires; the inner M.string() is not a
+      // harden call so only one report.
+      { messageId: 'unnecessaryHardenOfPatternMaker' },
+    ],
+    output: ``,
+  },
+  {
+    code: `
+function f() {
+  const a = M.recordOf(M.string(), M.any());
+  harden(a);
+}
+`,
+    errors: [{ messageId: 'unnecessaryHardenOfPatternMaker' }],
+    output: `
+function f() {
+  const a = M.recordOf(M.string(), M.any());
+\n}
+`,
+  },
+  {
+    // harden(M.string()) in expression position (not a statement) should
+    // be replaced rather than removed.
+    code: `const x = harden(M.string());`,
+    errors: [{ messageId: 'unnecessaryHardenOfPatternMaker' }],
+    output: `const x = M.string();`,
+  },
+];
+
+const tester = new RuleTester({
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+});
+
+tester.run('no-harden-pattern-maker', rule, {
+  valid,
+  invalid,
+});


### PR DESCRIPTION
Closes: #2632

## Description

Two complementary `@endo/eslint-plugin` changes around Pattern makers.

The existing `harden-exports` rule no longer demands `harden(name)` on an export whose declarator is initialized to a Pattern maker call (`M.something(...)`). Pattern makers already return hardened values, so the follow-up `harden()` is redundant noise. The check matches conservatively: only when the callee's immediate object identifier is the literal name `M`, and only on the declarator's initializer. Object literals, arrow functions, and non-`M.*` call initializers still warn.

A companion rule, `no-harden-pattern-maker`, flags the inverse: existing sites that wrap an already-hardened Pattern maker result with another `harden()` call. It fires on `harden(M.string())` and on the bound-identifier shape `const x = M.something(); harden(x);` (scope analysis via ESLint's built-in scope manager). A full repository sweep at error severity flagged zero existing sites, so the rule ships at `warn` severity in the recommended config; a regression would surface without breaking CI.

The framing follows @erights on #2632, who suggested that a lint rule of this shape should ultimately notice declarations initialized to literal expressions in general, not only `M.something(...)` calls. This PR takes the narrower `M.*` form as a first step; the broader literal-expression treatment is left for a follow-up.

### Security Considerations

None. Both rules are lint warnings only and do not change runtime behavior. They narrow the set of code patterns the linter complains about and broaden the set of patterns it flags, but emit no executable code.

### Scaling Considerations

None. The new checks are local AST inspections that run within the existing ESLint pass over each file.

### Documentation Considerations

None. The rules are configured in the recommended preset, so consumers picking up the plugin upgrade get the new behavior automatically. No user-facing API surface changed.

### Testing Considerations

Unit tests cover the new `harden-exports` skip cases (single and multi-declarator `M.*` initializers, nested `M.arrayOf(M.string())`, explicit `harden()` on an `M.*` export still allowed, object / arrow / non-`M.*` initializers still warn) and both `no-harden-pattern-maker` shapes (direct `harden(M.string())` and the bound-identifier path).

### Compatibility Considerations

Strictly more permissive for `harden-exports`: any code that passed the old rule still passes. `no-harden-pattern-maker` ships at `warn` in the recommended config, so it does not break existing CI on adoption.

### Upgrade Considerations

None.
