### PR TITLE
feat(immutable-arraybuffer,pass-style): passable byte arrays (freezable TypedArray emulation + byteArray brand check)

### DIFF
--- a/.changeset/bytes-tolerate-emulated-frozen-uint8array.md
+++ b/.changeset/bytes-tolerate-emulated-frozen-uint8array.md
@@ -1,0 +1,19 @@
+---
+'@endo/bytes': patch
+---
+
+Make the `@endo/bytes` operators tolerate every `Uint8Array` variant —
+native or emulated, frozen or mutable.
+
+When a `Uint8Array` is constructed over an emulated immutable `ArrayBuffer`
+(the `@endo/immutable-arraybuffer` shim on a platform without native support),
+the result is a plain object that `ArrayBuffer.isView` rejects: integer
+indexing reads `undefined`, and platform APIs such as `TextDecoder.decode` and
+`TypedArray.prototype.set` either throw or silently read zeros. `bytesToText`,
+`bytesEqual`, and `concatBytes` now copy such an emulated wrapper to a genuine
+`Uint8Array` before any platform call or indexing — the wrapper's native
+`slice` memcopies from the hidden genuine TypedArray it amplifies to, rather
+than `result.set(wrapper)`, which would read zeros because the wrapper exposes
+no integer-indexed own properties. This is a hidden performance cost on the
+emulated path that lets these ponyfills function identically across variants.
+Genuine views are passed through uncopied, so the common path is unaffected.

--- a/.changeset/freezable-typedarray-emulation.md
+++ b/.changeset/freezable-typedarray-emulation.md
@@ -1,0 +1,26 @@
+---
+'@endo/immutable-arraybuffer': minor
+'@endo/pass-style': minor
+'ses': patch
+---
+
+Add freezable TypedArray emulation for immutable-ArrayBuffer-backed views.
+
+After loading `@endo/immutable-arraybuffer/shim.js`, constructing a TypedArray
+from an emulated immutable `ArrayBuffer` produces an emulated freezable wrapper
+whose mutator methods (`copyWithin`, `fill`, `reverse`, `set`, `sort`) throw
+`TypeError`, whose `buffer` getter returns the immutable wrapper rather than
+the underlying genuine buffer, and which can be frozen via `Object.freeze`.
+The wrapper inherits directly from `T.prototype` with no intermediate prototype.
+
+The genuine-buffer constructor path (passing a regular mutable `ArrayBuffer`)
+is unchanged: the result is a normal writable TypedArray view.
+
+`@endo/pass-style`: a plain frozen `Uint8Array` backed by an immutable
+`ArrayBuffer` is now recognized as a passable `byteArray`, alongside an
+immutable `ArrayBuffer` itself. `passStyleOf` also reports a clear
+`Cannot pass mutable typed arrays` diagnostic for a mutable TypedArray rather
+than the generic non-remotable error.
+
+`ses`: the permits walk accepts the shim-installed `%TypedArrayPrototype%`
+slots without complaint; no new permit rows are required.

--- a/packages/bytes/src/concat.js
+++ b/packages/bytes/src/concat.js
@@ -1,9 +1,18 @@
 import harden from '@endo/harden';
 
+import { toGenuineBytes } from './to-genuine.js';
+
 /**
  * Concatenates a list of `Uint8Array` chunks into a single contiguous
  * `Uint8Array`.
  * Empty input yields an empty `Uint8Array`.
+ *
+ * Tolerates every `Uint8Array` variant among the chunks: native or emulated,
+ * frozen or mutable. An emulated freezable wrapper (from
+ * `@endo/immutable-arraybuffer`) is not a real `ArrayBufferView`, so
+ * `TypedArray.prototype.set` reads zeros from it; `toGenuineBytes` copies such a
+ * chunk to a genuine `Uint8Array` before the `set`, while genuine chunks are
+ * passed through uncopied.
  *
  * @param {readonly Uint8Array[]} chunks
  * @returns {Uint8Array}
@@ -16,8 +25,9 @@ export const concatBytes = chunks => {
   const result = new Uint8Array(totalLength);
   let offset = 0;
   for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.length;
+    const genuine = toGenuineBytes(chunk);
+    result.set(genuine, offset);
+    offset += genuine.length;
   }
   return result;
 };

--- a/packages/bytes/src/equals.js
+++ b/packages/bytes/src/equals.js
@@ -1,8 +1,16 @@
 import harden from '@endo/harden';
 
+import { toGenuineBytes } from './to-genuine.js';
+
 /**
  * Compares two `Uint8Array` values byte-for-byte.
  * Returns `true` when the two arrays have equal length and equal contents.
+ *
+ * Tolerates every `Uint8Array` variant on either side: native or emulated,
+ * frozen or mutable. An emulated freezable wrapper (from
+ * `@endo/immutable-arraybuffer`) exposes no integer-indexed own properties, so
+ * `toGenuineBytes` first copies it to a genuine `Uint8Array`; genuine views are
+ * passed through uncopied and compared by fast indexing.
  *
  * @param {Uint8Array} a
  * @param {Uint8Array} b
@@ -12,11 +20,13 @@ export const bytesEqual = (a, b) => {
   if (a === b) {
     return true;
   }
-  if (a.length !== b.length) {
+  const ga = toGenuineBytes(a);
+  const gb = toGenuineBytes(b);
+  if (ga.length !== gb.length) {
     return false;
   }
-  for (let i = 0; i < a.length; i += 1) {
-    if (a[i] !== b[i]) {
+  for (let i = 0; i < ga.length; i += 1) {
+    if (ga[i] !== gb[i]) {
       return false;
     }
   }

--- a/packages/bytes/src/to-genuine.js
+++ b/packages/bytes/src/to-genuine.js
@@ -1,0 +1,59 @@
+// @ts-check
+
+import harden from '@endo/harden';
+
+const { apply } = Reflect;
+
+// `ArrayBuffer.isView` is a TypeScript type guard (`value is ArrayBufferView`).
+// Because a `Uint8Array` *is* an `ArrayBufferView`, that guard would narrow the
+// `else` branch below to `never` — yet at runtime an emulated freezable wrapper
+// (statically a `Uint8Array`) reaches it precisely because `isView` returns
+// `false` for it. Retype to a plain predicate so the wrapper path keeps its
+// `Uint8Array` type.
+const isView = /** @type {(value: unknown) => boolean} */ (ArrayBuffer.isView);
+
+// Capture `%TypedArrayPrototype%.slice` so we can copy an emulated freezable
+// wrapper's bytes into a genuine `Uint8Array` with a single native memcopy.
+// `@endo/immutable-arraybuffer` installs `slice` as a freezable-aware delegate:
+// applied to a wrapper it amplifies to the wrapper's hidden genuine TypedArray
+// and returns a fresh mutable `Uint8Array` of the same bytes. We cannot instead
+// `result.set(wrapper)` into a genuine target: the wrapper exposes no
+// integer-indexed own properties, so `set` reads `undefined` (coerced to `0`)
+// for every byte and silently yields zeros.
+const { prototype: uint8ArrayPrototype } = Uint8Array;
+const typedArrayPrototype = Object.getPrototypeOf(uint8ArrayPrototype);
+const { slice: typedArraySlice } = typedArrayPrototype;
+
+/**
+ * Returns a genuine `Uint8Array` with the same bytes as `view`, suitable both
+ * for integer indexing and for passing down to platform APIs (`TextDecoder`,
+ * `TypedArray.prototype.set`, ...) that require a real `ArrayBufferView`.
+ *
+ * A genuine `Uint8Array` — whether mutable or backed by a native immutable
+ * `ArrayBuffer` — is returned unchanged: `ArrayBuffer.isView` is `true` for it
+ * and the platform accepts it directly, so no copy is incurred on the common
+ * path.
+ *
+ * An emulated freezable wrapper produced by `@endo/immutable-arraybuffer`
+ * (constructing a `Uint8Array` over an emulated immutable `ArrayBuffer` on a
+ * platform that has not yet shipped the proposal natively) is a plain object
+ * that `ArrayBuffer.isView` rejects and that platform APIs throw on. Its bytes
+ * are copied into a fresh mutable `Uint8Array` by the wrapper's native `slice`,
+ * which memcopies from the hidden genuine TypedArray it amplifies to.
+ *
+ * This is the deliberate "prefer poor performance over not working" copy the
+ * immutable-ArrayBuffer design calls for: a hidden cost on the emulated path
+ * that lets the `@endo/bytes` ponyfills function identically across every
+ * `Uint8Array` variant — native or emulated, frozen or mutable — at layers
+ * that will eventually support frozen views natively and without penalty.
+ *
+ * @param {Uint8Array} view
+ * @returns {Uint8Array}
+ */
+export const toGenuineBytes = view => {
+  if (isView(view)) {
+    return view;
+  }
+  return apply(typedArraySlice, view, []);
+};
+harden(toGenuineBytes);

--- a/packages/bytes/src/to-string.js
+++ b/packages/bytes/src/to-string.js
@@ -2,6 +2,8 @@
 
 import harden from '@endo/harden';
 
+import { toGenuineBytes } from './to-genuine.js';
+
 // Capture both `TextDecoder` modes once at module load.
 // The default UTF-8 decoder substitutes U+FFFD for malformed sequences;
 // the `fatal: true` decoder throws on the same input.
@@ -23,14 +25,21 @@ const fatalTextDecoder = new TextDecoder('utf-8', { fatal: true });
  * invalid input. The default lenient mode substitutes the
  * Unicode replacement character (U+FFFD) for malformed sequences.
  *
+ * Tolerates every `Uint8Array` variant: native or emulated, frozen or mutable.
+ * `TextDecoder.decode` requires a real `ArrayBufferView`, so an emulated
+ * freezable wrapper (from `@endo/immutable-arraybuffer`) is first copied to a
+ * genuine `Uint8Array` by `toGenuineBytes`; genuine views are passed through
+ * uncopied.
+ *
  * @param {Uint8Array} view
  * @param {BytesToTextOptions} [options]
  * @returns {string}
  */
 export const bytesToText = (view, options = undefined) => {
+  const genuine = toGenuineBytes(view);
   if (options !== undefined && options.fatal) {
-    return fatalTextDecoder.decode(view);
+    return fatalTextDecoder.decode(genuine);
   }
-  return lenientTextDecoder.decode(view);
+  return lenientTextDecoder.decode(genuine);
 };
 harden(bytesToText);

--- a/packages/bytes/test/main.test.js
+++ b/packages/bytes/test/main.test.js
@@ -1,4 +1,5 @@
 import test from '@endo/ses-ava/test.js';
+import harden from '@endo/harden';
 import { passStyleOf } from '@endo/pass-style';
 
 import { bytesEqual } from '../src/equals.js';
@@ -248,4 +249,80 @@ test('concatImmutables: result is hardened', t => {
   const parts = [bytesToImmutable(new Uint8Array([42]))];
   const result = concatImmutables(parts);
   t.true(Object.isFrozen(result));
+});
+
+// Emulated-frozen-Uint8Array tolerance.
+//
+// On platforms without native immutable-ArrayBuffer support, constructing a
+// `Uint8Array` over an emulated immutable `ArrayBuffer` yields an emulated
+// freezable wrapper: a plain object inheriting from `Uint8Array.prototype` with
+// no integer-indexed own properties. `ArrayBuffer.isView` is false for it,
+// `wrapper[i]` reads `undefined`, and platform APIs (`TextDecoder.decode`,
+// `TypedArray.prototype.set`) reject it. The `@endo/bytes` ponyfills must
+// nonetheless function identically on it, copying to a genuine `Uint8Array`
+// before any platform call or indexing. These tests pin that contract.
+
+/**
+ * Builds an emulated frozen `Uint8Array` over an emulated immutable
+ * `ArrayBuffer`.
+ *
+ * @param {number[]} values
+ * @returns {Uint8Array}
+ */
+const makeEmulatedFrozenBytes = values => {
+  const immutable = bytesToImmutable(new Uint8Array(values));
+  return harden(new Uint8Array(immutable));
+};
+
+test('precondition: emulated wrapper is not a real ArrayBufferView and is not directly indexable', t => {
+  const emulated = makeEmulatedFrozenBytes([1, 2, 3]);
+  // If either assertion ever fails, the emulation has changed shape and the
+  // tolerance below is no longer exercising the intended path.
+  t.false(ArrayBuffer.isView(emulated));
+  // `emulated[0]` reads through `[[Get]]`; the wrapper has no integer-indexed
+  // own property, so the result is `undefined` at runtime even though the
+  // static `Uint8Array` index type is `number` (hence the cast).
+  t.is(/** @type {number | undefined} */ (emulated[0]), undefined);
+  t.is(emulated.at(0), 1);
+});
+
+test('bytesToText: decodes an emulated frozen Uint8Array (copies before TextDecoder)', t => {
+  const original = 'Hello, 你好 \u{1F600}';
+  const emulated = makeEmulatedFrozenBytes([...bytesFromText(original)]);
+  t.is(bytesToText(emulated), original);
+  t.is(bytesToText(emulated, { fatal: true }), original);
+});
+
+test('bytesEqual: emulated wrapper equals a genuine Uint8Array of the same bytes', t => {
+  const genuine = new Uint8Array([0, 1, 2, 0xff, 0x80]);
+  const emulated = makeEmulatedFrozenBytes([0, 1, 2, 0xff, 0x80]);
+  t.true(bytesEqual(emulated, genuine));
+  t.true(bytesEqual(genuine, emulated));
+  t.true(bytesEqual(emulated, makeEmulatedFrozenBytes([0, 1, 2, 0xff, 0x80])));
+});
+
+test('bytesEqual: emulated wrapper differs from a genuine Uint8Array', t => {
+  const genuine = new Uint8Array([1, 2, 3]);
+  t.false(bytesEqual(makeEmulatedFrozenBytes([1, 2, 4]), genuine));
+  t.false(bytesEqual(makeEmulatedFrozenBytes([1, 2]), genuine));
+});
+
+test('concatBytes: emulated and genuine chunks interleave byte-for-byte', t => {
+  const chunks = [
+    makeEmulatedFrozenBytes([1, 2]),
+    new Uint8Array([3, 4, 5]),
+    makeEmulatedFrozenBytes([]),
+    makeEmulatedFrozenBytes([6]),
+    new Uint8Array([7]),
+  ];
+  const result = concatBytes(chunks);
+  t.deepEqual([...result], [1, 2, 3, 4, 5, 6, 7]);
+});
+
+test('concatBytes + bytesToText composition over emulated chunks: round-trip', t => {
+  const parts = ['Hello, ', '世界', '!'].map(s =>
+    makeEmulatedFrozenBytes([...bytesFromText(s)]),
+  );
+  const combined = concatBytes(parts);
+  t.is(bytesToText(combined), 'Hello, 世界!');
 });

