### PR TITLE
fix(compartment-mapper): exports cannot rewrite internal specifiers

### DIFF
--- a/.changeset/tame-eels-bet.md
+++ b/.changeset/tame-eels-bet.md
@@ -1,0 +1,5 @@
+---
+'@endo/compartment-mapper': patch
+---
+
+Fixed an issue where certain combinations of conditions and subpath exports could result in the wrong module being loaded.

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -974,11 +974,32 @@ const translateGraph = (
       label,
       sourceDirname,
       internalAliases,
-      patterns,
+      patterns: inferredPatterns,
       parsers,
       types,
       packageDescriptor,
     } = graph[dependeeLocation];
+
+    // Patterns installed on this compartment.
+    //
+    // A package's own "exports" patterns are keyed by the subpath an *importer*
+    // asks for, so they must never be installed verbatim: "./cjs/*" means
+    // "pkg/cjs/*" to the outside world, and Node never re-resolves a package's
+    // own internal specifiers through "exports". Installed as-is, they hijack
+    // those specifiers, either loading the wrong module in silence; or, when the
+    // pattern matches its own output as "./cjs/*" -> "./cjs/*.cjs" does,
+    // appending another suffix on every pass until an OOM exception. Fun!
+    //
+    // Export patterns still reach this compartment name-prefixed, via
+    // `digestExternalAliases` below: reflexively so the package can reference
+    // itself by name, and onto each dependee so it can reference this one.
+    //
+    // Only "imports" patterns, which are keyed by "#" and are internal by
+    // definition, belong to the package's own compartment as inferred.
+    const patterns = inferredPatterns.filter(({ from }) =>
+      from.startsWith('#'),
+    );
+
     /** @type {Record<string, CompartmentModuleConfiguration>} */
     const moduleDescriptors = create(null);
     /** @type {Record<string, ScopeDescriptor<PackageCompartmentDescriptorName>>} */

--- a/packages/compartment-mapper/test/_subpath-patterns-assertions.js
+++ b/packages/compartment-mapper/test/_subpath-patterns-assertions.js
@@ -1,9 +1,12 @@
 /**
  * Shared assertion logic for subpath pattern tests.
  *
- * Both the Node.js parity tests and the Compartment Mapper (Endo) tests
- * import from this module so that the expected values are defined in exactly
- * one place. If both test suites pass, parity is verified by construction.
+ * Both the Node.js parity tests and the Compartment Mapper (Endo) tests import
+ * from this module so that the expected values are defined in exactly one
+ * place. If both test suites pass, parity is verified by construction.
+ *
+ * A shallow clone is taken of the namespace because the result is a `Module`
+ * object, which would not otherwise satisfy AVA's `deepEqual` assertion.
  *
  * @module
  */
