### PR TITLE
fix(patterns): bump version for publishing

### DIFF
--- a/.changeset/six-coins-lie.md
+++ b/.changeset/six-coins-lie.md
@@ -1,0 +1,5 @@
+---
+'@endo/patterns': minor
+---
+
+Bump version for publishing only.

--- a/packages/patterns/package.json
+++ b/packages/patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/patterns",
-  "version": "1.9.1",
+  "version": "2.0.0",
   "description": "Pattern matching for Passable objects, expressed as Passable data",
   "keywords": [],
   "author": "Endo contributors",


### PR DESCRIPTION
This bumps the version to v2.0.0 to align it with what is actually in the registry; v2.0.0 is already published, but our `package.json` lags behind.  Version v1.9.1 could not be published.

Once this is merged, the next release will bump the version to v2.0.1.