--- a/packages/immutable-arraybuffer/README.md
+++ b/packages/immutable-arraybuffer/README.md
@@ -72,12 +72,96 @@ See [Platform support for `transferToImmutable`](#platform-support-for-transfert
 Without either, the shim still shims `ArrayBuffer.prototype.sliceToImmutable` but omits `ArrayBuffer.prototype.transferToImmutable`.
 - The shim's emulated immutable buffers are not real `ArrayBuffer` exotic objects.
 If they were, the shim would not be able to protect them from being written.
-Even though they implement the full proposed `ArrayBuffer` API, they cannot be plug-compatible: they cannot be used as the backing stores of `DataView`s or `TypedArray`s.
-Perhaps follow-on shims might modify `DataView` and `TypedArray` to emulate that as well, but that is hard and beyond the ambition of this shim.
+Even though they implement the full proposed `ArrayBuffer` API, they cannot be plug-compatible as direct exotic-object arguments to all native APIs.
+The freezable `TypedArray` emulation (see below) extends the shim to cover the most common consumer path (`new T(iab)`), but `DataView` construction from an emulated immutable buffer is not yet covered.
 - Unlike genuine `ArrayBuffer` or `SharedArrayBuffer` exotic objects, the shim's emulated immutable buffers cannot be cloned or transfered between JS threads.
 - This is a plain *JavaScript* shim, not by itself a *Hardened JavaScript* polyfill/shim.
 Thus, the objects and function it creates are not hardened by this shim itself.
 Rather, the ses-shim is expected to import this, and then treat the resulting objects as if they were additional primordials, to be hardened during `lockdown`'s harden phase.
+
+## The Freezable TypedArray Emulation
+
+The shim also installs a freezable `TypedArray` emulation alongside the `ArrayBuffer`-side install.
+After the shim loads, constructing a `TypedArray` from an emulated immutable `ArrayBuffer` produces an emulated freezable wrapper:
+
+```js
+import '@endo/immutable-arraybuffer/shim.js';
+
+const ab = new ArrayBuffer(4);
+const iab = ab.sliceToImmutable();
+
+const view = new Uint8Array(iab);
+
+view instanceof Uint8Array;                // true
+Object.getPrototypeOf(view) === Uint8Array.prototype; // true (no intermediate prototype)
+view.buffer === iab;                       // true (returns the immutable wrapper)
+view.byteLength;                           // 4
+view.at(0);                               // 0
+
+view.fill(1);                             // throws TypeError (mutator blocked)
+view.set([1]);                            // throws TypeError
+view.reverse();                           // throws TypeError
+view.copyWithin(0, 1);                    // throws TypeError
+view.sort();                              // throws TypeError
+
+Object.freeze(view);
+Object.isFrozen(view);                    // true
+```
+
+The emulation covers all eleven concrete `TypedArray` constructors (`Int8Array`, `Int16Array`, `Int32Array`, `Uint8Array`, `Uint8ClampedArray`, `Uint16Array`, `Uint32Array`, `Float32Array`, `Float64Array`, `BigInt64Array`, `BigUint64Array`).
+
+Constructing from a genuine mutable `ArrayBuffer` produces a genuine writable `TypedArray` view, unchanged from before:
+
+```js
+const mutableAb = new ArrayBuffer(4);
+const view = new Uint8Array(mutableAb);
+view.fill(1); // succeeds: genuine writable view
+```
+
+### Indexed assignment on emulated freezable views
+
+The emulated wrapper is a plain ordinary object, not a native integer-indexed exotic.
+An indexed assignment (`view[0] = 42`) therefore creates an own property on the wrapper rather than writing to the underlying buffer.
+The underlying buffer's bytes are never touched.
+
+On a non-frozen wrapper the own property shadows the prototype's read delegate; `view[0]` reads back `42` while `Uint8Array.prototype.at.call(view, 0)` still reads `0` (the underlying byte).
+On a frozen wrapper the assignment throws `TypeError` in strict mode (ES module code is always strict), and the buffer is unchanged.
+
+This is a known constraint of the TC39 proposal: there is no way to intercept integer-indexed assignments on a plain object via the prototype chain.
+
+## Function expressions versus declarations
+
+Throughout `src/lib.js`, exported bindings that hold function values use `const`
+with a named function expression rather than `function` declarations.
+The reason is JavaScript function-declaration hoisting.
+
+In the presence of an import cycle, a hoisted `function` declaration's value is
+accessible to an importing module before the exporting module finishes
+initializing.
+An early importer that reads the exported name gets the function value already
+present (because hoisting put it there before the module body ran), but any
+other module-level state the function closes over may not yet be initialized,
+creating a subtle hazard.
+
+By using `const` instead, the JavaScript standard specifies that an early
+importer in a cycle that reads the name before the exporting module's
+initializer runs would get a Temporal Dead Zone (TDZ) error, making the hazard
+visible at runtime rather than silent.
+
+Two implementation notes for ses-shim environments:
+
+- The ses-shim's compiler from JS ESM module code to JS evaluable code does not
+  correctly implement TDZ.
+  A cycle hazard of this kind may therefore not be caught at runtime when
+  running under the ses-shim.
+- XS (Moddable's engine) uses native compartment and module support and does
+  implement TDZ correctly, so the same hazard would be caught at runtime on XS.
+
+This file introduces no such import cycle; the convention is documented here
+so future maintainers understand why function declarations are avoided throughout
+endo.
+
+Source: erights review comment 3439479281 on `src/lib.js` line 578.
 
 ## Platform support for `transferToImmutable`
 

--- a/packages/immutable-arraybuffer/src/lib.js
+++ b/packages/immutable-arraybuffer/src/lib.js
@@ -10,12 +10,28 @@ const {
   WeakMap,
   // Capture structuredClone before it can be scuttled.
   structuredClone: optStructuredClone,
+  Int8Array,
+  Int16Array,
+  Int32Array,
+  Uint8ClampedArray,
+  Uint16Array,
+  Uint32Array,
+  Float32Array,
+  Float64Array,
+  BigInt64Array,
+  BigUint64Array,
   // eslint-disable-next-line no-restricted-globals
 } = globalThis;
 
-const { freeze, defineProperty, getOwnPropertyDescriptor, getPrototypeOf } =
-  Object;
-const { apply, ownKeys } = Reflect;
+const {
+  freeze,
+  defineProperty,
+  getOwnPropertyDescriptor,
+  getPrototypeOf,
+  setPrototypeOf,
+  create,
+} = Object;
+const { apply, ownKeys, construct } = Reflect;
 
 // Capture the WeakMap prototype methods up front so we can use them with
 // `apply` below, without exposing the `buffers` WeakMap to post-hoc
@@ -54,12 +70,72 @@ const optArrayBufferMaxByteLength = getOwnPropertyDescriptor(
   'maxByteLength',
 )?.get;
 
+// %TypedArray% is the abstract superclass of all TypedArray constructors.
+// `getPrototypeOf(Uint8Array)` reaches it via the constructor's prototype chain.
+// Captured before the shim can shadow any of the global TypedArray constructors.
+const TypedArray = getPrototypeOf(Uint8Array);
+
 const typedArrayPrototype = getPrototypeOf(Uint8Array.prototype);
 const { set: uint8ArraySet } = typedArrayPrototype;
 // @ts-expect-error TS doesn't know it'll be there
-const { get: uint8ArrayBuffer } = getOwnPropertyDescriptor(
+const { get: typedArrayBufferGetter } = getOwnPropertyDescriptor(
   typedArrayPrototype,
   'buffer',
+);
+
+// Capture all %TypedArrayPrototype% methods and accessors before the shim can
+// shadow them. The five mutator methods are used for the brand-check throw /
+// delegate pattern; all read-only methods are used for the amplifier-delegate
+// pattern (plain wrappers delegate to the hidden genuine TypedArray).
+const {
+  copyWithin: typedArrayCopyWithin,
+  entries: typedArrayEntries,
+  every: typedArrayEvery,
+  fill: typedArrayFill,
+  filter: typedArrayFilter,
+  find: typedArrayFind,
+  findIndex: typedArrayFindIndex,
+  findLast: typedArrayFindLast,
+  findLastIndex: typedArrayFindLastIndex,
+  forEach: typedArrayForEach,
+  includes: typedArrayIncludes,
+  indexOf: typedArrayIndexOf,
+  join: typedArrayJoin,
+  keys: typedArrayKeys,
+  lastIndexOf: typedArrayLastIndexOf,
+  map: typedArrayMap,
+  reduce: typedArrayReduce,
+  reduceRight: typedArrayReduceRight,
+  reverse: typedArrayReverse,
+  set: typedArraySet,
+  slice: typedArraySlice,
+  some: typedArraySome,
+  sort: typedArraySort,
+  subarray: typedArraySubarray,
+  toLocaleString: typedArrayToLocaleString,
+  toString: typedArrayToString,
+  values: typedArrayValues,
+  at: typedArrayAt,
+  toReversed: typedArrayToReversed,
+  toSorted: typedArrayToSorted,
+  with: typedArrayWith,
+} = typedArrayPrototype;
+
+// Capture read-accessor getters for byteLength, byteOffset, and length.
+// @ts-expect-error TS doesn't know they'll be there
+const { get: typedArrayByteLengthGetter } = getOwnPropertyDescriptor(
+  typedArrayPrototype,
+  'byteLength',
+);
+// @ts-expect-error TS doesn't know they'll be there
+const { get: typedArrayByteOffsetGetter } = getOwnPropertyDescriptor(
+  typedArrayPrototype,
+  'byteOffset',
+);
+// @ts-expect-error TS doesn't know they'll be there
+const { get: typedArrayLengthGetter } = getOwnPropertyDescriptor(
+  typedArrayPrototype,
+  'length',
 );
 
 /**
@@ -296,7 +372,10 @@ for (const key of ownKeys(immutableArrayBufferLibProperties)) {
     enumerable: false,
   });
 }
-freeze(immutableArrayBufferLibProperties);
+// Do not freeze: the shim passes these descriptors directly to
+// `defineProperties`, and frozen descriptors (configurable: false,
+// writable: false) would conflict with SES's later tamings. Leave the
+// record unfrozen so descriptors are directly usable.
 
 // Internal-test export. The helper itself is load-bearing for every
 // method on `immutableArrayBufferLibProperties`, but the package's
@@ -418,7 +497,7 @@ if (optArrayBufferTransfer) {
         const oldTA = new Uint8Array(buffer);
         const newTA = new Uint8Array(newLength);
         apply(uint8ArraySet, newTA, [oldTA]);
-        buffer = apply(uint8ArrayBuffer, newTA, []);
+        buffer = apply(typedArrayBufferGetter, newTA, []);
       }
     }
     const result = makeImmutableArrayBufferInternal(buffer);
@@ -429,3 +508,745 @@ if (optArrayBufferTransfer) {
 }
 
 export const optTransferBufferToImmutable = transferBufferToImmutable;
+
+// Freezable TypedArray emulation
+//
+// The design document is at:
+//   packages/immutable-arraybuffer/designs/freezable-typedarray.md
+//
+// This section extends the immutable-ArrayBuffer lib surface with two exported bindings:
+//   - makePseudoTypedArrayConstructor (export; factory for per-flavor pseudo-constructors)
+//   - freezableTypedArrayLibProperties (export; property record the shim copies onto
+//                                       %TypedArrayPrototype%)
+//
+// The following are module-internal:
+//   - hiddenTypedArrays  (brand WeakMap)
+//   - amplifyTypedArray  (returns the hidden genuine TypedArray or the receiver on fallthrough)
+//   - virtualTypedArrayBufferGetter  (getter for %TypedArrayPrototype%.buffer)
+//
+// The internal `buffers` and `reverseBuffers` WeakMaps from the ArrayBuffer
+// side are reused for `view.buffer` redirections.
+
+/**
+ * Inverse map: genuine backing ArrayBuffer -> emulated immutable wrapper.
+ * The ArrayBuffer-side lib owns `buffers` (wrapper -> genuine); this map is
+ * the reverse direction, used by `virtualTypedArrayBufferGetter` to hand back
+ * the immutable wrapper when a view's buffer is looked up.
+ *
+ * @type {WeakMap<ArrayBuffer, ArrayBuffer>}
+ */
+const reverseBuffers = new WeakMap();
+
+/**
+ * Brand WeakMap for emulated freezable TypedArray wrappers. Maps each wrapper
+ * to its hidden genuine TypedArray (the one constructed from the actual
+ * underlying ArrayBuffer). The genuine TypedArray is the storage delegate;
+ * the wrapper is the public-facing object.
+ *
+ * @type {WeakMap<TypedArray, TypedArray>}
+ */
+const hiddenTypedArrays = new WeakMap();
+
+/**
+ * Amplifier-with-this-fallthrough for freezable TypedArrays. Returns the
+ * hidden genuine TypedArray when `typedArray` is an emulated freezable wrapper
+ * (present in the brand WeakMap), and returns `typedArray` itself otherwise.
+ * This lets the methods on `%TypedArrayPrototype%` (after the shim install)
+ * work as drop-in replacements for genuine TypedArrays.
+ *
+ * @param {TypedArray} typedArray
+ * @returns {TypedArray}
+ */
+const amplifyTypedArray = typedArray => {
+  const result = apply(weakmapGet, hiddenTypedArrays, [typedArray]);
+  if (result !== undefined) {
+    return result;
+  }
+  return typedArray;
+};
+
+/**
+ * Getter that replaces `%TypedArrayPrototype%.buffer`.
+ * When `this` is an emulated freezable wrapper (registered in `hiddenTypedArrays`),
+ * it returns the immutable ArrayBuffer wrapper via `reverseBuffers`. Otherwise
+ * it delegates to the captured genuine `%TypedArrayPrototype%.buffer` getter.
+ *
+ * Declared via concise method syntax (inside a temporary object literal) rather
+ * than a `function` declaration or `function`-keyword expression. A
+ * `function`-keyword function has both `[[Construct]]` and `[[Call]]` behaviors
+ * (callable with `new`) and an irrelevant `prototype` property pointing at an
+ * extra object, so `freeze` of such a function is not equivalent to `harden`
+ * and leaves behind hazardous mutability. An arrow function cannot be used
+ * here because this getter must be `this`-sensitive. Concise method syntax
+ * avoids both problems: the method has only `[[Call]]`, no `prototype`
+ * property, and no `[[Construct]]`.
+ *
+ * The surrounding `const` binding avoids JavaScript function-declaration
+ * hoisting. In the presence of an import cycle a hoisted function
+ * declaration's value is available to an importing module before the exporting
+ * module finishes initializing, which can expose uninitialized state. A `const`
+ * binding produces a Temporal Dead Zone (TDZ) error for the early importer
+ * instead.
+ * Note: the ses-shim's compiler from JS ESM module code to JS evaluable code
+ * does not implement TDZ correctly, so this cycle hazard may not be caught at
+ * runtime under ses-shim.
+ * XS uses native compartment and module support and does implement TDZ, so the
+ * hazard would be caught there.
+ * This particular PR introduces no such import cycle; the note is for future
+ * maintainers.
+ * See the README section "Function expressions versus declarations" for full
+ * context (erights review comments 3439479281, 3439500526).
+ */
+const taGetters = {
+  /** @type {(this: object) => ArrayBuffer} */
+  get buffer() {
+    const genuineTA = apply(weakmapGet, hiddenTypedArrays, [this]);
+    if (genuineTA !== undefined) {
+      // The hidden genuine TypedArray's buffer is the genuine backing buffer.
+      const genuineAB = apply(typedArrayBufferGetter, genuineTA, []);
+      // Return the immutable wrapper (reverseBuffers maps genuine -> wrapper).
+      const immutableWrapper = apply(weakmapGet, reverseBuffers, [genuineAB]);
+      if (immutableWrapper !== undefined) {
+        return immutableWrapper;
+      }
+      return genuineAB;
+    }
+    // Fallthrough: delegate to the genuine getter.
+    return apply(typedArrayBufferGetter, this, []);
+  },
+};
+
+// `getOwnPropertyDescriptor` returns `PropertyDescriptor | undefined`, and
+// `PropertyDescriptor.get` is typed `(() => any) | undefined` because a
+// descriptor can be a data descriptor. We know `taGetters.buffer` is an
+// accessor we just defined, so both the descriptor and its `get` are present.
+// @ts-expect-error TS doesn't know it'll be there
+const { get: virtualTypedArrayBufferGetter } = getOwnPropertyDescriptor(
+  taGetters,
+  'buffer',
+);
+
+/**
+ * Factory for per-flavor pseudo-constructors. Each pseudo-constructor replaces
+ * the corresponding global TypedArray constructor (for example `Uint8Array`).
+ * When called with an emulated immutable ArrayBuffer as the first argument, it
+ * produces an emulated freezable TypedArray wrapper. For all other call shapes
+ * it falls through to the genuine constructor via `Reflect.construct`.
+ *
+ * The wrapper is a plain ordinary object whose `[[Prototype]]` is
+ * `OriginalConstructor.prototype`. This is the "drop-the-pseudo-prototype"
+ * shape: no intermediate prototype exists between the wrapper and the genuine
+ * prototype.
+ *
+ * @param {Function} OriginalConstructor - The genuine TypedArray constructor to wrap.
+ * @returns {Function} A pseudo-constructor with the same `.name` and `.prototype`.
+ */
+export const makePseudoTypedArrayConstructor = OriginalConstructor => {
+  /**
+   * @param {...any} args
+   * @returns {object}
+   */
+  function PseudoTypedArray(...args) {
+    // Determine whether the first argument is an emulated immutable
+    // ArrayBuffer.
+    const [firstArg] = args;
+    const isHidden =
+      firstArg !== undefined && apply(weakmapHas, buffers, [firstArg]);
+
+    if (!isHidden) {
+      // Fallthrough: delegate to the genuine constructor.
+      return construct(
+        OriginalConstructor,
+        args,
+        new.target ?? OriginalConstructor,
+      );
+    }
+
+    // Emulated-immutable branch.
+    // Retrieve the genuine backing ArrayBuffer from the `buffers` WeakMap.
+    const genuineAB = apply(weakmapGet, buffers, [firstArg]);
+
+    // Build the remaining constructor arguments using the genuine buffer.
+    const [, ...restArgs] = args;
+    const genuineTA = construct(OriginalConstructor, [genuineAB, ...restArgs]);
+
+    // Create the emulated freezable wrapper as a plain object whose prototype
+    // is OriginalConstructor.prototype (no intermediate prototype).
+    const wrapper = create(OriginalConstructor.prototype);
+
+    // Register the wrapper in the brand WeakMap (wrapper -> genuine TypedArray).
+    apply(weakmapSet, hiddenTypedArrays, [wrapper, genuineTA]);
+
+    // Register the reverse mapping so `view.buffer` can reconstruct the
+    // immutable wrapper from the genuine backing buffer.
+    apply(weakmapSet, reverseBuffers, [genuineAB, firstArg]);
+
+    return wrapper;
+  }
+
+  // Preserve the constructor name for debugging and instanceof checks.
+  defineProperty(PseudoTypedArray, 'name', {
+    value: OriginalConstructor.name,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+
+  // The `prototype` property must be the genuine prototype so that
+  // `instanceof T` and `Object.getPrototypeOf(wrapper) === T.prototype`
+  // both hold. We share the genuine prototype rather than creating a new one.
+  PseudoTypedArray.prototype = OriginalConstructor.prototype;
+
+  // Set the `prototype.constructor` to the pseudo-constructor so that SES's
+  // intrinsic walk finds consistency: after we install PseudoTypedArray as
+  // `globalThis.BigInt64Array` (for example), SES samples `BigInt64Array` and
+  // resolves it to PseudoTypedArray. It then walks the permit graph and checks
+  // that `intrinsics.%BigInt64ArrayPrototype%.constructor === intrinsics.BigInt64Array`.
+  // If `prototype.constructor` still points to the original constructor,
+  // that check fails. Updating `prototype.constructor` to PseudoTypedArray
+  // ensures both pointers agree with the intrinsics map.
+  //
+  // This does NOT affect genuine TypedArray construction:
+  // `new OriginalConstructor(realAb)` delegates to the captured genuine
+  // constructor via `Reflect.construct`, which ignores `prototype.constructor`.
+  defineProperty(OriginalConstructor.prototype, 'constructor', {
+    value: PseudoTypedArray,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  // Set the pseudo-constructor's `[[Prototype]]` to `%TypedArray%` (the
+  // abstract TypedArray superclass). SES's intrinsic walk validates that
+  // each concrete TypedArray constructor inherits from `%TypedArray%` via the
+  // constructor chain (`BigInt64Array.__proto__ === TypedArray`). A plain
+  // function's default `Function.prototype` prototype would fail that check.
+  setPrototypeOf(PseudoTypedArray, TypedArray);
+
+  // Copy the `BYTES_PER_ELEMENT` static property from the original constructor.
+  // Callers such as `packages/captp/src/atomics.js` read this constant
+  // directly off the constructor (`BigUint64Array.BYTES_PER_ELEMENT`,
+  // `Int32Array.BYTES_PER_ELEMENT`). The shim replaces the global binding with
+  // `PseudoTypedArray`, so the property must be present on the replacement or
+  // those reads return `undefined`, making arithmetic expressions produce NaN.
+  //
+  // `BYTES_PER_ELEMENT` is not inherited through the prototype chain on
+  // TypedArray constructors; each concrete constructor carries its own own-
+  // property value (8 for BigUint64Array, 4 for Int32Array, etc.).
+  defineProperty(PseudoTypedArray, 'BYTES_PER_ELEMENT', {
+    // @ts-expect-error TS2339: BYTES_PER_ELEMENT exists on TypedArray constructors but not on Function
+    value: OriginalConstructor.BYTES_PER_ELEMENT,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+
+  // Do NOT freeze here. SES's `hardenIntrinsics` will freeze all
+  // primordials (including the pseudo-constructors installed on globalThis)
+  // as part of `lockdown()`. Pre-freezing would cause SES's pre-lockdown
+  // consistency check ("all intrinsics must be unfrozen before repairIntrinsics")
+  // to fail. The function is effectively immutable at runtime because the
+  // only callers are the shim install path (which has already run) and
+  // callers of the returned constructor.
+  return PseudoTypedArray;
+};
+
+/**
+ * Property record the shim copies onto `%TypedArrayPrototype%`. Contains:
+ *
+ * - The `buffer`, `byteLength`, `byteOffset`, and `length` accessor
+ *   replacements. Each discriminates on `hiddenTypedArrays` brand membership:
+ *   on hit it delegates to the hidden genuine TypedArray (amplifier pattern);
+ *   on miss it delegates to the captured genuine accessor (fallthrough).
+ *
+ * - Mutator-throws descriptors for the five mutator methods: `copyWithin`,
+ *   `fill`, `reverse`, `set`, `sort`. On emulated freezable wrappers each
+ *   throws `TypeError`; on genuine TypedArrays each delegates to the captured
+ *   genuine method (the amplifier-with-this-fallthrough shape).
+ *
+ * - Amplifier-delegate wrappers for all remaining read-only `%TypedArrayPrototype%`
+ *   methods. Plain ordinary wrappers cannot be passed as `this` to any native
+ *   TypedArray method that checks for integer-indexed exotic internal slots.
+ *   The amplifier resolves the wrapper to its hidden genuine TypedArray first,
+ *   so the captured genuine method receives a valid `this`.
+ *
+ * The record's properties are made non-enumerable below, matching the shape
+ * of the genuine `%TypedArrayPrototype%`.
+ */
+export const freezableTypedArrayLibProperties = {
+  __proto__: null,
+
+  // Accessors: `buffer`, `byteLength`, `byteOffset`, `length`
+
+  /**
+   * @this {object}
+   * @returns {ArrayBuffer}
+   */
+  get buffer() {
+    return apply(virtualTypedArrayBufferGetter, this, []);
+  },
+  /**
+   * @this {object}
+   * @returns {number}
+   */
+  get byteLength() {
+    return apply(typedArrayByteLengthGetter, amplifyTypedArray(this), []);
+  },
+  /**
+   * @this {object}
+   * @returns {number}
+   */
+  get byteOffset() {
+    return apply(typedArrayByteOffsetGetter, amplifyTypedArray(this), []);
+  },
+  /**
+   * @this {object}
+   * @returns {number}
+   */
+  get length() {
+    return apply(typedArrayLengthGetter, amplifyTypedArray(this), []);
+  },
+
+  // Mutator methods: throw on emulated freezable wrappers
+
+  /**
+   * @this {object}
+   * @param {number} [target]
+   * @param {number} [start]
+   * @param {number} [end]
+   * @returns {object}
+   */
+  copyWithin(target = undefined, start = undefined, end = undefined) {
+    if (apply(weakmapHas, hiddenTypedArrays, [this])) {
+      throw TypeError(
+        'Cannot copyWithin on a freezable TypedArray backed by an immutable ArrayBuffer',
+      );
+    }
+    return apply(typedArrayCopyWithin, this, [target, start, end]);
+  },
+  /**
+   * @this {object}
+   * @param {any} [value]
+   * @param {number} [start]
+   * @param {number} [end]
+   * @returns {object}
+   */
+  fill(value = undefined, start = undefined, end = undefined) {
+    if (apply(weakmapHas, hiddenTypedArrays, [this])) {
+      throw TypeError(
+        'Cannot fill a freezable TypedArray backed by an immutable ArrayBuffer',
+      );
+    }
+    return apply(typedArrayFill, this, [value, start, end]);
+  },
+  /**
+   * @this {object}
+   * @returns {object}
+   */
+  reverse() {
+    if (apply(weakmapHas, hiddenTypedArrays, [this])) {
+      throw TypeError(
+        'Cannot reverse a freezable TypedArray backed by an immutable ArrayBuffer',
+      );
+    }
+    return apply(typedArrayReverse, this, []);
+  },
+  /**
+   * @this {object}
+   * @param {any} array
+   * @param {number} [offset]
+   * @returns {void}
+   */
+  set(array = undefined, offset = undefined) {
+    if (apply(weakmapHas, hiddenTypedArrays, [this])) {
+      throw TypeError(
+        'Cannot set on a freezable TypedArray backed by an immutable ArrayBuffer',
+      );
+    }
+    return apply(typedArraySet, this, [array, offset]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [compareFn]
+   * @returns {object}
+   */
+  sort(compareFn = undefined) {
+    if (apply(weakmapHas, hiddenTypedArrays, [this])) {
+      throw TypeError(
+        'Cannot sort a freezable TypedArray backed by an immutable ArrayBuffer',
+      );
+    }
+    return apply(typedArraySort, this, [compareFn]);
+  },
+
+  // Read-only method delegates: amplify then call the captured genuine method
+
+  /**
+   * @this {object}
+   * @param {number} [index]
+   * @returns {any}
+   */
+  at(index = undefined) {
+    return apply(typedArrayAt, amplifyTypedArray(this), [index]);
+  },
+  /**
+   * @this {object}
+   * @returns {Iterator}
+   */
+  entries() {
+    return apply(typedArrayEntries, amplifyTypedArray(this), []);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [predicate]
+   * @param {any} [thisArg]
+   * @returns {boolean}
+   */
+  every(predicate = undefined, thisArg = undefined) {
+    return apply(typedArrayEvery, amplifyTypedArray(this), [
+      predicate,
+      thisArg,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [predicate]
+   * @param {any} [thisArg]
+   * @returns {object}
+   */
+  filter(predicate = undefined, thisArg = undefined) {
+    return apply(typedArrayFilter, amplifyTypedArray(this), [
+      predicate,
+      thisArg,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [predicate]
+   * @param {any} [thisArg]
+   * @returns {any}
+   */
+  find(predicate = undefined, thisArg = undefined) {
+    return apply(typedArrayFind, amplifyTypedArray(this), [predicate, thisArg]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [predicate]
+   * @param {any} [thisArg]
+   * @returns {number}
+   */
+  findIndex(predicate = undefined, thisArg = undefined) {
+    return apply(typedArrayFindIndex, amplifyTypedArray(this), [
+      predicate,
+      thisArg,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [predicate]
+   * @param {any} [thisArg]
+   * @returns {any}
+   */
+  findLast(predicate = undefined, thisArg = undefined) {
+    if (typedArrayFindLast === undefined) {
+      throw TypeError(
+        'TypedArray.prototype.findLast is not available on this platform',
+      );
+    }
+    return apply(typedArrayFindLast, amplifyTypedArray(this), [
+      predicate,
+      thisArg,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [predicate]
+   * @param {any} [thisArg]
+   * @returns {number}
+   */
+  findLastIndex(predicate = undefined, thisArg = undefined) {
+    if (typedArrayFindLastIndex === undefined) {
+      throw TypeError(
+        'TypedArray.prototype.findLastIndex is not available on this platform',
+      );
+    }
+    return apply(typedArrayFindLastIndex, amplifyTypedArray(this), [
+      predicate,
+      thisArg,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [callback]
+   * @param {any} [thisArg]
+   * @returns {void}
+   */
+  forEach(callback = undefined, thisArg = undefined) {
+    return apply(typedArrayForEach, amplifyTypedArray(this), [
+      callback,
+      thisArg,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {any} searchElement
+   * @param {number} [fromIndex]
+   * @returns {boolean}
+   */
+  includes(searchElement = undefined, fromIndex = undefined) {
+    return apply(typedArrayIncludes, amplifyTypedArray(this), [
+      searchElement,
+      fromIndex,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {any} searchElement
+   * @param {number} [fromIndex]
+   * @returns {number}
+   */
+  indexOf(searchElement = undefined, fromIndex = undefined) {
+    return apply(typedArrayIndexOf, amplifyTypedArray(this), [
+      searchElement,
+      fromIndex,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {string} [separator]
+   * @returns {string}
+   */
+  join(separator = undefined) {
+    return apply(typedArrayJoin, amplifyTypedArray(this), [separator]);
+  },
+  /**
+   * @this {object}
+   * @returns {Iterator}
+   */
+  keys() {
+    return apply(typedArrayKeys, amplifyTypedArray(this), []);
+  },
+  /**
+   * @this {object}
+   * @param {any} searchElement
+   * @param {number} [fromIndex]
+   * @returns {number}
+   */
+  lastIndexOf(searchElement = undefined, fromIndex = undefined) {
+    return apply(typedArrayLastIndexOf, amplifyTypedArray(this), [
+      searchElement,
+      fromIndex,
+    ]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [callback]
+   * @param {any} [thisArg]
+   * @returns {object}
+   */
+  map(callback = undefined, thisArg = undefined) {
+    return apply(typedArrayMap, amplifyTypedArray(this), [callback, thisArg]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [callback]
+   * @param {any} [initialValue]
+   * @returns {any}
+   */
+  reduce(callback = undefined, initialValue = undefined) {
+    return apply(
+      typedArrayReduce,
+      amplifyTypedArray(this),
+      arguments.length > 1 ? [callback, initialValue] : [callback],
+    );
+  },
+  /**
+   * @this {object}
+   * @param {Function} [callback]
+   * @param {any} [initialValue]
+   * @returns {any}
+   */
+  reduceRight(callback = undefined, initialValue = undefined) {
+    return apply(
+      typedArrayReduceRight,
+      amplifyTypedArray(this),
+      arguments.length > 1 ? [callback, initialValue] : [callback],
+    );
+  },
+  /**
+   * @this {object}
+   * @param {number} [start]
+   * @param {number} [end]
+   * @returns {object}
+   */
+  slice(start = undefined, end = undefined) {
+    return apply(typedArraySlice, amplifyTypedArray(this), [start, end]);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [predicate]
+   * @param {any} [thisArg]
+   * @returns {boolean}
+   */
+  some(predicate = undefined, thisArg = undefined) {
+    return apply(typedArraySome, amplifyTypedArray(this), [predicate, thisArg]);
+  },
+  /**
+   * @this {object}
+   * @param {number} [begin]
+   * @param {number} [end]
+   * @returns {object}
+   */
+  subarray(begin = undefined, end = undefined) {
+    const genuineTA = apply(weakmapGet, hiddenTypedArrays, [this]);
+    if (genuineTA !== undefined) {
+      // `this` is an emulated freezable wrapper. Delegate to the hidden genuine
+      // TypedArray to get the sub-view genuine TypedArray, then wrap it in a new
+      // emulated freezable wrapper so the safety contract (`sub.buffer === iab`)
+      // holds for sub-views.
+      const genuineSub = apply(typedArraySubarray, genuineTA, [begin, end]);
+      // `create(getPrototypeOf(this))` is sufficient rather than calling the
+      // pseudo-constructor because the sub-view wrapper needs exactly three
+      // things the parent wrapper already provides:
+      //
+      // 1. The right prototype. `getPrototypeOf(this)` is
+      //    `OriginalConstructor.prototype`, the same prototype the
+      //    pseudo-constructor would set via `create(OriginalConstructor.prototype)`.
+      //    The shim's freezable behaviors live on that prototype (installed onto
+      //    `%TypedArrayPrototype%`), so they are already inherited.
+      //
+      // 2. A `hiddenTypedArrays` registration. The line below registers
+      //    `subWrapper -> genuineSub` in the brand WeakMap, which is what
+      //    `amplifyTypedArray` and every method that discriminates on brand
+      //    membership require. No other per-instance state is needed.
+      //
+      // 3. A `reverseBuffers` entry for `view.buffer` redirection. A sub-array
+      //    shares its backing buffer with the parent; `typedArraySubarray` does
+      //    not allocate a new buffer. The pseudo-constructor's `reverseBuffers`
+      //    registration maps the genuine backing buffer to the immutable wrapper,
+      //    and that entry was already written when the parent was constructed.
+      //    The sub-view's genuine buffer is the same genuine buffer, so no new
+      //    `reverseBuffers` entry is needed.
+      //
+      // Static properties (`BYTES_PER_ELEMENT`) live on
+      // `OriginalConstructor.prototype.constructor`, not on the instance, so
+      // they are also already present via the prototype chain. There is no
+      // instance state that the pseudo-constructor would add that `create` does
+      // not already provide.
+      const subWrapper = create(getPrototypeOf(this));
+      apply(weakmapSet, hiddenTypedArrays, [subWrapper, genuineSub]);
+      // `reverseBuffers` already maps the genuine backing buffer to the immutable
+      // wrapper from when the parent wrapper was constructed; no new entry needed.
+      return subWrapper;
+    }
+    return apply(typedArraySubarray, this, [begin, end]);
+  },
+  /**
+   * @this {object}
+   * @param {...any} args
+   * @returns {string}
+   */
+  toLocaleString(...args) {
+    return apply(typedArrayToLocaleString, amplifyTypedArray(this), args);
+  },
+  /**
+   * @this {object}
+   * @returns {string}
+   */
+  toString() {
+    return apply(typedArrayToString, amplifyTypedArray(this), []);
+  },
+  /**
+   * @this {object}
+   * @returns {Iterator}
+   */
+  values() {
+    return apply(typedArrayValues, amplifyTypedArray(this), []);
+  },
+  /**
+   * The default iterator for TypedArrays is `%TypedArrayPrototype%.values`.
+   * In the baseline runtime `%TypedArrayPrototype%[Symbol.iterator]` is the
+   * same function object as `%TypedArrayPrototype%.values`. After the shim
+   * installs a new `values` wrapper, `Symbol.iterator` would still point at
+   * the original genuine `values` function unless we re-install it here as
+   * well. Without this entry, `for...of` loops and spread syntax on emulated
+   * freezable wrappers throw `TypeError: this is not a typed array.`
+   *
+   * @this {object}
+   * @returns {Iterator}
+   */
+  [Symbol.iterator]() {
+    return apply(typedArrayValues, amplifyTypedArray(this), []);
+  },
+  /**
+   * @this {object}
+   * @returns {object}
+   */
+  toReversed() {
+    if (typedArrayToReversed === undefined) {
+      throw TypeError(
+        'TypedArray.prototype.toReversed is not available on this platform',
+      );
+    }
+    return apply(typedArrayToReversed, amplifyTypedArray(this), []);
+  },
+  /**
+   * @this {object}
+   * @param {Function} [compareFn]
+   * @returns {object}
+   */
+  toSorted(compareFn = undefined) {
+    if (typedArrayToSorted === undefined) {
+      throw TypeError(
+        'TypedArray.prototype.toSorted is not available on this platform',
+      );
+    }
+    return apply(typedArrayToSorted, amplifyTypedArray(this), [compareFn]);
+  },
+  /**
+   * @this {object}
+   * @param {number} [index]
+   * @param {any} [value]
+   * @returns {object}
+   */
+  with(index = undefined, value = undefined) {
+    if (typedArrayWith === undefined) {
+      throw TypeError(
+        'TypedArray.prototype.with is not available on this platform',
+      );
+    }
+    return apply(typedArrayWith, amplifyTypedArray(this), [index, value]);
+  },
+};
+
+// Make all properties non-enumerable, matching %TypedArrayPrototype%'s shape.
+for (const key of ownKeys(freezableTypedArrayLibProperties)) {
+  defineProperty(freezableTypedArrayLibProperties, key, {
+    enumerable: false,
+  });
+}
+// Do not freeze: the shim passes these descriptors directly to
+// `defineProperties`, and frozen descriptors (configurable: false,
+// writable: false) would prevent SES's `tameLocaleMethods` from later
+// replacing `toLocaleString`. Leave the record unfrozen so descriptors
+// are directly usable.
+
+/**
+ * The eleven concrete TypedArray constructors that share `%TypedArrayPrototype%`.
+ * The shim replaces each with a pseudo-constructor from `makePseudoTypedArrayConstructor`.
+ *
+ * @type {Array<{name: string, Ctor: Function}>}
+ */
+export const concreteTypedArrayCtors = [
+  { name: 'Int8Array', Ctor: Int8Array },
+  { name: 'Int16Array', Ctor: Int16Array },
+  { name: 'Int32Array', Ctor: Int32Array },
+  { name: 'Uint8Array', Ctor: Uint8Array },
+  { name: 'Uint8ClampedArray', Ctor: Uint8ClampedArray },
+  { name: 'Uint16Array', Ctor: Uint16Array },
+  { name: 'Uint32Array', Ctor: Uint32Array },
+  { name: 'Float32Array', Ctor: Float32Array },
+  { name: 'Float64Array', Ctor: Float64Array },
+  { name: 'BigInt64Array', Ctor: BigInt64Array },
+  { name: 'BigUint64Array', Ctor: BigUint64Array },
+];

--- a/packages/immutable-arraybuffer/src/shim.js
+++ b/packages/immutable-arraybuffer/src/shim.js
@@ -1,6 +1,11 @@
 /* global globalThis */
 
-import { immutableArrayBufferLibProperties } from './lib.js';
+import {
+  immutableArrayBufferLibProperties,
+  freezableTypedArrayLibProperties,
+  makePseudoTypedArrayConstructor,
+  concreteTypedArrayCtors,
+} from './lib.js';
 
 const {
   ArrayBuffer,
@@ -8,7 +13,12 @@ const {
   // eslint-disable-next-line no-restricted-globals
 } = globalThis;
 
-const { getOwnPropertyDescriptors, defineProperties } = Object;
+const {
+  getOwnPropertyDescriptors,
+  defineProperties,
+  defineProperty,
+  getPrototypeOf,
+} = Object;
 const { prototype: arrayBufferPrototype } = ArrayBuffer;
 
 // Stage-3 install policy: detect-then-skip.
@@ -32,8 +42,51 @@ const { prototype: arrayBufferPrototype } = ArrayBuffer;
 // divergent platform implementations. The Immutable ArrayBuffer proposal
 // is past that threshold.
 if (!('sliceToImmutable' in arrayBufferPrototype)) {
+  // ArrayBuffer-side install (immutable ArrayBuffer shim).
   defineProperties(
     arrayBufferPrototype,
     getOwnPropertyDescriptors(immutableArrayBufferLibProperties),
   );
+
+  // Freezable TypedArray install.
+  //
+  // The %TypedArrayPrototype% is the shared abstract superclass prototype
+  // that all eleven concrete TypedArray constructors (Int8Array, Uint8Array,
+  // etc.) inherit through their own `.prototype`. Installing the property
+  // record once on %TypedArrayPrototype% covers all eleven flavors.
+  //
+  // `getPrototypeOf(Uint8Array.prototype)` is the standard way to reach
+  // %TypedArrayPrototype% without a dedicated
+  // intrinsic name.
+  const typedArrayPrototype = getPrototypeOf(
+    // eslint-disable-next-line no-restricted-globals
+    globalThis.Uint8Array.prototype,
+  );
+
+  // Install the lib property record onto %TypedArrayPrototype%.
+  //
+  // `freezableTypedArrayLibProperties` is an unfrozen record whose
+  // descriptors are configurable and writable (matching the shape of the
+  // native %TypedArrayPrototype% methods), so we can pass them directly
+  // to `defineProperties` without reopening.
+  defineProperties(
+    typedArrayPrototype,
+    getOwnPropertyDescriptors(freezableTypedArrayLibProperties),
+  );
+
+  // Replace each of the eleven concrete global TypedArray constructors with
+  // the pseudo-constructor produced by the lib. The pseudo-constructor
+  // discriminates on `buffers` brand membership and falls through to
+  // the genuine constructor for all other call shapes.
+  for (const { name, Ctor } of concreteTypedArrayCtors) {
+    const PseudoCtor = makePseudoTypedArrayConstructor(Ctor);
+    defineProperty(
+      // eslint-disable-next-line no-restricted-globals
+      globalThis,
+      name,
+      {
+        value: PseudoCtor,
+      },
+    );
+  }
 }

--- a/packages/immutable-arraybuffer/test/_lib-setup.md
+++ b/packages/immutable-arraybuffer/test/_lib-setup.md
@@ -19,9 +19,6 @@ shim has run.
 The lib's free-function helpers (`sliceBufferToImmutable`,
 `optTransferBufferToImmutable`) remain importable from the lib module
 for tests that want to exercise the free-function call shape directly.
-They are also (today) re-exported from `index.js` for pre-shim callers;
-the premise-2 follow-up PR will retire the free-function exports from
-the package's module surface but not from the lib module itself.
 
 The `shim-amplifier.test.js` and `shim-slice.test.js` / `shim-transfer.test.js`
 test files have always installed the shim at module top (their purpose

--- a/packages/immutable-arraybuffer/test/lib-slice.test.js
+++ b/packages/immutable-arraybuffer/test/lib-slice.test.js
@@ -105,24 +105,27 @@ test('Standard TypedArray behavior baseline', t => {
 // This could have been written as a test.failing as compared to
 // the immutable ArrayBuffer we'll propose. However, I'd rather test what
 // the shim purposely does instead.
-test('TypedArray on Immutable ArrayBuffer lib limitations', t => {
+test('TypedArray on Immutable ArrayBuffer: freezable-TypedArray emulation now supported', t => {
+  // As of the freezable-TypedArray shim (PR implementing
+  // designs/freezable-typedarray.md), calling a TypedArray constructor with an
+  // emulated immutable ArrayBuffer produces an emulated freezable wrapper
+  // whose byteLength matches the underlying buffer, whose mutator methods
+  // throw TypeError, and whose buffer accessor returns the immutable wrapper.
+  // The old limitation (producing a 0-byte TypedArray) no longer applies.
   const ab1 = new ArrayBuffer(2);
-  const dv1 = new DataView(ab1);
-  t.is(dv1.buffer, ab1);
-  t.is(dv1.byteLength, 2);
   const ta1 = new Uint8Array(ab1);
   ta1[0] = 3;
   ta1[1] = 4;
-  t.is(ta1.byteLength, 2);
 
   const iab = sliceBufferToImmutable(ab1);
-  // Unfortunately, unlike the immutable ArrayBuffer to be proposed,
-  // calling a TypedArray constructor with the shim implementation of
-  // an immutable ArrayBuffer as argument treats it as an unrecognized object,
-  // rather than throwing an error or acting as a non-changeable TypedArray.
   t.is(iab.byteLength, 2);
   const ta3 = new Uint8Array(iab);
-  t.is(ta3.byteLength, 0);
+  // The emulated freezable wrapper covers the full 2 bytes.
+  t.is(ta3.byteLength, 2);
+  // Mutators throw on the emulated freezable wrapper.
+  t.throws(() => ta3.set([0, 0]), { instanceOf: TypeError });
+  // The buffer accessor returns the immutable wrapper.
+  t.is(ta3.buffer, iab);
 });
 
 const testTransfer = t => {

--- a/packages/immutable-arraybuffer/test/lib-transfer.test.js
+++ b/packages/immutable-arraybuffer/test/lib-transfer.test.js
@@ -107,27 +107,33 @@ test('Standard TypedArray behavior baseline', t => {
   t.is(ta2.byteLength, 0);
 });
 
-// This could have been written as a test.failing as compared to
-// the immutable ArrayBuffer we'll propose. However, I'd rather test what
 // the shim purposely does instead.
-test('TypedArray on Immutable ArrayBuffer lib limitations', t => {
+test('TypedArray on Immutable ArrayBuffer: freezable-TypedArray emulation now supported', t => {
+  // As of the freezable-TypedArray shim (PR implementing
+  // designs/freezable-typedarray.md), calling a TypedArray constructor with an
+  // emulated immutable ArrayBuffer produced by transferToImmutable produces an
+  // emulated freezable wrapper whose byteLength matches the underlying buffer.
+  // The old limitation (producing a 0-byte TypedArray) no longer applies.
+  if (optTransferBufferToImmutable === undefined) {
+    t.pass(
+      'Platform lacks transfer or structuredClone; skip transferToImmutable coverage',
+    );
+    return;
+  }
   const ab1 = new ArrayBuffer(2);
-  const dv1 = new DataView(ab1);
-  t.is(dv1.buffer, ab1);
-  t.is(dv1.byteLength, 2);
   const ta1 = new Uint8Array(ab1);
   ta1[0] = 3;
   ta1[1] = 4;
-  t.is(ta1.byteLength, 2);
 
   const iab = optTransferBufferToImmutable(ab1);
-  // Unfortunately, unlike the immutable ArrayBuffer to be proposed,
-  // calling a TypedArray constructor with the shim implementation of
-  // an immutable ArrayBuffer as argument treats it as an unrecognized object,
-  // rather than throwing an error or acting as a non-changeable TypedArray.
   t.is(iab.byteLength, 2);
   const ta3 = new Uint8Array(iab);
-  t.is(ta3.byteLength, 0);
+  // The emulated freezable wrapper covers the full 2 bytes.
+  t.is(ta3.byteLength, 2);
+  // Mutators throw on the emulated freezable wrapper.
+  t.throws(() => ta3.set([0, 0]), { instanceOf: TypeError });
+  // The buffer accessor returns the immutable wrapper.
+  t.is(ta3.buffer, iab);
 });
 
 const testTransfer = t => {

--- a/packages/immutable-arraybuffer/test/lib-typedarray.test.js
+++ b/packages/immutable-arraybuffer/test/lib-typedarray.test.js
@@ -1,0 +1,112 @@
+// @ts-nocheck
+// Lib-level unit tests for the freezable-TypedArray emulation.
+// These tests exercise the property-record and pseudo-constructor machinery in
+// isolation (with the ArrayBuffer-side shim installed so that
+// `sliceBufferToImmutable` and friends are available via the prototype).
+import '../src/shim.js';
+import test from 'ava';
+import {
+  sliceBufferToImmutable,
+  makePseudoTypedArrayConstructor,
+} from '../src/lib.js';
+
+const { getPrototypeOf } = Object;
+
+// makePseudoTypedArrayConstructor - wrapping an immutable ArrayBuffer
+
+test('makePseudoTypedArrayConstructor wraps an immutable ArrayBuffer', t => {
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([1, 2, 3, 4]);
+  const iab = sliceBufferToImmutable(ab);
+
+  const PseudoUint8Array = makePseudoTypedArrayConstructor(Uint8Array);
+  const view = new PseudoUint8Array(iab);
+
+  // The wrapper's prototype is Uint8Array.prototype (no intermediate prototype).
+  t.is(getPrototypeOf(view), Uint8Array.prototype);
+
+  // The amplifier (via .buffer getter) returns the immutable wrapper, not the
+  // genuine backing buffer.
+  // `virtualTypedArrayBufferGetter` is exercised internally; we observe its
+  // effect through the installed `view.buffer` accessor.
+  t.is(view.buffer, iab);
+  t.true(view.buffer.immutable);
+});
+
+// makePseudoTypedArrayConstructor - forwarding a non-immutable first arg
+
+test('makePseudoTypedArrayConstructor forwards a non-immutable first arg', t => {
+  const realAb = new ArrayBuffer(4);
+  new Uint8Array(realAb).set([10, 20, 30, 40]);
+
+  const PseudoUint8Array = makePseudoTypedArrayConstructor(Uint8Array);
+  const view = new PseudoUint8Array(realAb);
+
+  // Fallthrough path: the result is a genuine TypedArray, not a wrapper.
+  t.is(getPrototypeOf(view), Uint8Array.prototype);
+
+  // `view.buffer` returns the real buffer (amplifyTypedArray falls through to
+  // the receiver itself for a genuine TypedArray).
+  t.is(view.buffer, realAb);
+
+  // Mutators work normally on the genuine view.
+  view[0] = 99;
+  t.is(view[0], 99);
+});
+
+// buffer getter - returns genuine buffer for a genuine TypedArray (fallthrough)
+
+test('buffer getter returns the real buffer for a genuine TypedArray', t => {
+  const realAb = new ArrayBuffer(4);
+  const view = new Uint8Array(realAb);
+
+  // `virtualTypedArrayBufferGetter` is installed on %TypedArrayPrototype%;
+  // `view.buffer` exercises the fallthrough path.
+  t.is(view.buffer, realAb);
+  t.false(view.buffer.immutable);
+});
+
+// buffer getter - redirects to the immutable wrapper when the TypedArray is
+// an emulated freezable
+
+test('buffer getter redirects to the immutable wrapper when present', t => {
+  const ab = new ArrayBuffer(4);
+  const iab = sliceBufferToImmutable(ab);
+
+  const PseudoUint8Array = makePseudoTypedArrayConstructor(Uint8Array);
+  const view = new PseudoUint8Array(iab);
+
+  // `virtualTypedArrayBufferGetter` is installed on %TypedArrayPrototype%;
+  // `view.buffer` exercises the emulated-wrapper path.
+  t.is(view.buffer, iab);
+  t.true(view.buffer.immutable);
+});
+
+// amplifyTypedArray - brand-WeakMap amplifier (observed through read delegates)
+
+test('amplifyTypedArray delegates reads from the hidden genuine TypedArray for a wrapper', t => {
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([5, 6, 7, 8]);
+  const iab = sliceBufferToImmutable(ab);
+
+  const PseudoUint8Array = makePseudoTypedArrayConstructor(Uint8Array);
+  const view = new PseudoUint8Array(iab);
+
+  // `amplifyTypedArray` is called by the `byteLength`, `length`, and `at`
+  // property descriptors installed on %TypedArrayPrototype%. The values
+  // match the underlying bytes.
+  t.is(view.byteLength, 4);
+  t.is(view.length, 4);
+  t.is(view.at(0), 5);
+  t.is(view.at(3), 8);
+});
+
+test('amplifyTypedArray falls through for a genuine TypedArray', t => {
+  // A genuine TypedArray is not in `hiddenTypedArrays`; `amplifyTypedArray`
+  // returns the receiver itself.
+  // We observe this by verifying that `byteLength` reads from the view
+  // directly (the genuine buffer's length, not a wrapper's).
+  const view = new Uint8Array(new ArrayBuffer(4));
+  t.is(view.byteLength, 4);
+  t.is(view.length, 4);
+});

--- a/packages/immutable-arraybuffer/test/shim-slice.test.js
+++ b/packages/immutable-arraybuffer/test/shim-slice.test.js
@@ -100,27 +100,26 @@ test('Standard TypedArray behavior baseline', t => {
   t.is(ta2.byteLength, 0);
 });
 
-// This could have been written as a test.failing as compared to
-// the immutable ArrayBuffer we'll propose. However, I'd rather test what
 // the shim purposely does instead.
-test('TypedArray on Immutable ArrayBuffer shim limitations', t => {
+test('TypedArray on Immutable ArrayBuffer: freezable-TypedArray emulation now supported', t => {
+  // As of the freezable-TypedArray shim (PR implementing
+  // designs/freezable-typedarray.md), calling a TypedArray constructor with
+  // `sliceToImmutable()`'s result produces an emulated freezable wrapper.
+  // The old limitation (producing a 0-byte TypedArray) no longer applies.
   const ab1 = new ArrayBuffer(2);
-  const dv1 = new DataView(ab1);
-  t.is(dv1.buffer, ab1);
-  t.is(dv1.byteLength, 2);
   const ta1 = new Uint8Array(ab1);
   ta1[0] = 3;
   ta1[1] = 4;
-  t.is(ta1.byteLength, 2);
 
   const iab = ab1.sliceToImmutable();
-  // Unfortunately, unlike the immutable ArrayBuffer to be proposed,
-  // calling a TypedArray constructor with the shim implementation of
-  // an immutable ArrayBuffer as argument treats it as an unrecognized object,
-  // rather than throwing an error or acting as a non-changeable TypedArray.
   t.is(iab.byteLength, 2);
   const ta3 = new Uint8Array(iab);
-  t.is(ta3.byteLength, 0);
+  // The emulated freezable wrapper covers the full 2 bytes.
+  t.is(ta3.byteLength, 2);
+  // Mutators throw on the emulated freezable wrapper.
+  t.throws(() => ta3.set([0, 0]), { instanceOf: TypeError });
+  // The buffer accessor returns the immutable wrapper.
+  t.is(ta3.buffer, iab);
 });
 
 const testTransfer = t => {

--- a/packages/immutable-arraybuffer/test/shim-transfer.test.js
+++ b/packages/immutable-arraybuffer/test/shim-transfer.test.js
@@ -100,27 +100,32 @@ test('Standard TypedArray behavior baseline', t => {
   t.is(ta2.byteLength, 0);
 });
 
-// This could have been written as a test.failing as compared to
-// the immutable ArrayBuffer we'll propose. However, I'd rather test what
 // the shim purposely does instead.
-test('TypedArray on Immutable ArrayBuffer shim limitations', t => {
+test('TypedArray on Immutable ArrayBuffer: freezable-TypedArray emulation now supported', t => {
+  // As of the freezable-TypedArray shim (PR implementing
+  // designs/freezable-typedarray.md), calling a TypedArray constructor with
+  // `transferToImmutable()`'s result produces an emulated freezable wrapper.
+  // The old limitation (producing a 0-byte TypedArray) no longer applies.
+  if (!('transferToImmutable' in ArrayBuffer.prototype)) {
+    t.pass(
+      'Platform lacks transferToImmutable; skip transferToImmutable coverage',
+    );
+    return;
+  }
   const ab1 = new ArrayBuffer(2);
-  const dv1 = new DataView(ab1);
-  t.is(dv1.buffer, ab1);
-  t.is(dv1.byteLength, 2);
   const ta1 = new Uint8Array(ab1);
   ta1[0] = 3;
   ta1[1] = 4;
-  t.is(ta1.byteLength, 2);
 
   const iab = ab1.transferToImmutable();
-  // Unfortunately, unlike the immutable ArrayBuffer to be proposed,
-  // calling a TypedArray constructor with the shim implementation of
-  // an immutable ArrayBuffer as argument treats it as an unrecognized object,
-  // rather than throwing an error or acting as a non-changeable TypedArray.
   t.is(iab.byteLength, 2);
   const ta3 = new Uint8Array(iab);
-  t.is(ta3.byteLength, 0);
+  // The emulated freezable wrapper covers the full 2 bytes.
+  t.is(ta3.byteLength, 2);
+  // Mutators throw on the emulated freezable wrapper.
+  t.throws(() => ta3.set([0, 0]), { instanceOf: TypeError });
+  // The buffer accessor returns the immutable wrapper.
+  t.is(ta3.buffer, iab);
 });
 
 const testTransfer = t => {

--- a/packages/immutable-arraybuffer/test/shim-typedarray-per-flavor.test.js
+++ b/packages/immutable-arraybuffer/test/shim-typedarray-per-flavor.test.js
@@ -1,0 +1,207 @@
+// @ts-nocheck
+// Per-flavor parameterized coverage for the freezable-TypedArray emulation.
+// Runs a matrix of assertions over all eleven concrete TypedArray constructors.
+//
+// Per-flavor sample values:
+//   - Non-BigInt flavors: 1  (numeric)
+//   - BigInt flavors (BigInt64Array, BigUint64Array): 1n  (BigInt)
+//
+// The BigInt distinction matters because the native TypedArray operations throw
+// a TypeError on a type-mismatch *before* reaching the brand check, which
+// would mask the mutator-throws path the tests are verifying.
+import '../src/shim.js';
+import test from 'ava';
+
+const { getPrototypeOf, freeze, isFrozen } = Object;
+
+/**
+ * @type {Array<{name: string, Ctor: Function, sample: number|bigint, zero: number|bigint}>}
+ */
+const flavors = [
+  { name: 'Int8Array', Ctor: Int8Array, sample: 1, zero: 0 },
+  { name: 'Int16Array', Ctor: Int16Array, sample: 1, zero: 0 },
+  { name: 'Int32Array', Ctor: Int32Array, sample: 1, zero: 0 },
+  { name: 'Uint8Array', Ctor: Uint8Array, sample: 1, zero: 0 },
+  {
+    name: 'Uint8ClampedArray',
+    Ctor: Uint8ClampedArray,
+    sample: 1,
+    zero: 0,
+  },
+  { name: 'Uint16Array', Ctor: Uint16Array, sample: 1, zero: 0 },
+  { name: 'Uint32Array', Ctor: Uint32Array, sample: 1, zero: 0 },
+  { name: 'Float32Array', Ctor: Float32Array, sample: 1, zero: 0 },
+  { name: 'Float64Array', Ctor: Float64Array, sample: 1, zero: 0 },
+  { name: 'BigInt64Array', Ctor: BigInt64Array, sample: 1n, zero: 0n },
+  { name: 'BigUint64Array', Ctor: BigUint64Array, sample: 1n, zero: 0n },
+];
+
+for (const { name, Ctor, sample, zero } of flavors) {
+  const tName = label => `${name}: ${label}`;
+
+  // Construction from an immutable buffer
+
+  test(
+    tName(
+      'construction from an immutable buffer succeeds; __proto__ is T.prototype',
+    ),
+    t => {
+      const ab = new ArrayBuffer(16);
+      const iab = ab.sliceToImmutable();
+      const view = new Ctor(iab);
+      t.is(getPrototypeOf(view), Ctor.prototype);
+      t.true(view instanceof Ctor);
+    },
+  );
+
+  // Mutator methods throw TypeError on frozen wrappers
+
+  test(tName('copyWithin throws TypeError on emulated freezable view'), t => {
+    const iab = new ArrayBuffer(16).sliceToImmutable();
+    const view = new Ctor(iab);
+    t.throws(() => view.copyWithin(0, 1), { instanceOf: TypeError });
+  });
+
+  test(tName('fill throws TypeError on emulated freezable view'), t => {
+    const iab = new ArrayBuffer(16).sliceToImmutable();
+    const view = new Ctor(iab);
+    t.throws(() => view.fill(sample), { instanceOf: TypeError });
+  });
+
+  test(tName('reverse throws TypeError on emulated freezable view'), t => {
+    const iab = new ArrayBuffer(16).sliceToImmutable();
+    const view = new Ctor(iab);
+    t.throws(() => view.reverse(), { instanceOf: TypeError });
+  });
+
+  test(tName('set throws TypeError on emulated freezable view'), t => {
+    const iab = new ArrayBuffer(16).sliceToImmutable();
+    const view = new Ctor(iab);
+    t.throws(() => view.set([sample]), { instanceOf: TypeError });
+  });
+
+  test(tName('sort throws TypeError on emulated freezable view'), t => {
+    const iab = new ArrayBuffer(16).sliceToImmutable();
+    const view = new Ctor(iab);
+    t.throws(() => view.sort(), { instanceOf: TypeError });
+  });
+
+  // Indexed assignment does not modify the underlying buffer
+
+  test(
+    tName(
+      'indexed assignment on non-frozen wrapper creates own property; buffer unchanged',
+    ),
+    t => {
+      const ab = new ArrayBuffer(16);
+      const iab = ab.sliceToImmutable();
+      const view = new Ctor(iab);
+
+      // Byte 0 is the per-flavor zero before assignment.
+      t.is(Ctor.prototype.at.call(view, 0), zero);
+
+      // Assign — creates an own property on the plain wrapper.
+      view[0] = sample;
+
+      // The own property reads back.
+      t.is(view[0], sample);
+
+      // The underlying buffer's byte 0 is still zero.
+      t.is(Ctor.prototype.at.call(view, 0), zero);
+    },
+  );
+
+  test(
+    tName(
+      'indexed assignment on frozen wrapper throws in strict mode; buffer unchanged',
+    ),
+    t => {
+      // ES modules run in strict mode. In strict mode, assigning to a frozen
+      // ordinary object throws TypeError. In non-strict mode the assignment
+      // would be silently swallowed. Either way the underlying buffer is
+      // unchanged. See designs/freezable-typedarray.md, frozen-wrapper example.
+      const iab = new ArrayBuffer(16).sliceToImmutable();
+      const view = new Ctor(iab);
+      freeze(view);
+
+      // In strict mode (ES module), assigning to a frozen object throws.
+      t.throws(
+        () => {
+          view[0] = sample;
+        },
+        { instanceOf: TypeError },
+      );
+
+      // The underlying buffer's byte 0 is still zero.
+      t.is(Ctor.prototype.at.call(view, 0), zero);
+    },
+  );
+
+  // Read-only surface
+
+  test(tName('byteLength, byteOffset, length return correct values'), t => {
+    const ab = new ArrayBuffer(16);
+    const iab = ab.sliceToImmutable();
+    const view = new Ctor(iab);
+    // byteLength and length are flavor-dependent; byteOffset is always 0 here.
+    t.is(view.byteOffset, 0);
+    t.is(view.byteLength, 16);
+    t.is(view.buffer, iab);
+  });
+
+  test(tName('at(0) returns correct value'), t => {
+    const ab = new ArrayBuffer(16);
+    const iab = ab.sliceToImmutable();
+    const view = new Ctor(iab);
+    t.is(view.at(0), zero);
+  });
+
+  test(
+    tName('with(0, sample), toReversed, toSorted return correct values'),
+    t => {
+      const ab = new ArrayBuffer(16);
+      const iab = ab.sliceToImmutable();
+      const view = new Ctor(iab);
+
+      // `with` is a non-mutating method that returns a new TypedArray.
+      // On an emulated freezable wrapper that has no indexed slots, `view.with(0, sample)`
+      // delegates via the amplifier to the hidden genuine TypedArray.
+      const withResult = view.with(0, sample);
+      // The result is a new TypedArray (not the wrapper itself).
+      t.not(withResult, view);
+
+      // `toReversed` and `toSorted` are non-mutating; they return new TypedArrays.
+      const reversed = view.toReversed();
+      t.not(reversed, view);
+
+      const sorted = view.toSorted();
+      t.not(sorted, view);
+    },
+  );
+
+  // Object.freeze
+
+  test(tName('Object.freeze(view); Object.isFrozen(view) === true'), t => {
+    const iab = new ArrayBuffer(16).sliceToImmutable();
+    const view = new Ctor(iab);
+    freeze(view);
+    t.true(isFrozen(view));
+  });
+
+  // Fallthrough constructor (genuine mutable buffer)
+
+  test(
+    tName(
+      'fallthrough constructor on genuine mutable buffer produces genuine writable view',
+    ),
+    t => {
+      const realAb = new ArrayBuffer(16);
+      const view = new Ctor(realAb);
+      t.is(getPrototypeOf(view), Ctor.prototype);
+      t.is(view.buffer, realAb);
+      // Write succeeds.
+      view[0] = sample;
+      t.is(view[0], sample);
+    },
+  );
+}

--- a/packages/immutable-arraybuffer/test/shim-typedarray.test.js
+++ b/packages/immutable-arraybuffer/test/shim-typedarray.test.js
@@ -1,0 +1,239 @@
+// @ts-nocheck
+// Shim-level integration tests for the freezable-TypedArray emulation.
+// These tests exercise the shim-installed pseudo-constructors and
+// %TypedArrayPrototype% property record after the full shim install.
+import '../src/shim.js';
+import test from 'ava';
+
+const { getPrototypeOf, freeze, isFrozen } = Object;
+
+// Basic construction
+
+test('shim: global Uint8Array on an immutable ArrayBuffer wraps as emulated freezable', t => {
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([1, 2, 3, 4]);
+  const iab = ab.sliceToImmutable();
+
+  const view = new Uint8Array(iab);
+
+  // The wrapper's prototype is Uint8Array.prototype (no intermediate prototype).
+  t.is(getPrototypeOf(view), Uint8Array.prototype);
+  t.true(view instanceof Uint8Array);
+
+  // `view.buffer` returns the immutable wrapper, not the genuine backing buffer.
+  t.is(view.buffer, iab);
+  t.true(view.buffer.immutable);
+});
+
+test('shim: global Uint8Array on a regular ArrayBuffer forwards to the OriginalConstructor', t => {
+  const realAb = new ArrayBuffer(4);
+  new Uint8Array(realAb).set([10, 20, 30, 40]);
+
+  const view = new Uint8Array(realAb);
+
+  // Fallthrough path: genuine TypedArray.
+  t.is(view.buffer, realAb);
+  t.false(view.buffer.immutable);
+
+  // Mutators succeed on the genuine view.
+  view[0] = 99;
+  t.is(view[0], 99);
+});
+
+// `view.buffer` getter
+
+test('shim: virtual buffer getter returns the real buffer for a genuine TypedArray', t => {
+  const realAb = new ArrayBuffer(4);
+  const view = new Uint8Array(realAb);
+  t.is(view.buffer, realAb);
+});
+
+test('shim: virtual buffer getter redirects to the immutable wrapper when present', t => {
+  const iab = new ArrayBuffer(4).sliceToImmutable();
+  const view = new Uint8Array(iab);
+  t.is(view.buffer, iab);
+  t.true(view.buffer.immutable);
+});
+
+// Mutators throw on emulated freezable views
+
+test('shim: emulated freezable mutators complain', t => {
+  const iab = new ArrayBuffer(4).sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  t.throws(() => view.copyWithin(0, 1), { instanceOf: TypeError });
+  t.throws(() => view.fill(0), { instanceOf: TypeError });
+  t.throws(() => view.reverse(), { instanceOf: TypeError });
+  t.throws(() => view.set([0]), { instanceOf: TypeError });
+  t.throws(() => view.sort(), { instanceOf: TypeError });
+});
+
+// Read-only delegations (`byteLength`, `at`, `length`, `byteOffset`)
+
+test('shim: emulated freezable byteLength and at redirect via amplifyTypedArray', t => {
+  const ab = new ArrayBuffer(8);
+  new Uint8Array(ab).set([10, 20, 30, 40, 50, 60, 70, 80]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  t.is(view.byteLength, 8);
+  t.is(view.length, 8);
+  t.is(view.byteOffset, 0);
+  t.is(view.at(0), 10);
+  t.is(view.at(7), 80);
+});
+
+// `subarray` returns a view whose `buffer` is the immutable wrapper
+
+test('shim: emulated freezable subarray returns a wrapped view whose buffer is the immutable wrapper', t => {
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([1, 2, 3, 4]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  const sub = view.subarray(1, 3);
+  // `subarray` on an emulated wrapper now returns a new emulated wrapper
+  // backed by the sub-view of the hidden genuine TypedArray. The safety
+  // contract (`sub.buffer === iab`) is preserved: the sub-view's `.buffer`
+  // redirects to the same immutable ArrayBuffer wrapper as the parent view.
+  t.is(sub.byteLength, 2);
+  t.is(sub.byteOffset, 1);
+  // Indexed element access uses `at()` (the amplifier-delegate path) rather
+  // than `sub[0]` (which would read an own property on the plain wrapper object,
+  // returning `undefined` for unset indices, per the wrapper semantics).
+  t.is(sub.at(0), 2);
+  t.is(sub.at(1), 3);
+  // Core safety-contract assertion: the sub-view's buffer is the immutable wrapper.
+  t.is(sub.buffer, iab);
+  t.true(sub.buffer.immutable);
+  // Chained subarray must also preserve the immutable buffer reference.
+  t.is(view.subarray(0, 2).subarray(0, 1).buffer, iab);
+});
+
+// Symbol.iterator: for...of and spread work on emulated freezable wrappers
+
+test('shim: for...of loop works on an emulated freezable wrapper', t => {
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([10, 20, 30, 40]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  const collected = [];
+  for (const v of view) {
+    collected.push(v);
+  }
+  t.deepEqual(collected, [10, 20, 30, 40]);
+});
+
+test('shim: spread syntax works on an emulated freezable wrapper', t => {
+  const ab = new ArrayBuffer(3);
+  new Uint8Array(ab).set([7, 8, 9]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  t.deepEqual([...view], [7, 8, 9]);
+});
+
+test('shim: Symbol.iterator on %TypedArrayPrototype% matches the values wrapper after shim install', t => {
+  // After the shim installs a `values` wrapper on %TypedArrayPrototype%, the
+  // `Symbol.iterator` slot must point at the same (or equivalent) wrapper, not
+  // the original genuine `values` function. This regression test pins the fix:
+  // if `Symbol.iterator` is left pointing at the original genuine function,
+  // `for...of` on a freezable wrapper throws `TypeError: this is not a typed array.`
+  const ab = new ArrayBuffer(2);
+  new Uint8Array(ab).set([1, 2]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  // Both iteration protocols must work on an emulated freezable wrapper.
+  t.deepEqual([...view.values()], [1, 2]);
+  const iterResult = [];
+  for (const v of view) {
+    iterResult.push(v);
+  }
+  t.deepEqual(iterResult, [1, 2]);
+});
+
+// detect-then-skip is idempotent under re-import
+
+test('shim: detect-then-skip is idempotent under re-import', async t => {
+  // The gate is keyed on `'sliceToImmutable' in ArrayBuffer.prototype`.
+  // A second import of the shim must not overwrite the already-installed surface.
+  const sliceFnBefore = ArrayBuffer.prototype.sliceToImmutable;
+
+  // Dynamic re-import exercises the gate from a fresh module invocation.
+  await import('../src/shim.js');
+
+  t.is(
+    ArrayBuffer.prototype.sliceToImmutable,
+    sliceFnBefore,
+    'second shim import did not replace the already-installed sliceToImmutable',
+  );
+});
+
+// Indexed assignment semantics (proposal-level constraint)
+
+test('shim: indexed assignment on a non-frozen emulated freezable view creates a wrapper-local own property; the underlying immutable buffer is unchanged', t => {
+  const ab = new ArrayBuffer(4);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  // The underlying buffer's byte 0 is 0.
+  t.is(Uint8Array.prototype.at.call(view, 0), 0);
+
+  // Indexed assignment performs OrdinarySet on the plain wrapper, creating an
+  // own data property '0' => 42.  The underlying buffer is not touched.
+  view[0] = 42;
+
+  // `view[0]` now reads the own property.
+  t.is(view[0], 42);
+
+  // But the underlying buffer's byte 0 is still 0.
+  t.is(Uint8Array.prototype.at.call(view, 0), 0);
+});
+
+test('shim: indexed assignment on a frozen emulated freezable view throws in strict mode; the underlying immutable buffer is unchanged', t => {
+  // ES modules are implicitly strict. In strict mode, an indexed assignment
+  // to a frozen ordinary object throws TypeError ("Cannot add property 0,
+  // object is not extensible"). In non-strict mode the same assignment would
+  // be silently swallowed. Both behaviors leave the underlying immutable
+  // buffer unchanged; the proposal's buffer-immutability guarantee holds
+  // regardless of mode. See designs/freezable-typedarray.md section
+  // "Indexed assignment never modifies the underlying buffer", frozen example.
+  const ab = new ArrayBuffer(4);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  freeze(view);
+  t.true(isFrozen(view));
+
+  // In strict mode (ES module), assigning to a frozen object throws.
+  t.throws(
+    () => {
+      view[0] = 42;
+    },
+    { instanceOf: TypeError },
+  );
+
+  // The underlying buffer's byte 0 is still 0 (unchanged regardless of mode).
+  t.is(Uint8Array.prototype.at.call(view, 0), 0);
+});
+
+// Object.freeze + Object.isFrozen (the proposal's TypedArray-can-be-frozen
+// guarantee)
+
+test('shim: Object.freeze(view); Object.isFrozen(view) === true', t => {
+  const iab = new ArrayBuffer(4).sliceToImmutable();
+  const view = new Uint8Array(iab);
+
+  freeze(view);
+  t.true(isFrozen(view));
+});
+
+// No intermediate prototype
+
+test('shim: Object.getPrototypeOf(view) === Uint8Array.prototype on an emulated freezable view', t => {
+  const iab = new ArrayBuffer(4).sliceToImmutable();
+  const view = new Uint8Array(iab);
+  t.is(getPrototypeOf(view), Uint8Array.prototype);
+});

--- a/packages/pass-style/src/byteArray.js
+++ b/packages/pass-style/src/byteArray.js
@@ -31,6 +31,20 @@ const immutableGetter =
     immutableDescriptor?.get
   ) || (() => false);
 
+// Capture the `%TypedArrayPrototype%.at` method so we can read a byte
+// through the genuine integer-indexed protocol without going through the
+// wrapper's own (possibly shadowing) data property. On the emulated
+// freezable-TypedArray path installed by `@endo/immutable-arraybuffer`,
+// this captured reference points at the shim-installed amplifier, which
+// resolves the wrapper to its hidden genuine TypedArray and reads from
+// the underlying immutable buffer. On the native path (post-Stage-3), it
+// points at the genuine `%TypedArrayPrototype%.at`, which reads via the
+// integer-indexed exotic. Either way, the read bypasses any own data
+// property on the wrapper.
+const { prototype: uint8ArrayPrototype } = Uint8Array;
+const typedArrayPrototype = getPrototypeOf(uint8ArrayPrototype);
+const { at: typedArrayAt } = typedArrayPrototype;
+
 // The permitted own-property keys on an emulated immutable buffer, paired
 // with the `typeof` of the data-property value the key must carry. The
 // `@endo/immutable-arraybuffer` package installs `[Symbol.toStringTag] =
@@ -46,6 +60,211 @@ const immutableGetter =
 /** @type {Map<string | symbol, string>} */
 const allowedOwnDataProperties = new Map([[Symbol.toStringTag, 'string']]);
 
+// Tests whether an arbitrary key is the canonical string form of a
+// non-negative integer that fits into a JavaScript Number's safe-integer
+// range, the keys spec-mandated as own properties on a TypedArray's
+// integer-indexed exotic surface. Spec callout: a "valid integer index"
+// for TypedArrays uses `CanonicalNumericIndexString` and is constrained
+// to non-negative integers strictly less than the array's `length`.
+// `String(Number(key)) === key` rules out leading zeros, decimal points,
+// scientific notation, and the trailing `'-0'` form; the explicit
+// `Number.isInteger` and non-negativity checks rule out NaN, Infinity,
+// and negative integers. The caller still verifies the index is below
+// `length` after this returns true.
+/**
+ * @param {string | symbol} key
+ * @returns {boolean}
+ */
+const isCanonicalIndexKey = key => {
+  if (typeof key !== 'string') {
+    return false;
+  }
+  const n = Number(key);
+  return Number.isInteger(n) && n >= 0 && String(n) === key && n <= 2 ** 53 - 1;
+};
+
+/**
+ * Validates the well-formedness of a candidate already known to be a frozen
+ * `ArrayBuffer` that claims `immutable === true` and has the expected
+ * prototype. Used directly for the raw-immutable-buffer arm of the
+ * `byteArray` brand check, and indirectly as a sub-check on the buffer
+ * underlying a `Uint8Array` wrapper.
+ *
+ * @param {ArrayBuffer} candidate
+ */
+const assertRestValidImmutableArrayBuffer = candidate => {
+  getPrototypeOf(candidate) === arrayBufferPrototype ||
+    assert.fail(X`Malformed ByteArray ${candidate}`, TypeError);
+  apply(immutableGetter, candidate, []) ||
+    Fail`Must be an immutable ArrayBuffer: ${candidate}`;
+  for (const key of ownKeys(candidate)) {
+    const expectedValueType = allowedOwnDataProperties.get(key);
+    expectedValueType !== undefined ||
+      assert.fail(
+        X`ByteArrays must not have own properties: ${candidate}`,
+        TypeError,
+      );
+    const descriptor = getOwnPropertyDescriptor(candidate, key);
+    // The descriptor cannot be undefined: `key` was just enumerated by
+    // `ownKeys(candidate)`. The conjunction below asserts the shape
+    // the brand contract requires: a non-enumerable data property whose
+    // value has the expected `typeof`. The dynamic `typeof` comparison
+    // against the allowlist's recorded type-name is intentional here;
+    // the standard `valid-typeof` lint rule expects a literal RHS.
+    const valueType =
+      descriptor && 'value' in descriptor ? typeof descriptor.value : undefined;
+    (descriptor !== undefined &&
+      descriptor.enumerable === false &&
+      valueType === expectedValueType) ||
+      assert.fail(
+        X`ByteArray own-property ${key} must be a non-enumerable data property of typeof ${expectedValueType}: ${candidate}`,
+        TypeError,
+      );
+  }
+};
+
+/**
+ * Validates that the candidate is a "plain frozen `Uint8Array` backed by a
+ * plain frozen immutable `ArrayBuffer`". The unifying definition accepts
+ * exactly two well-formed shapes, distinguished by their own-key count:
+ *
+ * - **Emulated-wrapper shape** (produced by `@endo/immutable-arraybuffer`):
+ *   a plain ordinary object whose `[[Prototype]]` is `Uint8Array.prototype`
+ *   with **no own integer-indexed own properties**, regardless of `length`.
+ *   The shim exposes data through the prototype-chain amplifier; there are
+ *   never any own indexed slots on the wrapper itself.
+ *
+ * - **Native shape** (produced by a TC39-spec-following engine once the
+ *   Immutable ArrayBuffer proposal ships): an integer-indexed exotic with
+ *   exactly `length`-many own enumerable indexed data properties, each
+ *   matching the underlying buffer byte at that offset.
+ *
+ * Any other own-key count (between 0 and `length`, exclusive, or above
+ * `length`) is post-construction tampering and is rejected. Non-index own
+ * properties are rejected in both shapes. Indexed own properties that are
+ * present on a native-shape wrapper but whose value disagrees with the
+ * underlying buffer byte are also rejected.
+ *
+ * Assumes the candidate has already passed the `isFrozen` gate that
+ * `passStyleOf` applies before reaching any helper.
+ *
+ * @param {Uint8Array} candidate
+ */
+const assertRestValidPlainFrozenUint8Array = candidate => {
+  getPrototypeOf(candidate) === uint8ArrayPrototype ||
+    assert.fail(X`Malformed ByteArray ${candidate}`, TypeError);
+  // `candidate.buffer` is typed as `ArrayBufferLike` (a union that
+  // includes `SharedArrayBuffer`); narrow to `ArrayBuffer` for the
+  // sub-check. The `confirmCanBeByteArray` guard already established
+  // that the buffer is an `ArrayBuffer` whose `immutable` accessor
+  // returned true, so the narrowing is safe at runtime.
+  const buffer = /** @type {ArrayBuffer} */ (candidate.buffer);
+  // The buffer must itself satisfy the immutable-ArrayBuffer arm of the
+  // brand check: a plain frozen immutable `ArrayBuffer`. Reusing the
+  // same sub-check guarantees the two arms agree on what counts as a
+  // valid backing buffer.
+  apply(immutableGetter, buffer, []) ||
+    Fail`Uint8Array byteArray must be backed by an immutable ArrayBuffer: ${candidate}`;
+  assertRestValidImmutableArrayBuffer(buffer);
+  // `length` is the count of bytes the wrapper exposes. It is read via
+  // the prototype's `length` accessor, which on the emulated path
+  // delegates to the hidden genuine TypedArray and on the native path
+  // reads the integer-indexed exotic's `[[ArrayLength]]` slot.
+  const length = candidate.length;
+  // Collect and validate own keys in one pass, counting indexed keys as we go.
+  // On the emulated path the count must be 0 (no own indexed properties at
+  // all, regardless of length). On the native path the count must be exactly
+  // `length`. Any other count indicates tampering and is rejected after the
+  // loop.
+  let ownIndexCount = 0;
+  for (const key of ownKeys(candidate)) {
+    if (!isCanonicalIndexKey(key)) {
+      assert.fail(
+        X`Plain frozen Uint8Array byteArray must not have own non-index properties: ${candidate}`,
+        TypeError,
+      );
+    }
+    const index = Number(/** @type {string} */ (key));
+    index < length ||
+      assert.fail(
+        X`Plain frozen Uint8Array byteArray own index ${key} must be below length ${length}: ${candidate}`,
+        TypeError,
+      );
+    const descriptor = getOwnPropertyDescriptor(candidate, key);
+    // The descriptor cannot be undefined: `key` was just enumerated by
+    // `ownKeys(candidate)`. Integer-indexed own properties on a frozen
+    // `Uint8Array` are enumerable data properties per spec (after freeze:
+    // non-writable, non-configurable). On the native exotic path the
+    // shape is forced by the integer-indexed-exotic internal methods.
+    const value =
+      descriptor && 'value' in descriptor ? descriptor.value : undefined;
+    (descriptor !== undefined &&
+      'value' in descriptor &&
+      descriptor.enumerable === true &&
+      typeof value === 'number') ||
+      assert.fail(
+        X`Plain frozen Uint8Array byteArray own index ${key} must be an enumerable number-valued data property: ${candidate}`,
+        TypeError,
+      );
+    // The own data property's value must match the byte the wrapper
+    // reads through the integer-indexed protocol. On the native exotic
+    // path the equality is structural (the own property *is* the
+    // integer-indexed read). The captured `typedArrayAt` bypasses any
+    // own data property on the wrapper and reads through the prototype
+    // chain, ensuring the comparison is against the underlying buffer byte.
+    const byteFromBuffer = apply(typedArrayAt, candidate, [index]);
+    value === byteFromBuffer ||
+      assert.fail(
+        X`Plain frozen Uint8Array byteArray own index ${key} value ${value} must equal underlying byte ${byteFromBuffer}: ${candidate}`,
+        TypeError,
+      );
+    ownIndexCount += 1;
+  }
+  // Accept only the two well-formed shapes:
+  //   - Emulated path: 0 own indexed properties (plain object, any length).
+  //   - Native path: exactly `length`-many own indexed properties.
+  // Any other count (e.g., a single shadowing write on an emulated wrapper
+  // before freeze) is rejected as post-construction tampering, even if the
+  // written value matches the underlying buffer byte.
+  ownIndexCount === 0 ||
+    ownIndexCount === length ||
+    assert.fail(
+      X`Plain frozen Uint8Array byteArray must have either no own indexed properties (emulated) or exactly length ${length} own indexed properties (native), not ${ownIndexCount}: ${candidate}`,
+      TypeError,
+    );
+};
+
+/**
+ * Discriminates the two accepted shapes for the `byteArray` pass style:
+ *
+ * 1. An immutable `ArrayBuffer` (the original shape that the brand check
+ *    accepted before the freezable-TypedArray emulation landed).
+ * 2. A `Uint8Array` whose backing buffer is an immutable `ArrayBuffer`
+ *    (the shape produced by `new Uint8Array(iab)` where `iab` is an
+ *    immutable buffer; per the freezable-TypedArray proposal the wrapper
+ *    is frozen and is therefore eligible to pass).
+ *
+ * The check is fast and conservative: it confirms the shape's
+ * top-level brand without recursing into the buffer. `assertRestValid`
+ * performs the deeper validation.
+ *
+ * @param {unknown} candidate
+ * @returns {boolean}
+ */
+const confirmCanBeByteArray = candidate => {
+  if (candidate instanceof ArrayBuffer) {
+    return /** @type {boolean} */ (apply(immutableGetter, candidate, []));
+  }
+  if (candidate instanceof Uint8Array) {
+    const { buffer } = candidate;
+    return (
+      buffer instanceof ArrayBuffer &&
+      /** @type {boolean} */ (apply(immutableGetter, buffer, []))
+    );
+  }
+  return false;
+};
+
 /**
  * @type {PassStyleHelper}
  */
@@ -53,39 +272,15 @@ export const ByteArrayHelper = harden({
   styleName: 'byteArray',
 
   confirmCanBeValid: (candidate, reject) =>
-    (candidate instanceof ArrayBuffer && candidate.immutable) ||
-    (reject && reject`Immutable ArrayBuffer expected: ${candidate}`),
+    confirmCanBeByteArray(candidate) ||
+    (reject &&
+      reject`Immutable ArrayBuffer or Uint8Array on immutable ArrayBuffer expected: ${candidate}`),
 
   assertRestValid: (candidate, _passStyleOfRecur) => {
-    getPrototypeOf(candidate) === arrayBufferPrototype ||
-      assert.fail(X`Malformed ByteArray ${candidate}`, TypeError);
-    apply(immutableGetter, candidate, []) ||
-      Fail`Must be an immutable ArrayBuffer: ${candidate}`;
-    for (const key of ownKeys(candidate)) {
-      const expectedValueType = allowedOwnDataProperties.get(key);
-      expectedValueType !== undefined ||
-        assert.fail(
-          X`ByteArrays must not have own properties: ${candidate}`,
-          TypeError,
-        );
-      const descriptor = getOwnPropertyDescriptor(candidate, key);
-      // The descriptor cannot be undefined: `key` was just enumerated by
-      // `ownKeys(candidate)`. The conjunction below asserts the shape
-      // the brand contract requires: a non-enumerable data property whose
-      // value has the expected `typeof`. The dynamic `typeof` comparison
-      // against the allowlist's recorded type-name is intentional here;
-      // the standard `valid-typeof` lint rule expects a literal RHS.
-      const valueType =
-        descriptor && 'value' in descriptor
-          ? typeof descriptor.value
-          : undefined;
-      (descriptor !== undefined &&
-        descriptor.enumerable === false &&
-        valueType === expectedValueType) ||
-        assert.fail(
-          X`ByteArray own-property ${key} must be a non-enumerable data property of typeof ${expectedValueType}: ${candidate}`,
-          TypeError,
-        );
+    if (candidate instanceof Uint8Array) {
+      assertRestValidPlainFrozenUint8Array(candidate);
+    } else {
+      assertRestValidImmutableArrayBuffer(candidate);
     }
   },
 });

--- a/packages/pass-style/src/passStyleOf.js
+++ b/packages/pass-style/src/passStyleOf.js
@@ -194,6 +194,15 @@ const makePassStyleOf = passStyleHelpers => {
               return helper.styleName;
             }
           }
+          // A TypedArray that was not claimed by any helper (most commonly a
+          // Uint8Array backed by a mutable ArrayBuffer) must not fall through to
+          // the remotable path with a confusing "non-methods" error. Provide the
+          // same diagnostic as the early `isFrozen` gate above, which normally
+          // catches the mutable case before it reaches here. Under unsafe harden
+          // taming `isFrozen` may return true for unfrozen objects, so the early
+          // gate can be bypassed; this check closes that gap.
+          isTypedArray(inner) &&
+            assert.fail(X`Cannot pass mutable typed arrays like ${inner}.`);
           assertValid(remotableHelper, inner, passStyleOfRecur);
           return 'remotable';
         }

--- a/packages/pass-style/src/types.d.ts
+++ b/packages/pass-style/src/types.d.ts
@@ -213,9 +213,10 @@ export type PassableCap =
 export type CopyArray<T extends Passable = any> = readonly T[];
 
 /**
- * A hardened immutable ArrayBuffer.
+ * A hardened immutable `ArrayBuffer`, or a plain frozen `Uint8Array` backed by
+ * one.
  */
-export type ByteArray = ArrayBuffer;
+export type ByteArray = ArrayBuffer | Uint8Array;
 
 /**
  * A Passable dictionary in which each key is a string and each value is Passable.

--- a/packages/pass-style/test/byteArray.test.js
+++ b/packages/pass-style/test/byteArray.test.js
@@ -10,12 +10,27 @@
 // point reaches the byteArray brand check. The canonical-shape case
 // asserts that the emulated immutable installed by the lib passes the
 // check unchanged.
+//
+// The second section covers the freezable-Uint8Array arm of the brand
+// check: a plain frozen `Uint8Array` whose backing buffer is a plain
+// frozen immutable `ArrayBuffer` is accepted as a `byteArray`. The
+// "plain" definition accepts exactly two well-formed shapes:
+//   - Emulated path: no own indexed properties at all, regardless of
+//     length. The `@endo/immutable-arraybuffer` shim produces this shape;
+//     any own indexed property is post-construction tampering and is
+//     rejected even when the value agrees with the underlying buffer byte.
+//   - Native path: exactly `length`-many own indexed properties, each an
+//     enumerable data property whose value matches the underlying buffer
+//     byte. This is the shape a spec-conformant engine will produce once
+//     the Immutable ArrayBuffer proposal ships natively.
+// Non-index own properties are rejected on both paths.
 import test from '@endo/ses-ava/test.js';
 
 import harden from '@endo/harden';
 import { passStyleOf } from '../src/passStyleOf.js';
 
-const { defineProperty, getOwnPropertyDescriptor } = Object;
+const { defineProperty, freeze, getOwnPropertyDescriptor } = Object;
+const { ownKeys } = Reflect;
 
 test('byteArray accepts an emulated immutable ArrayBuffer with the standard toStringTag slot', t => {
   const iab = harden(new ArrayBuffer(0).sliceToImmutable());
@@ -92,6 +107,192 @@ test('byteArray rejects an emulated immutable carrying a same-key Symbol with a 
   });
   harden(iab);
   t.throws(() => passStyleOf(iab), {
+    message: /ByteArrays must not have own properties/,
+  });
+});
+
+// Plain frozen Uint8Array backed by plain frozen immutable ArrayBuffer.
+
+test('byteArray accepts a plain frozen Uint8Array backed by an immutable ArrayBuffer', t => {
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([1, 2, 3, 4]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+  harden(view);
+  t.is(passStyleOf(view), 'byteArray');
+});
+
+test('byteArray accepts a plain frozen Uint8Array on a zero-length immutable ArrayBuffer (emulated, no own indexed properties)', t => {
+  const iab = new ArrayBuffer(0).sliceToImmutable();
+  const view = new Uint8Array(iab);
+  harden(view);
+  t.is(passStyleOf(view), 'byteArray');
+});
+
+test('byteArray accepts a plain frozen non-empty emulated Uint8Array with no own indexed properties', t => {
+  // The emulated freezable-TypedArray wrapper is a plain ordinary object
+  // with no own integer-indexed properties regardless of length. Data is
+  // accessible through the prototype-chain amplifier that resolves to the
+  // hidden genuine TypedArray. This test confirms the acceptance criterion
+  // is "no own indexed properties" rather than "zero length".
+  const ab = new ArrayBuffer(8);
+  new Uint8Array(ab).set([10, 20, 30, 40, 50, 60, 70, 80]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+  // Verify the emulated wrapper has no own indexed properties.
+  t.deepEqual(
+    ownKeys(view).filter(k => typeof k === 'string' && /^\d+$/.test(k)),
+    [],
+  );
+  harden(view);
+  t.is(passStyleOf(view), 'byteArray');
+});
+
+test('byteArray rejects a Uint8Array backed by a mutable ArrayBuffer', t => {
+  // A `Uint8Array` on a mutable backing buffer cannot be frozen on either
+  // the emulated or the native path: integer-indexed exotic slots are
+  // non-configurable accessor-like properties and `Object.freeze` is
+  // defined to reject them. `passStyleOf` therefore rejects the wrapper
+  // with the "Cannot pass mutable typed arrays" message at the early
+  // `isFrozen` gate, before any helper is consulted.
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([1, 2, 3, 4]);
+  const view = new Uint8Array(ab);
+  t.throws(() => passStyleOf(view), {
+    message: /Cannot pass mutable typed arrays/,
+  });
+});
+
+test('byteArray rejects a Uint8Array on an immutable ArrayBuffer with a shadowing index that disagrees with the buffer', t => {
+  // The emulated wrapper is a plain ordinary object whose `[[Prototype]]`
+  // is `Uint8Array.prototype`. Before freezing, `view[0] = 99` succeeds
+  // by creating an own data property on the wrapper that shadows the
+  // prototype-based integer-indexed read. The underlying immutable
+  // buffer's byte 0 is unchanged. After freezing, the wrapper carries an
+  // own enumerable data property `'0'` whose value (99) disagrees with
+  // the byte the underlying buffer would yield (10); the brand check
+  // catches the disagreement.
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([10, 20, 30, 40]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+  view[0] = 99;
+  harden(view);
+  t.throws(() => passStyleOf(view), {
+    message: /must equal underlying byte/,
+  });
+});
+
+test('byteArray rejects an emulated Uint8Array whose own indexed property matches the buffer byte', t => {
+  // On the emulated path the wrapper is a plain ordinary object with no own
+  // indexed properties; any own indexed property is post-construction
+  // tampering. The brand check rejects the wrapper even when the own
+  // property's value happens to agree with the underlying buffer byte,
+  // because an emulated wrapper must have zero own indexed properties (not
+  // one, not length-many: zero).
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([10, 20, 30, 40]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+  // Write the same value the buffer already holds at index 0.
+  view[0] = 10;
+  harden(view);
+  t.throws(() => passStyleOf(view), {
+    message: /must have either no own indexed properties.*or exactly length/,
+  });
+});
+
+test('byteArray rejects a Uint8Array on an immutable ArrayBuffer with an out-of-range own index', t => {
+  // An own data property whose key is a canonical integer but whose
+  // index is at or beyond the wrapper's `length`. This shape can arise
+  // on the emulated path through a deliberate `defineProperty` after
+  // construction; the brand check rejects it as not in `[0, length)`.
+  const ab = new ArrayBuffer(2);
+  new Uint8Array(ab).set([1, 2]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+  defineProperty(view, '2', {
+    value: 3,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
+  freeze(view);
+  t.throws(() => passStyleOf(view), {
+    message: /must be below length/,
+  });
+});
+
+test('byteArray rejects a Uint8Array on an immutable ArrayBuffer with a non-index own property', t => {
+  // An own data property whose key is not a canonical integer. The
+  // brand check rejects all such keys regardless of descriptor shape.
+  const iab = new ArrayBuffer(0).sliceToImmutable();
+  const view = new Uint8Array(iab);
+  defineProperty(view, 'extra', {
+    value: 'hello',
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  harden(view);
+  t.throws(() => passStyleOf(view), {
+    message: /must not have own non-index properties/,
+  });
+});
+
+test('byteArray rejects a Uint8Array on an immutable ArrayBuffer with a non-canonical numeric key', t => {
+  // A key like `'01'` or `'1.5'` is not a canonical integer index per
+  // `CanonicalNumericIndexString`. The brand check rejects it as a
+  // non-index own property even though `Number(key)` is finite.
+  const iab = new ArrayBuffer(4).sliceToImmutable();
+  const view = new Uint8Array(iab);
+  defineProperty(view, '01', {
+    value: 0,
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
+  freeze(view);
+  t.throws(() => passStyleOf(view), {
+    message: /must not have own non-index properties/,
+  });
+});
+
+test('byteArray rejects a Uint8Array on an immutable ArrayBuffer with an accessor own property at an integer index', t => {
+  // An accessor own property at a canonical index key is not a data
+  // property of the spec-required shape; reject it. The wrapper's
+  // shape after this `defineProperty` plus `freeze` is observable as a
+  // canonical index key with an accessor descriptor; the brand check
+  // rejects on the missing `value` slot.
+  const ab = new ArrayBuffer(2);
+  new Uint8Array(ab).set([1, 2]);
+  const iab = ab.sliceToImmutable();
+  const view = new Uint8Array(iab);
+  defineProperty(view, '0', {
+    get: () => 1,
+    enumerable: true,
+    configurable: false,
+  });
+  freeze(view);
+  t.throws(() => passStyleOf(view), {
+    message: /must be an enumerable number-valued data property/,
+  });
+});
+
+test('byteArray rejects a Uint8Array whose backing immutable ArrayBuffer carries an extraneous own property', t => {
+  // The backing-buffer sub-check reuses the immutable-ArrayBuffer arm
+  // verbatim. A buffer carrying an unallowed own data property fails
+  // the sub-check before the wrapper's own keys are walked.
+  const iab = new ArrayBuffer(2).sliceToImmutable();
+  defineProperty(iab, 'tampered', {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  const view = new Uint8Array(iab);
+  harden(view);
+  t.throws(() => passStyleOf(view), {
     message: /ByteArrays must not have own properties/,
   });
 });

--- a/packages/ses/test/immutable-arraybuffer.test.js
+++ b/packages/ses/test/immutable-arraybuffer.test.js
@@ -12,3 +12,43 @@ test('ses Immutable ArrayBuffer shim installed and hardened', t => {
   t.true(isFrozen(iabProto));
   t.true(isFrozen(iabProto.slice));
 });
+
+test('ses: emulated freezable Uint8Array is hardened and Object.isFrozen(view) === true after lockdown', t => {
+  // After lockdown(), harden() has been applied to all primordials.
+  // The emulated freezable wrapper is a plain object inheriting from
+  // Uint8Array.prototype (a frozen prototype), so Object.isFrozen(view)
+  // is true after `Object.freeze(view)` (which harden invokes transitively
+  // via the prototype-walk phase).
+  const iab = new ArrayBuffer(4).sliceToImmutable();
+  const view = new Uint8Array(iab);
+  // Object.freeze on a plain object succeeds (no integer-indexed exotic slots).
+  Object.freeze(view);
+  t.true(isFrozen(view));
+});
+
+test('ses: permits walk does not complain about %TypedArrayPrototype% slots the shim installs', t => {
+  // If lockdown() completed without throwing a permits-walk TypeError, the
+  // shim-installed slots (buffer accessor replacement, mutator-throws wrappers,
+  // read-delegate wrappers) all fit within the existing %TypedArrayPrototype%
+  // permits entry. This test asserts the post-lockdown surface is present.
+  const tp = getPrototypeOf(Uint8Array.prototype);
+  t.true('buffer' in tp);
+  t.true('byteLength' in tp);
+  t.true('copyWithin' in tp);
+  t.true('fill' in tp);
+  t.true('reverse' in tp);
+  t.true('set' in tp);
+  t.true('sort' in tp);
+});
+
+test('ses: emulated freezable view mutator methods still throw after lockdown', t => {
+  // The harden phase freezes all primordials; verify the lib's discrimination
+  // logic (brand WeakMap lookup) still works correctly after hardening.
+  const iab = new ArrayBuffer(4).sliceToImmutable();
+  const view = new Uint8Array(iab);
+  t.throws(() => view.fill(0), { instanceOf: TypeError });
+  t.throws(() => view.set([0]), { instanceOf: TypeError });
+  t.throws(() => view.reverse(), { instanceOf: TypeError });
+  t.throws(() => view.sort(), { instanceOf: TypeError });
+  t.throws(() => view.copyWithin(0, 1), { instanceOf: TypeError });
+});


### PR DESCRIPTION
Introduces passable byte arrays. Ferried from bot fork endojs/endo-but-for-bots#503, rebased onto current `master`.

The feature now spans four commits:

## 1. Freezable TypedArray emulation (`@endo/immutable-arraybuffer`)

After loading `@endo/immutable-arraybuffer/shim.js`, constructing a TypedArray from an emulated immutable `ArrayBuffer` yields an emulated freezable wrapper instead of the previous 0-byte fallback:

- Mutator methods (`copyWithin`, `fill`, `reverse`, `set`, `sort`) throw `TypeError`; the `buffer` getter returns the immutable wrapper; `Object.freeze` works on the view.
- The wrapper inherits directly from `T.prototype` with no intermediate prototype; emulation covers all eleven concrete TypedArray constructors via a single install on `%TypedArrayPrototype%`.
- Construction from a genuine mutable `ArrayBuffer` is unchanged.
- `Symbol.iterator` installed (for...of/spread); `subarray()` returns a wrapped sub-view; `BYTES_PER_ELEMENT` forwarded so post-lockdown reads are correct.

## 2. `byteArray` brand check for plain frozen `Uint8Array` (`@endo/pass-style`)

A plain frozen `Uint8Array` backed by a plain frozen immutable `ArrayBuffer` is now recognized as a passable `byteArray`, alongside the raw immutable `ArrayBuffer` shape. The plain-wrapper definition distinguishes the emulated path (zero own indexed properties) from a future native TC39 integer-indexed-exotic path (exactly `length`-many own enumerable data properties each agreeing with the backing byte), rejecting any other shape. `passStyleOf` also reports a clear `Cannot pass mutable typed arrays` diagnostic rather than the generic non-remotable error under `LOCKDOWN_HARDEN_TAMING=unsafe`.

## 3. `@endo/bytes` ponyfills tolerate the emulated wrapper (new)

A `Uint8Array` over an emulated immutable `ArrayBuffer` is a plain object that `ArrayBuffer.isView` rejects — integer indexing reads `undefined`, and `TextDecoder.decode` / `TypedArray.prototype.set` throw or silently read zeros. `bytesToText`, `bytesEqual`, and `concatBytes` now copy such an emulated wrapper to a genuine `Uint8Array` (via the wrapper's native `slice`, which memcopies from the hidden genuine TypedArray it amplifies to) before any platform call or indexing. Genuine views pass through uncopied, so the common path is unaffected.

## 4. ses permits (test)

The `ses` permits walk accepts the shim-installed `%TypedArrayPrototype%` slots with no new permit rows; covered by a regression test.

## Changesets

`@endo/immutable-arraybuffer` minor, `@endo/pass-style` minor, `ses` patch (in `freezable-typedarray-emulation.md`); `@endo/bytes` patch (in `bytes-tolerate-emulated-frozen-uint8array.md`).

## Testing

On top of current `master`: `@endo/immutable-arraybuffer` 217, `@endo/pass-style` 41, `@endo/bytes` 38, `ses` 513 — all passing; lint clean.
