### PR TITLE
chore(eslint): fix import/no-extraneous-dependencies override

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,7 +39,7 @@ export default defineConfig(
       'import/no-extraneous-dependencies': [
         'error',
         {
-          devDependencies: ['packages/*/test/**', 'packages/**/*.test-d.ts'],
+          devDependencies: ['**/test/**', '**/*.test-d.ts'],
           whitelist: ['ava', 'tsd', 'typescript'],
         },
       ],


### PR DESCRIPTION
The way this rule was configured would cause the rule to work correctly when `eslint` is run from the workspace root, but not from the workspaces themselves. This would cause `import-x/no-extraneous-dependencies` to complain about _any_ dev dep (sans those in `whitelist`) present in test files, claiming they should be dependencies instead of dev dependencies.