### PR TITLE
fix(ses): Prevent Node.js console logging from invoking custom inspect methods

### DIFF
--- a/.changeset/lemon-states-do.md
+++ b/.changeset/lemon-states-do.md
@@ -1,0 +1,6 @@
+---
+'ses': patch
+---
+
+- `consoleTaming: 'safe'` prevents Node.js console logging from invoking custom
+  inspect methods

--- a/docs/lockdown.md
+++ b/docs/lockdown.md
@@ -33,7 +33,7 @@ Each option is explained in its own section below.
 |----------------------------------|------------------|----------------------------------------|-------|
 | `regExpTaming`                   | `'safe'`         | `'unsafe'`                             | `RegExp.prototype.compile` ([details](#regexptaming-options)) |
 | `localeTaming`                   | `'safe'`         | `'unsafe'`                             | `toLocaleString`           ([details](#localetaming-options)) |
-| `consoleTaming`                  | `'safe'`         | `'unsafe'`                             | deep stacks                ([details](#consoletaming-options)) |
+| `consoleTaming`                  | `'safe'`         | `'unsafe'`                             | deep stacks and custom methods ([details](#consoletaming-options)) |
 | `errorTaming`                    | `'safe'`         | `'unsafe'` `'unsafe-debug'`            | `errorInstance.stack`      ([details](#errortaming-options)) |
 | `errorTrapping`                  | `'platform'`     | `'exit'` `'abort'` `'report'` `'none'` | handling of uncaught exceptions ([details](#errortrapping-options)) |
 | `reporting`                      | `'platform'`     | `'console'` `'none'`                   | where to report warnings ([details](#reporting-options))
@@ -179,10 +179,15 @@ is negligible.
 **Background**: Most JavaScript environments provide a `console` object on the
 global object with interesting information hiding properties. JavaScript code
 can use the `console` to send information to the console's logging output, but
-cannot see that output. The `console` is a *write-only device*. The logging
-output is normally placed where a human programmer, who is in a controlling
-position over that computation, can see the output. This output is, accordingly,
-formatted mostly for human consumption; typically for diagnosing problems.
+cannot see that output. The `console` is notionally a *write-only device*,
+although its concrete implementation often goes beyond that to include invoking
+formatting methods on its arguments (which in the case of Node.js also provides
+object arguments that can form a [covert communications channel
+](https://papers.agoric.com/taxonomy-of-security-issues/#overt-side-and-covert-channels)).
+The logging output is normally placed where a human programmer, who is in a
+controlling position over that computation, can see the output. This output is,
+accordingly, formatted mostly for human consumption; typically for diagnosing
+problems.
 
 Given these constraints, it is both safe and helpful for the `console` to reveal
 to the human programmer information that it would not reveal to the objects it
@@ -191,7 +196,7 @@ to the programmer much more information than would be revealed by the normal
 `console`. To do so, by default during `lockdown` SES virtualizes the builtin
 `console`, by replacing it with a wrapper. The wrapper is a virtual `console`
 that implements the standard `console` API mostly by forwarding to the original
-wrapped `console`.
+wrapped `console` while suppressing its custom method invocations.
 In addition, the virtual `console` has a special relationship with
 error objects and with the SES `assert` package, so that errors can report yet
 more diagnostic information that should remain hidden from other objects. See

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -191,7 +191,7 @@ below.
   <tr>
     <td><code>consoleTaming</code></td>
     <td><code>'safe'</code> (default) or <code>'unsafe'</code></td>
-    <td><code>'safe'</code> wraps start console to show deep stacks,<br>
+    <td><code>'safe'</code> wraps start console to show deep stacks and suppress custom method invocation,<br>
         <code>'unsafe'</code> uses the original start console.</td>
   </tr>
   <tr>

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -15,6 +15,7 @@ import {
   defineProperty,
   freeze,
   fromEntries,
+  globalThis,
   isError,
   stringEndsWith,
   stringIncludes,
@@ -224,10 +225,31 @@ const ErrorInfo = {
 freeze(ErrorInfo);
 
 /** @type {MakeCausalConsole} */
-export const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
-  if (!baseConsole) {
+export const makeCausalConsole = (feralConsole, loggedErrorHandler) => {
+  if (!feralConsole) {
     return undefined;
   }
+
+  // In Node.js, the global console does a deep scan of its inputs for methods
+  // keyed by Symbol.for('nodejs.util.inspect.custom'), and invokes any that are
+  // found with unhardened arguments as described at
+  // https://nodejs.org/docs/latest/api/util.html#custom-inspection-functions-on-objects
+  // To circumvent that problematic behavior, we use its
+  // https://nodejs.org/docs/latest/api/console.html#class-console Console
+  // constructor to build a replacement that explicitly opts out by setting the
+  // `customInspect` option to false.
+  // https://nodejs.org/docs/latest/api/util.html#utilinspectobject-options
+  /** @type {new (options: any) => typeof console} */
+  const Console = /** @type {any} */ (feralConsole).Console;
+  const { stdout, stderr } = globalThis.process || { __proto__: null };
+  const baseConsole =
+    typeof Console === 'function' && (stdout || stderr)
+      ? new Console({
+          stdout,
+          stderr,
+          inspectOptions: { colors: undefined, customInspect: false },
+        })
+      : feralConsole;
 
   const { getStackString, tagError, takeMessageLogArgs, takeNoteLogArgsArray } =
     loggedErrorHandler;

--- a/packages/ses/test/error/tame-console-unfilteredError.test.js
+++ b/packages/ses/test/error/tame-console-unfilteredError.test.js
@@ -81,3 +81,29 @@ test('tameConsole - unlogged safe', t => {
   annotateError(ubarErr, X`caused by ${ufooErr},${obj}`);
   t.pass();
 });
+
+test.failing('tameConsole - argument method invocation', t => {
+  // https://nodejs.org/docs/latest/api/util.html#utilinspectobject-options
+  // https://nodejs.org/docs/latest/api/util.html#custom-inspection-functions-on-objects
+  // https://nodejs.org/docs/latest/api/util.html#utilinspectcustom
+  const nodejsCustomInspectSymbol = Symbol.for('nodejs.util.inspect.custom');
+  const makeSpyKit = id => {
+    const log = [];
+    const spy = {
+      id,
+      [nodejsCustomInspectSymbol]: (...args) => {
+        log.push([nodejsCustomInspectSymbol, args]);
+        return `<custom output for ${id}>`;
+      },
+    };
+    return [spy, log];
+  };
+
+  const [argSpy, argSpyCalls] = makeSpyKit('argSpy');
+  console.log(argSpy);
+  t.deepEqual(argSpyCalls, [], 'must not invoke object methods');
+
+  const [deepArgSpy, deepArgSpyCalls] = makeSpyKit('deepArgSpy');
+  console.log({ deepArgSpy });
+  t.deepEqual(deepArgSpyCalls, [], 'must not invoke methods on a deep object');
+});

--- a/packages/ses/test/error/tame-console-unfilteredError.test.js
+++ b/packages/ses/test/error/tame-console-unfilteredError.test.js
@@ -82,7 +82,7 @@ test('tameConsole - unlogged safe', t => {
   t.pass();
 });
 
-test.failing('tameConsole - argument method invocation', t => {
+test('tameConsole - argument method invocation', t => {
   // https://nodejs.org/docs/latest/api/util.html#utilinspectobject-options
   // https://nodejs.org/docs/latest/api/util.html#custom-inspection-functions-on-objects
   // https://nodejs.org/docs/latest/api/util.html#utilinspectcustom

--- a/packages/ses/test/error/tame-console-unsafeError.test.js
+++ b/packages/ses/test/error/tame-console-unsafeError.test.js
@@ -83,7 +83,7 @@ test('tameConsole - unlogged safe', t => {
   t.pass();
 });
 
-test.failing('tameConsole - argument method invocation', t => {
+test('tameConsole - argument method invocation', t => {
   // https://nodejs.org/docs/latest/api/util.html#utilinspectobject-options
   // https://nodejs.org/docs/latest/api/util.html#custom-inspection-functions-on-objects
   // https://nodejs.org/docs/latest/api/util.html#utilinspectcustom

--- a/packages/ses/test/error/tame-console-unsafeError.test.js
+++ b/packages/ses/test/error/tame-console-unsafeError.test.js
@@ -82,3 +82,29 @@ test('tameConsole - unlogged safe', t => {
   annotateError(ubarErr, X`caused by ${ufooErr},${obj}`);
   t.pass();
 });
+
+test.failing('tameConsole - argument method invocation', t => {
+  // https://nodejs.org/docs/latest/api/util.html#utilinspectobject-options
+  // https://nodejs.org/docs/latest/api/util.html#custom-inspection-functions-on-objects
+  // https://nodejs.org/docs/latest/api/util.html#utilinspectcustom
+  const nodejsCustomInspectSymbol = Symbol.for('nodejs.util.inspect.custom');
+  const makeSpyKit = id => {
+    const log = [];
+    const spy = {
+      id,
+      [nodejsCustomInspectSymbol]: (...args) => {
+        log.push([nodejsCustomInspectSymbol, args]);
+        return `<custom output for ${id}>`;
+      },
+    };
+    return [spy, log];
+  };
+
+  const [argSpy, argSpyCalls] = makeSpyKit('argSpy');
+  console.log(argSpy);
+  t.deepEqual(argSpyCalls, [], 'must not invoke object methods');
+
+  const [deepArgSpy, deepArgSpyCalls] = makeSpyKit('deepArgSpy');
+  console.log({ deepArgSpy });
+  t.deepEqual(deepArgSpyCalls, [], 'must not invoke methods on a deep object');
+});

--- a/packages/ses/test/error/tame-console.test.js
+++ b/packages/ses/test/error/tame-console.test.js
@@ -102,3 +102,30 @@ test('tameConsole - unlogged safe', t => {
   annotateError(ubarErr, X`caused by ${ufooErr},${obj}`);
   t.pass();
 });
+
+// A tame console must not invoke argument methods with unhardened arguments.
+test.failing('tameConsole - argument method invocation', t => {
+  // https://nodejs.org/docs/latest/api/util.html#utilinspectobject-options
+  // https://nodejs.org/docs/latest/api/util.html#custom-inspection-functions-on-objects
+  // https://nodejs.org/docs/latest/api/util.html#utilinspectcustom
+  const nodejsCustomInspectSymbol = Symbol.for('nodejs.util.inspect.custom');
+  const makeSpyKit = id => {
+    const log = [];
+    const spy = {
+      id,
+      [nodejsCustomInspectSymbol]: (...args) => {
+        log.push([nodejsCustomInspectSymbol, args]);
+        return `<custom output for ${id}>`;
+      },
+    };
+    return [spy, log];
+  };
+
+  const [argSpy, argSpyCalls] = makeSpyKit('argSpy');
+  console.log(argSpy);
+  t.deepEqual(argSpyCalls, [], 'must not invoke object methods');
+
+  const [deepArgSpy, deepArgSpyCalls] = makeSpyKit('deepArgSpy');
+  console.log({ deepArgSpy });
+  t.deepEqual(deepArgSpyCalls, [], 'must not invoke methods on a deep object');
+});

--- a/packages/ses/test/error/tame-console.test.js
+++ b/packages/ses/test/error/tame-console.test.js
@@ -104,7 +104,7 @@ test('tameConsole - unlogged safe', t => {
 });
 
 // A tame console must not invoke argument methods with unhardened arguments.
-test.failing('tameConsole - argument method invocation', t => {
+test('tameConsole - argument method invocation', t => {
   // https://nodejs.org/docs/latest/api/util.html#utilinspectobject-options
   // https://nodejs.org/docs/latest/api/util.html#custom-inspection-functions-on-objects
   // https://nodejs.org/docs/latest/api/util.html#utilinspectcustom


### PR DESCRIPTION
Closes: TBD

## Description

Reported by @ChALkeR 

Updates `consoleTaming: 'safe'` to suppress invocation of custom inspect methods by delegating to an internal console instance constructed with appropriate `inspectOptions` configuration rather than to the global console (which defaults to `customInspect: true`).
Further reading:
* https://nodejs.org/docs/latest/api/util.html#utilinspectobject-options
* https://nodejs.org/docs/latest/api/util.html#custom-inspection-functions-on-objects
* https://nodejs.org/docs/latest/api/util.html#utilinspectcustom

### Security Considerations

We could also go further and suppress the callbacks associated with [console format specifiers](https://console.spec.whatwg.org/#formatting-specifiers) by prepending an empty string to (string, unknown, ...unknown[]) arguments (such that `console.log("%d", { valueOf: () => 42 })` is effectively transformed into `console.log("", "%d", { valueOf: () => 42 })` and logs ` %d { valueOf: [Function: valueOf] }` rather than `42`).

### Scaling Considerations

n/a

### Documentation Considerations

Updates [lockdown.md](https://github.com/endojs/endo/blob/master/docs/lockdown.md) and [reference.md](https://github.com/endojs/endo/blob/master/docs/reference.md).

### Testing Considerations

Covered in packages/ses/test/error/tame-console*test.js.

### Compatibility Considerations

We never intended to support the Node.js functionality.

### Upgrade Considerations

This is a patch fix that introduces no compatibility concerns of its own.