### PR TITLE
@endo/ses-ava: ava is now a peer dep

### DIFF
--- a/.changeset/funny-boats-accept.md
+++ b/.changeset/funny-boats-accept.md
@@ -1,0 +1,5 @@
+---
+'@endo/ses-ava': major
+---
+
+`ava` is now a peer dependency of `@endo/ses-ava` instead of a direct dependency.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -55,8 +55,6 @@ const config: KnipConfig = {
         // consider any .test-d.ts file to be a tsd test including in src dirs
         entry: ['**/*.test-d.ts'],
       },
-      // ses-ava invokes ava, but knip cannot detect this
-      ignoreDependencies: ['ava'],
     },
     'packages/cli': {
       ignoreBinaries: ['tail'],

--- a/packages/env-options/package.json
+++ b/packages/env-options/package.json
@@ -31,7 +31,6 @@
     "test": "exit 0"
   },
   "devDependencies": {
-    "ava": "catalog:dev",
     "eslint": "catalog:dev",
     "typescript": "catalog:dev"
   },

--- a/packages/ses-ava/package.json
+++ b/packages/ses-ava/package.json
@@ -44,14 +44,17 @@
     "@endo/env-options": "workspace:^",
     "@endo/harden": "workspace:^",
     "@endo/init": "workspace:^",
-    "ava": "^6 || ^7 || ^8",
     "ses": "workspace:^"
   },
   "devDependencies": {
     "@endo/panic": "workspace:^",
+    "ava": "catalog:dev",
     "c8": "catalog:dev",
     "eslint": "catalog:dev",
     "typescript": "catalog:dev"
+  },
+  "peerDependencies": {
+    "ava": "^6 || ^7 || ^8"
   },
   "files": [
     "./*.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,11 +1276,13 @@ __metadata:
     "@endo/harden": "workspace:^"
     "@endo/init": "workspace:^"
     "@endo/panic": "workspace:^"
-    ava: "npm:^6 || ^7 || ^8"
+    ava: "catalog:dev"
     c8: "catalog:dev"
     eslint: "catalog:dev"
     ses: "workspace:^"
     typescript: "catalog:dev"
+  peerDependencies:
+    ava: ^6 || ^7 || ^8
   bin:
     ses-ava: bin/ses-ava.cjs
   languageName: unknown
@@ -3403,7 +3405,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ava@npm:^6 || ^7 || ^8, ava@npm:^8.0.1":
+"ava@npm:^8.0.1":
   version: 8.0.1
   resolution: "ava@npm:8.0.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,7 +767,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@endo/env-options@workspace:packages/env-options"
   dependencies:
-    ava: "catalog:dev"
     eslint: "catalog:dev"
     typescript: "catalog:dev"
   languageName: unknown


### PR DESCRIPTION
`ava` should be a peer dependency of `@endo/ses-ava` instead of a direct dependency. This is a breaking change.