### PR TITLE
test(env-options,marshal): per-compartment options are scoped

### DIFF
--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -51,6 +51,7 @@
     "@endo/pass-style": "workspace:^"
   },
   "devDependencies": {
+    "@endo/compartment-mapper": "workspace:^",
     "@endo/init": "workspace:^",
     "@endo/lockdown": "workspace:^",
     "@endo/ses-ava": "workspace:^",

--- a/packages/marshal/test/_fixtures-env-options-in-compartment/main.js
+++ b/packages/marshal/test/_fixtures-env-options-in-compartment/main.js
@@ -1,0 +1,72 @@
+// Entry-point fixture for env-options-in-compartment.test.js.
+//
+// Loaded via `importLocation` from `@endo/compartment-mapper` so that
+// `@endo/env-options` is resolved and instantiated inside a sub-compartment
+// using the package's actual on-disk source.
+// The compartment-mapper plumbs the per-compartment `process` global into the
+// sub-compartment's `globalThis`, allowing the captor to read the
+// sub-compartment's own `process.env` rather than the parent process's.
+//
+// This module mirrors the `ENDO_RANK_STRINGS` branch in
+// `packages/marshal/src/rankOrder.js` for plain strings: the option is
+// captured once at module evaluation and used to choose between code-unit
+// and code-point comparison.
+
+import { getEnvironmentOption } from '@endo/env-options';
+
+const ENDO_RANK_STRINGS = getEnvironmentOption(
+  'ENDO_RANK_STRINGS',
+  'utf16-code-unit-order',
+  ['unicode-code-point-order', 'error-if-order-choice-matters'],
+);
+
+export const capturedSetting = ENDO_RANK_STRINGS;
+
+/**
+ * @param {string} left
+ * @param {string} right
+ * @returns {-1 | 0 | 1}
+ */
+const codeUnitCompare = (left, right) => {
+  // eslint-disable-next-line no-nested-ternary
+  return left < right ? -1 : left > right ? 1 : 0;
+};
+
+/**
+ * @param {string} left
+ * @param {string} right
+ * @returns {-1 | 0 | 1}
+ */
+const codePointCompare = (left, right) => {
+  // Iterate by code point rather than by UTF-16 code unit.
+  const leftCps = [...left];
+  const rightCps = [...right];
+  const n = Math.min(leftCps.length, rightCps.length);
+  for (let i = 0; i < n; i += 1) {
+    const a = /** @type {number} */ (leftCps[i].codePointAt(0));
+    const b = /** @type {number} */ (rightCps[i].codePointAt(0));
+    if (a !== b) return a < b ? -1 : 1;
+  }
+  // eslint-disable-next-line no-nested-ternary
+  return leftCps.length < rightCps.length
+    ? -1
+    : leftCps.length > rightCps.length
+      ? 1
+      : 0;
+};
+
+/**
+ * @param {string} left
+ * @param {string} right
+ * @returns {-1 | 0 | 1}
+ */
+export const compareStrings = (left, right) => {
+  switch (ENDO_RANK_STRINGS) {
+    case 'utf16-code-unit-order':
+      return codeUnitCompare(left, right);
+    case 'unicode-code-point-order':
+      return codePointCompare(left, right);
+    default:
+      throw Error(`Unexpected ENDO_RANK_STRINGS ${ENDO_RANK_STRINGS}`);
+  }
+};

--- a/packages/marshal/test/_fixtures-env-options-in-compartment/package.json
+++ b/packages/marshal/test/_fixtures-env-options-in-compartment/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "env-options-in-compartment-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./main.js",
+  "dependencies": {
+    "@endo/env-options": "workspace:^"
+  }
+}

