### PR TITLE
chore: remove lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,0 @@
-{
-  "includeMergedTags": true,
-  "npmClient": "yarn",
-  "version": "independent",
-  "useNx": false
-}


### PR DESCRIPTION
Lerna is no longer used (ref: #3281), so we can remove `lerna.json`.
