### PR TITLE
fix(ses): fix Node.js-specific permits

### DIFF
--- a/packages/ses/src/permits.js
+++ b/packages/ses/src/permits.js
@@ -2083,6 +2083,9 @@ export const permitted = {
     encodeInto: fn,
     encoding: getter,
     '@@toStringTag': 'string',
+
+    // Non-standard property used by Node.js
+    'RegisteredSymbol(nodejs.util.inspect.custom)': false,
   },
 
   TextDecoder: {
@@ -2098,6 +2101,9 @@ export const permitted = {
     fatal: getter,
     ignoreBOM: getter,
     '@@toStringTag': 'string',
+
+    // Non-standard property used by Node.js
+    'RegisteredSymbol(nodejs.util.inspect.custom)': false,
   },
 
   // Appendix B


### PR DESCRIPTION
Node.js adds a `Symbol(nodejs.util.inspect.custom)` method to `TextEncoder.prototype` and `TextDecoder.prototype`.

This currently causes SES warnings since #3322:

```
  Removing intrinsics.%TextEncoderPrototype%.RegisteredSymbol(nodejs.util.inspect.custom)
  Removing intrinsics.%TextDecoderPrototype%.RegisteredSymbol(nodejs.util.inspect.custom)
```

Out of an abundance of caution, I have disabled these methods. **However,** they seem fairly harmless to me; the implementation looks like this: 

https://github.com/nodejs/node/blob/9caf674ea72bde60e1d470ac0fab00ac2cdcb1d1/lib/internal/encoding.js#L372-L382

If it is not harmful to enable them, then I would prefer to do that.