### PR TITLE
chore(ci): fix zizmor warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         # This action will create/update Changesets' Release PR *or* create a
         # GitHub Release and tags if its Release PR was just merged
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           publish: yarn changeset tag
           createGithubReleases: true


### PR DESCRIPTION
Apparently the comment should reference a tag instead of a branch.

Per `zizmor` warning:

```
Warning: release.yml:63: action's hash pin has mismatched or missing version comment: points to commit a45c4d594aa4
```