@@ -41,11 +44,21 @@ export const expectedImportsEdgeCasesDev = {
 };
 
 /**
+ * A package's own `exports` patterns are keyed by the subpath an importer asks
+ * for, so they apply to `own-export-patterns-lib/feature/helper.js` but never
+ * to the library's own `./feature/helper.js`.
+ */
+export const expectedOwnExportPatterns = {
+  internal: 'internal-relative',
+  external: 'external-subpath',
+};
+
+/**
  * @param {ExecutionContext} t
  * @param {object} namespace
  */
 export const assertMain = (t, namespace) => {
-  t.like(namespace, expectedMain);
+  t.deepEqual({ ...namespace }, expectedMain);
 };
 
 /**
@@ -53,7 +66,7 @@ export const assertMain = (t, namespace) => {
  * @param {object} namespace
  */
 export const assertConditionalBlue = (t, namespace) => {
-  t.like(namespace, expectedConditionalBlue);
+  t.deepEqual({ ...namespace }, expectedConditionalBlue);
 };
 
 /**
@@ -61,7 +74,7 @@ export const assertConditionalBlue = (t, namespace) => {
  * @param {object} namespace
  */
 export const assertConditionalDefault = (t, namespace) => {
-  t.like(namespace, expectedConditionalDefault);
+  t.deepEqual({ ...namespace }, expectedConditionalDefault);
 };
 
 /**
@@ -69,7 +82,7 @@ export const assertConditionalDefault = (t, namespace) => {
  * @param {object} namespace
  */
 export const assertPrecedence = (t, namespace) => {
-  t.like(namespace, expectedPrecedence);
+  t.deepEqual({ ...namespace }, expectedPrecedence);
 };
 
 /**
@@ -77,7 +90,7 @@ export const assertPrecedence = (t, namespace) => {
  * @param {object} namespace
  */
 export const assertImportsEdgeCasesDefault = (t, namespace) => {
-  t.like(namespace, expectedImportsEdgeCasesDefault);
+  t.deepEqual({ ...namespace }, expectedImportsEdgeCasesDefault);
 };
 
 /**
@@ -85,5 +98,13 @@ export const assertImportsEdgeCasesDefault = (t, namespace) => {
  * @param {object} namespace
  */
 export const assertImportsEdgeCasesDev = (t, namespace) => {
-  t.like(namespace, expectedImportsEdgeCasesDev);
+  t.deepEqual({ ...namespace }, expectedImportsEdgeCasesDev);
+};
+
+/**
+ * @param {ExecutionContext} t
+ * @param {object} namespace
+ */
+export const assertOwnExportPatterns = (t, namespace) => {
+  t.deepEqual({ ...namespace }, expectedOwnExportPatterns);
 };

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-app-cjs/main.js
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-app-cjs/main.js
@@ -1,0 +1,3 @@
+const { main } = require('exports-edge-cases-lib');
+
+module.exports = { main };

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-app-cjs/package.json
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-app-cjs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "exports-edge-cases-app-cjs",
+  "version": "1.0.0",
+  "dependencies": {
+    "exports-edge-cases-lib": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-lib/README.md
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-lib/README.md
@@ -1,0 +1,9 @@
+# exports-edge-cases-lib
+
+This fixture exercises some edge cases in the `exports` field of a `package.json` file.
+
+Regarding recursive matching:
+
+- The ordering of conditions within the `.` export is important. Because `mapNodeModules` _always_ uses the `import` condition, and we need to exercise the `require` condition, the `require` condition **must** be listed first.
+- The `./cjs/*` export exercises the potential for recursive matching. It _only_ triggers if the last character of the key is a wildcard (`*`); in other words, `./cjs/*.cjs` would be insufficient to test the edge case.
+- This particular fixture is a practical example mimicking a real-world scenario. See the `own-export-patterns-lib` fixture, which exercises the root cause of the recursive matching bug.

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-lib/cjs/main.cjs
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-lib/cjs/main.cjs
@@ -1,0 +1,1 @@
+module.exports  = {main: 'exports-edge-cases-main-cjs'};

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-lib/package.json
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/exports-edge-cases-lib/package.json
@@ -3,11 +3,15 @@
   "version": "1.0.0",
   "type": "module",
   "exports": {
-    ".": "./src/main.js",
+    ".": {
+      "require": "./cjs/main.cjs",
+      "import": "./src/main.js"
+    },
     "./": "./src/slash-target.js",
     "./nested": {
       "import": "./src/nested-esm.js"
-    }
+    },
+    "./cjs/*": "./cjs/*.cjs"
   },
   "scripts": {
     "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-app/main.js
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-app/main.js
@@ -1,0 +1,4 @@
+import { origin as internal } from 'own-export-patterns-lib';
+import { origin as external } from 'own-export-patterns-lib/feature/helper.js';
+
+export { internal, external };

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-app/package.json
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "own-export-patterns-app",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "own-export-patterns-lib": "^1.0.0"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/README.md
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/README.md
@@ -1,0 +1,11 @@
+# own-export-patterns-lib
+
+This fixture asserts that a package's own `exports` patterns do not apply to the package's own internal relative specifiers.
+
+The `"./feature/*.js"` export is keyed by the subpath an *importer* asks for, so it means `own-export-patterns-lib/feature/*.js` to the outside world. Node never re-resolves a package's internal relative specifiers through `exports`, so `./main.js` importing `./feature/helper.js` must reach `feature/helper.js` on disk.
+
+Of note:
+
+- The pattern target lives under a *different* directory than the pattern key, so the rewrite terminates: `./dist/feature-helper.js` does not match  `./feature/*.js` in turn. Contrast `exports-edge-cases-lib`, whose pattern matches its own output and so recurses until memory runs out. Here the hijack is silent, which is the more dangerous of the two failures.
+- `dist/feature-helper.js` exists and exports a distinguishable value, so the test detects the hijack as a wrong module rather than a missing file.
+- The app imports the library both ways, so the test also pins the behavior that must be preserved: the `feature/helper.js` *subpath* still resolves through the pattern.

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/feature/helper.js
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/feature/helper.js
@@ -1,0 +1,1 @@
+export const origin = 'internal-relative';

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/lib/feature-helper.js
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/lib/feature-helper.js
@@ -1,0 +1,3 @@
+// Reachable only as own-export-patterns-lib/feature/helper.js, via the
+// "./feature/*.js" export pattern.
+export const origin = 'external-subpath';

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/main.js
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/main.js
@@ -1,0 +1,3 @@
+// Node resolves this against the location of this module, never through the
+// package's own "exports" patterns, so it must reach ./feature/helper.js.
+export { origin } from './feature/helper.js';

--- a/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/package.json
+++ b/packages/compartment-mapper/test/fixtures-package-imports-exports/node_modules/own-export-patterns-lib/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "own-export-patterns-lib",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./main.js",
+    "./feature/*.js": "./lib/feature-*.js"
+  },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL TEST FIXTURES; exit -1"
+  }
+}

