### PR TITLE
chore: fix tsconfig.json files for @endo/chacha12 and @endo/random

### DIFF
--- a/packages/chacha12/tsconfig.json
+++ b/packages/chacha12/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.eslint-base.json",
   "include": [
     "*.js",
-    "*.ts",
-    "src",
-    "test"
+    "src/**/*.js",
+    "test/**/*.js"
   ]
 }

--- a/packages/random/tsconfig.json
+++ b/packages/random/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "../../tsconfig.eslint-base.json",
   "include": [
     "*.js",
-    "*.ts",
-    "src",
-    "test",
+    "src/**/*.js",
+    "test/**/*.js",
     "types.d.ts"
   ]
 }


### PR DESCRIPTION
These two `tsconfig.json` files were broadly including TS sources and they should not. This causes re-runs of composite builds (or watch mode) to fail.

* * *

If we wanted to prevent these configuration problems via CI, the command would be:

```sh
yarn build:types && yarn build:types
```

This would fail if the `include`s are too broad, since they will pick up `.d.ts` files and `tsc` will refuse to overwrite them.

The drawback is that `yarn build:types` from scratch takes ~40s on my M4 Max (the second `yarn build:types` takes about 300ms), so if we _do_ add it to CI, I recommend isolating it to its own workflow that only runs if a `**/tsconfig*.json` file was modified (or if we can do this filter via a conditional in a job step).