--- a/packages/marshal/test/env-options-in-compartment.test.js
+++ b/packages/marshal/test/env-options-in-compartment.test.js
@@ -1,0 +1,103 @@
+// Verifies that `ENDO_RANK_STRINGS`, when set on a sub-compartment's own
+// `process.env`, configures string-ranking decisions made by code running
+// inside that sub-compartment, independent of the parent's (process-level)
+// setting.
+//
+// The parent of this test is loaded with the default `utf16-code-unit-order`
+// regime (no `tools/prepare-*.js` import).
+// Inside the sub-compartment we set `ENDO_RANK_STRINGS =
+// 'unicode-code-point-order'` on its own `process.env` and then observe that
+// string ranking inside the sub-compartment follows code-point order while
+// ranking in the parent follows code-unit order.
+//
+// The sub-compartment is constructed by `@endo/compartment-mapper`'s
+// `importLocation`, which loads `@endo/env-options` from its actual on-disk
+// source (the way a real consumer would), with `globals.process` plumbed in
+// per-compartment.
+//
+// See https://github.com/endojs/endo/issues/2879
+
+import '@endo/init/debug.js';
+
+import fs from 'node:fs';
+import url from 'node:url';
+
+import test from '@endo/ses-ava/test.js';
+import { importLocation } from '@endo/compartment-mapper';
+import { makeReadPowers } from '@endo/compartment-mapper/node-powers.js';
+
+import { compareRank as parentCompareRank } from '../src/rankOrder.js';
+import { multiplanarStrings, sorted } from '../tools/marshal-test-data.js';
+
+/** @import { RankCompare } from '../src/types.js' */
+
+/**
+ * @typedef {object} CompareStringsNamespace
+ * @property {RankCompare} compareStrings
+ * @property {string} capturedSetting
+ */
+
+const readPowers = makeReadPowers({ fs, url });
+
+const fixtureLocation = new URL(
+  './_fixtures-env-options-in-compartment/main.js',
+  import.meta.url,
+).toString();
+
+/**
+ * @param {string} setting
+ * @returns {Promise<CompareStringsNamespace>}
+ */
+const importFixtureWithEnvOption = async setting => {
+  const { namespace } = await importLocation(readPowers, fixtureLocation, {
+    globals: {
+      process: { env: { ENDO_RANK_STRINGS: setting } },
+    },
+  });
+  return /** @type {CompareStringsNamespace} */ (
+    /** @type {unknown} */ (namespace)
+  );
+};
+
+const { bmpHigh, surrogatePair } = multiplanarStrings;
+
+test('per-compartment ENDO_RANK_STRINGS controls string ranking inside the compartment', async t => {
+  // Parent has the default setting.
+  // These two strings disagree between code-unit and code-point order
+  // (the canonical example from the ICU paper), so they reveal which
+  // order is in effect.
+  // utf16-code-unit-order: surrogatePair < bmpHigh
+  // unicode-code-point-order: bmpHigh < surrogatePair
+  t.is(parentCompareRank(surrogatePair, bmpHigh), -1);
+  t.is(parentCompareRank(bmpHigh, surrogatePair), 1);
+
+  const { compareStrings, capturedSetting } = await importFixtureWithEnvOption(
+    'unicode-code-point-order',
+  );
+
+  // The sub-compartment captured its own setting, not the parent's.
+  t.is(capturedSetting, 'unicode-code-point-order');
+
+  // Inside the sub-compartment, code-point order swaps the result.
+  t.is(compareStrings(surrogatePair, bmpHigh), 1);
+  t.is(compareStrings(bmpHigh, surrogatePair), -1);
+
+  // And the resulting sort differs from the parent's.
+  const strs = harden([bmpHigh, surrogatePair]);
+  t.deepEqual(sorted(strs, parentCompareRank), [surrogatePair, bmpHigh]);
+  t.deepEqual(sorted(strs, compareStrings), [bmpHigh, surrogatePair]);
+});
+
+test('two sibling sub-compartments capture different ENDO_RANK_STRINGS', async t => {
+  const utf16 = await importFixtureWithEnvOption('utf16-code-unit-order');
+  const codePoint = await importFixtureWithEnvOption(
+    'unicode-code-point-order',
+  );
+
+  t.is(utf16.capturedSetting, 'utf16-code-unit-order');
+  t.is(codePoint.capturedSetting, 'unicode-code-point-order');
+
+  // Same inputs, opposite results.
+  t.is(utf16.compareStrings(surrogatePair, bmpHigh), -1);
+  t.is(codePoint.compareStrings(surrogatePair, bmpHigh), 1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,6 +963,7 @@ __metadata:
   resolution: "@endo/marshal@workspace:packages/marshal"
   dependencies:
     "@endo/common": "workspace:^"
+    "@endo/compartment-mapper": "workspace:^"
     "@endo/env-options": "workspace:^"
     "@endo/errors": "workspace:^"
     "@endo/eventual-send": "workspace:^"


### PR DESCRIPTION
Closes: #2879

## Description

Adds a test confirming that `@endo/env-options` reads `globalThis.process.env` from the compartment it runs in, so settings like `ENDO_RANK_STRINGS` are scoped per compartment rather than leaking from the parent.

The test loads `@endo/env-options` into a sub-compartment via `@endo/compartment-mapper`'s `importLocation`, with the sub-compartment's own `process.env` supplied through per-compartment `globals.process.env`. It then checks that string ranking inside the sub-compartment follows that compartment's `ENDO_RANK_STRINGS` setting (`unicode-code-point-order`) while the parent retains the default (`utf16-code-unit-order`), and that two sibling sub-compartments observe their own envs independently.

### Security Considerations

No new authorities. The change is test-only; it documents and pins existing per-compartment isolation of env-options rather than altering any boundary.

### Scaling Considerations

None. The added test runs at the same cost as the package's existing tests.

### Documentation Considerations

None. The behavior under test (env-options reading the running compartment's `process.env`) is already the intended contract.

### Testing Considerations

This PR is itself the test. It exercises the captor through `@endo/compartment-mapper` the way a real downstream consumer would, rather than constructing a `ModuleSource` by hand.

### Compatibility Considerations

None. No usage patterns change.

### Upgrade Considerations

None.
