### PR TITLE
feat(ses): Apply special error logging to console.dir

### DIFF
--- a/.changeset/tedious-berry-two.md
+++ b/.changeset/tedious-berry-two.md
@@ -1,0 +1,5 @@
+---
+'ses': patch
+---
+
+- `console.dir(error)` emits the same enriched output as `console.log(error)`

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -17,6 +17,7 @@ import {
   fromEntries,
   globalThis,
   isError,
+  isPrimitive,
   stringEndsWith,
   stringIncludes,
   stringSplit,
@@ -96,6 +97,8 @@ export const consoleLevelMethods = freeze([
 /**
  * We special case `console.assert` because it contains `fmt?, ...args` just
  * like the `consoleLevelMethods`, but not in the same place.
+ * We special case `console.dir` because its second argument is not data to be
+ * logged.
  * We special case `console.timeLog` because it contains the same kind of
  * `...args`, but with no format string.
  *
@@ -103,6 +106,7 @@ export const consoleLevelMethods = freeze([
  */
 export const consoleSpecialMethods = freeze([
   ['assert', 'error'], // (value, fmt?, ...args)
+  ['dir', 'log'], // (item, options?)
   ['timeLog', 'log'], // (label?, ...args) no fmt string
 ]);
 
@@ -122,7 +126,6 @@ export const consoleOtherMethods = freeze([
   ['clear', 'info'], // (), level is not well defined
   ['count', 'info'], // (label?)
   ['countReset', 'info'], // (label?), level is not well defined
-  ['dir', 'log'], // (item, options?)
   ['groupEnd', 'log'], // ()
   // In theory tabular data may be or contain an error. However, we currently
   // do not detect these and may never.
@@ -544,6 +547,21 @@ export const makeCausalConsole = (feralConsole, loggedErrorHandler) => {
     }
   });
 
+  const dirMethod = defineName('dir', (value, options) => {
+    const subErrors = [];
+    const dirArg = extractErrorArgs([value], subErrors)[0];
+    if (isPrimitive(options)) {
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      baseConsole.dir(dirArg, options);
+    } else {
+      // https://nodejs.org/docs/latest/api/console.html#consoledirobj-options
+      const { colors, depth, showHidden } = options;
+      // eslint-disable-next-line @endo/no-polymorphic-call
+      baseConsole.dir(dirArg, { colors, depth, showHidden });
+    }
+    logSubErrors('error', subErrors);
+  });
+
   const timeLogMethod = defineName('timeLog', (...timeLogArgs) => {
     if (timeLogArgs.length <= 1) {
       // eslint-disable-next-line @endo/no-polymorphic-call
@@ -574,6 +592,7 @@ export const makeCausalConsole = (feralConsole, loggedErrorHandler) => {
     [
       ...levelMethods,
       ['assert', assertMethod],
+      ['dir', dirMethod],
       ['timeLog', timeLogMethod],
       ...otherMethods,
     ],
@@ -648,6 +667,9 @@ export const defineCausalConsoleFromLogger = loggedErrorHandler => {
         defineName(name, (...args) => logWithIndent(name, ...args)),
       ]),
     ]);
+    baseConsole.dir = defineName('dir', (...args) =>
+      logWithIndent('dir', ...args),
+    );
     // https://console.spec.whatwg.org/#grouping
     for (const name of ['group', 'groupCollapsed']) {
       if (baseConsole[name]) {

--- a/packages/ses/test/error/sanitize-by-method.test.js
+++ b/packages/ses/test/error/sanitize-by-method.test.js
@@ -63,6 +63,11 @@ test('console sanitize by method', t => {
             console.assert(false, 'a%cb', err2, err1);
             break;
           }
+          case 'dir': {
+            t.is(level, 'log');
+            console.dir(err1);
+            break;
+          }
           case 'timeLog': {
             t.is(level, 'log');
             console.timeLog('a%cb', err2, err1);
@@ -86,6 +91,8 @@ test('console sanitize by method', t => {
       ['groupEnd'],
       // each special method is its own case
       ['assert', false, 'ab', '(Error#1)'],
+      // each special method is its own case
+      ['dir', '(Error#1)', undefined],
       // each special method is its own case
       ['timeLog', 'a%cb', '(Error#2)', '(Error#1)'],
       ['group', 'Nested 2 errors'],


### PR DESCRIPTION
## Description

The causal console looks for errors in arguments to `console.log`/`console.error`/etc., but not in arguments to `console.dir`. The latter method is not nearly as common, but should still be accommodated.

### Security Considerations

None known.

### Scaling Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Covered by unit tests.

### Compatibility Considerations

This should be a strict improvement if any code is using `console.dir`.

### Upgrade Considerations

Nothing unusual.
