### PR TITLE
chore: fix release process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,12 +118,10 @@ Packages without one (e.g. `ses`, which ships hand-rolled `types.d.ts`) are
 silently excluded; their types resolve through normal `package.json`
 `"types"`/`"exports"` fields as usual.
 
-**Coexistence with `prepack`:** the composite build and per-package
-`prepack` both emit `.d.ts` files alongside their `.js` sources. They share
-output locations but track build state independently. If you've run `prepack`
-for any package and then switch to the composite build (or vice versa), you
-may see TS5055 "would overwrite input file" errors caused by stale outputs.
-Run `yarn clean` to reset.
+**Stale outputs:** if you have previously run a per-package `tsc --build`
+(e.g. via a local `yarn pack`) and then run the composite build, `tsc` may
+reject the stale `.d.ts` files with TS5055 "would overwrite input file".
+Run `yarn clean` to reset before running `yarn build:types`.
 
 ## Commit conventions
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "prettier": "^3.8.3",
     "ses": "workspace:^",
     "source-map": "^0.7.6",
-    "ts-node-pack": "^0.3.5",
     "tsd": "catalog:dev",
     "type-coverage": "^2.29.7",
     "typedoc": "^0.28.19",

--- a/packages/bytes/package.json
+++ b/packages/bytes/package.json
@@ -32,8 +32,6 @@
   },
   "scripts": {
     "build": "exit 0",
-    "prepack": "git clean -fX -e node_modules/ && tsc --build tsconfig.build.json",
-    "postpack": "git clean -fX -e node_modules/",
     "cover": "c8 ses-ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/chacha12/package.json
+++ b/packages/chacha12/package.json
@@ -30,8 +30,6 @@
   },
   "scripts": {
     "build": "exit 0",
-    "prepack": "git clean -fX -e node_modules/ && tsc --build tsconfig.build.json",
-    "postpack": "git clean -fX -e node_modules/",
     "cover": "c8 ses-ava",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -33,8 +33,6 @@
   },
   "scripts": {
     "build": "exit 0",
-    "prepack": "git clean -fX -e node_modules/ && tsc --build tsconfig.build.json",
-    "postpack": "git clean -fX -e node_modules/",
     "bench": "node test/random.bench.js",
     "cover": "c8 ses-ava",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/syrup-frame/package.json
+++ b/packages/syrup-frame/package.json
@@ -30,8 +30,6 @@
   },
   "scripts": {
     "build": "exit 0",
-    "prepack": "git clean -fX -e node_modules/ && tsc --build tsconfig.build.json",
-    "postpack": "git clean -fX -e node_modules/",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",
     "lint:eslint": "eslint .",

--- a/packages/trampoline/package.json
+++ b/packages/trampoline/package.json
@@ -34,9 +34,7 @@
   "scripts": {
     "build": "exit 0",
     "build:types": "tsc --build tsconfig.build.json",
-    "prepack": "git clean -fX -e node_modules/ && yarn build:types",
     "clean:types": "git clean -fX -e node_modules/",
-    "postpack": "yarn clean:types",
     "cover": "c8 ava --config test/_ava-ses.config.js",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "eslint --fix .",

--- a/scripts/pack-all.mjs
+++ b/scripts/pack-all.mjs
@@ -1,31 +1,42 @@
 #!/usr/bin/env node
 /**
- * @file Build a publishable .tgz for every public workspace using ts-node-pack.
+ * @file Build a publishable .tgz for every public workspace.
  *
- * Yarn 4 does not support swapping the pack engine, so we drive ts-node-pack
- * directly. Each tarball is written to `dist/` at the workspace root, named
- * `<scope>-<name>-<version>.tgz`.
+ * The flow:
+ *   1. `git clean -fX -e node_modules` — wipe ignored artifacts (stale .d.ts,
+ *      coverage, etc.) so `tsc --build` can't hit TS5055 "would overwrite input
+ *      file" and so tarballs always reflect the current source tree.
+ *   2. `yarn build` — runs the real per-workspace build scripts.  Only `ses`
+ *      does substantive work (producing `dist/ses.cjs` and friends); every
+ *      other package has `build: exit 0`.
+ *   3. `yarn build:types` — composite `tsc --build tsconfig.composite.json`,
+ *      emits `.d.ts` for every workspace in dependency order.  `tsconfig.
+ *      composite.json` files are git-tracked so step 1 does not remove them.
+ *   4. `yarn workspaces foreach --all --no-private pack --out <abs distDir>/
+ *      %s-%v.tgz` — pack every public workspace.  The `--out` path must be
+ *      absolute: `foreach` changes cwd per workspace, so a relative path would
+ *      scatter tarballs into each package's own dist/.  `workspace:` specifiers are
+ *      resolved by Yarn natively; `catalog:` specifiers are not used in runtime
+ *      deps (only devDependencies), so they never appear in published tarballs.
+ *   5. Creates `dist/` dir if missing.
+ *   6. `git clean -fX -e node_modules -e /dist` — restore pristine source tree
+ *      while preserving the tarballs in the repo-root `dist/`.  The anchored
+ *      `-e /dist` leaves only the top-level `dist/` intact.
  *
- * Freshness guarantee: `dist/` is recursively removed before this script
- * writes anything. There is no incremental mode, no skip-if-newer path, no
- * way to leave a stale `.tgz` behind from a previous run. Combined with
- * `release-npm.mjs` invoking this script unconditionally before publish,
- * the published tarballs are always a function of the current source tree
- * and nothing else. (If you bypass `release:npm` and `npm publish dist/*.tgz`
- * manually after editing source without re-packing, that's on you.)
+ * Freshness guarantee: `dist/` is recursively removed before step 4, so there
+ * is no way for a previous run's stale or partial output to survive.  Combined
+ * with `release-npm.mjs` invoking this script unconditionally before publish,
+ * the published tarballs are always a function of the current source tree.
  *
  * Used by:
  *   - `yarn pack:all` (dev / CI smoke)
  *   - `yarn release:npm` (publish flow, via release-npm.mjs)
  *   - `scripts/files.sh` (file inventory)
- *   - `scripts/compare-pack.mjs` (legacy-vs-new tarball diff)
+ *   - `scripts/compare-pack.mjs` (new-vs-legacy tarball diff)
  */
-import { execFile, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { mkdirSync, readdirSync, rmSync } from 'node:fs';
 import path from 'node:path';
-import { promisify } from 'node:util';
-
-const execFileAsync = promisify(execFile);
 
 /**
  * @import {SpawnOptions} from 'node:child_process';
@@ -34,39 +45,11 @@ const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(new URL('..', import.meta.url).pathname);
 const distDir = path.join(repoRoot, 'dist');
 
-const { stdout: binStdout } = await execFileAsync(
-  'yarn',
-  ['bin', 'ts-node-pack'],
-  { cwd: repoRoot, maxBuffer: 1024 * 1024 },
-);
-const tsNodePackBin = binStdout.trim().split('\n').pop();
-if (!tsNodePackBin || !existsSync(tsNodePackBin)) {
-  throw new Error(`ts-node-pack binary not found (got "${tsNodePackBin}")`);
-}
-
-// `npm query` doesn't see Yarn 4 pnpm-linked workspaces; use Yarn directly.
-// Output is one JSON object per line (NDJSON), not a JSON array.
-const { stdout: listStdout } = await execFileAsync(
-  'yarn',
-  ['workspaces', 'list', '--json', '--no-private'],
-  { cwd: repoRoot, maxBuffer: 16 * 1024 * 1024 },
-);
-/** @type {{location: string, name: string}[]} */
-const workspaces = listStdout
-  .split('\n')
-  .filter(line => line.trim())
-  .map(line => JSON.parse(line))
-  // The root workspace shows up with location "."; skip it.
-  .filter(ws => ws.location !== '.');
-
-if (existsSync(distDir)) rmSync(distDir, { recursive: true, force: true });
-mkdirSync(distDir, { recursive: true });
-
 /**
  * Run a command, inheriting stdio; reject on non-zero exit.
  * @param {string} cmd
  * @param {string[]} argv
- * @param {SpawnOptions} options
+ * @param {SpawnOptions} [options]
  */
 const run = (cmd, argv, options) =>
   new Promise((resolve, reject) => {
@@ -77,12 +60,59 @@ const run = (cmd, argv, options) =>
     );
   });
 
-for (const ws of workspaces) {
-  const pkgDir = path.join(repoRoot, ws.location);
-  process.stderr.write(`pack-all: ${ws.name}\n`);
-  await run(process.execPath, [tsNodePackBin, pkgDir], { cwd: distDir });
-}
+console.error('pack-all: step 1 — git clean -fX');
+await run('git', ['clean', '-fX', '-e', 'node_modules'], { cwd: repoRoot });
 
-process.stderr.write(
-  `\npack-all: ${workspaces.length} tarball(s) in ${path.relative(repoRoot, distDir)}/\n`,
+console.error('pack-all: step 2 — yarn build');
+await run('yarn', ['build'], { cwd: repoRoot });
+
+console.error('pack-all: step 3 — yarn build:types');
+await run('yarn', ['build:types'], { cwd: repoRoot });
+
+// prep dist dir
+rmSync(distDir, { recursive: true, force: true });
+mkdirSync(distDir, { recursive: true });
+
+console.error('pack-all: step 4 — yarn workspaces foreach pack');
+// The --out path MUST be absolute: foreach changes cwd per workspace, so a
+// relative path would drop tarballs into packages/*/dist/ instead of root
+// dist/.
+//
+// NOTE: Yarn's special template variable `%s` is the package name _verbatim_,
+// so any package with an `@endo` scope will be named e.g.,
+// `@endo-<name>-<version>.tgz`. This diverges from npm's behavior, which is to
+// omit the leading `@`.
+const outTemplate = path.join(distDir, '%s-%v.tgz');
+await run(
+  'yarn',
+  [
+    'workspaces',
+    'foreach',
+    '--all',
+    '--no-private',
+    'pack',
+    '--out',
+    outTemplate,
+  ],
+  { cwd: repoRoot },
+);
+
+const tarballs = readdirSync(distDir)
+  .filter(name => name.endsWith('.tgz'))
+  .sort();
+
+console.error('pack-all: step 6 — git clean -fX (preserving dist/)');
+await run('git', ['clean', '-fX', '-e', 'node_modules', '-e', '/dist'], {
+  cwd: repoRoot,
+});
+
+// ── Done ─────────────────────────────────────────────────────────────────────
+
+for (const name of tarballs) {
+  console.error(
+    `pack-all: wrote ${path.relative(process.cwd(), path.join(distDir, name))}`,
+  );
+}
+console.error(
+  `\npack-all: wrote ${tarballs.length} tarball(s) in ${path.relative(repoRoot, distDir)}/`,
 );

--- a/scripts/release-npm.mjs
+++ b/scripts/release-npm.mjs
@@ -1,22 +1,32 @@
 #!/usr/bin/env node
+
 /**
  * @file Publish all public workspace tarballs to npm.
  *
  * Replaces the previous `lerna publish from-package` flow. Lerna's from-package
  * mode invokes `npm publish` per workspace dir, which would ship raw `.ts`
- * sources unless we re-introduce a prepack hook. Instead we pre-build tarballs
- * with `ts-node-pack` (via pack-all.mjs) and `npm publish` each one, which is
- * the same model npm itself recommends.
+ * sources and miss generated declarations. Instead we pre-build tarballs with
+ * `yarn pack` (after a composite `tsc --build` for declarations) via
+ * `pack-all.mjs`, then `npm publish` each one.
+ *
+ * `pack-all.mjs` temporarily mutates the working tree (emits `.d.ts`, builds
+ * `ses/dist/`) and then restores it via `git clean` after packing. The
+ * `dist/` directory at the repo root is the only artifact that survives.
  *
  * Tagging and version bumps are handled by Changesets. The script honors the
  * standard `NPM_CONFIG_TAG` / `npm_config_tag` env var; pass `--tag <dist-tag>`
  * to override on the command line.
+ *
+ * Pass `--dry-run` to forward `--dry-run` to every `npm publish`, exercising
+ * the whole flow (install, pack, count check, registry lookups) without
+ * uploading anything. Already-published versions are still skipped, so a dry
+ * run reports exactly the set of tarballs a real run would upload.
  */
 import { execFile, spawn } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
+import { parseArgs, promisify } from 'node:util';
 
 /**
  * @import {SpawnOptions} from 'node:child_process';
@@ -28,9 +38,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const distDir = path.join(repoRoot, 'dist');
 
-const tagFlag = process.argv.indexOf('--tag');
-const tag =
-  tagFlag >= 0 ? process.argv[tagFlag + 1] : process.env.npm_config_tag;
+const { values } = parseArgs({
+  options: {
+    tag: { type: 'string' },
+    'dry-run': { type: 'boolean', default: false },
+  },
+});
+
+const tag = values.tag ?? process.env.npm_config_tag;
+const dryRun = values['dry-run'];
 
 /**
  * Read `name` and `version` from the package.json inside a published tarball.
@@ -91,13 +107,11 @@ const run = (cmd, argv, options) =>
     );
   });
 
-// Always re-pack so the tarballs match HEAD. pack-all.mjs wipes dist/ at
-// the start of every run, so there is no way for a previous run's stale
-// or partial output to reach `npm publish`. This is structurally
-// equivalent to the old `prepack`/`postpack` lifecycle's invariant that
-// every publish recompiled from source, except that here the source tree
-// is never mutated and failures leave no residue.
-console.error('release:npm: building tarballs via ts-node-pack');
+// Ensure the workspace is up to date before packing.
+console.error('release-npm: yarn install --immutable');
+await run('yarn', ['install', '--immutable'], { cwd: repoRoot });
+
+console.error('release-npm: building tarballs');
 await run(process.execPath, [path.join(__dirname, 'pack-all.mjs')], {
   cwd: repoRoot,
 });
@@ -111,7 +125,7 @@ const tarballs = readdirSync(distDir)
   .sort();
 
 if (tarballs.length === 0) {
-  throw new Error('release:npm: no tarballs to publish');
+  throw new Error('release-npm: no tarballs to publish');
 }
 
 // Sanity check: one tarball per public workspace, no more and no less.
@@ -130,36 +144,45 @@ const expectedPackages = wsStdout
   .filter(ws => ws.location !== '.');
 if (tarballs.length !== expectedPackages.length) {
   throw new Error(
-    `release:npm: tarball count mismatch — expected ${expectedPackages.length} ` +
+    `release-npm: tarball count mismatch — expected ${expectedPackages.length} ` +
       `public workspace(s), found ${tarballs.length} tarball(s) in ${path.relative(repoRoot, distDir)}/. ` +
       `Refusing to publish a partial release.`,
   );
 }
 
 console.error(
-  `release:npm: publishing ${tarballs.length} tarball(s)${tag ? ` with --tag ${tag}` : ''}`,
+  `release-npm: publishing ${tarballs.length} tarball(s)${tag ? ` with --tag ${tag}` : ''}${dryRun ? ' (dry run)' : ''}`,
 );
 let publishedCount = 0;
 let skippedCount = 0;
-for (const tgz of tarballs) {
+
+const publishableTarballs = /** @type {[string, boolean][]} */ (
+  await Promise.all(
+    tarballs.map(async tgz => {
+      const { name, version } = await readTarballManifest(tgz);
+      if (await isPublished(name, version)) {
+        console.error(`  skip ${name}@${version} (already published)`);
+        skippedCount += 1;
+        return [tgz, false];
+      }
+      return [tgz, true];
+    }),
+  )
+)
+  .filter(([_, isPublished]) => !!isPublished)
+  .map(([tgz]) => tgz);
+
+for (const tgz of publishableTarballs) {
   const rel = path.relative(repoRoot, tgz);
-  const { name, version } = await readTarballManifest(tgz);
-  // Idempotency: never attempt to publish a version that is already on the
-  // registry. This lets `release:npm` be re-run safely after a partial
-  // failure — already-published packages are skipped, the rest go out.
-  if (await isPublished(name, version)) {
-    console.error(`  skip ${name}@${version} (already published)`);
-    skippedCount += 1;
-    continue;
-  }
-  console.error(`  npm publish ${rel}`);
+  console.error(`  npm publish ${rel}${dryRun ? ' --dry-run' : ''}`);
   const argv = ['publish'];
   if (tag) argv.push('--tag', tag);
+  if (dryRun) argv.push('--dry-run');
   argv.push(tgz);
   await run('npm', argv, { cwd: repoRoot });
   publishedCount += 1;
 }
 
 console.error(
-  `release:npm: done (${publishedCount} published, ${skippedCount} skipped)`,
+  `release-npm: done (${publishedCount} ${dryRun ? 'would be published' : 'published'}, ${skippedCount} skipped)`,
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,48 +1947,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pnpm/catalogs.config@npm:^1100.0.0":
-  version: 1100.0.0
-  resolution: "@pnpm/catalogs.config@npm:1100.0.0"
-  dependencies:
-    "@pnpm/error": "npm:1100.0.0"
-  checksum: 10c0/638c7fcf1a0e9144dee2ab7b4f8c1727e8fce258f2b0143fe4a22399bb2a61f229673800dc4501e2942cce5f6f78a7d9445c1882c5341e7b6eb4653da6712fd4
-  languageName: node
-  linkType: hard
-
-"@pnpm/catalogs.protocol-parser@npm:^1100.0.0":
-  version: 1100.0.0
-  resolution: "@pnpm/catalogs.protocol-parser@npm:1100.0.0"
-  checksum: 10c0/556b3386202df398b1191cb61698b14235142e9388b44a87ed48e535657868612e3310af12cdd31e7f738051a046ba2e6ce044403ac4b8c97a9d6280d2eef825
-  languageName: node
-  linkType: hard
-
-"@pnpm/catalogs.resolver@npm:^1100.0.0":
-  version: 1100.0.0
-  resolution: "@pnpm/catalogs.resolver@npm:1100.0.0"
-  dependencies:
-    "@pnpm/catalogs.protocol-parser": "npm:^1100.0.0"
-    "@pnpm/error": "npm:^1100.0.0"
-  checksum: 10c0/df4b33de640558b895470306ee95eec3b77e09c48c37a47f04417a2b63f943f2e00c7b7e705ea84dcf2aef10d7542e35211319d23f331080559299e0624e3361
-  languageName: node
-  linkType: hard
-
-"@pnpm/constants@npm:1100.0.0":
-  version: 1100.0.0
-  resolution: "@pnpm/constants@npm:1100.0.0"
-  checksum: 10c0/38d03aacfc5f55abc1331e09b84f2f1d0c8f0dd097f3e6624594769922374e970fc1728dc6e001c8abf0215ac4e9cfd5b4ab3ac0ff96abd161482ef48988f959
-  languageName: node
-  linkType: hard
-
-"@pnpm/error@npm:1100.0.0, @pnpm/error@npm:^1100.0.0":
-  version: 1100.0.0
-  resolution: "@pnpm/error@npm:1100.0.0"
-  dependencies:
-    "@pnpm/constants": "npm:1100.0.0"
-  checksum: 10c0/5a0518a0ca59f322522ab67848bc56e7c9a81fa65060b01b5af972f5d236d4f1c335081cbc604b01b7ce99588bff1b8c0a8405220ddba3f12940cff3c0f46ec5
-  languageName: node
-  linkType: hard
-
 "@rollup/plugin-commonjs@npm:^28.0.2":
   version: 28.0.6
   resolution: "@rollup/plugin-commonjs@npm:28.0.6"
@@ -2984,13 +2942,6 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/67966499dd272ecde1c2e467084411132891523d057487587879d39ac04207f4351b7b2324c83198013967fbfa632c1612adc960114a30770fbe07a0773b32c2
-  languageName: node
-  linkType: hard
-
-"amaro@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "amaro@npm:0.3.2"
-  checksum: 10c0/9ab88d11e14aebcc2926a95d2574fe4de47543c3301100cbafa9fce2977d2cb23bf1983b85d46a11d88f23dfa643cd301532400526fe7cec1e46efa8f3bc3c8e
   languageName: node
   linkType: hard
 
@@ -5325,15 +5276,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore-walk@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "ignore-walk@npm:8.0.0"
-  dependencies:
-    minimatch: "npm:^10.0.3"
-  checksum: 10c0/fec71d904adaaf233f2f5a67cc547857d960abe1f41a8b43f675617a322aabe9401fb9afa13aba825d21d91c454d5cad72ecba156e69443f3df40288d6ebd058
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^5.0.5, ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
@@ -6336,7 +6278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:6 || 7 || 8 || 9 || 10, minimatch@npm:^10.0.3, minimatch@npm:^10.2.2, minimatch@npm:^10.2.4, minimatch@npm:^10.2.5, minimatch@npm:^9.0.3 || ^10.1.2":
+"minimatch@npm:6 || 7 || 8 || 9 || 10, minimatch@npm:^10.2.2, minimatch@npm:^10.2.4, minimatch@npm:^10.2.5, minimatch@npm:^9.0.3 || ^10.1.2":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -6718,16 +6660,6 @@ __metadata:
     semver: "npm:^7.3.5"
     validate-npm-package-name: "npm:^7.0.0"
   checksum: 10c0/bf4ecdbfac876250f17710c6d0fac014bb345555acc80ce3b9e685d828107f3682378a9c413278c2fe4e958f4aad261677769be9a2b7c3965ab219b5bb852197
-  languageName: node
-  linkType: hard
-
-"npm-packlist@npm:^10.0.4":
-  version: 10.0.4
-  resolution: "npm-packlist@npm:10.0.4"
-  dependencies:
-    ignore-walk: "npm:^8.0.0"
-    proc-log: "npm:^6.0.0"
-  checksum: 10c0/500ec00ed5edc3f7136255a8c17dfd36fb718182af61a86a68768aa3b325f69739953fe8888fa8e4765db00e7892a9d0a30093b145d091b23e96b7d1bbf1187e
   languageName: node
   linkType: hard
 
@@ -7694,7 +7626,6 @@ __metadata:
     prettier: "npm:^3.8.3"
     ses: "workspace:^"
     source-map: "npm:^0.7.6"
-    ts-node-pack: "npm:^0.3.5"
     tsd: "catalog:dev"
     type-coverage: "npm:^2.29.7"
     typedoc: "npm:^0.28.19"
@@ -8521,21 +8452,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/767849383c114e7f1971fa976b20e73ac28fd0c70d8d65c0004790bf4d8f89888c7e4cf6d5949f9c1beae9bc3c64835bef77bbe27fddf45a3c7b60cebcf85c8c
-  languageName: node
-  linkType: hard
-
-"ts-node-pack@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "ts-node-pack@npm:0.3.5"
-  dependencies:
-    "@pnpm/catalogs.config": "npm:^1100.0.0"
-    "@pnpm/catalogs.resolver": "npm:^1100.0.0"
-    amaro: "npm:^0.3.2"
-    npm-packlist: "npm:^10.0.4"
-    yaml: "npm:^2.9.0"
-  bin:
-    ts-node-pack: src/cli.js
-  checksum: 10c0/aa42da5710ca241924465de0d95f2c5843872b34099f91b67c00c467e2162b0dc01e3edbab240873832c43e1ccaa4b1ae6597c9b27fcfe496f5b64447959f735
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**WARNING**: This likely has negative implications for landing #3137 as-is.

The last release caused `@endo/evasive-transform` (and perhaps others!) to publish without type declarations due to behavior of `ts-node-pack`.  My intent with this PR is expediently fix the release process and offers no opinions about an idealized future process.

This refactors the `pack-all` script in the following ways:

- Drops `ts-node-pack`
- Uses the composite TS build to build all packages in one shot

Additionally, this refactors the `release-npm` script in the following ways:

- Adds a `--dry-run` flag which is passed into `npm publish` (note that all other operations, including `git clean` and `yarn pack` still occur)
- Runs some work in parallel
- Uses `util.parseArgs`, `console.error`

