### PR TITLE
fix(compartment-mapper): avoid special package names when mapping

### DIFF
--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -226,15 +226,17 @@ const assertPackageDescriptor = allegedPackageDescriptor => {
  * Asserts that the given `PackageDescriptor` has a non-empty `name`.
  *
  * `name` is required by {@link PackageDescriptor} and the compartment mapper
- * relies on it to label and link compartments. Without it, downstream
- * failures are obscure (for example, the bundler reports an undefined name
- * far from the offending `package.json`). This surfaces a precise
- * diagnostic that points at the offending file so the misconfiguration
- * is easy to fix.
+ * relies on it to label and link compartments. Without it, downstream failures
+ * are obscure (for example, the bundler reports an undefined name far from the
+ * offending `package.json`). This surfaces a precise diagnostic that points at
+ * the offending file so the misconfiguration is easy to fix.
+ *
+ * The names of the entry compartment and attenuators compartment are reserved
+ * and cannot be used.
  *
  * @param {PackageDescriptor} packageDescriptor
- * @param {string} packageDescriptorLocation - URL of the `package.json`
- * file that produced this descriptor, used to attribute errors.
+ * @param {string} packageDescriptorLocation - URL of the `package.json` file
+ * that produced this descriptor, used to attribute errors.
  * @returns {void}
  */
 const assertPackageDescriptorHasName = (
@@ -245,6 +247,11 @@ const assertPackageDescriptorHasName = (
   if (name === undefined || name === '') {
     throw Error(
       `package.json at ${q(packageDescriptorLocation)} must have a "name" field; consider naming it after the parent directory`,
+    );
+  }
+  if (name === ENTRY_COMPARTMENT || name === ATTENUATORS_COMPARTMENT) {
+    throw Error(
+      `package.json at ${q(packageDescriptorLocation)} must not have a "name" field of ${q(name)}`,
     );
   }
 };

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -251,7 +251,7 @@ const assertPackageDescriptorHasName = (
   }
   if (name === ENTRY_COMPARTMENT || name === ATTENUATORS_COMPARTMENT) {
     throw Error(
-      `package.json at ${q(packageDescriptorLocation)} must not have a "name" field of ${q(name)}`,
+      `package.json at ${q(packageDescriptorLocation)} must not have a "name" field of ${q(name)}. This might indicate malware.`,
     );
   }
 };

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/README.md
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/README.md
@@ -1,0 +1,10 @@
+# bad package names
+
+This fixture contains packages matching the entry compartment name and the attenuators compartment name, both of which have special meaning in the compartment mapper.
+
+This sort of occurrence is assumed to only be possible after manual editing of `package.json`, as the npm registry considers either of these names to be invalid.
+
+Such packages should not be allowed to be created by `mapNodeModules`.
+
+- `app` / `your-package` - matches the entry compartment name
+- `app2` / `a-package` - matches the attenuators compartment name

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/a-package/index.js
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/a-package/index.js
@@ -1,0 +1,1 @@
+export const name = '<ATTENUATORS>';

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/a-package/package.json
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/a-package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "<ATTENUATORS>",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/app/index.js
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/app/index.js
@@ -1,0 +1,1 @@
+export { name } from 'your-package';

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/app/package.json
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "app",
+  "type": "module",
+  "dependencies": {
+    "your-package": "*"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/app2/index.js
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/app2/index.js
@@ -1,0 +1,1 @@
+export { name } from 'a-package';

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/app2/package.json
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/app2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "app",
+  "type": "module",
+  "dependencies": {
+    "a-package": "*"
+  }
+}

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/your-package/index.js
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/your-package/index.js
@@ -1,0 +1,1 @@
+export const name = '$root$';

--- a/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/your-package/package.json
+++ b/packages/compartment-mapper/test/fixtures-bad-package-name/node_modules/your-package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "$root$",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/packages/compartment-mapper/test/map-node-modules.test.js
+++ b/packages/compartment-mapper/test/map-node-modules.test.js
@@ -63,7 +63,7 @@ const phonyFixture = /** @type {const} */ ({
   entrypoint: 'file:///node_modules/app/index.js',
 });
 
-test(`mapNodeModules() should return compartment descriptors containing shortest path`, async t => {
+test(`mapNodeModules - should return compartment descriptors containing shortest path`, async t => {
   const shortestPathFixture = new URL(
     'fixtures-shortest-path/node_modules/app/index.js',
     import.meta.url,
@@ -90,7 +90,7 @@ test(`mapNodeModules() should return compartment descriptors containing shortest
 });
 
 test.serial(
-  'mapNodeModules() should consider peerDependenciesMeta without corresponding peerDependencies when the dependency is present',
+  'mapNodeModules - should consider peerDependenciesMeta without corresponding peerDependencies when the dependency is present',
   async t => {
     t.plan(2);
     const moduleLocation = new URL(
@@ -109,7 +109,7 @@ test.serial(
   },
 );
 
-test('mapNodeModules() should not consider peerDependenciesMeta without corresponding peerDependencies when the dependency is missing', async t => {
+test('mapNodeModules - should not consider peerDependenciesMeta without corresponding peerDependencies when the dependency is missing', async t => {
   const moduleLocation = new URL(
     'fixtures-missing-optional-peer-dependencies/node_modules/app/index.js',
     import.meta.url,
@@ -965,6 +965,28 @@ test('mapNodeModules - packageDataHook provides all package data', async t => {
     expectedCanonicalNames,
     'should receive exactly the expected canonical names from the project fixture',
   );
+});
+
+test('mapNodeModules - bad project names - should throw an error if the package name is the same as the entry compartment', async t => {
+  const badNameFixture = new URL(
+    'fixtures-bad-package-name/node_modules/app/index.js',
+    import.meta.url,
+  ).href;
+
+  await t.throwsAsync(mapNodeModules(readPowers, badNameFixture), {
+    message: new RegExp(`must not have a "name" field of "\\$root\\$"`),
+  });
+});
+
+test('mapNodeModules - bad project names - should throw an error if the package name is the same as the attenuators compartment', async t => {
+  const badNameFixture = new URL(
+    'fixtures-bad-package-name/node_modules/app2/index.js',
+    import.meta.url,
+  ).href;
+
+  await t.throwsAsync(mapNodeModules(readPowers, badNameFixture), {
+    message: new RegExp(`must not have a "name" field of "<ATTENUATORS>"`),
+  });
 });
 
 test('additionalLocations - adds package to compartment map', async t => {


### PR DESCRIPTION
This change causes `mapNodeModules()` to fail if it encounters a `package.json` containing a `name` field matching either the entry compartment canonical name (`$root$`) or the attenuators compartment canonical name (`<ATTENUATORS>`).