### PR TITLE
fix(eslint-plugin): drop conflicting `project` parser option

### DIFF
--- a/packages/eslint-plugin/lib/configs/internal.js
+++ b/packages/eslint-plugin/lib/configs/internal.js
@@ -5,8 +5,11 @@ const dynamicConfig = {
   overrides: /** @type {*[]} */ ([]),
 };
 
+// The project service discovers the nearest tsconfig per file and falls
+// back to `defaultProject` for stray `*.js` files. It supersedes the older
+// `project` glob, which must not be set alongside it: newer
+// typescript-eslint parsers reject enabling both.
 const parserOptions = {
-  useProjectService: true,
   sourceType: 'module',
   projectService: {
     allowDefaultProject: ['*.js'],


### PR DESCRIPTION
## Problem

The shared `@endo/internal` ESLint config (`packages/eslint-plugin/lib/configs/internal.js`) set both `projectService` and the redundant `useProjectService: true` flag in `parserOptions`. With the installed typescript-eslint (8.59), enabling the legacy `project` mechanism alongside `projectService` is rejected — the parser throws `Parsing error: Enabling "project" does nothing when "projectService" is enabled` at `0:0` for every file, so lint was effectively broken monorepo-wide.

## Fix

Drop the now-redundant `useProjectService: true` (and, where still present, the legacy `project` glob and its `rootTsProjectGlob` const). The project service is the sole mechanism: it discovers the nearest `tsconfig` per file and falls back to `defaultProject` for stray `*.js` files. A short comment documents that the two mechanisms must not both be set.

## Verification

- `npx corepack yarn eslint` on a package source file now exits 0 with no `Parsing error … projectService` lines.
- Type-aware linting still engages: a temporary probe doing `{} + 1` (`// @ts-nocheck`) correctly reported a `@typescript-eslint/restrict-plus-operands` error, confirming type information is available to the parser. The probe was removed before committing.