--- a/packages/compartment-mapper/test/subpath-patterns-node-parity.test.js
+++ b/packages/compartment-mapper/test/subpath-patterns-node-parity.test.js
@@ -12,6 +12,7 @@ import {
   assertConditionalDefault,
   assertPrecedence,
   assertImportsEdgeCasesDefault,
+  assertOwnExportPatterns,
 } from './_subpath-patterns-assertions.js';
 
 const fixtureBase = new URL(
@@ -161,6 +162,16 @@ test('absolute path in subpath pattern is rejected by Node.js', async t => {
       code: 'ERR_INVALID_PACKAGE_TARGET',
     },
   );
+});
+
+test("Node does not apply a package's own export patterns to its internal specifiers", async t => {
+  const ns = await import(
+    new URL(
+      'fixtures-package-imports-exports/node_modules/own-export-patterns-app/main.js',
+      import.meta.url,
+    ).href
+  );
+  assertOwnExportPatterns(t, ns);
 });
 
 test('Node prefers the longer full pattern key on equal prefix length', async t => {

--- a/packages/compartment-mapper/test/subpath-patterns.test.js
+++ b/packages/compartment-mapper/test/subpath-patterns.test.js
@@ -21,6 +21,7 @@ import {
   assertConditionalDefault,
   assertPrecedence,
   assertImportsEdgeCasesDev,
+  assertOwnExportPatterns,
 } from './_subpath-patterns-assertions.js';
 
 const fixture = new URL(
@@ -169,6 +170,35 @@ test('exports edge cases: ./ key skipped, nested subpath with name != "."', asyn
   );
   t.is(namespace.main, 'exports-edge-cases-main');
   t.is(namespace.nested, 'nested-esm');
+});
+
+test('exports edge cases: avoid recursive matching', async t => {
+  const exportsEdgeCasesFixture = new URL(
+    'fixtures-package-imports-exports/node_modules/exports-edge-cases-app-cjs/main.js',
+    import.meta.url,
+  ).toString();
+  const { namespace } = await importLocation(
+    readPowers,
+    exportsEdgeCasesFixture,
+    {
+      conditions: new Set(['require']),
+    },
+  );
+  t.is(namespace.main, 'exports-edge-cases-main-cjs');
+});
+
+test("exports edge cases: a package's own export patterns cannot rewrite its internal specifiers", async t => {
+  // Unlike `exports-edge-cases-lib`, this pattern does not match its own
+  // output, but would otherwise load the wrong module.
+  const ownExportPatternsFixture = new URL(
+    'fixtures-package-imports-exports/node_modules/own-export-patterns-app/main.js',
+    import.meta.url,
+  ).toString();
+  const { namespace } = await importLocation(
+    readPowers,
+    ownExportPatternsFixture,
+  );
+  assertOwnExportPatterns(t, namespace);
 });
 
 test('non-object exports field causes an exception', async t => {


### PR DESCRIPTION
Fixes #3349

The problem described in #3349 (and the proposed fix) was a symptom of a more serious, underlying issue; exports could overwrite internal specifiers causing the incorrect module to be loaded.

I've modified an existing fixture to highlight the issue I reported in the bug, but also added a couple more fixtures which prove the fix solves the root-cause bug (and updated the subpath-exports-"node-parity" tests).