### PR TITLE
fix(eslint-plugin)!: upgrade to latest eslint-plugin-jsdoc

### DIFF
--- a/.changeset/forty-islands-poke.md
+++ b/.changeset/forty-islands-poke.md
@@ -1,0 +1,7 @@
+---
+'@endo/eslint-plugin': major
+---
+
+Certain tags are no longer allowed by our `jsdoc/check-tag-names` rule configuration, including `@code`.
+
+The new rules `jsdoc/reject-any-type` and `jsdoc/ts-no-empty-object-type` have been disabled.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { OptionDefaults } from 'typedoc';
 import { configs as endoConfigs, hardenedGlobals } from '@endo/eslint-plugin';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';
@@ -97,6 +98,25 @@ export default defineConfig(
       'no-useless-assignment': 'off',
       'no-restricted-globals': 'off',
       '@endo/no-polymorphic-call': 'off',
+    },
+  },
+
+  // allow any tag supported by TypeDoc
+  {
+    files: ['packages/**'],
+    rules: {
+      'jsdoc/check-tag-names': [
+        'error',
+        {
+          // these tags from TypeDoc all begin with @ which the eslint plugin
+          // doesn't expect
+          definedTags: [
+            ...OptionDefaults.blockTags,
+            ...OptionDefaults.modifierTags,
+          ].map(tag => tag.slice(1)),
+          inlineTags: OptionDefaults.inlineTags.map(tag => tag.slice(1)),
+        },
+      ],
     },
   },
 

--- a/packages/compartment-mapper/src/types/policy-schema.ts
+++ b/packages/compartment-mapper/src/types/policy-schema.ts
@@ -64,7 +64,7 @@ export type PropertyPolicy = Record<string, boolean>;
  * the type `any` also makes that test succeed, so `PolicyItem<any>` used to
  * reduce to the same as `void` and
  * `PackagePolicy<any, any, any, any> = SomePackagePolicy` was not a supertype of
