### PR TITLE
feat(ses): add four new permitted intrinsics shipping in V8 v14.6

### DIFF
--- a/.changeset/breezy-insects-do.md
+++ b/.changeset/breezy-insects-do.md
@@ -1,0 +1,5 @@
+---
+'ses': minor
+---
+
+Allows `Map.prototype.getOrInsert`, `Map.prototype.getOrInsertComputed`, `WeakMap.prototype.getOrInsert` and `WeakMap.prototype.getOrInsertComputed`.

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -865,6 +865,8 @@ export const permitted = {
     getYear: fn,
     setYear: fn,
     toGMTString: fn,
+
+    toTemporalInstant: false,
   },
 
   // Text Processing
@@ -1253,6 +1255,8 @@ export const permitted = {
     entries: fn,
     forEach: fn,
     get: fn,
+    getOrInsert: fn,
+    getOrInsertComputed: fn,
     has: fn,
     keys: fn,
     set: fn,
@@ -1324,6 +1328,8 @@ export const permitted = {
     constructor: 'WeakMap',
     delete: fn,
     get: fn,
+    getOrInsert: fn,
+    getOrInsertComputed: fn,
     has: fn,
     set: fn,
     '@@toStringTag': 'string',


### PR DESCRIPTION
- `Map.prototype.getOrInsert`
- `Map.prototype.getOrInsertComputed`
- `WeakMap.prototype.getOrInsert`
- `WeakMap.prototype.getOrInsertComputed`

`Date.prototype.toTemporalInstant` is marked as `false` to omit it from the warning that `lockdown` would otherwise emit.

Ref: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V26.md#2026-05-05-version-2600-current-rafaelgss