### PR TITLE
fix(ses): Sanitize console format strings

### DIFF
--- a/.changeset/rich-zoos-make.md
+++ b/.changeset/rich-zoos-make.md
@@ -1,0 +1,9 @@
+---
+'ses': patch
+---
+
+The console format specifier `%c` is for consuming a CSS style string and applying that style to the rendering of the remaining arguments. Node.js and browsers both parse `%c` the same way and have it consume one argument.
+- Browsers actually make use of the CSS, leading to security problems (e.g., https://issues.chromium.org/40056332 ).
+- Node.js ignores the `%c` and its corresponding argument, which is allowed by the [WHATWG Console specification](https://console.spec.whatwg.org/).
+
+To avoid the CSS security problems on all platforms, under the defaut `consoleTaming: 'safe'`, we now sanitize out the `%c` and corresponding argument, emulating the allowed current Node.js behavior on all platforms. This fixes this CSS vulnerability while maintaining compatibility with the specification. We also treat unknown specifiers in a future-proof manner.

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -22,6 +22,8 @@ import {
   stringSplit,
   weaksetAdd,
   weaksetHas,
+  stringIndexOf,
+  stringSlice,
 } from '../commons.js';
 
 /**
@@ -76,7 +78,7 @@ const defineName = (name, fn) => defineProperty(fn, 'name', { value: name });
  * This is the same as the log severity of these on other
  * platform console implementations when they all agree.
  *
- * @type {readonly [ConsoleProps, LogSeverity | undefined][]}
+ * @type {readonly [ConsoleProps, LogSeverity][]}
  */
 export const consoleLevelMethods = freeze([
   ['debug', 'debug'], // (fmt?, ...args) verbose level on Chrome
@@ -92,24 +94,34 @@ export const consoleLevelMethods = freeze([
 ]);
 
 /**
+ * We special case `console.assert` because it contains `fmt?, ...args` just
+ * like the `consoleLevelMethods`, but not in the same place.
+ * We special case `console.timeLog` because it contains the same kind of
+ * `...args`, but with no format string.
+ *
+ * @type {readonly [ConsoleProps, LogSeverity][]}
+ */
+export const consoleSpecialMethods = freeze([
+  ['assert', 'error'], // (value, fmt?, ...args)
+  ['timeLog', 'log'], // (label?, ...args) no fmt string
+]);
+
+/**
  * Those console methods other than those already enumerated by
- * `consoleLevelMethods`.
+ * `consoleLevelMethods` and `consoleSpecialMethods`.
  *
  * Each is paired with what we consider to be their log severity level.
  * This is the same as the log severity of these on other
  * platform console implementations when they all agree.
  *
- * @type {readonly [ConsoleProps, LogSeverity | undefined][]}
+ * @type {readonly [ConsoleProps, LogSeverity][]}
  */
 export const consoleOtherMethods = freeze([
-  ['assert', 'error'], // (value, fmt?, ...args)
-  ['timeLog', 'log'], // (label?, ...args) no fmt string
-
   // Insensitive to whether any argument is an error. All arguments can pass
   // thru to baseConsole as is.
-  ['clear', undefined], // ()
+  ['clear', 'info'], // (), level is not well defined
   ['count', 'info'], // (label?)
-  ['countReset', undefined], // (label?)
+  ['countReset', 'info'], // (label?), level is not well defined
   ['dir', 'log'], // (item, options?)
   ['groupEnd', 'log'], // ()
   // In theory tabular data may be or contain an error. However, we currently
@@ -119,14 +131,15 @@ export const consoleOtherMethods = freeze([
   ['timeEnd', 'info'], // (label?)
 
   // Node Inspector only, MDN, and TypeScript, but not whatwg
-  ['profile', undefined], // (label?)
-  ['profileEnd', undefined], // (label?)
-  ['timeStamp', undefined], // (label?)
+  ['profile', 'info'], // (label?)
+  ['profileEnd', 'info'], // (label?)
+  ['timeStamp', 'info'], // (label?)
 ]);
 
-/** @type {readonly [ConsoleProps, LogSeverity | undefined][]} */
+/** @type {readonly [ConsoleProps, LogSeverity][]} */
 const consoleMethodPermits = freeze([
   ...consoleLevelMethods,
+  ...consoleSpecialMethods,
   ...consoleOtherMethods,
 ]);
 
@@ -156,6 +169,111 @@ const consoleMethodPermits = freeze([
  *   // A variety of other symbols also seen on Node
  * ]);
  */
+
+/**
+ * If `formatData` consists of `[fmt, ...args]` and `fmt` is a string
+ * containing a `%c` specifier that acts as an `%c` specifier
+ * according to https://console.spec.whatwg.org/#formatting-specifiers
+ * then omit it and its corresponding argument. For the rest of the `fmt`
+ * string and its corresponding arguments, return them as a replacement
+ * `formatData` to be fed to the underlying console log functions.
+ *
+ * The test takes into account the number of remaining `args`.
+ * A `%c` beyond `args` does not act as a specifier.
+ * The additional issue not mentioned at
+ * https://console.spec.whatwg.org/#formatting-specifiers
+ * is that `%%` is an escaped `%`, so the `%c` found within,
+ * for example, `%%c` does not act as a specifier.
+ * Instead, it gets rendered as `%c` without consuming an argument.
+ *
+ * Note terminology differences from the spec-internal `Logger` function
+ * at https://console.spec.whatwg.org/#formatting-specifiers .
+ *
+ * | `Logger` terminology | `sanitizeFormatData` terminology |
+ * | ---------------------|----------------------------------|
+ * | `args`               | `formatData`                     |
+ * | `first`              | `fmt`                            |
+ * | `rest`               | `args`                           |
+ *
+ * Exported only for testing.
+ *
+ * @param {any[]} formatData
+ * @returns {any[]}
+ */
+export const sanitizeFormatData = ([...formatData]) => {
+  freeze(formatData);
+  if (formatData.length <= 1) {
+    return formatData;
+  }
+  const [fmt, ...args] = formatData;
+  if (typeof fmt !== 'string' || !stringIncludes(fmt, '%')) {
+    return formatData;
+  }
+
+  let startPos = 0;
+  let argI = 0;
+  let newFmt = '';
+  const newArgs = [];
+  for (
+    let percentPos = stringIndexOf(fmt, '%');
+    // Notice the `- 1` below, which leaves room for one more character after
+    // the `'%'`.
+    percentPos >= startPos && percentPos < fmt.length - 1 && argI < args.length;
+    percentPos = stringIndexOf(fmt, '%', startPos)
+  ) {
+    // The four cases in the following switch are purposely partially
+    // redundant. But the total code is small and our attempts at more
+    // reuse made the code less clear. Clarity sometimes wins over DRY.
+    const char = fmt[percentPos + 1];
+    switch (char) {
+      case 's':
+      case 'd':
+      case 'i':
+      case 'f':
+      case 'o':
+      case 'O': {
+        // transfer segment + % + char
+        newFmt += stringSlice(fmt, startPos, percentPos + 2);
+        startPos = percentPos + 2;
+        // transfer 1 arg
+        arrayPush(newArgs, args[argI]);
+        argI += 1;
+        break;
+      }
+      case 'c': {
+        // transfer segment. Consume %c
+        newFmt += stringSlice(fmt, startPos, percentPos);
+        startPos = percentPos + 2;
+        // consume 1 arg
+        argI += 1;
+        break;
+      }
+      case '%': {
+        // transfer segment + % + char. Ignore args
+        newFmt += stringSlice(fmt, startPos, percentPos + 2);
+        startPos = percentPos + 2;
+        break;
+      }
+      default: {
+        // transfer segment + %% + char. Ignore args
+        // So that %<unspecified> is treated as unknown even if
+        // implemented by the local platform, such as %j on Node.
+        newFmt += stringSlice(fmt, startPos, percentPos);
+        newFmt += `%%${char}`;
+        startPos = percentPos + 2;
+        break;
+      }
+    }
+  }
+  if (startPos < fmt.length) {
+    newFmt += stringSlice(fmt, startPos, fmt.length);
+  }
+  for (; argI < args.length; argI += 1) {
+    arrayPush(newArgs, args[argI]);
+  }
+  return /** @type {any[]} */ (freeze([newFmt, ...newArgs]));
+};
+freeze(sanitizeFormatData);
 
 // //////////////////////////// Logging Console ////////////////////////////////
 
@@ -398,32 +516,53 @@ export const makeCausalConsole = (feralConsole, loggedErrorHandler) => {
     logSubErrors(severity, subErrors, errorTag);
   };
 
-  const levelMethods = arrayMap(consoleLevelMethods, ([level, _]) => {
+  const levelMethods = arrayMap(consoleLevelMethods, ([name, level]) => {
     /**
      * @param {...any} logArgs
      */
-    const levelMethod = defineName(level, (...logArgs) => {
+    const levelMethod = defineName(name, (...logArgs) => {
       const subErrors = [];
-      const argTags = extractErrorArgs(logArgs, subErrors);
-      if (baseConsole[level]) {
-        // eslint-disable-next-line @endo/no-polymorphic-call
-        baseConsole[level](...argTags);
-      }
-      // @ts-expect-error ConsoleProp vs LogSeverity mismatch
+      const argTags = extractErrorArgs(sanitizeFormatData(logArgs), subErrors);
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      baseConsole[name](...argTags);
       logSubErrors(level, subErrors);
     });
-    return [level, freeze(levelMethod)];
+    return [name, freeze(levelMethod)];
   });
-  const otherMethodNames = arrayFilter(
-    consoleOtherMethods,
-    ([name, _]) => name in baseConsole,
-  );
-  const otherMethods = arrayMap(otherMethodNames, ([name, _]) => {
+
+  const assertMethod = defineName('assert', (...assertArgs) => {
+    if (assertArgs.length <= 1) {
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      baseConsole.assert(...assertArgs);
+    } else {
+      const [cond, ...logArgs] = assertArgs;
+      const subErrors = [];
+      const argTags = extractErrorArgs(sanitizeFormatData(logArgs), subErrors);
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      baseConsole.assert(cond, ...argTags);
+      logSubErrors('error', subErrors);
+    }
+  });
+
+  const timeLogMethod = defineName('timeLog', (...timeLogArgs) => {
+    if (timeLogArgs.length <= 1) {
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      baseConsole.timeLog(...timeLogArgs);
+    } else {
+      const [label, ...logArgs] = timeLogArgs;
+      const subErrors = [];
+      const argTags = extractErrorArgs(sanitizeFormatData(logArgs), subErrors);
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      baseConsole.timeLog(label, ...argTags);
+      logSubErrors('log', subErrors);
+    }
+  });
+
+  const otherMethods = arrayMap(consoleOtherMethods, ([name, _level]) => {
     /**
      * @param {...any} args
      */
     const otherMethod = defineName(name, (...args) => {
-      // @ts-ignore
       // eslint-disable-next-line @endo/no-polymorphic-call
       baseConsole[name](...args);
       return undefined;
@@ -431,7 +570,17 @@ export const makeCausalConsole = (feralConsole, loggedErrorHandler) => {
     return [name, freeze(otherMethod)];
   });
 
-  const causalConsole = fromEntries([...levelMethods, ...otherMethods]);
+  const methodEntries = arrayFilter(
+    [
+      ...levelMethods,
+      ['assert', assertMethod],
+      ['timeLog', timeLogMethod],
+      ...otherMethods,
+    ],
+    ([name, _]) => name in baseConsole,
+  );
+
+  const causalConsole = fromEntries(methodEntries);
   return /** @type {VirtualConsole} */ (freeze(causalConsole));
 };
 freeze(makeCausalConsole);

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -51,7 +51,7 @@ export const enJoin = (terms, conjunction) => {
  * @param {string} str The noun to prepend
  * @returns {string} The noun prepended with a/an
  */
-const an = str => {
+export const an = str => {
   str = `${str}`;
   if (str.length >= 1 && stringIncludes('aeiouAEIOU', str[0])) {
     return `an ${str}`;
@@ -59,7 +59,6 @@ const an = str => {
   return `a ${str}`;
 };
 freeze(an);
-export { an };
 
 /**
  * Like `JSON.stringify` but does not blow up if given a cycle or a bigint.
@@ -88,7 +87,7 @@ export { an };
  * @param {(string|number)=} spaces
  * @returns {string}
  */
-const bestEffortStringify = (payload, spaces = undefined) => {
+export const bestEffortStringify = (payload, spaces = undefined) => {
   const seenSet = new Set();
   const replacer = (_, val) => {
     switch (typeof val) {
@@ -192,4 +191,3 @@ const bestEffortStringify = (payload, spaces = undefined) => {
   }
 };
 freeze(bestEffortStringify);
-export { bestEffortStringify };

--- a/packages/ses/test/error/_console-sanitize-test-data.js
+++ b/packages/ses/test/error/_console-sanitize-test-data.js
@@ -1,0 +1,33 @@
+/**
+ * @type {[beforeArgs: any[], afterArgs: any[], beforeStr: string, afterStr: string][]}
+ */
+export const sanitizeBeforeAfterData = [
+  [[], [], '', ''],
+  // A %c beyond all args is not a format specifier
+  [['a%cb'], ['a%cb'], 'a%cb', 'a%cb'],
+  // Consume %c and its corresponding arg
+  [['a%cb', 3, 4], ['ab', 4], 'ab 4', 'ab 4'],
+  // %% is an escaped %, so this %c is not a format specifier
+  [['a%%cb', 3, 4], ['a%%cb', 3, 4], 'a%cb 3 4', 'a%cb 3 4'],
+  // %c after even number of % is a format specifier
+  [['a%%%cb', 3, 4], ['a%%b', 4], 'a%b 4', 'a%b 4'],
+  // Combo test of normal %c vs one beyond all args
+  [['a%cb%cd', 3], ['ab%cd'], 'ab%cd', 'ab%cd'],
+  // Unknown %<char> is not a specifier
+  [['a%zb', 3, 4], ['a%%zb', 3, 4], 'a%zb 3 4', 'a%zb 3 4'],
+  [
+    ['a%zb', { x: 3 }, { y: 4 }],
+    ['a%%zb', { x: 3 }, { y: 4 }],
+    'a%zb { x: 3 } { y: 4 }',
+    'a%zb { x: 3 } { y: 4 }',
+  ],
+  // Unspecified %<char> is not a specifier even if locally implemented.
+  // The known case is %j is not in the whatwg std but Node implements it
+  [['a%jb', 3, 4], ['a%%jb', 3, 4], 'a3b 4', 'a%jb 3 4'],
+  [
+    ['a%jb', { x: 3 }, { y: 4 }],
+    ['a%%jb', { x: 3 }, { y: 4 }],
+    'a{"x":3}b { y: 4 }', // on Node
+    'a%jb { x: 3 } { y: 4 }',
+  ],
+];

--- a/packages/ses/test/error/_throws-and-logs.js
+++ b/packages/ses/test/error/_throws-and-logs.js
@@ -12,7 +12,8 @@ import {
 // const internalDebugConsole = console;
 
 const defaultCompareLogs = freeze((t, log, goldenLog) => {
-  t.is(log.length, goldenLog.length, 'wrong log length');
+  const data = JSON.stringify({ log, goldenLog }, undefined, ' ');
+  t.is(log.length, goldenLog.length, `wrong log length ${data}`);
   log.forEach((logRecord, i) => {
     const goldenRecord = goldenLog[i];
     logRecord.forEach((logEntry, j) => {
@@ -49,7 +50,7 @@ const getBogusStackString = error => {
   return `stack of ${error.name}`;
 };
 
-// Intended to be used with tape or something like it.
+// Intended to be used with ava or something like it.
 //
 // Wraps thunk() but also checks the console.
 // TODO It currently checks the console by temporarily assigning
@@ -68,7 +69,7 @@ const getBogusStackString = error => {
 // assertLogs(t, () => /*as above*/,
 //            [['error', 'what ', err]]);
 // ```
-export const assertLogs = freeze((t, thunk, goldenLog, options = {}) => {
+export const assertLogs = (t, thunk, goldenLog, options = {}) => {
   const {
     checkLogs = true,
     wrapWithCausal = false,
@@ -109,9 +110,10 @@ export const assertLogs = freeze((t, thunk, goldenLog, options = {}) => {
       compareLogs(t, log, goldenLog);
     }
   }
-});
+};
+freeze(assertLogs);
 
-// Intended to be used with tape or something like it.
+// Intended to be used with ava or something like it.
 //
 // Wraps t.throws(thunk, msg) but also checks the console.
 // TODO It currently checks the console by temporarily assigning
@@ -131,11 +133,10 @@ export const assertLogs = freeze((t, thunk, goldenLog, options = {}) => {
 // throwsAndLogs(t, () => /*as above*/, /foo/,
 //               [['error', 'what ', err]]);
 // ```
-export const throwsAndLogs = freeze(
-  (t, thunk, regexp, goldenLog, options = {}) => {
-    // assertLogs(t, () => t.throws(thunk, { message: regexp }), goldenLog);
-    t.throws(() => assertLogs(t, thunk, goldenLog, options), {
-      message: regexp,
-    });
-  },
-);
+export const throwsAndLogs = (t, thunk, regexp, goldenLog, options = {}) => {
+  // assertLogs(t, () => t.throws(thunk, { message: regexp }), goldenLog);
+  t.throws(() => assertLogs(t, thunk, goldenLog, options), {
+    message: regexp,
+  });
+};
+freeze(throwsAndLogs);

--- a/packages/ses/test/error/sanitize-by-method.test.js
+++ b/packages/ses/test/error/sanitize-by-method.test.js
@@ -1,0 +1,116 @@
+import test from 'ava';
+import '../../index.js';
+import {
+  consoleLevelMethods,
+  consoleSpecialMethods,
+  consoleOtherMethods,
+} from '../../src/error/console.js';
+import { assertLogs } from './_throws-and-logs.js';
+
+lockdown();
+
+// We use error so we can tell whether the console treats these as
+// format string args, even if there is no format string (timeLog)
+const err2 = new Error('E coli');
+const err1 = new Error('guinea pig', { cause: err2 });
+
+test('console sanitize by method', t => {
+  assertLogs(
+    t,
+    () => {
+      console.log('a%cb', err2, err1);
+    },
+    // without causal console, no sanitizing
+    [['log', 'a%cb', err2, err1]],
+  );
+
+  for (const [name, level] of consoleLevelMethods) {
+    assertLogs(
+      t,
+      () => {
+        // @ts-ignore Of course it doesn't know the type of an indexed get
+        console[name]('a%cb', err2, err1);
+      },
+      [
+        // causal console sanitizes console format string and matching args
+        // of level-methods
+        // causal console sanitizes console format string and matching args
+        // of level-methods
+        [name, 'ab', '(Error#1)'],
+        [level, 'Error#1:', 'guinea pig'],
+        [level, `stack of Error\n`],
+        [level, 'Error#1 cause:', '(Error#2)'],
+        ['group', 'Nested error under Error#1'],
+        [level, 'Error#2:', 'E coli'],
+        [level, `stack of Error\n`],
+        ['groupEnd'],
+      ],
+      {
+        wrapWithCausal: true,
+      },
+    );
+  }
+
+  assertLogs(
+    t,
+    () => {
+      for (const [name, level] of consoleSpecialMethods) {
+        switch (name) {
+          case 'assert': {
+            t.is(level, 'error');
+            // normal level args shifted one
+            console.assert(true, 'a%cb', err2, err1);
+            console.assert(false, 'a%cb', err2, err1);
+            break;
+          }
+          case 'timeLog': {
+            t.is(level, 'log');
+            console.timeLog('a%cb', err2, err1);
+            break;
+          }
+          default: {
+            throw new Error(`unexpected special console method ${name}`);
+          }
+        }
+      }
+    },
+    [
+      // each special method is its own case
+      ['assert', true, 'ab', '(Error#1)'],
+      ['error', 'Error#1:', 'guinea pig'],
+      ['error', 'stack of Error\n'],
+      ['error', 'Error#1 cause:', '(Error#2)'],
+      ['group', 'Nested error under Error#1'],
+      ['error', 'Error#2:', 'E coli'],
+      ['error', 'stack of Error\n'],
+      ['groupEnd'],
+      // each special method is its own case
+      ['assert', false, 'ab', '(Error#1)'],
+      // each special method is its own case
+      ['timeLog', 'a%cb', '(Error#2)', '(Error#1)'],
+      ['group', 'Nested 2 errors'],
+      ['groupEnd'],
+    ],
+    {
+      wrapWithCausal: true,
+    },
+  );
+
+  for (const [name, _] of consoleOtherMethods) {
+    assertLogs(
+      t,
+      () => {
+        // @ts-ignore Of course it doesn't know the type of an indexed get
+        console[name]('a%cb', err2, err1);
+      },
+      [
+        // causal console does not santize other-methods, since they have
+        // no format strings.
+        [name, 'a%cb', err2, err1],
+      ],
+      {
+        wrapWithCausal: true,
+      },
+    );
+  }
+});

--- a/packages/ses/test/error/sanitize-format-data.test.js
+++ b/packages/ses/test/error/sanitize-format-data.test.js
@@ -1,0 +1,22 @@
+import util from 'node:util';
+import test from 'ava';
+
+import { sanitizeFormatData } from '../../src/error/console.js';
+import { sanitizeBeforeAfterData } from './_console-sanitize-test-data.js';
+
+test('sanitizeFormatData', t => {
+  for (const [
+    beforeArgs,
+    afterArgs,
+    beforeStr,
+    afterStr,
+  ] of sanitizeBeforeAfterData) {
+    t.deepEqual(sanitizeFormatData(beforeArgs), afterArgs);
+    if (typeof util?.format === 'function') {
+      t.is(util.format(...beforeArgs), beforeStr);
+      t.is(util.format(...afterArgs), afterStr);
+    } else {
+      t.log('no util.format, so limited test');
+    }
+  }
+});


### PR DESCRIPTION
Closes: #TBD

## Description

Reported by @ChALkeR 

The console format specifier `%c` is for consuming a CSS style string and applying that style to the rendering of the remaining arguments. Node.js and browsers both parse `%c` the same way and have it consume one argument.
- Browsers actually make use of the CSS, leading to security problems (e.g., https://issues.chromium.org/40056332 ).
- Node.js ignores the `%c` and its corresponding argument, which is allowed by the [WHATWG Console specification](https://console.spec.whatwg.org/).

To avoid the CSS security problems on all platforms, under the defaut `consoleTaming: 'safe'`, we now sanitize out the `%c` and corresponding argument, emulating the allowed current Node.js behavior on all platforms. This fixes this CSS vulnerability while maintaining compatibility with the specification.

We also treat unknown specifiers in a future-proof manner. For example, `%j` is unspecified by the WHATWG spec, but it is implemented by Node.js to render its corresponding argument as JSON. Being unspecified, `%j` would just print literally without consuming an argument. But on Node.js, because it consumes an argument, all the remaining arguments are shifted from their standard treatment.

### Security Considerations

The point. @ChALkeR found that the browser's processing of the `%c` CSS string can cause it to fetch resources from the network, breaking confinement and the write-only nature of `console`. We can only widely and safely share `console` if it is write-only to everyone that cannot read the console log output.

### Scaling Considerations

None

### Documentation Considerations

Not really. After this change, the `ses` console still conforms to the WHATWG spec, including the allowed behavior of ignoring `%c` and its argument as Node.js does.

### Testing Considerations

Two tests. The `sanitize-by-method.test.js` test also caught some previously undiscovered bugs in the ses console implementation.

### Compatibility Considerations

With this PR, the ses console conforms to the WHATWG spec, and so is compatible with any code relying only on the spec. The two minor compat concerns with previous behavior on the ses console on various platforms:
- Even on browsers, `%c` will not be ignored.
- Even on Node.js, `%j` will be treated as not a specified specifier, shifting the treatment of remaining arguments from what Node does.

### Upgrade Considerations

None.