### PR TITLE
fix(evasive-transform): bump version for release

### DIFF
--- a/.changeset/young-candles-call.md
+++ b/.changeset/young-candles-call.md
@@ -1,0 +1,5 @@
+---
+'@endo/evasive-transform': patch
+---
+
+Bump for release only.


### PR DESCRIPTION
Because v2.3.0 was published incorrectly, we need to issue a patch to publish a new version.