- * policies with extra string literals (for example, LavaMoat's {@code "root"} on
+ * policies with extra string literals (for example, LavaMoat's `root` on
  * package imports). A separate branch for a wide
  * `any` type parameter yields
  * `PolicyItem<any> = WildcardPolicy | PropertyPolicy | any` so

--- a/packages/compartment-mapper/src/types/powers.ts
+++ b/packages/compartment-mapper/src/types/powers.ts
@@ -1,7 +1,7 @@
 /**
  * The compartment mapper requires certain host capabilities.
  * These are the platform-neutral types for those capabilities.
- * For example, {@file node-powers.js} adapts Node.js how modules
+ * For example, `node-powers.js` adapts Node.js' own modules
  * to various subsets of these capabilities.
  *
  * @module

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,7 +31,7 @@
     "@typescript-eslint/utils": "^8.62.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "npm:eslint-plugin-import-x@4.16.2",
-    "eslint-plugin-jsdoc": "^50.8.0",
+    "eslint-plugin-jsdoc": "^63.0.14",
     "eslint-plugin-unicorn": "^56.0.1",
     "typescript-eslint": "^8.39.1"
   },

--- a/packages/eslint-plugin/src/configs/shared.js
+++ b/packages/eslint-plugin/src/configs/shared.js
@@ -403,9 +403,10 @@ export const styleRules = {
   'no-unused-expressions': 'off',
   'no-loop-func': 'off',
   'no-inner-declarations': 'off',
-
+  'jsdoc/ts-no-empty-object-type': 'off',
   'jsdoc/no-multi-asterisks': ['warn', { allowWhitespace: true }],
   'jsdoc/no-undefined-types': 'off',
+  'jsdoc/reject-any-type': 'off',
   'jsdoc/require-jsdoc': 'off',
   'jsdoc/require-property-description': 'off',
   'jsdoc/require-param-description': 'off',

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -1,10 +1,49 @@
-import { toStringTagSymbol, iteratorSymbol } from './commons.js';
-
 /**
- * Exports {@code enablements}, a recursively defined
- * JSON record defining the optimum set of intrinsics properties
- * that need to be "repaired" before hardening is applied on
- * enviromments subject to the override mistake.
+ * Exports `enablements`, a recursively defined JSON record defining the optimum
+ * set of intrinsics properties that need to be "repaired" before hardening is
+ * applied on enviromments subject to the override mistake.
+ *
+ * Because "repairing" replaces data properties with accessors, every time a
+ * repaired property is accessed, the associated getter is invoked, which
+ * degrades the runtime performance of all code executing in the repaired
+ * enviromment, compared to the non-repaired case. In order to maintain
+ * performance, we only repair the properties of objects for which hardening
+ * causes a breakage of their normal intended usage.
+ *
+ * There are three unwanted cases:
+ *
+ * - Overriding properties on objects typically used as records, namely `Object`
+ *   and `Array`. In the case of arrays, the situation is unintentional, a given
+ *   program might not be aware that non-numerical properties are stored on the
+ *   underlying object instance, not on the array. When an object is typically
+ *   used as a map, we repair all of its prototype properties.
+ * - Overriding properties on objects that provide defaults on their prototype
+ *   and that programs typically set using an assignment, such as
+ *   `Error.prototype.message` and `Function.prototype.name` (both default to
+ *   `""`).
+ * - Setting-up a prototype chain, where a constructor is set to extend another
+ *   one. This is typically set by assignment, for example
+ *   `Child.prototype.constructor = Child`, instead of invoking
+ *   `Object.defineProperty()`.
+ *
+ * Each JSON record enumerates the disposition of the properties on some
+ * corresponding intrinsic object.
+ *
+ * For each such record, the values associated with its property names can be:
+ *
+ * - `true`, in which case this property is simply repaired. The value associated
+ *   with that property is not traversed. For example, `Function.prototype.name`
+ *   leads to true, meaning that the `name` property of `Function.prototype`
+ *   should be repaired (which is needed when inheriting from `Function` and
+ *   setting the subclass's `prototype.name` property). If the property is
+ *   already an accessor property, it is not repaired (because accessors are not
+ *   subject to the override mistake).
+ * - `*`, in which case this property is not repaired but the value associated
+ *   with that property are traversed and repaired.
+ * - Another record, in which case this property is not repaired and that next
+ *   record represents the disposition of the object which is its value. For
+ *   example,`FunctionPrototype` leads to another record explaining which
+ *   properties `Function.prototype` need to be repaired.
  *
  * @author JF Paradis
  * @author Mark S. Miller
@@ -12,59 +51,11 @@ import { toStringTagSymbol, iteratorSymbol } from './commons.js';
  * @module
  */
 
-/**
- * <p>Because "repairing" replaces data properties with accessors, every
- * time a repaired property is accessed, the associated getter is invoked,
- * which degrades the runtime performance of all code executing in the
- * repaired enviromment, compared to the non-repaired case. In order
- * to maintain performance, we only repair the properties of objects
- * for which hardening causes a breakage of their normal intended usage.
- *
- * There are three unwanted cases:
- * <ul>
- * <li>Overriding properties on objects typically used as records,
- *     namely {@code "Object"} and {@code "Array"}. In the case of arrays,
- *     the situation is unintentional, a given program might not be aware
- *     that non-numerical properties are stored on the underlying object
- *     instance, not on the array. When an object is typically used as a
- *     map, we repair all of its prototype properties.
- * <li>Overriding properties on objects that provide defaults on their
- *     prototype and that programs typically set using an assignment, such as
- *     {@code "Error.prototype.message"} and {@code "Function.prototype.name"}
- *     (both default to "").
- * <li>Setting-up a prototype chain, where a constructor is set to extend
- *     another one. This is typically set by assignment, for example
- *     {@code "Child.prototype.constructor = Child"}, instead of invoking
- *     Object.defineProperty();
- *
- * <p>Each JSON record enumerates the disposition of the properties on
- * some corresponding intrinsic object.
- *
- * <p>For each such record, the values associated with its property
- * names can be:
- * <ul>
- * <li>true, in which case this property is simply repaired. The
- *     value associated with that property is not traversed. For
- *     example, {@code "Function.prototype.name"} leads to true,
- *     meaning that the {@code "name"} property of {@code
- *     "Function.prototype"} should be repaired (which is needed
- *     when inheriting from @code{Function} and setting the subclass's
- *     {@code "prototype.name"} property). If the property is
- *     already an accessor property, it is not repaired (because
- *     accessors are not subject to the override mistake).
- * <li>"*", in which case this property is not repaired but the
- *     value associated with that property are traversed and repaired.
- * <li>Another record, in which case this property is not repaired
- *     and that next record represents the disposition of the object
- *     which is its value. For example,{@code "FunctionPrototype"}
- *     leads to another record explaining which properties {@code
- *     Function.prototype} need to be repaired.
- */
+import { toStringTagSymbol, iteratorSymbol } from './commons.js';
 
 /**
- * Minimal enablements when all the code is modern and known not to
- * step into the override mistake, except for the following pervasive
- * cases.
+ * Minimal enablements when all the code is modern and known not to step into
+ * the override mistake, except for the following pervasive cases.
  */
 export const minEnablements = {
   '%ObjectPrototype%': {

--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -6,7 +6,7 @@ import { arrayPush, arrayForEach } from './commons.js';
 /** @import {GenericErrorConstructor} from '../types.js' */
 
 /**
- * Exports {@code permits}, a recursively defined
+ * Exports `permits`, a recursively defined
  * JSON record enumerating all intrinsics and their properties
  * according to ECMA specs.
  *
@@ -259,20 +259,20 @@ export { NativeErrors };
  *     are also considered blacklisted and are removed.
  * <li>A string value equal to a primitive ("number", "string", etc),
  *     in which case the property is permitted if its value property
- *     is typeof the given type. For example, {@code "Infinity"} leads to
- *     "number" and property values that fail {@code typeof "number"}.
+ *     is typeof the given type. For example, `Infinity` leads to
+ *     "number" and property values that fail `typeof "number`.
  *     are removed.
  * <li>A string value equal to an intinsic name ("ObjectPrototype",
  *     "Array", etc), in which case the property permitted if its
  *     value property is equal to the value of the corresponfing
- *     intrinsics. For example, {@code Map.prototype} leads to
+ *     intrinsics. For example, `Map.prototype` leads to
  *     "MapPrototype" and the property is removed if its value is
  *     not equal to %MapPrototype%
  * <li>Another record, in which case this property is simply
  *     permitted and that next record represents the disposition of
- *     the object which is its value. For example, {@code "Object"}
- *     leads to another record explaining what properties {@code
- *     "Object"} may have and how each such property should be treated.
+ *     the object which is its value. For example, `Object`
+ *     leads to another record explaining what properties
+ *     `Object` may have and how each such property should be treated.
  *
  * <p>Notes:
  * <li>"[[Proto]]" is used to refer to the "[[Prototype]]" internal

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,7 +790,7 @@ __metadata:
     eslint: "catalog:dev"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-import: "npm:eslint-plugin-import-x@4.16.2"
-    eslint-plugin-jsdoc: "npm:^50.8.0"
+    eslint-plugin-jsdoc: "npm:^63.0.14"
     eslint-plugin-unicorn: "npm:^56.0.1"
     typescript: "catalog:dev"
     typescript-eslint: "npm:^8.39.1"
@@ -1419,6 +1419,26 @@ __metadata:
     esquery: "npm:^1.6.0"
     jsdoc-type-pratt-parser: "npm:~4.1.0"
   checksum: 10c0/a5fa480066e38678e8a2cd8656fc5529f1f7ba6deef08f698e55a1b1582968e9b2d3126d9349684811bb1391370292937bc4390fb8dee1a2f36393ded8f95dab
+  languageName: node
+  linkType: hard
+
+"@es-joy/jsdoccomment@npm:~0.88.0":
+  version: 0.88.0
+  resolution: "@es-joy/jsdoccomment@npm:0.88.0"
+  dependencies:
+    "@types/estree": "npm:^1.0.9"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    comment-parser: "npm:1.4.7"
+    esquery: "npm:^1.7.0"
+    jsdoc-type-pratt-parser: "npm:~7.2.0"
+  checksum: 10c0/145c7ce6c797495dd7e2562b725175f216cd463080fe262ffd10daebec9e3803bb5009c5053a8110d56d27abb2fdf75483aa18db04ee1fe3b9d96a79c50fd57f
+  languageName: node
+  linkType: hard
+
+"@es-joy/resolve.exports@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@es-joy/resolve.exports@npm:1.2.0"
+  checksum: 10c0/7e4713471f5eccb17a925a12415a2d9e372a42376813a19f6abd9c35e8d01ab1403777265817da67c6150cffd4f558d9ad51e26a8de6911dad89d9cb7eedacd8
   languageName: node
   linkType: hard
 
@@ -2221,6 +2241,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sindresorhus/base62@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@sindresorhus/base62@npm:1.0.0"
+  checksum: 10c0/9a14df0f058fdf4731c30f0f05728a4822144ee42236030039d7fa5a1a1072c2879feba8091fd4a17c8922d1056bc07bada77c31fddc3e15836fc05a266fd918
+  languageName: node
+  linkType: hard
+
 "@sindresorhus/merge-streams@npm:^4.0.0":
   version: 4.0.0
   resolution: "@sindresorhus/merge-streams@npm:4.0.0"
@@ -2309,7 +2336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8, @types/estree@npm:^1.0.9":
   version: 1.0.9
   resolution: "@types/estree@npm:1.0.9"
   checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
@@ -2594,6 +2621,13 @@ __metadata:
   version: 8.62.1
   resolution: "@typescript-eslint/types@npm:8.62.1"
   checksum: 10c0/dfa1c9ef016c867a57d3fbef89f7968f3135d8d4621de1a8d2818258f79ed61f26fb6a3381ef27dde0a880817bfd5883f642f03a027dc127d771007022d1d880
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:^8.59.4":
+  version: 8.64.0
+  resolution: "@typescript-eslint/types@npm:8.64.0"
+  checksum: 10c0/15ab2b38febfe9d01de801ddca277187e0525ee18c47c94c0d7babe27b69d5680a8e15c7dab5fdf97a050b15c2ab51385f11bc6d6db8264f5a834fa80a83bac1
   languageName: node
   linkType: hard
 
@@ -3742,6 +3776,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comment-parser@npm:1.4.7":
+  version: 1.4.7
+  resolution: "comment-parser@npm:1.4.7"
+  checksum: 10c0/09a8e6cc4a9f92e8828bbd8819d8b025cb1bf03d8d611e372627380f55b6401bb0009cf1b7940a028794f150891bfe855185b94173eb89f14b824e847335278d
+  languageName: node
+  linkType: hard
+
 "comment-parser@npm:^1.4.1":
   version: 1.4.6
   resolution: "comment-parser@npm:1.4.6"
@@ -4420,6 +4461,30 @@ __metadata:
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
   checksum: 10c0/8829eb841666e897ddce2677e8288fcdc231bab73add93236e14f2fc7f5d494f5809ac7fc1f809c64817abe532e9a7f4a6aa2eeac303c518d4f70f22ef13642c
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jsdoc@npm:^63.0.14":
+  version: 63.0.14
+  resolution: "eslint-plugin-jsdoc@npm:63.0.14"
+  dependencies:
+    "@es-joy/jsdoccomment": "npm:~0.88.0"
+    "@es-joy/resolve.exports": "npm:1.2.0"
+    are-docs-informative: "npm:^0.0.2"
+    comment-parser: "npm:1.4.7"
+    debug: "npm:^4.4.3"
+    escape-string-regexp: "npm:^4.0.0"
+    espree: "npm:^11.2.0"
+    esquery: "npm:^1.7.0"
+    html-entities: "npm:^2.6.0"
+    object-deep-merge: "npm:^2.0.1"
+    parse-imports-exports: "npm:^0.2.4"
+    semver: "npm:^7.8.5"
+    spdx-expression-parse: "npm:^4.0.0"
+    to-valid-identifier: "npm:^1.0.0"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+  checksum: 10c0/641fd9ae45152dc5ef88c4b44ef839e202cba26bd4dc355d21966f17bfb5cbededbe2e4036916ad795ce9082ac9aba8ccbebe4c8d3b66543950a3699a95423f0
   languageName: node
   linkType: hard
 
@@ -5156,6 +5221,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-entities@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "html-entities@npm:2.6.0"
+  checksum: 10c0/7c8b15d9ea0cd00dc9279f61bab002ba6ca8a7a0f3c36ed2db3530a67a9621c017830d1d2c1c65beb9b8e3436ea663e9cf8b230472e0e413359399413b27c8b7
+  languageName: node
+  linkType: hard
+
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
@@ -5821,6 +5893,13 @@ __metadata:
   version: 4.1.0
   resolution: "jsdoc-type-pratt-parser@npm:4.1.0"
   checksum: 10c0/7700372d2e733a32f7ea0a1df9cec6752321a5345c11a91b2ab478a031a426e934f16d5c1f15c8566c7b2c10af9f27892a29c2c789039f595470e929a4aa60ea
+  languageName: node
+  linkType: hard
+
+"jsdoc-type-pratt-parser@npm:~7.2.0":
+  version: 7.2.0
+  resolution: "jsdoc-type-pratt-parser@npm:7.2.0"
+  checksum: 10c0/efe7e87583adba264234d445b47c5bfdb98c81d5c8ce8ea4c5ebcf4e249cc152cf6ecb0ec3e040a7359f391899556858fc8a22f9deb2373885cdd8ee6e221b29
   languageName: node
   linkType: hard
 
@@ -6705,6 +6784,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-deep-merge@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "object-deep-merge@npm:2.0.1"
+  checksum: 10c0/c20580c462a3579ccc49a51c04a131d956d1d22197a92ddb2ad13c6201f54351708df47225a639660c46495f5c913c52609a6bac68feb74ddc27cddfd9a0f287
+  languageName: node
+  linkType: hard
+
 "once@npm:^1.3.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
@@ -7393,6 +7479,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reserved-identifiers@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "reserved-identifiers@npm:1.2.0"
+  checksum: 10c0/b82651b12e6c608e80463c3753d275bc20fd89294d0415f04e670aeec3611ae3582ddc19e8fedd497e7d0bcbfaddab6a12823ec86e855b1e6a245e0a734eb43d
+  languageName: node
+  linkType: hard
+
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -7693,6 +7786,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/92d6871d6347e1f99d0ba396a70f2545ccf2a032cda3d378fa0699edf7506b5c6d266aed55c8b88e72bd91a30d2351e4f39db479375374430fcdc4b58f4e3c1a
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.8.5":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 
@@ -8385,6 +8487,16 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"to-valid-identifier@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "to-valid-identifier@npm:1.0.0"
+  dependencies:
+    "@sindresorhus/base62": "npm:^1.0.0"
+    reserved-identifiers: "npm:^1.0.0"
+  checksum: 10c0/569b49f43b5aaaa20677e67f0f1cdcff344855149934cfb80c793c7ac7c30e191b224bc81cab40fb57641af9ca73795c78053c164a2addc617671e2d22c13a4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### chore(ses): lint

- Replace usages of unknown/invalid inline tag `@code` with Markdown backticks
- Reformat exposition in `enablements.js` from HTML to Markdown; move exposition to `@module` documentation.

### chore(eslint): allow all valid TypeDoc tag names

This change allows all tag names known by TypeDoc to be allowed by the `jsdoc/check-tag-names` rule.

This was implemented in such a way that we will incur minimal maintenance burden, since the tags come directly from that package itself; look mom, no hardcoding.

Fixes [#3151](https://github.com/boneskull/endo/issues/3151).

> [!NOTE]
> Since the implementation depends on `typedoc`, it's not exactly suitable to stuff into `@endo/eslint-plugin`.  That said, there's a good argument for splitting this specific configuration out into its own shared config; something like `eslint-config-jsdoc-typedoc`. I'm sure there are other users of TypeDoc & `eslint-plugin-jsdoc` which have encountered this problem (and I'm sure they just disabled the `check-tag-names` rule).

### fix(eslint-plugin)!: upgrade to latest eslint-plugin-jsdoc

BREAKING CHANGES: Certain tags are no longer allowed by our `jsdoc/check-tag-names` rule configuration, including `@code`.

The new rules `jsdoc/reject-any-type` and `jsdoc/ts-no-empty-object-type` have been disabled.

This new version of the plugin adds more options for the `jsdoc/check-tag-names` rule, which we need to fix [#3151](https://github.com/boneskull/endo/issues/3151).