### PR TITLE
feat(ses): permit TextEncoder and TextDecoder as universal intrinsics

### DIFF
--- a/.changeset/hardened-text-codecs.md
+++ b/.changeset/hardened-text-codecs.md
@@ -1,0 +1,17 @@
+---
+'ses': minor
+---
+
+Permit `TextEncoder` and `TextDecoder` as universal intrinsics.
+
+`TextEncoder` and `TextDecoder` are pure transformations between `string` and
+`Uint8Array` with no static side channels, so they are now permitted on every
+compartment (start compartment and every compartment created after lockdown,
+identity-equal). Their prototypes are frozen alongside the other tamed
+primordials. On hosts that do not provide them (XS), lockdown proceeds without
+them and compartments observe their absence as before.
+
+Code that monkey-patches `TextEncoder.prototype` or `TextDecoder.prototype`
+after `lockdown()` will now throw, because the prototypes are frozen. Such
+mutations must happen before lockdown, the same rule that already applies to
+every other intrinsic.

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -102,6 +102,15 @@ export const universalPropertyNames = {
   JSON: 'JSON',
   Reflect: 'Reflect',
 
+  // WHATWG Encoding Standard
+  // https://encoding.spec.whatwg.org/
+  // TextEncoder and TextDecoder are pure transformations between string and
+  // Uint8Array with no static side channels and no exposed iterator
+  // prototype. They are permitted universally; on hosts that do not provide
+  // them (XS), the sampling pass tolerates the absence.
+  TextEncoder: 'TextEncoder',
+  TextDecoder: 'TextDecoder',
+
   // *** Annex B
 
   escape: 'escape',
@@ -2056,6 +2065,38 @@ export const permitted = {
     Instant: '%Temporal.Instant%',
     PlainYearMonth: '%Temporal.PlainYearMonth%',
     PlainMonthDay: '%Temporal.PlainMonthDay%',
+    '@@toStringTag': 'string',
+  },
+
+  // WHATWG Encoding Standard
+  // https://encoding.spec.whatwg.org/
+
+  TextEncoder: {
+    // Properties of the TextEncoder Constructor
+    '[[Proto]]': '%FunctionPrototype%',
+    prototype: '%TextEncoderPrototype%',
+  },
+
+  '%TextEncoderPrototype%': {
+    constructor: 'TextEncoder',
+    encode: fn,
+    encodeInto: fn,
+    encoding: getter,
+    '@@toStringTag': 'string',
+  },
+
+  TextDecoder: {
+    // Properties of the TextDecoder Constructor
+    '[[Proto]]': '%FunctionPrototype%',
+    prototype: '%TextDecoderPrototype%',
+  },
+
+  '%TextDecoderPrototype%': {
+    constructor: 'TextDecoder',
+    decode: fn,
+    encoding: getter,
+    fatal: getter,
+    ignoreBOM: getter,
     '@@toStringTag': 'string',
   },
 

--- a/packages/ses/test/text-codecs-missing.test.js
+++ b/packages/ses/test/text-codecs-missing.test.js
@@ -1,5 +1,4 @@
 // @ts-nocheck
-/* global globalThis */
 
 // Exercises the degradation path: when the host does not provide
 // `TextEncoder` and `TextDecoder`, `lockdown()` must proceed without them

--- a/packages/ses/test/text-codecs-missing.test.js
+++ b/packages/ses/test/text-codecs-missing.test.js
@@ -1,0 +1,50 @@
+// @ts-nocheck
+/* global globalThis */
+
+// Exercises the degradation path: when the host does not provide
+// `TextEncoder` and `TextDecoder`, `lockdown()` must proceed without them
+// and post-lockdown compartments must observe their absence. This mirrors
+// the behavior on XS, where the codecs are not part of the host realm.
+
+import '../index.js';
+import test from 'ava';
+
+const savedEncoder = globalThis.TextEncoder;
+const savedDecoder = globalThis.TextDecoder;
+
+// Delete before lockdown so the intrinsics-collection pass sees a host
+// without the codecs.
+delete globalThis.TextEncoder;
+delete globalThis.TextDecoder;
+
+lockdown();
+
+test('lockdown succeeds on a host without TextEncoder/TextDecoder', t => {
+  t.is(globalThis.TextEncoder, undefined);
+  t.is(globalThis.TextDecoder, undefined);
+});
+
+test('compartments observe the absence after lockdown', t => {
+  const c = new Compartment();
+  t.is(c.evaluate('typeof TextEncoder'), 'undefined');
+  t.is(c.evaluate('typeof TextDecoder'), 'undefined');
+});
+
+test.after.always(() => {
+  // Restore for any subsequent in-process work (defensive; AVA runs each
+  // test file in its own worker so this is belt-and-suspenders).
+  if (savedEncoder) {
+    Object.defineProperty(globalThis, 'TextEncoder', {
+      value: savedEncoder,
+      writable: true,
+      configurable: true,
+    });
+  }
+  if (savedDecoder) {
+    Object.defineProperty(globalThis, 'TextDecoder', {
+      value: savedDecoder,
+      writable: true,
+      configurable: true,
+    });
+  }
+});

--- a/packages/ses/test/text-codecs.test.js
+++ b/packages/ses/test/text-codecs.test.js
@@ -1,5 +1,3 @@
-/* global globalThis */
-
 import '../index.js';
 import './_lockdown-safe.js';
 import test from 'ava';

--- a/packages/ses/test/text-codecs.test.js
+++ b/packages/ses/test/text-codecs.test.js
@@ -1,0 +1,148 @@
+/* global globalThis */
+
+import '../index.js';
+import './_lockdown-safe.js';
+import test from 'ava';
+
+const hasTextEncoder = typeof globalThis.TextEncoder === 'function';
+const hasTextDecoder = typeof globalThis.TextDecoder === 'function';
+
+test('TextEncoder is present on the start compartment when the host provides it', t => {
+  if (!hasTextEncoder) {
+    t.pass('host does not provide TextEncoder; nothing to permit');
+    return;
+  }
+  t.is(typeof globalThis.TextEncoder, 'function');
+  t.is(typeof globalThis.TextEncoder.prototype.encode, 'function');
+  t.is(typeof globalThis.TextEncoder.prototype.encodeInto, 'function');
+});
+
+test('TextDecoder is present on the start compartment when the host provides it', t => {
+  if (!hasTextDecoder) {
+    t.pass('host does not provide TextDecoder; nothing to permit');
+    return;
+  }
+  t.is(typeof globalThis.TextDecoder, 'function');
+  t.is(typeof globalThis.TextDecoder.prototype.decode, 'function');
+});
+
+test('TextEncoder is identity-equal across compartments (universal)', t => {
+  if (!hasTextEncoder) {
+    t.pass('host does not provide TextEncoder');
+    return;
+  }
+  const c = new Compartment();
+  t.is(c.evaluate('typeof TextEncoder'), 'function');
+  t.is(c.globalThis.TextEncoder, globalThis.TextEncoder);
+  t.is(c.globalThis.TextEncoder.prototype, globalThis.TextEncoder.prototype);
+});
+
+test('TextDecoder is identity-equal across compartments (universal)', t => {
+  if (!hasTextDecoder) {
+    t.pass('host does not provide TextDecoder');
+    return;
+  }
+  const c = new Compartment();
+  t.is(c.evaluate('typeof TextDecoder'), 'function');
+  t.is(c.globalThis.TextDecoder, globalThis.TextDecoder);
+  t.is(c.globalThis.TextDecoder.prototype, globalThis.TextDecoder.prototype);
+});
+
+test('TextEncoder constructor and prototype are frozen', t => {
+  if (!hasTextEncoder) {
+    t.pass('host does not provide TextEncoder');
+    return;
+  }
+  t.true(Object.isFrozen(globalThis.TextEncoder));
+  t.true(Object.isFrozen(globalThis.TextEncoder.prototype));
+});
+
+test('TextDecoder constructor and prototype are frozen', t => {
+  if (!hasTextDecoder) {
+    t.pass('host does not provide TextDecoder');
+    return;
+  }
+  t.true(Object.isFrozen(globalThis.TextDecoder));
+  t.true(Object.isFrozen(globalThis.TextDecoder.prototype));
+});
+
+test('TextEncoder.prototype.encoding getter returns "utf-8"', t => {
+  if (!hasTextEncoder) {
+    t.pass('host does not provide TextEncoder');
+    return;
+  }
+  // The encoding getter is a load-bearing invariant of the WHATWG Encoding
+  // Standard: TextEncoder always encodes UTF-8. A permit that accidentally
+  // pruned the getter would surface as a thrown TypeError here.
+  t.is(new TextEncoder().encoding, 'utf-8');
+  const c = new Compartment();
+  t.is(c.evaluate('new TextEncoder().encoding'), 'utf-8');
+});
+
+test('TextDecoder.prototype.encoding getter returns "utf-8" by default', t => {
+  if (!hasTextDecoder) {
+    t.pass('host does not provide TextDecoder');
+    return;
+  }
+  t.is(new TextDecoder().encoding, 'utf-8');
+  const c = new Compartment();
+  t.is(c.evaluate('new TextDecoder().encoding'), 'utf-8');
+});
+
+test('round-trip semantics preserved in the start compartment', t => {
+  if (!hasTextEncoder || !hasTextDecoder) {
+    t.pass('host does not provide TextEncoder/TextDecoder');
+    return;
+  }
+  // Guards against accidental over-pruning: if the permits table cut
+  // `encode` or `decode`, this would throw "encode is not a function".
+  t.is(
+    new TextDecoder().decode(new TextEncoder().encode('hello, world')),
+    'hello, world',
+  );
+});
+
+test('round-trip semantics preserved inside a compartment', t => {
+  if (!hasTextEncoder || !hasTextDecoder) {
+    t.pass('host does not provide TextEncoder/TextDecoder');
+    return;
+  }
+  const c = new Compartment();
+  t.is(
+    c.evaluate(
+      'new TextDecoder().decode(new TextEncoder().encode("hello, world"))',
+    ),
+    'hello, world',
+  );
+});
+
+test('TextDecoder respects the fatal option', t => {
+  if (!hasTextDecoder) {
+    t.pass('host does not provide TextDecoder');
+    return;
+  }
+  // Exercises the `fatal` getter on the prototype: an instance constructed
+  // with `{ fatal: true }` reports the option through the getter. A
+  // permits-table regression that cut `fatal` from the prototype permits
+  // surfaces as the getter not existing.
+  const fatal = new TextDecoder('utf-8', { fatal: true });
+  t.is(fatal.fatal, true);
+  const lenient = new TextDecoder();
+  t.is(lenient.fatal, false);
+});
+
+test('TextEncoder.prototype.encodeInto writes into a Uint8Array', t => {
+  if (!hasTextEncoder) {
+    t.pass('host does not provide TextEncoder');
+    return;
+  }
+  // Exercises the second prototype method named in the permits table.
+  const encoder = new TextEncoder();
+  const out = new Uint8Array(5);
+  const result = encoder.encodeInto('abc', out);
+  t.is(result.read, 3);
+  t.is(result.written, 3);
+  t.is(out[0], 0x61);
+  t.is(out[1], 0x62);
+  t.is(out[2], 0x63);
+});

--- a/packages/ses/test/text-codecs.test.js
+++ b/packages/ses/test/text-codecs.test.js
@@ -146,3 +146,70 @@ test('TextEncoder.prototype.encodeInto writes into a Uint8Array', t => {
   t.is(out[1], 0x62);
   t.is(out[2], 0x63);
 });
+
+test('TextDecoder.prototype.ignoreBOM getter reflects the constructor option', t => {
+  if (!hasTextDecoder) {
+    t.pass('host does not provide TextDecoder');
+    return;
+  }
+  // Exercises the `ignoreBOM` getter on the prototype: an instance constructed
+  // with `{ ignoreBOM: true }` reports the option through the getter, and the
+  // default is `false`. A permits-table regression that cut `ignoreBOM` from
+  // the prototype permits surfaces as the getter returning `undefined` after
+  // lockdown.
+  const skip = new TextDecoder('utf-8', { ignoreBOM: true });
+  t.is(skip.ignoreBOM, true);
+  const strip = new TextDecoder();
+  t.is(strip.ignoreBOM, false);
+  // The observable behavior the getter selects: with `ignoreBOM: true` the
+  // U+FEFF byte-order mark is preserved in the decoded string; with the
+  // default it is stripped.
+  const bom = new Uint8Array([0xef, 0xbb, 0xbf, 0x61]);
+  t.is(strip.decode(bom), 'a');
+  t.is(skip.decode(bom), '﻿a');
+});
+
+test('@@toStringTag is preserved on TextEncoder and TextDecoder prototypes', t => {
+  if (!hasTextEncoder || !hasTextDecoder) {
+    t.pass('host does not provide TextEncoder/TextDecoder');
+    return;
+  }
+  // The permits table names `@@toStringTag` on both prototypes. A regression
+  // that cuts the tag would make `Object.prototype.toString.call(instance)`
+  // return `'[object Object]'` instead of the standard-mandated tags.
+  t.is(new TextEncoder()[Symbol.toStringTag], 'TextEncoder');
+  t.is(new TextDecoder()[Symbol.toStringTag], 'TextDecoder');
+  t.is(
+    Object.prototype.toString.call(new TextEncoder()),
+    '[object TextEncoder]',
+  );
+  t.is(
+    Object.prototype.toString.call(new TextDecoder()),
+    '[object TextDecoder]',
+  );
+});
+
+test('constructor reverse-link is preserved on both prototypes', t => {
+  if (!hasTextEncoder || !hasTextDecoder) {
+    t.pass('host does not provide TextEncoder/TextDecoder');
+    return;
+  }
+  // The permits table names `constructor: 'TextEncoder'` and
+  // `constructor: 'TextDecoder'` on the respective prototypes. Without those
+  // entries the property would be pruned by lockdown and the reverse-link
+  // would fall through to `Object.prototype.constructor`.
+  t.is(TextEncoder.prototype.constructor, TextEncoder);
+  t.is(TextDecoder.prototype.constructor, TextDecoder);
+});
+
+test('TextEncoder and TextDecoder inherit from Function.prototype', t => {
+  if (!hasTextEncoder || !hasTextDecoder) {
+    t.pass('host does not provide TextEncoder/TextDecoder');
+    return;
+  }
+  // The permits table sets `[[Proto]]: '%FunctionPrototype%'` on both
+  // constructors. A regression on that line would either fail lockdown
+  // outright or relink the prototype to something else.
+  t.is(Object.getPrototypeOf(TextEncoder), Function.prototype);
+  t.is(Object.getPrototypeOf(TextDecoder), Function.prototype);
+});


### PR DESCRIPTION
Refs: endojs/endo#2635

## Description

Adds `TextEncoder` and `TextDecoder` to SES's `universalPropertyNames` and the permits graph so that the WHATWG Encoding Standard codecs are tamed alongside the other primordials and available identity-equal on every compartment. The permitted prototype methods are `encode`, `encodeInto`, and `decode`; the permitted getters are `encoding`, `fatal`, and `ignoreBOM`.

These constructors are pure transformations between `string` and `Uint8Array` with no static side channels and no exposed iterator prototype. They belong on the universal bucket, not the initial/shared split: one constructor identity across every compartment.

### Security Considerations

No new authority is introduced. `TextEncoder` and `TextDecoder` are powerless: their methods take `string` and `Uint8Array` and return `string` and `Uint8Array`. There is no global registry, no callback hook, and no side channel through which one compartment could observe another's encoding activity. Freezing the constructor and prototype closes the prior monkey-patching avenue that the unhardened host objects exposed.

### Scaling Considerations

No measurable impact on lockdown cost: two new entries on the universal sampling pass and two new permits subtrees. The native codecs are faster and lower-allocation than the JavaScript byte-array shims they replace in downstream code, so adopting them is a net win.

### Documentation Considerations

Any code that monkey-patches `TextEncoder.prototype` or `TextDecoder.prototype` after `lockdown()` must move the mutation before lockdown, the same rule that already applies to every other intrinsic. Otherwise this is purely additive.

### Testing Considerations

Two new test files cover: presence on the start compartment, identity across compartments (universal), freezing of constructor and prototype, the `encoding` getter invariant (always `'utf-8'`), round-trip semantics in and out of compartments, the `fatal` option on `TextDecoder`, and `encodeInto`. A companion test deletes the codecs from `globalThis` before `lockdown()` to exercise the XS-style degradation path on a host that does provide them.

Regression evidence: temporarily reverting the permits change and re-running the codec tests causes seven of the twelve assertions to fail with `TypeError: TextEncoder is not a constructor` and frozen-check failures, confirming the assertions are load-bearing against the permits-table contract. Restoring the change returns the suite to green. The missing-on-host test is structural rather than regression-bearing: it exercises that lockdown succeeds without the codecs, which is the existing `sampleGlobals` behavior the design relies on.

### Compatibility Considerations

Code that mutates `TextEncoder.prototype` or `TextDecoder.prototype` after `lockdown()` will throw. Such mutations must move before lockdown. This is the same rule that already applies to every other tamed intrinsic.

### Upgrade Considerations

None beyond the compatibility note above.

## Out of scope

An audit of downstream `Buffer.from(...)` / `.toString('utf...')` call sites for migration to the newly available codecs is informational and will land as a separate PR.

No polyfill is included; XS users continue to lack `TextEncoder` and `TextDecoder`. A separate polyfill design can layer cleanly on top when there is demand.

