### PR TITLE
chore(ci): add composite types build check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,15 @@ jobs:
       - name: Check composite tsconfig files are up to date
         run: yarn build:types:check
 
+      # this will fail if the "include" paths in the tsconfigs are too broad,
+      # (e.g., "*.ts"); typescript will complain about overwriting files
+      - name: Check tsconfigs are compatible with composite build
+        run: yarn build:types && yarn build:types
+
+      # types must be cleaned up after to avoid problems with the docs build below
+      - name: Cleanup types
+        run: yarn clean
+
       - name: Check package uniformity
         run: node scripts/check-package-uniformity.mjs
 


### PR DESCRIPTION
This adds a step to the `lint` job which ensures compatibility with the composite types build.

It performs this check by building the types _twice_; if the second build fails, then there is a problem with a `tsconfig.json` somewhere; likely its list of included paths is too broad (e.g., `*.ts`).  This is because TS will consider the generated `d.ts` files as includes and will refuse to overwrite them.

After this check, we must cleanup the generated types, because it materially affects the TypeDoc build (unfortunately).