### PR TITLE
fix(eslint-plugin): resolve catalog: deps in published manifest

### DIFF
--- a/.changeset/eslint-plugin-catalog-deps.md
+++ b/.changeset/eslint-plugin-catalog-deps.md
@@ -1,0 +1,9 @@
+---
+'@endo/eslint-plugin': patch
+---
+
+Republish with resolved dependency versions. The 2.6.0 manifest on npm
+shipped `catalog:` protocol specifiers for `eslint-plugin-import` and
+`typescript`, which npm cannot resolve; the publish toolchain now resolves
+the `catalog:` protocol to concrete version ranges at pack time. Fixes
+https://github.com/endojs/endo/issues/3304.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier": "^3.8.3",
     "ses": "workspace:^",
     "source-map": "^0.7.6",
-    "ts-node-pack": "^0.3.2",
+    "ts-node-pack": "^0.3.5",
     "tsd": "catalog:dev",
     "type-coverage": "^2.29.7",
     "typedoc": "^0.28.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,6 +1876,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pnpm/catalogs.config@npm:^1100.0.0":
+  version: 1100.0.0
+  resolution: "@pnpm/catalogs.config@npm:1100.0.0"
+  dependencies:
+    "@pnpm/error": "npm:1100.0.0"
+  checksum: 10c0/638c7fcf1a0e9144dee2ab7b4f8c1727e8fce258f2b0143fe4a22399bb2a61f229673800dc4501e2942cce5f6f78a7d9445c1882c5341e7b6eb4653da6712fd4
+  languageName: node
+  linkType: hard
+
+"@pnpm/catalogs.protocol-parser@npm:^1100.0.0":
+  version: 1100.0.0
+  resolution: "@pnpm/catalogs.protocol-parser@npm:1100.0.0"
+  checksum: 10c0/556b3386202df398b1191cb61698b14235142e9388b44a87ed48e535657868612e3310af12cdd31e7f738051a046ba2e6ce044403ac4b8c97a9d6280d2eef825
+  languageName: node
+  linkType: hard
+
+"@pnpm/catalogs.resolver@npm:^1100.0.0":
+  version: 1100.0.0
+  resolution: "@pnpm/catalogs.resolver@npm:1100.0.0"
+  dependencies:
+    "@pnpm/catalogs.protocol-parser": "npm:^1100.0.0"
+    "@pnpm/error": "npm:^1100.0.0"
+  checksum: 10c0/df4b33de640558b895470306ee95eec3b77e09c48c37a47f04417a2b63f943f2e00c7b7e705ea84dcf2aef10d7542e35211319d23f331080559299e0624e3361
+  languageName: node
+  linkType: hard
+
+"@pnpm/constants@npm:1100.0.0":
+  version: 1100.0.0
+  resolution: "@pnpm/constants@npm:1100.0.0"
+  checksum: 10c0/38d03aacfc5f55abc1331e09b84f2f1d0c8f0dd097f3e6624594769922374e970fc1728dc6e001c8abf0215ac4e9cfd5b4ab3ac0ff96abd161482ef48988f959
+  languageName: node
+  linkType: hard
+
+"@pnpm/error@npm:1100.0.0, @pnpm/error@npm:^1100.0.0":
+  version: 1100.0.0
+  resolution: "@pnpm/error@npm:1100.0.0"
+  dependencies:
+    "@pnpm/constants": "npm:1100.0.0"
+  checksum: 10c0/5a0518a0ca59f322522ab67848bc56e7c9a81fa65060b01b5af972f5d236d4f1c335081cbc604b01b7ce99588bff1b8c0a8405220ddba3f12940cff3c0f46ec5
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-commonjs@npm:^28.0.2":
   version: 28.0.6
   resolution: "@rollup/plugin-commonjs@npm:28.0.6"
@@ -8211,7 +8253,7 @@ __metadata:
     prettier: "npm:^3.8.3"
     ses: "workspace:^"
     source-map: "npm:^0.7.6"
-    ts-node-pack: "npm:^0.3.2"
+    ts-node-pack: "npm:^0.3.5"
     tsd: "catalog:dev"
     type-coverage: "npm:^2.29.7"
     typedoc: "npm:^0.28.19"
@@ -9230,15 +9272,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node-pack@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "ts-node-pack@npm:0.3.2"
+"ts-node-pack@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "ts-node-pack@npm:0.3.5"
   dependencies:
+    "@pnpm/catalogs.config": "npm:^1100.0.0"
+    "@pnpm/catalogs.resolver": "npm:^1100.0.0"
     amaro: "npm:^0.3.2"
     npm-packlist: "npm:^10.0.4"
+    yaml: "npm:^2.9.0"
   bin:
     ts-node-pack: src/cli.js
-  checksum: 10c0/b2b565881cb8ec05f73160943f14e787049ee68e04091f59dac4ccbc3bd100b5a5197e67a4b56fc1515890e62105d8264c68285cecb810deb25b9bf22c433e3f
+  checksum: 10c0/aa42da5710ca241924465de0d95f2c5843872b34099f91b67c00c467e2162b0dc01e3edbab240873832c43e1ccaa4b1ae6597c9b27fcfe496f5b64447959f735
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

`@endo/eslint-plugin` 2.6.0 shipped Yarn `catalog:` protocol specifiers in its published `dependencies`:

```json
"eslint-plugin-import": "catalog:dev",
"typescript": "catalog:dev"
```

npm cannot resolve `catalog:`, so installing the package from the registry produces a broken dependency manifest.

Fixes #3304.

## Root cause

endo's publish pipeline (`release-npm.mjs` → `pack-all.mjs`) packs with **`ts-node-pack`**, not `yarn pack`. `ts-node-pack` resolved the `workspace:` protocol but copied `catalog:` verbatim into the published `package.json`. Only the publishing package manager understands `catalog:`; npm does not.

`@endo/eslint-plugin` was the only affected package — every other package uses `catalog:` solely in `devDependencies`, which `ts-node-pack` strips from the tarball.

## Fix

- The fix lives in `ts-node-pack`, which now resolves the `catalog:` protocol at pack time (released as `0.3.5`). It reads the workspace catalog config (`.yarnrc.yml` / `pnpm-workspace.yaml`) and rewrites each `catalog:` spec to the concrete range, delegating catalog semantics to `@pnpm/catalogs.config` + `@pnpm/catalogs.resolver`. It also preserves `npm:` alias entries verbatim (e.g. `npm:eslint-plugin-import-x@4.16.2`), which `yarn pack` itself strips.
- This PR bumps the `ts-node-pack` pin `^0.3.2` → `^0.3.5` and adds a changeset to republish `@endo/eslint-plugin` with the resolved versions.

## Verification

Re-packing `@endo/eslint-plugin` through endo's own toolchain after the bump:

```
eslint-plugin-import → npm:eslint-plugin-import-x@4.16.2
typescript           → ~6.0.3
```

No `catalog:` specs remain in any installable dependency section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)