### PR TITLE
fix(pass-style): bump version for dist-tag

### DIFF
--- a/.changeset/khaki-windows-lay.md
+++ b/.changeset/khaki-windows-lay.md
@@ -1,0 +1,5 @@
+---
+'@endo/pass-style': patch
+---
+
+Version bump for `latest` dist-tag only. This is the same version as v1.8.2.

--- a/packages/pass-style/package.json
+++ b/packages/pass-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endo/pass-style",
-  "version": "1.8.2",
+  "version": "2.0.0",
   "description": "Defines the taxonomy of Passable objects.",
   "keywords": [],
   "author": "Endo contributors",


### PR DESCRIPTION
This bumps the version of `@endo/pass-style` to v2.0.0, which will be released next as v2.0.1. It is the same version as v1.8.2.

v2.0.0 was erroneously published previously without an update to `package.json`, so we are unable to assign the `latest` dist-tag to the actual latest version of the package until that latest version is semantically the "newest" version, due to npm registry policy.