### PR TITLE
test(ses): isImmutableDataProperty regression for iOS Safari fix (#947)

### DIFF
--- a/packages/ses/test/scope-constants.test.js
+++ b/packages/ses/test/scope-constants.test.js
@@ -292,3 +292,35 @@ test('getScopeConstants - global object and module lexicals', t => {
     'should only return global contants not hidden by module lexicals',
   );
 });
+
+test('getScopeConstants - tolerates own name with undefined descriptor (iOS Safari quirk, #947)', t => {
+  // iOS Safari 15.0-15.2 reported `showModalDialog` in
+  // `Object.getOwnPropertyNames(window)` while
+  // `Object.getOwnPropertyDescriptor(window, 'showModalDialog')` returned
+  // `undefined`, breaking `lockdown()`. Simulate the same anomaly with a
+  // proxy global that lists `phantom` as an own name but returns no
+  // descriptor for it. `getScopeConstants` must skip the phantom name
+  // rather than crash on `undefined.configurable`.
+  // See https://bugs.webkit.org/show_bug.cgi?id=234282
+  const phantomGlobal = new Proxy(
+    Object.create(null, { real: { value: true } }),
+    {
+      ownKeys() {
+        return ['real', 'phantom'];
+      },
+      getOwnPropertyDescriptor(target, key) {
+        if (key === 'phantom') {
+          return undefined;
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    },
+  );
+
+  t.notThrows(() => getScopeConstants(phantomGlobal));
+  t.deepEqual(
+    getScopeConstants(phantomGlobal),
+    { globalObjectConstants: ['real'], moduleLexicalConstants: [] },
+    'should drop names whose descriptor is undefined',
+  );
+});


### PR DESCRIPTION
## Description

Adds a regression test pinning the iOS Safari `lockdown()` fix in `packages/ses/src/scope-constants.js`.

iOS Safari 15.0–15.2 reported `showModalDialog` in `Object.getOwnPropertyNames(window)` while `Object.getOwnPropertyDescriptor(window, 'showModalDialog')` returned `undefined`, breaking `lockdown()` with `TypeError: Cannot read properties of undefined (reading 'configurable')` thrown from `isImmutableDataProperty`. The runtime fix (a `desc &&` guard at the head of the function) is already in place; this test pins it.

The test drives the public `getScopeConstants` entry point with a `Proxy`-backed global that lists `phantom` as an own name but returns `undefined` from `getOwnPropertyDescriptor` for it, mirroring the WebKit anomaly. It asserts `getScopeConstants` does not throw and that `phantom` is dropped from `globalObjectConstants`. Reverting the `desc &&` guard makes the test fail with the original error — verified locally.

The test targets the public `getScopeConstants` rather than the unexported `isImmutableDataProperty` helper, so it stays stable across future refactors.

Test-only change; no runtime impact.

Reference: https://bugs.webkit.org/show_bug.cgi?id=234282

Ferried from the bot fork: endojs/endo-but-for-bots#182.

Closes #947
