### PR TITLE
fix(ses): makeError can now narrow return type

### DIFF
--- a/.changeset/tame-states-care.md
+++ b/.changeset/tame-states-care.md
@@ -1,0 +1,5 @@
+---
+'ses': patch
+---
+
+`makeError` now narrows type of return instance when `errConstructor` provided.

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -48,7 +48,17 @@ import './internal-types.js';
 import { makeNoteLogArgsArrayKit } from './note-log-args.js';
 
 /**
- * @import {BaseAssert, Assert, AssertionFunctions, AssertionUtilities, DeprecatedAssertionUtilities, Stringable, DetailsToken, MakeAssert} from '../../types.js';
+ * @import {BaseAssert,
+ *   Assert,
+ *   AssertionFunctions,
+ *   AssertionUtilities,
+ *   DeprecatedAssertionUtilities,
+ *   Stringable,
+ *   DetailsToken,
+ *   MakeAssert,
+ *   Details,
+ *   GenericErrorConstructor,
+ *   AssertMakeErrorOptions} from '../../types.js';
  * @import {LogArgs, NoteCallback, LoggedErrorHandler} from './internal-types.js';
  */
 
@@ -333,8 +343,8 @@ export const sanitizeError = error => {
  * @type {AssertionUtilities['makeError']}
  */
 const makeError = (
-  optDetails = redactedDetails`Assert failed`,
-  errConstructor = globalThis.Error,
+  optDetails,
+  errConstructor,
   {
     errorName = undefined,
     cause = undefined,
@@ -342,25 +352,40 @@ const makeError = (
     sanitize = true,
   } = {},
 ) => {
+  // The first two parameters above cannot be inferred unless this is rewritten
+  // as a function declaration using an @overload tag. This is a workaround so
+  // that we at least have type-safety within the function body.
+  //
+  // Note that due to the overload of AssertionUtilities['makeError'], strict
+  // mode will complain if default parameters are provided in the method
+  // signature. The below workaround (optDetails -> details; errConstructor ->
+  // errCtor) is functionally equivalent but allows us to use type assertions to
+  // workaround the strict mode issue.
+  let details = /** @type {Details} */ (
+    optDetails ?? redactedDetails`Assert failed`
+  );
+
+  // Internally, this is a GenericErrorConstructor, but externally it can be
+  // some T which extends GenericErrorConstructor.
+  const errCtor = /** @type {GenericErrorConstructor} */ (
+    errConstructor ?? globalThis.Error
+  );
   // Promote string-valued `optDetails` into a minimal DetailsParts
   // consisting of that string as the sole literal part with no substitutions.
-  if (typeof optDetails === 'string') {
-    optDetails = redactedDetails([optDetails]);
+  if (typeof details === 'string') {
+    details = redactedDetails([details]);
   }
-  const hiddenDetails = weakmapGet(hiddenDetailsMap, optDetails);
+  const hiddenDetails = weakmapGet(hiddenDetailsMap, details);
   if (hiddenDetails === undefined) {
-    throw TypeError(`unrecognized details ${quote(optDetails)}`);
+    throw TypeError(`unrecognized details ${quote(details)}`);
   }
   const messageString = getMessageString(hiddenDetails);
   const opts = cause && { cause };
   let error;
-  if (
-    typeof AggregateError !== 'undefined' &&
-    errConstructor === AggregateError
-  ) {
+  if (typeof AggregateError !== 'undefined' && errCtor === AggregateError) {
     error = AggregateError(errors || [], messageString, opts);
   } else {
-    const ErrorCtor = /** @type {ErrorConstructor} */ (errConstructor);
+    const ErrorCtor = /** @type {ErrorConstructor} */ (errCtor);
     error = ErrorCtor(messageString, opts);
     // Since we need to tolerate `errors` on an AggregateError, we may as well
     // tolerate it on all errors.
@@ -380,7 +405,11 @@ const makeError = (
   if (sanitize) {
     sanitizeError(error);
   }
-  // The next line is a particularly fruitful place to put a breakpoint.
+  // Externally, the return type below is InstanceType<T> where T extends
+  // GenericErrorConstructor. Internally, it's
+  // InstanceType<GenericErrorConstructor> for simplicity of implementation.
+
+  //  The next line is a particularly fruitful place to put a breakpoint.
   return error;
 };
 freeze(makeError);

--- a/packages/ses/types.d.ts
+++ b/packages/ses/types.d.ts
@@ -393,11 +393,33 @@ export interface AssertionUtilities {
    * Create an error with a `message` in which unquoted {@link details}
    * substitution values may have been redacted into lossy `typeof` output but
    * are still available for logging to an associated console.
+   *
+   * Narrows the return type to the constructor type.
+   *
+   * @template T The constructor to use
+   * @param details The details of what was asserted
+   * @param errConstructor The constructor to use
+   * @param options Options
+   * @returns Instance of `T`
+   */
+  makeError<T extends GenericErrorConstructor>(
+    details: Details,
+    errConstructor: T,
+    options?: AssertMakeErrorOptions,
+  ): InstanceType<T>;
+
+  /**
+   * Create an error with a `message` in which unquoted {@link details}
+   * substitution values may have been redacted into lossy `typeof` output but
+   * are still available for logging to an associated console.
+   *
+   * @param details The details of what was asserted
+   * @param errConstructor The constructor to use
+   * @param options Options
+   * @returns Instance of `Error`
    */
   makeError(
-    /** The details of what was asserted */
     details?: Details,
-    /** An optional alternate error constructor to use */
     errConstructor?: GenericErrorConstructor,
     options?: AssertMakeErrorOptions,
   ): Error;


### PR DESCRIPTION
This ~~type-only~~ change overloads `AssertionUtilities.makeError` so that if an `errConstructor` is provided, the return type will be the instance of that `errConstructor`.

Ref: #3130